### PR TITLE
Refactor model management to support apis 

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -47,6 +47,11 @@ public class KNNConstants {
     public static final String PLUGIN_NAME = "knn";
     public static final String MODEL_METADATA_FIELD = "knn-models";
 
+    public static final String MODEL_STATE = "state";
+    public static final String MODEL_TIMESTAMP = "timestamp";
+    public static final String MODEL_DESCRIPTION = "description";
+    public static final String MODEL_ERROR = "error";
+
     // nmslib specific constants
     public static final String NMSLIB_NAME = "nmslib";
     public static final String SPACE_TYPE = "spaceType"; // used as field info key

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -115,7 +115,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
                 Model model = ModelCache.getInstance().get(modelId);
 
                 if (model.getModelBlob() == null) {
-                    throw new RuntimeException("Model blob cannot be null");
+                    throw new RuntimeException("There is no model with id \"" + modelId + "\"");
                 }
 
                 if (model.getModelMetadata().getKnnEngine() != knnEngine) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -114,6 +114,10 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
                 String modelId = field.attributes().get(MODEL_ID);
                 Model model = ModelCache.getInstance().get(modelId);
 
+                if (model.getModelBlob() == null) {
+                    throw new RuntimeException("Model cannot be null");
+                }
+
                 if (model.getModelMetadata().getKnnEngine() != knnEngine) {
                     throw new RuntimeException("Model Engine \"" + model.getModelMetadata().getKnnEngine().getName()
                             + "\" cannot be different than index engine \"" + knnEngine.getName() + "\"");

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -115,7 +115,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
                 Model model = ModelCache.getInstance().get(modelId);
 
                 if (model.getModelBlob() == null) {
-                    throw new RuntimeException("Model cannot be null");
+                    throw new RuntimeException("Model blob cannot be null");
                 }
 
                 if (model.getModelMetadata().getKnnEngine() != knnEngine) {

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -33,7 +33,8 @@ public class Model {
         this.modelMetadata = Objects.requireNonNull(modelMetadata, "modelMetadata must not be null");
 
         if (ModelState.CREATED.equals(this.modelMetadata.getState()) && modelBlob == null) {
-            throw new IllegalArgumentException("Model blob cannot be null when model metadata says model is created");
+            throw new IllegalArgumentException("Cannot construct model in state CREATED when model binary is null. " +
+                    "State must be either TRAINING or FAILED");
         }
 
         this.modelBlob = new AtomicReference<>(modelBlob);

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -87,7 +87,7 @@ public class Model {
         Model other = (Model) obj;
 
         EqualsBuilder equalsBuilder = new EqualsBuilder();
-        equalsBuilder.append(modelMetadata, other.modelMetadata);
+        equalsBuilder.append(getModelMetadata(), other.getModelMetadata());
         equalsBuilder.append(getModelBlob(), other.getModelBlob());
 
         return equalsBuilder.isEquals();
@@ -95,6 +95,6 @@ public class Model {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(modelMetadata).append(getModelBlob()).toHashCode();
+        return new HashCodeBuilder().append(getModelMetadata()).append(getModelBlob()).toHashCode();
     }
 }

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -63,10 +63,10 @@ public class Model {
      * @return length of model blob
      */
     public int getLength() {
-        if (modelBlob.get() == null) {
+        if (getModelBlob() == null) {
             return 0;
         }
-        return modelBlob.get().length;
+        return getModelBlob().length;
     }
 
     /**
@@ -88,13 +88,13 @@ public class Model {
 
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         equalsBuilder.append(modelMetadata, other.modelMetadata);
-        equalsBuilder.append(modelBlob.get(), other.modelBlob.get());
+        equalsBuilder.append(getModelBlob(), other.getModelBlob());
 
         return equalsBuilder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(modelMetadata).append(modelBlob.get()).toHashCode();
+        return new HashCodeBuilder().append(modelMetadata).append(getModelBlob()).toHashCode();
     }
 }

--- a/src/main/java/org/opensearch/knn/indices/ModelCache.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelCache.java
@@ -93,7 +93,7 @@ public final class ModelCache {
         try {
             return cache.get(modelId, () -> modelDao.get(modelId));
         } catch (ExecutionException ee) {
-            throw new IllegalStateException("Unable to retrieve model blob for \"" + modelId + "\": " + ee);
+            throw new IllegalStateException("Unable to retrieve model binary for \"" + modelId + "\": " + ee);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -12,7 +12,6 @@
 package org.opensearch.knn.indices;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +32,9 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
@@ -44,6 +45,7 @@ import org.opensearch.knn.plugin.transport.UpdateModelMetadataRequest;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -91,6 +93,15 @@ public interface ModelDao {
      * @param listener  handles acknowledged response
      */
     void put(Model model, ActionListener<AcknowledgedResponse> listener) throws IOException;
+
+    /**
+     * Update model of model id with new model.
+     *
+     * @param modelId model id to update
+     * @param model new model
+     * @param listener handles index response
+     */
+    void update(String modelId, Model model, ActionListener<AcknowledgedResponse> listener) throws IOException;
 
     /**
      * Get a model from the system index. Call blocks.
@@ -184,66 +195,95 @@ public interface ModelDao {
 
         @Override
         public void put(String modelId, Model model, ActionListener<AcknowledgedResponse> listener) throws IOException {
-            String base64Model = Base64.getEncoder().encodeToString(model.getModelBlob());
-
-            Map<String, Object> parameters = ImmutableMap.of(
-                    KNNConstants.KNN_ENGINE, model.getModelMetadata().getKnnEngine().getName(),
-                    KNNConstants.METHOD_PARAMETER_SPACE_TYPE, model.getModelMetadata().getSpaceType().getValue(),
-                    KNNConstants.DIMENSION, model.getModelMetadata().getDimension(),
-                    KNNConstants.MODEL_BLOB_PARAMETER, base64Model
-            );
-
-            IndexRequestBuilder indexRequestBuilder = client.prepareIndex(MODEL_INDEX_NAME, "_doc");
-            indexRequestBuilder.setId(modelId);
-            indexRequestBuilder.setSource(parameters);
-
-            // Fail if the id already exists. Models are not updateable
-            indexRequestBuilder.setOpType(DocWriteRequest.OpType.CREATE);
-            indexRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-            // After the model is indexed, update metadata
-            ActionListener<IndexResponse> putMetadataListener = getUpdateModelMetadataListener(model.getModelMetadata(),
-                    listener);
-
-            if (!isCreated()) {
-                create(ActionListener.wrap(createIndexResponse -> indexRequestBuilder.execute(putMetadataListener),
-                        listener::onFailure));
-                return;
-            }
-
-            indexRequestBuilder.execute(putMetadataListener);
+            putInternal(modelId, model, listener, DocWriteRequest.OpType.CREATE);
         }
 
         @Override
         public void put(Model model, ActionListener<AcknowledgedResponse> listener) throws IOException {
-            String base64Model = Base64.getEncoder().encodeToString(model.getModelBlob());
+            putInternal(null, model, listener, DocWriteRequest.OpType.CREATE);
+        }
 
-            Map<String, Object> parameters = ImmutableMap.of(
-                    KNNConstants.KNN_ENGINE, model.getModelMetadata().getKnnEngine().getName(),
-                    KNNConstants.METHOD_PARAMETER_SPACE_TYPE, model.getModelMetadata().getSpaceType().getValue(),
-                    KNNConstants.DIMENSION, model.getModelMetadata().getDimension(),
-                    KNNConstants.MODEL_BLOB_PARAMETER, base64Model
-            );
+        @Override
+        public void update(String modelId, Model model, ActionListener<AcknowledgedResponse> listener)
+                throws IOException {
+            putInternal(modelId, model, listener, DocWriteRequest.OpType.INDEX);
+        }
+
+        private void putInternal(@Nullable String modelId, Model model, ActionListener<AcknowledgedResponse> listener,
+                                 DocWriteRequest.OpType requestOpType) throws IOException {
+
+            if (model == null) {
+                throw new IllegalArgumentException("Model cannot be null");
+            }
+
+            ModelMetadata modelMetadata = model.getModelMetadata();
+
+            Map<String, Object> parameters = new HashMap<String, Object>() {{
+                put(KNNConstants.KNN_ENGINE, modelMetadata.getKnnEngine().getName());
+                put(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, modelMetadata.getSpaceType().getValue());
+                put(KNNConstants.DIMENSION, modelMetadata.getDimension());
+                put(KNNConstants.MODEL_STATE, modelMetadata.getState().getName());
+                put(KNNConstants.MODEL_TIMESTAMP, modelMetadata.getTimestamp().toString());
+                put(KNNConstants.MODEL_DESCRIPTION, modelMetadata.getDescription());
+                put(KNNConstants.MODEL_ERROR, modelMetadata.getError());
+            }};
+
+            byte[] modelBlob = model.getModelBlob();
+
+            if (modelBlob == null && ModelState.CREATED.equals(modelMetadata.getState())) {
+                throw new IllegalArgumentException("Model blob cannot be null when model state is CREATED");
+            }
+
+            // Only add model if it is not null
+            if (modelBlob != null) {
+                String base64Model = Base64.getEncoder().encodeToString(modelBlob);
+                parameters.put(KNNConstants.MODEL_BLOB_PARAMETER, base64Model);
+            }
 
             IndexRequestBuilder indexRequestBuilder = client.prepareIndex(MODEL_INDEX_NAME, "_doc");
+
+            // Set id for request only if modelId is present
+            if (modelId != null) {
+                indexRequestBuilder.setId(modelId);
+            }
+
             indexRequestBuilder.setSource(parameters);
 
-            // Fail if the id already exists. Models are not updateable
-            indexRequestBuilder.setOpType(DocWriteRequest.OpType.CREATE);
+            indexRequestBuilder.setOpType(requestOpType); // Delegate whether this request can update based on opType
             indexRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-            // After the model is indexed, update metadata
-            ActionListener<IndexResponse> putMetadataListener = getUpdateModelMetadataListener(model.getModelMetadata(),
-                    listener);
+            // After metadata update finishes, remove item from cache if necessary. If no model id is
+            // passed then nothing needs to be removed from the cache
+            //TODO: Bug. Model needs to be removed from all nodes caches, not just local.
+            ActionListener<AcknowledgedResponse> onMetaListener;
+            if (modelId != null) {
+                onMetaListener = ActionListener.wrap(response -> {
+                    ModelCache.getInstance().remove(modelId);
+                    listener.onResponse(response);
+                }, listener::onFailure);
+            } else {
+                onMetaListener = listener;
+            }
 
-            // If the index has not been created yet, create it and then add the document
+            // After the model is indexed, update metadata only if the model is in CREATED state
+            ActionListener<IndexResponse> onIndexListener;
+            if (ModelState.CREATED.equals(model.getModelMetadata().getState())) {
+                onIndexListener = getUpdateModelMetadataListener(model.getModelMetadata(), onMetaListener);
+            } else {
+                onIndexListener = ActionListener.wrap(
+                        indexResponse -> onMetaListener.onResponse(new AcknowledgedResponse(true)),
+                        onMetaListener::onFailure
+                );
+            }
+
+            // Create the model index if it does not already exist
             if (!isCreated()) {
-                create(ActionListener.wrap(createIndexResponse -> indexRequestBuilder.execute(putMetadataListener),
-                        listener::onFailure));
+                create(ActionListener.wrap(createIndexResponse -> indexRequestBuilder.execute(onIndexListener),
+                        onIndexListener::onFailure));
                 return;
             }
 
-            indexRequestBuilder.execute(putMetadataListener);
+            indexRequestBuilder.execute(onIndexListener);
         }
 
         private ActionListener<IndexResponse> getUpdateModelMetadataListener(ModelMetadata modelMetadata,
@@ -269,15 +309,23 @@ public interface ModelDao {
             Object engine = responseMap.get(KNNConstants.KNN_ENGINE);
             Object space = responseMap.get(KNNConstants.METHOD_PARAMETER_SPACE_TYPE);
             Object dimension = responseMap.get(KNNConstants.DIMENSION);
+            Object state = responseMap.get(KNNConstants.MODEL_STATE);
+            Object timestamp  = responseMap.get(KNNConstants.MODEL_TIMESTAMP);
+            Object description = responseMap.get(KNNConstants.MODEL_DESCRIPTION);
+            Object error = responseMap.get(KNNConstants.MODEL_ERROR);
             Object blob = responseMap.get(KNNConstants.MODEL_BLOB_PARAMETER);
 
-            if (blob == null) {
-                throw new IllegalArgumentException("No model available in \"" + MODEL_INDEX_NAME + "\" index with id \""
-                        + modelId + "\".");
+            // If byte blob is not there, it means that the state has not yet been updated to CREATED.
+            byte[] byteBlob = null;
+            if (blob != null) {
+                byteBlob = Base64.getDecoder().decode((String) blob);
             }
+
             ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.getEngine((String) engine),
-                    SpaceType.getSpace((String) space), (Integer) dimension);
-            return new Model(modelMetadata, Base64.getDecoder().decode((String) blob));
+                    SpaceType.getSpace((String) space), (Integer) dimension, ModelState.getModelState((String) state),
+                    TimeValue.parseTimeValue((String) timestamp, KNNConstants.MODEL_TIMESTAMP), (String) description,
+                    (String) error);
+            return new Model(modelMetadata, byteBlob);
         }
 
         @Override
@@ -326,6 +374,7 @@ public interface ModelDao {
             deleteRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             // On model deletion from the index, remove the model from the model cache
+            //TODO: Bug. Model needs to be removed from all nodes caches, not just local.
             ActionListener<DeleteResponse> onModelDeleteListener = ActionListener.wrap(deleteResponse -> {
                 ModelCache.getInstance().remove(modelId);
                 listener.onResponse(deleteResponse);

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -255,6 +255,7 @@ public interface ModelDao {
             // After metadata update finishes, remove item from cache if necessary. If no model id is
             // passed then nothing needs to be removed from the cache
             //TODO: Bug. Model needs to be removed from all nodes caches, not just local.
+            // https://github.com/opensearch-project/k-NN/issues/93
             ActionListener<IndexResponse> onMetaListener;
             if (modelId != null) {
                 onMetaListener = ActionListener.wrap(response -> {
@@ -375,6 +376,7 @@ public interface ModelDao {
 
             // On model deletion from the index, remove the model from the model cache
             //TODO: Bug. Model needs to be removed from all nodes caches, not just local.
+            // https://github.com/opensearch-project/k-NN/issues/93
             ActionListener<DeleteResponse> onModelDeleteListener = ActionListener.wrap(deleteResponse -> {
                 ModelCache.getInstance().remove(modelId);
                 listener.onResponse(deleteResponse);

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -231,7 +231,7 @@ public interface ModelDao {
             byte[] modelBlob = model.getModelBlob();
 
             if (modelBlob == null && ModelState.CREATED.equals(modelMetadata.getState())) {
-                throw new IllegalArgumentException("Model blob cannot be null when model state is CREATED");
+                throw new IllegalArgumentException("Model binary cannot be null when model state is CREATED");
             }
 
             // Only add model if it is not null

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -168,13 +168,8 @@ public class ModelMetadata implements Writeable {
 
     @Override
     public String toString() {
-        return knnEngine.getName() + DELIMITER +
-                spaceType.getValue() + DELIMITER +
-                dimension + DELIMITER +
-                state.get() + DELIMITER +
-                timestamp + DELIMITER +
-                description + DELIMITER +
-                error;
+        return String.join(DELIMITER, knnEngine.getName(), spaceType.getValue(), Integer.toString(dimension),
+                getState().toString(), timestamp.toString(), description, error);
     }
 
     @Override
@@ -189,7 +184,7 @@ public class ModelMetadata implements Writeable {
         equalsBuilder.append(knnEngine, other.knnEngine);
         equalsBuilder.append(spaceType, other.spaceType);
         equalsBuilder.append(dimension, other.dimension);
-        equalsBuilder.append(state.get(), other.state.get());
+        equalsBuilder.append(getState(), other.getState());
         equalsBuilder.append(timestamp, other.timestamp);
         equalsBuilder.append(description, other.description);
         equalsBuilder.append(error, other.error);
@@ -199,7 +194,7 @@ public class ModelMetadata implements Writeable {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(dimension).append(state.get())
+        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(dimension).append(getState())
                 .append(timestamp).append(description).append(error).toHashCode();
     }
 
@@ -233,7 +228,7 @@ public class ModelMetadata implements Writeable {
         out.writeString(knnEngine.getName());
         out.writeString(spaceType.getValue());
         out.writeInt(dimension);
-        state.get().writeTo(out);
+        getState().writeTo(out);
         out.writeTimeValue(timestamp);
         out.writeString(description);
         out.writeString(error);

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -181,21 +181,21 @@ public class ModelMetadata implements Writeable {
         ModelMetadata other = (ModelMetadata) obj;
 
         EqualsBuilder equalsBuilder = new EqualsBuilder();
-        equalsBuilder.append(knnEngine, other.knnEngine);
-        equalsBuilder.append(spaceType, other.spaceType);
-        equalsBuilder.append(dimension, other.dimension);
+        equalsBuilder.append(getKnnEngine(), other.getKnnEngine());
+        equalsBuilder.append(getSpaceType(), other.getSpaceType());
+        equalsBuilder.append(getDimension(), other.getDimension());
         equalsBuilder.append(getState(), other.getState());
-        equalsBuilder.append(timestamp, other.timestamp);
-        equalsBuilder.append(description, other.description);
-        equalsBuilder.append(error, other.error);
+        equalsBuilder.append(getTimestamp(), other.getTimestamp());
+        equalsBuilder.append(getDescription(), other.getDescription());
+        equalsBuilder.append(getError(), other.getError());
 
         return equalsBuilder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(dimension).append(getState())
-                .append(timestamp).append(description).append(error).toHashCode();
+        return new HashCodeBuilder().append(getKnnEngine()).append(getSpaceType()).append(getDimension())
+                .append(getState()).append(getTimestamp()).append(getDescription()).append(getError()).toHashCode();
     }
 
     /**
@@ -225,12 +225,12 @@ public class ModelMetadata implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(knnEngine.getName());
-        out.writeString(spaceType.getValue());
-        out.writeInt(dimension);
+        out.writeString(getKnnEngine().getName());
+        out.writeString(getSpaceType().getValue());
+        out.writeInt(getDimension());
         getState().writeTo(out);
-        out.writeTimeValue(timestamp);
-        out.writeString(description);
-        out.writeString(error);
+        out.writeTimeValue(getTimestamp());
+        out.writeString(getDescription());
+        out.writeString(getError());
     }
 }

--- a/src/main/java/org/opensearch/knn/indices/ModelState.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelState.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.indices;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+/**
+ * Defines life cycle state of the model
+ */
+public enum ModelState implements Writeable {
+    TRAINING("training"),
+    CREATED("created"),
+    FAILED("failed");
+
+    private final String name;
+
+    ModelState(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get the name of the state the model is in.
+     *
+     * @return ModelState's name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        streamOutput.writeString(this.getName());
+    }
+
+    /**
+     * Return ModelState from StreamInput
+     *
+     * @param in StreamInput to read from
+     * @return ModelState read from stream input
+     */
+    public static ModelState readFrom(StreamInput in) throws IOException {
+        return getModelState(in.readString());
+    }
+
+    /**
+     * Retrieve model state from the name
+     *
+     * @param name of the state
+     * @return ModelState
+     */
+    public static ModelState getModelState(String name) {
+        if (TRAINING.getName().equals(name)) {
+            return TRAINING;
+        }
+
+        if (CREATED.getName().equals(name)) {
+            return CREATED;
+        }
+
+        if (FAILED.getName().equals(name)) {
+            return FAILED;
+        }
+
+        throw new IllegalArgumentException("Unable to find model state: \"" + name + "\"");
+    }
+}

--- a/src/main/resources/mappings/model-index.json
+++ b/src/main/resources/mappings/model-index.json
@@ -9,6 +9,18 @@
     "dimension": {
       "type": "integer"
     },
+    "state": {
+      "type": "keyword"
+    },
+    "timestamp": {
+      "type": "date"
+    },
+    "description": {
+      "type": "keyword"
+    },
+    "error": {
+      "type": "keyword"
+    },
     "model_blob": {
       "type": "binary"
     }

--- a/src/test/java/org/opensearch/knn/index/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorFieldMapperTests.java
@@ -26,6 +26,7 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.ValidationException;
@@ -40,6 +41,7 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -112,7 +114,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 .build();
 
         String modelId = "Random modelId";
-        ModelMetadata mockedModelMetadata = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129);
+        ModelMetadata mockedModelMetadata = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129,
+                ModelState.CREATED, TimeValue.timeValueHours(10), "", "");
         builder.modelId.setValue(modelId);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
 
@@ -353,7 +356,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         int dimension = 133;
 
         ModelDao mockModelDao = mock(ModelDao.class);
-        ModelMetadata mockModelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension);
+        ModelMetadata mockModelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension,
+                ModelState.CREATED, TimeValue.timeValueDays(10), "", "");
         when(mockModelDao.getMetadata(modelId)).thenReturn(mockModelMetadata);
 
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> mockModelDao);

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.JNIService;
@@ -61,6 +62,7 @@ import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelCache;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
 import org.opensearch.watcher.ResourceWatcherService;
 import org.mockito.Mockito;
 
@@ -220,7 +222,12 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         // Setup model cache
         ModelDao modelDao = mock(ModelDao.class);
-        Model mockModel = new Model(new ModelMetadata(knnEngine, spaceType, dimension), modelBlob);
+
+        // Set model state to created
+        ModelMetadata modelMetadata1 = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(3), "", "");
+
+        Model mockModel = new Model(modelMetadata1, modelBlob);
         when(modelDao.get(modelId)).thenReturn(mockModel);
 
         Settings settings = settings(CURRENT).put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), 10).build();

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -16,6 +16,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -31,7 +32,8 @@ public class ModelCacheTests extends KNNTestCase {
     public void testGet_normal() throws ExecutionException, InterruptedException {
         String modelId = "test-model-id";
         int dimension = 2;
-        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), "hello".getBytes());
+        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), "hello".getBytes());
         long cacheSize = 100L;
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -55,7 +57,8 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
         long cacheSize = 500;
 
