### PR TITLE
Make model id part of index

### DIFF
--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -168,7 +168,11 @@ public class Model implements Writeable, ToXContentObject {
     }
 
     private static String getModelIDFromResponse(Map<String, Object> responseMap) {
-        return (String) responseMap.get(MODEL_ID);
+        Object modelId = responseMap.get(MODEL_ID);
+        if (modelId == null) {
+            return null;
+        }
+        return (String) modelId;
     }
 
     private static byte[] getModelBlobFromResponse(Map<String, Object> responseMap){

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -11,8 +11,6 @@
 
 package org.opensearch.knn.indices;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.StreamInput;
@@ -127,16 +125,12 @@ public class Model implements Writeable, ToXContentObject {
         if (obj == null || getClass() != obj.getClass())
             return false;
         Model other = (Model) obj;
-
-        EqualsBuilder equalsBuilder = new EqualsBuilder();
-        equalsBuilder.append(getModelID(), other.getModelID());
-
-        return equalsBuilder.isEquals();
+        return other.getModelID().equals(this.getModelID());
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(getModelID()).toHashCode();
+        return getModelID().hashCode();
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/indices/Model.java
+++ b/src/main/java/org/opensearch/knn/indices/Model.java
@@ -130,15 +130,13 @@ public class Model implements Writeable, ToXContentObject {
 
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         equalsBuilder.append(getModelID(), other.getModelID());
-        equalsBuilder.append(getModelMetadata(), other.getModelMetadata());
-        equalsBuilder.append(getModelBlob(), other.getModelBlob());
 
         return equalsBuilder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(getModelID()).append(getModelMetadata()).append(getModelBlob()).toHashCode();
+        return new HashCodeBuilder().append(getModelID()).toHashCode();
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -13,6 +13,8 @@ package org.opensearch.knn.training;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.Strings;
+import org.opensearch.common.UUIDs;
 import org.opensearch.knn.index.JNIService;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
@@ -25,6 +27,7 @@ import org.opensearch.knn.indices.ModelState;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Encapsulates all information required to generate and train a model.
@@ -57,7 +60,8 @@ public class TrainingJob implements Runnable {
                        NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext,
                        NativeMemoryEntryContext.AnonymousEntryContext modelAnonymousEntryContext,
                        int dimension, String description) {
-        this.modelId = modelId;
+        // Generate random base64 string if one is not provided
+        this.modelId = Strings.hasText(modelId) ? modelId : UUIDs.randomBase64UUID();
         this.knnMethodContext = Objects.requireNonNull(knnMethodContext, "MethodContext cannot be null.");
         this.nativeMemoryCacheManager = Objects.requireNonNull(nativeMemoryCacheManager,
                 "NativeMemoryCacheManager cannot be null.");
@@ -75,7 +79,8 @@ public class TrainingJob implements Runnable {
                                 description,
                                 ""
                         ),
-                        null
+                        null,
+                        this.modelId
                     );
     }
 
@@ -86,15 +91,6 @@ public class TrainingJob implements Runnable {
      */
     public String getModelId() {
         return modelId;
-    }
-
-    /**
-     * Setter for model id.
-     *
-     * @param modelId to set
-     */
-    public void setModelId(String modelId) {
-        this.modelId = modelId;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -97,10 +97,6 @@ public class TrainingJobRunner {
                     trainingJob,
                     ActionListener.wrap(
                             indexResponse -> {
-                                // Update model id with id from response. We do this because users may or may not
-                                // provide an id
-                                trainingJob.setModelId(indexResponse.getId());
-
                                 // Respond to the request with the initial index response
                                 listener.onResponse(indexResponse);
                                 train(trainingJob);
@@ -169,9 +165,9 @@ public class TrainingJobRunner {
     private void serializeModel(TrainingJob trainingJob, ActionListener<IndexResponse> listener, boolean update)
             throws IOException {
         if (update) {
-            modelDao.update(trainingJob.getModelId(), trainingJob.getModel(), listener);
+            modelDao.update(trainingJob.getModel(), listener);
         } else {
-            modelDao.put(trainingJob.getModelId(), trainingJob.getModel(), listener);
+            modelDao.put(trainingJob.getModel(), listener);
         }
     }
 

--- a/src/main/resources/mappings/model-index.json
+++ b/src/main/resources/mappings/model-index.json
@@ -1,5 +1,8 @@
 {
   "properties": {
+    "model_id": {
+      "type": "keyword"
+    },
     "engine": {
       "type": "keyword"
     },

--- a/src/test/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNRestTestCase.java
@@ -672,6 +672,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         );
 
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+                .field(MODEL_ID, modelId)
                 .field(MODEL_STATE, modelMetadata.getState().getName())
                 .field(KNN_ENGINE, modelMetadata.getKnnEngine().getName())
                 .field(METHOD_PARAMETER_SPACE_TYPE, modelMetadata.getSpaceType().getValue())

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -53,7 +53,7 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
-        Model model = new Model(modelMetadata, modelBlob);
+        Model model = new Model(modelMetadata, modelBlob, modelId);
 
         // Check that an index can be created from the model.
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
@@ -63,7 +63,7 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
         String indexName = "test-index";
         String fieldName = "test-field";
 
-        modelDao.put(modelId, model, ActionListener.wrap(indexResponse -> {
+        modelDao.put(model, ActionListener.wrap(indexResponse -> {
             CreateIndexRequestBuilder createIndexRequestBuilder = client().admin().indices().prepareCreate(indexName)
                     .setSettings(Settings.builder()
                             .put("number_of_shards", 1)

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -229,7 +229,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
         ModelMetadata modelMetadata1 = new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
 
-        Model mockModel = new Model(modelMetadata1, modelBlob);
+        Model mockModel = new Model(modelMetadata1, modelBlob, modelId);
         when(modelDao.get(modelId)).thenReturn(mockModel);
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata1);
 

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -35,7 +35,7 @@ public class ModelCacheTests extends KNNTestCase {
         String modelId = "test-model-id";
         int dimension = 2;
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), "hello".getBytes());
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), "hello".getBytes(), modelId);
         String cacheSize = "10%";
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -61,7 +61,7 @@ public class ModelCacheTests extends KNNTestCase {
 
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""),
-                new byte[BYTES_PER_KILOBYTES + 1]);
+                new byte[BYTES_PER_KILOBYTES + 1], modelId);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -108,10 +108,10 @@ public class ModelCacheTests extends KNNTestCase {
 
         int size1 = BYTES_PER_KILOBYTES;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size1], modelId1);
         int size2 = BYTES_PER_KILOBYTES * 3;
         Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size2]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size2], modelId2);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -144,10 +144,10 @@ public class ModelCacheTests extends KNNTestCase {
 
         int size1 = BYTES_PER_KILOBYTES;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size1], modelId1);
         int size2 = BYTES_PER_KILOBYTES * 3;
         Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size2]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size2], modelId2);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId1)).thenReturn(mockModel1);
