### PR TITLE
Add Recall Tests

### DIFF
--- a/src/test/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNRestTestCase.java
@@ -11,6 +11,7 @@ import com.google.common.primitives.Floats;
 import org.apache.commons.lang.StringUtils;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.knn.index.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.indices.ModelDao;
@@ -780,6 +781,65 @@ public class KNNRestTestCase extends ODFERestTestCase {
             addKnnDoc(indexName, String.valueOf(i+1), fieldName, Floats.asList(vector).toArray());
         }
 
+    }
+
+    public void bulkAddKnnDocs(String index, String fieldName,  float[][] indexVectors, int docCount) throws IOException {
+        Request request = new Request(
+                "POST",
+                "/_bulk"
+        );
+
+        request.addParameter("refresh", "true");
+        StringBuilder sb = new StringBuilder();
+
+        for(int i = 0; i < docCount; i++){
+            sb.append("{ \"index\" : { \"_index\" : \"")
+                    .append(index)
+                    .append("\", \"_id\" : \"")
+                    .append(i+1)
+                    .append("\" } }\n")
+                    .append("{ \"")
+                    .append(fieldName)
+                    .append("\" : ")
+                    .append(Arrays.toString(indexVectors[i]))
+                    .append(" }\n");
+        }
+
+        request.setJsonEntity(sb.toString());
+
+        Response response = client().performRequest(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 200);
+    }
+
+    public float[][] getIndexVectorsFromIndex(String testIndex, String testField, int docCount, int dimensions) throws IOException {
+        float[][] vectors = new float[docCount][dimensions];
+
+        QueryBuilder qb = new MatchAllQueryBuilder();
+
+        Request request = new Request(
+                "POST",
+                "/" + testIndex + "/_search"
+        );
+
+        request.addParameter("size", Integer.toString(docCount));
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.field("query", qb);
+        builder.endObject();
+        request.setJsonEntity(Strings.toString(builder));
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
+                RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), testField);
+        int i = 0;
+
+        for(KNNResult result : results) {
+            float[] primitiveArray = Floats.toArray(Arrays.stream(result.getVector()).collect(Collectors.toList()));
+            vectors[i++] = primitiveArray;
+        }
+
+        return vectors;
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.recall;
+
+import com.google.common.primitives.Floats;
+import org.apache.http.util.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.TestUtils;
+import org.opensearch.knn.index.KNNQueryBuilder;
+import org.opensearch.knn.index.SpaceType;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY;
+import static org.opensearch.knn.index.KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED;
+
+public class RecallTestsIT extends KNNRestTestCase {
+
+    private final String testFieldName = "test-field";
+    private final int dimensions = 50;
+    private final int docCount = 10000;
+    private final int queryCount = 100;
+    private final int k = 5;
+    private final double expRecallValue = 1.0;
+
+    public void testRecallL2StandardData() throws Exception {
+        String testIndexStandard = "test-index-standard";
+
+        addDocs(testIndexStandard, testFieldName, dimensions, docCount, true);
+        float[][] indexVectors = getIndexVectorsFromIndex(testIndexStandard, testFieldName, docCount, dimensions);
+        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, true);
+        float[][] groundTruthValues = TestUtils.computeGroundTruthDistances(indexVectors, queryVectors, SpaceType.L2, k);
+        List<List<float[]>> searchResults = getSearchResults(testIndexStandard, testFieldName, queryVectors, k);
+        double recallValue = TestUtils.calculateRecallValue(queryVectors, searchResults, groundTruthValues, k, SpaceType.L2);
+        assertEquals(expRecallValue, recallValue, 0.2);
+    }
+
+    public void testRecallL2RandomData() throws Exception {
+        String testIndexRandom = "test-index-random";
+
+        addDocs(testIndexRandom, testFieldName, dimensions, docCount, false);
+        float[][] indexVectors = getIndexVectorsFromIndex(testIndexRandom, testFieldName, docCount, dimensions);
+        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, false);
+        float[][] groundTruthValues = TestUtils.computeGroundTruthDistances(indexVectors, queryVectors, SpaceType.L2, k);
+        List<List<float[]>> searchResults = getSearchResults(testIndexRandom, testFieldName, queryVectors, k);
+        double recallValue = TestUtils.calculateRecallValue(queryVectors, searchResults, groundTruthValues, k, SpaceType.L2);
+        assertEquals(expRecallValue, recallValue, 0.2);
+    }
+
+    private void addDocs(String testIndex, String testField, int dimensions, int docCount, boolean isStandard) throws Exception{
+        createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(testField, dimensions));
+
+        updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, 2);
+        updateClusterSettings(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, true);
+
+        bulkAddKnnDocs(testIndex, testField, TestUtils.getIndexVectors(docCount, dimensions, isStandard), docCount);
+    }
+
+    private List<List<float[]>> getSearchResults(String testIndex, String testField, float[][] queryVectors, int k) throws IOException {
+        List<List<float[]>> searchResults = new ArrayList<>();
+        List<float[]> kVectors;
+
+        for(int i = 0; i < queryVectors.length; i++){
+            KNNQueryBuilder knnQueryBuilderRecall = new KNNQueryBuilder(testField, queryVectors[i], k);
+            Response respRecall = searchKNNIndex(testIndex, knnQueryBuilderRecall,k);
+            List<KNNResult> resultsRecall = parseSearchResponse(EntityUtils.toString(respRecall.getEntity()), testField);
+
+            assertEquals(resultsRecall.size(), k);
+            kVectors = new ArrayList<>();
+            for(KNNResult result : resultsRecall){
+                kVectors.add(Floats.toArray(Arrays.stream(result.getVector()).collect(Collectors.toList())));
+            }
+            searchResults.add(kVectors);
+        }
+
+        return searchResults;
+    }
+}

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.knn.recall;
 
