### PR TITLE
Refactor benchmark dataset format and add big ann benchmark format

### DIFF
--- a/benchmarks/perf-tool/README.md
+++ b/benchmarks/perf-tool/README.md
@@ -219,7 +219,7 @@ Ingests a dataset of vectors into the cluster.
 | index_name | Name of index to ingest into | No default |
 | field_name | Name of field to ingest into | No default |
 | bulk_size | Documents per bulk request | 300 |
-| dataset_format | Format the dataset is in. Currently only hdf5 is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. This will use the "train" data as the data to ingest. | 'hdf5' |
+| dataset_format | Format the dataset is in. Currently hdf5 and bigann is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. | 'hdf5' |
 | dataset_path | Path to dataset | No default |
 
 ##### Metrics
@@ -241,8 +241,10 @@ Runs a set of queries against an index.
 | index_name | Name of index to search | No default |
 | field_name | Name field to search | No default |
 | calculate_recall | Whether to calculate recall values | False |
-| dataset_format | Format the dataset is in. Currently only hdf5 is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. This will use the "test" data as the data to use for queries. | 'hdf5' |
+| dataset_format | Format the dataset is in. Currently hdf5 and bigann is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. | 'hdf5' |
 | dataset_path | Path to dataset | No default |
+| neighbors_format | Format the neighbors dataset is in. Currently hdf5 and bigann is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. | 'hdf5' |
+| neighbors_path | Path to neighbors dataset | No default |
 
 ##### Metrics
 

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -39,9 +39,15 @@ class HDF5DataSet(DataSet):
         self.current = 0
 
     def read(self, chunk_size: int):
-        ##TODO: This should only return the maximum number of results
-        v = cast(np.ndarray, self.data[self.current:self.current + chunk_size])
-        self.current += chunk_size
+        if self.current >= self.size():
+            return None
+
+        end_i = self.current + chunk_size
+        if end_i > self.size():
+            end_i = self.size()
+
+        v = cast(np.ndarray, self.data[self.current:end_i])
+        self.current = end_i
         return v
 
     def get_data(self):

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -23,7 +23,7 @@ def parse_dataset(dataset_format: str, dataset_path: str,
     if dataset_format == 'bigann':
         return BigANNVectorDataSet(dataset_path)
 
-    raise Exception("Unknown dataset format")
+    raise Exception("Unsupported data-set format")
 
 
 def parse_string_param(key: str, first_map, second_map, default) -> str:

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -30,7 +30,7 @@ class DataSet(ABC):
         pass
 
 
-class HDF5DataSet(Dataset):
+class HDF5DataSet(DataSet):
 
     def __init__(self, dataset_path: str, selector: str):
         file = h5py.File(dataset_path)

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -9,15 +9,15 @@
 
 from okpt.io.config.parsers.base import ConfigurationError
 from okpt.io.dataset import HDF5DataSet, BigANNNeighborDataSet, \
-    BigANNVectorDataSet, DataSet
+    BigANNVectorDataSet, DataSet, Context
 
 
 def parse_dataset(dataset_format: str, dataset_path: str,
-                  selector: str = None) -> DataSet:
+                  context: Context) -> DataSet:
     if dataset_format == 'hdf5':
-        return HDF5DataSet(dataset_path, selector)
+        return HDF5DataSet(dataset_path, context)
 
-    if dataset_format == 'bigann' and selector == "neighbors":
+    if dataset_format == 'bigann' and context == Context.NEIGHBORS:
         return BigANNNeighborDataSet(dataset_path)
 
     if dataset_format == 'bigann':

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -10,6 +10,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Union, cast
 import h5py
+import numpy as np
 
 from okpt.io.config.parsers.base import ConfigurationError
 

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -6,6 +6,7 @@
 
 """Utility functions for parsing"""
 
+from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Union, cast
 import h5py

--- a/benchmarks/perf-tool/okpt/io/config/parsers/util.py
+++ b/benchmarks/perf-tool/okpt/io/config/parsers/util.py
@@ -8,7 +8,7 @@
 
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Union, cast
+from typing import cast
 import h5py
 import numpy as np
 
