### PR TITLE
Fix field validation in VectorReader

### DIFF
--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.knn.index.memory;
 
-import org.opensearch.indices.IndicesService;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.knn.index.IndexUtil;
 
 import java.io.IOException;
@@ -129,7 +129,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
 
         private final int size;
         private final NativeMemoryLoadStrategy.TrainingLoadStrategy trainingLoadStrategy;
-        private final IndicesService indicesService;
+        private final ClusterService clusterService;
         private final String trainIndexName;
         private final String trainFieldName;
         private final int maxVectorCount;
@@ -142,7 +142,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
          * @param trainIndexName name of index used to pull training data from
          * @param trainFieldName name of field used to pull training data from
          * @param trainingLoadStrategy strategy to load training data into memory
-         * @param indicesService service used to extract information about indices
+         * @param clusterService service used to extract information about indices
          * @param maxVectorCount maximum number of vectors there can be
          * @param searchSize size each search request should return during loading
          */
@@ -150,7 +150,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
                                         String trainIndexName,
                                         String trainFieldName,
                                         NativeMemoryLoadStrategy.TrainingLoadStrategy trainingLoadStrategy,
-                                        IndicesService indicesService,
+                                        ClusterService clusterService,
                                         int maxVectorCount,
                                         int searchSize) {
             super(generateKey(trainIndexName, trainFieldName));
@@ -158,7 +158,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             this.trainingLoadStrategy = trainingLoadStrategy;
             this.trainIndexName = trainIndexName;
             this.trainFieldName = trainFieldName;
-            this.indicesService = indicesService;
+            this.clusterService = clusterService;
             this.maxVectorCount = maxVectorCount;
             this.searchSize = searchSize;
         }
@@ -210,12 +210,12 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         }
 
         /**
-         * Getter for indices service.
+         * Getter for cluster service.
          *
-         * @return indices service
+         * @return cluster service
          */
