### PR TITLE
Disable simd for arm faiss

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -78,9 +78,11 @@ if [ "$ARCHITECTURE" = "x64" ]; then
     sed -i -e 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
 fi
 
-# For arm, march=native is broken in centos 7. Manually override to lowest version of armv8.
+# For arm, march=native is broken in centos 7. Manually override to lowest version of armv8. Also, disable simd in faiss
+# file. This is broken on centos 7 as well.
 if [ "$ARCHITECTURE" = "arm64" ]; then
     sed -i -e 's/-march=native/-march=armv8-a/g' external/nmslib/similarity_search/CMakeLists.txt
+    sed -i -e 's/__aarch64__/__undefine_aarch64__/g' external/faiss/faiss/utils/distances_simd.cpp
 fi
 
 if [ "$JAVA_HOME" = "" ]; then


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR undefines simd instructions in faiss's distances_simd.h file in our build logic. These were not compiling on ARM Centos 7. I was able to confirm that this change fixes the build. In the future, I will take a closer look at this

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
