### PR TITLE
Generalize error message set in model metadata

### DIFF
--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -116,7 +116,8 @@ public class TrainingJob implements Runnable {
         } catch (Exception e) {
             logger.error("Failed to get training data for model \"" + modelId + "\": " + e.getMessage());
             modelMetadata.setState(ModelState.FAILED);
-            modelMetadata.setError(e.getMessage());
+            modelMetadata.setError("Failed to get training data into memory. " +
+                    "Check if there is enough memory to perform the request.");
 
             if (trainingDataAllocation != null) {
                 nativeMemoryCacheManager.invalidate(trainingDataEntryContext.getKey());
@@ -134,7 +135,8 @@ public class TrainingJob implements Runnable {
         } catch (Exception e) {
             logger.error("Failed to allocate space in native memory for model \"" + modelId + "\": " + e.getMessage());
             modelMetadata.setState(ModelState.FAILED);
-            modelMetadata.setError(e.getMessage());
+            modelMetadata.setError("Failed to allocate space in native memory for the model. " +
+                    "Check if there is enough memory to perform the request.");
 
             trainingDataAllocation.readUnlock();
             nativeMemoryCacheManager.invalidate(trainingDataEntryContext.getKey());
@@ -173,7 +175,8 @@ public class TrainingJob implements Runnable {
         } catch (Exception e) {
             logger.error("Failed to run training job for model \"" + modelId + "\": " + e.getMessage());
             modelMetadata.setState(ModelState.FAILED);
-            modelMetadata.setError(e.getMessage());
+            modelMetadata.setError("Failed to execute training. May be caused by an invalid method definition or " +
+                    "not enough memory to perform training.");
         } finally {
             // Invalidate right away so we dont run into any big memory problems
             trainingDataAllocation.readUnlock();

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -116,7 +116,7 @@ public class TrainingJob implements Runnable {
         } catch (Exception e) {
             logger.error("Failed to get training data for model \"" + modelId + "\": " + e.getMessage());
             modelMetadata.setState(ModelState.FAILED);
-            modelMetadata.setError("Failed to get training data into memory. " +
+            modelMetadata.setError("Failed to load training data into memory. " +
                     "Check if there is enough memory to perform the request.");
 
             if (trainingDataAllocation != null) {

--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -149,7 +149,7 @@ public class TrainingJobRunner {
 
             ModelMetadata modelMetadata = trainingJob.getModel().getModelMetadata();
             modelMetadata.setState(ModelState.FAILED);
-            modelMetadata.setError(ree.getMessage());
+            modelMetadata.setError("Training job execution was rejected. Node's training queue is at capacity.");
 
             try {
                 serializeModel(trainingJob, loggingListener, true);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -228,7 +228,7 @@ public class TrainingJobTests extends KNNTestCase {
         Model model = trainingJob.getModel();
         assertEquals(ModelState.FAILED, trainingJob.getModel().getModelMetadata().getState());
         assertNotNull(model);
-        assertEquals(testException, model.getModelMetadata().getError());
+        assertFalse(model.getModelMetadata().getError().isEmpty());
     }
 
     public void testRun_failure_onGetModelAnonymousAllocation() throws ExecutionException {
@@ -291,7 +291,7 @@ public class TrainingJobTests extends KNNTestCase {
         Model model = trainingJob.getModel();
         assertEquals(ModelState.FAILED, trainingJob.getModel().getModelMetadata().getState());
         assertNotNull(model);
-        assertEquals(testException, model.getModelMetadata().getError());
+        assertFalse(model.getModelMetadata().getError().isEmpty());
     }
 
     public void testRun_failure_closedTrainingDataAllocation() throws ExecutionException {


### PR DESCRIPTION
### Description
This change generalizes the error message exposed to user when training fails. Before, we just set the message as the exception. However, this can expose internal details of the service. So, this generalizes the messages.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
