### PR TITLE
Update model index to include additional meta data

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -91,7 +91,7 @@ public class KNNVectorFieldMapper extends ParametrizedFieldMapper {
      * Define the max dimension a knn_vector mapping can have. This limit is somewhat arbitrary. In the future, we
      * should make this configurable.
      */
-    static final int MAX_DIMENSION = 10000;
+    public static final int MAX_DIMENSION = 10000;
 
     private static KNNVectorFieldMapper toType(FieldMapper in) {
         return (KNNVectorFieldMapper) in;

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -11,31 +11,77 @@
 
 package org.opensearch.knn.indices;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.util.Objects;
 
 public class Model {
+
     final private KNNEngine knnEngine;
     final private SpaceType spaceType;
     final private byte[] modelBlob;
 
+    /**
+     * Constructor
+     *
+     * @param knnEngine engine model is built with
+     * @param spaceType space type model uses
+     * @param modelBlob binary representation of model template index
+     */
     public Model(KNNEngine knnEngine, SpaceType spaceType, byte[] modelBlob) {
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
         this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
         this.modelBlob = Objects.requireNonNull(modelBlob, "modelBlob must not be null");
     }
 
+    /**
+     * getter for model's knnEngine
+     *
+     * @return knnEngine
+     */
     public KNNEngine getKnnEngine() {
         return knnEngine;
     }
 
+    /**
+     * getter for model's spaceType
+     *
+     * @return spaceType
+     */
     public SpaceType getSpaceType() {
         return spaceType;
     }
 
+    /**
+     * getter for model's binary blob
+     *
+     * @return modelBlob
+     */
     public byte[] getModelBlob() {
         return modelBlob;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        Model other = (Model) obj;
+
+        EqualsBuilder equalsBuilder = new EqualsBuilder();
+        equalsBuilder.append(knnEngine, other.knnEngine);
+        equalsBuilder.append(spaceType, other.spaceType);
+        equalsBuilder.append(modelBlob, other.modelBlob);
+
+        return equalsBuilder.isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(modelBlob).toHashCode();
     }
 }

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.indices;
+
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.Objects;
+
+public class Model {
+    final private KNNEngine knnEngine;
+    final private SpaceType spaceType;
+    final private byte[] modelBlob;
+
+    public Model(KNNEngine knnEngine, SpaceType spaceType, byte[] modelBlob) {
+        this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
+        this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
+        this.modelBlob = Objects.requireNonNull(modelBlob, "modelBlob must not be null");
+    }
+
+    public KNNEngine getKnnEngine() {
+        return knnEngine;
+    }
+
+    public SpaceType getSpaceType() {
+        return spaceType;
+    }
+
+    public byte[] getModelBlob() {
+        return modelBlob;
+    }
+}

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -18,10 +18,13 @@ import org.opensearch.knn.index.util.KNNEngine;
 
 import java.util.Objects;
 
+import static org.opensearch.knn.index.KNNVectorFieldMapper.MAX_DIMENSION;
+
 public class Model {
 
     final private KNNEngine knnEngine;
     final private SpaceType spaceType;
+    final private int dimension;
     final private byte[] modelBlob;
 
     /**
@@ -31,9 +34,13 @@ public class Model {
      * @param spaceType space type model uses
      * @param modelBlob binary representation of model template index
      */
-    public Model(KNNEngine knnEngine, SpaceType spaceType, byte[] modelBlob) {
+    public Model(KNNEngine knnEngine, SpaceType spaceType, int dimension, byte[] modelBlob) {
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
         this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
+        if (dimension <= 0 || dimension >= MAX_DIMENSION) {
+            throw new IllegalArgumentException("Dimension value must be greater than 0 and less than " + MAX_DIMENSION);
+        }
+        this.dimension = dimension;
         this.modelBlob = Objects.requireNonNull(modelBlob, "modelBlob must not be null");
     }
 
@@ -56,6 +63,15 @@ public class Model {
     }
 
     /**
+     * getter for model's dimension
+     *
+     * @return dimension
+     */
+    public int getDimension() {
+        return dimension;
+    }
+
+    /**
      * getter for model's binary blob
      *
      * @return modelBlob
@@ -75,6 +91,7 @@ public class Model {
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         equalsBuilder.append(knnEngine, other.knnEngine);
         equalsBuilder.append(spaceType, other.spaceType);
+        equalsBuilder.append(dimension, other.dimension);
         equalsBuilder.append(modelBlob, other.modelBlob);
 
         return equalsBuilder.isEquals();
@@ -82,6 +99,6 @@ public class Model {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(modelBlob).toHashCode();
+        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(dimension).append(modelBlob).toHashCode();
     }
 }

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -38,7 +38,8 @@ public class Model {
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
         this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
         if (dimension <= 0 || dimension >= MAX_DIMENSION) {
-            throw new IllegalArgumentException("Dimension value must be greater than 0 and less than " + MAX_DIMENSION);
+            throw new IllegalArgumentException("Dimension \"" + dimension + "\" is invalid. Value must be greater " +
+                    "than 0 and less than " + MAX_DIMENSION);
         }
         this.dimension = dimension;
         this.modelBlob = Objects.requireNonNull(modelBlob, "modelBlob must not be null");

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -80,6 +80,15 @@ public class Model {
         return modelBlob;
     }
 
+    /**
+     * getter for model's length
+     *
+     * @return length of model blob
+     */
+    public int getLength() {
+        return modelBlob.length;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj)

--- a/src/main/java/org/opensearch/knn/indices/ModelCache.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelCache.java
@@ -78,7 +78,7 @@ public final class ModelCache {
                 .recordStats()
                 .concurrencyLevel(1)
                 .maximumWeight(cacheSizeInBytes)
-                .weigher((k, v) -> v.getModelBlob().length);
+                .weigher((k, v) -> v.getLength());
 
         cache = cacheBuilder.build();
     }
@@ -103,7 +103,7 @@ public final class ModelCache {
      * @return total weight
      */
     public long getTotalWeight() {
-        return cache.asMap().values().stream().map(model -> (long) model.getModelBlob().length)
+        return cache.asMap().values().stream().map(model -> (long) model.getLength())
                 .reduce(0L, Long::sum);
     }
 

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -176,6 +176,7 @@ public interface ModelDao {
             Map<String, Object> parameters = ImmutableMap.of(
                     KNNConstants.KNN_ENGINE, model.getKnnEngine().getName(),
                     KNNConstants.METHOD_PARAMETER_SPACE_TYPE, model.getSpaceType().getValue(),
+                    KNNConstants.DIMENSION, model.getDimension(),
                     KNNConstants.MODEL_BLOB_PARAMETER, base64Model
             );
 
@@ -203,6 +204,7 @@ public interface ModelDao {
             Map<String, Object> parameters = ImmutableMap.of(
                     KNNConstants.KNN_ENGINE, model.getKnnEngine().getName(),
                     KNNConstants.METHOD_PARAMETER_SPACE_TYPE, model.getSpaceType().getValue(),
+                    KNNConstants.DIMENSION, model.getDimension(),
                     KNNConstants.MODEL_BLOB_PARAMETER, base64Model
             );
 
@@ -225,7 +227,7 @@ public interface ModelDao {
         @Override
         public Model get(String modelId) throws ExecutionException, InterruptedException {
             /*
-                GET /<model_index>/<modelId>?source_includes=<model_blob>&_local
+                GET /<model_index>/<modelId>?_local
             */
             GetRequestBuilder getRequestBuilder = new GetRequestBuilder(client, GetAction.INSTANCE, MODEL_INDEX_NAME)
                     .setId(modelId)
@@ -235,6 +237,7 @@ public interface ModelDao {
             Map<String, Object> responseMap = getResponse.getSourceAsMap();
             Object engine = responseMap.get(KNNConstants.KNN_ENGINE);
             Object space = responseMap.get(KNNConstants.METHOD_PARAMETER_SPACE_TYPE);
+            Object dimension = responseMap.get(KNNConstants.DIMENSION);
             Object blob = responseMap.get(KNNConstants.MODEL_BLOB_PARAMETER);
 
             if (blob == null) {
@@ -243,7 +246,7 @@ public interface ModelDao {
             }
 
             return new Model(KNNEngine.getEngine((String) engine), SpaceType.getSpace((String) space),
-                    Base64.getDecoder().decode((String) blob));
+                    (Integer) dimension, Base64.getDecoder().decode((String) blob));
         }
 
         private String getMapping() throws IOException {

--- a/src/main/resources/mappings/model-index.json
+++ b/src/main/resources/mappings/model-index.json
@@ -3,6 +3,9 @@
     "engine": {
       "type": "keyword"
     },
+    "space_type": {
+      "type": "keyword"
+    },
     "model_blob": {
       "type": "binary"
     }

--- a/src/main/resources/mappings/model-index.json
+++ b/src/main/resources/mappings/model-index.json
@@ -6,6 +6,9 @@
     "space_type": {
       "type": "keyword"
     },
+    "dimension": {
+      "type": "integer"
+    },
     "model_blob": {
       "type": "binary"
     }

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -30,7 +30,8 @@ public class ModelCacheTests extends KNNTestCase {
 
     public void testGet_normal() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
-        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, "hello".getBytes());
+        int dimension = 2;
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, "hello".getBytes());
         long cacheSize = 100L;
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -51,8 +52,10 @@ public class ModelCacheTests extends KNNTestCase {
 
     public void testGet_modelDoesNotFitInCache() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
+        int dimension = 2;
         long cacheSize = 500;
-        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,
+
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension,
                 new byte[Long.valueOf(cacheSize).intValue() + 1]);
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -95,12 +98,13 @@ public class ModelCacheTests extends KNNTestCase {
     public void testGetTotalWeight() throws ExecutionException, InterruptedException {
         String modelId1 = "test-model-id-1";
         String modelId2 = "test-model-id-2";
+        int dimension = 2;
         long cacheSize = 500L;
 
         int size1 = 100;
-        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,  new byte[size1]);
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[size1]);
         int size2 = 300;
-        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[size2]);
+        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -128,12 +132,13 @@ public class ModelCacheTests extends KNNTestCase {
     public void testRemove_normal() throws ExecutionException, InterruptedException {
         String modelId1 = "test-model-id-1";
         String modelId2 = "test-model-id-2";
+        int dimension = 2;
         long cacheSize = 500L;
 
         int size1 = 100;
-        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,  new byte[size1]);
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[size1]);
         int size2 = 300;
-        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[size2]);
+        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -167,8 +172,9 @@ public class ModelCacheTests extends KNNTestCase {
 
     public void testRebuild_normal() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
+        int dimension = 2;
         long cacheSize = 100L;
-        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, "hello".getBytes());
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, "hello".getBytes());
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -198,9 +204,10 @@ public class ModelCacheTests extends KNNTestCase {
 
     public void testRebuild_afterSettingUpdate() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
+        int dimension = 2;
 
         int modelSize = 101;
-        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize]);
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[modelSize]);
 
         long cacheSize1 = 100L;
         long cacheSize2 = 200L;
@@ -255,8 +262,9 @@ public class ModelCacheTests extends KNNTestCase {
 
     public void testContains() throws ExecutionException, InterruptedException {
         String modelId1 = "test-model-id-1";
+        int dimension = 2;
         int modelSize1 = 100;
-        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize1]);
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
 
@@ -282,13 +290,14 @@ public class ModelCacheTests extends KNNTestCase {
     }
 
     public void testRemoveAll() throws ExecutionException, InterruptedException {
+        int dimension = 2;
         String modelId1 = "test-model-id-1";
         int modelSize1 = 100;
-        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize1]);
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
         int modelSize2 = 100;
-        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize2]);
+        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[modelSize2]);
 
         long cacheSize = 500L;
 

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -17,6 +17,8 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
 
 import java.util.concurrent.ExecutionException;
 
