### PR TITLE
Package openmp lib with knnlib in zip and minor fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ task cmakeJniLib(type:Exec) {
 task buildJniLib(type:Exec) {
     dependsOn cmakeJniLib
     workingDir 'jni'
-    commandLine 'make'
+    commandLine 'make', 'opensearchknn'
 }
 
 test {

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -113,7 +113,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/faiss EXCLUDE_FROM_ALL)
 
 # ------------------------------ Lib Compiling ------------------------------
 add_library(${TARGET_LIB} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/org_opensearch_knn_index_JNIService.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/jni_util.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/nmslib_wrapper.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/faiss_wrapper.cpp)
-target_link_libraries(${TARGET_LIB} faiss NonMetricSpaceLib ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} OpenMP::OpenMP_CXX gfortran)
+target_link_libraries(${TARGET_LIB} faiss NonMetricSpaceLib OpenMP::OpenMP_CXX)
 target_include_directories(${TARGET_LIB} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include $ENV{JAVA_HOME}/include $ENV{JAVA_HOME}/include/${JVM_OS_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include)
 
 set_target_properties(${TARGET_LIB} PROPERTIES SUFFIX ${LIB_EXT})
@@ -147,8 +147,6 @@ target_link_libraries(
         gmock_main
         faiss
         NonMetricSpaceLib
-        ${BLAS_LIBRARIES}
-        ${LAPACK_LIBRARIES}
         OpenMP::OpenMP_CXX
         ${TARGET_LIB}
 )

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -40,11 +40,11 @@ TEST(FaissCreateIndexTest, BasicAssertions) {
 
     std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
     std::string spaceType = knn_jni::L2;
-    std::string method = "Flat";  // TODO: Revert bach to HNSW32,Flat
+    std::string index_description = "Flat";  // TODO: Revert bach to HNSW32,Flat
 
     std::unordered_map<std::string, jobject> parametersMap;
     parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
-    parametersMap[knn_jni::METHOD] = (jobject)&method;
+    parametersMap[knn_jni::INDEX_DESCRIPTION] = (jobject)&index_description;
 
     // Set up jni
     JNIEnv *jniEnv = nullptr;
@@ -245,11 +245,11 @@ TEST(FaissTrainIndexTest, BasicAssertions) {
     // Define the index configuration
     int dim = 2;
     std::string spaceType = knn_jni::L2;
-    std::string method = "IVF4,Flat";
+    std::string index_description = "IVF4,Flat";
 
     std::unordered_map<std::string, jobject> parametersMap;
     parametersMap[knn_jni::SPACE_TYPE] = (jobject) &spaceType;
-    parametersMap[knn_jni::METHOD] = (jobject) &method;
+    parametersMap[knn_jni::INDEX_DESCRIPTION] = (jobject) &index_description;
 
     // Define training data
     int numTrainingVectors = 256;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -101,6 +101,11 @@ zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
 mkdir $distributions/knnlib
 cp ./jni/release/libopensearchknn* $distributions/knnlib
+
+# Copy libomp to be packaged with the knnlib contents
+ompPath=$(ldconfig -p | grep libgomp | cut -d ' ' -f 4)
+cp $ompPath $distributions/knnlib
+
 cd $distributions
 zip -ur $zipPath knnlib
 cd $work_dir


### PR DESCRIPTION
### Description
This PR adds the libgomp library into the knn zip. This will make it so that tar users do not need to install openmp on their machine to use. 

I tested by building the zip and copying it in to opensearch tar on arm and x64 for AL2, Ub16, Ub20. 

Along with this, I fixed a testcase for JNI, simplified CMake logic and fixed build.gradle to just build the lib and not the tests.
 
### Issues Resolved
#174 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
