### PR TITLE
Change googletest from master to main

### DIFF
--- a/jni/CMakeLists.txt.in
+++ b/jni/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG master
+        GIT_TAG main
         SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Changes google test from master to main. WIll fix https://github.com/opensearch-project/k-NN/actions/runs/1463837306.


### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
