### PR TITLE
Enabled automated license header checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@ buildSrc/libs
 buildSrc/build/
 .gradle/
 build
-.idea/
+.idea/*
 !.idea/codeStyles/codeStyleConfig.xml
+!.idea/copyright
 .DS_Store
 *.log
 out/

--- a/.idea/copyright/SPDX_ALv2.xml
+++ b/.idea/copyright/SPDX_ALv2.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="SPDX-License-Identifier: Apache-2.0&#10;&#10;The OpenSearch Contributors require contributions made to&#10;this file be licensed under the Apache-2.0 license or a&#10;compatible open source license.&#10;&#10;Modifications Copyright OpenSearch Contributors. See&#10;GitHub history for details." />
+    <option name="myName" value="SPDX-ALv2" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="SPDX-ALv2" />
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ dependencies {
     }
 }
 
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 loggerUsageCheck.enabled = false


### PR DESCRIPTION
### Description
1. Re-enabled the 'licenseHeaders' check in the build.gradle file.
2. Added an IntelliJ copyright profile to auto-generate the SPDX license header.
 
### Issues Resolved
Related to - opensearch-project/opensearch-plugins#49
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <vermketa@amazon.com>