### PR TITLE
Fix broken remove model cache test

### DIFF
--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -34,7 +34,7 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
 
     public void testNodeOperation_modelNotInCache() {
         ClusterService clusterService = mock(ClusterService.class);
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), 100).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), "10%").build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
                 ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -59,7 +59,7 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
 
     public void testNodeOperation_modelInCache() throws ExecutionException, InterruptedException {
         ClusterService clusterService = mock(ClusterService.class);
-        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), 100).build();
+        Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), "10%").build();
         ClusterSettings clusterSettings = new ClusterSettings(settings,
                 ImmutableSet.of(MODEL_CACHE_SIZE_LIMIT_SETTING));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Fixes broken test case that expects percent or byte value as opposed to a number: https://github.com/opensearch-project/k-NN/runs/4086130652?check_suite_focus=true
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
