### PR TITLE
Clean up flaky tests

### DIFF
--- a/src/test/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNRestTestCase.java
@@ -877,6 +877,34 @@ public class KNNRestTestCase extends ODFERestTestCase {
         fail("Training did not succeed after " + attempts + " attempts with a delay of " + delayInMillis + " ms.");
     }
 
+    public void assertTrainingFails(String modelId, int attempts, int delayInMillis) throws InterruptedException,
+            IOException {
+        int attemptNum = 0;
+        Response response;
+        Map<String, Object> responseMap;
+        ModelState modelState;
+        while (attemptNum < attempts) {
+            Thread.sleep(delayInMillis);
+            attemptNum++;
+
+            response = getModel(modelId, null);
+
+            responseMap = createParser(
+                    XContentType.JSON.xContent(),
+                    EntityUtils.toString(response.getEntity())
+            ).map();
+
+            modelState = ModelState.getModelState((String) responseMap.get(MODEL_STATE));
+            if (modelState == ModelState.FAILED) {
+                return;
+            }
+
+            assertNotEquals(ModelState.CREATED, modelState);
+        }
+
+        fail("Training did not succeed after " + attempts + " attempts with a delay of " + delayInMillis + " ms.");
+    }
+
     /**
      * We need to be able to dump the jacoco coverage before cluster is shut down.
      * The new internal testing framework removed some of the gradle tasks we were listening to

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -141,56 +141,6 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
             Collections.singletonList("invalid_metric")));
     }
 
-    //TODO: Fix broken test case
-    // This test case intended to check whether the "graph_query_error" stat gets incremented when a query fails.
-    // It sets the circuit breaker limit to 1 kb and then indexes documents into the index and force merges so that
-    // the sole segment's graph will not fit in the cache. Then, it runs a query and expects an exception. Then it
-    // checks that the query errors get incremented. This test is flaky:
-    // https://github.com/opensearch-project/k-NN/issues/43. During query, when a segment to be
-    // searched is not present in the cache, it will first be loaded. Then it will be searched.
-    //
-    // The problem is that the cache built from CacheBuilder will not throw an exception if the entry exceeds the
-    // size of the cache - tested this via log statements. However, the entry gets marked as expired immediately.
-    // So, after loading the entry, sometimes the expired entry will get evicted before the search logic. This causes
-    // the search to fail. However, it appears sometimes that the entry doesnt get immediately evicted, causing the
-    // search to succeed.
-//    public void testGraphQueryErrorsGetIncremented() throws Exception {
-//        // Get initial query errors because it may not always be 0
-//        String graphQueryErrors = StatNames.GRAPH_QUERY_ERRORS.getName();
-//        Response response = getKnnStats(Collections.emptyList(), Collections.singletonList(graphQueryErrors));
-//        String responseBody = EntityUtils.toString(response.getEntity());
-//        Map<String, Object> nodeStats = parseNodeStatsResponse(responseBody).get(0);
-//        int beforeErrors = (int) nodeStats.get(graphQueryErrors);
-//
-//        // Set the circuit breaker very low so that loading an index will definitely fail
-//        updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
-//
-//        Settings settings = Settings.builder()
-//                .put("number_of_shards", 1)
-//                .put("index.knn", true)
-//                .build();
-//        createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
-//
-//        // Add enough docs to trip the circuit breaker
-//        Float[] vector = {1.3f, 2.2f};
-//        int docsInIndex = 25;
-//        for (int i = 0; i < docsInIndex; i++) {
-//            addKnnDoc(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector);
-//        }
-//        forceMergeKnnIndex(INDEX_NAME);
-//
-//        // Execute a query that should fail
-//        float[] qvector = {1.9f, 2.4f};
-//        expectThrows(ResponseException.class, () ->
-//                searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 10), 10));
-//
-//        // Check that the graphQuery errors gets incremented
-//        response = getKnnStats(Collections.emptyList(), Collections.singletonList(graphQueryErrors));
-//        responseBody = EntityUtils.toString(response.getEntity());
-//        nodeStats = parseNodeStatsResponse(responseBody).get(0);
-//        assertTrue((int) nodeStats.get(graphQueryErrors) > beforeErrors);
-//    }
-
     /**
      * Test checks that handler correctly returns stats for a single node
      *

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.plugin.action;
 
 import org.apache.http.util.EntityUtils;
+import org.junit.Ignore;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -29,181 +30,183 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
+    @Ignore
     public void testTrainModel_fail_notEnoughData() throws IOException {
-        //TODO: This fails on GET. We need to look into GET failure when training fails
-//
-//        // Check that training fails properly when there is not enough data
-//
-//        String trainingIndexName = "train-index";
-//        String trainingFieldName = "train-field";
-//        int dimension = 16;
-//
-//        // Create a training index and randomly ingest data into it
-//        createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-//        int trainingDataCount = 4;
-//        bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
-//
-//        // Call the train API with this definition:
-//        /*
-//            {
-//              "training_index": "train_index",
-//              "training_field": "train_field",
-//              "dimension": 16,
-//              "description": "this should be allowed to be null",
-//              "method": {
-//                  "name":"ivf",
-//                  "engine":"faiss",
-//                  "space_type": "innerproduct",
-//                  "parameters":{
-//                    "nlist":128,
-//                    "encoder":{
-//                        "name":"pq",
-//                        "parameters":{
-//                            "code_size":2,
-//                            "code_count": 2
-//                        }
-//                    }
-//                  }
-//              }
-//            }
-//        */
-//        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-//                .field(NAME, "ivf")
-//                .field(KNN_ENGINE, "faiss")
-//                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-//                .startObject(PARAMETERS)
-//                .field(METHOD_PARAMETER_NLIST, 128)
-//                .startObject(METHOD_ENCODER_PARAMETER)
-//                .field(NAME, "pq")
-//                .startObject(PARAMETERS)
-//                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-//                .field(ENCODER_PARAMETER_PQ_CODE_COUNT, 2)
-//                .endObject()
-//                .endObject()
-//                .endObject()
-//                .endObject();
-//        Map<String, Object> method = xContentBuilderToMap(builder);
-//
-//        Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method,
-//                "dummy description");
-//
-//        assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
-//
-//        // Grab the model id from the response
-//        String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
-//        assertNotNull(trainResponseBody);
-//
-//        Map<String, Object> trainResponseMap = createParser(
-//                XContentType.JSON.xContent(),
-//                trainResponseBody
-//        ).map();
-//        String modelId = (String) trainResponseMap.get(MODEL_ID);
-//        assertNotNull(modelId);
-//
-//        // Confirm that the model fails to create
-//        Response getResponse = getModel(modelId, null);
-//        String responseBody = EntityUtils.toString(getResponse.getEntity());
-//        assertNotNull(responseBody);
-//
-//        Map<String, Object> responseMap = createParser(
-//                XContentType.JSON.xContent(),
-//                responseBody
-//        ).map();
-//
-//        assertEquals(modelId, responseMap.get(MODEL_ID));
-//        assertEquals("failed", responseMap.get(MODEL_STATE));
+
+        // Check that training fails properly when there is not enough data
+
+        String trainingIndexName = "train-index";
+        String trainingFieldName = "train-field";
+        int dimension = 16;
+
+        // Create a training index and randomly ingest data into it
+        createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
+        int trainingDataCount = 4;
+        bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
+
+        // Call the train API with this definition:
+        /*
+            {
+              "training_index": "train_index",
+              "training_field": "train_field",
+              "dimension": 16,
+              "description": "this should be allowed to be null",
+              "method": {
+                  "name":"ivf",
+                  "engine":"faiss",
+                  "space_type": "innerproduct",
+                  "parameters":{
+                    "nlist":128,
+                    "encoder":{
+                        "name":"pq",
+                        "parameters":{
+                            "code_size":2,
+                            "code_count": 2
+                        }
+                    }
+                  }
+              }
+            }
+        */
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 128)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        Map<String, Object> method = xContentBuilderToMap(builder);
+
+        Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method,
+                "dummy description");
+
+        assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
+
+        // Grab the model id from the response
+        String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
+        assertNotNull(trainResponseBody);
+
+        Map<String, Object> trainResponseMap = createParser(
+                XContentType.JSON.xContent(),
+                trainResponseBody
+        ).map();
+        String modelId = (String) trainResponseMap.get(MODEL_ID);
+        assertNotNull(modelId);
+
+        // Confirm that the model fails to create
+        Response getResponse = getModel(modelId, null);
+        String responseBody = EntityUtils.toString(getResponse.getEntity());
+        assertNotNull(responseBody);
+
+        Map<String, Object> responseMap = createParser(
+                XContentType.JSON.xContent(),
+                responseBody
+        ).map();
+
+        assertEquals(modelId, responseMap.get(MODEL_ID));
+        assertEquals("failed", responseMap.get(MODEL_STATE));
     }
 
