### PR TITLE
Add reset for vector

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+          args: --accept=200,403,429  **/*.html **/*.md **/*.txt **/*.json
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -432,6 +432,9 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
             vector.add(value);
             context.parser().nextToken();
+        } else if (token == XContentParser.Token.VALUE_NULL) {
+            context.path().remove();
+            return;
         }
 
         if (dimension != vector.size()) {

--- a/src/test/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNRestTestCase.java
@@ -79,6 +79,8 @@ import static org.opensearch.knn.plugin.stats.StatNames.INDICES_IN_CACHE;
 public class KNNRestTestCase extends ODFERestTestCase {
     public static final String INDEX_NAME = "test_index";
     public static final String FIELD_NAME = "test_field";
+    private static final String DOCUMENT_FIELD_SOURCE = "_source";
+    private static final String DOCUMENT_FIELD_FOUND = "found";
 
     @AfterClass
     public static void dumpCoverage() throws IOException, MalformedObjectNameException {
@@ -484,6 +486,28 @@ public class KNNRestTestCase extends ODFERestTestCase {
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
             RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    /**
+     * Retrieve document by index and document id
+     */
+    protected Map<String, Object> getKnnDoc(final String index, final String docId) throws IOException {
+        final Request request = new Request(
+                "GET",
+                "/" + index + "/_doc/" + docId
+        );
+        final Response response = client().performRequest(request);
+
+        final Map<String, Object> responseMap =
+                createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity())).map();
+
+        assertNotNull(responseMap);
+        assertTrue((Boolean) responseMap.get(DOCUMENT_FIELD_FOUND));
+        assertNotNull(responseMap.get(DOCUMENT_FIELD_SOURCE));
+
+        final Map<String, Object> docMap = (Map<String, Object>) responseMap.get(DOCUMENT_FIELD_SOURCE);
+
+        return docMap;
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -427,9 +427,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         //retrieving document by id
         final Map<String, Object> knnDocMap = getKnnDoc(INDEX_NAME, docOneId);
-        assertNotNull(knnDocMap.get(FIELD_NAME));
-        final Float[] vectorInDocument = ((List<Double>) knnDocMap.get(FIELD_NAME)).stream()
-                .map(Double::floatValue).toArray(Float[]::new);
+        final Float[] vectorInDocument = getVectorFromDocument(knnDocMap, FIELD_NAME);
         assertEquals(vectorForDocumentOne.length, vectorInDocument.length);
         assertArrayEquals(vectorForDocumentOne, vectorInDocument);
 
@@ -447,5 +445,25 @@ public class OpenSearchIT extends KNNRestTestCase {
                 parseSearchResponse(EntityUtils.toString(updatedResponse.getEntity()), FIELD_NAME);
         assertEquals(1, updatedResults.size());
         assertEquals(docTwoId, updatedResults.get(0).getDocId());
+
+        // update vector value back to original value
+        updateKnnDoc(INDEX_NAME, docOneId, FIELD_NAME, vectorForDocumentOne);
+        final Response restoreInitialVectorValueResponse = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
+        final List<KNNResult> restoreInitialVectorValueResults =
+                parseSearchResponse(EntityUtils.toString(restoreInitialVectorValueResponse.getEntity()), FIELD_NAME);
+        assertEquals(1, restoreInitialVectorValueResults.size());
+        assertEquals(docOneId, restoreInitialVectorValueResults.get(0).getDocId());
+
+        final Map<String, Object> knnDocMapRestoreInitialVectorValue = getKnnDoc(INDEX_NAME, docOneId);
+        final Float[] vectorRestoreInitialValue = getVectorFromDocument(knnDocMapRestoreInitialVectorValue, FIELD_NAME);
+        assertEquals(vectorForDocumentOne.length, vectorRestoreInitialValue.length);
+        assertArrayEquals(vectorForDocumentOne, vectorRestoreInitialValue);
+    }
+
+    private Float[] getVectorFromDocument(final Map<String, Object> knnDocMap, final String fieldName) {
+        assertNotNull(knnDocMap.get(fieldName));
+        final Float[] vectorInDocument = ((List<Double>) knnDocMap.get(fieldName)).stream()
+                .map(Double::floatValue).toArray(Float[]::new);
+        return vectorInDocument;
     }
 }

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -399,4 +399,46 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         assertEquals(3, parseTotalSearchHits(EntityUtils.toString(response.getEntity())));
     }
+
+    public void testIndexingVectorValidation_updateVectorWithNull() throws Exception {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .build();
+
+        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
+
+        // valid case with 4 dimension
+        final Float[] vector = {6.0f, 7.0f, 8.0f, 9.0f};
+        final String docId = "1";
+        addKnnDoc(INDEX_NAME, docId, FIELD_NAME, vector);
+
+        //checking that document in retrievable with correct vector values and searchable by knn plugin
+        int k = 1;
+        float[] queryVector = {5.0f, 6.0f, 7.0f, 10.0f};
+        final KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k);
+        final Response response = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
+        final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+        assertEquals(1, results.size());
+
+        //retrieving the document by id
+        final Map<String, Object> knnDocMap = getKnnDoc(INDEX_NAME, docId);
+        assertNotNull(knnDocMap.get(FIELD_NAME));
+        final Float[] vectorInDocument = ((List<Double>) knnDocMap.get(FIELD_NAME)).stream()
+                .map(Double::floatValue).toArray(Float[]::new);
+        assertEquals(vector.length, vectorInDocument.length);
+        assertArrayEquals(vector, vectorInDocument);
+
+        // update vector value to null
+        updateKnnDoc(INDEX_NAME, docId, FIELD_NAME, null);
+
+        //retrieving updated document by id, vector should be null
+        final Map<String, Object> knnDocMapUpdated = getKnnDoc(INDEX_NAME, docId);
+        assertNull(knnDocMapUpdated.get(FIELD_NAME));
+
+        //checking if document is not discoverable by knn plugin anymore
+        final Response updatedResponse = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
+        final List<KNNResult> updatedResults =
+                parseSearchResponse(EntityUtils.toString(updatedResponse.getEntity()), FIELD_NAME);
+        assertEquals(0, updatedResults.size());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -416,20 +416,15 @@ public class OpenSearchIT extends KNNRestTestCase {
         final String docTwoId = "2";
         addKnnDoc(INDEX_NAME, docTwoId, FIELD_NAME, vectorForDocumentTwo);
 
-        //checking that one of two documents in retrievable based on closer similarity to query vector
-        int k = 1;
+        //checking that both documents are retrievable based on knn search query
+        int k = 2;
         float[] queryVector = {5.0f, 6.0f, 7.0f, 10.0f};
         final KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, k);
         final Response response = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
         final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
-        assertEquals(1, results.size());
+        assertEquals(2, results.size());
         assertEquals(docOneId, results.get(0).getDocId());
-
-        //retrieving document by id
-        final Map<String, Object> knnDocMap = getKnnDoc(INDEX_NAME, docOneId);
-        final Float[] vectorInDocument = getVectorFromDocument(knnDocMap, FIELD_NAME);
-        assertEquals(vectorForDocumentOne.length, vectorInDocument.length);
-        assertArrayEquals(vectorForDocumentOne, vectorInDocument);
+        assertEquals(docTwoId, results.get(1).getDocId());
 
         // update vector value to null
         updateKnnDoc(INDEX_NAME, docOneId, FIELD_NAME, null);
@@ -438,32 +433,28 @@ public class OpenSearchIT extends KNNRestTestCase {
         final Map<String, Object> knnDocMapUpdated = getKnnDoc(INDEX_NAME, docOneId);
         assertNull(knnDocMapUpdated.get(FIELD_NAME));
 
-        //checking that first document one is no longer discoverable by knn plugin
-        //expected result is the document two which had originally less similarity score
+        //checking that first document one is no longer returned by knn search
         final Response updatedResponse = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
         final List<KNNResult> updatedResults =
                 parseSearchResponse(EntityUtils.toString(updatedResponse.getEntity()), FIELD_NAME);
         assertEquals(1, updatedResults.size());
         assertEquals(docTwoId, updatedResults.get(0).getDocId());
 
-        // update vector value back to original value
+        // update vector back to original value
         updateKnnDoc(INDEX_NAME, docOneId, FIELD_NAME, vectorForDocumentOne);
         final Response restoreInitialVectorValueResponse = searchKNNIndex(INDEX_NAME, knnQueryBuilder, k);
         final List<KNNResult> restoreInitialVectorValueResults =
                 parseSearchResponse(EntityUtils.toString(restoreInitialVectorValueResponse.getEntity()), FIELD_NAME);
-        assertEquals(1, restoreInitialVectorValueResults.size());
-        assertEquals(docOneId, restoreInitialVectorValueResults.get(0).getDocId());
+        assertEquals(2, restoreInitialVectorValueResults.size());
+        assertEquals(docOneId, results.get(0).getDocId());
+        assertEquals(docTwoId, results.get(1).getDocId());
 
+        //retrieving updated document by id, vector should be not null but has the original value
         final Map<String, Object> knnDocMapRestoreInitialVectorValue = getKnnDoc(INDEX_NAME, docOneId);
-        final Float[] vectorRestoreInitialValue = getVectorFromDocument(knnDocMapRestoreInitialVectorValue, FIELD_NAME);
-        assertEquals(vectorForDocumentOne.length, vectorRestoreInitialValue.length);
+        assertNotNull(knnDocMapRestoreInitialVectorValue.get(FIELD_NAME));
+        final Float[] vectorRestoreInitialValue = ((List<Double>) knnDocMapRestoreInitialVectorValue.get(FIELD_NAME)).stream()
+                .map(Double::floatValue).toArray(Float[]::new);
         assertArrayEquals(vectorForDocumentOne, vectorRestoreInitialValue);
     }
 
-    private Float[] getVectorFromDocument(final Map<String, Object> knnDocMap, final String fieldName) {
-        assertNotNull(knnDocMap.get(fieldName));
-        final Float[] vectorInDocument = ((List<Double>) knnDocMap.get(fieldName)).stream()
-                .map(Double::floatValue).toArray(Float[]::new);
-        return vectorInDocument;
-    }
 }


### PR DESCRIPTION
Add ability to reset vector value by using 'null'

### Description
Adding possibility to unset vector's value by updating vector field with 'null' value
 
### Issues Resolved
#51 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