-        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension),
+        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""),
                 new byte[Long.valueOf(cacheSize).intValue() + 1]);
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -102,9 +105,11 @@ public class ModelCacheTests extends KNNTestCase {
         long cacheSize = 500L;
 
         int size1 = 100;
-        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[size1]);
+        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[size1]);
         int size2 = 300;
-        Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[size2]);
+        Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -136,9 +141,11 @@ public class ModelCacheTests extends KNNTestCase {
         long cacheSize = 500L;
 
         int size1 = 100;
-        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[size1]);
+        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[size1]);
         int size2 = 300;
-        Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[size2]);
+        Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -174,7 +181,8 @@ public class ModelCacheTests extends KNNTestCase {
         String modelId = "test-model-id";
         int dimension = 2;
         long cacheSize = 100L;
-        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), "hello".getBytes());
+        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), "hello".getBytes());
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -207,7 +215,8 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
 
         int modelSize = 101;
-        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[modelSize]);
+        Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[modelSize]);
 
         long cacheSize1 = 100L;
         long cacheSize2 = 200L;
@@ -264,7 +273,8 @@ public class ModelCacheTests extends KNNTestCase {
         String modelId1 = "test-model-id-1";
         int dimension = 2;
         int modelSize1 = 100;
-        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[modelSize1]);
+        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
 