@@ -28,6 +28,10 @@ class DataSet(ABC):
 
     @abstractmethod
     def size(self):
+        pass
+
+    @abstractmethod
+    def reset(self):
         pass
 
 
@@ -55,6 +59,9 @@ class HDF5DataSet(DataSet):
 
     def size(self):
         return self.data.len()
+
+    def reset(self):
+        self.current = 0
 
 
 def parse_dataset(dataset_format: str, dataset_path: str,

--- a/benchmarks/perf-tool/okpt/io/dataset.py
+++ b/benchmarks/perf-tool/okpt/io/dataset.py
@@ -97,16 +97,28 @@ class BigANNNeighborDataSet(DataSet):
         self.file = open(dataset_path, 'rb')
         self.num_queries = int.from_bytes(self.file.read(4), "little")
         self.k = int.from_bytes(self.file.read(4), "little")
+        self.current = 0
 
     def read(self, chunk_size: int):
-        return [[int.from_bytes(self.file.read(4), "little") for _ in
-                 range(self.k)] for _ in range(chunk_size)]
+        if self.current >= self.size():
+            return None
+
+        end_i = self.current + chunk_size
+        if end_i > self.size():
+            end_i = self.size()
+
+        v = [[int.from_bytes(self.file.read(4), "little") for _ in
+              range(self.k)] for _ in range(end_i - self.current)]
+
+        self.current = end_i
+        return v
 
     def size(self):
         return self.num_queries
 
     def reset(self):
         self.file.seek(8)
+        self.current = 0
 
 
 class BigANNVectorDataSet(DataSet):

--- a/benchmarks/perf-tool/okpt/io/dataset.py
+++ b/benchmarks/perf-tool/okpt/io/dataset.py
@@ -60,8 +60,9 @@ class DataSet(ABC):
 
 
 class HDF5DataSet(DataSet):
-    """ Data-set format corresponding to ann-benchmarks -
-    https://github.com/erikbern/ann-benchmarks#data-sets"""
+    """ Data-set format corresponding to `ANN Benchmarks
+    <https://github.com/erikbern/ann-benchmarks#data-sets>`_ 
+    """
 
     def __init__(self, dataset_path: str, context: Context):
         file = h5py.File(dataset_path)
@@ -101,8 +102,8 @@ class HDF5DataSet(DataSet):
 
 
 class BigANNNeighborDataSet(DataSet):
-    """ Data-set format for neighbor data-sets for Big ANN Benchmarks -
-    https://big-ann-benchmarks.com/index.html#bench-datasets """
+    """ Data-set format for neighbor data-sets for `Big ANN Benchmarks
+    <https://big-ann-benchmarks.com/index.html#bench-datasets>`_"""
 
     def __init__(self, dataset_path: str):
         self.file = open(dataset_path, 'rb')
@@ -133,8 +134,9 @@ class BigANNNeighborDataSet(DataSet):
 
 
 class BigANNVectorDataSet(DataSet):
-    """ Data-set format for vector data-sets for Big ANN Benchmarks -
-    https://big-ann-benchmarks.com/index.html#bench-datasets """
+    """ Data-set format for vector data-sets for `Big ANN Benchmarks
+    <https://big-ann-benchmarks.com/index.html#bench-datasets>`_
+    """
 
     def __init__(self, dataset_path: str):
         self.file = open(dataset_path, 'rb')

--- a/benchmarks/perf-tool/okpt/io/dataset.py
+++ b/benchmarks/perf-tool/okpt/io/dataset.py
@@ -19,11 +19,18 @@ Classes:
 """
 
 from abc import ABC, ABCMeta, abstractmethod
+from enum import Enum
 from typing import cast
 import h5py
 import numpy as np
 
 import struct
+
+
+class Context(Enum):
+    INDEX = 1
+    QUERY = 2
+    NEIGHBORS = 3
 
 
 class DataSet(ABC):
@@ -44,9 +51,9 @@ class DataSet(ABC):
 
 class HDF5DataSet(DataSet):
 
-    def __init__(self, dataset_path: str, selector: str):
+    def __init__(self, dataset_path: str, context: Context):
         file = h5py.File(dataset_path)
-        self.data = cast(h5py.Dataset, file[selector])
+        self.data = cast(h5py.Dataset, file[self._parse_context(context)])
         self.current = 0
 
     def read(self, chunk_size: int):
@@ -66,6 +73,17 @@ class HDF5DataSet(DataSet):
 
     def reset(self):
         self.current = 0
+
+    @staticmethod
+    def _parse_context(context: Context) -> str:
+        if context == Context.NEIGHBORS:
+            return "neighbors"
+
+        if context == Context.INDEX:
+            return "train"
+
+        if context == Context.QUERY:
+            return "test"
 
 
 class BigANNNeighborDataSet(DataSet):

--- a/benchmarks/perf-tool/okpt/io/dataset.py
+++ b/benchmarks/perf-tool/okpt/io/dataset.py
@@ -82,7 +82,7 @@ class BigANNNeighborDataSet(DataSet):
 
     def read(self, chunk_size: int):
         return [[int.from_bytes(self.file.read(4), "little") for _ in
-                 range(self.k)] for _ in range(self.num_queries)]
+                 range(self.k)] for _ in range(chunk_size)]
 
     def size(self):
         return self.num_queries

--- a/benchmarks/perf-tool/okpt/io/dataset.py
+++ b/benchmarks/perf-tool/okpt/io/dataset.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+"""Defines DataSet interface and implements particular formats
+
+A DataSet is thas the basic functionality that it can be read in chunks, or
+read completely and reset to the start.
+
+Currently, we support HDF5 formats from ann-benchmarks and big-ann-benchmarks
+datasets.
+
+Classes:
+    HDF5DataSet: Format used in ann-benchmarks
+    BigANNNeighborDataSet: Neighbor format for big-ann-benchmarks
+    BigANNVectorDataSet: Vector format for big-ann-benchmarks
+"""
+
+from abc import ABC, ABCMeta, abstractmethod
+from typing import cast
+import h5py
+import numpy as np
+
+import struct
+
+
+class DataSet(ABC):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def read(self, chunk_size: int):
+        pass
+
+    @abstractmethod
+    def size(self):
+        pass
+
+    @abstractmethod
+    def reset(self):
+        pass
+
+
+class HDF5DataSet(DataSet):
+
+    def __init__(self, dataset_path: str, selector: str):
+        file = h5py.File(dataset_path)
+        self.data = cast(h5py.Dataset, file[selector])
+        self.current = 0
+
+    def read(self, chunk_size: int):
+        if self.current >= self.size():
+            return None
+
+        end_i = self.current + chunk_size
+        if end_i > self.size():
+            end_i = self.size()
+
+        v = cast(np.ndarray, self.data[self.current:end_i])
+        self.current = end_i
+        return v
+
+    def size(self):
+        return self.data.len()
+
+    def reset(self):
+        self.current = 0
+
+
+class BigANNNeighborDataSet(DataSet):
+    """
+    Neighbors:
+    1. num_queries(uint32_t) K (uint32)
+    2. num_queries X K x sizeof(uint32_t) bytes of data representing the IDs
+    3. followed by num_queries X K x sizeof(float)
+    """
+    def __init__(self, dataset_path: str):
+        self.file = open(dataset_path, 'rb')
+        self.num_queries = int.from_bytes(self.file.read(4), "little")
+        self.k = int.from_bytes(self.file.read(4), "little")
+
+    def read(self, chunk_size: int):
+        return [[int.from_bytes(self.file.read(4), "little") for _ in
+                 range(self.k)] for _ in range(self.num_queries)]
+
+    def size(self):
+        return self.num_queries
+
+    def reset(self):
+        self.file.seek(8)
+
+
+class BigANNVectorDataSet(DataSet):
+    """
+    1. 8 bytes of data consisting of num_points(uint32_t) num_dimensions(uint32)
+    2. num_pts X num_dimensions x sizeof(type) bytes of data stored one vector
+    after another.
+    """
+    def __init__(self, dataset_path: str):
+        self.file = open(dataset_path, 'rb')
+        self.num_points = int.from_bytes(self.file.read(4), "little")
+        self.dimension = int.from_bytes(self.file.read(4), "little")
+        self.reader = _value_reader(dataset_path)
+        self.current = 0
+
+    def read(self, chunk_size: int):
+        if self.current >= self.size():
+            return None
+
+        end_i = self.current + chunk_size
+        if end_i > self.size():
+            end_i = self.size()
+
+        v = np.asarray([self._read_vector() for _ in
+                        range(end_i - self.current)])
+        self.current = end_i
+        return v
+
+    def _read_vector(self):
+        return np.asarray([self.reader(self.file) for _ in
+                           range(self.dimension)])
+
+    def size(self):
+        return self.num_points
+
+    def reset(self):
+        self.file.seek(8)  # Seek to 8 bytes to skip re-reading metadata
+        self.current = 0
+
+
+def _value_reader(file_name):
+    ext = file_name.split('.')[-1]
+    # .fbin, .u8bin, and .i8bin to represent float32, uint8 and int8
+    if ext == "u8bin":
+        return lambda file: float(int.from_bytes(file.read(1), "little"))
+
+    if ext == "fbin":
+        return lambda file: struct.unpack('<f', file.read(4))
+
+    raise Exception("Unknown extension")

--- a/benchmarks/perf-tool/okpt/io/dataset.py
+++ b/benchmarks/perf-tool/okpt/io/dataset.py
@@ -6,7 +6,7 @@
 
 """Defines DataSet interface and implements particular formats
 
-A DataSet is thas the basic functionality that it can be read in chunks, or
+A DataSet is the basic functionality that it can be read in chunks, or
 read completely and reset to the start.
 
 Currently, we support HDF5 formats from ann-benchmarks and big-ann-benchmarks
@@ -61,7 +61,7 @@ class DataSet(ABC):
 
 class HDF5DataSet(DataSet):
     """ Data-set format corresponding to `ANN Benchmarks
-    <https://github.com/erikbern/ann-benchmarks#data-sets>`_ 
+    <https://github.com/erikbern/ann-benchmarks#data-sets>`_
     """
 
     def __init__(self, dataset_path: str, context: Context):

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -297,6 +297,8 @@ class IngestStep(OpenSearchStep):
             float(index_response['took']) for index_response in index_responses
         ]
 
