### PR TITLE
Update PACKAGE_VERSION to k-NN plugin version

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -40,6 +40,10 @@ endif()
 set(KNN_INDEX KNNIndexV2_0_11)
 set(KNN_PACKAGE_NAME opensearch-knnlib)
 
+if(NOT KNN_PLUGIN_VERSION)
+    set(KNN_PLUGIN_VERSION local)
+endif()
+
 # Check if similarity search exists
 find_path(NMS_REPO_DIR NAMES similarity_search PATHS ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib)
 
@@ -88,7 +92,7 @@ endif()
 set(KNN_MAINTAINER "OpenSearch Team <opensearch@amazon.com>")
 set(OPENSEARCH_DOWNLOAD_URL "https://opensearch.org/downloads.html")
 set(CPACK_PACKAGE_NAME ${KNN_PACKAGE_NAME})
-set(CPACK_PACKAGE_VERSION 1.13.0.0)
+set(CPACK_PACKAGE_VERSION ${KNN_PLUGIN_VERSION})
 set(CMAKE_INSTALL_PREFIX /usr)
 set(CPACK_GENERATOR "RPM;DEB")
 SET(CPACK_OUTPUT_FILE_PREFIX packages)


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Allow CPACK_PACKAGE_VERSION to be set from command line.
if no value is passed, "local" will be used as default plugin version.

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