@@ -184,7 +184,7 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
         String cacheSize = "10%";
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), "hello".getBytes());
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), "hello".getBytes(), modelId);
 
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.get(modelId)).thenReturn(mockModel);
@@ -218,7 +218,7 @@ public class ModelCacheTests extends KNNTestCase {
 
         int modelSize = 2 * BYTES_PER_KILOBYTES;
         Model mockModel = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize], modelId);
 
         String cacheSize1 = "1kb";
         String cacheSize2 = "4kb";
@@ -276,7 +276,7 @@ public class ModelCacheTests extends KNNTestCase {
         int dimension = 2;
         int modelSize1 = 100;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize1], modelId1);
 
         String modelId2 = "test-model-id-2";
 
@@ -306,12 +306,12 @@ public class ModelCacheTests extends KNNTestCase {
         String modelId1 = "test-model-id-1";
         int modelSize1 = BYTES_PER_KILOBYTES;
         Model mockModel1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize1]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize1], modelId1);
 
         String modelId2 = "test-model-id-2";
         int modelSize2 = BYTES_PER_KILOBYTES*2;
         Model mockModel2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize2]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[modelSize2], modelId2);
 
         String cacheSize = "10%";
 

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -26,57 +26,57 @@ import static org.opensearch.knn.index.KNNVectorFieldMapper.MAX_DIMENSION;
 public class ModelTests extends KNNTestCase {
 
     public void testNullConstructor() {
-        expectThrows(NullPointerException.class, () -> new Model(null, null));
+        expectThrows(NullPointerException.class, () -> new Model(null, null, "test-model"));
     }
 
     public void testInvalidConstructor() {
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
                 SpaceType.DEFAULT, -1, ModelState.FAILED, ZonedDateTime.now(ZoneOffset.UTC).toString(),
-                "", ""), null));
+                "", ""), null, "test-model"));
     }
 
     public void testInvalidDimension() {
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
                 SpaceType.DEFAULT, -1, ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(),
-                "", ""), new byte[16]));
+                "", ""), new byte[16], "test-model"));
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
                 SpaceType.DEFAULT, 0, ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(),
