### PR TITLE
Fix requires training to check nested params

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethod.java
@@ -84,10 +84,11 @@ public class KNNMethod {
     /**
      * returns whether training is required or not
      *
+     * @param knnMethodContext context to check if training is required on
      * @return true if training is required; false otherwise
      */
-    public boolean isTrainingRequired() {
-        return methodComponent.IsTrainingRequired();
+    public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
+        return methodComponent.isTrainingRequired(knnMethodContext.getMethodComponent());
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -16,7 +16,6 @@ import org.opensearch.knn.common.KNNConstants;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -121,24 +120,29 @@ public class MethodComponent {
         MethodComponentContext parameterMethodComponentContext;
         for (Map.Entry<String, Object> providedParameter : providedParameters.entrySet()) {
 
+            // Its not this methods job to check if the provided parameter is valid. If it is not, it doesnt
+            // training
             if (!parameters.containsKey(providedParameter.getKey())) {
-                // Its not this methods job to check if the provided parameter is valid. If it is not, it doesnt
-                // training
                 continue;
             }
 
             // MethodComponentContextParameters are parameters that are MethodComponentContexts.
             // MethodComponent may or may not require training. So, we have to check if the parameter requires training
             parameter = parameters.get(providedParameter.getKey());
+            if (!(parameter instanceof Parameter.MethodComponentContextParameter)) {
+                continue;
+            }
+            methodParameter = (Parameter.MethodComponentContextParameter) parameter;
+
             providedValue = providedParameter.getValue();
-            if (parameter instanceof Parameter.MethodComponentContextParameter &&
-                    providedValue instanceof MethodComponentContext) {
-                methodParameter = (Parameter.MethodComponentContextParameter) parameter;
-                parameterMethodComponentContext = (MethodComponentContext) providedValue;
-                methodComponent = methodParameter.getMethodComponent(parameterMethodComponentContext.getName());
-                if (methodComponent.isTrainingRequired(parameterMethodComponentContext)) {
-                    return true;
-                }
+            if (!(providedValue instanceof MethodComponentContext)) {
+                continue;
+            }
+            parameterMethodComponentContext = (MethodComponentContext) providedValue;
+
+            methodComponent = methodParameter.getMethodComponent(parameterMethodComponentContext.getName());
+            if (methodComponent.isTrainingRequired(parameterMethodComponentContext)) {
+                return true;
             }
         }
 

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -115,6 +115,7 @@ public class MethodComponent {
         }
 
         Parameter<?> parameter;
+        Object providedValue;
         Parameter.MethodComponentContextParameter methodParameter;
         MethodComponent methodComponent;
         MethodComponentContext parameterMethodComponentContext;
@@ -129,9 +130,11 @@ public class MethodComponent {
             // MethodComponentContextParameters are parameters that are MethodComponentContexts.
             // MethodComponent may or may not require training. So, we have to check if the parameter requires training
             parameter = parameters.get(providedParameter.getKey());
-            if (parameter instanceof Parameter.MethodComponentContextParameter) {
+            providedValue = providedParameter.getValue();
+            if (parameter instanceof Parameter.MethodComponentContextParameter &&
+                    providedValue instanceof MethodComponentContext) {
                 methodParameter = (Parameter.MethodComponentContextParameter) parameter;
-                parameterMethodComponentContext = (MethodComponentContext) providedParameter.getValue();
+                parameterMethodComponentContext = (MethodComponentContext) providedValue;
                 methodComponent = methodParameter.getMethodComponent(parameterMethodComponentContext.getName());
                 if (methodComponent.isTrainingRequired(parameterMethodComponentContext)) {
                     return true;

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -200,7 +200,7 @@ public interface KNNLibrary {
         @Override
         public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
             String methodName = knnMethodContext.getMethodComponent().getName();
-            return getMethod(methodName).isTrainingRequired();
+            return getMethod(methodName).isTrainingRequired(knnMethodContext);
         }
 
         @Override

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -25,8 +25,11 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
@@ -120,11 +123,25 @@ public class KNNMethodContextTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.NMSLIB, SpaceType.L2, hnswMethod);
         assertFalse(knnMethodContext.isTrainingRequired());
 
-        // Check for FAISS
+        // Check for FAISS not required
         hnswMethod = new MethodComponentContext(METHOD_HNSW, Collections.emptyMap());
         knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, hnswMethod);
         assertFalse(knnMethodContext.isTrainingRequired());
 
+        // Check FAISS required
+        MethodComponentContext pq = new MethodComponentContext(ENCODER_PQ, Collections.emptyMap());
+
+        MethodComponentContext hnswMethodPq = new MethodComponentContext(METHOD_HNSW, ImmutableMap.of(METHOD_ENCODER_PARAMETER, pq));
+        knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, hnswMethodPq);
+        assertTrue(knnMethodContext.isTrainingRequired());
+
+        MethodComponentContext ivfMethod = new MethodComponentContext(METHOD_IVF, Collections.emptyMap());
+        knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, ivfMethod);
+        assertTrue(knnMethodContext.isTrainingRequired());
+
+        MethodComponentContext ivfMethodPq = new MethodComponentContext(METHOD_IVF, ImmutableMap.of(METHOD_ENCODER_PARAMETER, pq));
+        knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, ivfMethodPq);
+        assertTrue(knnMethodContext.isTrainingRequired());
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR fixes a bug in the require training logic. Encoders are parameters of methods. For instance:
```
{
  "name": "ivf",
  "parameters": {
      "encoder": {
           "name": "pq",
           ...
      }
  }
}
```
 
Because the encoder may require training, it needs to be checked as well.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
