### PR TITLE
Use published daily snapshot dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,17 +27,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          ref: '1.x'
-          path: OpenSearch
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-
       - name: Run build
         run: |
           ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -26,22 +26,18 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
 
     // This isn't applying from repositories.gradle so repeating git diff it here
     repositories {
+        mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        mavenLocal()
         jcenter()
     }
-
-    repositories {
-        mavenLocal()
-    }
-
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
@@ -61,9 +57,10 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    mavenLocal()
     jcenter()
 }
 


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Fetch dependencies from published locations in the following order
maven local, aws sonatype, central.
 
### Issues Resolved
#106  
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
