### PR TITLE
Default to nmslib in KNNWeight if engine isnt specified

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/KNNWeight.java
@@ -108,7 +108,8 @@ public class KNNWeight extends Weight {
                 knnEngine = modelMetadata.getKnnEngine();
                 spaceType = modelMetadata.getSpaceType();
             } else {
-                knnEngine = KNNEngine.getEngine(fieldInfo.getAttribute(KNN_ENGINE));
+                String engineName = fieldInfo.attributes().getOrDefault(KNN_ENGINE, KNNEngine.NMSLIB.getName());
+                knnEngine = KNNEngine.getEngine(engineName);
                 spaceType = SpaceType.getSpace(fieldInfo.getAttribute(SPACE_TYPE));
             }
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
In KNNWeight, we attempt to read the name of the engine used for the field of the segment being searched. For ES 7.x indices, the engine field attribute will not be set. In these cases, we should default to nmslib (because faiss had not been introduced in ODFE).

In order to test, I followed the repro steps [here](https://github.com/opensearch-project/k-NN/issues/255#issuecomment-1010602369) and validated that search at the end does not produce an exception:
```
curl -X POST "localhost:9200/odfe_index/_search?pretty" -H 'Content-Type: application/json' -d'
> {
>   "size" : 2,
>   "query": {
>     "knn": {
>       "target_field": {
>         "vector": [3, 4],
>         "k": 2
>       }
>     }
>   }
> }
> '
{
  "took" : 272,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 0.0020768433,
    "hits" : [
      {
        "_index" : "odfe_index",
        "_type" : "_doc",
        "_id" : "Eg1XTH4Bymf1hVqcz8y8",
        "_score" : 0.0020768433,
        "_source" : {
          "target_field" : [
            18.5,
            19.5
          ]
        }
      },
      {
        "_index" : "odfe_index",
        "_type" : "_doc",
        "_id" : "Ew1XTH4Bymf1hVqcz8y_",
        "_score" : 0.0018331805,
        "_source" : {
          "target_field" : [
            19.5,
            20.5
          ]
        }
      }
    ]
  }
}
```
 
### Issues Resolved
#255 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
