### PR TITLE
Include Model Index status as part of Stats API

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/stats/KNNStatsConfig.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/KNNStatsConfig.java
@@ -26,11 +26,13 @@
 package org.opensearch.knn.plugin.stats;
 
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
+import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.plugin.stats.suppliers.KNNCircuitBreakerSupplier;
 import org.opensearch.knn.plugin.stats.suppliers.KNNCounterSupplier;
 import org.opensearch.knn.plugin.stats.suppliers.KNNInnerCacheStatsSupplier;
 import com.google.common.cache.CacheStats;
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.knn.plugin.stats.suppliers.ModelIndexStatusSupplier;
 import org.opensearch.knn.plugin.stats.suppliers.NativeMemoryCacheManagerSupplier;
 
 import java.util.Map;
@@ -67,6 +69,8 @@ public class KNNStatsConfig {
                     new KNNCounterSupplier(KNNCounter.GRAPH_INDEX_REQUESTS)))
             .put(StatNames.CIRCUIT_BREAKER_TRIGGERED.getName(), new KNNStat<>(true,
                     new KNNCircuitBreakerSupplier()))
+            .put(StatNames.MODEL_INDEX_STATUS.getName(), new KNNStat<>(true,
+                    new ModelIndexStatusSupplier<>(ModelDao::getHealthStatus)))
             .put(StatNames.KNN_QUERY_REQUESTS.getName(), new KNNStat<>(false,
                     new KNNCounterSupplier(KNNCounter.KNN_QUERY_REQUESTS)))
             .put(StatNames.SCRIPT_COMPILATIONS.getName(), new KNNStat<>(false,

--- a/src/main/java/org/opensearch/knn/plugin/stats/StatNames.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/StatNames.java
@@ -43,6 +43,7 @@ public enum StatNames {
     CACHE_CAPACITY_REACHED("cache_capacity_reached"),
     INDICES_IN_CACHE("indices_in_cache"),
     CIRCUIT_BREAKER_TRIGGERED("circuit_breaker_triggered"),
+    MODEL_INDEX_STATUS("model_index_status"),
     GRAPH_QUERY_ERRORS(KNNCounter.GRAPH_QUERY_ERRORS.getName()),
     GRAPH_QUERY_REQUESTS(KNNCounter.GRAPH_QUERY_REQUESTS.getName()),
     GRAPH_INDEX_ERRORS(KNNCounter.GRAPH_INDEX_ERRORS.getName()),

--- a/src/main/java/org/opensearch/knn/plugin/stats/suppliers/ModelIndexStatusSupplier.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/suppliers/ModelIndexStatusSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.plugin.stats.suppliers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ResourceNotFoundException;
+import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
+import org.opensearch.knn.indices.ModelDao;
+
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ModelIndexStatusSupplier<T> implements Supplier<T> {
+    public static Logger logger = LogManager.getLogger(ModelIndexStatusSupplier.class);
+    private Function<ModelDao, T> getter;
+
+    /**
+     * Constructor
+     *
+     * @param getter ModelDAO Method to supply a value
+     */
+    public ModelIndexStatusSupplier(Function<ModelDao, T> getter) {
+        this.getter = getter;
+    }
+
+    @Override
+    public T get() {
+        try{
+            return getter.apply(ModelDao.OpenSearchKNNModelDao.getInstance());
+        } catch (ResourceNotFoundException e) { //catch to prevent exception to be raised.
+            logger.info(e.getMessage());
+            return null; // to let consumer knows that no value is available for getter.
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -21,8 +21,10 @@ import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.SpaceType;
@@ -94,6 +96,33 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         assertFalse(modelDao.isCreated());
         createIndex(MODEL_INDEX_NAME);
         assertTrue(modelDao.isCreated());
+    }
+
+    public void testModelIndexHealth() throws InterruptedException, ExecutionException, IOException {
+        ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
+
+        // model index doesn't exist
+        expectThrows(IndexNotFoundException.class, () -> modelDao.getHealthStatus());
+
+        createIndex(MODEL_INDEX_NAME);
+
+        // insert model
+        String modelId = "created-1";
+        byte[] modelBlob = "hello".getBytes();
+        int dimension = 2;
+
+        Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
+            ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
+        addDoc(modelId, model);
+        assertEquals(model, modelDao.get(modelId));
+        assertEquals(ClusterHealthStatus.GREEN, modelDao.getHealthStatus());
+
+        modelId = "failed-2";
+        model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.FAILED,
+            ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
+        addDoc(modelId, model);
+        assertEquals(model, modelDao.get(modelId));
+        assertEquals(ClusterHealthStatus.GREEN, modelDao.getHealthStatus());
     }
 
     public void testPut_withId() throws InterruptedException, IOException {

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -21,7 +21,6 @@ import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
-import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.IndexNotFoundException;
@@ -112,17 +111,17 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         int dimension = 2;
 
         Model model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.CREATED,
-            ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
-        addDoc(modelId, model);
+            ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob, modelId);
+        addDoc(model);
         assertEquals(model, modelDao.get(modelId));
-        assertEquals(ClusterHealthStatus.GREEN, modelDao.getHealthStatus());
+        assertNotNull(modelDao.getHealthStatus());
 
         modelId = "failed-2";
         model = new Model(new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, dimension, ModelState.FAILED,
-            ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob);
-        addDoc(modelId, model);
+            ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""), modelBlob, modelId);
+        addDoc(model);
         assertEquals(model, modelDao.get(modelId));
-        assertEquals(ClusterHealthStatus.GREEN, modelDao.getHealthStatus());
+        assertNotNull(modelDao.getHealthStatus());
     }
 
     public void testPut_withId() throws InterruptedException, IOException {


### PR DESCRIPTION
### Description
Add Model Index Status to Stats API.
1. if model index is not created, value will be null,
2. if model index exists, return index health status as model index status.
 
### Issues Resolved
#151 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
