### PR TITLE
Add training execution functionality

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -36,6 +36,8 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_EF_SEARCH = "ef_search";
     public static final String METHOD_PARAMETER_EF_CONSTRUCTION = "ef_construction";
     public static final String METHOD_PARAMETER_M = "m";
+    public static final String METHOD_IVF = "ivf";
+    public static final String METHOD_PARAMETER_NLIST = "nlist";
     public static final String METHOD_PARAMETER_SPACE_TYPE = "space_type"; // used for mapping parameter
     public static final String COMPOUND_EXTENSION = "c";
     public static final String JNI_LIBRARY_NAME = "OpensearchKNN";
@@ -71,5 +73,6 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_NPROBES = "nprobes";
     public static final String ENCODER_FLAT = "flat";
     public static final String FAISS_HNSW_DESCRIPTION = "HNSW";
+    public static final String FAISS_IVF_DESCRIPTION = "IVF";
     public static final String FAISS_FLAT_DESCRIPTION = "Flat";
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -72,7 +72,19 @@ public class KNNConstants {
     public static final String METHOD_ENCODER_PARAMETER = "encoder";
     public static final String METHOD_PARAMETER_NPROBES = "nprobes";
     public static final String ENCODER_FLAT = "flat";
+    public static final String ENCODER_PQ = "pq";
+    public static final String ENCODER_PARAMETER_PQ_CODE_COUNT = "code_count";
+    public static final String ENCODER_PARAMETER_PQ_CODE_SIZE = "code_size";
     public static final String FAISS_HNSW_DESCRIPTION = "HNSW";
     public static final String FAISS_IVF_DESCRIPTION = "IVF";
     public static final String FAISS_FLAT_DESCRIPTION = "Flat";
+    public static final String FAISS_PQ_DESCRIPTION = "PQ";
+
+    // Parameter defaults/limits
+    public static final Integer ENCODER_PARAMETER_PQ_CODE_COUNT_DEFAULT = 1;
+    public static final Integer ENCODER_PARAMETER_PQ_CODE_COUNT_LIMIT = 1024;
+    public static final Integer ENCODER_PARAMETER_PQ_CODE_SIZE_DEFAULT = 8;
+    public static final Integer ENCODER_PARAMETER_PQ_CODE_SIZE_LIMIT = 128;
+    public static final Integer METHOD_PARAMETER_NLIST_DEFAULT = 4;
+    public static final Integer METHOD_PARAMETER_NLIST_LIMIT = 20000;
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -52,6 +52,9 @@ public class KNNConstants {
     public static final String MODEL_DESCRIPTION = "description";
     public static final String MODEL_ERROR = "error";
 
+    public static final String KNN_THREAD_POOL_PREFIX = "knn";
+    public static final String TRAIN_THREAD_POOL = "training";
+
     // nmslib specific constants
     public static final String NMSLIB_NAME = "nmslib";
     public static final String SPACE_TYPE = "spaceType"; // used as field info key

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Manages native memory allocations made by JNI.
  */
-public final class NativeMemoryCacheManager implements Closeable {
+public class NativeMemoryCacheManager implements Closeable {
 
     public static String GRAPH_COUNT = "graph_count";
 

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -28,11 +28,14 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.opensearch.knn.common.KNNConstants.FAISS_HNSW_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.FAISS_IVF_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 
 /**
  * KNNLibrary is an interface that helps the plugin communicate with k-NN libraries
@@ -312,6 +315,18 @@ public interface KNNLibrary {
                         .setMapGenerator(((methodComponent, methodComponentContext) ->
                                 MethodAsMapBuilder.builder(FAISS_HNSW_DESCRIPTION, methodComponent, methodComponentContext)
                                         .addParameter(METHOD_PARAMETER_M, "", "")
+                                        .addParameter(METHOD_ENCODER_PARAMETER, ",", "")
+                                        .build()))
+                        .build())
+                        .addSpaces(SpaceType.L2, SpaceType.INNER_PRODUCT).build(),
+                METHOD_IVF, KNNMethod.Builder.builder(MethodComponent.Builder.builder(METHOD_IVF)
+                        .addParameter(METHOD_PARAMETER_NLIST,
+                                new Parameter.IntegerParameter(1000, v -> v > 0 && v < 20_000))
+                        .addParameter(METHOD_ENCODER_PARAMETER,
+                                new Parameter.MethodComponentContextParameter(ENCODER_DEFAULT, encoderComponents))
+                        .setMapGenerator(((methodComponent, methodComponentContext) ->
+                                MethodAsMapBuilder.builder(FAISS_IVF_DESCRIPTION, methodComponent, methodComponentContext)
+                                        .addParameter(METHOD_PARAMETER_NLIST, "", "")
                                         .addParameter(METHOD_ENCODER_PARAMETER, ",", "")
                                         .build()))
                         .build())

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -27,8 +27,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_COUNT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_COUNT_DEFAULT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_COUNT_LIMIT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE_DEFAULT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE_LIMIT;
 import static org.opensearch.knn.common.KNNConstants.FAISS_HNSW_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.FAISS_IVF_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.FAISS_PQ_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
@@ -36,6 +43,8 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRU
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST_DEFAULT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST_LIMIT;
 
 /**
  * KNNLibrary is an interface that helps the plugin communicate with k-NN libraries
@@ -292,12 +301,28 @@ public interface KNNLibrary {
         public final static MethodComponentContext ENCODER_DEFAULT = new MethodComponentContext(
                 KNNConstants.ENCODER_FLAT, Collections.emptyMap());
 
+        //TODO: To think about in future: for PQ, if dimension is not divisible by code count, PQ will fail. Right now,
+        // we do not have a way to base validation off of dimension. Failure will happen during training in JNI.
         public final static Map<String, MethodComponent> encoderComponents = ImmutableMap.of(
-                        KNNConstants.ENCODER_FLAT, MethodComponent.Builder.builder(KNNConstants.ENCODER_FLAT)
+                KNNConstants.ENCODER_FLAT, MethodComponent.Builder.builder(KNNConstants.ENCODER_FLAT)
                         .setMapGenerator(((methodComponent, methodComponentContext) ->
                                 MethodAsMapBuilder.builder(KNNConstants.FAISS_FLAT_DESCRIPTION, methodComponent,
-                                        methodComponentContext).build()))
-                        .build());
+                                        methodComponentContext).build())).build(),
+                KNNConstants.ENCODER_PQ, MethodComponent.Builder.builder(KNNConstants.ENCODER_PQ)
+                        .addParameter(ENCODER_PARAMETER_PQ_CODE_COUNT,
+                                new Parameter.IntegerParameter(ENCODER_PARAMETER_PQ_CODE_COUNT_DEFAULT, v -> v > 0
+                                        && v < ENCODER_PARAMETER_PQ_CODE_COUNT_LIMIT))
+                        .addParameter(ENCODER_PARAMETER_PQ_CODE_SIZE,
+                                new Parameter.IntegerParameter(ENCODER_PARAMETER_PQ_CODE_SIZE_DEFAULT, v -> v > 0
+                                        && v < ENCODER_PARAMETER_PQ_CODE_SIZE_LIMIT))
+                        .setRequiresTraining(true)
+                        .setMapGenerator(((methodComponent, methodComponentContext) ->
+                                MethodAsMapBuilder.builder(FAISS_PQ_DESCRIPTION, methodComponent, methodComponentContext)
+                                        .addParameter(ENCODER_PARAMETER_PQ_CODE_COUNT, "", "")
+                                        .addParameter(ENCODER_PARAMETER_PQ_CODE_SIZE, "x", "")
+                                        .build()))
+                        .build()
+        );
 
         // Define methods supported by faiss
         public final static Map<String, KNNMethod> METHODS = ImmutableMap.of(
@@ -321,7 +346,7 @@ public interface KNNLibrary {
                         .addSpaces(SpaceType.L2, SpaceType.INNER_PRODUCT).build(),
                 METHOD_IVF, KNNMethod.Builder.builder(MethodComponent.Builder.builder(METHOD_IVF)
                         .addParameter(METHOD_PARAMETER_NLIST,
-                                new Parameter.IntegerParameter(1000, v -> v > 0 && v < 20_000))
+                                new Parameter.IntegerParameter(METHOD_PARAMETER_NLIST_DEFAULT, v -> v > 0 && v < METHOD_PARAMETER_NLIST_LIMIT))
                         .addParameter(METHOD_ENCODER_PARAMETER,
                                 new Parameter.MethodComponentContextParameter(ENCODER_DEFAULT, encoderComponents))
                         .setRequiresTraining(true)

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -324,6 +324,7 @@ public interface KNNLibrary {
                                 new Parameter.IntegerParameter(1000, v -> v > 0 && v < 20_000))
                         .addParameter(METHOD_ENCODER_PARAMETER,
                                 new Parameter.MethodComponentContextParameter(ENCODER_DEFAULT, encoderComponents))
+                        .setRequiresTraining(true)
                         .setMapGenerator(((methodComponent, methodComponentContext) ->
                                 MethodAsMapBuilder.builder(FAISS_IVF_DESCRIPTION, methodComponent, methodComponentContext)
                                         .addParameter(METHOD_PARAMETER_NLIST, "", "")

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -163,7 +163,7 @@ public class ModelMetadata implements Writeable {
      * @param error set on failure
      */
     public synchronized void setError(String error) {
-        this.error = Objects.requireNonNull(error, "error must not be null");
+        this.error = error;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -78,6 +78,8 @@ import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
 import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ExecutorBuilder;
+import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -90,6 +92,8 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
+import static org.opensearch.knn.common.KNNConstants.KNN_THREAD_POOL_PREFIX;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
 
 /**
  * Entry point for the KNN plugin where we define mapper for knn_vector type
@@ -237,5 +241,19 @@ public class KNNPlugin extends Plugin implements MapperPlugin, SearchPlugin, Act
     @Override
     public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new KNNScoringScriptEngine();
+    }
+
+    @Override
+    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
+        return ImmutableList.of(
+                new FixedExecutorBuilder(
+                        settings,
+                        TRAIN_THREAD_POOL,
+                        1,
+                        1,
+                        KNN_THREAD_POOL_PREFIX,
+                        false
+                )
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -65,6 +65,7 @@ import org.opensearch.index.mapper.Mapper;
 import org.opensearch.knn.plugin.stats.KNNStatsConfig;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataAction;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataTransportAction;
+import org.opensearch.knn.training.TrainingJobRunner;
 import org.opensearch.knn.training.VectorReader;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.EnginePlugin;
@@ -161,6 +162,7 @@ public class KNNPlugin extends Plugin implements MapperPlugin, SearchPlugin, Act
         KNNSettings.state().initialize(client, clusterService);
         ModelDao.OpenSearchKNNModelDao.initialize(client, clusterService, environment.settings());
         ModelCache.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
+        TrainingJobRunner.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
         knnStats = new KNNStats(KNNStatsConfig.KNN_STATS);
         return ImmutableList.of(knnStats);

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.knn.index.JNIService;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.memory.NativeMemoryAllocation;
+import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
+import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates all information required to generate and train a model.
+ */
+public class TrainingJob implements Runnable {
+
+    public static Logger logger = LogManager.getLogger(TrainingJob.class);
+
+    private final KNNMethodContext knnMethodContext;
+    private final NativeMemoryCacheManager nativeMemoryCacheManager;
+    private final NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext;
+    private final Model model;
+
+    private String modelId;
+
+    /**
+     * Constructor.
+     *
+     * @param modelId String to identify model. If null, one will be generated.
+     * @param knnMethodContext Method definition used to construct model.
+     * @param nativeMemoryCacheManager Cache manager loads training data into native memory.
+     * @param trainingDataEntryContext Training data configuration
+     * @param dimension model's dimension
+     * @param description user provided description of the model.
+     */
+    public TrainingJob(String modelId, KNNMethodContext knnMethodContext,
+                       NativeMemoryCacheManager nativeMemoryCacheManager,
+                       NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext,
+                       int dimension, String description) {
+        this.modelId = modelId;
+        this.knnMethodContext = Objects.requireNonNull(knnMethodContext, "MethodContext cannot be null.");
+        this.nativeMemoryCacheManager = Objects.requireNonNull(nativeMemoryCacheManager,
+                "NativeMemoryCacheManager cannot be null.");
+        this.trainingDataEntryContext = Objects.requireNonNull(trainingDataEntryContext,
+                "TrainingDataEntryContext cannot be null.");
+        this.model = new Model(
+                        new ModelMetadata(
+                                knnMethodContext.getEngine(),
+                                knnMethodContext.getSpaceType(),
+                                dimension,
+                                ModelState.TRAINING,
+                                TimeValue.timeValueMillis(System.currentTimeMillis()),
+                                description,
+                                ""
+                        ),
+                        null
+                    );
+    }
+
+    /**
+     * Getter for model id.
+     *
+     * @return modelId
+     */
+    public String getModelId() {
+        return modelId;
+    }
+
+    /**
+     * Setter for model id.
+     *
+     * @param modelId to set
+     */
+    public void setModelId(String modelId) {
+        this.modelId = modelId;
+    }
+
+    /**
+     * Getter for model
+     *
+     * @return model
+     */
+    public Model getModel() {
+        return model;
+    }
+
+    @Override
+    public void run() {
+        NativeMemoryAllocation nativeMemoryAllocation = null;
+        ModelMetadata modelMetadata = model.getModelMetadata();
+
+        try {
+            // Get training data
+            nativeMemoryAllocation = nativeMemoryCacheManager.get(trainingDataEntryContext, false);
+
+            // Acquire lock on allocation -- this will wait until training data is loaded
+            nativeMemoryAllocation.readLock();
+        } catch (Exception e) {
+            modelMetadata.setState(ModelState.FAILED);
+            modelMetadata.setError(e.getMessage());
+
+            if (nativeMemoryAllocation != null) {
+                nativeMemoryCacheManager.invalidate(trainingDataEntryContext.getKey());
+            }
+
+            logger.error("Failed to get training data for model \"" + modelId + "\": " + modelMetadata.getError());
+            return;
+        }
+
+        // Once lock is acquired, train the model. We need a separate try/catch block due to the fact that the lock
+        // needs to be released after it is acquired, but cannot be released if it has not been acquired.
+        try {
+            if (nativeMemoryAllocation.isClosed()) {
+                throw new RuntimeException("Unable to load training data into memory: allocation is already closed");
+            }
+
+            byte[] modelBlob = JNIService.trainIndex(
+                    model.getModelMetadata().getKnnEngine().getMethodAsMap(knnMethodContext),
+                    model.getModelMetadata().getDimension(),
+                    nativeMemoryAllocation.getMemoryAddress(),
+                    model.getModelMetadata().getKnnEngine().getName()
+            );
+
+            // Once training finishes, update model
+            model.setModelBlob(modelBlob);
+            modelMetadata.setState(ModelState.CREATED);
+        } catch (Exception e) {
+            modelMetadata.setState(ModelState.FAILED);
+            logger.error("Exception \"" + modelId + "\": " + e);
+            modelMetadata.setError(e.getMessage());
+            nativeMemoryAllocation.readUnlock();
+            logger.error("Failed to run training job for model \"" + modelId + "\": " + modelMetadata.getError());
+        } finally {
+            // Invalidate right away so we dont run into any big memory problems
+            nativeMemoryCacheManager.invalidate(trainingDataEntryContext.getKey());
+            nativeMemoryAllocation.readUnlock();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
+
+/**
+ * TrainingJobRunner is a singleton class responsible for submitting TrainingJobs to the k-NN training pool executor.
+ * Capacity of queue and number of threads of the executor can be configured from executor construction (in KNNPlugin).
+ */
+public class TrainingJobRunner {
+
+    public static Logger logger = LogManager.getLogger(TrainingJobRunner.class);
+
+    private static TrainingJobRunner INSTANCE;
+    private static ModelDao modelDao;
+    private static ThreadPool threadPool;
+
+    private final Semaphore semaphore;
+    private final AtomicInteger jobCount;
+
+    /**
+     * Get singleton instance of TrainingJobRunner
+     *
+     * @return singleton instance of TrainingJobRunner
+     */
+    public static synchronized TrainingJobRunner getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TrainingJobRunner();
+        }
+        return INSTANCE;
+    }
+
+    private TrainingJobRunner() {
+        this.jobCount = new AtomicInteger(0);
+        this.semaphore = new Semaphore(1);
+    }
+
+    /**
+     * Initializes static components.
+     *
+     * @param threadPool threadPool to use to get KNN Training Executor
+     * @param modelDao modelDao used to serialize the models
+     */
+    public static void initialize(ThreadPool threadPool, ModelDao modelDao) {
+        TrainingJobRunner.threadPool = threadPool;
+        TrainingJobRunner.modelDao = modelDao;
+    }
+
+    /**
+     * Execute a training job. This function will first grab a permit, and then serialize the initial model, then
+     * execute training, and then serialize the final result.
+     *
+     * @param trainingJob training job to be executed
+     * @param listener listener to handle final model serialization response (or exception)
+     */
+    public void execute(TrainingJob trainingJob, ActionListener<IndexResponse> listener) throws IOException {
+        // If the semaphore cannot be acquired, the node is unable to execute this job. This allows us to limit
+        // the number of training jobs that enter this function. Although the training threadpool size will also prevent
+        // this, we want to prevent this before we perform any serialization.
+        if (!semaphore.tryAcquire()) {
+            throw new RejectedExecutionException("Unable to run training job: No training capacity on node.");
+        }
+
+        jobCount.incrementAndGet();
+
+        // Serialize model before training. The model should be in the training state and the model binary should be
+        // null. This notifies users that their model is training, but not yet ready for use.
+        try {
+            serializeModel(
+                    trainingJob,
+                    ActionListener.wrap(
+                            indexResponse -> {
+                                // Update model id with id from response. We do this because users may or may not
+                                // provide an id
+                                trainingJob.setModelId(indexResponse.getId());
+                                train(trainingJob, listener);
+                            },
+                            exception -> {
+                                // Serialization failed. Let listener handle the exception, but free up resources.
+                                jobCount.decrementAndGet();
+                                semaphore.release();
+                                logger.error("Unable to initialize model serialization: " + exception.getMessage());
+                                listener.onFailure(exception);
+                            }
+                    ),
+                    false
+            );
+        } catch (IOException ioe) {
+            jobCount.decrementAndGet();
+            semaphore.release();
+            throw ioe;
+        }
+    }
+
+    private void train(TrainingJob trainingJob, ActionListener<IndexResponse> listener) {
+        // Attempt to submit job to training thread pool. On failure, release the resources and serialize the failure.
+        try {
+            threadPool.executor(TRAIN_THREAD_POOL).execute(() -> {
+                try {
+                    trainingJob.run();
+                    serializeModel(trainingJob, listener, true);
+                } catch (IOException e) {
+                    logger.error("Unable to serialize model \"" + trainingJob.getModelId() + "\": " + e.getMessage());
+                    listener.onFailure(e);
+                } catch (Exception e) {
+                    logger.error("Unable to complete training for \"" + trainingJob.getModelId() + "\": "
+                            + e.getMessage());
+                    listener.onFailure(e);
+                } finally {
+                    jobCount.decrementAndGet();
+                    semaphore.release();
+                }
+            });
+        } catch (RejectedExecutionException ree) {
+            logger.error("Unable to train model \"" + trainingJob.getModelId() + "\": " + ree.getMessage());
+
+            ModelMetadata modelMetadata = trainingJob.getModel().getModelMetadata();
+            modelMetadata.setState(ModelState.FAILED);
+            modelMetadata.setError(ree.getMessage());
+
+            try {
+                serializeModel(trainingJob, listener, true);
+            } catch (IOException ioe) {
+                logger.error("Unable to serialize the failure for model \"" + trainingJob.getModelId() + "\": " + ioe);
+                listener.onFailure(ioe);
+            } finally {
+                jobCount.decrementAndGet();
+                semaphore.release();
+            }
+        }
+    }
+
+    private void serializeModel(TrainingJob trainingJob, ActionListener<IndexResponse> listener, boolean update)
+            throws IOException {
+        if (update) {
+            modelDao.update(trainingJob.getModelId(), trainingJob.getModel(), listener);
+        } else {
+            modelDao.put(trainingJob.getModelId(), trainingJob.getModel(), listener);
+        }
+    }
+
+    /**
+     * Get all jobs in the runner.
+     *
+     * @return number of running jobs.
+     */
+    public int getJobCount() {
+        return jobCount.get();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/index/JNIServiceTests.java
@@ -26,7 +26,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_COUNT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 
 public class JNIServiceTests extends KNNTestCase {
 
@@ -164,7 +171,7 @@ public class JNIServiceTests extends KNNTestCase {
         float[][] vectors = new float[][]{};
 
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, "something",
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod), FAISS_NAME));
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod), FAISS_NAME));
     }
 
     public void testCreateIndex_faiss_invalid_vectorDocIDMismatch() throws IOException {
@@ -175,7 +182,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile1 = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors1,
-                tmpFile1.toAbsolutePath().toString(), ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER,
+                tmpFile1.toAbsolutePath().toString(), ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER,
                         faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
                 FAISS_NAME));
 
@@ -183,7 +190,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile2 = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors2,
-                tmpFile2.toAbsolutePath().toString(), ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER,
+                tmpFile2.toAbsolutePath().toString(), ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER,
                         faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
                 FAISS_NAME));
     }
