### PR TITLE
Updating timestamp internal representation to string

### DIFF
--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -34,7 +34,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
@@ -223,7 +222,7 @@ public interface ModelDao {
                 put(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, modelMetadata.getSpaceType().getValue());
                 put(KNNConstants.DIMENSION, modelMetadata.getDimension());
                 put(KNNConstants.MODEL_STATE, modelMetadata.getState().getName());
-                put(KNNConstants.MODEL_TIMESTAMP, modelMetadata.getTimestamp().toString());
+                put(KNNConstants.MODEL_TIMESTAMP, modelMetadata.getTimestamp());
                 put(KNNConstants.MODEL_DESCRIPTION, modelMetadata.getDescription());
                 put(KNNConstants.MODEL_ERROR, modelMetadata.getError());
             }};
@@ -324,7 +323,7 @@ public interface ModelDao {
 
             ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.getEngine((String) engine),
                     SpaceType.getSpace((String) space), (Integer) dimension, ModelState.getModelState((String) state),
-                    TimeValue.parseTimeValue((String) timestamp, KNNConstants.MODEL_TIMESTAMP), (String) description,
+                    (String) timestamp, (String) description,
                     (String) error);
             return new Model(modelMetadata, byteBlob);
         }

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -13,7 +13,6 @@ package org.opensearch.knn.training;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.index.JNIService;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
@@ -23,6 +22,8 @@ import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**
@@ -65,7 +66,7 @@ public class TrainingJob implements Runnable {
                                 knnMethodContext.getSpaceType(),
                                 dimension,
                                 ModelState.TRAINING,
-                                TimeValue.timeValueMillis(System.currentTimeMillis()),
+                                ZonedDateTime.now(ZoneOffset.UTC).toString(),
                                 description,
                                 ""
                         ),

--- a/src/test/java/org/opensearch/knn/index/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorFieldMapperTests.java
@@ -26,7 +26,6 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.ValidationException;
@@ -44,6 +43,8 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
@@ -115,7 +116,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
         String modelId = "Random modelId";
         ModelMetadata mockedModelMetadata = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129,
-                ModelState.CREATED, TimeValue.timeValueHours(10), "", "");
+                ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
         builder.modelId.setValue(modelId);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
 
@@ -357,7 +358,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
         ModelDao mockModelDao = mock(ModelDao.class);
         ModelMetadata mockModelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension,
-                ModelState.CREATED, TimeValue.timeValueDays(10), "", "");
+                ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
         when(mockModelDao.getMetadata(modelId)).thenReturn(mockModelMetadata);
 
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> mockModelDao);

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.common.settings.ClusterSettings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.JNIService;
@@ -67,6 +66,8 @@ import org.opensearch.watcher.ResourceWatcherService;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -225,7 +226,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         // Set model state to created
         ModelMetadata modelMetadata1 = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(3), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         Model mockModel = new Model(modelMetadata1, modelBlob);
         when(modelDao.get(modelId)).thenReturn(mockModel);

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -16,11 +16,12 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
@@ -33,7 +34,7 @@ public class ModelCacheTests extends KNNTestCase {
         String modelId = "test-model-id";
         int dimension = 2;
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), "hello".getBytes());
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), "hello".getBytes());
         long cacheSize = 100L;
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -58,7 +59,7 @@ public class ModelCacheTests extends KNNTestCase {
         long cacheSize = 500;
 
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""),
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""),
                 new byte[Long.valueOf(cacheSize).intValue() + 1]);
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -106,10 +107,10 @@ public class ModelCacheTests extends KNNTestCase {
 
         int size1 = 100;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[size1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size1]);
         int size2 = 300;
         Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[size2]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -142,10 +143,10 @@ public class ModelCacheTests extends KNNTestCase {
 
         int size1 = 100;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[size1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size1]);
         int size2 = 300;
         Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[size2]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size2]);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -182,7 +183,7 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
         long cacheSize = 100L;
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), "hello".getBytes());
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), "hello".getBytes());
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -216,7 +217,7 @@ public class ModelCacheTests extends KNNTestCase {
 
         int modelSize = 101;
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[modelSize]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize]);
 
         long cacheSize1 = 100L;
         long cacheSize2 = 200L;
@@ -274,7 +275,7 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
         int modelSize1 = 100;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[modelSize1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
 
@@ -304,12 +305,12 @@ public class ModelCacheTests extends KNNTestCase {
         String modelId1 = "test-model-id-1";
         int modelSize1 = 100;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[modelSize1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize1]);
 
         String modelId2 = "test-model-id-2";
         int modelSize2 = 100;
         Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[modelSize2]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize2]);
 
         long cacheSize = 500L;
 

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -21,7 +21,6 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.engine.VersionConflictEngineException;
@@ -31,6 +30,8 @@ import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -102,7 +103,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         int dimension = 2;
 
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
@@ -149,7 +150,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         int dimension = 2;
 
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
@@ -203,7 +204,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 exception -> fail("Unable to put the model: " + exception));
 
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
         modelDao.put(model, docCreationListenerNoModelId);
         assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
     }