@@ -28,7 +30,7 @@ public class ModelCacheTests extends KNNTestCase {
 
     public void testGet_normal() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
-        byte[] mockModel = "hello".getBytes();
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, "hello".getBytes());
         long cacheSize = 100L;
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -44,13 +46,14 @@ public class ModelCacheTests extends KNNTestCase {
         ModelCache.initialize(modelDao, clusterService);
         ModelCache modelCache = new ModelCache();
 
-        assertArrayEquals(mockModel, modelCache.get(modelId));
+        assertEquals(mockModel, modelCache.get(modelId));
     }
 
     public void testGet_modelDoesNotFitInCache() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
         long cacheSize = 500;
-        byte[] mockModel = new byte[Long.valueOf(cacheSize).intValue() + 1];
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,
+                new byte[Long.valueOf(cacheSize).intValue() + 1]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -65,7 +68,7 @@ public class ModelCacheTests extends KNNTestCase {
         ModelCache.initialize(modelDao, clusterService);
         ModelCache modelCache = new ModelCache();
 
-        assertArrayEquals(mockModel, modelCache.get(modelId));
+        assertEquals(mockModel, modelCache.get(modelId));
         assertFalse(modelCache.contains(modelId));
     }
 
@@ -95,9 +98,9 @@ public class ModelCacheTests extends KNNTestCase {
         long cacheSize = 500L;
 
         int size1 = 100;
-        byte[] mockModel1 = new byte[size1];
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,  new byte[size1]);
         int size2 = 300;
