### PR TITLE
Fix snapshot build, build against OpenSearch 1.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,15 +32,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/OpenSearch'
-          ref: '1.0'
+          ref: '1.x'
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
 
       - name: Run build
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0
+          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -277,7 +277,7 @@ afterEvaluate {
 
         requires('opensearch', versions.opensearch, EQUAL)
         //TODO: Use default knn lib version for now, fix will be compare with version that is used in build step.
-        requires("opensearch-knnlib",  "local",  EQUAL)
+        requires("opensearch-knnlib",  "1.1.0.0",  EQUAL)
         packager = 'Amazon'
         vendor = 'Amazon'
         os = 'LINUX'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
 
@@ -91,7 +91,6 @@ if (!usingRemoteCluster) {
 }
 
 ext {
-    opensearchVersion = '1.0.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.TXT')
@@ -100,8 +99,10 @@ ext {
 
 allprojects {
     group = 'org.opensearch'
-    version = "${opensearchVersion}.0"
-
+    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
     apply from: 'build-tools/repositories.gradle'
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
@@ -275,7 +276,8 @@ afterEvaluate {
         dirMode 0755
 
         requires('opensearch', versions.opensearch, EQUAL)
-        requires("opensearch-knnlib",  "${opensearchVersion}.0",  EQUAL)
+        //TODO: Use default knn lib version for now, fix will be compare with version that is used in build step.
+        requires("opensearch-knnlib",  "local",  EQUAL)
         packager = 'Amazon'
         vendor = 'Amazon'
         os = 'LINUX'

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -41,7 +41,7 @@ set(KNN_INDEX KNNIndexV2_0_11)
 set(KNN_PACKAGE_NAME opensearch-knnlib)
 
 if(NOT KNN_PLUGIN_VERSION)
-    set(KNN_PLUGIN_VERSION local)
+    set(KNN_PLUGIN_VERSION "1.1.0.0")
 endif()
 
 # Check if similarity search exists


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
update ci to build against 1.x branch and use snapshot.
 
### Issues Resolved
#78 #73  
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
