### PR TITLE
Fix bugs in parameter passing to JNI

### DIFF
--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -26,7 +26,8 @@ namespace knn_jni {
         // Create an index with ids and vectors. Instead of creating a new index, this function creates the index
         // based off of the template index passed in. The index is serialized to indexPathJ.
         void CreateIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                     jobjectArray vectorsJ, jstring indexPathJ, jbyteArray templateIndexJ);
+                                     jobjectArray vectorsJ, jstring indexPathJ, jbyteArray templateIndexJ,
+                                     jobject parametersJ);
 
         // Load an index from indexPathJ into memory.
         //

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -171,6 +171,7 @@ namespace knn_jni {
     extern const std::string INDEX_DESCRIPTION;
     extern const std::string PARAMETERS;
     extern const std::string TRAINING_DATASET_SIZE_LIMIT;
+    extern const std::string INDEX_THREAD_QUANTITY;
 
     extern const std::string L2;
     extern const std::string L1;

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -29,10 +29,10 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndex
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    createIndexFromTemplate
- * Signature: ([I[[FLjava/lang/String;[B)V
+ * Signature: ([I[[FLjava/lang/String;[BLjava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromTemplate
-  (JNIEnv *, jclass, jintArray, jobjectArray, jstring, jbyteArray);
+  (JNIEnv *, jclass, jintArray, jobjectArray, jstring, jbyteArray, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -463,6 +463,7 @@ const std::string knn_jni::METHOD = "method";
 const std::string knn_jni::INDEX_DESCRIPTION = "index_description";
 const std::string knn_jni::PARAMETERS = "parameters";
 const std::string knn_jni::TRAINING_DATASET_SIZE_LIMIT = "training_dataset_size_limit";
+const std::string knn_jni::INDEX_THREAD_QUANTITY = "indexThreadQty";
 
 const std::string knn_jni::L2 = "l2";
 const std::string knn_jni::L1 = "l1";

--- a/jni/src/nmslib_wrapper.cpp
+++ b/jni/src/nmslib_wrapper.cpp
@@ -58,6 +58,12 @@ void knn_jni::nmslib_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, J
         auto m = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::M]);
         indexParameters.push_back(knn_jni::M_NMSLIB + "=" + std::to_string(m));
     }
+
+    if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
+        auto indexThreadQty = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
+        indexParameters.push_back(knn_jni::INDEX_THREAD_QUANTITY + "=" + std::to_string(indexThreadQty));
+    }
+
     jniUtil->DeleteLocalRef(env, parametersJ);
 
     // Get the path to save the index

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -55,10 +55,11 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromT
                                                                                         jintArray idsJ,
                                                                                         jobjectArray vectorsJ,
                                                                                         jstring indexPathJ,
-                                                                                        jbyteArray templateIndexJ)
+                                                                                        jbyteArray templateIndexJ,
+                                                                                        jobject parametersJ)
 {
     try {
-        knn_jni::faiss_wrapper::CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsJ, indexPathJ, templateIndexJ);
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsJ, indexPathJ, templateIndexJ, parametersJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -73,7 +73,7 @@ public class KNNConstants {
     public static final String HNSW_ALGO_M = "M";
     public static final String HNSW_ALGO_EF_CONSTRUCTION = "efConstruction";
     public static final String HNSW_ALGO_EF_SEARCH = "efSearch";
-    public static final String HNSW_ALGO_INDEX_THREAD_QTY = "indexThreadQty";
+    public static final String INDEX_THREAD_QTY = "indexThreadQty";
 
     // Faiss specific constants
     public static final String FAISS_NAME = "faiss";

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -167,6 +167,9 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
     private void createKNNIndexFromTemplate(byte[] model, KNNCodecUtil.Pair pair, KNNEngine knnEngine,
                                             String indexPath) {
         //TODO: I think we should add parameters back to this method to support thread_qty
+//        Map<String, Object> trainParameters = model.getModelMetadata().getKnnEngine().getMethodAsMap(knnMethodContext);
+//        trainParameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(
+//                KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
         AccessController.doPrivileged(
                 (PrivilegedAction<Void>) () -> {
                     JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, knnEngine.getName());
@@ -203,11 +206,9 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             );
         }
 
-        // Used to set the number of threads during indexing -- we could probably generalize this pretty easy
-        if (knnEngine.equals(KNNEngine.NMSLIB)) {
-            parameters.put(KNNConstants.HNSW_ALGO_INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(
-                    KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
-        }
+        // Used to determine how many threads to use when indexing
+        parameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(
+                KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
 
         // Pass the path for the nms library to save the file
         AccessController.doPrivileged(

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -25,6 +25,7 @@
 
 package org.opensearch.knn.index.codec.KNN80Codec;
 
+import com.google.common.collect.ImmutableMap;
 import org.opensearch.common.xcontent.DeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -166,13 +167,12 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
 
     private void createKNNIndexFromTemplate(byte[] model, KNNCodecUtil.Pair pair, KNNEngine knnEngine,
                                             String indexPath) {
-        //TODO: I think we should add parameters back to this method to support thread_qty
-//        Map<String, Object> trainParameters = model.getModelMetadata().getKnnEngine().getMethodAsMap(knnMethodContext);
-//        trainParameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(
-//                KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
+        Map<String, Object> parameters = ImmutableMap.of(KNNConstants.INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(
+                KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
         AccessController.doPrivileged(
                 (PrivilegedAction<Void>) () -> {
-                    JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, knnEngine.getName());
+                    JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, parameters,
+                            knnEngine.getName());
                     return null;
                 }
         );

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -53,8 +53,10 @@ class FaissService {
      * @param data array of float arrays to be indexed
      * @param indexPath path to save index file to
      * @param templateIndex empty template index
+     * @param parameters additional build time parameters
      */
-    public static native void createIndexFromTemplate(int[] ids, float[][] data, String indexPath, byte[] templateIndex);
+    public static native void createIndexFromTemplate(int[] ids, float[][] data, String indexPath, byte[] templateIndex,
+                                                      Map<String, Object> parameters);
 
     /**
      * Load an index into memory

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -52,12 +52,13 @@ public class JNIService {
      * @param data array of float arrays to be indexed
      * @param indexPath path to save index file to
      * @param templateIndex empty template index
+     * @param parameters parameters to build index
      * @param engineName name of engine to build index for
      */
     public static void createIndexFromTemplate(int[] ids, float[][] data, String indexPath, byte[] templateIndex,
-                                                      String engineName) {
+                                               Map<String, Object> parameters, String engineName) {
         if (KNNEngine.FAISS.getName().equals(engineName)) {
-            FaissService.createIndexFromTemplate(ids, data, indexPath, templateIndex);
+            FaissService.createIndexFromTemplate(ids, data, indexPath, templateIndex, parameters);
             return;
         }
 

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -35,6 +35,7 @@ import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_S
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.INDEX_THREAD_QTY;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
@@ -577,7 +578,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         Path tmpFile1 = createTempFile();
         JNIService.createIndexFromTemplate(testData.indexData.docs, testData.indexData.vectors,
-                tmpFile1.toAbsolutePath().toString(), faissIndex, FAISS_NAME);
+                tmpFile1.toAbsolutePath().toString(), faissIndex, ImmutableMap.of(INDEX_THREAD_QTY, 1), FAISS_NAME);
         assertTrue(tmpFile1.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(tmpFile1.toAbsolutePath().toString(), Collections.emptyMap(),

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutionException;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.INDEX_THREAD_QTY;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 
@@ -170,7 +171,7 @@ public class TrainingJobTests extends KNNTestCase {
         fillFloatArrayRandomly(vectors);
 
         Path indexPath = createTempFile();
-        JNIService.createIndexFromTemplate(ids, vectors, indexPath.toString(), model.getModelBlob(), knnEngine.getName());
+        JNIService.createIndexFromTemplate(ids, vectors, indexPath.toString(), model.getModelBlob(), ImmutableMap.of(INDEX_THREAD_QTY, 1), knnEngine.getName());
         assertNotEquals(0, new File(indexPath.toString()).length());
     }
 


### PR DESCRIPTION
### Description
This change fixes a couple bugs related to parameter passing in the JNI. First, we accidentally deleted the logic to pass efSearch and indexThreadQty to jni for nmslib. This fix is added here.

Second, faiss uses OpenMP for thread management. To set the number of threads, we can use the function `omp_set_num_threads`. This function will determine how many threads to use for parallel sections of the code later in the thread. This call will only impact the parallel function calls made in this thread so it is thread safe. This PR adds the indexThreadQty setting to set this for faiss.
 
### Check List
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