-        byte[] mockModel2 = new byte[size2];
+        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -128,9 +131,9 @@ public class ModelCacheTests extends KNNTestCase {
         long cacheSize = 500L;
 
         int size1 = 100;
-        byte[] mockModel1 = new byte[size1];
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,  new byte[size1]);
         int size2 = 300;
-        byte[] mockModel2 = new byte[size2];
+        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -165,7 +168,7 @@ public class ModelCacheTests extends KNNTestCase {
     public void testRebuild_normal() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
         long cacheSize = 100L;
-        byte[] mockModel = "hello".getBytes();
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, "hello".getBytes());
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -182,7 +185,7 @@ public class ModelCacheTests extends KNNTestCase {
 
         // Add element to cache - nothing should be kept
         modelCache.get(modelId);
-        assertEquals(mockModel.length, modelCache.getTotalWeight());
+        assertEquals(mockModel.getModelBlob().length, modelCache.getTotalWeight());
 
         // Rebuild and make sure cache is empty
         modelCache.rebuild();
@@ -190,14 +193,14 @@ public class ModelCacheTests extends KNNTestCase {
 
         // Add element again
         modelCache.get(modelId);
-        assertEquals(mockModel.length, modelCache.getTotalWeight());
+        assertEquals(mockModel.getModelBlob().length, modelCache.getTotalWeight());
     }
 
     public void testRebuild_afterSettingUpdate() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
 
         int modelSize = 101;
-        byte[] mockModel = new byte[modelSize];
+        Model mockModel = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize]);
 
         long cacheSize1 = 100L;
         long cacheSize2 = 200L;
