### PR TITLE
Add equals and hashcode to KNNMethodContext MethodComponentContext

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ dependencies {
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     compile group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
     compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
+    compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     configurations.all {
         resolutionStrategy {

--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -19,6 +19,8 @@ import org.opensearch.index.mapper.MapperParsingException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -174,5 +176,26 @@ public class KNNMethodContext implements ToXContentFragment {
         builder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
         builder = methodComponent.toXContent(builder, params);
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        KNNMethodContext other = (KNNMethodContext) obj;
+
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        equalsBuilder.append(knnEngine, other.knnEngine);
+        equalsBuilder.append(spaceType, other.spaceType);
+        equalsBuilder.append(methodComponent, other.methodComponent);
+
+        return equalsBuilder.isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(methodComponent).toHashCode();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -17,6 +17,8 @@ import org.opensearch.index.mapper.MapperParsingException;
 
 import java.io.IOException;
 import java.util.Map;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
@@ -95,6 +97,25 @@ public class MethodComponentContext implements ToXContentFragment {
         builder.field(NAME, name);
         builder.field(PARAMETERS, parameters);
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        MethodComponentContext other = (MethodComponentContext) obj;
+
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        equalsBuilder.append(name, other.name);
+        equalsBuilder.append(parameters, other.parameters);
+        return equalsBuilder.isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(name).append(parameters).toHashCode();
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -217,4 +217,57 @@ public class KNNMethodContextTests extends KNNTestCase {
         assertEquals(spaceType, out.get(METHOD_PARAMETER_SPACE_TYPE));
         assertEquals(knnEngine, out.get(KNN_ENGINE));
     }
+
+    public void testEquals() {
+        SpaceType spaceType1 = SpaceType.L1;
+        SpaceType spaceType2 = SpaceType.L2;
+        String name1 = "name1";
+        String name2 = "name2";
+        Map<String, Object> parameters1 = ImmutableMap.of(
+                "param1", "v1",
+                "param2", 18
+        );
+
+        MethodComponentContext methodComponentContext1 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodComponentContext2 = new MethodComponentContext(name2, parameters1);
+
+        KNNMethodContext methodContext1 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext2 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext3 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext2);
+        KNNMethodContext methodContext4 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext1);
+        KNNMethodContext methodContext5 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext2);
+
+        assertNotEquals(methodContext1, null);
+        assertEquals(methodContext1, methodContext1);
+        assertEquals(methodContext1, methodContext2);
+        assertNotEquals(methodContext1, methodContext3);
+        assertNotEquals(methodContext1, methodContext4);
+        assertNotEquals(methodContext1, methodContext5);
+    }
+
+    public void testHashCode() {
+        SpaceType spaceType1 = SpaceType.L1;
+        SpaceType spaceType2 = SpaceType.L2;
+        String name1 = "name1";
+        String name2 = "name2";
+        Map<String, Object> parameters1 = ImmutableMap.of(
+                "param1", "v1",
+                "param2", 18
+        );
+
+        MethodComponentContext methodComponentContext1 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodComponentContext2 = new MethodComponentContext(name2, parameters1);
+
+        KNNMethodContext methodContext1 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext2 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext1);
+        KNNMethodContext methodContext3 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType1, methodComponentContext2);
+        KNNMethodContext methodContext4 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext1);
+        KNNMethodContext methodContext5 = new KNNMethodContext(KNNEngine.DEFAULT, spaceType2, methodComponentContext2);
+
+        assertEquals(methodContext1.hashCode(), methodContext1.hashCode());
+        assertEquals(methodContext1.hashCode(), methodContext2.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext3.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext4.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext5.hashCode());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.index;
 
+import com.google.common.collect.ImmutableMap;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -18,6 +19,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.mapper.MapperParsingException;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.NAME;
@@ -166,5 +168,53 @@ public class MethodComponentContextTests extends KNNTestCase {
 
         assertEquals(paramVal1, paramMap.get(paramKey1));
         assertEquals(paramVal2, paramMap.get(paramKey2));
+    }
+
+    public void testEquals() {
+        String name1 = "name1";
+        String name2 = "name2";
+        Map<String, Object> parameters1 = ImmutableMap.of(
+                "param1", "v1",
+                "param2", 18
+        );
+
+        Map<String, Object> parameters2 = new HashMap<>(parameters1);
+
+        Map<String, Object> parameters3 = ImmutableMap.of(
+                "param1", "v1"
+        );
+
+
+        MethodComponentContext methodContext1 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodContext2 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodContext3 = new MethodComponentContext(name2, parameters2);
+
+        assertEquals(methodContext1, methodContext1);
+        assertEquals(methodContext1, methodContext2);
+        assertNotEquals(methodContext1, methodContext3);
+        assertNotEquals(methodContext1, null);
+    }
+
+    public void testHashCode() {
+        String name1 = "name1";
+        String name2 = "name2";
+        Map<String, Object> parameters1 = ImmutableMap.of(
+                "param1", "v1",
+                "param2", 18
+        );
+
+        Map<String, Object> parameters2 = new HashMap<>(parameters1);
+
+        Map<String, Object> parameters3 = ImmutableMap.of(
+                "param1", "v1"
+        );
+
+        MethodComponentContext methodContext1 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodContext2 = new MethodComponentContext(name1, parameters1);
+        MethodComponentContext methodContext3 = new MethodComponentContext(name2, parameters2);
+
+        assertEquals(methodContext1.hashCode(), methodContext1.hashCode());
+        assertEquals(methodContext1.hashCode(), methodContext2.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext3.hashCode());
     }
 }


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR adds equals and hashcode overrides to KNNMethodContext and MethodComponentContext in order to prevent mapper merge from failing.
 
### Issues Resolved
#38 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
