### PR TITLE
Add action to get training job count on each node

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -57,6 +57,9 @@ public class KNNConstants {
     public static final String KNN_THREAD_POOL_PREFIX = "knn";
     public static final String TRAIN_THREAD_POOL = "training";
 
+    public static final String TRAINING_JOB_COUNT_FIELD_NAME = "training_job_count";
+    public static final String NODES_KEY = "nodes";
+
     // nmslib specific constants
     public static final String NMSLIB_NAME = "nmslib";
     public static final String SPACE_TYPE = "spaceType"; // used as field info key

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -63,6 +63,8 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.knn.plugin.stats.KNNStatsConfig;
+import org.opensearch.knn.plugin.transport.TrainingJobRouteDecisionInfoAction;
+import org.opensearch.knn.plugin.transport.TrainingJobRouteDecisionInfoTransportAction;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataAction;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataTransportAction;
 import org.opensearch.knn.training.TrainingJobRunner;
@@ -196,7 +198,9 @@ public class KNNPlugin extends Plugin implements MapperPlugin, SearchPlugin, Act
         return Arrays.asList(
                 new ActionHandler<>(KNNStatsAction.INSTANCE, KNNStatsTransportAction.class),
                 new ActionHandler<>(KNNWarmupAction.INSTANCE, KNNWarmupTransportAction.class),
-                new ActionHandler<>(UpdateModelMetadataAction.INSTANCE, UpdateModelMetadataTransportAction.class)
+                new ActionHandler<>(UpdateModelMetadataAction.INSTANCE, UpdateModelMetadataTransportAction.class),
+                new ActionHandler<>(TrainingJobRouteDecisionInfoAction.INSTANCE,
+                        TrainingJobRouteDecisionInfoTransportAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoAction.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.common.io.stream.Writeable;
+
+/**
+ * Action used to collect information from each node to determine which node would be best to route a particular
+ * training job to.
+ */
+public class TrainingJobRouteDecisionInfoAction extends ActionType<TrainingJobRouteDecisionInfoResponse> {
+
+    public static final String NAME = "cluster:admin/knn_training_job_route_decision_info_action";
+    public static final TrainingJobRouteDecisionInfoAction INSTANCE = new TrainingJobRouteDecisionInfoAction(NAME,
+            TrainingJobRouteDecisionInfoResponse::new);
+
+    /**
+     * Constructor.
+     *
+     * @param name name of action
+     * @param responseReader reader for TrainingJobRouteDecisionInfoResponse response
+     */
+    public TrainingJobRouteDecisionInfoAction(String name,
+                                              Writeable.Reader<TrainingJobRouteDecisionInfoResponse> responseReader) {
+        super(name, responseReader);
+    }
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeRequest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.support.nodes.BaseNodeRequest;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Request sent to each node to gather info that will be used to determine where to route a job. Right now,
+ * this is fairly simple. However, in the future, we could add different filter parameters here.
+ */
+public class TrainingJobRouteDecisionInfoNodeRequest extends BaseNodeRequest {
+
+    /**
+     * Constructor
+     */
+    public TrainingJobRouteDecisionInfoNodeRequest() {
+        super();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param in input stream
+     * @throws IOException in case of I/O errors
+     */
+    public TrainingJobRouteDecisionInfoNodeRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeResponse.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeResponse.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.ToXContentFragment;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.TRAINING_JOB_COUNT_FIELD_NAME;
+
+/**
+ * Node level response containing training job route decision info.
+ */
+public class TrainingJobRouteDecisionInfoNodeResponse extends BaseNodeResponse implements ToXContentFragment {
+
+    private final Integer trainingJobCount;
+
+    /**
+     * Constructor
+     *
+     * @param in  stream
+     * @throws IOException in case of I/O errors
+     */
+    public TrainingJobRouteDecisionInfoNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        this.trainingJobCount = in.readInt();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param node node
+     */
+    public TrainingJobRouteDecisionInfoNodeResponse(DiscoveryNode node, Integer trainingJobCount) {
+        super(node);
+        this.trainingJobCount = trainingJobCount;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeInt(trainingJobCount);
+    }
+
+    /**
+     * Getter for training job count
+     *
+     * @return The count of the training jobs on the node
+     */
+    public Integer getTrainingJobCount() {
+        return trainingJobCount;
+    }
+
+    /**
+     * Add training job route decision info to xcontent builder
+     *
+     * @param builder XContentBuilder
+     * @param params Params
+     * @return XContentBuilder
+     * @throws IOException thrown by builder for invalid field
+     */
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.field(TRAINING_JOB_COUNT_FIELD_NAME, trainingJobCount);
+        return builder;
+    }
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoRequest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Request to get training job route decision info from some/all nodes in the cluster. Caller is
+ * responsible for filtering out non-data nodes.
+ */
+public class TrainingJobRouteDecisionInfoRequest extends BaseNodesRequest<TrainingJobRouteDecisionInfoRequest> {
+
+    /**
+     * Constructor
+     *
+     * @param in input stream
+     * @throws java.io.IOException in case of I/O errors
+     */
+    public TrainingJobRouteDecisionInfoRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param nodeIds NodeIDs from which to retrieve job route decision info
+     */
+    public TrainingJobRouteDecisionInfoRequest(String... nodeIds) {
+        super(nodeIds);
+    }
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoResponse.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoResponse.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.NODES_KEY;
+
+/**
+ * Aggregated response for training job route decision info
+ */
+public class TrainingJobRouteDecisionInfoResponse extends BaseNodesResponse<TrainingJobRouteDecisionInfoNodeResponse>
+        implements ToXContentObject {
+
+    /**
+     * Constructor
+     *
+     * @param in StreamInput
+     * @throws IOException thrown when unable to read from stream
+     */
+    public TrainingJobRouteDecisionInfoResponse(StreamInput in) throws IOException {
+        super(new ClusterName(in), in.readList(TrainingJobRouteDecisionInfoNodeResponse::new), in.readList(FailedNodeException::new));
+    }
+
+    /**
+     * Constructor
+     *
+     * @param clusterName name of cluster
+     * @param nodes List of KNNStatsNodeResponses
+     * @param failures List of failures from nodes
+     */
+    public TrainingJobRouteDecisionInfoResponse(ClusterName clusterName,
+                                                List<TrainingJobRouteDecisionInfoNodeResponse> nodes,
+                                                List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public void writeNodesTo(StreamOutput out, List<TrainingJobRouteDecisionInfoNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public List<TrainingJobRouteDecisionInfoNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(TrainingJobRouteDecisionInfoNodeResponse::new);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // Add node responses to response
+        String nodeId;
+        DiscoveryNode node;
+        builder.startObject(NODES_KEY);
+        for (TrainingJobRouteDecisionInfoNodeResponse jobRouteDecInfo : getNodes()) {
+            node = jobRouteDecInfo.getNode();
+            nodeId = node.getId();
+            builder.startObject(nodeId);
+            jobRouteDecInfo.toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportAction.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.knn.training.TrainingJobRunner;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Broadcasts request to collect training job route decision info from all nodes and aggregates it into a single
+ * response.
+ */
+public class TrainingJobRouteDecisionInfoTransportAction extends
+        TransportNodesAction<TrainingJobRouteDecisionInfoRequest, TrainingJobRouteDecisionInfoResponse,
+        TrainingJobRouteDecisionInfoNodeRequest, TrainingJobRouteDecisionInfoNodeResponse> {
+    /**
+     * Constructor
+     *
+     * @param threadPool ThreadPool to use
+     * @param clusterService ClusterService
+     * @param transportService TransportService
+     * @param actionFilters Action Filters
+     */
+    @Inject
+    public TrainingJobRouteDecisionInfoTransportAction(
+            ThreadPool threadPool,
+            ClusterService clusterService,
+            TransportService transportService,
+            ActionFilters actionFilters
+    ) {
+        super(TrainingJobRouteDecisionInfoAction.NAME, threadPool, clusterService, transportService, actionFilters,
+                TrainingJobRouteDecisionInfoRequest::new, TrainingJobRouteDecisionInfoNodeRequest::new,
+                ThreadPool.Names.MANAGEMENT, TrainingJobRouteDecisionInfoNodeResponse.class);
+    }
+
+    @Override
+    protected TrainingJobRouteDecisionInfoResponse newResponse(TrainingJobRouteDecisionInfoRequest request,
+                                                               List<TrainingJobRouteDecisionInfoNodeResponse> responses,
+                                                               List<FailedNodeException> failures) {
+        return new TrainingJobRouteDecisionInfoResponse(
+                clusterService.getClusterName(),
+                responses,
+                failures
+        );
+    }
+
+    @Override
+    protected TrainingJobRouteDecisionInfoNodeRequest newNodeRequest(TrainingJobRouteDecisionInfoRequest request) {
+        return new TrainingJobRouteDecisionInfoNodeRequest();
+    }
+
+    @Override
+    protected TrainingJobRouteDecisionInfoNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new TrainingJobRouteDecisionInfoNodeResponse(in);
+    }
+
+    @Override
+    protected TrainingJobRouteDecisionInfoNodeResponse nodeOperation(TrainingJobRouteDecisionInfoNodeRequest request) {
+        return new TrainingJobRouteDecisionInfoNodeResponse(clusterService.localNode(),
+                TrainingJobRunner.getInstance().getJobCount());
+    }
+}

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeResponseTests.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import com.google.common.collect.Maps;
+import com.google.common.net.InetAddresses;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.opensearch.knn.common.KNNConstants.TRAINING_JOB_COUNT_FIELD_NAME;
+
+public class TrainingJobRouteDecisionInfoNodeResponseTests extends KNNTestCase {
+
+    public void testStreams() throws IOException {
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+
+        int trainingJobCount = 13;
+        InetAddress inetAddress = InetAddresses.fromInteger(randomInt());
+        DiscoveryNode discoveryNode = new DiscoveryNode("id", new TransportAddress(inetAddress, 9200),
+                Version.CURRENT);
+
+        TrainingJobRouteDecisionInfoNodeResponse original =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode, trainingJobCount);
+
+        original.writeTo(streamOutput);
+
+        TrainingJobRouteDecisionInfoNodeResponse copy =
+                new TrainingJobRouteDecisionInfoNodeResponse(streamOutput.bytes().streamInput());
+
+        assertEquals(original.getTrainingJobCount(), copy.getTrainingJobCount());
+    }
+
+    public void testGetTrainingJobCount() {
+        int trainingJobCount = 13;
+
+        DiscoveryNode discoveryNode = mock(DiscoveryNode.class);
+
+        TrainingJobRouteDecisionInfoNodeResponse response =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode, trainingJobCount);
+
+        assertEquals(trainingJobCount, response.getTrainingJobCount().intValue());
+    }
+
+    public void testToXContent() throws IOException {
+        int trainingJobCount = 13;
+
+        // We expect this:
+        // {
+        //    "training_job_count": 13
+        // }
+        XContentBuilder expectedXContentBuilder = XContentFactory.jsonBuilder().startObject()
+                .field(TRAINING_JOB_COUNT_FIELD_NAME, trainingJobCount)
+                .endObject();
+
+        Map<String, Object> expected = xContentBuilderToMap(expectedXContentBuilder);
+
+        DiscoveryNode discoveryNode = mock(DiscoveryNode.class);
+        TrainingJobRouteDecisionInfoNodeResponse response =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode, trainingJobCount);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder = response.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+        Map<String, Object> actual = xContentBuilderToMap(builder);
+
+        assertTrue(Maps.difference(expected, actual).areEqual());
+    }
+}

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoResponseTests.java
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.net.InetAddresses;
+import org.opensearch.Version;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.NODES_KEY;
+import static org.opensearch.knn.common.KNNConstants.TRAINING_JOB_COUNT_FIELD_NAME;
+
+public class TrainingJobRouteDecisionInfoResponseTests extends KNNTestCase {
+
+    public void testStreams() throws IOException {
+
+        // Initialize nodes and data
+        InetAddress inetAddress1 = InetAddresses.fromInteger(randomInt());
+        String node1Id = "node-1";
+        DiscoveryNode discoveryNode1 = new DiscoveryNode(node1Id, new TransportAddress(inetAddress1, 9200),
+                Version.CURRENT);
+        Integer trainingJobCount1 = 1;
+        TrainingJobRouteDecisionInfoNodeResponse nodeResponse1 =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode1, trainingJobCount1);
+
+        InetAddress inetAddress2 = InetAddresses.fromInteger(randomInt());
+        String node2Id = "node-2";
+        DiscoveryNode discoveryNode2 = new DiscoveryNode(node2Id, new TransportAddress(inetAddress2, 9200),
+                Version.CURRENT);
+        Integer trainingJobCount2 = 2;
+        TrainingJobRouteDecisionInfoNodeResponse nodeResponse2 =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode2, trainingJobCount2);
+
+        InetAddress inetAddress3 = InetAddresses.fromInteger(randomInt());
+        String node3Id = "node-3";
+        DiscoveryNode discoveryNode3 = new DiscoveryNode(node3Id, new TransportAddress(inetAddress3, 9200),
+                Version.CURRENT);
+        Integer trainingJobCount3 = 3;
+        TrainingJobRouteDecisionInfoNodeResponse nodeResponse3 =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode3, trainingJobCount3);
+
+        List<TrainingJobRouteDecisionInfoNodeResponse> nodeResponses = ImmutableList.of(
+                nodeResponse1,
+                nodeResponse2,
+                nodeResponse3
+        );
+
+        List<FailedNodeException> failedNodeExceptions = Collections.emptyList();
+
+        // Setup output
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+
+        TrainingJobRouteDecisionInfoResponse original =
+                new TrainingJobRouteDecisionInfoResponse(ClusterName.DEFAULT, nodeResponses, failedNodeExceptions);
+
+        original.writeTo(streamOutput);
+
+        // Read back streamed out into streamed in
+        TrainingJobRouteDecisionInfoResponse copy =
+                new TrainingJobRouteDecisionInfoResponse(streamOutput.bytes().streamInput());
+
+        Map<String, TrainingJobRouteDecisionInfoNodeResponse> originalNodeResponseMap = original.getNodesMap();
+        Map<String, TrainingJobRouteDecisionInfoNodeResponse> copyNodeResponseMap = copy.getNodesMap();
+        assertEquals(originalNodeResponseMap.keySet(), copyNodeResponseMap.keySet());
+        assertTrue(originalNodeResponseMap.containsKey(node2Id));
+        assertEquals(originalNodeResponseMap.get(node2Id).getTrainingJobCount(),
+                copyNodeResponseMap.get(node2Id).getTrainingJobCount());
+    }
+
+    public void testToXContent() throws IOException {
+
+        // Set up the data
+        String id1 = "id_1";
+        DiscoveryNode discoveryNode1 = mock(DiscoveryNode.class);
+        when(discoveryNode1.getId()).thenReturn(id1);
+        Integer trainingJobCount1 = 1;
+        TrainingJobRouteDecisionInfoNodeResponse nodeResponse1 =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode1, trainingJobCount1);
+
+        String id2 = "id_2";
+        DiscoveryNode discoveryNode2 = mock(DiscoveryNode.class);
+        when(discoveryNode2.getId()).thenReturn(id2);
+        Integer trainingJobCount2 = 2;
+        TrainingJobRouteDecisionInfoNodeResponse nodeResponse2 =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode2, trainingJobCount2);
+
+        String id3 = "id_3";
+        DiscoveryNode discoveryNode3 = mock(DiscoveryNode.class);
+        when(discoveryNode3.getId()).thenReturn(id3);
+        Integer trainingJobCount3 = 3;
+        TrainingJobRouteDecisionInfoNodeResponse nodeResponse3 =
+                new TrainingJobRouteDecisionInfoNodeResponse(discoveryNode3, trainingJobCount3);
+
+        // We expect this:
+        // {
+        //    "nodes": {
+        //          "id_1": {
+        //              "training_job_count": 1
+        //          },
+        //          "id_2": {
+        //              "training_job_count": 2
+        //          },
+        //          "id_3": {
+        //              "training_job_count": 3
+        //          },
+        //    }
+        // }
+        XContentBuilder expectedXContentBuilder = XContentFactory.jsonBuilder().startObject()
+                .startObject(NODES_KEY)
+                .startObject(id1)
+                .field(TRAINING_JOB_COUNT_FIELD_NAME, trainingJobCount1)
+                .endObject()
+                .startObject(id2)
+                .field(TRAINING_JOB_COUNT_FIELD_NAME, trainingJobCount2)
+                .endObject()
+                .startObject(id3)
+                .field(TRAINING_JOB_COUNT_FIELD_NAME, trainingJobCount3)
+                .endObject()
+                .endObject()
+                .endObject();
+        Map<String, Object> expected = xContentBuilderToMap(expectedXContentBuilder);
+
+        // Configure response
+        List<TrainingJobRouteDecisionInfoNodeResponse> nodeResponses = ImmutableList.of(
+                nodeResponse1,
+                nodeResponse2,
+                nodeResponse3
+        );
+
+        List<FailedNodeException> failedNodeExceptions = Collections.emptyList();
+
+        TrainingJobRouteDecisionInfoResponse response =
+                new TrainingJobRouteDecisionInfoResponse(ClusterName.DEFAULT, nodeResponses, failedNodeExceptions);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder = response.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+        Map<String, Object> actual = xContentBuilderToMap(builder);
+
+        // Check responses are equal
+        assertTrue(Maps.difference(expected, actual).areEqual());
+    }
+}

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportActionTests.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.index.shard.ShardId;
+import org.opensearch.knn.KNNSingleNodeTestCase;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.training.TrainingJob;
+import org.opensearch.knn.training.TrainingJobRunner;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
+
+public class TrainingJobRouteDecisionInfoTransportActionTests extends KNNSingleNodeTestCase {
+
+    ExecutorService executorService;
+
+    @Before
+    public void setup() {
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void teardown() {
+        executorService.shutdown();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testNodeOperation() throws IOException, InterruptedException {
+        // Ensure initial value of train job count is 0
+        TrainingJobRouteDecisionInfoTransportAction action = node().injector()
+                .getInstance(TrainingJobRouteDecisionInfoTransportAction.class);
+
+        TrainingJobRouteDecisionInfoNodeRequest request =
+                new TrainingJobRouteDecisionInfoNodeRequest();
+
+        TrainingJobRouteDecisionInfoNodeResponse response1 = action.nodeOperation(request);
+        assertEquals(0, response1.getTrainingJobCount().intValue());
+
+        // Setup mocked training job
+        String modelId = "model-id";
+        Model model = mock(Model.class);
+        TrainingJob trainingJob = mock(TrainingJob.class);
+        when(trainingJob.getModelId()).thenReturn(modelId);
+        when(trainingJob.getModel()).thenReturn(model);
+        doAnswer(invocationOnMock -> null).when(trainingJob).setModelId(modelId);
+        doAnswer(invocationOnMock -> null).when(trainingJob).run();
+
+        ModelDao modelDao = mock(ModelDao.class);
+
+        // Here we check to make sure there is a running job
+        doAnswer(invocationOnMock -> {
+            TrainingJobRouteDecisionInfoNodeResponse response2 = action.nodeOperation(request);
+            assertEquals(1, response2.getTrainingJobCount().intValue());
+
+            IndexResponse indexResponse = new IndexResponse(
+                    new ShardId(MODEL_INDEX_NAME, "uuid", 0),
+                    "any-type",
+                    modelId,
+                    0,
+                    0,
+                    0,
+                    true
+            );
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onResponse(indexResponse);
+            return null;
+        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+
+        // Set up the rest of the training logic
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        ActionListener<IndexResponse> responseListener = ActionListener.wrap(indexResponse -> {
+            inProgressLatch.countDown();
+        }, e -> fail("Failure should not have occurred"));
+
+        doAnswer(invocationOnMock -> {
+            responseListener.onResponse(mock(IndexResponse.class));
+            return null;
+        }).when(modelDao).update(modelId, model, responseListener);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+
+        // Initialize runner and execute job
+        TrainingJobRunner.initialize(threadPool, modelDao);
+        TrainingJobRunner.getInstance().execute(trainingJob, responseListener);
+
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a transport action that gets the number of jobs running on each node in the cluster. The response of this action will look like:
```
{
  "nodes": {
    "id_1": {
      "training_job_count": 1
    },
    "id_2": {
      "training_job_count": 2
    },
    "id_3": {
      "training_job_count": 3
    },
  }
}
```

This action will be used in the training api to determine which node the job should be sent to.

This PR builds on top of #103. The only changes in this PR are in the following files:
1. src/main/java/org/opensearch/knn/common/KNNConstants.java
1. src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
1. src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoAction.java
1. src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeRequest.java
1. src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeResponse.java
1. src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoRequest.java
1. src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoResponse.java
1. src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportAction.java
1. src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeResponseTests.java
1. src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoResponseTests.java
1. src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportActionTests.java
 
### Issues Resolved
#104 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