@@ -293,11 +303,13 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
         String modelId1 = "test-model-id-1";
         int modelSize1 = 100;
-        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[modelSize1]);
+        Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
         int modelSize2 = 100;
-        Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension), new byte[modelSize2]);
+        Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[modelSize2]);
 
         long cacheSize = 500L;
 

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -21,7 +21,6 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
-import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -107,8 +106,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListener = ActionListener.wrap(response -> {
-            assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
+            assertEquals(modelId, response.getId());
 
             // We need to use executor service here so master thread does not block
             modelGetterExecutor.submit(() -> {
@@ -128,7 +127,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // User provided model id that already exists
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListenerDuplicateId = ActionListener.wrap(
+        ActionListener<IndexResponse> docCreationListenerDuplicateId = ActionListener.wrap(
                 response -> fail("Model already exists, but creation was successful"),
                 exception -> {
                     if (!(ExceptionsHelper.unwrapCause(exception) instanceof VersionConflictEngineException)) {
@@ -154,8 +153,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListener = ActionListener.wrap(response -> {
-            assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
+            assertEquals(modelId, response.getId());
 
             // We need to use executor service here so master thread does not block
             modelGetterExecutor.submit(() -> {
@@ -176,7 +175,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // User provided model id that already exists
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListenerDuplicateId = ActionListener.wrap(
+        ActionListener<IndexResponse> docCreationListenerDuplicateId = ActionListener.wrap(
                 response -> fail("Model already exists, but creation was successful"),
                 exception -> {
                     if (!(ExceptionsHelper.unwrapCause(exception) instanceof VersionConflictEngineException)) {
@@ -198,8 +197,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // User does not provide model id
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListenerNoModelId = ActionListener.wrap(response -> {
-                    assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> docCreationListenerNoModelId = ActionListener.wrap(response -> {
                     inProgressLatch.countDown();
                 },
                 exception -> fail("Unable to put the model: " + exception));
@@ -240,8 +238,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListener = ActionListener.wrap(response -> {
-            assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
+            assertEquals(modelId, response.getId());
 
             // We need to use executor service here so master thread does not block
             modelGetterExecutor.submit(() -> {
@@ -265,8 +263,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 TimeValue.timeValueDays(10), "", ""), modelBlob);
 
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> updateListener = ActionListener.wrap(response -> {
-            assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> updateListener = ActionListener.wrap(response -> {
+            assertEquals(modelId, response.getId());
 
             // We need to use executor service here so master thread does not block
             modelGetterExecutor.submit(() -> {
@@ -337,8 +335,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        ActionListener<AcknowledgedResponse> docCreationListener = ActionListener.wrap(response -> {
-            assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
+            assertEquals(modelId, response.getId());
 
             ModelMetadata modelMetadata1 = modelDao.getMetadata(modelId);
             assertEquals(modelMetadata, modelMetadata1);
@@ -383,8 +381,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
                 TimeValue.timeValueDays(10), "", ""), modelBlob);
 
-        ActionListener<AcknowledgedResponse> docCreationListener = ActionListener.wrap(response -> {
-            assertTrue(response.isAcknowledged());
+        ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
+            assertEquals(modelId, response.getId());
             modelDao.delete(modelId, deleteModelExistsListener);
         }, exception -> fail("Unable to put the model: " + exception));
 

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -261,7 +261,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
 
         // User provided model id that already exists - should be able to update
-        Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+        Model updatedModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
                 TimeValue.timeValueDays(10), "", ""), modelBlob);
 
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
@@ -271,7 +271,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
             // We need to use executor service here so master thread does not block
             modelGetterExecutor.submit(() -> {
                 try {
-                    assertEquals(model2, modelDao.get(modelId));
+                    assertEquals(updatedModel, modelDao.get(modelId));
                 } catch (ExecutionException | InterruptedException e) {
                     fail(e.getMessage());
                 }
@@ -281,7 +281,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
             inProgressLatch2.countDown();
         }, exception -> fail("Unable to put the model: " + exception));
 
-        modelDao.update(modelId, model2, updateListener);
+        modelDao.update(modelId, updatedModel, updateListener);
         assertTrue(inProgressLatch2.await(100, TimeUnit.SECONDS));
     }
 

--- a/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.indices;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -25,7 +26,8 @@ public class ModelMetadataTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         int dimension = 128;
 
-        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension);
+        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         modelMetadata.writeTo(streamOutput);
@@ -37,66 +39,195 @@ public class ModelMetadataTests extends KNNTestCase {
 
     public void testGetKnnEngine() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
-        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.L2, 128);
+        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
 
         assertEquals(knnEngine, modelMetadata.getKnnEngine());
     }
 
     public void testGetSpaceType() {
         SpaceType spaceType = SpaceType.L2;
-        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, spaceType, 128);
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, spaceType, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
 
         assertEquals(spaceType, modelMetadata.getSpaceType());
     }
 
     public void testGetDimension() {
         int dimension = 128;
-        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, dimension);
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
 
         assertEquals(dimension, modelMetadata.getDimension());
+    }
+
+    public void testGetState() {
+        ModelState modelState = ModelState.FAILED;
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, modelState,
+                TimeValue.timeValueDays(10), "", "");
+
+        assertEquals(modelState, modelMetadata.getState());
+    }
+
+    public void testGetTimestamp() {
+        TimeValue timeValue = TimeValue.timeValueDays(10);
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED,
+                timeValue, "", "");
+
+        assertEquals(timeValue, modelMetadata.getTimestamp());
+    }
+
+    public void testDescription() {
+        String description = "test description";
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED,
+                TimeValue.timeValueDays(10), description, "");
+
+        assertEquals(description, modelMetadata.getDescription());
+    }
+
+    public void testGetError() {
+        String error = "test error";
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", error);
+
+        assertEquals(error, modelMetadata.getError());
+    }
+
+    public void testSetState() {
+        ModelState modelState = ModelState.FAILED;
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, modelState,
+                TimeValue.timeValueDays(10), "", "");
+
+        assertEquals(modelState, modelMetadata.getState());
+
+        ModelState updatedState = ModelState.CREATED;
+        modelMetadata.setState(updatedState);
+        assertEquals(updatedState, modelMetadata.getState());
+    }
+
+    public void testSetError() {
+        String error = "";
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.TRAINING,
+                TimeValue.timeValueDays(10), "", error);
+
+        assertEquals(error, modelMetadata.getError());
+
+        String updatedError = "test error";
+        modelMetadata.setError(updatedError);
+        assertEquals(updatedError, modelMetadata.getError());
     }
 
     public void testToString() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         SpaceType spaceType = SpaceType.L2;
         int dimension = 128;
+        ModelState modelState = ModelState.TRAINING;
+        TimeValue timestamp = TimeValue.timeValueDays(10);
+        String description = "test-description";
+        String error = "test-error";
 
-        String expected = knnEngine.getName() + "," + spaceType.getValue() + "," + dimension;
+        String expected = knnEngine.getName() + "," +
+                spaceType.getValue() + "," +
+                dimension + "," +
+                modelState.getName() + "," +
+                timestamp + "," +
+                description + "," +
+                error;
 
-        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension);
+        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, modelState,
+                timestamp, description, error);
 
         assertEquals(expected, modelMetadata.toString());
     }
 
     public void testEquals() {
-        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
-        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
-        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 129);
+        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+
+        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(11), "", "");
+        ModelMetadata modelMetadata8 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "diff descript", "");
+        ModelMetadata modelMetadata9 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "diff error");
 
         assertEquals(modelMetadata1, modelMetadata1);
         assertEquals(modelMetadata1, modelMetadata2);
         assertNotEquals(modelMetadata1, null);
+
         assertNotEquals(modelMetadata1, modelMetadata3);
+        assertNotEquals(modelMetadata1, modelMetadata4);
+        assertNotEquals(modelMetadata1, modelMetadata5);
+        assertNotEquals(modelMetadata1, modelMetadata6);
+        assertNotEquals(modelMetadata1, modelMetadata7);
+        assertNotEquals(modelMetadata1, modelMetadata8);
+        assertNotEquals(modelMetadata1, modelMetadata9);
     }
 
     public void testHashCode() {
-        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
-        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
-        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 129);
+        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+
+        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING,
+                TimeValue.timeValueDays(10), "", "");
+        ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(11), "", "");
+        ModelMetadata modelMetadata8 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "diff descript", "");
+        ModelMetadata modelMetadata9 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "diff error");
 
         assertEquals(modelMetadata1.hashCode(), modelMetadata1.hashCode());
         assertEquals(modelMetadata1.hashCode(), modelMetadata2.hashCode());
         assertNotEquals(modelMetadata1.hashCode(), modelMetadata3.hashCode());
+
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata3.hashCode());
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata4.hashCode());
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata5.hashCode());
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata6.hashCode());
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata7.hashCode());
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata8.hashCode());
+        assertNotEquals(modelMetadata1.hashCode(), modelMetadata9.hashCode());
     }
 
     public void testFromString() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         SpaceType spaceType = SpaceType.L2;
         int dimension = 128;