@@ -253,7 +256,7 @@ public class ModelCacheTests extends KNNTestCase {
     public void testContains() throws ExecutionException, InterruptedException {
         String modelId1 = "test-model-id-1";
         int modelSize1 = 100;
-        byte[] mockModel1 = new byte[modelSize1];
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
 
@@ -281,11 +284,11 @@ public class ModelCacheTests extends KNNTestCase {
     public void testRemoveAll() throws ExecutionException, InterruptedException {
         String modelId1 = "test-model-id-1";
         int modelSize1 = 100;
-        byte[] mockModel1 = new byte[modelSize1];
+        Model mockModel1 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
         int modelSize2 = 100;
-        byte[] mockModel2 = new byte[modelSize2];
+        Model mockModel2 = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, new byte[modelSize2]);
 
         long cacheSize = 500L;
 

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -15,49 +15,70 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 
+import static org.opensearch.knn.index.KNNVectorFieldMapper.MAX_DIMENSION;
+
 public class ModelTests extends KNNTestCase {
 
     public void testNullConstructor() {
-        expectThrows(NullPointerException.class, () -> new Model(null, null, null));
+        expectThrows(NullPointerException.class, () -> new Model(null, null, 2, null));
+    }
+
+    public void testInvalidDimension() {
+        expectThrows(IllegalArgumentException.class, () -> new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, -1,
+                new byte[16]));
+        expectThrows(IllegalArgumentException.class, () -> new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, 0,
+                new byte[16]));
+        expectThrows(IllegalArgumentException.class, () -> new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT,
+                MAX_DIMENSION + 1, new byte[16]));
     }
 
     public void testGetKnnEngine() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
-        Model model = new Model(knnEngine, SpaceType.DEFAULT, new byte[16]);
+        Model model = new Model(knnEngine, SpaceType.DEFAULT, 2, new byte[16]);
         assertEquals(knnEngine, model.getKnnEngine());
     }
 
     public void testGetSpaceType() {
         SpaceType spaceType = SpaceType.DEFAULT;
-        Model model = new Model(KNNEngine.DEFAULT, spaceType, new byte[16]);
+        Model model = new Model(KNNEngine.DEFAULT, spaceType, 2, new byte[16]);
         assertEquals(spaceType, model.getSpaceType());
+    }
+
+    public void testGetDimension() {
+        int dimension = 128;
+        Model model = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, new byte[16]);
+        assertEquals(dimension, model.getDimension());
     }
 
     public void testGetModelBlob() {
         byte[] modelBlob = "hello".getBytes();
-        Model model = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, modelBlob);
+        Model model = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, modelBlob);
         assertArrayEquals(modelBlob, model.getModelBlob());
     }
 
     public void testEquals() {
-        Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
-        Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
-        Model model3 = new Model(KNNEngine.DEFAULT, SpaceType.L2, new byte[16]);
-        Model model4 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[32]);
+        Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[16]);
+        Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[16]);
+        Model model3 = new Model(KNNEngine.DEFAULT, SpaceType.L2, 2, new byte[16]);
+        Model model4 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[32]);
+        Model model5 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 4, new byte[16]);
 
         assertEquals(model1, model1);
         assertEquals(model1, model2);
         assertNotEquals(model1, model3);
         assertNotEquals(model1, model4);
