### PR TITLE
Update action name from default to constant for UpdateModelMetadataTransportAction

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportAction.java
@@ -52,14 +52,13 @@ public class UpdateModelMetadataTransportAction extends TransportMasterNodeActio
     private UpdateModelMetadataExecutor updateModelMetadataExecutor;
 
     @Inject
-    public UpdateModelMetadataTransportAction(String actionName,
-                                              TransportService transportService,
+    public UpdateModelMetadataTransportAction(TransportService transportService,
                                               ClusterService clusterService,
                                               ThreadPool threadPool,
                                               ActionFilters actionFilters,
                                               IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(actionName, transportService, clusterService, threadPool, actionFilters, UpdateModelMetadataRequest::new,
-                indexNameExpressionResolver);
+        super(UpdateModelMetadataAction.NAME, transportService, clusterService, threadPool, actionFilters,
+                UpdateModelMetadataRequest::new, indexNameExpressionResolver);
         this.updateModelMetadataExecutor = new UpdateModelMetadataExecutor();
     }
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This adds the UpdateModelMetadataAction name to the constructor of UpdateModelMetadataTransportAction. This was not caught before because the action name defaulted to "". But, when I tried adding another action with the default action name, I received an error.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