-        public IndicesService getIndicesService() {
-            return indicesService;
+        public ClusterService getClusterService() {
+            return clusterService;
         }
 
         private static String generateKey(String trainIndexName, String trainFieldName) {

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
@@ -156,7 +156,7 @@ public interface NativeMemoryLoadStrategy<T extends NativeMemoryAllocation, U ex
             trainingDataAllocation.writeLock();
 
             vectorReader.read(
-                    nativeMemoryEntryContext.getIndicesService(),
+                    nativeMemoryEntryContext.getClusterService(),
                     nativeMemoryEntryContext.getTrainIndexName(),
                     nativeMemoryEntryContext.getTrainFieldName(),
                     nativeMemoryEntryContext.getMaxVectorCount(),

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelTransportAction.java
@@ -14,8 +14,8 @@ package org.opensearch.knn.plugin.transport;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
@@ -32,14 +32,14 @@ import java.io.IOException;
  */
 public class TrainingModelTransportAction extends HandledTransportAction<TrainingModelRequest, TrainingModelResponse> {
 
-    private final IndicesService indicesService;
+    private final ClusterService clusterService;
 
     @Inject
     public TrainingModelTransportAction(TransportService transportService,
                                         ActionFilters actionFilters,
-                                        IndicesService indicesService) {
+                                        ClusterService clusterService) {
         super(TrainingModelAction.NAME, transportService, actionFilters, TrainingModelRequest::new);
-        this.indicesService = indicesService;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -52,7 +52,7 @@ public class TrainingModelTransportAction extends HandledTransportAction<Trainin
                         request.getTrainingIndex(),
                         request.getTrainingField(),
                         NativeMemoryLoadStrategy.TrainingLoadStrategy.getInstance(),
-                        indicesService,
+                        clusterService,
                         request.getMaximumVectorCount(),
                         request.getSearchSize()
                 );

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
 import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
+import org.opensearch.knn.plugin.stats.KNNCounter;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -126,6 +127,8 @@ public class TrainingJob implements Runnable {
                 nativeMemoryCacheManager.invalidate(trainingDataEntryContext.getKey());
             }
 
+            KNNCounter.TRAINING_ERRORS.increment();
+
             return;
         }
 
@@ -147,6 +150,8 @@ public class TrainingJob implements Runnable {
             if (modelAnonymousAllocation != null) {
                 nativeMemoryCacheManager.invalidate(modelAnonymousEntryContext.getKey());
             }
+
+            KNNCounter.TRAINING_ERRORS.increment();
 
             return;
         }
@@ -184,6 +189,9 @@ public class TrainingJob implements Runnable {
             modelMetadata.setState(ModelState.FAILED);
             modelMetadata.setError("Failed to execute training. May be caused by an invalid method definition or " +
                     "not enough memory to perform training.");
+
+            KNNCounter.TRAINING_ERRORS.increment();
+
         } finally {
             // Invalidate right away so we dont run into any big memory problems
             trainingDataAllocation.readUnlock();

--- a/src/main/java/org/opensearch/knn/training/VectorReader.java
+++ b/src/main/java/org/opensearch/knn/training/VectorReader.java
@@ -19,10 +19,10 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequestBuilder;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ValidationException;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.query.ExistsQueryBuilder;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.knn.index.IndexUtil;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.sort.SortOrder;
@@ -50,7 +50,7 @@ public class VectorReader {
     /**
      * Read vectors from a provided index/field and pass them to vectorConsumer that will do something with them.
      *
-     * @param indicesService
+     * @param clusterService cluster service to get information about the index
      * @param indexName name of index containing vectors
      * @param fieldName name of field containing vectors
      * @param maxVectorCount maximum number of vectors to return
@@ -58,7 +58,7 @@ public class VectorReader {
      * @param vectorConsumer consumer used to do something with the collected vectors after each search
      * @param listener ActionListener that should be called once all search operations complete
      */
-    public void read(IndicesService indicesService, String indexName, String fieldName, int maxVectorCount,
+    public void read(ClusterService clusterService, String indexName, String fieldName, int maxVectorCount,
                      int searchSize, Consumer<List<Float[]>> vectorConsumer, ActionListener<SearchResponse> listener) {
 
         ValidationException validationException = null;
@@ -74,7 +74,7 @@ public class VectorReader {
             validationException.addValidationError("searchSize must be > 0 and <= 10000");
         }
 
-        IndexMetadata indexMetadata = indicesService.clusterService().state().metadata().index(indexName);
+        IndexMetadata indexMetadata = clusterService.state().metadata().index(indexName);
         if (indexMetadata == null) {
             validationException = validationException == null ? new ValidationException() : validationException;
             validationException.addValidationError("index \"" + indexName + "\" does not exist");

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryEntryContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryEntryContextTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index.memory;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.indices.IndicesService;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.IndexUtil;
@@ -198,18 +199,18 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
     }
 
     public void testTrainingDataEntryContext_getIndicesService() {
-        IndicesService indicesService = mock(IndicesService.class);
+        ClusterService clusterService = mock(ClusterService.class);
         NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext = new NativeMemoryEntryContext.TrainingDataEntryContext(
                 0,
                 "test",
                 "test",
                 null,
-                indicesService,
+                clusterService,
                 0,
                 0
         );
 
-        assertEquals(indicesService, trainingDataEntryContext.getIndicesService());
+        assertEquals(clusterService, trainingDataEntryContext.getClusterService());
     }
 
     private static class TestNativeMemoryAllocation implements NativeMemoryAllocation {

--- a/src/test/java/org/opensearch/knn/training/VectorReaderTests.java
+++ b/src/test/java/org/opensearch/knn/training/VectorReaderTests.java
@@ -14,8 +14,8 @@ package org.opensearch.knn.training;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ValidationException;
-import org.opensearch.indices.IndicesService;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 
 import java.io.IOException;
@@ -61,13 +61,13 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         }
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Read all vectors and confirm they match vectors
         TestVectorConsumer testVectorConsumer = new TestVectorConsumer();
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        vectorReader.read(indicesService, indexName, fieldName, 10000, 10, testVectorConsumer,
+        vectorReader.read(clusterService, indexName, fieldName, 10000, 10, testVectorConsumer,
                 ActionListener.wrap(response -> inProgressLatch1.countDown(), e -> fail(e.toString())));
 
         assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
@@ -115,13 +115,13 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         }
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Read all vectors and confirm they match vectors
         TestVectorConsumer testVectorConsumer = new TestVectorConsumer();
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        vectorReader.read(indicesService, indexName, fieldName, 10000, 10, testVectorConsumer,
+        vectorReader.read(clusterService, indexName, fieldName, 10000, 10, testVectorConsumer,
                 ActionListener.wrap(response -> inProgressLatch1.countDown(), e -> fail(e.toString())));
 
         assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
@@ -160,13 +160,13 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         }
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Read maxNumVectorsRead vectors
         TestVectorConsumer testVectorConsumer = new TestVectorConsumer();
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
-        vectorReader.read(indicesService, indexName, fieldName, maxNumVectorsRead, 10, testVectorConsumer,
+        vectorReader.read(clusterService, indexName, fieldName, maxNumVectorsRead, 10, testVectorConsumer,
                 ActionListener.wrap(response -> inProgressLatch1.countDown(), e -> fail(e.toString())));
 
         assertTrue(inProgressLatch1.await(100, TimeUnit.SECONDS));
@@ -186,10 +186,10 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         createKnnIndexMapping(indexName, fieldName, dim);
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
-        expectThrows(ValidationException.class, () -> vectorReader.read(indicesService, indexName, fieldName, -10, 10, null, null));
+        expectThrows(ValidationException.class, () -> vectorReader.read(clusterService, indexName, fieldName, -10, 10, null, null));
     }
 
     public void testRead_invalid_searchSize() {
@@ -203,14 +203,14 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         createKnnIndexMapping(indexName, fieldName, dim);
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Search size is negative
-        expectThrows(ValidationException.class, () -> vectorReader.read(indicesService, indexName, fieldName, 100, -10, null, null));
+        expectThrows(ValidationException.class, () -> vectorReader.read(clusterService, indexName, fieldName, 100, -10, null, null));
 
         // Search size is greater than 10000
-        expectThrows(ValidationException.class, () -> vectorReader.read(indicesService, indexName, fieldName, 100, 20000, null, null));
+        expectThrows(ValidationException.class, () -> vectorReader.read(clusterService, indexName, fieldName, 100, 20000, null, null));
     }
 
     public void testRead_invalid_indexDoesNotExist() {
@@ -219,11 +219,11 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         String fieldName = "test-field";
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Should throw a validation exception because index does not exist
-        expectThrows(ValidationException.class, () -> vectorReader.read(indicesService, indexName, fieldName, 10000, 10, null, null));
+        expectThrows(ValidationException.class, () -> vectorReader.read(clusterService, indexName, fieldName, 10000, 10, null, null));
     }
 
     public void testRead_invalid_fieldDoesNotExist() {
@@ -233,11 +233,11 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         createIndex(indexName);
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Should throw a validation exception because field is not k-NN
-        expectThrows(ValidationException.class, () -> vectorReader.read(indicesService, indexName, fieldName, 10000, 10, null, null));
+        expectThrows(ValidationException.class, () -> vectorReader.read(clusterService, indexName, fieldName, 10000, 10, null, null));
     }
 
     public void testRead_invalid_fieldIsNotKnn() throws InterruptedException, ExecutionException, IOException {
@@ -248,11 +248,11 @@ public class VectorReaderTests extends KNNSingleNodeTestCase {
         addDoc(indexName, "test-id", fieldName, "dummy");
 
         // Configure VectorReader
-        IndicesService indicesService = node().injector().getInstance(IndicesService.class);
+        ClusterService clusterService = node().injector().getInstance(ClusterService.class);
         VectorReader vectorReader = new VectorReader(client());
 
         // Should throw a validation exception because field does not exist
-        expectThrows(ValidationException.class, () -> vectorReader.read(indicesService, indexName, fieldName, 10000, 10, null, null));
+        expectThrows(ValidationException.class, () -> vectorReader.read(clusterService, indexName, fieldName, 10000, 10, null, null));
     }
 
     private static class TestVectorConsumer implements Consumer<List<Float[]>> {


### PR DESCRIPTION
### Description
This PR fixes the bug when training data index shard is not on training node. It uses the validation logic used in training model request in VectorReader. Additionally, for VectorReader, IndicesService is swapped out with ClusterService.

Lastly, this PR adds a couple error increments in TrainingJob that were not getting picked up.
 
### Issues Resolved
#205 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
