### PR TITLE
Add streaming functionality to KNNMethodContext and MethodComponentContext

### DIFF
--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -215,14 +215,10 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
         @Override
         public Object read(StreamInput in) throws IOException {
             boolean isValueMethodComponentContext = in.readBoolean();
-            Object value;
             if (isValueMethodComponentContext) {
-                value = new MethodComponentContext(in);
-            } else {
-                value = in.readGenericValue();
+                return new MethodComponentContext(in);
             }
-
-            return value;
+            return in.readGenericValue();
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -13,6 +13,9 @@ package org.opensearch.knn.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.xcontent.ToXContentFragment;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.MapperParsingException;
@@ -33,7 +36,7 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  *
  * Each component is composed of a name and a map of parameters.
  */
-public class MethodComponentContext implements ToXContentFragment {
+public class MethodComponentContext implements ToXContentFragment, Writeable {
 
     private static Logger logger = LogManager.getLogger(MethodComponentContext.class);
 
@@ -49,6 +52,17 @@ public class MethodComponentContext implements ToXContentFragment {
     public MethodComponentContext(String name, Map<String, Object> parameters) {
         this.name = name;
         this.parameters = parameters;
+    }
+
+    /**
+     * Constructor from stream.
+     *
+     * @param in StreamInput
+     * @throws IOException on stream failure
+     */
+    public MethodComponentContext(StreamInput in) throws IOException {
+        this.name = in.readString();
+        this.parameters = in.readMap();
     }
 
     /**
@@ -166,5 +180,11 @@ public class MethodComponentContext implements ToXContentFragment {
      */
     public Map<String, Object> getParameters() {
         return parameters;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.name);
+        out.writeMap(this.parameters);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.index;
 
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.util.KNNEngine;
 import com.google.common.collect.ImmutableMap;
@@ -31,6 +32,31 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 
 public class KNNMethodContextTests extends KNNTestCase {
+
+    /**
+     * Test reading from and writing to streams
+     */
+    public void testStreams() throws IOException {
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        SpaceType spaceType = SpaceType.INNER_PRODUCT;
+        String name = "test-name";
+        Map<String, Object> parameters = ImmutableMap.of(
+                "test-p-1", 10,
+                "test-p-2", "string-p"
+        );
+
+        MethodComponentContext originalMethodComponent = new MethodComponentContext(name, parameters);
+
+        KNNMethodContext original = new KNNMethodContext(knnEngine, spaceType, originalMethodComponent);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+
+        KNNMethodContext copy = new KNNMethodContext(streamOutput.bytes().streamInput());
+
+        assertEquals(original, copy);
+    }
+
     /**
      * Test method component getter
      */

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -26,6 +27,27 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class MethodComponentContextTests extends KNNTestCase {
+
+    /**
+     * Test reading from and writing to streams
+     */
+    public void testStreams() throws IOException {
+        String name = "test-name";
+        Map<String, Object> parameters = ImmutableMap.of(
+                "test-p-1", 10,
+                "test-p-2", "string-p"
+        );
+
+        MethodComponentContext original = new MethodComponentContext(name, parameters);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+
+        MethodComponentContext copy = new MethodComponentContext(streamOutput.bytes().streamInput());
+
+        assertEquals(original, copy);
+    }
+
     /**
      * Test parse where input is invalid
      */

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -20,6 +20,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.mapper.MapperParsingException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,9 +34,13 @@ public class MethodComponentContextTests extends KNNTestCase {
      */
     public void testStreams() throws IOException {
         String name = "test-name";
+        String nestedName = "nested-name";
+        MethodComponentContext nestedParam = new MethodComponentContext(nestedName, Collections.emptyMap());
+
         Map<String, Object> parameters = ImmutableMap.of(
                 "test-p-1", 10,
-                "test-p-2", "string-p"
+                "test-p-2", "string-p",
+                "test-p-3", nestedParam
         );
 
         MethodComponentContext original = new MethodComponentContext(name, parameters);


### PR DESCRIPTION
### Description
This PR implements streaming for KNNMethodContext and MethodComponentContext classes. The train request for the train api will have a KNNMethodContext, so KNNMethodContext needs to implement stream interfaces so that the request can be passed around to different nodes.
 
### Issues Resolved
#114 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
