### PR TITLE
Removing jcenter repo from repositories blocks in gradle files

### DIFF
--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -5,6 +5,5 @@
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
     }
 
     dependencies {
@@ -45,7 +44,6 @@ repositories {
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    jcenter()
 }
 
 apply plugin: 'opensearch.opensearchplugin'


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Removing all direct dependencies on jcenter() within a repositories block. Repository has been shut down and replaced by mavenCentral(), see parent issue for detailed explanation. 
 
### Issues Resolved
[Remove jcenter repository #260](https://github.com/opensearch-project/k-NN/issues/260)
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
