### PR TITLE
[Benchmark] Remove ingest results collection

### DIFF
--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -287,6 +287,8 @@ class IngestStep(OpenSearchStep):
         def action(doc_id):
             return {'index': {'_index': self.index_name, '_id': doc_id}}
 
+        # Maintain minimal state outside of this loop. For large data sets, too
+        # much state may cause out of memory failure
         for i in range(0, self.doc_count, self.bulk_size):
             partition = self.dataset.read(self.bulk_size)
             if partition is None:

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -287,14 +287,12 @@ class IngestStep(OpenSearchStep):
         def action(doc_id):
             return {'index': {'_index': self.index_name, '_id': doc_id}}
 
-        index_responses = []
         for i in range(0, self.doc_count, self.bulk_size):
             partition = self.dataset.read(self.bulk_size)
             if partition is None:
                 break
             body = bulk_transform(partition, self.field_name, action, i)
-            result = bulk_index(self.opensearch, self.index_name, body)
-            index_responses.append(result)
+            bulk_index(self.opensearch, self.index_name, body)
 
         self.dataset.reset()
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
When running a benchmark with one of the BIGANN data sets, the tool was killed due to OOM during ingest step:

```
dmesg -T| grep -E -i -B100 'killed process'
...
[Fri Jan 28 02:00:36 2022] Out of memory: Killed process 8825 (python3) total-vm:72456280kB, anon-rss:70883120kB, file-rss:0kB, shmem-rss:0kB, UID:1000 pgtables:139388kB oom_score_adj:0
```

Looking into the ingest step, I realized the problem was most likely that we were collecting the responses to the index requests. Because we dont use these responses (we just track total time), we can just get rid of this collection.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