+        ModelState modelState = ModelState.TRAINING;
+        TimeValue timestamp = TimeValue.timeValueDays(10);
+        String description = "test-description";
+        String error = "test-error";
 
-        String stringRep1 = knnEngine.getName() + "," + spaceType.getValue() + "," + dimension;
+        String stringRep1 = knnEngine.getName() + "," +
+                spaceType.getValue() + "," +
+                dimension + "," +
+                modelState.getName() + "," +
+                timestamp + "," +
+                description + "," +
+                error;
 
-        ModelMetadata expected = new ModelMetadata(knnEngine, spaceType, dimension);
+
+        ModelMetadata expected = new ModelMetadata(knnEngine, spaceType, dimension, modelState,
+                timestamp, description, error);
         ModelMetadata fromString1 = ModelMetadata.fromString(stringRep1);
 
         assertEquals(expected, fromString1);

--- a/src/test/java/org/opensearch/knn/indices/ModelStateTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelStateTests.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.indices;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+
+public class ModelStateTests extends KNNTestCase {
+
+    public void testStreams() throws IOException {
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        ModelState original = ModelState.CREATED;
+
+        original.writeTo(streamOutput);
+
+        ModelState modelStateCopy = ModelState.readFrom(streamOutput.bytes().streamInput());
+
+        assertEquals(original, modelStateCopy);
+    }
+
+    public void testGetModelState() {
+        assertEquals(ModelState.CREATED, ModelState.getModelState(ModelState.CREATED.getName()));
+    }
+}

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.indices;
 
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -23,40 +24,72 @@ public class ModelTests extends KNNTestCase {
         expectThrows(NullPointerException.class, () -> new Model(null, null));
     }
 