+        self.dataset.reset()
+
         return results
 
     def _get_measures(self) -> List[str]:
@@ -370,6 +372,9 @@ class QueryStep(OpenSearchStep):
                                               self.k, self.k)
             results[f'recall@{str(self.r)}'] = recall_at_r(
                 ids, self.neighbors.get_data(), self.r, self.k)
+
+        self.dataset.reset()
+        self.neighbors.reset()
 
         return results
 

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -19,6 +19,7 @@ from opensearchpy import OpenSearch, RequestsHttpConnection
 
 from okpt.io.config.parsers.base import ConfigurationError
 from okpt.io.config.parsers.util import parse_string_param, parse_int_param, parse_dataset, parse_bool_param
+from okpt.io.dataset import Context
 from okpt.io.utils.reader import parse_json_from_path
 from okpt.test.steps import base
 from okpt.test.steps.base import StepConfig
@@ -274,7 +275,8 @@ class IngestStep(OpenSearchStep):
                                             step_config.config, {}, 'hdf5')
         dataset_path = parse_string_param('dataset_path', step_config.config,
                                           {}, None)
-        self.dataset = parse_dataset(dataset_format, dataset_path, "train")
+        self.dataset = parse_dataset(dataset_format, dataset_path,
+                                     Context.INDEX)
 
     def _action(self):
         results = {}
