### PR TITLE
Add vector reader to scan index containing k-NN vectors

### DIFF
--- a/src/main/java/org/opensearch/knn/training/VectorReader.java
+++ b/src/main/java/org/opensearch/knn/training/VectorReader.java
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.search.SearchRequestBuilder;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchScrollRequestBuilder;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.ValidationException;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.search.SearchHit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class VectorReader {
+
+
+    public static Logger logger = LogManager.getLogger(VectorReader.class);
+
+    private final IndicesService indicesService;
+    private final Client client;
+    private final TimeValue scrollTime = new TimeValue(60000);
+
+    /**
+     * Constructor
+     *
+     * @param indicesService service used to get field metadata to validate parameters
+     * @param client used to make search requests against the cluster
+     */
+    public VectorReader(IndicesService indicesService, Client client) {
+        this.indicesService = indicesService;
+        this.client = client;
+    }
+
+    /**
+     * Read vectors from a provided index/field and pass them to vectorConsumer that will do something with them.
+     *
+     * @param indexName name of index containing vectors
+     * @param fieldName name of field containing vectors
+     * @param maxVectorCount maximum number of vectors to return
+     * @param searchSize maximum number of vectors to return in a given search
+     * @param vectorConsumer consumer used to do something with the collected vectors after each search
+     * @param listener ActionListener that should be called once all search operations complete
+     */
+    public void read(String indexName, String fieldName, int maxVectorCount, int searchSize,
+                     Consumer<List<Float[]>> vectorConsumer, ActionListener<SearchResponse> listener) {
+
+        // Validate arguments
+        if (maxVectorCount <= 0) {
+            throw new ValidationException();
+        }
+
+        if (searchSize > 10000 || searchSize <= 0) {
+            throw new ValidationException();
+        }
+
+        IndexMetadata indexMetadata = indicesService.clusterService().state().metadata().index(indexName);
+        if (indexMetadata == null) {
+            throw new ValidationException();
+        }
+
+        MappedFieldType fieldType = indicesService.indexServiceSafe(indexMetadata.getIndex()).mapperService()
+                .fieldType(fieldName);
+
+        if (!(fieldType instanceof KNNVectorFieldMapper.KNNVectorFieldType)) {
+            throw new ValidationException();
+        }
+
+        // Start reading vectors from index
+        ActionListener<SearchResponse> vectorReaderListener = getVectorReaderListener(fieldName,
+                maxVectorCount, 0, vectorConsumer, listener);
+
+        createSearchRequestBuilder(indexName, fieldName, Integer.min(maxVectorCount, searchSize))
+                .execute(vectorReaderListener);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ActionListener<SearchResponse> getVectorReaderListener(String fieldName,
+                                                                   final int maxVectorCount,
+                                                                   final int collectedVectorCount,
+                                                                   Consumer<List<Float[]>> vectorConsumer,
+                                                                   ActionListener<SearchResponse> listener) {
+        return ActionListener.wrap(searchResponse -> {
+            // Get the vectors from the search response
+            // Either add the entire set of returned hits, or maxVectorCount - collectedVectorCount hits
+            SearchHit[] hits = searchResponse.getHits().getHits();
+            int vectorsToAdd = Integer.min(maxVectorCount - collectedVectorCount, hits.length);
+            List<Float[]> trainingData = new ArrayList<>();
+
+            for (int i = 0; i < vectorsToAdd; i++) {
+                trainingData.add(((List<Double>) hits[i].getSourceAsMap().get(fieldName)).stream()
+                        .map(Double::floatValue)
+                        .toArray(Float[]::new));
+            }
+
+            final int updatedVectorCount = collectedVectorCount + trainingData.size();
+
+            // Do something with the vectors
+            vectorConsumer.accept(trainingData);
+
+            if (vectorsToAdd == 0 || updatedVectorCount >= maxVectorCount) {
+                listener.onResponse(searchResponse);
+            } else {
+                ActionListener<SearchResponse> vectorReaderListener = getVectorReaderListener(fieldName, maxVectorCount,
+                        updatedVectorCount, vectorConsumer, listener);
+
+                // Create a new search that starts where the last search left off
+                createSearchScrollRequestBuilder(searchResponse).execute(vectorReaderListener);
+            }
+        }, listener::onFailure);
+    }
+
+    private SearchRequestBuilder createSearchRequestBuilder(String indexName, String fieldName, int resultSize) {
+        ExistsQueryBuilder queryBuilder = new ExistsQueryBuilder(fieldName);
+
+        SearchRequestBuilder searchRequestBuilder = client.prepareSearch(indexName);
+        searchRequestBuilder.setScroll(scrollTime);
+        searchRequestBuilder.setQuery(queryBuilder);
+        searchRequestBuilder.setSize(resultSize);
+
+        // We are only interested in reading vectors from a particular field
+        searchRequestBuilder.setFetchSource(fieldName, null);
+
+        return searchRequestBuilder;
+    }
+
+    private SearchScrollRequestBuilder createSearchScrollRequestBuilder(SearchResponse searchResponse) {
+        SearchScrollRequestBuilder searchScrollRequestBuilder = client.prepareSearchScroll(searchResponse.getScrollId());
+        searchScrollRequestBuilder.setScroll(scrollTime);
+        return searchScrollRequestBuilder;
+    }
+}

--- a/src/main/java/org/opensearch/knn/training/VectorReader.java
+++ b/src/main/java/org/opensearch/knn/training/VectorReader.java
@@ -26,6 +26,7 @@ import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.knn.index.KNNVectorFieldMapper;
 import org.opensearch.search.SearchHit;
+import org.opensearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -147,6 +148,7 @@ public class VectorReader {
         searchRequestBuilder.setScroll(scrollTime);
         searchRequestBuilder.setQuery(queryBuilder);
         searchRequestBuilder.setSize(resultSize);
+        searchRequestBuilder.addSort("_doc", SortOrder.ASC);
 
         // We are only interested in reading vectors from a particular field
         searchRequestBuilder.setFetchSource(fieldName, null);

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -120,6 +120,24 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
     }
 
     /**
+     * Add any document to index
+     */
+    protected void addDoc(String index, String docId, String fieldName, String dummyValue)
+            throws IOException, InterruptedException, ExecutionException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+                .field(fieldName, dummyValue)
+                .endObject();
+        IndexRequest indexRequest = new IndexRequest()
+                .index(index)
+                .id(docId)
+                .source(builder)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        IndexResponse response = client().index(indexRequest).get();
+        assertEquals(response.status(), RestStatus.CREATED);
+    }
+
+    /**
      * Run a search against a k-NN index
      */
     protected void searchKNNIndex(String index, String fieldName, float[] vector, int k) {

--- a/src/test/java/org/opensearch/knn/training/VectorReaderTests.java
+++ b/src/test/java/org/opensearch/knn/training/VectorReaderTests.java
@@ -1,0 +1,275 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.common.ValidationException;
+import org.opensearch.indices.IndicesService;
+import org.opensearch.knn.KNNSingleNodeTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class VectorReaderTests extends KNNSingleNodeTestCase {
+
+    public static Logger logger = LogManager.getLogger(VectorReaderTests.class);
+
+    public void testRead_valid_completeIndex() throws InterruptedException, ExecutionException, IOException {
+        // Create an index with knn disabled
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        int dim = 16;
+        int numVectors = 100;
+        createIndex(indexName);
+
+        // Add a field mapping to the index
+        createKnnIndexMapping(indexName, fieldName, dim);
+
+        // Create list of random vectors and ingest
+        Random random = new Random();
+        List<Float[]> vectors = new ArrayList<>();
+        for (int i = 0; i < numVectors; i++) {
+            Float[] vector = new Float[dim];
+
+            for (int j = 0; j < dim; j++) {
+                vector[j] = random.nextFloat();
+            }
+
+            vectors.add(vector);
+
+            addKnnDoc(indexName, Integer.toString(i), fieldName, vector);
+        }
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Read all vectors and confirm they match vectors
+        TestVectorConsumer testVectorConsumer = new TestVectorConsumer();
+        final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
+        vectorReader.read(indexName, fieldName, 10000, 10, testVectorConsumer,
+                ActionListener.wrap(response -> inProgressLatch1.countDown(), e -> fail(e.toString())));
+
+        assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
+
+        List<Float[]> consumedVectors = testVectorConsumer.getVectorsConsumed();
+        assertEquals(numVectors, consumedVectors.size());
+
+        List<Float> flatVectors = vectors.stream().flatMap(Arrays::stream).collect(Collectors.toList());
+        List<Float> flatConsumedVectors = consumedVectors.stream().flatMap(Arrays::stream).collect(Collectors.toList());
+        assertEquals(new HashSet<>(flatVectors), new HashSet<>(flatConsumedVectors));
+    }
+
+    public void testRead_valid_incompleteIndex() throws InterruptedException, ExecutionException, IOException {
+        // Check if we get the right number of vectors if the index contains docs that are missing fields
+        // Create an index with knn disabled
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        int dim = 16;
+        int numVectors = 100;
+        createIndex(indexName);
+
+        // Add a field mapping to the index
+        createKnnIndexMapping(indexName, fieldName, dim);
+
+        // Create list of random vectors and ingest
+        Random random = new Random();
+        List<Float[]> vectors = new ArrayList<>();
+        for (int i = 0; i < numVectors; i++) {
+            Float[] vector = new Float[dim];
+
+            for (int j = 0; j < dim; j++) {
+                vector[j] = random.nextFloat();
+            }
+
+            vectors.add(vector);
+
+            addKnnDoc(indexName, Integer.toString(i ), fieldName, vector);
+        }
+
+        // Create documents that do not have fieldName for training
+        int docsWithoutKNN = 100;
+        String fieldNameWithoutKnn = "test-field-2";
+        for (int i = 0; i < docsWithoutKNN; i++) {
+            addDoc(indexName, Integer.toString(i + numVectors), fieldNameWithoutKnn, "dummyValue");
+        }
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Read all vectors and confirm they match vectors
+        TestVectorConsumer testVectorConsumer = new TestVectorConsumer();
+        final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
+        vectorReader.read(indexName, fieldName, 10000, 10, testVectorConsumer,
+                ActionListener.wrap(response -> inProgressLatch1.countDown(), e -> fail(e.toString())));
+
+        assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
+
+        List<Float[]> consumedVectors = testVectorConsumer.getVectorsConsumed();
+        assertEquals(numVectors, consumedVectors.size());
+
+        List<Float> flatVectors = vectors.stream().flatMap(Arrays::stream).collect(Collectors.toList());
+        List<Float> flatConsumedVectors = consumedVectors.stream().flatMap(Arrays::stream).collect(Collectors.toList());
+        assertEquals(new HashSet<>(flatVectors), new HashSet<>(flatConsumedVectors));
+    }
+
+    public void testRead_valid_OnlyGetMaxVectors() throws InterruptedException, ExecutionException, IOException {
+        // Check if we can limit the number of docs via max operation
+        // Create an index with knn disabled
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        int dim = 16;
+        int numVectorsIndex = 100;
+        int maxNumVectorsRead = 20;
+        createIndex(indexName);
+
+        // Add a field mapping to the index
+        createKnnIndexMapping(indexName, fieldName, dim);
+
+        // Create list of random vectors and ingest
+        Random random = new Random();
+        for (int i = 0; i < numVectorsIndex; i++) {
+            Float[] vector = new Float[dim];
+
+            for (int j = 0; j < dim; j++) {
+                vector[j] = random.nextFloat();
+            }
+
+            addKnnDoc(indexName, Integer.toString(i ), fieldName, vector);
+        }
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Read maxNumVectorsRead vectors
+        TestVectorConsumer testVectorConsumer = new TestVectorConsumer();
+        final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
+        vectorReader.read(indexName, fieldName, maxNumVectorsRead, 10, testVectorConsumer,
+                ActionListener.wrap(response -> inProgressLatch1.countDown(), e -> fail(e.toString())));
+
+        assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
+
+        List<Float[]> consumedVectors = testVectorConsumer.getVectorsConsumed();
+        assertEquals(maxNumVectorsRead, consumedVectors.size());
+    }
+
+    public void testRead_invalid_maxVectorCount() {
+        // Create the index
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        int dim = 16;
+        createIndex(indexName);
+
+        // Add a field mapping to the index
+        createKnnIndexMapping(indexName, fieldName, dim);
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        expectThrows(ValidationException.class, () -> vectorReader.read(indexName, fieldName, -10, 10, null, null));
+    }
+
+    public void testRead_invalid_searchSize() {
+        // Create the index
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        int dim = 16;
+        createIndex(indexName);
+
+        // Add a field mapping to the index
+        createKnnIndexMapping(indexName, fieldName, dim);
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Search size is negative
+        expectThrows(ValidationException.class, () -> vectorReader.read(indexName, fieldName, 100, -10, null, null));
+
+        // Search size is greater than 10000
+        expectThrows(ValidationException.class, () -> vectorReader.read(indexName, fieldName, 100, 20000, null, null));
+    }
+
+    public void testRead_invalid_indexDoesNotExist() {
+        // Check that read throws a validation exception when the index does not exist
+        String indexName = "test-index";
+        String fieldName = "test-field";
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Should throw a validation exception because index does not exist
+        expectThrows(ValidationException.class, () -> vectorReader.read(indexName, fieldName, 10000, 10, null, null));
+    }
+
+    public void testRead_invalid_fieldDoesNotExist() {
+        // Check that read throws a validation exception when the field does not exist
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        createIndex(indexName);
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Should throw a validation exception because field is not k-NN
+        expectThrows(ValidationException.class, () -> vectorReader.read(indexName, fieldName, 10000, 10, null, null));
+    }
+
+    public void testRead_invalid_fieldIsNotKnn() throws InterruptedException, ExecutionException, IOException {
+        // Check that read throws a validation exception when the field does not exist
+        String indexName = "test-index";
+        String fieldName = "test-field";
+        createIndex(indexName);
+        addDoc(indexName, "test-id", fieldName, "dummy");
+
+        // Configure VectorReader
+        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        VectorReader vectorReader = new VectorReader(indicesService, client());
+
+        // Should throw a validation exception because field does not exist
+        expectThrows(ValidationException.class, () -> vectorReader.read(indexName, fieldName, 10000, 10, null, null));
+    }
+
+    private static class TestVectorConsumer implements Consumer<List<Float[]>> {
+
+        List<Float[]> vectorsConsumed;
+
+        TestVectorConsumer() {
+            vectorsConsumed = new ArrayList<>();
+        }
+
+        @Override
+        public void accept(List<Float[]> vectors) {
+            vectorsConsumed.addAll(vectors);
+        }
+
+        public List<Float[]> getVectorsConsumed() {
+            return vectorsConsumed;
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Adds a vector reader for training that scans an index for knn_vector's based on the field, and passes them to a Consumer to do "something" with. In the future, "something", can pass the training data to the jni layer where it can be used for training.

The vector reader executes a scan query against the index, collecting all documents in the index that contain the knn field of interest. The scan terminates either when the index has no more documents to search, or the maximum number of vectors has been collected. 
 
### Issues Resolved
#27 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