-                "", ""), new byte[16]));
+                "", ""), new byte[16], "test-model"));
         expectThrows(IllegalArgumentException.class, () -> new Model(new ModelMetadata(KNNEngine.DEFAULT,
                 SpaceType.DEFAULT, MAX_DIMENSION + 1, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[16]));
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[16], "test-model"));
     }
 
     public void testGetModelMetadata() {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         ModelMetadata modelMetadata = new ModelMetadata(knnEngine, SpaceType.DEFAULT, 2, ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(), "", "");
-        Model model = new Model(modelMetadata, new byte[16]);
+        Model model = new Model(modelMetadata, new byte[16], "test-model");
         assertEquals(modelMetadata, model.getModelMetadata());
     }
 
     public void testGetModelBlob() {
         byte[] modelBlob = "hello".getBytes();
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob, "test-model");
         assertArrayEquals(modelBlob, model.getModelBlob());
     }
 
     public void testGetLength() {
         int size = 129;
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size]);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), new byte[size], "test-model");
         assertEquals(size, model.getLength());
 
         model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 2, ModelState.TRAINING,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), null);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), null, "test-model");
         assertEquals(0, model.getLength());
     }
 
     public void testSetModelBlob() {
         byte[] blob1 = "Hello blob 1".getBytes();
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), blob1);
+                ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), blob1, "test-model");
         assertEquals(blob1, model.getModelBlob());
         byte[] blob2 = "Hello blob 2".getBytes();
 
@@ -89,15 +89,15 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
         Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
         Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
         Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[32]);
+                time, "", ""), new byte[32], "test-model");
         Model model5 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 4, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
 
         assertEquals(model1, model1);
         assertEquals(model1, model2);
@@ -111,13 +111,13 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
         Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
         Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[32]);
+                time, "", ""), new byte[32], "test-model");
         Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 4, ModelState.CREATED,
-                time, "", ""), new byte[16]);
+                time, "", ""), new byte[16], "test-model");
 
         assertEquals(model1.hashCode(), model1.hashCode());
         assertEquals(model1.hashCode(), model2.hashCode());
@@ -138,6 +138,7 @@ public class ModelTests extends KNNTestCase {
         ModelMetadata metadata = new ModelMetadata(knnEngine, spaceType, dimension, modelState,
             timestamp, description, error);
         Map<String,Object> modelAsMap = new HashMap<>();
+        modelAsMap.put(KNNConstants.MODEL_ID, modelID);
         modelAsMap.put(KNNConstants.KNN_ENGINE, knnEngine.getName());
         modelAsMap.put(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
         modelAsMap.put(KNNConstants.DIMENSION, dimension);
@@ -150,7 +151,7 @@ public class ModelTests extends KNNTestCase {
         byte[] blob1 = "hello".getBytes();
         Model expected = new Model(metadata, blob1, modelID);
 
-        Model fromMap = Model.getModelFromSourceMap(modelAsMap, modelID);
+        Model fromMap = Model.getModelFromSourceMap(modelAsMap);
         assertEquals(expected, fromMap);
     }
 }

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -89,21 +89,15 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
+                time, "", ""), new byte[16], "test-model-1");
         Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
+                time, "", ""), new byte[16], "test-model-1");
         Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
-        Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[32], "test-model");
-        Model model5 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 4, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
+                time, "", ""), new byte[16], "test-model-2");
 
         assertEquals(model1, model1);
         assertEquals(model1, model2);
         assertNotEquals(model1, model3);
