### PR TITLE
Add validation to check max int limit in train API

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -14,6 +14,7 @@ package org.opensearch.knn.plugin.rest;
 import com.google.common.collect.ImmutableList;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.TrainingJobRouterAction;
@@ -105,11 +106,11 @@ public class RestTrainModelHandler extends BaseRestHandler {
             } else if (KNN_METHOD.equals(fieldName) && ensureNotSet(fieldName, knnMethodContext)) {
                 knnMethodContext = KNNMethodContext.parse(parser.map());
             } else if (DIMENSION.equals(fieldName) && ensureNotSet(fieldName, dimension)) {
-                dimension = parser.intValue();
+                dimension = (Integer) NumberFieldMapper.NumberType.INTEGER.parse(parser.objectBytes(), false);
             } else if (MAX_VECTOR_COUNT_PARAMETER.equals(fieldName) && ensureNotSet(fieldName, maximumVectorCount)) {
-                maximumVectorCount = parser.intValue();
+                maximumVectorCount = (Integer) NumberFieldMapper.NumberType.INTEGER.parse(parser.objectBytes(), false);
             } else if (SEARCH_SIZE_PARAMETER.equals(fieldName) && ensureNotSet(fieldName, searchSize)) {
-                searchSize = parser.intValue();
+                searchSize = (Integer) NumberFieldMapper.NumberType.INTEGER.parse(parser.objectBytes(), false);
             } else if (MODEL_DESCRIPTION.equals(fieldName) && ensureNotSet(fieldName, description)) {
                 description = parser.text();
             } else {


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR checks to see if the int parameters in the training API are within integer bounds. If not, it will throw an illegal argument exception which will get propagated back to the user as a 400 error. 

For validation, we use the NumberFieldMappers INTEGER type's parser. Code can be found [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/mapper/NumberFieldMapper.java#L568-L584). 

Validation:
```
curl -X POST "localhost:9200/_plugins/_knn/models/_train" -H 'Content-Type: application/json' -d'
{
  "training_index": "train_index",
  "training_field": "train_field",
  "dimension": 8,
  "description": "this should be allowed to be null",
  "max_training_vector_count": 1312321312313123112312123123,
  "method": {
      "name":"ivf",
      "engine":"faiss",
      "space_type": "l2",
      "parameters":{
        "nlist":16,
        "encoder":{
            "name":"pq",
            "parameters":{
                "code_size":8,
                "code_count": 2
            }
        }
      }
  }
}
'
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Value [1312321312313123112312123123] is out of range for an integer"}],"type":"illegal_argument_exception","reason":"Value [1312321312313123112312123123] is out of range for an integer"},"status":400}
```
 

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