@@ -196,22 +203,22 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(null, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), FAISS_NAME));
 
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, null, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), FAISS_NAME));
 
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, null,
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), FAISS_NAME));
 
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
                 null, FAISS_NAME));
 
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), null));
     }
 
@@ -223,7 +230,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, "invalid"), FAISS_NAME));
     }
 
@@ -235,7 +242,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), FAISS_NAME));
     }
 
@@ -258,7 +265,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, "invalid",
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "invalid",
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), FAISS_NAME));
     }
 
@@ -270,7 +277,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER, "IVF13",
+                ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "IVF13",
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue(), KNNConstants.PARAMETERS,
                         ImmutableMap.of(KNNConstants.METHOD_PARAMETER_NPROBES, "14")), FAISS_NAME));
 
@@ -287,7 +294,7 @@ public class JNIServiceTests extends KNNTestCase {
                 Path tmpFile1 = createTempFile();
                 JNIService.createIndex(testData.indexData.docs, testData.indexData.vectors, tmpFile1.toAbsolutePath().toString(),
                         ImmutableMap.of(
-                                KNNConstants.INDEX_DESCRIPTION_PARAMETER, method,
+                                INDEX_DESCRIPTION_PARAMETER, method,
                                 KNNConstants.SPACE_TYPE, spaceType.getValue()
                         ),
                         FAISS_NAME);
@@ -365,7 +372,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(testData.indexData.docs, testData.indexData.vectors, tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(
-                        KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                        INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()
                 ),
                 FAISS_NAME);
@@ -441,7 +448,7 @@ public class JNIServiceTests extends KNNTestCase {
         Path tmpFile = createTempFile();
 
         JNIService.createIndex(testData.indexData.docs, testData.indexData.vectors,
-                tmpFile.toAbsolutePath().toString(), ImmutableMap.of(KNNConstants.INDEX_DESCRIPTION_PARAMETER,
+                tmpFile.toAbsolutePath().toString(), ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER,
                         faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
                 FAISS_NAME);
         assertTrue(tmpFile.toFile().length() > 0);
@@ -466,7 +473,7 @@ public class JNIServiceTests extends KNNTestCase {
                 JNIService.createIndex(testData.indexData.docs, testData.indexData.vectors,
                         tmpFile.toAbsolutePath().toString(),
                         ImmutableMap.of(
-                                KNNConstants.INDEX_DESCRIPTION_PARAMETER, method,
+                                INDEX_DESCRIPTION_PARAMETER, method,
                                 KNNConstants.SPACE_TYPE, spaceType.getValue()
                         ),
                         FAISS_NAME);
@@ -512,7 +519,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(testData.indexData.docs, testData.indexData.vectors, tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(
-                        KNNConstants.INDEX_DESCRIPTION_PARAMETER, faissMethod,
+                        INDEX_DESCRIPTION_PARAMETER, faissMethod,
                         KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()
                 ),
                 FAISS_NAME);
@@ -563,7 +570,7 @@ public class JNIServiceTests extends KNNTestCase {
         }
 
         Map<String, Object> parameters = ImmutableMap.of(
-                KNNConstants.INDEX_DESCRIPTION_PARAMETER, "IVF16,PQ4",
+                INDEX_DESCRIPTION_PARAMETER, "IVF16,PQ4",
                 KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()
         );
 
@@ -586,11 +593,24 @@ public class JNIServiceTests extends KNNTestCase {
             assertEquals(trainPointer1, trainPointer2);
         }
 
-        Map<String, Object> parameters = ImmutableMap.of(
-                KNNConstants.INDEX_DESCRIPTION_PARAMETER, "IVF16,Flat",
-                KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()
-        );
+        SpaceType spaceType = SpaceType.L2;
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, spaceType,
+                new MethodComponentContext(METHOD_IVF,
+                        ImmutableMap.of(
+                                METHOD_PARAMETER_NLIST, 16,
+                                METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_PQ,
+                                        ImmutableMap.of(
+                                                ENCODER_PARAMETER_PQ_CODE_COUNT, 16,
+                                                ENCODER_PARAMETER_PQ_CODE_SIZE, 8
+                                        )))));
 
+        String description = knnMethodContext.getEngine().getMethodAsMap(knnMethodContext).get(INDEX_DESCRIPTION_PARAMETER).toString();
+        assertEquals("IVF16,PQ16x8", description);
+
+        Map<String, Object> parameters = ImmutableMap.of(
+                INDEX_DESCRIPTION_PARAMETER, description,
+                KNNConstants.SPACE_TYPE, spaceType.getValue()
+        );
 
         byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer1, FAISS_NAME);
 

--- a/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
@@ -1,0 +1,226 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
+
+public class TrainingJobRunnerTests extends KNNTestCase {
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    @Before
+    public void setup() {
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void teardown() {
+        executorService.shutdown();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExecute_success() throws IOException, InterruptedException {
+        // Test makes sure the correct execution logic follows on successful run
+
+        TrainingJobRunner trainingJobRunner = TrainingJobRunner.getInstance();
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+
+        String modelId = "test-model-id";
+        Model model = mock(Model.class);
+        TrainingJob trainingJob = mock(TrainingJob.class);
+        when(trainingJob.getModelId()).thenReturn(modelId);
+        when(trainingJob.getModel()).thenReturn(model);
+        doAnswer(invocationOnMock -> null).when(trainingJob).setModelId(modelId);
+        doAnswer(invocationOnMock -> null).when(trainingJob).run();
+
+        // Return a result for put with modelId as well as created set to true. For update, same
+        // thing except created should be false
+        ModelDao modelDao = mock(ModelDao.class);
+        doAnswer(invocationOnMock -> {
+            assertEquals(1, trainingJobRunner.getJobCount()); // Make sure job count is correct
+            IndexResponse indexResponse = new IndexResponse(
+                    new ShardId(MODEL_INDEX_NAME, "uuid", 0),
+                    "any-type",
+                    modelId,
+                    0,
+                    0,
+                    0,
+                    true
+                    );
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onResponse(indexResponse);
+            return null;
+        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+
+        // All validation will need to be done in this listener
+        // On successful allocation, the response should return success. This listener will be called after the update
+        // finishes
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        ActionListener<IndexResponse> responseListener = ActionListener.wrap(indexResponse -> {
+            assertEquals(modelId, indexResponse.getId());
+            inProgressLatch.countDown();
+        }, e -> {
+            fail("Failure should not have occurred");
+        });
+
+        doAnswer(invocationOnMock -> {
+            IndexResponse indexResponse = new IndexResponse(
+                    new ShardId(MODEL_INDEX_NAME, "uuid", 0),
+                    "any-type",
+                    modelId,
+                    0,
+                    0,
+                    0,
+                    false
+            );
+            responseListener.onResponse(indexResponse);
+            return null;
+        }).when(modelDao).update(modelId, model, responseListener);
+
+        // Finally, initialize the singleton runner, execute the job.
+        TrainingJobRunner.initialize(threadPool, modelDao);
+
+        trainingJobRunner.execute(trainingJob, responseListener);
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+
+        // Make sure these methods get called once
+        verify(trainingJob, times(1)).setModelId(modelId);
+        verify(trainingJob, times(1)).run();
+        verify(modelDao, times(1))
+                .put(anyString(), any(Model.class), any(ActionListener.class));
+        verify(modelDao, times(1)).update(modelId, model, responseListener);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExecute_failure_rejected() throws IOException, InterruptedException {
+        // This test makes sure we reject another request when one is ongoing. To do this, we call
+        // trainingJobRunner.execute(trainingJob, responseListener) in the mocked modeldao.update. At this point,
+        // the call should produce a failure because a training job is already ongoing.
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+
+        String modelId = "test-model-id";
+        Model model = mock(Model.class);
+        TrainingJob trainingJob = mock(TrainingJob.class);
+        when(trainingJob.getModelId()).thenReturn(modelId);
+        when(trainingJob.getModel()).thenReturn(model);
+        doAnswer(invocationOnMock -> null).when(trainingJob).setModelId(modelId);
+        doAnswer(invocationOnMock -> null).when(trainingJob).run();
+
+        // Return a result for modelDao put with modelId as well as created set to true. For update, same
+        // thing except created should be false
+        ModelDao modelDao = mock(ModelDao.class);
+        doAnswer(invocationOnMock -> {
+            IndexResponse indexResponse = new IndexResponse(
+                    new ShardId(MODEL_INDEX_NAME, "uuid", 0),
+                    "any-type",
+                    modelId,
+                    0,
+                    0,
+                    0,
+                    true
+            );
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onResponse(indexResponse);
+            return null;
+        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+
+        // No-op listener
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        ActionListener<IndexResponse> responseListener = ActionListener.wrap(indexResponse -> {
+            inProgressLatch.countDown();
+        }, e -> {
+            fail("Should not reach this state");
+        });
+
+        TrainingJobRunner trainingJobRunner = TrainingJobRunner.getInstance();
+        doAnswer(invocationOnMock -> {
+            expectThrows(RejectedExecutionException.class, () -> trainingJobRunner.execute(trainingJob, responseListener));
+            responseListener.onResponse(null);
+            return null;
+        }).when(modelDao).update(modelId, model, responseListener);
+
+        // Finally, initialize the singleton runner, execute the job.
+        TrainingJobRunner.initialize(threadPool, modelDao);
+        trainingJobRunner.execute(trainingJob, responseListener);
+
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testExecute_failure_serialization() throws IOException, InterruptedException {
+        // This test confirms that execution fails as expected if initial serialization fails
+
+        TrainingJobRunner trainingJobRunner = TrainingJobRunner.getInstance();
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+
+        String modelId = "test-model-id";
+        Model model = mock(Model.class);
+        TrainingJob trainingJob = mock(TrainingJob.class);
+        when(trainingJob.getModelId()).thenReturn(modelId);
+        when(trainingJob.getModel()).thenReturn(model);
+
+        // Listener should validate exception comes through
+        String message = "some error";
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        ActionListener<IndexResponse> responseListener = ActionListener.wrap(
+                indexResponse -> fail("Should not reach this state"),
+                e -> {
+                    assertEquals(e.getMessage(), message);
+                    assertEquals(0, trainingJobRunner.getJobCount()); // Make sure resources are free
+                    inProgressLatch.countDown();
+                });
+
+        // ModelDao put should just call listeners onFailure
+        ModelDao modelDao = mock(ModelDao.class);
+        doAnswer(invocationOnMock -> {
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onFailure(new RuntimeException(message));
+            return null;
+        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+
+
+
+        // Finally, initialize the singleton runner, execute the job.
+        TrainingJobRunner.initialize(threadPool, modelDao);
+        trainingJobRunner.execute(trainingJob, responseListener);
+
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -1,0 +1,322 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.JNIService;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.MethodComponentContext;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.memory.NativeMemoryAllocation;
+import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
+import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+
+public class TrainingJobTests extends KNNTestCase {
+
+    public void testGetModelId() {
+        String modelId = "test-model-id";
+        KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
+        when(knnMethodContext.getEngine()).thenReturn(KNNEngine.DEFAULT);
+        when(knnMethodContext.getSpaceType()).thenReturn(SpaceType.DEFAULT);
+
+        TrainingJob trainingJob = new TrainingJob(
+                modelId,
+                knnMethodContext,
+                mock(NativeMemoryCacheManager.class),
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
+                10,
+                ""
+        );
+
+        assertEquals(modelId, trainingJob.getModelId());
+    }
+
+    public void testSetModelId() {
+        KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
+        when(knnMethodContext.getEngine()).thenReturn(KNNEngine.DEFAULT);
+        when(knnMethodContext.getSpaceType()).thenReturn(SpaceType.DEFAULT);
+
+        TrainingJob trainingJob = new TrainingJob(
+                "test-model-id",
+                knnMethodContext,
+                mock(NativeMemoryCacheManager.class),
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
+                10,
+                ""
+        );
+
+        String setModelId = "test-model-id-2";
+        trainingJob.setModelId(setModelId);
+
+        assertEquals(setModelId, trainingJob.getModelId());
+    }
+
+    public void testGetModel() {
+        SpaceType spaceType = SpaceType.INNER_PRODUCT;
+        KNNEngine knnEngine = KNNEngine.DEFAULT;
+        int dimension = 10;
+        String desciption = "test description";
+        String error = "";
+
+        KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
+        when(knnMethodContext.getEngine()).thenReturn(knnEngine);
+        when(knnMethodContext.getSpaceType()).thenReturn(spaceType);
+
+        TrainingJob trainingJob = new TrainingJob(
+                "test-model-id",
+                knnMethodContext,
+                mock(NativeMemoryCacheManager.class),
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
+                dimension,
+                desciption
+        );
+
+        Model model = new Model(
+                new ModelMetadata(
+                        knnEngine,
+                        spaceType,
+                        dimension,
+                        ModelState.TRAINING,
+                        trainingJob.getModel().getModelMetadata().getTimestamp(),
+                        desciption,
+                        error
+                ),
+                null
+        );
+
+        assertEquals(model, trainingJob.getModel());
+    }
+
+    public void testRun_success() throws IOException, ExecutionException {
+        // Successful end to end run case
+        String modelId = "test-model-id";
+
+        // Define the method setup for method that requires training
+        int nlists = 5;
+        int dimension = 16;
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        KNNMethodContext knnMethodContext = new KNNMethodContext(knnEngine, SpaceType.INNER_PRODUCT,
+                new MethodComponentContext(METHOD_IVF, ImmutableMap.of(METHOD_PARAMETER_NLIST, nlists)));
+
+        // Set up training data
+        int tdataPoints = 100;
+        float[][] trainingData = new float[tdataPoints][dimension];
+        fillFloatArrayRandomly(trainingData);
+        long memoryAddress = JNIService.transferVectors(0, trainingData);
+
+        // Setup mock allocation
+        NativeMemoryAllocation nativeMemoryAllocation = mock(NativeMemoryAllocation.class);
+        doAnswer(invocationOnMock -> null).when(nativeMemoryAllocation).readLock();
+        doAnswer(invocationOnMock -> null).when(nativeMemoryAllocation).readUnlock();
+        when(nativeMemoryAllocation.isClosed()).thenReturn(false);
+        when(nativeMemoryAllocation.getMemoryAddress()).thenReturn(memoryAddress);
+
+        String tdataKey = "t-data-key";
+        NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext =
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class);
+        when(trainingDataEntryContext.getKey()).thenReturn(tdataKey);
+
+        NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
+        when(nativeMemoryCacheManager.get(trainingDataEntryContext, false)).thenReturn(nativeMemoryAllocation);
+        doAnswer(invocationOnMock -> {
+            JNIService.freeVectors(memoryAddress);
+            return null;
+        }).when(nativeMemoryCacheManager).invalidate(tdataKey);
+
+        TrainingJob trainingJob = new TrainingJob(
+                modelId,
+                knnMethodContext,
+                nativeMemoryCacheManager,
+                trainingDataEntryContext,
+                dimension,
+                ""
+        );
+
+        trainingJob.run();
+
+        Model model = trainingJob.getModel();
+        assertNotNull(model);
+
+        assertEquals(ModelState.CREATED, model.getModelMetadata().getState());
+
+        // Simple test that creates the index from template and doesnt fail
+        int[] ids = { 1, 2, 3, 4};
+        float[][] vectors = new float[ids.length][dimension];
+        fillFloatArrayRandomly(vectors);
+
+        Path indexPath = createTempFile();
+        JNIService.createIndexFromTemplate(ids, vectors, indexPath.toString(), model.getModelBlob(), knnEngine.getName());
+        assertNotEquals(0, new File(indexPath.toString()).length());
+    }
+
+    public void testRun_failure_onGetTrainingDataAllocation() throws ExecutionException {
+        // In this test, getting a training data allocation should fail. Then, run should fail and update the error of
+        // the model
+        String modelId = "test-model-id";
+
+        // Define the method setup for method that requires training
+        int nlists = 5;
+        int dimension = 16;
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        KNNMethodContext knnMethodContext = new KNNMethodContext(knnEngine, SpaceType.INNER_PRODUCT,
+                new MethodComponentContext(METHOD_IVF, ImmutableMap.of(METHOD_PARAMETER_NLIST, nlists)));
+
+        String tdataKey = "t-data-key";
+        NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext =
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class);
+        when(trainingDataEntryContext.getKey()).thenReturn(tdataKey);
+
+        // Throw error on getting data
+        NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
+        String testException = "test exception";
+        when(nativeMemoryCacheManager.get(trainingDataEntryContext, false))
+                .thenThrow(new RuntimeException(testException));
+
+        TrainingJob trainingJob = new TrainingJob(
+                modelId,
+                knnMethodContext,
+                nativeMemoryCacheManager,
+                trainingDataEntryContext,
+                dimension,
+                ""
+        );
+
+        trainingJob.run();
+
+        Model model = trainingJob.getModel();
+        assertEquals(ModelState.FAILED, trainingJob.getModel().getModelMetadata().getState());
+        assertNotNull(model);
+        assertEquals(testException, model.getModelMetadata().getError());
+    }
+
+    public void testRun_failure_closedTrainingDataAllocation() throws ExecutionException {
+        // In this test, the training data allocation should be closed. Then, run should fail and update the error of
+        // the model
+        String modelId = "test-model-id";
+
+        // Define the method setup for method that requires training
+        int nlists = 5;
+        int dimension = 16;
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        KNNMethodContext knnMethodContext = new KNNMethodContext(knnEngine, SpaceType.INNER_PRODUCT,
+                new MethodComponentContext(METHOD_IVF, ImmutableMap.of(METHOD_PARAMETER_NLIST, nlists)));
+
+        String tdataKey = "t-data-key";
+        NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext =
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class);
+        when(trainingDataEntryContext.getKey()).thenReturn(tdataKey);
+
+
+        // Setup mock allocation thats closed
+        NativeMemoryAllocation nativeMemoryAllocation = mock(NativeMemoryAllocation.class);
+        doAnswer(invocationOnMock -> null).when(nativeMemoryAllocation).readLock();
+        doAnswer(invocationOnMock -> null).when(nativeMemoryAllocation).readUnlock();
+        when(nativeMemoryAllocation.isClosed()).thenReturn(true);
+        when(nativeMemoryAllocation.getMemoryAddress()).thenReturn((long) 0);
+
+        // Throw error on getting data
+        NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
+        when(nativeMemoryCacheManager.get(trainingDataEntryContext, false)).thenReturn(nativeMemoryAllocation);
+
+        TrainingJob trainingJob = new TrainingJob(
+                modelId,
+                knnMethodContext,
+                nativeMemoryCacheManager,
+                trainingDataEntryContext,
+                dimension,
+                ""
+        );
+
+        trainingJob.run();
+
+        Model model = trainingJob.getModel();
+        assertNotNull(model);
+        assertEquals(ModelState.FAILED, trainingJob.getModel().getModelMetadata().getState());
+    }
+
+    public void testRun_failure_notEnoughTrainingData() throws ExecutionException {
+        // In this test case, we ensure that failure happens gracefully when there isnt enough training data
+        String modelId = "test-model-id";
+
+        // Define the method setup for method that requires training
+        int nlists = 1024; // setting this to 1024 will cause training to fail when there is only 2 data points
+        int dimension = 16;
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        KNNMethodContext knnMethodContext = new KNNMethodContext(knnEngine, SpaceType.INNER_PRODUCT,
+                new MethodComponentContext(METHOD_IVF, ImmutableMap.of(METHOD_PARAMETER_NLIST, nlists)));
+
+        // Set up training data
+        int tdataPoints = 2;
+        float[][] trainingData = new float[tdataPoints][dimension];
+        fillFloatArrayRandomly(trainingData);
+        long memoryAddress = JNIService.transferVectors(0, trainingData);
+
+        // Setup mock allocation
+        NativeMemoryAllocation nativeMemoryAllocation = mock(NativeMemoryAllocation.class);
+        doAnswer(invocationOnMock -> null).when(nativeMemoryAllocation).readLock();
+        doAnswer(invocationOnMock -> null).when(nativeMemoryAllocation).readUnlock();
+        when(nativeMemoryAllocation.isClosed()).thenReturn(false);
+        when(nativeMemoryAllocation.getMemoryAddress()).thenReturn(memoryAddress);
+
+        String tdataKey = "t-data-key";
+        NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext =
+                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class);
+        when(trainingDataEntryContext.getKey()).thenReturn(tdataKey);
+
+        NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
+        when(nativeMemoryCacheManager.get(trainingDataEntryContext, false)).thenReturn(nativeMemoryAllocation);
+        doAnswer(invocationOnMock -> {
+            JNIService.freeVectors(memoryAddress);
+            return null;
+        }).when(nativeMemoryCacheManager).invalidate(tdataKey);
+
+        TrainingJob trainingJob = new TrainingJob(
+                modelId,
+                knnMethodContext,
+                nativeMemoryCacheManager,
+                trainingDataEntryContext,
+                dimension,
+                ""
+        );
+
+        trainingJob.run();
+
+        Model model = trainingJob.getModel();
+        assertNotNull(model);
+        assertEquals(ModelState.FAILED, model.getModelMetadata().getState());
+        assertFalse(model.getModelMetadata().getError().isEmpty());
+    }
+
+    private void fillFloatArrayRandomly(float [][] vectors) {
+        for (int i = 0; i < vectors.length; i++) {
+            for (int j = 0; j < vectors[i].length; j++) {
+                vectors[i][j] = randomFloat();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR adds training execution functionality by making several changes:
1. A single thread, KNN training pool is added in the KNNPlugin. This will allow us to sandbox resources for training
2. TrainingJob class is a runnable that was added to encapsulate everything needed to perform training
3. TrainingJobRunner class was added to handle job submission and model serialization. In handling job submission, it will only allow 1 job to be ran at a time. If a job is submitted while one is already running, it will be rejected. It serializes the model before and after training to the model system index. It adds error messages to the model on failure.

From a review perspective, please pay attention to how errors are being handled in TrainingJobRunner. I would appreciate feedback on this.

In addition to this functionality, this PR adds support for faiss's IVF and PQ algorithms. Both of these algorithms require training.
 
### Issues Resolved
#94
 
### Check List
- [X] New functionality includes testing.
  - [x] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