-        assertNotEquals(model1, model4);
-        assertNotEquals(model1, model5);
     }
 
     public void testHashCode() {
@@ -111,18 +105,15 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
+                time, "", ""), new byte[16], "test-model-1");
         Model model2 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
+                time, "", ""), new byte[16], "test-model-1");
         Model model3 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED,
-                time, "", ""), new byte[32], "test-model");
-        Model model4 = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 4, ModelState.CREATED,
-                time, "", ""), new byte[16], "test-model");
+                time, "", ""), new byte[16], "test-model-2");
 
         assertEquals(model1.hashCode(), model1.hashCode());
         assertEquals(model1.hashCode(), model2.hashCode());
         assertNotEquals(model1.hashCode(), model3.hashCode());
-        assertNotEquals(model1.hashCode(), model4.hashCode());
     }
 
     public void testModelFromSourceMap() {

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -118,7 +118,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
 
             for(SearchHit hit: searchResponse.getHits().getHits()){
                 assertTrue(testModelID.contains(hit.getId()));
-                Model model = Model.getModelFromSourceMap(hit.getSourceAsMap(), hit.getId());
+                Model model = Model.getModelFromSourceMap(hit.getSourceAsMap());
                 assertEquals(getModelMetadata(),model.getModelMetadata());
                 assertArrayEquals(testModelBlob, model.getModelBlob());
             }

--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -70,7 +70,7 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
         Model model = new Model(
                 new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 16, ModelState.CREATED,
                 "timestamp", "description", ""),
-                new byte[128]
+                new byte[128], modelId
         );
 
         when(modelDao.get(modelId)).thenReturn(model);

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoTransportActionTests.java
@@ -69,7 +69,6 @@ public class TrainingJobRouteDecisionInfoTransportActionTests extends KNNSingleN
         TrainingJob trainingJob = mock(TrainingJob.class);
         when(trainingJob.getModelId()).thenReturn(modelId);
         when(trainingJob.getModel()).thenReturn(model);
-        doAnswer(invocationOnMock -> null).when(trainingJob).setModelId(modelId);
         doAnswer(invocationOnMock -> null).when(trainingJob).run();
 
         ModelDao modelDao = mock(ModelDao.class);
@@ -88,9 +87,9 @@ public class TrainingJobRouteDecisionInfoTransportActionTests extends KNNSingleN
                     0,
                     true
             );
-            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onResponse(indexResponse);
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[1]).onResponse(indexResponse);
             return null;
-        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+        }).when(modelDao).put(any(Model.class), any(ActionListener.class));
 
         // Set up the rest of the training logic
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -101,7 +100,7 @@ public class TrainingJobRouteDecisionInfoTransportActionTests extends KNNSingleN
         doAnswer(invocationOnMock -> {
             responseListener.onResponse(mock(IndexResponse.class));
             return null;
-        }).when(modelDao).update(modelId, model, responseListener);
+        }).when(modelDao).update(model, responseListener);
 
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
@@ -52,7 +52,6 @@ public class TrainingJobRunnerTests extends KNNTestCase {
         TrainingJob trainingJob = mock(TrainingJob.class);
         when(trainingJob.getModelId()).thenReturn(modelId);
         when(trainingJob.getModel()).thenReturn(model);
-        doAnswer(invocationOnMock -> null).when(trainingJob).setModelId(modelId);
         doAnswer(invocationOnMock -> null).when(trainingJob).run();
 
         // This gets called right after the initial put, before training begins. Just check that the model id is
@@ -74,13 +73,13 @@ public class TrainingJobRunnerTests extends KNNTestCase {
                     0,
                     true
                     );
-            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onResponse(indexResponse);
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[1]).onResponse(indexResponse);
             return null;
-        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+        }).when(modelDao).put(any(Model.class), any(ActionListener.class));
 
         // Function finishes when update is called
         doAnswer(invocationOnMock -> null)
-                .when(modelDao).update(anyString(), any(Model.class), any(ActionListener.class));
+                .when(modelDao).update(any(Model.class), any(ActionListener.class));
 
         // Finally, initialize the singleton runner, execute the job.
         TrainingJobRunner.initialize(threadPool, modelDao);
