### PR TITLE
Modify ModelDoa's getMetadata to return null instead of throw exception

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -235,6 +235,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             if (modelIdAsString != null) {
                 ModelMetadata modelMetadata = modelDao.getMetadata(modelIdAsString);
 
+                if (modelMetadata == null) {
+                    throw new IllegalArgumentException("Model \"" + modelId + "\" does not exist");
+                }
+
                 return new ModelFieldMapper(
                         name,
                         new KNNVectorFieldType(buildFullName(context), meta.getValue(), modelMetadata.getDimension()),

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -334,17 +334,23 @@ public interface ModelDao {
             IndexMetadata indexMetadata = clusterService.state().metadata().index(MODEL_INDEX_NAME);
 
             if (indexMetadata == null) {
+                logger.debug("ModelMetadata for model \"" + modelId + "\" is null. " + MODEL_INDEX_NAME +
+                        " index does not exist.");
                 return null;
             }
 
             Map<String, String> models = indexMetadata.getCustomData(MODEL_METADATA_FIELD);
             if (models == null) {
+                logger.debug("ModelMetadata for model \"" + modelId + "\" is null. " + MODEL_INDEX_NAME +
+                        "'s custom metadata does not exist.");
                 return null;
             }
 
             String modelMetadata = models.get(modelId);
 
             if (modelMetadata == null) {
+                logger.debug("ModelMetadata for model \"" + modelId + "\" is null. Model \"" + modelId + "\" does " +
+                        "not exist.");
                 return null;
             }
 

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -117,7 +117,7 @@ public interface ModelDao {
      * Get metadata for a model. Non-blocking.
      *
      * @param modelId to retrieve
-     * @return modelMetadata
+     * @return modelMetadata. If model metadata does not exist, returns null
      */
     ModelMetadata getMetadata(String modelId);
 
@@ -334,18 +334,18 @@ public interface ModelDao {
             IndexMetadata indexMetadata = clusterService.state().metadata().index(MODEL_INDEX_NAME);
 
             if (indexMetadata == null) {
-                throw new RuntimeException("Model index's metadata does not exist");
+                return null;
             }
 
             Map<String, String> models = indexMetadata.getCustomData(MODEL_METADATA_FIELD);
             if (models == null) {
-                throw new RuntimeException("Model metadata does not exist");
+                return null;
             }
 
             String modelMetadata = models.get(modelId);
 
             if (modelMetadata == null) {
-                throw new RuntimeException("Model \"" + modelId + "\" does not exist");
+                return null;
             }
 
             return ModelMetadata.fromString(modelMetadata);

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -315,12 +315,12 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         String modelId = "test-model";
 
         // Model Index does not exist
-        expectThrows(RuntimeException.class, () -> modelDao.getMetadata(modelId));
+        assertNull(modelDao.getMetadata(modelId));
 
         createIndex(MODEL_INDEX_NAME);
 
         // Model id does not exist
-        expectThrows(RuntimeException.class, () -> modelDao.getMetadata(modelId));
+        assertNull(modelDao.getMetadata(modelId));
 
         // Model exists
         byte [] modelBlob = "hello".getBytes();


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This is a small change in modeldao. Instead of throwing an exception when the model is not there, it will return null. This is primarily because when validating a training request, we need to make sure that the model does not already exist, as we do not support updates. So, instead of catching an error, we can just do a null check.
 
### Check List
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
