### PR TITLE
Add lib into knn zip during build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,7 +70,7 @@ work_dir=$PWD
 git submodule update --init -- jni/external/nmslib
 git submodule update --init -- jni/external/faiss
 
-# Build knnlib and copy it to libs
+# Build knnlib
 cd jni
 
 # For x64, generalize arch so library is compatible for processors without simd instruction extensions


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This change manually adds the k-NN library into plugin zip during the build process. Previously, this was done in the the install phase: https://github.com/opensearch-project/opensearch-build/blob/main/scripts/components/k-NN/install.sh. However, this is unnecessary because we can just do it during the build phase. Once this PR is merged, I will remove the install script from opensearch-build. I will also backport change to 1.1.

Tested on ec2-instance, with $OUTPUT=tmp. Picking up at line 99:
```
[k-NN]$ zipPath=$(find . -path \*build/distributions/*.zip)  # Path to the zip produced by gradle (does not include lib)
[k-NN]$ zipName=$(basename $zipPath)
[k-NN]$ newZipDir=$work_dir/knn-stage  # Folder where the new zip will be located
[k-NN]$ newZipStage=$newZipDir/stage  # Folder where will build the new zip
[k-NN]$ mkdir -p $newZipDir
[k-NN]$ mkdir -p $newZipStage
[k-NN]$
[k-NN]$ cp $zipPath $newZipStage
[k-NN]$ cd $newZipStage
[stage]$ unzip *.zip
Archive:  opensearch-knn-1.1.0.0-SNAPSHOT.zip
  inflating: plugin-descriptor.properties
  inflating: plugin-security.policy
  inflating: opensearch-knn-1.1.0.0-SNAPSHOT.jar
  inflating: guava-29.0-jre.jar
  inflating: failureaccess-1.0.1.jar
  inflating: commons-lang-2.6.jar
  inflating: listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  inflating: jsr305-3.0.2.jar
  inflating: checker-qual-2.11.1.jar
  inflating: error_prone_annotations-2.3.4.jar
  inflating: j2objc-annotations-1.3.jar
[stage]$ rm *.zip
[stage]$ mkdir knnlib
[stage]$ cp $work_dir/jni/release/lib*knn* ./knnlib
[stage]$ zip -r $newZipDir/$zipName *
  adding: checker-qual-2.11.1.jar (deflated 31%)
  adding: commons-lang-2.6.jar (deflated 7%)
  adding: error_prone_annotations-2.3.4.jar (deflated 35%)
  adding: failureaccess-1.0.1.jar (deflated 40%)
  adding: guava-29.0-jre.jar (deflated 11%)
  adding: j2objc-annotations-1.3.jar (deflated 31%)
  adding: jsr305-3.0.2.jar (deflated 26%)
  adding: knnlib/ (stored 0%)
  adding: knnlib/libopensearchknn.so (deflated 68%)
  adding: listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar (deflated 33%)
  adding: opensearch-knn-1.1.0.0-SNAPSHOT.jar (deflated 10%)
  adding: plugin-descriptor.properties (deflated 55%)
  adding: plugin-security.policy (deflated 27%)
[stage]$ cd $work_dir
[k-NN]$ rm -rf $newZipStage
[k-NN]$
[k-NN]$ echo "COPY $newZipDir/*.zip"
COPY /home/ec2-user/k-NN/knn-stage/*.zip
[k-NN]$ mkdir -p $OUTPUT/plugins
[k-NN]$ cp $newZipDir/*.zip ${OUTPUT}/plugins
[k-NN]$ rm -rf $newZipDir
[k-NN]$
[k-NN]$
[k-NN]$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
	modified:   jni/external/faiss (untracked content)
	modified:   jni/external/nmslib (modified content)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	tmp/

no changes added to commit (use "git add" and/or "git commit -a")
[k-NN]$ ls tmp/plugins/
opensearch-knn-1.1.0.0-SNAPSHOT.zip
[k-NN]$ ls tmp
plugins
```
 
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
