### PR TITLE
Update delete model response

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelAction.java
@@ -13,14 +13,20 @@ package org.opensearch.knn.plugin.transport;
 
 import org.opensearch.action.ActionType;
 import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.common.io.stream.Writeable;
 
-public class DeleteModelAction extends ActionType<DeleteResponse> {
+public class DeleteModelAction extends ActionType<DeleteModelResponse> {
 
 
     public static final DeleteModelAction INSTANCE = new DeleteModelAction();
     public static final String NAME = "cluster:admin/knn_delete_model_action";
 
     private DeleteModelAction() {
-        super(NAME, DeleteResponse::new);
+        super(NAME, DeleteModelResponse::new);
+    }
+
+    @Override
+    public Writeable.Reader<DeleteModelResponse> getResponseReader() {
+        return DeleteModelResponse::new;
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelResponse.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelResponse.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.DocWriteResponse;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+
+/**
+ * {@link DeleteModelResponse} represents Response returned by {@link DeleteModelRequest}
+ */
+public class DeleteModelResponse extends ActionResponse implements ToXContentObject {
+
+    public static final String RESULT = "result";
+    public static final String ERROR_MSG = "error";
+    private final String modelID;
+    private final String result;
+    private final String errorMessage;
+
+    public DeleteModelResponse(@Nonnull String modelID, @Nonnull String result, @Nullable String errorMessage) {
+        this.modelID = modelID;
+        this.result = result;
+        this.errorMessage = errorMessage;
+    }
+
+    public DeleteModelResponse(StreamInput in) throws IOException {
+        super(in);
+        this.modelID = in.readString();
+        this.result = in.readString();
+        this.errorMessage = in.readOptionalString();
+    }
+
+    public String getModelID() {
+        return modelID;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        /* Response should look like below:
+            {
+                "model_id": "my_model_id"
+                "result": "not_found",
+                "error": "Model my_model_id doesn't exist"
+        }
+         */
+        builder.startObject();
+        builder.field(MODEL_ID, getModelID());
+        builder.field(RESULT, getResult());
+        if (Strings.hasText(errorMessage)){
+            builder.field(ERROR_MSG, getErrorMessage());
+        }
+        builder.endObject();
+        return builder;
+
+    }
+
+    @Override
+    public void writeTo(StreamOutput output) throws IOException {
+        output.writeString(modelID);
+        output.writeString(getResult());
+        output.writeOptionalString(getErrorMessage());
+    }
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelTransportAction.java
@@ -20,7 +20,7 @@ import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-public class DeleteModelTransportAction extends HandledTransportAction<DeleteModelRequest, DeleteResponse> {
+public class DeleteModelTransportAction extends HandledTransportAction<DeleteModelRequest, DeleteModelResponse> {
 
 
     private final ModelDao modelDao;
@@ -32,7 +32,7 @@ public class DeleteModelTransportAction extends HandledTransportAction<DeleteMod
     }
 
     @Override
-    protected void doExecute(Task task, DeleteModelRequest request, ActionListener<DeleteResponse> listener) {
+    protected void doExecute(Task task, DeleteModelRequest request, ActionListener<DeleteModelResponse> listener) {
         String modelID = request.getModelID();
         modelDao.delete(modelID, listener);
     }

--- a/src/test/java/org/opensearch/knn/plugin/transport/DeleteModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/DeleteModelResponseTests.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.transport;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+
+import java.io.IOException;
+
+public class DeleteModelResponseTests extends KNNTestCase {
+
+    public void testStreams() throws IOException {
+        String modelId = "test-model";
+        DeleteModelResponse deleteModelResponse = new DeleteModelResponse(modelId, "delete action failed", "error message");
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        deleteModelResponse.writeTo(streamOutput);
+        DeleteModelResponse deleteModelResponseCopy = new DeleteModelResponse(streamOutput.bytes().streamInput());
+        assertEquals(deleteModelResponse.getModelID(), deleteModelResponseCopy.getModelID());
+        assertEquals(deleteModelResponse.getResult(), deleteModelResponseCopy.getResult());
+        assertEquals(deleteModelResponse.getErrorMessage(), deleteModelResponseCopy.getErrorMessage());
+    }
+
+
+    public void testXContentWithError() throws IOException {
+        String modelId = "test-model";
+        DeleteModelResponse deleteModelResponse = new DeleteModelResponse(modelId, "not_found", "model id not found");
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        deleteModelResponse.writeTo(streamOutput);
+        String expectedResponseString = "{\"model_id\":\"test-model\",\"result\":\"not_found\",\"error\":\"model id not found\"}";
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        deleteModelResponse.toXContent(xContentBuilder, null);
+        assertEquals(expectedResponseString, Strings.toString(xContentBuilder));
+    }
+
+    public void testXContentWithoutError() throws IOException {
+        String modelId = "test-model";
+        DeleteModelResponse deleteModelResponse = new DeleteModelResponse(modelId, "deleted", null);
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        deleteModelResponse.writeTo(streamOutput);
+        String expectedResponseString = "{\"model_id\":\"test-model\",\"result\":\"deleted\"}";
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        deleteModelResponse.toXContent(xContentBuilder, null);
+        assertEquals(expectedResponseString, Strings.toString(xContentBuilder));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Since DeleteResponse displays model index name, added
DeleteModelResponse to display only the model id and status.
Updated tests accordingly.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
