### PR TITLE
Update CI to point to 1.0.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/OpenSearch'
-          ref: '1.0'
+          ref: '1.0.0'
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Fixes failure seen here: https://github.com/opensearch-project/k-NN/actions/runs/1186790338/workflow#L35.

OpenSearch 1.0 points to 1.0.1. However, this has not yet been released. Therefore, we update CI to point directly to 1.0.0.
 
### Check List
- [ X ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
