### PR TITLE
Fix issue setting parameters

### DIFF
--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -87,12 +87,7 @@ void knn_jni::faiss_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JN
     }
 
     // Add extra parameters that cant be configured with the index factory
-    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
-        jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
-        auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
-        SetExtraParameters(jniUtil, env, subParametersCpp, indexWriter.get());
-        jniUtil->DeleteLocalRef(env, subParametersJ);
-    }
+    SetExtraParameters(jniUtil, env, parametersCpp, indexWriter.get());
     jniUtil->DeleteLocalRef(env, parametersJ);
 
     // Check that the index does not need to be trained
@@ -264,12 +259,7 @@ jbyteArray knn_jni::faiss_wrapper::TrainIndex(knn_jni::JNIUtilInterface * jniUti
     }
 
     // Add extra parameters that cant be configured with the index factory
-    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
-        jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
-        auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
-        SetExtraParameters(jniUtil, env, subParametersCpp, indexWriter.get());
-        jniUtil->DeleteLocalRef(env, subParametersJ);
-    }
+    SetExtraParameters(jniUtil, env, parametersCpp, indexWriter.get());
 
     // Train index if needed
     auto *trainingVectorsPointerCpp = reinterpret_cast<std::vector<float>*>(trainVectorsPointerJ);

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -305,7 +305,7 @@ public class MethodComponent {
      *
      * @param methodComponentContext context containing user provided parameter
      * @param methodComponent component containing method parameters and defaults
-     * @return
+     * @return Map of user provided parameters with defaults filled in as needed
      */
     public static Map<String, Object> getParameterMapWithDefaultsAdded(MethodComponentContext methodComponentContext,
                                                                        MethodComponent methodComponent) {

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -74,7 +74,7 @@ public class MethodComponent {
         if (mapGenerator == null) {
             Map<String, Object> parameterMap = new HashMap<>();
             parameterMap.put(KNNConstants.NAME, methodComponentContext.getName());
-            parameterMap.put(KNNConstants.PARAMETERS, methodComponentContext.getParameters());
+            parameterMap.put(KNNConstants.PARAMETERS, getParameterMapWithDefaultsAdded(methodComponentContext, this));
             return parameterMap;
         }
         return mapGenerator.apply(this, methodComponentContext);
@@ -298,5 +298,27 @@ public class MethodComponent {
         public MethodComponent build() {
             return new MethodComponent(this);
         }
+    }
+
+    /**
+     * Returns a map of the user provided parameters in addition to default parameters the user may not have passed
+     *
+     * @param methodComponentContext context containing user provided parameter
+     * @param methodComponent component containing method parameters and defaults
+     * @return
+     */
+    public static Map<String, Object> getParameterMapWithDefaultsAdded(MethodComponentContext methodComponentContext,
+                                                                       MethodComponent methodComponent) {
+        Map<String, Object> parametersWithDefaultsMap = new HashMap<>();
+        Map<String, Object> userProvidedParametersMap = methodComponentContext.getParameters();
+        for (Parameter<?> parameter : methodComponent.getParameters().values()) {
+            if (methodComponentContext.getParameters().containsKey(parameter.getName())) {
+                parametersWithDefaultsMap.put(parameter.getName(), userProvidedParametersMap.get(parameter.getName()));
+            } else {
+                parametersWithDefaultsMap.put(parameter.getName(), parameter.getDefaultValue());
+            }
+        }
+
+        return parametersWithDefaultsMap;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -24,7 +24,6 @@ import org.opensearch.knn.index.SpaceType;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -564,7 +563,7 @@ public interface KNNLibrary {
             static MethodAsMapBuilder builder(String baseDescription, MethodComponent methodComponent,
                                               MethodComponentContext methodComponentContext) {
                 return new MethodAsMapBuilder(baseDescription, methodComponent,
-                        new HashMap<>(methodComponentContext.getParameters()));
+                        MethodComponent.getParameterMapWithDefaultsAdded(methodComponentContext, methodComponent));
             }
         }
 

--- a/src/test/java/org/opensearch/knn/index/MethodComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentTests.java
@@ -13,7 +13,6 @@ package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.common.ValidationException;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 
@@ -112,22 +111,39 @@ public class MethodComponentTests extends KNNTestCase {
 
     public void testGetAsMap_withoutGenerator() throws IOException {
         String methodName = "test-method";
+        String parameterName1 = "valid1";
+        String parameterName2 = "valid2";
+        int default1 = 4;
+        int default2 = 5;
+
         MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
-                .addParameter("valid1", new Parameter.IntegerParameter("valid1",1, v -> v > 0))
-                .addParameter("valid2", new Parameter.IntegerParameter("valid2",1, v -> v > 0))
+                .addParameter(parameterName1, new Parameter.IntegerParameter(parameterName1, default1, v -> v > 0))
+                .addParameter(parameterName2, new Parameter.IntegerParameter(parameterName2, default2, v -> v > 0))
                 .build();
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject()
                 .field(NAME, methodName)
                 .startObject(PARAMETERS)
-                .field("valid1", 16)
-                .field("valid2", 128)
+                .field(parameterName1, 16)
+                .field(parameterName2, 128)
                 .endObject()
                 .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
 
         assertEquals(in, methodComponent.getAsMap(methodComponentContext));
+
+        xContentBuilder = XContentFactory.jsonBuilder().startObject()
+                .field(NAME, methodName)
+                .startObject(PARAMETERS)
+                .endObject()
+                .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        methodComponentContext = MethodComponentContext.parse(in);
+
+        Map<String, Object> methodAsMap = methodComponent.getAsMap(methodComponentContext);
+        assertEquals(default1, methodAsMap.get(parameterName1));
+        assertEquals(default2, methodAsMap.get(parameterName2));
     }
 
     public void testGetAsMap_withGenerator() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/MethodComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentTests.java
@@ -141,10 +141,6 @@ public class MethodComponentTests extends KNNTestCase {
         methodComponentContext = MethodComponentContext.parse(in);
 
         Map<String, Object> methodAsMap = methodComponent.getAsMap(methodComponentContext);
-        for (Map.Entry<String, Object> entry : methodAsMap.entrySet()) {
-            logger.info("Key: " + entry.getKey() + " Value: " + entry.getValue());
-        }
-
         assertEquals(default1, ((Map<String, Object>) methodAsMap.get(PARAMETERS)).get(parameterName1));
         assertEquals(default2, ((Map<String, Object>) methodAsMap.get(PARAMETERS)).get(parameterName2));
     }

--- a/src/test/java/org/opensearch/knn/index/MethodComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentTests.java
@@ -109,6 +109,7 @@ public class MethodComponentTests extends KNNTestCase {
         assertNull(methodComponent4.validate(componentContext4));
     }
 
+    @SuppressWarnings("unchecked")
     public void testGetAsMap_withoutGenerator() throws IOException {
         String methodName = "test-method";
         String parameterName1 = "valid1";
@@ -135,15 +136,17 @@ public class MethodComponentTests extends KNNTestCase {
 
         xContentBuilder = XContentFactory.jsonBuilder().startObject()
                 .field(NAME, methodName)
-                .startObject(PARAMETERS)
-                .endObject()
                 .endObject();
         in = xContentBuilderToMap(xContentBuilder);
         methodComponentContext = MethodComponentContext.parse(in);
 
         Map<String, Object> methodAsMap = methodComponent.getAsMap(methodComponentContext);
-        assertEquals(default1, methodAsMap.get(parameterName1));
-        assertEquals(default2, methodAsMap.get(parameterName2));
+        for (Map.Entry<String, Object> entry : methodAsMap.entrySet()) {
+            logger.info("Key: " + entry.getKey() + " Value: " + entry.getValue());
+        }
+
+        assertEquals(default1, ((Map<String, Object>) methodAsMap.get(PARAMETERS)).get(parameterName1));
+        assertEquals(default2, ((Map<String, Object>) methodAsMap.get(PARAMETERS)).get(parameterName2));
     }
 
     public void testGetAsMap_withGenerator() throws IOException {


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR fixes 2 bugs. First, in the faiss jni, it was trying to parse a sub map in the parameters to set additional parameters. However, in Java, no sub map of parameters is created. The additional parameters are just added to the parameters directly. To fix this, we just flatten out the setting extra parameters call. This is hard to test with unit tests, so I verified manually with logs.

Second, this PR fixes an issue with passing default values to the JNI. Previously, defaults were not getting added to the parameter map, so they were not getting passed to the JNI. This was causing us to use the defaults of the libraries. To fix this, I added a step of adding default parameters into the map when they are not passed by the user.
 
### Check List
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
