### PR TITLE
Allow model to implement Writeable, ToXContent

### DIFF
--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -14,15 +14,37 @@ package org.opensearch.knn.indices;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
 
+import java.io.IOException;
+import java.util.Base64;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class Model {
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_BLOB_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ERROR;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_TIMESTAMP;
 
+public class Model implements Writeable, ToXContent {
+
+    private String modelID;
     private ModelMetadata modelMetadata;
     private AtomicReference<byte[]> modelBlob;
 
+    //TODO: Remove this constructor, by migrate dependents to other constructor
     /**
      * Constructor
      *
@@ -41,12 +63,49 @@ public class Model {
     }
 
     /**
+     * Constructor
+     *
+     * @param modelMetadata metadata about the model
+     * @param modelBlob binary representation of model template index. Can be null if model is not yet in CREATED state.
+     * @param modelID model identifier
+     */
+    public Model(ModelMetadata modelMetadata, @Nullable byte[] modelBlob, String modelID) {
+        this(modelMetadata,modelBlob);
+        this.modelID = Objects.requireNonNull(modelID, "model id must not be null");
+    }
+
+    private byte[] readOptionalModelBlob(StreamInput in) throws IOException {
+        return in.readBoolean() ? in.readByteArray(): null;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param in Stream input
+     */
+    public Model(StreamInput in) throws IOException {
+        this.modelMetadata = new ModelMetadata(in);
+        this.modelBlob = new AtomicReference<>(readOptionalModelBlob(in));
+        this.modelID = in.readOptionalString();
+    }
+
+
+    /**
      * getter for model's metadata
      *
-     * @return knnEngine
+     * @return model's metadata
      */
     public ModelMetadata getModelMetadata() {
         return modelMetadata;
+    }
+
+    /**
+     * getter for model's identifier
+     *
+     * @return model's id
+     */
+    public String getModelID() {
+        return modelID;
     }
 
     /**
@@ -97,5 +156,50 @@ public class Model {
     @Override
     public int hashCode() {
         return new HashCodeBuilder().append(getModelMetadata()).append(getModelBlob()).toHashCode();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        if(Strings.hasText(modelID)){
+            builder.field(MODEL_ID, modelID);
+        }
+        builder.field(MODEL_STATE, getModelMetadata().getState().getName());
+        builder.field(MODEL_TIMESTAMP, getModelMetadata().getTimestamp());
+        builder.field(MODEL_DESCRIPTION, getModelMetadata().getDescription());
+        builder.field(MODEL_ERROR, getModelMetadata().getError());
+
+        String base64Model = "";
+        if(getModelBlob() != null){
+            base64Model = Base64.getEncoder().encodeToString(getModelBlob());
+        }
+        builder.field(MODEL_BLOB_PARAMETER, base64Model);
+
+        builder.field(METHOD_PARAMETER_SPACE_TYPE, getModelMetadata().getSpaceType().getValue());
+        builder.field(DIMENSION, getModelMetadata().getDimension());
+        builder.field(KNN_ENGINE, getModelMetadata().getKnnEngine().getName());
+
+        return xContentBuilder.endObject();
+    }
+
+    private void writeOptionalModelBlob(StreamOutput output) throws IOException {
+        if(getModelBlob() == null){
+            output.writeBoolean(false);
+            return;
+        }
+        output.writeBoolean(true);
+        output.writeByteArray(getModelBlob());
+    }
+
+    /**
+     * Write this into the {@linkplain StreamOutput}.
+     *
+     * @param output instance of {@linkplain StreamOutput}.
+     */
+    @Override
+    public void writeTo(StreamOutput output) throws IOException {
+        getModelMetadata().writeTo(output);
+        writeOptionalModelBlob(output);
+        output.writeOptionalString(modelID);
     }
 }

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -386,8 +386,8 @@ public interface ModelDao {
                     return;
                 }
                 final Map<String, Object> responseMap = response.getSourceAsMap();
-                Model model = new Model(getMetadataFromResponse(responseMap), getModelBlobFromResponse(responseMap));
-                actionListener.onResponse(new GetModelResponse(modelId, model));
+                Model model = new Model(getMetadataFromResponse(responseMap), getModelBlobFromResponse(responseMap), modelId);
+                actionListener.onResponse(new GetModelResponse(model));
 
             }, actionListener::onFailure));
         }

--- a/src/main/java/org/opensearch/knn/plugin/transport/GetModelResponse.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/GetModelResponse.java
@@ -16,48 +16,23 @@ import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.knn.indices.Model;
-import org.opensearch.knn.indices.ModelMetadata;
 
 import java.io.IOException;