@@ -217,7 +218,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // Model is in invalid state
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
         model.getModelMetadata().setState(ModelState.CREATED);
 
         expectThrows(IllegalArgumentException.class, () -> modelDao.put(model, ActionListener.wrap(
@@ -234,7 +235,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         int dimension = 2;
 
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", ""), null);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), null);
 
         // Listener to confirm that everything was updated as expected
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
@@ -260,7 +261,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // User provided model id that already exists - should be able to update
         Model updatedModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
 
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
         ActionListener<IndexResponse> updateListener = ActionListener.wrap(response -> {
@@ -298,13 +299,13 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // model id exists
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
         addDoc(modelId, model);
         assertEquals(model, modelDao.get(modelId));
 
         // Get model during training
         model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", ""), null);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), null);
         addDoc(modelId, model);
         assertEquals(model, modelDao.get(modelId));
     }
@@ -329,7 +330,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         SpaceType spaceType = SpaceType.INNER_PRODUCT;
         int dimension = 2;
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         Model model = new Model(modelMetadata, modelBlob);
 
@@ -379,7 +380,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // model id exists
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
 
         ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
             assertEquals(modelId, response.getId());

--- a/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
@@ -12,12 +12,14 @@
 package org.opensearch.knn.indices;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 public class ModelMetadataTests extends KNNTestCase {
 
@@ -27,7 +29,7 @@ public class ModelMetadataTests extends KNNTestCase {
         int dimension = 128;
 
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         modelMetadata.writeTo(streamOutput);
@@ -40,7 +42,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testGetKnnEngine() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         assertEquals(knnEngine, modelMetadata.getKnnEngine());
     }
@@ -48,7 +50,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testGetSpaceType() {
         SpaceType spaceType = SpaceType.L2;
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, spaceType, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         assertEquals(spaceType, modelMetadata.getSpaceType());
     }
@@ -56,7 +58,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testGetDimension() {
         int dimension = 128;
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         assertEquals(dimension, modelMetadata.getDimension());
     }
@@ -64,13 +66,13 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testGetState() {
         ModelState modelState = ModelState.FAILED;
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, modelState,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         assertEquals(modelState, modelMetadata.getState());
     }
 
     public void testGetTimestamp() {
-        TimeValue timeValue = TimeValue.timeValueDays(10);
+        String timeValue = ZonedDateTime.now(ZoneOffset.UTC).toString();
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED,
                 timeValue, "", "");
 
@@ -80,7 +82,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testDescription() {
         String description = "test description";
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED,
-                TimeValue.timeValueDays(10), description, "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), description, "");
 
         assertEquals(description, modelMetadata.getDescription());
     }
@@ -88,7 +90,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testGetError() {
         String error = "test error";
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", error);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", error);
 
         assertEquals(error, modelMetadata.getError());
     }
@@ -96,7 +98,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testSetState() {
         ModelState modelState = ModelState.FAILED;
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, modelState,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         assertEquals(modelState, modelMetadata.getState());
 
@@ -108,7 +110,7 @@ public class ModelMetadataTests extends KNNTestCase {
     public void testSetError() {
         String error = "";
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", error);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", error);
 
         assertEquals(error, modelMetadata.getError());
 
@@ -122,7 +124,7 @@ public class ModelMetadataTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         int dimension = 128;
         ModelState modelState = ModelState.TRAINING;
-        TimeValue timestamp = TimeValue.timeValueDays(10);
+        String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String description = "test-description";
         String error = "test-error";
 
@@ -141,25 +143,30 @@ public class ModelMetadataTests extends KNNTestCase {
     }
 
     public void testEquals() {
+
+        String time1 = ZonedDateTime.now(ZoneOffset.UTC).toString();
+        String time2 = ZonedDateTime.of(2021, 9, 30,12, 20, 45, 1,
+                ZoneId.systemDefault()).toString();
+
         ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
 
         ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(11), "", "");
+                time2, "", "");
         ModelMetadata modelMetadata8 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "diff descript", "");
+                time1, "diff descript", "");
         ModelMetadata modelMetadata9 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "diff error");
+                time1, "", "diff error");
 
         assertEquals(modelMetadata1, modelMetadata1);
         assertEquals(modelMetadata1, modelMetadata2);
@@ -175,25 +182,30 @@ public class ModelMetadataTests extends KNNTestCase {
     }
 
     public void testHashCode() {
+
+        String time1 = ZonedDateTime.now(ZoneOffset.UTC).toString();
+        String time2 = ZonedDateTime.of(2021, 9, 30,12, 20, 45, 1,
+                ZoneId.systemDefault()).toString();
+
         ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
 
         ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", "");
+                time1, "", "");
         ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(11), "", "");
+                time2, "", "");
         ModelMetadata modelMetadata8 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "diff descript", "");
