### PR TITLE
Fix model cache configuration

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -99,4 +99,5 @@ public class KNNConstants {
     public static final Integer METHOD_PARAMETER_NLIST_DEFAULT = 4;
     public static final Integer METHOD_PARAMETER_NLIST_LIMIT = 20000;
     public static final Integer MAX_MODEL_DESCRIPTION_LENGTH = 1000; // max number of chars a model's description can be
+    public static final Integer MODEL_CACHE_EXPIRE_AFTER_ACCESS_TIME_MINUTES = 30;
 }

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -57,6 +57,7 @@ import static org.opensearch.common.settings.Setting.Property.Dynamic;
 import static org.opensearch.common.settings.Setting.Property.IndexScope;
 import static org.opensearch.common.settings.Setting.Property.NodeScope;
 import static org.opensearch.common.unit.ByteSizeValue.parseBytesSizeValue;
+import static org.opensearch.common.unit.MemorySizeValue.parseBytesSizeValueOrHeapRatio;
 
 /**
  * This class defines
@@ -91,7 +92,7 @@ public class KNNSettings {
     public static final String KNN_INDEX = "index.knn";
     public static final String MODEL_INDEX_NUMBER_OF_SHARDS = "knn.model_index_number_of_shards";
     public static final String MODEL_INDEX_NUMBER_OF_REPLICAS = "knn.model_index_number_of_replicas";
-    public static final String MODEL_CACHE_SIZE_IN_BYTES = "knn.model_cache.size_in_bytes";
+    public static final String MODEL_CACHE_SIZE_LIMIT = "knn.model_cache.size.limit";
 
     /**
      * Default setting values
@@ -102,10 +103,8 @@ public class KNNSettings {
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION = 512;
     public static final Integer KNN_DEFAULT_ALGO_PARAM_INDEX_THREAD_QTY = 1;
     public static final Integer KNN_DEFAULT_CIRCUIT_BREAKER_UNSET_PERCENTAGE = 75;
-    public static final Integer KNN_DEFAULT_MODEL_CACHE_SIZE_IN_BYTES = 50000000; // 50 Mb
-    public static final Integer KNN_MAX_MODEL_CACHE_SIZE_IN_BYTES = 80000000; // 80 Mb
-    public static final Integer KNN_MIN_MODEL_CACHE_SIZE_IN_BYTES = 0;
-
+    public static final String KNN_DEFAULT_MODEL_CACHE_SIZE_LIMIT = "10%"; // By default, set aside 10% of the JVM for the limit
+    public static final Double KNN_MAX_MODEL_CACHE_SIZE_LIMIT = 0.25; // Model cache limit cannot exceed 25% of the JVM heap
 
     /**
      * Settings Definition
@@ -164,13 +163,29 @@ public class KNNSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic);
 
-    public static final Setting<Long> MODEL_CACHE_SIZE_IN_BYTES_SETTING = Setting.longSetting(
-            MODEL_CACHE_SIZE_IN_BYTES,
-            KNN_DEFAULT_MODEL_CACHE_SIZE_IN_BYTES,
-            KNN_MIN_MODEL_CACHE_SIZE_IN_BYTES,
-            KNN_MAX_MODEL_CACHE_SIZE_IN_BYTES,
+    public static final Setting<ByteSizeValue> MODEL_CACHE_SIZE_LIMIT_SETTING = new Setting<>(
+            MODEL_CACHE_SIZE_LIMIT,
+            KNN_DEFAULT_MODEL_CACHE_SIZE_LIMIT,
+            (s) -> {
+                ByteSizeValue userDefinedLimit =  parseBytesSizeValueOrHeapRatio(s, MODEL_CACHE_SIZE_LIMIT);
+
+                // parseBytesSizeValueOrHeapRatio will make sure that the value entered falls between 0 and 100% of the
+                // JVM heap. However, we want the maximum percentage of the heap to be much smaller. So, we add
+                // some additional validation here before returning
+                ByteSizeValue jvmHeapSize = JvmInfo.jvmInfo().getMem().getHeapMax();
+                if (userDefinedLimit.getKbFrac() / jvmHeapSize.getKbFrac() > KNN_MAX_MODEL_CACHE_SIZE_LIMIT) {
+                    throw new OpenSearchParseException("{} ({} KB) cannot exceed {}% of the heap ({} KB).",
+                            MODEL_CACHE_SIZE_LIMIT,
+                            userDefinedLimit.getKb(),
+                            KNN_MAX_MODEL_CACHE_SIZE_LIMIT*100,
+                            jvmHeapSize.getKb());
+                }
+
+                return userDefinedLimit;
+            },
             Setting.Property.NodeScope,
-            Setting.Property.Dynamic);
+            Setting.Property.Dynamic
+    );
 
     /**
      * This setting identifies KNN index.
@@ -325,7 +340,7 @@ public class KNNSettings {
                 IS_KNN_INDEX_SETTING,
                 MODEL_INDEX_NUMBER_OF_SHARDS_SETTING,
                 MODEL_INDEX_NUMBER_OF_REPLICAS_SETTING,
-                MODEL_CACHE_SIZE_IN_BYTES_SETTING);
+                MODEL_CACHE_SIZE_LIMIT_SETTING);
         return Stream.concat(settings.stream(), dynamicCacheSettings.values().stream())
                      .collect(Collectors.toList());
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.Version.CURRENT;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
-import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_IN_BYTES_SETTING;
+import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_LIMIT_SETTING;
 
 /**
  * Test used for testing Codecs
@@ -233,9 +233,9 @@ public class  KNNCodecTestCase extends KNNTestCase {
         when(modelDao.get(modelId)).thenReturn(mockModel);
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata1);
 
-        Settings settings = settings(CURRENT).put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), 10).build();
+        Settings settings = settings(CURRENT).put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), 10).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
 
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(settings);

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_IN_BYTES_SETTING;
+import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_LIMIT_SETTING;
 
 public class ModelCacheTests extends KNNTestCase {
 
@@ -40,9 +40,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -65,9 +65,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -86,9 +86,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenThrow(new IllegalArgumentException());
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -117,9 +117,9 @@ public class ModelCacheTests extends KNNTestCase {
         when(modelDao.get(modelId2)).thenReturn(mockModel2);
 
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -132,7 +132,7 @@ public class ModelCacheTests extends KNNTestCase {
         modelCache.get(modelId1);
         modelCache.get(modelId2);
 
-        assertEquals(size1 + size2, modelCache.getTotalWeight());
+        assertEquals(size1 + size2, modelCache.getTotalWeightInKB());
     }
 
     public void testRemove_normal() throws ExecutionException, InterruptedException {
@@ -152,9 +152,9 @@ public class ModelCacheTests extends KNNTestCase {
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
         when(modelDao.get(modelId2)).thenReturn(mockModel2);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -167,15 +167,15 @@ public class ModelCacheTests extends KNNTestCase {
         modelCache.get(modelId1);
         modelCache.get(modelId2);
 
-        assertEquals(size1 + size2, modelCache.getTotalWeight());
+        assertEquals(size1 + size2, modelCache.getTotalWeightInKB());
 
         modelCache.remove(modelId1);
 
-        assertEquals( size2, modelCache.getTotalWeight());
+        assertEquals( size2, modelCache.getTotalWeightInKB());
 
         modelCache.remove(modelId2);
 
-        assertEquals( 0, modelCache.getTotalWeight());
+        assertEquals( 0, modelCache.getTotalWeightInKB());
     }
 
     public void testRebuild_normal() throws ExecutionException, InterruptedException {
@@ -188,9 +188,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -200,15 +200,15 @@ public class ModelCacheTests extends KNNTestCase {
 
         // Add element to cache - nothing should be kept
         modelCache.get(modelId);
-        assertEquals(mockModel.getModelBlob().length, modelCache.getTotalWeight());
+        assertEquals(mockModel.getModelBlob().length, modelCache.getTotalWeightInKB());
 
         // Rebuild and make sure cache is empty
         modelCache.rebuild();
-        assertEquals(0, modelCache.getTotalWeight());
+        assertEquals(0, modelCache.getTotalWeightInKB());
 
         // Add element again
         modelCache.get(modelId);
-        assertEquals(mockModel.getModelBlob().length, modelCache.getTotalWeight());
+        assertEquals(mockModel.getModelBlob().length, modelCache.getTotalWeightInKB());
     }
 
     public void testRebuild_afterSettingUpdate() throws ExecutionException, InterruptedException {
@@ -225,9 +225,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize1).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize1).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -237,16 +237,16 @@ public class ModelCacheTests extends KNNTestCase {
 
         // Add element to cache - element should not remain in cache
         modelCache.get(modelId);
-        assertEquals(0, modelCache.getTotalWeight());
+        assertEquals(0, modelCache.getTotalWeightInKB());
 
         // Rebuild and make sure cache is empty
-        Settings newSettings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize2).build();
+        Settings newSettings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize2).build();
         clusterService.getClusterSettings().applySettings(newSettings);
-        assertEquals(0, modelCache.getTotalWeight());
+        assertEquals(0, modelCache.getTotalWeightInKB());
 
         // Add element again - element should remain in cache
         modelCache.get(modelId);
-        assertEquals(modelSize, modelCache.getTotalWeight());
+        assertEquals(modelSize, modelCache.getTotalWeightInKB());
     }
 
     public void testRemove_modelNotInCache() {
@@ -255,9 +255,9 @@ public class ModelCacheTests extends KNNTestCase {
 
         ModelDao modelDao = mock(ModelDao.class);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -265,9 +265,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelCache.initialize(modelDao, clusterService);
         ModelCache modelCache = new ModelCache();
 
-        assertEquals( 0, modelCache.getTotalWeight());
+        assertEquals( 0, modelCache.getTotalWeightInKB());
         modelCache.remove(modelId1);
-        assertEquals( 0, modelCache.getTotalWeight());
+        assertEquals( 0, modelCache.getTotalWeightInKB());
     }
 
     public void testContains() throws ExecutionException, InterruptedException {
@@ -284,9 +284,9 @@ public class ModelCacheTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -318,9 +318,9 @@ public class ModelCacheTests extends KNNTestCase {
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
         when(modelDao.get(modelId2)).thenReturn(mockModel2);
 
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), cacheSize).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
@@ -331,8 +331,8 @@ public class ModelCacheTests extends KNNTestCase {
         modelCache.get(modelId1);
         modelCache.get(modelId2);
 
-        assertEquals( modelSize1 + modelSize2, modelCache.getTotalWeight());
+        assertEquals( modelSize1 + modelSize2, modelCache.getTotalWeightInKB());
         modelCache.removeAll();
-        assertEquals( 0, modelCache.getTotalWeight());
+        assertEquals( 0, modelCache.getTotalWeightInKB());
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -282,7 +282,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         assertTrainingSucceeds(modelId, 30, 1000);
     }
 
-    public void testTrainModel_success_noId() throws IOException {
+    public void testTrainModel_success_noId() throws IOException, InterruptedException {
         // Test to check if training succeeds when no id is passed in
 
         String trainingIndexName = "train-index";
@@ -363,5 +363,6 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 
+        assertTrainingSucceeds(modelId, 30, 1000);
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -28,15 +28,15 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_IN_BYTES_SETTING;
+import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_LIMIT_SETTING;
 
 public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestCase {
 
     public void testNodeOperation_modelNotInCache() {
         ClusterService clusterService = mock(ClusterService.class);
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), 100).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), 100).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
@@ -45,7 +45,7 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
 
         // Check that model cache is initially empty
         ModelCache modelCache = ModelCache.getInstance();
-        assertEquals(0, modelCache.getTotalWeight());
+        assertEquals(0, modelCache.getTotalWeightInKB());
 
         // Remove the model from the cache
         RemoveModelFromCacheTransportAction action = node().injector()
@@ -54,14 +54,14 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
         RemoveModelFromCacheNodeRequest request = new RemoveModelFromCacheNodeRequest("invalid-model");
         action.nodeOperation(request);
 
-        assertEquals(0L, modelCache.getTotalWeight());
+        assertEquals(0L, modelCache.getTotalWeightInKB());
     }
 
     public void testNodeOperation_modelInCache() throws ExecutionException, InterruptedException {
         ClusterService clusterService = mock(ClusterService.class);
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_IN_BYTES_SETTING.getKey(), 100).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), 100).build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
-                ImmutableSet.of(MODEL_CACHE_SIZE_IN_BYTES_SETTING));
+                ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
@@ -88,6 +88,6 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
         RemoveModelFromCacheNodeRequest request = new RemoveModelFromCacheNodeRequest(modelId);
         action.nodeOperation(request);
 
-        assertEquals(0L, modelCache.getTotalWeight());
+        assertEquals(0L, modelCache.getTotalWeightInKB());
     }
 }


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
The model cache is used to store models in the heap during indexing. We set a capacity for this cache to control memory consumption.

This PR cleans up the cache's configuration. First, it converts the max size limit setting to a ByteSizeValue setting. This is customary for memory related settings. Second, it adds a 30 minute expiry time on the cache. So, if an item is not accessed for 30 minutes, it will be removed from the cache. This setting is an internal implementation detail, so I do not expose it as a user facing setting.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
