### PR TITLE
Add caching of java classes/methods

### DIFF
--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -44,8 +44,7 @@ namespace knn_jni {
         virtual jclass FindClass(JNIEnv * env, const std::string& className) = 0;
 
         // Find a java method given a particular class, name and signature
-        virtual jmethodID FindMethod(JNIEnv * env, jclass jClass, const std::string& methodName,
-                                     const std::string& methodSignature) = 0;
+        virtual jmethodID FindMethod(JNIEnv * env, const std::string& className, const std::string& methodName) = 0;
 
         // --------------------------------------------------------------------------
 
@@ -120,13 +119,16 @@ namespace knn_jni {
     // Class that implements JNIUtilInterface methods
     class JNIUtil: public JNIUtilInterface {
     public:
+        // Initialize and Uninitialize methods are used for caching/cleaning up Java classes and methods
+        void Initialize(JNIEnv* env);
+        void Uninitialize(JNIEnv* env);
+
         void ThrowJavaException(JNIEnv* env, const char* type = "", const char* message = "");
         void HasExceptionInStack(JNIEnv* env);
         void HasExceptionInStack(JNIEnv* env, const std::string& message);
         void CatchCppExceptionAndThrowJava(JNIEnv* env);
         jclass FindClass(JNIEnv * env, const std::string& className);
-        jmethodID FindMethod(JNIEnv * env, jclass jClass, const std::string& methodName,
-                             const std::string& methodSignature);
+        jmethodID FindMethod(JNIEnv * env, const std::string& className, const std::string& methodName);
         std::string ConvertJavaStringToCppString(JNIEnv * env, jstring javaString);
         std::unordered_map<std::string, jobject> ConvertJavaMapToCppMap(JNIEnv *env, jobject parametersJ);
         std::string ConvertJavaObjectToCppString(JNIEnv *env, jobject objectJ);
@@ -152,6 +154,10 @@ namespace knn_jni {
         void ReleaseIntArrayElements(JNIEnv *env, jintArray array, jint *elems, jint mode);
         void SetObjectArrayElement(JNIEnv *env, jobjectArray array, jsize index, jobject val);
         void SetByteArrayRegion(JNIEnv *env, jbyteArray array, jsize start, jsize len, const jbyte * buf);
+
+    private:
+        std::unordered_map<std::string, jclass> cachedClasses;
+        std::unordered_map<std::string, jmethodID> cachedMethods;
     };
 
     // ------------------------------- CONSTANTS --------------------------------

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -200,7 +200,7 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniU
     }
 
     jclass resultClass = jniUtil->FindClass(env,"org/opensearch/knn/index/KNNQueryResult");
-    jmethodID allArgs = jniUtil->FindMethod(env, resultClass, "<init>", "(IF)V");
+    jmethodID allArgs = jniUtil->FindMethod(env, "org/opensearch/knn/index/KNNQueryResult", "<init>");
 
     jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
 

--- a/jni/src/nmslib_wrapper.cpp
+++ b/jni/src/nmslib_wrapper.cpp
@@ -195,7 +195,7 @@ jobjectArray knn_jni::nmslib_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jni
     int resultSize = neighbors->Size();
 
     jclass resultClass = jniUtil->FindClass(env,"org/opensearch/knn/index/KNNQueryResult");
-    jmethodID allArgs = jniUtil->FindMethod(env, resultClass, "<init>", "(IF)V");
+    jmethodID allArgs = jniUtil->FindMethod(env, "org/opensearch/knn/index/KNNQueryResult", "<init>");
 
     jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
 

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -20,6 +20,25 @@
 #include "jni_util.h"
 
 static knn_jni::JNIUtil jniUtil;
+static const jint KNN_FAISS_JNI_VERSION = JNI_VERSION_1_1;
+
+jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+    // Obtain the JNIEnv from the VM and confirm JNI_VERSION
+    JNIEnv* env;
+    if (vm->GetEnv((void**)&env, KNN_FAISS_JNI_VERSION) != JNI_OK) {
+        return JNI_ERR;
+    }
+
+    jniUtil.Initialize(env);
+
+    return KNN_FAISS_JNI_VERSION;
+}
+
+void JNI_OnUnload(JavaVM *vm, void *reserved) {
+    JNIEnv* env;
+    vm->GetEnv((void**)&env, KNN_FAISS_JNI_VERSION);
+    jniUtil.Uninitialize(env);
+}
 
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndex(JNIEnv * env, jclass cls, jintArray idsJ,
                                                                             jobjectArray vectorsJ, jstring indexPathJ,

--- a/jni/src/org_opensearch_knn_jni_NmslibService.cpp
+++ b/jni/src/org_opensearch_knn_jni_NmslibService.cpp
@@ -18,6 +18,24 @@
 #include "nmslib_wrapper.h"
 
 static knn_jni::JNIUtil jniUtil;
+static const jint KNN_NMSLIB_JNI_VERSION = JNI_VERSION_1_1;
+
+jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+    JNIEnv* env;
+    if (vm->GetEnv((void**)&env, KNN_NMSLIB_JNI_VERSION) != JNI_OK) {
+        return JNI_ERR;
+    }
+
+    jniUtil.Initialize(env);
+
+    return KNN_NMSLIB_JNI_VERSION;
+}
+
+void JNI_OnUnload(JavaVM *vm, void *reserved) {
+    JNIEnv* env;
+    vm->GetEnv((void**)&env, KNN_NMSLIB_JNI_VERSION);
+    jniUtil.Uninitialize(env);
+}
 
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_NmslibService_createIndex(JNIEnv * env, jclass cls, jintArray idsJ,
                                                                              jobjectArray vectorsJ, jstring indexPathJ,

--- a/jni/tests/test_util.cpp
+++ b/jni/tests/test_util.cpp
@@ -90,8 +90,9 @@ test_util::MockJNIUtil::MockJNIUtil() {
     // meaningful in the unit tests
     ON_CALL(*this, FindMethod)
             .WillByDefault(
-                    [this](JNIEnv *env, jclass jClass, const std::string &methodName,
-                           const std::string &methodSignature) { return (jmethodID)1; });
+                    [this](JNIEnv *env, const std::string &className, const std::string &methodName) {
+                        return (jmethodID)1;
+                    });
 
     // arrayJ is re-interpreted as a std::vector<uint8_t> *
     ON_CALL(*this, GetJavaBytesArrayLength)

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -55,9 +55,7 @@ namespace test_util {
                     (JNIEnv * env, jobject objectJ));
         MOCK_METHOD(void, DeleteLocalRef, (JNIEnv * env, jobject obj));
         MOCK_METHOD(jclass, FindClass, (JNIEnv * env, const std::string& className));
-        MOCK_METHOD(jmethodID, FindMethod,
-                    (JNIEnv * env, jclass jClass, const std::string& methodName,
-                            const std::string& methodSignature));
+        MOCK_METHOD(jmethodID, FindMethod, (JNIEnv * env, const std::string& className, const std::string& methodName));
         MOCK_METHOD(jbyte*, GetByteArrayElements,
                     (JNIEnv * env, jbyteArray array, jboolean* isCopy));
         MOCK_METHOD(jfloat*, GetFloatArrayElements,


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR adds Java class and method caching to both JNI libraries. FindClass/FindMethod functions can be expensive calls from C++ layer, so it is [recommended](https://developer.ibm.com/articles/j-jni/) to cache these values. For caching implementation, I followed [this SO post answer](https://stackoverflow.com/a/13940735). From a high level, the JNI_onLoad and JNI_onUnload methods will be called when the library is loaded/unloaded by the JVM. Here, we call an initialization function which sets up the caches.

gradle tests as well as google tests both pass.

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
