### PR TITLE
Change benchmark ingest took metric to total time

### DIFF
--- a/benchmarks/perf-tool/README.md
+++ b/benchmarks/perf-tool/README.md
@@ -226,7 +226,7 @@ Ingests a dataset of vectors into the cluster.
 
 | Metric Name | Description | Unit |  
 | ----------- | ----------- | ----------- |
-| took | Took times returned per bulk request aggregated as total, p50, p90 and p99 (when applicable). Note - this number does not mean the time it took to made the vectors searchable. Time from the refresh step should be looked at as well to determine this.| ms |
+| took | Total time to ingest the dataset into the index.| ms |
 
 #### query
 

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -279,7 +279,6 @@ class IngestStep(OpenSearchStep):
                                      Context.INDEX)
 
     def _action(self):
-        results = {}
 
         def action(doc_id):
             return {'index': {'_index': self.index_name, '_id': doc_id}}
@@ -295,13 +294,9 @@ class IngestStep(OpenSearchStep):
             index_responses.append(result)
             id += self.bulk_size
 
-        results['took'] = [
-            float(index_response['took']) for index_response in index_responses
-        ]
-
         self.dataset.reset()
 
-        return results
+        return {}
 
     def _get_measures(self) -> List[str]:
         return ['took']


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Measuring total ingest time as opposed to took time per bulk index request will give a better picture of how long it will take to make a particular set of documents searchable. 

For a document to become searchable, the index request needs to be processed and then the segment needs to be refreshed. During refresh is when the k-NN data structure is built. So, during indexing, refreshing typically takes up the majority of the time. 

If we are just measuring the time it takes to process the bulk request, the metrics will not include the refresh time it takes before refresh is explicitly called.

This change will produce a result set that could look like the following:
```
  "results": {
    "test_took": 175471.85223798454,
    "create_index_took_total": 67.68574402667582,
    "ingest_took_total": 95617.42494395003,
    "refresh_index_store_kb_total": 1528246.6162109375,
    "refresh_index_took_total": 15305.556511040777,
    "force_merge_took_total": 4803.185038967058,
    "query_took_total": 59678.0,
    "query_took_p50": 6.0,
    "query_took_p90": 6.0,
    "query_took_p99": 7.0,
    "query_memory_kb_total": 653051.0,
    "query_recall@K_total": 0.985015,
    "query_recall@1_total": 1.0
  }
```

In order to calculate the time it took for the documents to become searchable, we would add refresh_index_took_total and ingest_took_total (110,000 ms).
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