-import java.util.Base64;
-import java.util.Objects;
-
-import static org.opensearch.knn.common.KNNConstants.DIMENSION;
-import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
-import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
-import static org.opensearch.knn.common.KNNConstants.MODEL_BLOB_PARAMETER;
-import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
-import static org.opensearch.knn.common.KNNConstants.MODEL_ERROR;
-import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
-import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
-import static org.opensearch.knn.common.KNNConstants.MODEL_TIMESTAMP;
 
 /**
  * {@link GetModelResponse} represents Response returned by {@link GetModelRequest}
  */
 public class GetModelResponse extends ActionResponse implements ToXContentObject {
 
-    private final String modelID;
     private final Model model;
 
-    public GetModelResponse(String modelID, Model model) {
-        this.modelID = modelID;
+    public GetModelResponse(Model model) {
         this.model = model;
     }
 
     public GetModelResponse(StreamInput in) throws IOException {
         super(in);
-        this.modelID = in.readString();
-        ModelMetadata metadata = new ModelMetadata(in);
-        this.model = new Model(metadata, readOptionalModelBlob(in));
-    }
-
-    private byte[] readOptionalModelBlob(StreamInput in) throws IOException {
-        return in.readBoolean() ? in.readByteArray(): null;
-    }
-
-    public String getModelID() {
-        return modelID;
+        this.model = new Model(in);
     }
 
     public Model getModel() {
@@ -79,42 +54,12 @@ public class GetModelResponse extends ActionResponse implements ToXContentObject
                 "dimension": 128
         }
          */
-        builder.startObject();
-        builder.field(MODEL_ID, modelID);
-        builder.field(MODEL_STATE, model.getModelMetadata().getState().getName());
-        builder.field(MODEL_TIMESTAMP, model.getModelMetadata().getTimestamp());
-        builder.field(MODEL_DESCRIPTION, model.getModelMetadata().getDescription());
-        builder.field(MODEL_ERROR, model.getModelMetadata().getError());
-
-        String base64Model = "";
-        if(model.getModelBlob() != null){
-            base64Model = Base64.getEncoder().encodeToString(model.getModelBlob());
-        }
-        builder.field(MODEL_BLOB_PARAMETER, base64Model);
-
-        builder.field(METHOD_PARAMETER_SPACE_TYPE, model.getModelMetadata().getSpaceType().getValue());
-        builder.field(DIMENSION, model.getModelMetadata().getDimension());
-        builder.field(KNN_ENGINE, model.getModelMetadata().getKnnEngine().getName());
-
-        builder.endObject();
-
-        return builder;
-    }
-
-    private void writeOptionalModelBlob(StreamOutput output) throws IOException {
-        if(model.getModelBlob() == null){
-            output.writeBoolean(false);
-            return;
-        }
-        output.writeBoolean(true);
-        output.writeByteArray(model.getModelBlob());
+        return model.toXContent(builder, params);
     }
 
 
     @Override
     public void writeTo(StreamOutput output) throws IOException {
-        output.writeString(modelID);
-        model.getModelMetadata().writeTo(output);
-        writeOptionalModelBlob(output);
+        model.writeTo(output);
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -35,12 +35,11 @@ public class GetModelResponseTests extends KNNTestCase {
     public void testStreams() throws IOException {
         String modelId = "test-model";
         byte[] testModelBlob = "hello".getBytes();
-        Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob);
-        GetModelResponse getModelResponse = new GetModelResponse(modelId, model);
+        Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
+        GetModelResponse getModelResponse = new GetModelResponse(model);
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         getModelResponse.writeTo(streamOutput);
         GetModelResponse getModelResponseCopy = new GetModelResponse(streamOutput.bytes().streamInput());
-        assertEquals(getModelResponse.getModelID(), getModelResponseCopy.getModelID());
         assertEquals(getModelResponse.getModel(), getModelResponseCopy.getModel());
     }
 
@@ -48,8 +47,8 @@ public class GetModelResponseTests extends KNNTestCase {
     public void testXContent() throws IOException {
         String modelId = "test-model";
         byte[] testModelBlob = "hello".getBytes();
-        Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob);
-        GetModelResponse getModelResponse = new GetModelResponse(modelId, model);
+        Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob,modelId);
+        GetModelResponse getModelResponse = new GetModelResponse(model);
         String expectedResponseString = "{\"model_id\":\"test-model\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"model_blob\":\"aGVsbG8=\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\"}";
         XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         getModelResponse.toXContent(xContentBuilder, null);
@@ -58,8 +57,8 @@ public class GetModelResponseTests extends KNNTestCase {
 
     public void testXContentWithNoModelBlob() throws IOException {
         String modelId = "test-model";
-        Model model = new Model(getModelMetadata(ModelState.FAILED), null);
-        GetModelResponse getModelResponse = new GetModelResponse(modelId, model);
+        Model model = new Model(getModelMetadata(ModelState.FAILED), null, modelId);
+        GetModelResponse getModelResponse = new GetModelResponse(model);
         String expectedResponseString = "{\"model_id\":\"test-model\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"model_blob\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\"}";
         XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
         getModelResponse.toXContent(xContentBuilder, null);


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Refactor toXContent from GetModelResponse to Model, since it will be shared by SearchModelResponse
in future commits.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
