### PR TITLE
Set default space type to L2 to support bwc

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/KNNWeight.java
@@ -110,7 +110,8 @@ public class KNNWeight extends Weight {
             } else {
                 String engineName = fieldInfo.attributes().getOrDefault(KNN_ENGINE, KNNEngine.NMSLIB.getName());
                 knnEngine = KNNEngine.getEngine(engineName);
-                spaceType = SpaceType.getSpace(fieldInfo.getAttribute(SPACE_TYPE));
+                String spaceTypeName = fieldInfo.attributes().getOrDefault(SPACE_TYPE, SpaceType.L2.getValue());
+                spaceType = SpaceType.getSpace(spaceTypeName);
             }
 
             /*


### PR DESCRIPTION
### Description
This change adds L2 space type fall back during query. This prevents backwards compatibility issues for clusters upgrading from ES 7.1 and 7.4. In those versions, space type was not introduced as a field attribute yet.
 
### Issues Resolved
#255 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