+    public void testInvalidConstructor() {
+        expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
+                SpaceType.DEFAULT, -1, ModelState.FAILED, TimeValue.timeValueDays(10), "", ""),
+                null));
+    }
+
     public void testInvalidDimension() {
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, -1), new byte[16]));
+                SpaceType.DEFAULT, -1, ModelState.CREATED, TimeValue.timeValueDays(10), "", ""),
+                new byte[16]));
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, 0), new byte[16]));
+                SpaceType.DEFAULT, 0, ModelState.CREATED, TimeValue.timeValueDays(10), "", ""),
+                new byte[16]));
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, MAX_DIMENSION + 1), new byte[16]));
+                SpaceType.DEFAULT, MAX_DIMENSION + 1, ModelState.CREATED, TimeValue.timeValueDays(10), "", ""),
+                new byte[16]));
     }
 
     public void testGetModelMetadata() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
-        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.DEFAULT, 2);
+        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.DEFAULT, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
         Model model = new Model(modelMetadata, new byte[16]);
         assertEquals(modelMetadata, model.getModelMetadata());
     }
 
     public void testGetModelBlob() {
         byte[] modelBlob = "hello".getBytes();
-        Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2), modelBlob);
+        Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), modelBlob);
         assertArrayEquals(modelBlob, model.getModelBlob());
     }
 
     public void testGetLength() {
         int size = 129;
-        Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2), new byte[size]);
+        Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[size]);
         assertEquals(size, model.getLength());
