### PR TITLE
Make doc and query count configurable in benchmark

### DIFF
--- a/benchmarks/perf-tool/README.md
+++ b/benchmarks/perf-tool/README.md
@@ -219,8 +219,9 @@ Ingests a dataset of vectors into the cluster.
 | index_name | Name of index to ingest into | No default |
 | field_name | Name of field to ingest into | No default |
 | bulk_size | Documents per bulk request | 300 |
-| dataset_format | Format the dataset is in. Currently hdf5 and bigann is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. | 'hdf5' |
-| dataset_path | Path to dataset | No default |
+| dataset_format | Format the data-set is in. Currently hdf5 and bigann is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. | 'hdf5' |
+| dataset_path | Path to data-set | No default |
+| doc_count | Number of documents to create from data-set | Size of the data-set |
 
 ##### Metrics
 
@@ -245,6 +246,7 @@ Runs a set of queries against an index.
 | dataset_path | Path to dataset | No default |
 | neighbors_format | Format the neighbors dataset is in. Currently hdf5 and bigann is supported. The hdf5 file must be organized in the same way that the ann-benchmarks organizes theirs. | 'hdf5' |
 | neighbors_path | Path to neighbors dataset | No default |
+| query_count | Number of queries to create from data-set | Size of the data-set |
 
 ##### Metrics
 

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -288,11 +288,11 @@ class IngestStep(OpenSearchStep):
             return {'index': {'_index': self.index_name, '_id': doc_id}}
 
         index_responses = []
-        for doc_id_ in range(0, self.doc_count, self.bulk_size):
+        for i in range(0, self.doc_count, self.bulk_size):
             partition = self.dataset.read(self.bulk_size)
             if partition is None:
                 break
-            body = bulk_transform(partition, self.field_name, action, doc_id_)
+            body = bulk_transform(partition, self.field_name, action, i)
             result = bulk_index(self.opensearch, self.index_name, body)
             index_responses.append(result)
 

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -278,9 +278,9 @@ class IngestStep(OpenSearchStep):
         self.dataset = parse_dataset(dataset_format, dataset_path,
                                      Context.INDEX)
 
-        self.doc_count = parse_int_param('doc_count', step_config.config, {},
-                                         self.dataset.size())
-        self.doc_count = min(self.doc_count, self.dataset.size())
+        input_doc_count = parse_int_param('doc_count', step_config.config, {},
+                                          self.dataset.size())
+        self.doc_count = min(input_doc_count, self.dataset.size())
 
     def _action(self):
 
@@ -326,10 +326,10 @@ class QueryStep(OpenSearchStep):
         self.dataset = parse_dataset(dataset_format, dataset_path,
                                      Context.QUERY)
 
-        self.query_count = parse_int_param('query_count',
-                                           step_config.config, {},
-                                           self.dataset.size())
-        self.query_count = min(self.query_count, self.dataset.size())
+        input_query_count = parse_int_param('query_count',
+                                            step_config.config, {},
+                                            self.dataset.size())
+        self.query_count = min(input_query_count, self.dataset.size())
 
         neighbors_format = parse_string_param('neighbors_format',
                                               step_config.config, {}, 'hdf5')


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Makes the document and query count configurable in the benchmarking tool. With this functionality, users can now specify to only index or search a subset of the vectors in the data set. This is useful for indices that require training that may only need a subset of the data set for training.

A query or ingest step might look like this now:
```
steps:
...
  - name: ingest
    index_name: target_index
    field_name: target_field
    bulk_size: 500
    dataset_format: hdf5
    dataset_path: mydata.hdf5
    doc_count: 50000
...
  - name: query
    k: 100
    r: 1
    index_name: target_index
    field_name: target_field
    dataset_format: hdf5
    dataset_path: mydata.hdf5
    query_count: 5
    neighbors_format: hdf5
    neighbors_path: mydata.hdf5
```

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
