### PR TITLE
Remove unused code from function

### DIFF
--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -139,30 +139,18 @@ std::unordered_map<std::string, jobject> knn_jni::JNIUtil::ConvertJavaMapToCppMa
         throw std::runtime_error("Parameters cannot be null");
     }
 
-    // Load all of the class and methods to iterate over a map
-    jclass mapClassJ = this->FindClass(env, "java/util/Map");
-
+    // Load all of the methods to iterate over a map
     jmethodID entrySetMethodJ = this->FindMethod(env, "java/util/Map", "entrySet");
 
     jobject parametersEntrySetJ = env->CallObjectMethod(parametersJ, entrySetMethodJ);
     this->HasExceptionInStack(env, R"(Unable to call "entrySet" method on "java/util/Map")");
-
-    jclass setClassJ = this->FindClass(env, "java/util/Set");
-
     jmethodID iteratorJ = this->FindMethod(env, "java/util/Set", "iterator");
-
-    jclass iteratorClassJ = this->FindClass(env, "java/util/Iterator");
-
     jobject iterJ = env->CallObjectMethod(parametersEntrySetJ, iteratorJ);
     this->HasExceptionInStack(env, R"(Call to "iterator" method failed")");
 
     jmethodID hasNextMethodJ = this->FindMethod(env, "java/util/Iterator", "hasNext");
     jmethodID nextMethodJ = this->FindMethod(env, "java/util/Iterator", "next");
-
-    jclass entryClassJ = this->FindClass(env, "java/util/Map$Entry");
-
     jmethodID getKeyMethodJ = this->FindMethod(env, "java/util/Map$Entry", "getKey");
-
     jmethodID getValueMethodJ = this->FindMethod(env, "java/util/Map$Entry", "getValue");
 
     // Iterate over the java map and add entries to cpp unordered map


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Minor bug fix. With #186 we changed how we looked up classes and methods. With this change, it is no longer necessary to look up classes in the map conversion function. This PR removes those calls.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