+        assertNotEquals(model1, model5);
     }
 
     public void testHashCode() {
-        Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
-        Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
-        Model model3 = new Model(KNNEngine.DEFAULT, SpaceType.L2, new byte[32]);
+        Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[16]);
+        Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[16]);
+        Model model3 = new Model(KNNEngine.DEFAULT, SpaceType.L2, 2, new byte[32]);
+        Model model4 = new Model(KNNEngine.DEFAULT, SpaceType.L2, 4, new byte[16]);
 
         assertEquals(model1.hashCode(), model1.hashCode());
         assertEquals(model1.hashCode(), model2.hashCode());
         assertNotEquals(model1.hashCode(), model3.hashCode());
+        assertNotEquals(model1.hashCode(), model4.hashCode());
     }
 }

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.indices;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
+
+public class ModelTests extends KNNTestCase {
+
+    public void testNullConstructor() {
+        expectThrows(NullPointerException.class, () -> new Model(null, null, null));
+    }
+
+    public void testGetKnnEngine() {
+        KNNEngine knnEngine = KNNEngine.DEFAULT;
+        Model model = new Model(knnEngine, SpaceType.DEFAULT, new byte[16]);
+        assertEquals(knnEngine, model.getKnnEngine());
+    }
+
+    public void testGetSpaceType() {
+        SpaceType spaceType = SpaceType.DEFAULT;
+        Model model = new Model(KNNEngine.DEFAULT, spaceType, new byte[16]);
+        assertEquals(spaceType, model.getSpaceType());
+    }
+
+    public void testGetModelBlob() {
+        byte[] modelBlob = "hello".getBytes();
+        Model model = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, modelBlob);
+        assertArrayEquals(modelBlob, model.getModelBlob());
+    }
+
+    public void testEquals() {
+        Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
+        Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
+        Model model3 = new Model(KNNEngine.DEFAULT, SpaceType.L2, new byte[16]);
+        Model model4 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[32]);
+
+        assertEquals(model1, model1);
+        assertEquals(model1, model2);
+        assertNotEquals(model1, model3);
+        assertNotEquals(model1, model4);
+    }
+
+    public void testHashCode() {
+        Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
+        Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, new byte[16]);
+        Model model3 = new Model(KNNEngine.DEFAULT, SpaceType.L2, new byte[32]);
+
+        assertEquals(model1.hashCode(), model1.hashCode());
+        assertEquals(model1.hashCode(), model2.hashCode());
+        assertNotEquals(model1.hashCode(), model3.hashCode());
+    }
+}

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -56,6 +56,12 @@ public class ModelTests extends KNNTestCase {
         assertArrayEquals(modelBlob, model.getModelBlob());
     }
 
+    public void testGetLength() {
+        int size = 129;
+        Model model = new Model(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, new byte[size]);
+        assertEquals(size, model.getLength());
+    }
+
     public void testEquals() {
         Model model1 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[16]);
         Model model2 = new Model(KNNEngine.DEFAULT, SpaceType.L1, 2, new byte[16]);


### PR DESCRIPTION
### Description
Currently, the model system index stores a model's base64 encoded model_blob and associated knn_engine. This PR adds the space type and the dimension of the model to this index to make it easier for users to create indices and for the plugin to rescore queries. To accomplish this, it creates a `Model` class that stores all information about the model.

Eventually, a user should be able to create an index from a model with this simple mapping:
```
"my_vector":{
    "type":"knn_vector",
    "model_id": "my_model_id"
}
```

During index creation, we require a user to specify a dimension. This is later used for parsing ingested vectors/query vectors. Additionally, a user will be required to specify a dimension during training as well, which will be used to validate training data that is used. If we require the user to pass in this value twice and store it separately, this could lead to unnecessary work on the users part as well as the potential for misconfiguration. Because we will require the model to be created before a user can create their index, it makes sense to have the user only specify dimension when training/uploading a model. Then, this information can be retrieved from the model index or cache during index creation.

Space type is used in the plugin outside of the JNI to determine how to transform the score returned by the native library to a suitable OpenSearch score. So, similarly, we will have the user pass in this value during training/uploading and then write it as a field value when creating an index

### Issues Resolved
#27 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
