### PR TITLE
Bump OS version to 1.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.2-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
 

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
 endif()
 
 if(NOT KNN_PLUGIN_VERSION)
-    set(KNN_PLUGIN_VERSION "1.2.1.0")
+    set(KNN_PLUGIN_VERSION "1.2.2.0")
 endif()
 
 # Set architecture specific variables


### PR DESCRIPTION
Bump OS version to 1.2.2, which contains the update to log4j 2.16.0
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