+                time1, "diff descript", "");
         ModelMetadata modelMetadata9 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "diff error");
+                time1, "", "diff error");
 
         assertEquals(modelMetadata1.hashCode(), modelMetadata1.hashCode());
         assertEquals(modelMetadata1.hashCode(), modelMetadata2.hashCode());
@@ -213,7 +225,7 @@ public class ModelMetadataTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         int dimension = 128;
         ModelState modelState = ModelState.TRAINING;
-        TimeValue timestamp = TimeValue.timeValueDays(10);
+        String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String description = "test-description";
         String error = "test-error";
 

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -11,10 +11,12 @@
 
 package org.opensearch.knn.indices;
 
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import static org.opensearch.knn.index.KNNVectorFieldMapper.MAX_DIMENSION;
 
@@ -26,26 +28,26 @@ public class ModelTests extends KNNTestCase {
 
     public void testInvalidConstructor() {
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, -1, ModelState.FAILED, TimeValue.timeValueDays(10), "", ""),
-                null));
+                SpaceType.DEFAULT, -1, ModelState.FAILED, ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "", ""), null));
     }
 
     public void testInvalidDimension() {
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, -1, ModelState.CREATED, TimeValue.timeValueDays(10), "", ""),
-                new byte[16]));
+                SpaceType.DEFAULT, -1, ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "", ""), new byte[16]));
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, 0, ModelState.CREATED, TimeValue.timeValueDays(10), "", ""),
-                new byte[16]));
+                SpaceType.DEFAULT, 0, ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "", ""), new byte[16]));
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
-                SpaceType.DEFAULT, MAX_DIMENSION + 1, ModelState.CREATED, TimeValue.timeValueDays(10), "", ""),
-                new byte[16]));
+                SpaceType.DEFAULT, MAX_DIMENSION + 1, ModelState.CREATED,
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[16]));
     }
 
     public void testGetModelMetadata() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.DEFAULT, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
         Model model = new Model(modelMetadata, new byte[16]);
         assertEquals(modelMetadata, model.getModelMetadata());
     }
@@ -53,25 +55,25 @@ public class ModelTests extends KNNTestCase {
     public void testGetModelBlob() {
         byte[] modelBlob = "hello".getBytes();
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
         assertArrayEquals(modelBlob, model.getModelBlob());
     }
 
     public void testGetLength() {
         int size = 129;
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[size]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size]);
         assertEquals(size, model.getLength());
 
         model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.TRAINING,
-                TimeValue.timeValueDays(10), "", ""), null);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), null);
         assertEquals(0, model.getLength());
     }
 
     public void testSetModelBlob() {
         byte[] blob1 = "Hello blob 1".getBytes();
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), blob1);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), blob1);
         assertEquals(blob1, model.getModelBlob());
         byte[] blob2 = "Hello blob 2".getBytes();
 
@@ -80,16 +82,19 @@ public class ModelTests extends KNNTestCase {
     }
 
     public void testEquals() {
+
+        String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
+
         Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
         Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
         Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
         Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[32]);
+                time, "", ""), new byte[32]);
         Model model5 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 4, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
 
         assertEquals(model1, model1);
         assertEquals(model1, model2);
@@ -99,14 +104,17 @@ public class ModelTests extends KNNTestCase {
     }
 
     public void testHashCode() {
+
+        String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
+
         Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
         Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
         Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[32]);
+                time, "", ""), new byte[32]);
         Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 4, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", ""), new byte[16]);
+                time, "", ""), new byte[16]);
 
         assertEquals(model1.hashCode(), model1.hashCode());
         assertEquals(model1.hashCode(), model2.hashCode());

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
@@ -12,7 +12,6 @@
 package org.opensearch.knn.plugin.transport;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -20,6 +19,8 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 public class UpdateModelMetadataRequestTests extends KNNTestCase {
 
@@ -32,7 +33,7 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
         boolean isRemoveRequest = false;
 
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest(modelId, isRemoveRequest, modelMetadata);
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
@@ -46,8 +47,9 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
     }
 
     public void testValidate() {
+
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         UpdateModelMetadataRequest updateModelMetadataRequest1 = new UpdateModelMetadataRequest("test", true, null);
         assertNull(updateModelMetadataRequest1.validate());
@@ -78,7 +80,7 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
 
     public void testGetModelMetadata() {
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest("test", true, modelMetadata);
 
         assertEquals(modelMetadata, updateModelMetadataRequest.getModelMetadata());

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -16,7 +16,6 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -25,6 +24,8 @@ import org.opensearch.knn.indices.ModelState;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +60,7 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
         // Setup the model
         String modelId = "test-model";
         ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 128, ModelState.CREATED,
-                TimeValue.timeValueDays(10), "", "");
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
         // Get update  transport action
         UpdateModelMetadataTransportAction updateModelMetadataTransportAction = node().injector()


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Changes representation of model timestamp to a string so that indexing models does not fail.
 
### Issues Resolved
#112 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