@@ -324,14 +326,15 @@ class QueryStep(OpenSearchStep):
                                             step_config.config, {}, 'hdf5')
         dataset_path = parse_string_param('query_dataset_path',
                                           step_config.config, {}, None)
-        self.dataset = parse_dataset(dataset_format, dataset_path, "test")
+        self.dataset = parse_dataset(dataset_format, dataset_path,
+                                     Context.QUERY)
 
         neighbors_format = parse_string_param('neighbors_format',
                                               step_config.config, {}, 'hdf5')
         neighbors_path = parse_string_param('neighbors_path',
                                             step_config.config, {}, None)
         self.neighbors = parse_dataset(neighbors_format, neighbors_path,
-                                       "neighbors")
+                                       Context.NEIGHBORS)
         self.implicit_config = step_config.implicit_config
 
     def _action(self):
@@ -549,5 +552,5 @@ def query_index(opensearch: OpenSearch, index_name: str, body: dict,
                              _source_excludes=excluded_fields)
 
 
-def bulk_index(opensearch: OpenSearch, index_name: str, body: dict):
+def bulk_index(opensearch: OpenSearch, index_name: str, body: List):
     return opensearch.bulk(index=index_name, body=body, timeout='5m')

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -322,9 +322,9 @@ class QueryStep(OpenSearchStep):
                                              {}, None)
         self.calculate_recall = parse_bool_param('calculate_recall',
                                                  step_config.config, {}, False)
