### PR TITLE
Add nprobes as parameter to IVF

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -97,6 +97,8 @@ public class KNNConstants {
     public static final Integer ENCODER_PARAMETER_PQ_CODE_SIZE_DEFAULT = 8;
     public static final Integer ENCODER_PARAMETER_PQ_CODE_SIZE_LIMIT = 128;
     public static final Integer METHOD_PARAMETER_NLIST_DEFAULT = 4;
+    public static final Integer METHOD_PARAMETER_NPROBES_DEFAULT = 1;
+    public static final Integer METHOD_PARAMETER_NPROBES_LIMIT = 20000;
     public static final Integer METHOD_PARAMETER_NLIST_LIMIT = 20000;
     public static final Integer MAX_MODEL_DESCRIPTION_LENGTH = 1000; // max number of chars a model's description can be
 }

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -46,6 +46,9 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST_DEFAULT;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST_LIMIT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES_DEFAULT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES_LIMIT;
 
 /**
  * KNNLibrary is an interface that helps the plugin communicate with k-NN libraries
@@ -386,6 +389,8 @@ public interface KNNLibrary {
                         .build())
                         .addSpaces(SpaceType.L2, SpaceType.INNER_PRODUCT).build(),
                 METHOD_IVF, KNNMethod.Builder.builder(MethodComponent.Builder.builder(METHOD_IVF)
+                        .addParameter(METHOD_PARAMETER_NPROBES,
+                                new Parameter.IntegerParameter(METHOD_PARAMETER_NPROBES_DEFAULT, v -> v > 0 && v < METHOD_PARAMETER_NPROBES_LIMIT))
                         .addParameter(METHOD_PARAMETER_NLIST,
                                 new Parameter.IntegerParameter(METHOD_PARAMETER_NLIST_DEFAULT, v -> v > 0 && v < METHOD_PARAMETER_NLIST_LIMIT))
                         .addParameter(METHOD_ENCODER_PARAMETER,


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Small PR to add `nprobes` parameter as parameter for IVF method. `nprobes` will determine how many buckets are searched during query.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
