### PR TITLE
Fix parameter validation for both libs

### DIFF
--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -87,7 +87,12 @@ void knn_jni::faiss_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JN
     }
 
     // Add extra parameters that cant be configured with the index factory
-    SetExtraParameters(jniUtil, env, parametersCpp, indexWriter.get());
+    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
+        jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
+        auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
+        SetExtraParameters(jniUtil, env, subParametersCpp, indexWriter.get());
+        jniUtil->DeleteLocalRef(env, subParametersJ);
+    }
     jniUtil->DeleteLocalRef(env, parametersJ);
 
     // Check that the index does not need to be trained
@@ -259,7 +264,12 @@ jbyteArray knn_jni::faiss_wrapper::TrainIndex(knn_jni::JNIUtilInterface * jniUti
     }
 
     // Add extra parameters that cant be configured with the index factory
-    SetExtraParameters(jniUtil, env, parametersCpp, indexWriter.get());
+    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
+        jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
+        auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
+        SetExtraParameters(jniUtil, env, subParametersCpp, indexWriter.get());
+        jniUtil->DeleteLocalRef(env, subParametersJ);
+    }
 
     // Train index if needed
     auto *trainingVectorsPointerCpp = reinterpret_cast<std::vector<float>*>(trainVectorsPointerJ);

--- a/jni/src/nmslib_wrapper.cpp
+++ b/jni/src/nmslib_wrapper.cpp
@@ -49,14 +49,23 @@ void knn_jni::nmslib_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, J
     // Handle parameters
     auto parametersCpp = jniUtil->ConvertJavaMapToCppMap(env, parametersJ);
     std::vector<std::string> indexParameters;
-    if(parametersCpp.find(knn_jni::EF_CONSTRUCTION) != parametersCpp.end()) {
-        auto efConstruction = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::EF_CONSTRUCTION]);
-        indexParameters.push_back(knn_jni::EF_CONSTRUCTION_NMSLIB + "=" + std::to_string(efConstruction));
-    }
 
-    if(parametersCpp.find(knn_jni::M) != parametersCpp.end()) {
-        auto m = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::M]);
-        indexParameters.push_back(knn_jni::M_NMSLIB + "=" + std::to_string(m));
+    // Algorithm parameters will be in a sub map
+    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
+        jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
+        auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
+
+        if(subParametersCpp.find(knn_jni::EF_CONSTRUCTION) != subParametersCpp.end()) {
+            auto efConstruction = jniUtil->ConvertJavaObjectToCppInteger(env, subParametersCpp[knn_jni::EF_CONSTRUCTION]);
+            indexParameters.push_back(knn_jni::EF_CONSTRUCTION_NMSLIB + "=" + std::to_string(efConstruction));
+        }
+
+        if(subParametersCpp.find(knn_jni::M) != subParametersCpp.end()) {
+            auto m = jniUtil->ConvertJavaObjectToCppInteger(env, subParametersCpp[knn_jni::M]);
+            indexParameters.push_back(knn_jni::M_NMSLIB + "=" + std::to_string(m));
+        }
+
+        jniUtil->DeleteLocalRef(env, subParametersJ);
     }
 
     if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.index.codec.KNNCodecUtil.buildEngineFileName;
 
 /**
@@ -170,15 +171,16 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
                     SpaceType.DEFAULT.getValue()));
 
             String efConstruction = fieldAttributes.get(KNNConstants.HNSW_ALGO_EF_CONSTRUCTION);
+            Map<String, Object> algoParams = new HashMap<>();
             if (efConstruction != null) {
-                parameters.put(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, Integer.parseInt(efConstruction));
+                algoParams.put(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, Integer.parseInt(efConstruction));
             }
 
             String m = fieldAttributes.get(KNNConstants.HNSW_ALGO_M);
             if (m != null) {
-                parameters.put(KNNConstants.METHOD_PARAMETER_M, Integer.parseInt(m));
+                algoParams.put(KNNConstants.METHOD_PARAMETER_M, Integer.parseInt(m));
             }
-
+            parameters.put(PARAMETERS, algoParams);
         } else {
             parameters.putAll(
                     XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,

--- a/src/test/java/org/opensearch/knn/index/util/KNNLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/KNNLibraryTests.java
@@ -184,11 +184,16 @@ public class KNNLibraryTests extends KNNTestCase {
         String methodDescription = "test-description";
         String parameter1 = "test-parameter-1";
         Integer value1 = 10;
+        Integer defaultValue1 = 1;
         String parameter2 = "test-parameter-2";
         Integer value2 = 15;
+        Integer defaultValue2 = 2;
+        String parameter3 = "test-parameter-3";
+        Integer defaultValue3 = 3;
         MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
-                .addParameter(parameter1, new Parameter.IntegerParameter(parameter1, 10, value -> value > 0))
-                .addParameter(parameter2, new Parameter.IntegerParameter(parameter2, 15, value -> value > 0))
+                .addParameter(parameter1, new Parameter.IntegerParameter(parameter1, defaultValue1, value -> value > 0))
+                .addParameter(parameter2, new Parameter.IntegerParameter(parameter2, defaultValue2, value -> value > 0))
+                .addParameter(parameter3, new Parameter.IntegerParameter(parameter3, defaultValue3, value -> value > 0))
                 .build();
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject()
@@ -201,8 +206,12 @@ public class KNNLibraryTests extends KNNTestCase {
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
 
-        Map<String, Object> expectedMap = new HashMap<>(methodComponentContext.getParameters());
-        expectedMap.remove(parameter1);
+        Map<String, Object> expectedParametersMap = new HashMap<>(methodComponentContext.getParameters());
+        expectedParametersMap.put(parameter3, defaultValue3);
+        expectedParametersMap.remove(parameter1);
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put(PARAMETERS, expectedParametersMap);
+        expectedMap.put(NAME, methodName);
         expectedMap.put(INDEX_DESCRIPTION_PARAMETER, methodDescription + value1);
 
         Map<String, Object> methodAsMap = MethodAsMapBuilder

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -135,10 +135,10 @@ public class JNIServiceTests extends KNNTestCase {
         int[] docIds = new int[]{};
         float[][] vectors = new float[][]{};
 
+        Map<String, Object> parametersMap = ImmutableMap.of(KNNConstants.HNSW_ALGO_EF_CONSTRUCTION, "14", KNNConstants.METHOD_PARAMETER_M, "12");
         Path tmpFile = createTempFile();
         expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(),
-                ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue(),
-                        KNNConstants.HNSW_ALGO_EF_CONSTRUCTION, "14", KNNConstants.METHOD_PARAMETER_M, "12"),
+                ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue(), KNNConstants.PARAMETERS, parametersMap),
                 KNNEngine.NMSLIB.getName()));
     }
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR finishes fixing the issue that was originally addressed in #199. The problem was that nmslib expected algo parameters to be in a flat map while faiss expected algo parameters to be nested in a parameters sub map. This PR fixes that issue: the expectation is algo params are in a nested parameters sub map.

This logic is very confusing and should be simplified in the future. I will create an issue to track this
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