-        dataset_format = parse_string_param('query_dataset_format',
+        dataset_format = parse_string_param('dataset_format',
                                             step_config.config, {}, 'hdf5')
-        dataset_path = parse_string_param('query_dataset_path',
+        dataset_path = parse_string_param('dataset_path',
                                           step_config.config, {}, None)
         self.dataset = parse_dataset(dataset_format, dataset_path,
                                      Context.QUERY)

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -274,7 +274,7 @@ class IngestStep(OpenSearchStep):
                                             step_config.config, {}, 'hdf5')
         dataset_path = parse_string_param('dataset_path', step_config.config,
                                           {}, None)
-        self.dataset = parse_dataset(dataset_path, dataset_format)
+        self.dataset = parse_dataset(dataset_format, dataset_path, "train")
 
     def _action(self):
         results = {}

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -368,13 +368,14 @@ class QueryStep(OpenSearchStep):
             ids = [[int(hit['_id'])
                     for hit in query_response['hits']['hits']]
                    for query_response in query_responses]
-            results['recall@K'] = recall_at_r(ids, self.neighbors.get_data(),
+            results['recall@K'] = recall_at_r(ids, self.neighbors,
                                               self.k, self.k)
+            self.neighbors.reset()
             results[f'recall@{str(self.r)}'] = recall_at_r(
-                ids, self.neighbors.get_data(), self.r, self.k)
+                ids, self.neighbors, self.r, self.k)
+            self.neighbors.reset()
 
         self.dataset.reset()
-        self.neighbors.reset()
 
         return results
 

--- a/benchmarks/perf-tool/sample-configs/faiss-sift-ivf/test.yml
+++ b/benchmarks/perf-tool/sample-configs/faiss-sift-ivf/test.yml
@@ -51,6 +51,8 @@ steps:
     field_name: target_field
     dataset_format: hdf5
     dataset_path: ../dataset/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: ../dataset/sift-128-euclidean.hdf5
 cleanup:
   - name: delete_model
     model_id: test-model

--- a/benchmarks/perf-tool/sample-configs/nmslib-sift-hnsw/test.yml
+++ b/benchmarks/perf-tool/sample-configs/nmslib-sift-hnsw/test.yml
@@ -29,6 +29,8 @@ steps:
     field_name: target_field
     dataset_format: hdf5
     dataset_path: ../dataset/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: ../dataset/sift-128-euclidean.hdf5
 cleanup:
   - name: delete_index
     index_name: target_index


### PR DESCRIPTION
### Description
This change refactors how the benchmarking tool works with datasets. It creates a DataSet interface and implements the interface for the existing HDF5 format as well as the formats specified in [Big ANN Benchmarks](https://big-ann-benchmarks.com/index.html#bench-datasets). It then introduces these changes in the steps that need datasets. 

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