-import com.google.common.primitives.Floats;
 import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.knn.KNNRestTestCase;
@@ -21,9 +20,8 @@ import org.opensearch.knn.index.KNNQueryBuilder;
 import org.opensearch.knn.index.SpaceType;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY;
 import static org.opensearch.knn.index.KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED;
 
@@ -41,10 +39,10 @@ public class RecallTestsIT extends KNNRestTestCase {
 
         addDocs(testIndexStandard, testFieldName, dimensions, docCount, true);
         float[][] indexVectors = getIndexVectorsFromIndex(testIndexStandard, testFieldName, docCount, dimensions);
-        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, true);
-        float[][] groundTruthValues = TestUtils.computeGroundTruthDistances(indexVectors, queryVectors, SpaceType.L2, k);
-        List<List<float[]>> searchResults = getSearchResults(testIndexStandard, testFieldName, queryVectors, k);
-        double recallValue = TestUtils.calculateRecallValue(queryVectors, searchResults, groundTruthValues, k, SpaceType.L2);
+        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, docCount, true);
+        List<Set<String>> groundTruthValues = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, k);
+        List<List<String>> searchResults = bulkSearch(testIndexStandard, testFieldName, queryVectors, k);
+        double recallValue = TestUtils.calculateRecallValue(searchResults, groundTruthValues, k);
         assertEquals(expRecallValue, recallValue, 0.2);
     }
 
@@ -53,14 +51,14 @@ public class RecallTestsIT extends KNNRestTestCase {
 
         addDocs(testIndexRandom, testFieldName, dimensions, docCount, false);
         float[][] indexVectors = getIndexVectorsFromIndex(testIndexRandom, testFieldName, docCount, dimensions);
-        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, false);
-        float[][] groundTruthValues = TestUtils.computeGroundTruthDistances(indexVectors, queryVectors, SpaceType.L2, k);
-        List<List<float[]>> searchResults = getSearchResults(testIndexRandom, testFieldName, queryVectors, k);
-        double recallValue = TestUtils.calculateRecallValue(queryVectors, searchResults, groundTruthValues, k, SpaceType.L2);
+        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, docCount, false);
+        List<Set<String>> groundTruthValues = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, k);
+        List<List<String>> searchResults = bulkSearch(testIndexRandom, testFieldName, queryVectors, k);
+        double recallValue = TestUtils.calculateRecallValue(searchResults, groundTruthValues, k);
         assertEquals(expRecallValue, recallValue, 0.2);
     }
 
-    private void addDocs(String testIndex, String testField, int dimensions, int docCount, boolean isStandard) throws Exception{
+    private void addDocs(String testIndex, String testField, int dimensions, int docCount, boolean isStandard) throws Exception {
         createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(testField, dimensions));
 
         updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, 2);
@@ -69,23 +67,4 @@ public class RecallTestsIT extends KNNRestTestCase {
         bulkAddKnnDocs(testIndex, testField, TestUtils.getIndexVectors(docCount, dimensions, isStandard), docCount);
     }
 
-    private List<List<float[]>> getSearchResults(String testIndex, String testField, float[][] queryVectors, int k) throws IOException {
-        List<List<float[]>> searchResults = new ArrayList<>();
-        List<float[]> kVectors;
-
-        for(int i = 0; i < queryVectors.length; i++){
-            KNNQueryBuilder knnQueryBuilderRecall = new KNNQueryBuilder(testField, queryVectors[i], k);
-            Response respRecall = searchKNNIndex(testIndex, knnQueryBuilderRecall,k);
-            List<KNNResult> resultsRecall = parseSearchResponse(EntityUtils.toString(respRecall.getEntity()), testField);
-
-            assertEquals(resultsRecall.size(), k);
-            kVectors = new ArrayList<>();
-            for(KNNResult result : resultsRecall){
-                kVectors.add(Floats.toArray(Arrays.stream(result.getVector()).collect(Collectors.toList())));
-            }
-            searchResults.add(kVectors);
-        }
-
-        return searchResults;
-    }
 }


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Adding recall tests to integration tests and backward compatibility tests. This includes two separate tests where the vectors are generated using some standard function in one test and randomly generated vectors in other test. 'l2' is the spaceType used to measure distance between two points.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/250
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
