### PR TITLE
Move model metadata retrieval out of mapper build method

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/KNNQueryBuilder.java
@@ -25,6 +25,8 @@
 
 package org.opensearch.knn.index;
 
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -211,6 +213,22 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
 
         int dimension = ((KNNVectorFieldMapper.KNNVectorFieldType) mappedFieldType).getDimension();
+
+        //TODO: Fix this logic
+        if (dimension == -1) {
+            String modelId = ((KNNVectorFieldMapper.KNNVectorFieldType) mappedFieldType).getModelId();
+
+            if (modelId == null) {
+                throw new IllegalArgumentException("Field does not have dimension set.");
+            }
+
+            ModelMetadata modelMetadata = ModelDao.OpenSearchKNNModelDao.getInstance().getMetadata(modelId);
+
+            if (modelMetadata == null) {
+                throw new IllegalArgumentException("Model ID \"" + modelId + "\" does not exist.");
+            }
+            dimension = modelMetadata.getDimension();
+        }
 
         if (dimension != vector.length) {
             throw new IllegalArgumentException("Query vector has invalid dimension: " + vector.length +

--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -638,8 +638,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             ModelMetadata modelMetadata = this.modelDao.getMetadata(modelId);
 
             if (modelMetadata == null) {
-                throw new IllegalStateException("Model \"" + modelId + "\" does not exist. A new index will need to " +
-                        "be created.");
+                throw new IllegalStateException("Model \"" + modelId + "\" from " +
+                        context.mapperService().index().getName() + "'s mapping does not exist. Because the " +
+                        "\"" + MODEL_ID + "\" parameter is not updateable, this index will need to " +
+                        "be recreated with a valid model.");
             }
 
             parseCreateField(context, modelMetadata.getDimension());

--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -238,10 +238,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 // sometimes used to initialize the cluster state/update cluster state, we cannot get the state here
                 // safely. So, we are unable to validate the model. The model gets validated during ingestion.
 
-                if (modelMetadata == null) {
-                    throw new IllegalArgumentException("Model \"" + modelId + "\" does not exist");
-                }
-
                 return new ModelFieldMapper(
                         name,
                         new KNNVectorFieldType(buildFullName(context), meta.getValue(), -1, modelIdAsString),
@@ -319,9 +315,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         String modelId;
 
         public KNNVectorFieldType(String name, Map<String, String> meta, int dimension) {
-            super(name, false, false, true, TextSearchInfo.NONE, meta);
-            this.dimension = dimension;
-            this.modelId = null; // By default, this is null. It will only be set for a mapping with a modelId set.
+            this(name, meta, dimension, null);
         }
 
         public KNNVectorFieldType(String name, Map<String, String> meta, int dimension, String modelId) {

--- a/src/main/java/org/opensearch/knn/index/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/KNNWeight.java
@@ -47,6 +47,8 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.opensearch.common.io.PathUtils;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 
 import java.io.IOException;
@@ -60,6 +62,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 
@@ -91,6 +94,7 @@ public class KNNWeight extends Weight {
 
     @Override
     public Scorer scorer(LeafReaderContext context) throws IOException {
+        //TODO: WE NEED TO FIX THIS I GUESS
             SegmentReader reader = (SegmentReader) FilterLeafReader.unwrap(context.reader());
             String directory = ((FSDirectory) FilterDirectory.unwrap(reader.directory())).getDirectory().toString();
 
@@ -102,8 +106,23 @@ public class KNNWeight extends Weight {
                 return null;
             }
 
-            KNNEngine knnEngine = KNNEngine.getEngine(fieldInfo.getAttribute(KNN_ENGINE));
-            SpaceType spaceType = SpaceType.getSpace(fieldInfo.getAttribute(SPACE_TYPE));
+            KNNEngine knnEngine;
+            SpaceType spaceType;
+
+            // Here is where things will diverge
+            String modelId = fieldInfo.getAttribute(MODEL_ID);
+            if (modelId != null) {
+                ModelMetadata modelMetadata = ModelDao.OpenSearchKNNModelDao.getInstance().getMetadata(modelId);
+                if (modelMetadata == null) {
+                    throw new RuntimeException("ModelMetadata is null");
+                }
+
+                knnEngine = modelMetadata.getKnnEngine();
+                spaceType = modelMetadata.getSpaceType();
+            } else {
+                knnEngine = KNNEngine.getEngine(fieldInfo.getAttribute(KNN_ENGINE));
+                spaceType = SpaceType.getSpace(fieldInfo.getAttribute(SPACE_TYPE));
+            }
 
             /*
              * In case of compound file, extension would be <engine-extension> + c otherwise <engine-extension>

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -30,6 +30,7 @@ import org.opensearch.knn.index.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.KNNVectorFieldMapper;
 
+import org.opensearch.knn.index.KNNWeight;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
 import org.opensearch.knn.indices.ModelCache;
 import org.opensearch.knn.indices.ModelDao;
@@ -170,6 +171,8 @@ public class KNNPlugin extends Plugin implements MapperPlugin, SearchPlugin, Act
         ModelCache.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
         TrainingJobRunner.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
+        KNNQueryBuilder.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
+        KNNWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         knnStats = new KNNStats(KNNStatsConfig.KNN_STATS);
         return ImmutableList.of(knnStats);
     }

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.knn.KNNSingleNodeTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+
+public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
+
+    public void testCreateIndexFromModel() throws IOException, InterruptedException {
+        // This test confirms that we can create an index from cluster metadata
+
+        // Create a model offline
+        String modelId = "test-model";
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        SpaceType spaceType = SpaceType.L2;
+        int dimension = 3;
+
+        // "Train" a faiss flat index - this really just creates an empty index that does brute force k-NN
+        long vectorsPointer = JNIService.transferVectors(0, new float[0][0]);
+        byte [] modelBlob = JNIService.trainIndex(ImmutableMap.of(
+                INDEX_DESCRIPTION_PARAMETER, "Flat",
+                SPACE_TYPE, spaceType.getValue()), dimension, vectorsPointer,
+                KNNEngine.FAISS.getName());
+
+        // Setup model
+        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
+                TimeValue.timeValueDays(3), "", "");
+
+        Model model = new Model(modelMetadata, modelBlob);
+
+        // Check that an index can be created from the model.
+        ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        ActionListener<AcknowledgedResponse> mappingListener = ActionListener.wrap(response -> {
+            assertTrue(response.isAcknowledged());
+            inProgressLatch.countDown();
+        }, e -> fail("Unable to put mapping: " + e.getMessage()));
+
+        String indexName = "test-index";
+        String fieldName = "test-field";
+
+        modelDao.put(modelId, model, ActionListener.wrap(indexResponse -> {
+            createKNNIndex("test-index");
+            PutMappingRequest request = new PutMappingRequest(indexName).type("_doc");
+            request.source(fieldName, "type=knn_vector,model_id=" + modelId);
+            client().admin().indices().putMapping(request, mappingListener);
+        }, e ->fail("Unable to put model: " + e.getMessage())));
+
+        assertTrue(inProgressLatch.await(20, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -35,6 +35,7 @@ import org.opensearch.knn.index.JNIService;
 import org.opensearch.knn.index.KNNQuery;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.KNNWeight;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.codec.KNN87Codec.KNN87Codec;
@@ -230,6 +231,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         Model mockModel = new Model(modelMetadata1, modelBlob);
         when(modelDao.get(modelId)).thenReturn(mockModel);
+        when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata1);
 
         Settings settings = settings(CURRENT).put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), 10).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
@@ -251,9 +253,6 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         FieldType fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
         fieldType.putAttribute(KNNConstants.MODEL_ID, modelId);
-        fieldType.putAttribute(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName());
-        fieldType.putAttribute(KNNConstants.SPACE_TYPE, spaceType.getValue());
-        fieldType.putAttribute(KNNConstants.DIMENSION, String.valueOf(dimension));
         fieldType.freeze();
 
         // Add the documents to the index
@@ -277,6 +276,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
         writer.close();
 
         // Make sure that search returns the correct results
+        KNNWeight.initialize(modelDao);
         NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(createDisabledResourceWatcherService());
         float [] query = {10.0f, 10.0f, 10.0f};
         IndexSearcher searcher = new IndexSearcher(reader);


### PR DESCRIPTION
### Description
This change moves model metadata retrieval out of the model mapper build logic. The reason for this can be found in #110. From a user's perspective, the model_id they pass in during index creation will not be validated until they start ingesting documents. 

As a side effect of this change, we can no longer write values such as KNNEngine and SpaceType to the Mapper's Lucene fieldType. These values are read elsewhere in the plugin, such as during indexing in the KNNDocValuesConsumer, as well as during querying. Therefore, that logic needed to be changed as well.

I tested the changes manually on my train API implementation and they work. I also added a single node test case that creates an index from a model. Currently, this fails due to an issue with writing the timestamp. I will submit another PR to fix this.
 
### Issues Resolved
#110 
 
### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