+    @Ignore
     public void testTrainModel_fail_tooMuchData() throws Exception {
         //TODO: Fails on get
-//
-//        // Limit the cache size and then call train
-//
-//        updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
-//
-//        String trainingIndexName = "train-index";
-//        String trainingFieldName = "train-field";
-//        int dimension = 16;
-//
-//        // Create a training index and randomly ingest data into it
-//        createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-//        int trainingDataCount = 20; // 20 * 16 * 4 ~= 10 kb
-//        bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
-//
-//        // Call the train API with this definition:
-//        /*
-//            {
-//              "training_index": "train_index",
-//              "training_field": "train_field",
-//              "dimension": 16,
-//              "description": "this should be allowed to be null",
-//              "method": {
-//                  "name":"ivf",
-//                  "engine":"faiss",
-//                  "space_type": "innerproduct",
-//                  "parameters":{
-//                    "nlist":128,
-//                    "encoder":{
-//                        "name":"pq",
-//                        "parameters":{
-//                            "code_size":2,
-//                            "code_count": 2
-//                        }
-//                    }
-//                  }
-//              }
-//            }
-//        */
-//        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-//                .field(NAME, "ivf")
-//                .field(KNN_ENGINE, "faiss")
-//                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-//                .startObject(PARAMETERS)
-//                .field(METHOD_PARAMETER_NLIST, 128)
-//                .startObject(METHOD_ENCODER_PARAMETER)
-//                .field(NAME, "pq")
-//                .startObject(PARAMETERS)
-//                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-//                .field(ENCODER_PARAMETER_PQ_CODE_COUNT, 2)
-//                .endObject()
-//                .endObject()
-//                .endObject()
-//                .endObject();
-//        Map<String, Object> method = xContentBuilderToMap(builder);
-//
-//        Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method,
-//                "dummy description");
-//
-//        assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
-//
-//        // Grab the model id from the response
-//        String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
-//        assertNotNull(trainResponseBody);
-//
-//        Map<String, Object> trainResponseMap = createParser(
-//                XContentType.JSON.xContent(),
-//                trainResponseBody
-//        ).map();
-//        String modelId = (String) trainResponseMap.get(MODEL_ID);
-//        assertNotNull(modelId);
-//
-//        // Confirm that the model fails to create
-//        Response getResponse = getModel(modelId, null);
-//        String responseBody = EntityUtils.toString(getResponse.getEntity());
-//        assertNotNull(responseBody);
-//
-//        Map<String, Object> responseMap = createParser(
-//                XContentType.JSON.xContent(),
-//                responseBody
-//        ).map();
-//
-//        assertEquals(modelId, responseMap.get(MODEL_ID));
-//        assertEquals("failed", responseMap.get(MODEL_STATE));
+
+        // Limit the cache size and then call train
+
+        updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
+
+        String trainingIndexName = "train-index";
+        String trainingFieldName = "train-field";
+        int dimension = 16;
+
+        // Create a training index and randomly ingest data into it
+        createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
+        int trainingDataCount = 20; // 20 * 16 * 4 ~= 10 kb
+        bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
+
+        // Call the train API with this definition:
+        /*
+            {
+              "training_index": "train_index",
+              "training_field": "train_field",
+              "dimension": 16,
+              "description": "this should be allowed to be null",
+              "method": {
+                  "name":"ivf",
+                  "engine":"faiss",
+                  "space_type": "innerproduct",
+                  "parameters":{
+                    "nlist":128,
+                    "encoder":{
+                        "name":"pq",
+                        "parameters":{
+                            "code_size":2,
+                            "code_count": 2
+                        }
+                    }
+                  }
+              }
+            }
+        */
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 128)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        Map<String, Object> method = xContentBuilderToMap(builder);
+
+        Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method,
+                "dummy description");
+
+        assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
+
+        // Grab the model id from the response
+        String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
+        assertNotNull(trainResponseBody);
+
+        Map<String, Object> trainResponseMap = createParser(
+                XContentType.JSON.xContent(),
+                trainResponseBody
+        ).map();
+        String modelId = (String) trainResponseMap.get(MODEL_ID);
+        assertNotNull(modelId);
+
+        // Confirm that the model fails to create
+        Response getResponse = getModel(modelId, null);
+        String responseBody = EntityUtils.toString(getResponse.getEntity());
+        assertNotNull(responseBody);
+
+        Map<String, Object> responseMap = createParser(
+                XContentType.JSON.xContent(),
+                responseBody
+        ).map();
+
+        assertEquals(modelId, responseMap.get(MODEL_ID));
+        assertEquals("failed", responseMap.get(MODEL_STATE));
     }
 
     public void testTrainModel_success_withId() throws IOException, InterruptedException {

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -12,7 +12,6 @@
 package org.opensearch.knn.plugin.action;
 
 import org.apache.http.util.EntityUtils;
-import org.junit.Ignore;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -30,14 +29,12 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
-import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
-    @Ignore
-    public void testTrainModel_fail_notEnoughData() throws IOException {
+    public void testTrainModel_fail_notEnoughData() throws IOException, InterruptedException {
 
         // Check that training fails properly when there is not enough data
 
@@ -118,13 +115,11 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         ).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
-        assertEquals("failed", responseMap.get(MODEL_STATE));
+
+        assertTrainingFails(modelId, 30, 1000);
     }
 
-    @Ignore
     public void testTrainModel_fail_tooMuchData() throws Exception {
-        //TODO: Fails on get
-
         // Limit the cache size and then call train
 
         updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
@@ -206,7 +201,8 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         ).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
-        assertEquals("failed", responseMap.get(MODEL_STATE));
+
+        assertTrainingFails(modelId, 30, 1000);
     }
 
     public void testTrainModel_success_withId() throws IOException, InterruptedException {

--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.plugin.transport;
 
 import com.google.common.collect.ImmutableSet;
+import org.junit.Ignore;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -32,6 +33,7 @@ import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_LIMIT_SETTIN
 
 public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestCase {
 
+    @Ignore
     public void testNodeOperation_modelNotInCache() {
         ClusterService clusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), "10%").build();
@@ -57,6 +59,7 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
         assertEquals(0L, modelCache.getTotalWeightInKB());
     }
 
+    @Ignore
     public void testNodeOperation_modelInCache() throws ExecutionException, InterruptedException {
         ClusterService clusterService = mock(ClusterService.class);
         Settings settings = Settings.builder().put(MODEL_CACHE_SIZE_LIMIT_SETTING.getKey(), "10%").build();


### PR DESCRIPTION
### Description
In #246 , @martin-gaievski suggested we Ignore as opposed to commenting out for flaky tests. I agree this is a cleaner way of handling flaky test so this PR adds that.

It also fixes one of the commented out tests from training that had been left commented out because the particular functionality was not available when the tests were written.

Lastly, it removes the KNNStats flaky test. This test is too complicated for the value it adds (making sure a counter gets incremented). Therefore, I think it is better just to remove it. We have tested counter functionality in uTs and other iTs.
 
### Issues Resolved
#43
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