+
+        model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.TRAINING,
+                TimeValue.timeValueDays(10), "", ""), null);
+        assertEquals(0, model.getLength());
+    }
+
+    public void testSetModelBlob() {
+        byte[] blob1 = "Hello blob 1".getBytes();
+        Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), blob1);
+        assertEquals(blob1, model.getModelBlob());
+        byte[] blob2 = "Hello blob 2".getBytes();
+
+        model.setModelBlob(blob2);
+        assertEquals(blob2, model.getModelBlob());
     }
 
     public void testEquals() {
-        Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2), new byte[16]);
-        Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2), new byte[16]);
-        Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2), new byte[16]);
-        Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2), new byte[32]);
-        Model model5 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 4), new byte[16]);
+        Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+        Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+        Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+        Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[32]);
+        Model model5 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 4, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
 
         assertEquals(model1, model1);
         assertEquals(model1, model2);
@@ -66,10 +99,14 @@ public class ModelTests extends KNNTestCase {
     }
 
     public void testHashCode() {
-        Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2), new byte[16]);
-        Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2), new byte[16]);
-        Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2), new byte[32]);
-        Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 4), new byte[16]);
+        Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+        Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+        Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[32]);
+        Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 4, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", ""), new byte[16]);
 
         assertEquals(model1.hashCode(), model1.hashCode());
         assertEquals(model1.hashCode(), model2.hashCode());

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
@@ -12,10 +12,12 @@
 package org.opensearch.knn.plugin.transport;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
 
 import java.io.IOException;
 
