### PR TITLE
Removing default integtest.sh (1.x).

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,11 +36,11 @@ jobs:
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
 
       - name: Run build
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0-rc1
+          ./gradlew build -Dopensearch.version=1.0.0
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,2 @@
 OpenSearch k-NN
-Copyright 2021 OpenSearch k-NN Contributors
-
-OpenDistroForElasticsearch
-Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2021 OpenSearch Contributors

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build and Test k-NN](https://github.com/opensearch-project/k-NN/actions/workflows/CI.yml/badge.svg)](https://github.com/opensearch-project/k-NN/actions/workflows/CI.yml)
 [![codecov](https://codecov.io/gh/opensearch-project/k-NN/branch/main/graph/badge.svg?token=PYQO2GW39S)](https://codecov.io/gh/opensearch-project/k-NN)
-[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://docs-beta.opensearch.org/search-plugins/knn/index/)
+[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/search-plugins/knn/index/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/k-NN/)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
@@ -20,7 +20,7 @@
 
 * [Project Website](https://opensearch.org/)
 * [Downloads](https://opensearch.org/downloads.html).
-* [Documentation](https://docs-beta.opensearch.org/search-plugins/knn/index/)
+* [Documentation](https://opensearch.org/docs/search-plugins/knn/index/)
 * Need help? Try [Forums](https://discuss.opendistrocommunity.dev/c/k-nn/)
 * [Project Principles](https://opensearch.org/#principles)
 * [Contributing to OpenSearch k-NN](CONTRIBUTING.md)
@@ -43,4 +43,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0-rc1")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
         opensearch_group = "org.opensearch"
     }
 
@@ -100,7 +100,7 @@ ext {
 
 allprojects {
     group = 'org.opensearch'
-    version = "${opensearchVersion}.0-rc1"
+    version = "${opensearchVersion}.0"
 
     apply from: 'build-tools/repositories.gradle'
     plugins.withId('java') {

--- a/release-notes/opensearch-knn.release-notes-1.0.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-1.0.0.0.md
@@ -1,0 +1,17 @@
+## Version 1.0.0.0 Release Notes
+
+Compatible with OpenSearch 1.0.0
+### Bug Fixes
+
+* Add equals and hashcode to KNNMethodContext MethodComponentContext ([#48](https://github.com/opensearch-project/k-NN/pull/48))
+
+### Infrastructure
+
+* Enabled automated license header checks ([#41](https://github.com/opensearch-project/k-NN/pull/41))
+* Comment out flaky test ([#54](https://github.com/opensearch-project/k-NN/pull/54))
+
+### Documentation
+
+* Update template files ([#50](https://github.com/opensearch-project/k-NN/pull/50))
+* Include codecov badge ([#52](https://github.com/opensearch-project/k-NN/pull/52))
+

--- a/release-notes/opensearch-knn.release-notes-1.0.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-1.0.0.0.md
@@ -1,17 +1,40 @@
 ## Version 1.0.0.0 Release Notes
 
 Compatible with OpenSearch 1.0.0
+
+### Features
+
+* Add support for L-inf distance in AKNN, custom scoring and painless scripting ([#315](https://github.com/opendistro-for-elasticsearch/k-NN/pull/315))
+* Add support for inner product in ANN, custom scoring and painless ([#324](https://github.com/opendistro-for-elasticsearch/k-NN/pull/324))
+* Refactor interface to support method configuration in field mapping ([#20](https://github.com/opensearch-project/k-NN/pull/20))
+
+### Enhancements
+
+* Change mode for jni arrays release to prevent unnecessary copy backs ([#317](https://github.com/opendistro-for-elasticsearch/k-NN/pull/317))
+* Update minimum score to 0. ([#318](https://github.com/opendistro-for-elasticsearch/k-NN/pull/318))
+* Expose getValue method from KNNScriptDocValues ([#339](https://github.com/opendistro-for-elasticsearch/k-NN/pull/339))
+* Add extra place to increase knn graph query errors ([#26](https://github.com/opensearch-project/k-NN/pull/26))
+
 ### Bug Fixes
 
 * Add equals and hashcode to KNNMethodContext MethodComponentContext ([#48](https://github.com/opensearch-project/k-NN/pull/48))
+* Add dimension validation to ANN QueryBuilder ([#332](https://github.com/opendistro-for-elasticsearch/k-NN/pull/332))
+* Change score normalization for negative raw scores ([#337](https://github.com/opendistro-for-elasticsearch/k-NN/pull/337))
 
 ### Infrastructure
 
 * Enabled automated license header checks ([#41](https://github.com/opensearch-project/k-NN/pull/41))
 * Comment out flaky test ([#54](https://github.com/opensearch-project/k-NN/pull/54))
+* Update OpenSearch upstream to 1.0.0 ([#58](https://github.com/opensearch-project/k-NN/pull/58))
 
 ### Documentation
 
 * Update template files ([#50](https://github.com/opensearch-project/k-NN/pull/50))
 * Include codecov badge ([#52](https://github.com/opensearch-project/k-NN/pull/52))
 
+### Refactoring
+
+* Renaming RestAPIs while supporting backwards compatibility. ([#18](https://github.com/opensearch-project/k-NN/pull/18))
+* Rename namespace from opendistro to opensearch ([#21](https://github.com/opensearch-project/k-NN/pull/21))
+* Move constants out of index folder into common ([#320](https://github.com/opendistro-for-elasticsearch/k-NN/pull/320))
+* Expose inner_product space type, refactoring SpaceTypes ([#328](https://github.com/opendistro-for-elasticsearch/k-NN/pull/328))

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -159,45 +159,55 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
             Collections.singletonList("invalid_metric")));
     }
 
-    /**
-     * Test graph query increment
-     */
-    public void testGraphQueryErrorsGetIncremented() throws Exception {
-        // Get initial query errors because it may not always be 0
-        String graphQueryErrors = StatNames.GRAPH_QUERY_ERRORS.getName();
-        Response response = getKnnStats(Collections.emptyList(), Collections.singletonList(graphQueryErrors));
-        String responseBody = EntityUtils.toString(response.getEntity());
-        Map<String, Object> nodeStats = parseNodeStatsResponse(responseBody).get(0);
-        int beforeErrors = (int) nodeStats.get(graphQueryErrors);
-
-        // Set the circuit breaker very low so that loading an index will definitely fail
-        updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
-
-        Settings settings = Settings.builder()
-                .put("number_of_shards", 1)
-                .put("index.knn", true)
-                .build();
-        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
-
-        // Add enough docs to trip the circuit breaker
-        Float[] vector = {1.3f, 2.2f};
-        int docsInIndex = 25;
-        for (int i = 0; i < docsInIndex; i++) {
-            addKnnDoc(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector);
-        }
-        forceMergeKnnIndex(INDEX_NAME);
-
-        // Execute a query that should fail
-        float[] qvector = {1.9f, 2.4f};
-        expectThrows(ResponseException.class, () ->
-                searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 10), 10));
-
-        // Check that the graphQuery errors gets incremented
-        response = getKnnStats(Collections.emptyList(), Collections.singletonList(graphQueryErrors));
-        responseBody = EntityUtils.toString(response.getEntity());
-        nodeStats = parseNodeStatsResponse(responseBody).get(0);
-        assertTrue((int) nodeStats.get(graphQueryErrors) > beforeErrors);
-    }
+    //TODO: Fix broken test case
+    // This test case intended to check whether the "graph_query_error" stat gets incremented when a query fails.
+    // It sets the circuit breaker limit to 1 kb and then indexes documents into the index and force merges so that
+    // the sole segment's graph will not fit in the cache. Then, it runs a query and expects an exception. Then it
+    // checks that the query errors get incremented. This test is flaky:
+    // https://github.com/opensearch-project/k-NN/issues/43. During query, when a segment to be
+    // searched is not present in the cache, it will first be loaded. Then it will be searched.
+    //
+    // The problem is that the cache built from CacheBuilder will not throw an exception if the entry exceeds the
+    // size of the cache - tested this via log statements. However, the entry gets marked as expired immediately.
+    // So, after loading the entry, sometimes the expired entry will get evicted before the search logic. This causes
+    // the search to fail. However, it appears sometimes that the entry doesnt get immediately evicted, causing the
+    // search to succeed.
+//    public void testGraphQueryErrorsGetIncremented() throws Exception {
+//        // Get initial query errors because it may not always be 0
+//        String graphQueryErrors = StatNames.GRAPH_QUERY_ERRORS.getName();
+//        Response response = getKnnStats(Collections.emptyList(), Collections.singletonList(graphQueryErrors));
+//        String responseBody = EntityUtils.toString(response.getEntity());
+//        Map<String, Object> nodeStats = parseNodeStatsResponse(responseBody).get(0);
+//        int beforeErrors = (int) nodeStats.get(graphQueryErrors);
+//
+//        // Set the circuit breaker very low so that loading an index will definitely fail
+//        updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
+//
+//        Settings settings = Settings.builder()
+//                .put("number_of_shards", 1)
+//                .put("index.knn", true)
+//                .build();
+//        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
+//
+//        // Add enough docs to trip the circuit breaker
+//        Float[] vector = {1.3f, 2.2f};
+//        int docsInIndex = 25;
+//        for (int i = 0; i < docsInIndex; i++) {
+//            addKnnDoc(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector);
+//        }
+//        forceMergeKnnIndex(INDEX_NAME);
+//
+//        // Execute a query that should fail
+//        float[] qvector = {1.9f, 2.4f};
+//        expectThrows(ResponseException.class, () ->
+//                searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 10), 10));
+//
+//        // Check that the graphQuery errors gets incremented
+//        response = getKnnStats(Collections.emptyList(), Collections.singletonList(graphQueryErrors));
+//        responseBody = EntityUtils.toString(response.getEntity());
+//        nodeStats = parseNodeStatsResponse(responseBody).get(0);
+//        assertTrue((int) nodeStats.get(graphQueryErrors) > beforeErrors);
+//    }
 
     /**
      * Test checks that handler correctly returns stats for a single node


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/opensearch-build/issues/497, removing default integtest.sh on the 1.x brach.