### PR TITLE
Update upstream build and add validation for model training requirement

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,15 +30,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'opensearch-project/OpenSearch'
-          ref: '1.x'
+          ref: '1.1'
           path: OpenSearch
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
 
       - name: Run build
         run: |
-          ./gradlew build
+          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0-rc1")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
 
@@ -91,7 +91,6 @@ if (!usingRemoteCluster) {
 }
 
 ext {
-    opensearchVersion = '1.0.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.TXT')
@@ -100,8 +99,10 @@ ext {
 
 allprojects {
     group = 'org.opensearch'
-    version = "${opensearchVersion}.0-rc1"
-
+    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
     apply from: 'build-tools/repositories.gradle'
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
@@ -153,7 +154,7 @@ dependencies {
     }
 }
 
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 loggerUsageCheck.enabled = false
@@ -275,7 +276,8 @@ afterEvaluate {
         dirMode 0755
 
         requires('opensearch', versions.opensearch, EQUAL)
-        requires("opensearch-knnlib",  "${opensearchVersion}.0",  EQUAL)
+        //TODO: Use default knn lib version for now, fix will be compare with version that is used in build step.
+        requires("opensearch-knnlib",  "1.1.0.0",  EQUAL)
         packager = 'Amazon'
         vendor = 'Amazon'
         os = 'LINUX'

--- a/src/main/java/org/opensearch/knn/index/KNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethod.java
@@ -82,6 +82,15 @@ public class KNNMethod {
     }
 
     /**
+     * returns whether training is required or not
+     *
+     * @return true if training is required; false otherwise
+     */
+    public boolean isTrainingRequired() {
+        return methodComponent.IsTrainingRequired();
+    }
+
+    /**
      * Parse knnMethodContext into a map that the library can use to configure the index
      *
      * @param knnMethodContext from which to generate map

--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -103,6 +103,15 @@ public class KNNMethodContext implements ToXContentFragment {
     }
 
     /**
+     * This method returns whether training is requires or not from knnEngine
+     *
+     * @return true if training is required by knnEngine; false otherwise
+     */
+    public boolean isTrainingRequired() {
+        return knnEngine.isTrainingRequired(this);
+    }
+
+    /**
      * Parses an Object into a KNNMethodContext.
      *
      * @param in Object containing mapping to be parsed

--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -26,6 +26,7 @@
 package org.opensearch.knn.index;
 
 import org.opensearch.common.Strings;
+import org.opensearch.common.ValidationException;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.common.KNNConstants;
 
@@ -154,8 +155,14 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                     b.endObject();
                 }), m -> m.getMethodComponent().getName())
                 .setValidator(v -> {
-                    //TODO: This should also check if v requires training. If so, it should fail
-                    if(v != null) v.validate();
+                    if (v == null)
+                        return;
+                    if (v.isTrainingRequired()){
+                        ValidationException validationException = new ValidationException();
+                        validationException.addValidationError(KNN_METHOD + " requires training");
+                        throw validationException;
+                    }
+                    v.validate();
                 });
 
         protected final Parameter<Map<String, String>> meta = Parameter.metaParam();

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -16,6 +16,7 @@ import org.opensearch.knn.common.KNNConstants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -26,6 +27,7 @@ public class MethodComponent {
     private String name;
     private Map<String, Parameter<?>> parameters;
     private BiFunction<MethodComponent, MethodComponentContext, Map<String, Object>> mapGenerator;
+    final private boolean requiresTraining;
 
     /**
      * Constructor
@@ -36,6 +38,7 @@ public class MethodComponent {
         this.name = builder.name;
         this.parameters = builder.parameters;
         this.mapGenerator = builder.mapGenerator;
+        this.requiresTraining = builder.requiresTraining;
     }
 
     /**
@@ -93,6 +96,14 @@ public class MethodComponent {
             parameters.get(parameter.getKey()).validate(parameter.getValue());
         }
     }
+    /**
+     * gets requiresTraining value
+     *
+     * @return requiresTraining
+     */
+    public boolean IsTrainingRequired() {
+            return requiresTraining;
+    }
 
     /**
      * Builder class for MethodComponent
@@ -102,6 +113,7 @@ public class MethodComponent {
         private String name;
         private Map<String, Parameter<?>> parameters;
         private BiFunction<MethodComponent, MethodComponentContext, Map<String, Object>> mapGenerator;
+        private boolean requiresTraining;
 
         /**
          * Method to get a Builder instance
@@ -139,6 +151,16 @@ public class MethodComponent {
          */
         public Builder setMapGenerator(BiFunction<MethodComponent, MethodComponentContext, Map<String, Object>> mapGenerator) {
             this.mapGenerator = mapGenerator;
+            return this;
+        }
+
+        /**
+         * set requiresTraining
+         * @param requiresTraining parameter to be set
+         * @return Builder instance
+         */
+        public Builder setRequiresTraining(boolean requiresTraining){
+            this.requiresTraining = requiresTraining;
             return this;
         }
 

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -128,6 +128,12 @@ public enum KNNEngine implements KNNLibrary {
     }
 
     @Override
+    public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
+        return knnLibrary.isTrainingRequired(knnMethodContext);
+    }
+
+
+    @Override
     public Map<String, Object> getMethodAsMap(KNNMethodContext knnMethodContext) {
         return knnLibrary.getMethodAsMap(knnMethodContext);
     }

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -96,6 +96,14 @@ public interface KNNLibrary {
     void validateMethod(KNNMethodContext knnMethodContext);
 
     /**
+     * Returns whether training is required or not from knnMethodContext for the given library.
+     *
+     * @param knnMethodContext methodContext
+     * @return true if training is required; false otherwise
+     */
+    boolean isTrainingRequired(KNNMethodContext knnMethodContext);
+
+    /**
      * Generate method as map that can be used to configure the knn index from the jni
      *
      * @param knnMethodContext to generate parameter map from
@@ -175,6 +183,12 @@ public interface KNNLibrary {
         public void validateMethod(KNNMethodContext knnMethodContext) {
             String methodName = knnMethodContext.getMethodComponent().getName();
             getMethod(methodName).validate(knnMethodContext);
+        }
+
+        @Override
+        public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
+            String methodName = knnMethodContext.getMethodComponent().getName();
+            return getMethod(methodName).isTrainingRequired();
         }
 
         @Override

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -85,6 +85,23 @@ public class KNNMethodContextTests extends KNNTestCase {
     }
 
     /**
+     * Test KNNMethodContext requires training method
+     */
+    public void testRequiresTraining() {
+
+        // Check for NMSLIB
+        MethodComponentContext hnswMethod = new MethodComponentContext(METHOD_HNSW, Collections.emptyMap());
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.NMSLIB, SpaceType.L2, hnswMethod);
+        assertFalse(knnMethodContext.isTrainingRequired());
+
+        // Check for FAISS
+        hnswMethod = new MethodComponentContext(METHOD_HNSW, Collections.emptyMap());
+        knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, hnswMethod);
+        assertFalse(knnMethodContext.isTrainingRequired());
+
+    }
+
+    /**
      * Test context method parsing when input is invalid
      */
     public void testParse_invalid() throws IOException {


### PR DESCRIPTION
### Description
* Update build step to use 1.1.0-SNAPSHOT for upstream.

* With faiss, we will now support 2 methods of creating a k-NN OpenSearch index (ignoring legacy details):
From method definition
`{
    "type": "knn_vector",
    "method": {
        "name": "hnsw",
        "engine": "faiss",
        "parameters": {
            "m": 42
        }
    }
}`
From model template
`{
    "type": "knn_vector",
    "model_id": "asfnbjb"
}`

    It is implied that creating an index from the first mapping requires that the underlying method requires no training.
    If it did, it would fail. To differentiate those models that requires training from other, add new method that
    lets library to specify whether training is required or not. Later, add it to parameter validation to fail fast rather than
    fail during index operation.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
