### PR TITLE
Adding gradle task for running integ tests in remote cluster

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -178,6 +178,12 @@ In order to run the integration tests with a 3 node cluster, run this command:
 ./gradlew :integTest -PnumNodes=3
 ```
 
+Integration tests can be run with remote cluster. For that run the following command and replace host/port/cluster name values with ones for the target cluster:
+
+```
+./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=false
+```
+
 ### Debugging
 
 Sometimes it is useful to attach a debugger to either the OpenSearch cluster or the integration test runner to see what's going on. For running unit tests, hit **Debug** from the IDE's gutter to debug the tests. For the OpenSearch cluster, first, make sure that the debugger is listening on port `5005`. Then, to debug the cluster code, run:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -184,6 +184,12 @@ Integration tests can be run with remote cluster. For that run the following com
 ./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=false
 ```
 
+In case remote cluster is secured it's possible to pass username and password with the following command:
+
+```
+./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=true -Duser=admin -Dpassword=admin
+```
+
 ### Debugging
 
 Sometimes it is useful to attach a debugger to either the OpenSearch cluster or the integration test runner to see what's going on. For running unit tests, hit **Debug** from the IDE's gutter to debug the tests. For the OpenSearch cluster, first, make sure that the debugger is listening on port `5005`. Then, to debug the cluster code, run:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -181,7 +181,7 @@ In order to run the integration tests with a 3 node cluster, run this command:
 Integration tests can be run with remote cluster. For that run the following command and replace host/port/cluster name values with ones for the target cluster:
 
 ```
-./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=false
+./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=false -PnumNodes=1
 ```
 
 In case remote cluster is secured it's possible to pass username and password with the following command:

--- a/build.gradle
+++ b/build.gradle
@@ -222,6 +222,10 @@ task integTestRemote(type: RestIntegTestTask) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
 
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
     // Run tests with remote cluster only if rest case is defined
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@
 
 import java.util.concurrent.Callable
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
@@ -215,6 +216,18 @@ testClusters.integTest {
         }
     }
     systemProperty("java.library.path", "$rootDir/jni/release")
+}
+
+task integTestRemote(type: RestIntegTestTask) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    // Run tests with remote cluster only if rest case is defined
+    if (System.getProperty("tests.rest.cluster") != null) {
+        filter {
+            includeTestsMatching "org.opensearch.knn.*IT"
+        }
+    }
 }
 
 // bwcFilePath contains the gradlew assemble binary files of k-NN plugins

--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ task integTestRemote(type: RestIntegTestTask) {
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {
             includeTestsMatching "org.opensearch.knn.*IT"
+            excludeTestsMatching "org.opensearch.knn.bwc.*IT"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,8 @@ task integTestRemote(type: RestIntegTestTask) {
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
 
+    systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+
     // Run tests with remote cluster only if rest case is defined
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {

--- a/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
@@ -33,7 +33,7 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
         updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
 
         // Create index with 1 primary and numNodes-1 replicas so that the data will be on every node in the cluster
-        int numNodes = Integer.parseInt(System.getProperty("cluster.number_of_nodes"));
+        int numNodes = Integer.parseInt(System.getProperty("cluster.number_of_nodes", "1"));
         Settings settings = Settings.builder()
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", numNodes - 1)


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding integTestRemote gradle task that allows to run kNN integration tests in remote cluster 
 
### Issues Resolved
#198 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