@@ -29,7 +31,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
         String modelId = "test-model";
         boolean isRemoveRequest = false;
 
-        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension);
+        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest(modelId, isRemoveRequest, modelMetadata);
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
@@ -43,7 +46,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
     }
 
     public void testValidate() {
-        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
 
         UpdateModelMetadataRequest updateModelMetadataRequest1 = new UpdateModelMetadataRequest("test", true, null);
         assertNull(updateModelMetadataRequest1.validate());
@@ -73,7 +77,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
     }
 
     public void testGetModelMetadata() {
-        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest("test", true, modelMetadata);
 
         assertEquals(modelMetadata, updateModelMetadataRequest.getModelMetadata());

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -16,10 +16,12 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -56,7 +58,8 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
 
         // Setup the model
         String modelId = "test-model";
-        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128);
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128, ModelState.CREATED,
+                TimeValue.timeValueDays(10), "", "");
 
         // Get update  transport action
         UpdateModelMetadataTransportAction updateModelMetadataTransportAction = node().injector()
@@ -92,10 +95,10 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
 
                             inProgressLatch1.countDown();
 
-                        }, e -> fail("Update failed")));
-                    }, e -> fail("Update failed"))
+                        }, e -> fail("Update failed:" + e)));
+                    }, e -> fail("Update failed: " + e))
             );
-        }, e -> fail("Update failed")));
+        }, e -> fail("Update failed: "  + e)));
 
         assertTrue(inProgressLatch1.await(60, TimeUnit.SECONDS));
 


### PR DESCRIPTION

Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR adds additional metadata to the Model System index, so that we can implement the APIs specified in #70. The metadata that is added is:
1. State - the lifecycle state the model is in - training, created, failed
2. Timestamp - when the model was created
3. Description - field allowing users to add detail to their models
4. Error - When model is in failed state, error will indicate why it failed

Additonally, this PR adds update functionality in ModelDao so that models can initially start in TRAINING state and later be updated.

Along with this, some minor code quality changes were made as well.
 
This PR also adds a TODO to fix the bug in clearing the cache in the ModelDao. This will be tracked in #93.

This PR does not add search functionality to the ModelDao. This will need to be done in a future PR.

### Issues Resolved
#92 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
