### PR TITLE
Refactor field mapper conditional logic to subclass

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -179,8 +179,10 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
                                            String indexPath) throws IOException {
         Map<String, Object> parameters = new HashMap<>();
         Map<String, String> fieldAttributes = fieldInfo.attributes();
+        String parametersString = fieldAttributes.get(KNNConstants.PARAMETERS);
 
-        if (KNNEngine.NMSLIB.equals(knnEngine)) {
+        // parametersString will be null when legacy mapper is used
+        if (parametersString == null) {
             parameters.put(KNNConstants.SPACE_TYPE, fieldAttributes.getOrDefault(KNNConstants.SPACE_TYPE,
                     SpaceType.DEFAULT.getValue()));
 
@@ -195,7 +197,6 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             }
 
         } else {
-            String parametersString = fieldAttributes.get(KNNConstants.PARAMETERS);
             parameters.putAll(
                     XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,
                             DeprecationHandler.THROW_UNSUPPORTED_OPERATION, parametersString).map()


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Currently, there are several ways a user can specify a knn_vector field: provide a model, provide a method definition, or provide parameters to nmslib's hnsw implementation in the index settings. These alternative methods have caused the code in the field mapper to become messy. 

This PR refactors that conditional logic using polymorphism. KNNVectorFieldMapper is converted to an abstract class. For the 3 methods mentioned above, each has a corresponding mapper that extends KNNVectorFieldMapper. The primary job of the subclasses is to define what information needs to be put into the field info.
 
### Issues Resolved
#69 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
