### PR TITLE
Return 400 on failed training request

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -100,9 +100,9 @@ public class RestTrainModelHandler extends BaseRestHandler {
             parser.nextToken();
 
             if (TRAIN_INDEX_PARAMETER.equals(fieldName) && ensureNotSet(fieldName, trainingIndex)) {
-                trainingIndex = parser.text();
+                trainingIndex = parser.textOrNull();
             } else if (TRAIN_FIELD_PARAMETER.equals(fieldName) && ensureNotSet(fieldName, trainingField)) {
-                trainingField = parser.text();
+                trainingField = parser.textOrNull();
             } else if (KNN_METHOD.equals(fieldName) && ensureNotSet(fieldName, knnMethodContext)) {
                 knnMethodContext = KNNMethodContext.parse(parser.map());
             } else if (DIMENSION.equals(fieldName) && ensureNotSet(fieldName, dimension)) {
@@ -112,7 +112,7 @@ public class RestTrainModelHandler extends BaseRestHandler {
             } else if (SEARCH_SIZE_PARAMETER.equals(fieldName) && ensureNotSet(fieldName, searchSize)) {
                 searchSize = (Integer) NumberFieldMapper.NumberType.INTEGER.parse(parser.objectBytes(), false);
             } else if (MODEL_DESCRIPTION.equals(fieldName) && ensureNotSet(fieldName, description)) {
-                description = parser.text();
+                description = parser.textOrNull();
             } else {
                 throw new IllegalArgumentException("Unable to parse token. \"" + fieldName + "\" is not a valid " +
                         "parameter.");

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
@@ -20,6 +20,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
+import org.opensearch.common.ValidationException;
 import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -70,7 +71,9 @@ public class TrainingJobRouterTransportAction extends HandledTransportAction<Tra
                     DiscoveryNode node = selectNode(request.getPreferredNodeId(), response);
 
                     if (node == null) {
-                        listener.onFailure(new RejectedExecutionException("Cluster does not have capacity to train"));
+                        ValidationException exception = new ValidationException();
+                        exception.addValidationError("Cluster does not have capacity to train");
+                        listener.onFailure(exception);
                         return;
                     }
 

--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -82,7 +82,7 @@ public class TrainingJobRunner {
         // the number of training jobs that enter this function. Although the training threadpool size will also prevent
         // this, we want to prevent this before we perform any serialization.
         if (!semaphore.tryAcquire()) {
-            throw new RejectedExecutionException("Unable to run training job: No training capacity on node.");
+            throw new IllegalStateException("Unable to run training job: No training capacity on node.");
         }
 
         jobCount.incrementAndGet();

--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.common.ValidationException;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
@@ -82,7 +83,9 @@ public class TrainingJobRunner {
         // the number of training jobs that enter this function. Although the training threadpool size will also prevent
         // this, we want to prevent this before we perform any serialization.
         if (!semaphore.tryAcquire()) {
-            throw new IllegalStateException("Unable to run training job: No training capacity on node.");
+            ValidationException exception = new ValidationException();
+            exception.addValidationError("Unable to run training job: No training capacity on node.");
+            throw exception;
         }
 
         jobCount.incrementAndGet();


### PR DESCRIPTION
### Description
PR changes validation logic to throw 400 error codes as opposed to 500 errors codes during training.

In RestTrainModelHandler, change parser.text to parser.textOrNull to allow a user to pass in a null string argument. Validation is then done later.

In training request execution, throw a validation exception if there is no training capacity. This results in a 400 error being returned
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
