### PR TITLE
Delete local references when looping over map

### DIFF
--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -128,6 +128,10 @@ std::unordered_map<std::string, jobject> knn_jni::JNIUtil::ConvertJavaMapToCppMa
         this->HasExceptionInStack(env, R"(Could not call "getValue" method")");
 
         parametersCpp[keyCpp] = valueJ;
+
+        env->DeleteLocalRef(entryJ);
+        env->DeleteLocalRef(keyJ);
+        env->DeleteLocalRef(valueJ);
     }
 
     this->HasExceptionInStack(env, R"(Could not call "hasNext" method")");

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -131,7 +131,6 @@ std::unordered_map<std::string, jobject> knn_jni::JNIUtil::ConvertJavaMapToCppMa
 
         env->DeleteLocalRef(entryJ);
         env->DeleteLocalRef(keyJ);
-        env->DeleteLocalRef(valueJ);
     }
 
     this->HasExceptionInStack(env, R"(Could not call "hasNext" method")");


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Delete local references during map conversion. This should not have an effect on maps we're looping over now, given that they are so small, but could have an effect on maps we loop over in the future.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
