### PR TITLE
Return from training after model is initially serialized

### DIFF
--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -97,7 +97,20 @@ public class TrainingJobRunner {
                                 // Update model id with id from response. We do this because users may or may not
                                 // provide an id
                                 trainingJob.setModelId(indexResponse.getId());
-                                train(trainingJob, listener);
+
+                                // Respond to the request with the initial index response
+                                listener.onResponse(indexResponse);
+
+                                // Because we already responded to the request above, we should just add some
+                                // logging statements here.
+                                ActionListener<IndexResponse> loggingListener = ActionListener.wrap(
+                                        secondIndexResponse -> logger.debug("[KNN] Training for model \"" +
+                                                trainingJob.getModelId() + "\" was successful"),
+                                        e -> logger.error("[KNN] Training for model \"" + trainingJob.getModelId()  +
+                                                "\" failed with the following error: " + e.getMessage())
+                                );
+
+                                train(trainingJob, loggingListener);
                             },
                             exception -> {
                                 // Serialization failed. Let listener handle the exception, but free up resources.

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -206,7 +206,7 @@ public class FaissIT extends KNNRestTestCase {
         deleteKnnDoc(INDEX_NAME, "1");
     }
 
-    public void testEndToEnd_fromModel() throws IOException {
+    public void testEndToEnd_fromModel() throws IOException, InterruptedException {
         String modelId = "test-model";
         int dimension = 128;
 
@@ -230,6 +230,9 @@ public class FaissIT extends KNNRestTestCase {
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "faiss test description");
+
+        // Make sure training succeeds after 30 seconds
+        assertTrainingSucceeds(modelId, 30, 1000);
 
         // Create knn index from model
         String fieldName = "test-field-name";

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -207,7 +207,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
 //        assertEquals("failed", responseMap.get(MODEL_STATE));
     }
 
-    public void testTrainModel_success_withId() throws IOException {
+    public void testTrainModel_success_withId() throws IOException, InterruptedException {
         // Test checks that training when passing in an id succeeds
 
         String modelId = "test-model-id";
@@ -277,6 +277,9 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         ).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
+
+        // Make sure training succeeds after 30 seconds
+        assertTrainingSucceeds(modelId, 30, 1000);
     }
 
     public void testTrainModel_success_noId() throws IOException {


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This change will return the training response immediately after the model is initially serialized in the training state. For example:

```
POST /_plugins/_knn/models/my_model/_train
{
  "training_index": "train_index",
  "training_field": "train_field",
  "dimension": 8,
  "method": {
      "name":"ivf",
      "engine":"faiss",
      "space_type": "l2",
      "parameters":{
        "nlist":16,
        "encoder":{
            "name":"pq",
            "parameters":{
                "code_size":8,
                "code_count": 2
            }
        }
      }
  }
}

{"model_id":"my_model"}

GET /_plugins/_knn/models/my_model?pretty

{
  "model_id" : "my_model",
  "state" : "training",
  "timestamp" : "2021-10-15T20:18:06.357557Z",
  "error" : "",
  "model_blob" : "",
  "space_type" : "l2",
  "dimension" : 8,
  "engine" : "faiss"
}

...
GET /_plugins/_knn/models/my_model?pretty

{
  "model_id" : "my_model",
  "state" : "created",
  "timestamp" : "2021-10-15T20:18:06.357557Z",
  "error" : "",
  "model_blob" : "aaaaa....."
  "space_type" : "l2",
  "dimension" : 8,
  "engine" : "faiss"
}
```
 
Training can take a long time to complete. In some cases, the request will timeout before returning a response. If a user makes a request without specifying the model id and the request times out, it will be difficult to determine what the assigned id for the model is.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
