### PR TITLE
Adding write permissions to backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   backport:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Copying backport action permissions fix from OpenSearch repo [Fixing auto backport workflow](https://github.com/opensearch-project/OpenSearch/pull/1845). 

Currently backport action workflow is failing with "permission denied", [example](https://github.com/opensearch-project/k-NN/runs/4808810861?check_suite_focus=true).
 
### Issues Resolved
NA
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