@@ -91,11 +90,9 @@ public class TrainingJobRunnerTests extends KNNTestCase {
         executorService.awaitTermination(10, TimeUnit.SECONDS);
 
         // Make sure these methods get called once
-        verify(trainingJob, times(1)).setModelId(modelId);
         verify(trainingJob, times(1)).run();
-        verify(modelDao, times(1))
-                .put(anyString(), any(Model.class), any(ActionListener.class));
-        verify(modelDao, times(1)).update(anyString(), any(Model.class), any(ActionListener.class));
+        verify(modelDao, times(1)).put(any(Model.class), any(ActionListener.class));
+        verify(modelDao, times(1)).update(any(Model.class), any(ActionListener.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -114,7 +111,6 @@ public class TrainingJobRunnerTests extends KNNTestCase {
         TrainingJob trainingJob = mock(TrainingJob.class);
         when(trainingJob.getModelId()).thenReturn(modelId);
         when(trainingJob.getModel()).thenReturn(model);
-        doAnswer(invocationOnMock -> null).when(trainingJob).setModelId(modelId);
         doAnswer(invocationOnMock -> null).when(trainingJob).run();
 
         // This gets called right after the initial put, before training begins. Just check that the model id is
@@ -137,16 +133,16 @@ public class TrainingJobRunnerTests extends KNNTestCase {
                     0,
                     true
             );
-            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[2]).onResponse(indexResponse);
+            ((ActionListener<IndexResponse>)invocationOnMock.getArguments()[1]).onResponse(indexResponse);
             return null;
-        }).when(modelDao).put(anyString(), any(Model.class), any(ActionListener.class));
+        }).when(modelDao).put(any(Model.class), any(ActionListener.class));
 
         // Once update is called, try to start another training job. This should fail because the calling thread
         // is running training
         TrainingJobRunner trainingJobRunner = TrainingJobRunner.getInstance();
         doAnswer(invocationOnMock -> expectThrows(RejectedExecutionException.class,
                 () -> trainingJobRunner.execute(trainingJob, responseListener))).when(modelDao)
-                .update(modelId, model, responseListener);
+                .update(model, responseListener);
 
         // Finally, initialize the singleton runner, execute the job.
         TrainingJobRunner.initialize(threadPool, modelDao);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -57,27 +57,6 @@ public class TrainingJobTests extends KNNTestCase {
         assertEquals(modelId, trainingJob.getModelId());
     }
 
-    public void testSetModelId() {
-        KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
-        when(knnMethodContext.getEngine()).thenReturn(KNNEngine.DEFAULT);
-        when(knnMethodContext.getSpaceType()).thenReturn(SpaceType.DEFAULT);
-
-        TrainingJob trainingJob = new TrainingJob(
-                "test-model-id",
-                knnMethodContext,
-                mock(NativeMemoryCacheManager.class),
-                mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
-                mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
-                10,
-                ""
-        );
-
-        String setModelId = "test-model-id-2";
-        trainingJob.setModelId(setModelId);
-
-        assertEquals(setModelId, trainingJob.getModelId());
-    }
-
     public void testGetModel() {
         SpaceType spaceType = SpaceType.INNER_PRODUCT;
         KNNEngine knnEngine = KNNEngine.DEFAULT;
@@ -89,8 +68,9 @@ public class TrainingJobTests extends KNNTestCase {
         when(knnMethodContext.getEngine()).thenReturn(knnEngine);
         when(knnMethodContext.getSpaceType()).thenReturn(spaceType);
 
+        String modelID = "test-model-id";
         TrainingJob trainingJob = new TrainingJob(
-                "test-model-id",
+                modelID,
                 knnMethodContext,
                 mock(NativeMemoryCacheManager.class),
                 mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
@@ -109,7 +89,8 @@ public class TrainingJobTests extends KNNTestCase {
                         desciption,
                         error
                 ),
-                null
+                null,
+                modelID
         );
 
         assertEquals(model, trainingJob.getModel());


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR restructures the model id to be a part of the model index's mapping. Previously, the model_id was stored only as the document id of the model in the index. This PR adds the "model_id" field to the mapping.

Additionally, this PR refactors the model logic to require a non-null model id during construction. Therefore, to create a Model object, a non-null model id needs to be passed in.

This PR will allow users to filter model search by model_id using _source_includes.
 
### Issues Resolved
#136 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
