### PR TITLE
Convert size estimates for individual allocations to ints

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -49,7 +49,7 @@ public class KNNConstants {
     public static final String MODEL_INDEX_NAME = ".opensearch-knn-models";
     public static final String PLUGIN_NAME = "knn";
     public static final String MODEL_METADATA_FIELD = "knn-models";
-    public static final Long BYTES_PER_KILOBYTES = 1024L;
+    public static final Integer BYTES_PER_KILOBYTES = 1024;
     public static final String PREFERENCE_PARAMETER = "preference";
 
     public static final String MODEL_STATE = "state";

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -23,7 +23,7 @@ public class IndexUtil {
      * @param filePath path to the file
      * @return file size in kilobytes
      */
-    public static long getFileSizeInKB(String filePath) {
+    public static int getFileSizeInKB(String filePath) {
         if (filePath == null || filePath.isEmpty()) {
             return 0;
         }
@@ -32,6 +32,6 @@ public class IndexUtil {
             return 0;
         }
 
-        return (file.length() / BYTES_PER_KILOBYTES) + 1L; // Add one so that integer division rounds up
+        return Math.toIntExact((file.length() / BYTES_PER_KILOBYTES) + 1L); // Add one so that integer division rounds up
     }
 }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryAllocation.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryAllocation.java
@@ -73,7 +73,7 @@ public interface NativeMemoryAllocation {
      *
      * @return size of native memory allocation
      */
-    long getSizeInKb();
+    int getSizeInKb();
 
     /**
      * Represents native indices loaded into memory. Because these indices are backed by files, they should be
@@ -83,7 +83,7 @@ public interface NativeMemoryAllocation {
 
         private final ExecutorService executor;
         private final long memoryAddress;
-        private final long size;
+        private final int size;
         private volatile boolean closed;
         private final KNNEngine knnEngine;
         private final String indexPath;
@@ -102,7 +102,7 @@ public interface NativeMemoryAllocation {
          * @param openSearchIndexName Name of OpenSearch index this index is associated with
          * @param watcherHandle Handle for watching index file
          */
-        IndexAllocation(ExecutorService executorService, long memoryAddress, long size, KNNEngine knnEngine,
+        IndexAllocation(ExecutorService executorService, long memoryAddress, int size, KNNEngine knnEngine,
                         String indexPath, String openSearchIndexName, WatcherHandle<FileWatcher> watcherHandle) {
             this.executor = executorService;
             this.closed = false;
@@ -180,7 +180,7 @@ public interface NativeMemoryAllocation {
         }
 
         @Override
-        public long getSizeInKb() {
+        public int getSizeInKb() {
             return size;
         }
 
@@ -221,7 +221,7 @@ public interface NativeMemoryAllocation {
 
         private volatile boolean closed;
         private long memoryAddress;
-        private final long size;
+        private final int size;
 
         // Implement reader/writer with semaphores to deal with passing lock conditions between threads
         private int readCount;
@@ -235,7 +235,7 @@ public interface NativeMemoryAllocation {
          * @param memoryAddress pointer in memory to the training data allocation
          * @param size amount memory needed for allocation in kilobytes
          */
-        TrainingDataAllocation(ExecutorService executor, long memoryAddress, long size) {
+        TrainingDataAllocation(ExecutorService executor, long memoryAddress, int size) {
             this.executor = executor;
             this.closed = false;
             this.memoryAddress = memoryAddress;
@@ -355,7 +355,7 @@ public interface NativeMemoryAllocation {
         }
 
         @Override
-        public long getSizeInKb() {
+        public int getSizeInKb() {
             return size;
         }
 

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -75,7 +75,7 @@ public class NativeMemoryCacheManager implements Closeable {
 
         if(KNNSettings.state().getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED)) {
             maxWeight = KNNSettings.getCircuitBreakerLimit().getKb();
-            cacheBuilder.maximumWeight(maxWeight).weigher((k, v) -> (int)v.getSizeInKb());
+            cacheBuilder.maximumWeight(maxWeight).weigher((k, v) -> v.getSizeInKb());
         }
 
         if(KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED)) {

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -47,7 +47,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
      *
      * @return size calculator
      */
-    public abstract Long calculateSizeInKb();
+    public abstract Integer calculateSizeInKb();
 
     /**
      * Loads entry into memory.
@@ -81,7 +81,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         }
 
         @Override
-        public Long calculateSizeInKb() {
+        public Integer calculateSizeInKb() {
             return IndexSizeCalculator.INSTANCE.apply(this);
         }
 
@@ -108,14 +108,14 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             return parameters;
         }
 
-        private static class IndexSizeCalculator implements Function<IndexEntryContext, Long> {
+        private static class IndexSizeCalculator implements Function<IndexEntryContext, Integer> {
 
             static IndexSizeCalculator INSTANCE = new IndexSizeCalculator();
 
             IndexSizeCalculator() {}
 
             @Override
-            public Long apply(IndexEntryContext indexEntryContext) {
+            public Integer apply(IndexEntryContext indexEntryContext) {
                 return IndexUtil.getFileSizeInKB(indexEntryContext.getKey());
             }
         }
@@ -126,7 +126,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         private static final String KEY_PREFIX = "tdata#";
         private static final String DELIMETER = ":";
 
-        private final long size;
+        private final int size;
         private final NativeMemoryLoadStrategy.TrainingLoadStrategy trainingLoadStrategy;
         private final IndicesService indicesService;
         private final String trainIndexName;
@@ -145,7 +145,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
          * @param maxVectorCount maximum number of vectors there can be
          * @param searchSize size each search request should return during loading
          */
-        public TrainingDataEntryContext(long size,
+        public TrainingDataEntryContext(int size,
                                         String trainIndexName,
                                         String trainFieldName,
                                         NativeMemoryLoadStrategy.TrainingLoadStrategy trainingLoadStrategy,
@@ -163,7 +163,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         }
 
         @Override
-        public Long calculateSizeInKb() {
+        public Integer calculateSizeInKb() {
             return size;
         }
 

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
@@ -106,7 +106,7 @@ public class TrainingJobRouterTransportAction extends HandledTransportAction<Tra
         return selectedNode;
     }
 
-    protected void getTrainingIndexSizeInKB(TrainingModelRequest trainingModelRequest, ActionListener<Long> listener) {
+    protected void getTrainingIndexSizeInKB(TrainingModelRequest trainingModelRequest, ActionListener<Integer> listener) {
         // For this function, I referred to the rest count action: https://github.com/opensearch-project/OpenSearch/
         // blob/main/server/src/main/java/org/opensearch/rest/action/search/RestCountAction.java
         SearchRequest countRequest = new SearchRequest(trainingModelRequest.getTrainingIndex());
@@ -118,7 +118,6 @@ public class TrainingJobRouterTransportAction extends HandledTransportAction<Tra
             long trainingVectors = searchResponse.getHits().getTotalHits().value;
 
             // If there are more docs in the index than what the user wants to use for training, take the min
-            //TODO: We need to change max vector count to a long. For future PR.
             if (trainingModelRequest.getMaximumVectorCount() < trainingVectors) {
                 trainingVectors = trainingModelRequest.getMaximumVectorCount();
             }
@@ -134,7 +133,8 @@ public class TrainingJobRouterTransportAction extends HandledTransportAction<Tra
      * @param dimension dimension of vectors
      * @return size estimate
      */
-    public static long estimateVectorSetSizeInKb(long vectorCount, int dimension) {
-        return((Float.BYTES * dimension * vectorCount) / BYTES_PER_KILOBYTES ) + 1L;
+    public static int estimateVectorSetSizeInKb(long vectorCount, int dimension) {
+        // Ensure we do not overflow the int on estimate
+        return Math.toIntExact(((Float.BYTES * dimension * vectorCount) / BYTES_PER_KILOBYTES ) + 1L);
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -46,7 +46,7 @@ public class TrainingModelRequest extends ActionRequest {
     private int maximumVectorCount;
     private int searchSize;
 
-    private long trainingDataSizeInKB;
+    private int trainingDataSizeInKB;
 
     /**
      * Constructor.
@@ -96,7 +96,7 @@ public class TrainingModelRequest extends ActionRequest {
         this.description = in.readOptionalString();
         this.maximumVectorCount = in.readInt();
         this.searchSize = in.readInt();
-        this.trainingDataSizeInKB = in.readLong();
+        this.trainingDataSizeInKB = in.readInt();
     }
 
     /**
@@ -224,7 +224,7 @@ public class TrainingModelRequest extends ActionRequest {
      *
      * @return trainingDataSizeInKB
      */
-    public long getTrainingDataSizeInKB() {
+    public int getTrainingDataSizeInKB() {
         return trainingDataSizeInKB;
     }
 
@@ -233,7 +233,7 @@ public class TrainingModelRequest extends ActionRequest {
      *
      * @param trainingDataSizeInKB to be set.
      */
-    void setTrainingDataSizeInKB(long trainingDataSizeInKB) {
+    void setTrainingDataSizeInKB(int trainingDataSizeInKB) {
         if (trainingDataSizeInKB <= 0) {
             throw new IllegalArgumentException("Training data size " + trainingDataSizeInKB + " is invalid. " +
                     "Training data size must be greater than 0");
@@ -302,7 +302,7 @@ public class TrainingModelRequest extends ActionRequest {
         out.writeOptionalString(this.description);
         out.writeInt(this.maximumVectorCount);
         out.writeInt(this.searchSize);
-        out.writeLong(this.trainingDataSizeInKB);
+        out.writeInt(this.trainingDataSizeInKB);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
@@ -175,7 +175,7 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
     }
 
     public void testIndexAllocation_getSize() {
-        long size = 12;
+        int size = 12;
         NativeMemoryAllocation.IndexAllocation indexAllocation = new NativeMemoryAllocation.IndexAllocation(
                 null,
                 0,
@@ -351,7 +351,7 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
     }
 
     public void testTrainingDataAllocation_getSize() {
-        long size = 12;
+        int size = 12;
 
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
                 null,

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
@@ -54,7 +54,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
 
         // Put entry in cache and check that the weight matches
-        long size = 10;
+        int size = 10;
         TestNativeMemoryEntryContent testNativeMemoryEntryContent = new TestNativeMemoryEntryContent("test", size);
         nativeMemoryCacheManager.get(testNativeMemoryEntryContent, true);
 
@@ -76,8 +76,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         assertEquals(0, nativeMemoryCacheManager.getCacheSizeInKilobytes());
 
         // Put 2 entries in cache and check that the weight matches
-        long size1 = 10;
-        long size2 = 20;
+        int size1 = 10;
+        int size2 = 20;
         TestNativeMemoryEntryContent testNativeMemoryEntryContent1 = new TestNativeMemoryEntryContent("test-1", size1);
         nativeMemoryCacheManager.get(testNativeMemoryEntryContent1, true);
         TestNativeMemoryEntryContent testNativeMemoryEntryContent2 = new TestNativeMemoryEntryContent("test-2", size2);
@@ -90,7 +90,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     public void testGetCacheSizeAsPercentage() throws ExecutionException {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
         long maxWeight = nativeMemoryCacheManager.getMaxCacheSizeInKilobytes();
-        long entryWeight = maxWeight / 3;
+        int entryWeight = (int) (maxWeight / 3);
 
         TestNativeMemoryEntryContent testNativeMemoryEntryContent = new TestNativeMemoryEntryContent(
                 "test-1", entryWeight, 0);
@@ -105,8 +105,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
 
     public void testGetIndexSizeInKilobytes() throws ExecutionException, IOException {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
-        long genericEntryWeight = 100L;
-        long indexEntryWeight = 20L;
+        int genericEntryWeight = 100;
+        int indexEntryWeight = 20;
 
         TestNativeMemoryEntryContent testNativeMemoryEntryContent = new TestNativeMemoryEntryContent(
                 "test-1", genericEntryWeight, 0);
@@ -140,8 +140,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     public void testGetIndexSizeAsPercentage() throws ExecutionException, IOException {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
         long maxWeight = nativeMemoryCacheManager.getMaxCacheSizeInKilobytes();
-        long genericEntryWeight = maxWeight / 3;
-        long indexEntryWeight = maxWeight / 3;
+        int genericEntryWeight = (int) (maxWeight / 3);
+        int indexEntryWeight = (int) (maxWeight / 3);
 
         TestNativeMemoryEntryContent testNativeMemoryEntryContent = new TestNativeMemoryEntryContent(
                 "test-1", genericEntryWeight, 0);
@@ -176,8 +176,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     public void testGetIndexGraphCount() throws ExecutionException, IOException {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
         long maxWeight = nativeMemoryCacheManager.getMaxCacheSizeInKilobytes();
-        long genericEntryWeight = maxWeight / 3;
-        long indexEntryWeight = maxWeight / 3;
+        int genericEntryWeight = (int) (maxWeight / 3);
+        int indexEntryWeight = (int) (maxWeight / 3);
 
         TestNativeMemoryEntryContent testNativeMemoryEntryContent = new TestNativeMemoryEntryContent(
                 "test-1", genericEntryWeight, 0);
@@ -272,7 +272,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     public void testGet_evictable() throws ExecutionException {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
 
-        long size = 12;
+        int size = 12;
         long pointer = 64;
 
         TestNativeMemoryEntryContent testNativeMemoryEntryContent1 = new TestNativeMemoryEntryContent("test-1", size, pointer);
@@ -289,7 +289,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     public void testGet_unevictable() throws ExecutionException {
         // So, I think we will need to first load an entry that has a large size
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
-        long maxWeight = nativeMemoryCacheManager.getMaxCacheSizeInKilobytes();
+        int maxWeight = (int) nativeMemoryCacheManager.getMaxCacheSizeInKilobytes();
 
         TestNativeMemoryEntryContent testNativeMemoryEntryContent1 = new TestNativeMemoryEntryContent("test-1", maxWeight/2);
         nativeMemoryCacheManager.get(testNativeMemoryEntryContent1, true);
@@ -365,8 +365,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         String testKey3 = "test-3";
         String testKey4 = "test-4";
 
-        long size1 = 3;
-        long size2 = 5;
+        int size1 = 3;
+        int size2 = 5;
 
         NativeMemoryAllocation.IndexAllocation indexAllocation1 = new NativeMemoryAllocation.IndexAllocation(
                 null,
@@ -433,23 +433,23 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         indicesStats = nativeMemoryCacheManager.getIndicesCacheStats();
         assertEquals(2, indicesStats.get(indexName1).get(GRAPH_COUNT));
         assertEquals(2, indicesStats.get(indexName2).get(GRAPH_COUNT));
-        assertEquals(size1 + size2, indicesStats.get(indexName1).get(GRAPH_MEMORY_USAGE.getName()));
-        assertEquals(size1 + size2, indicesStats.get(indexName2).get(GRAPH_MEMORY_USAGE.getName()));
+        assertEquals((long) (size1 + size2), indicesStats.get(indexName1).get(GRAPH_MEMORY_USAGE.getName()));
+        assertEquals((long)size1 + size2, indicesStats.get(indexName2).get(GRAPH_MEMORY_USAGE.getName()));
 
         nativeMemoryCacheManager.close();
     }
 
     private static class TestNativeMemoryAllocation implements NativeMemoryAllocation {
 
-        long size;
+        int size;
         long memoryAddress;
 
-        TestNativeMemoryAllocation(long size) {
+        TestNativeMemoryAllocation(int size) {
             this.size = size;
             this.memoryAddress = 0;
         }
 
-        TestNativeMemoryAllocation(long size, long memoryAddress) {
+        TestNativeMemoryAllocation(int size, long memoryAddress) {
             this.size = size;
             this.memoryAddress = memoryAddress;
         }
@@ -490,7 +490,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         }
 
         @Override
-        public long getSizeInKb() {
+        public int getSizeInKb() {
             return size;
         }
     }
@@ -498,22 +498,22 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     private static class TestNativeMemoryEntryContent extends NativeMemoryEntryContext<TestNativeMemoryAllocation> {
 
         long memoryAddress;
-        long size;
+        int size;
 
-        TestNativeMemoryEntryContent(String key, long size) {
+        TestNativeMemoryEntryContent(String key, int size) {
             super(key);
             this.size = size;
             this.memoryAddress = 0;
         }
 
-        TestNativeMemoryEntryContent(String key, long size, long memoryAddress) {
+        TestNativeMemoryEntryContent(String key, int size, long memoryAddress) {
             super(key);
             this.size = size;
             this.memoryAddress = memoryAddress;
         }
 
         @Override
-        public Long calculateSizeInKb() {
+        public Integer calculateSizeInKb() {
             return size;
         }
 

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryEntryContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryEntryContextTests.java
@@ -77,7 +77,7 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
         }
 
         // Get the expected size of this function
-        long expectedSize = IndexUtil.getFileSizeInKB(tmpFile.toAbsolutePath().toString());
+        int expectedSize = IndexUtil.getFileSizeInKB(tmpFile.toAbsolutePath().toString());
 
         // Check that the indexEntryContext will return the same thing
         NativeMemoryEntryContext.IndexEntryContext indexEntryContext = new NativeMemoryEntryContext.IndexEntryContext(
@@ -250,14 +250,14 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
         }
 
         @Override
-        public long getSizeInKb() {
+        public int getSizeInKb() {
             return 0;
         }
     }
 
     private static class TestNativeMemoryEntryContext extends NativeMemoryEntryContext<TestNativeMemoryAllocation> {
 
-        long size;
+        int size;
 
         /**
          * Constructor
@@ -265,13 +265,13 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
          * @param key  String used to identify entry in the cache
          * @param size size this allocation will take up in the cache
          */
-        public TestNativeMemoryEntryContext(String key, long size) {
+        public TestNativeMemoryEntryContext(String key, int size) {
             super(key);
             this.size = size;
         }
 
         @Override
-        public Long calculateSizeInKb() {
+        public Integer calculateSizeInKb() {
             return size;
         }
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportActionTests.java
@@ -283,8 +283,8 @@ public class TrainingJobRouterTransportActionTests extends KNNTestCase {
 
         String trainingIndexName = "training-index";
         int dimension = 133;
-        long vectorCount = 1000000;
-        long expectedSize =  dimension * vectorCount * Float.BYTES / BYTES_PER_KILOBYTES + 1; // 519,531.25 KB ~= 520 MB
+        int vectorCount = 1000000;
+        int expectedSize =  dimension * vectorCount * Float.BYTES / BYTES_PER_KILOBYTES + 1; // 519,531.25 KB ~= 520 MB
 
         // Setup the request
         TrainingModelRequest trainingModelRequest = new TrainingModelRequest(
@@ -314,8 +314,8 @@ public class TrainingJobRouterTransportActionTests extends KNNTestCase {
         TrainingJobRouterTransportAction transportAction = new TrainingJobRouterTransportAction(
                 transportService, new ActionFilters(Collections.emptySet()), clusterService, client);
 
-        ActionListener<Long> listener = ActionListener.wrap(
-                size -> assertEquals(expectedSize, size.longValue()),
+        ActionListener<Integer> listener = ActionListener.wrap(
+                size -> assertEquals(expectedSize, size.intValue()),
                 e -> fail(e.getMessage())
         );
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
@@ -109,7 +109,7 @@ public class TrainingModelRequestTests extends KNNTestCase {
         String description = "some test description";
         int maxVectorCount = 100;
         int searchSize = 101;
-        long trainingSetSizeInKB = 102;
+        int trainingSetSizeInKB = 102;
 
         TrainingModelRequest trainingModelRequest = new TrainingModelRequest(
                 modelId,


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR switches all size estimates from Long to Int. For any native allocation type, we store a size number with it that corresponds to the number of kilobytes the allocation takes up in native memory. This is used by the cache to manage memory.

Each entry in the cache needs to provide its size as an int. Interestingly, however, the weight of the cache is a long. This is done [intentionally](https://github.com/google/guava/issues/3202).

Any way, this PR converts size estimates to ints and for functions that return long, it wraps them in `Math.toIntExact` function so that an exception will be thrown if int is overloaded by long.
 
### Issues Resolved
#126 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
