### PR TITLE
[BUG FIX] Add space type default and ef search parameter in warmup

### DIFF
--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -162,6 +162,14 @@ public class IndexUtil {
         return null;
     }
 
+    /**
+     * Gets the load time parameters for a given engine.
+     *
+     * @param spaceType Space for this particular segment
+     * @param knnEngine Engine used for the native library indices being loaded in
+     * @param indexName Name of OpenSearch index that the segment files belong to
+     * @return load parameters that will be passed to the JNI.
+     */
     public static Map<String, Object> getLoadParameters(SpaceType spaceType, KNNEngine knnEngine, String indexName) {
         Map<String, Object> loadParameters = Maps.newHashMap(ImmutableMap.of(
                 SPACE_TYPE, spaceType.getValue()

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -22,6 +22,7 @@ import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.BYTES_PER_KILOBYTES;
@@ -170,7 +171,7 @@ public class IndexUtil {
      * @param indexName Name of OpenSearch index that the segment files belong to
      * @return load parameters that will be passed to the JNI.
      */
-    public static Map<String, Object> getLoadParameters(SpaceType spaceType, KNNEngine knnEngine, String indexName) {
+    public static Map<String, Object> getParametersAtLoading(SpaceType spaceType, KNNEngine knnEngine, String indexName) {
         Map<String, Object> loadParameters = Maps.newHashMap(ImmutableMap.of(
                 SPACE_TYPE, spaceType.getValue()
         ));
@@ -181,6 +182,6 @@ public class IndexUtil {
             loadParameters.put(HNSW_ALGO_EF_SEARCH, KNNSettings.getEfSearchParam(indexName));
         }
 
-        return loadParameters;
+        return Collections.unmodifiableMap(loadParameters);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -11,10 +11,13 @@
 
 package org.opensearch.knn.index;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 
@@ -22,6 +25,8 @@ import java.io.File;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.BYTES_PER_KILOBYTES;
+import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 public class IndexUtil {
 
@@ -155,5 +160,19 @@ public class IndexUtil {
         }
 
         return null;
+    }
+
+    public static Map<String, Object> getLoadParameters(SpaceType spaceType, KNNEngine knnEngine, String indexName) {
+        Map<String, Object> loadParameters = Maps.newHashMap(ImmutableMap.of(
+                SPACE_TYPE, spaceType.getValue()
+        ));
+
+        // For nmslib, we need to add the dynamic ef_search parameter that needs to be passed in when the
+        // hnsw graphs are loaded into memory
+        if (KNNEngine.NMSLIB.equals(knnEngine)) {
+            loadParameters.put(HNSW_ALGO_EF_SEARCH, KNNSettings.getEfSearchParam(indexName));
+        }
+
+        return loadParameters;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
-import static org.opensearch.knn.index.IndexUtil.getLoadParameters;
+import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.buildEngineFileName;
 
 /**
@@ -86,7 +86,7 @@ public class KNNIndexShard {
                             new NativeMemoryEntryContext.IndexEntryContext(
                                     key,
                                     NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
-                                    getLoadParameters(value, KNNEngine.getEngineNameFromPath(key), getIndexName()),
+                                    getParametersAtLoading(value, KNNEngine.getEngineNameFromPath(key), getIndexName()),
                                     getIndexName()
                             ), true);
                 } catch (ExecutionException ex) {
@@ -122,6 +122,8 @@ public class KNNIndexShard {
 
             for (FieldInfo fieldInfo : reader.getFieldInfos()) {
                 if (fieldInfo.attributes().containsKey(KNNVectorFieldMapper.KNN_FIELD)) {
+                    // Space Type will not be present on ES versions 7.1 and 7.4 because the only available space type
+                    // was L2. So, if Space Type is not present, just fall back to L2
                     String spaceTypeName = fieldInfo.attributes().getOrDefault(SPACE_TYPE, SpaceType.L2.getValue());
                     SpaceType spaceType = SpaceType.getSpace(spaceTypeName);
                     String engineFileName = buildEngineFileName(reader.getSegmentInfo().info.name,

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.index.IndexUtil.getLoadParameters;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.buildEngineFileName;
 
 /**
@@ -86,7 +86,7 @@ public class KNNIndexShard {
                             new NativeMemoryEntryContext.IndexEntryContext(
                                     key,
                                     NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
-                                    ImmutableMap.of(SPACE_TYPE, value.getValue()),
+                                    getLoadParameters(value, KNNEngine.getEngineNameFromPath(key), getIndexName()),
                                     getIndexName()
                             ), true);
                 } catch (ExecutionException ex) {

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -122,7 +122,8 @@ public class KNNIndexShard {
 
             for (FieldInfo fieldInfo : reader.getFieldInfos()) {
                 if (fieldInfo.attributes().containsKey(KNNVectorFieldMapper.KNN_FIELD)) {
-                    SpaceType spaceType = SpaceType.getSpace(fieldInfo.attributes().get(SPACE_TYPE));
+                    String spaceTypeName = fieldInfo.attributes().getOrDefault(SPACE_TYPE, SpaceType.L2.getValue());
+                    SpaceType spaceType = SpaceType.getSpace(spaceTypeName);
                     String engineFileName = buildEngineFileName(reader.getSegmentInfo().info.name,
                             knnEngine.getLatestBuildVersion(), fieldInfo.name, fileExtension);
 

--- a/src/main/java/org/opensearch/knn/index/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/KNNWeight.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
-import static org.opensearch.knn.index.IndexUtil.getLoadParameters;
+import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 
 /**
@@ -142,7 +142,7 @@ public class KNNWeight extends Weight {
                         new NativeMemoryEntryContext.IndexEntryContext(
                                 indexPath.toString(),
                                 NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
-                                getLoadParameters(spaceType, knnEngine, knnQuery.getIndexName()),
+                                getParametersAtLoading(spaceType, knnEngine, knnQuery.getIndexName()),
                                 knnQuery.getIndexName()
                         ), true);
             } catch (ExecutionException e) {

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -12,7 +12,6 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.index.IndexUtil.getLoadParameters;
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
+
+public class IndexUtilTests extends KNNTestCase {
+    public void testGetLoadParameters() {
+        // Test faiss to ensure that space type gets set properly
+        SpaceType spaceType1 = SpaceType.COSINESIMIL;
+        KNNEngine knnEngine1 = KNNEngine.FAISS;
+        String indexName = "my-test-index";
+
+        Map<String, Object> loadParameters = getLoadParameters(spaceType1, knnEngine1, indexName);
+        assertEquals(1, loadParameters.size());
+        assertEquals(spaceType1.getValue(), loadParameters.get(SPACE_TYPE));
+
+        // Test nmslib to ensure both space type and ef search are properly set
+        SpaceType spaceType2 = SpaceType.L1;
+        KNNEngine knnEngine2 = KNNEngine.NMSLIB;
+        int efSearchValue = 413;
+
+        // We use the constant for the setting here as opposed to the identifier of efSearch in nmslib jni
+        Map<String, Object> indexSettings = ImmutableMap.of(
+                KNN_ALGO_PARAM_EF_SEARCH, efSearchValue
+        );
+
+        // Because ef search comes from an index setting, we need to mock the long line of calls to get those
+        // index settings
+        Settings settings = Settings.builder().loadFromMap(indexSettings).build();
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.getSettings()).thenReturn(settings);
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.index(anyString())).thenReturn(indexMetadata);
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        KNNSettings.state().setClusterService(clusterService);
+
+        loadParameters = getLoadParameters(spaceType2, knnEngine2, indexName);
+        assertEquals(2, loadParameters.size());
+        assertEquals(spaceType2.getValue(), loadParameters.get(SPACE_TYPE));
+        assertEquals(efSearchValue, loadParameters.get(HNSW_ALGO_EF_SEARCH));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
-import static org.opensearch.knn.index.IndexUtil.getLoadParameters;
+import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
 
 public class IndexUtilTests extends KNNTestCase {
@@ -37,7 +37,7 @@ public class IndexUtilTests extends KNNTestCase {
         KNNEngine knnEngine1 = KNNEngine.FAISS;
         String indexName = "my-test-index";
 
-        Map<String, Object> loadParameters = getLoadParameters(spaceType1, knnEngine1, indexName);
+        Map<String, Object> loadParameters = getParametersAtLoading(spaceType1, knnEngine1, indexName);
         assertEquals(1, loadParameters.size());
         assertEquals(spaceType1.getValue(), loadParameters.get(SPACE_TYPE));
 
@@ -64,7 +64,7 @@ public class IndexUtilTests extends KNNTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         KNNSettings.state().setClusterService(clusterService);
 
-        loadParameters = getLoadParameters(spaceType2, knnEngine2, indexName);
+        loadParameters = getParametersAtLoading(spaceType2, knnEngine2, indexName);
         assertEquals(2, loadParameters.size());
         assertEquals(spaceType2.getValue(), loadParameters.get(SPACE_TYPE));
         assertEquals(efSearchValue, loadParameters.get(HNSW_ALGO_EF_SEARCH));


### PR DESCRIPTION
### Description
Warmup is used to load native library files into memory so that there are no initial latency penalties during search. The load process for search and warmup are very similar. 

Currently, warmup api has a similar bug to #267. It does not default to a space type. For customers upgrading to 1.2 from ES 7.1 or 7.4 this will cause warmup failure. This only applies to 1.2. 1.1 and 1.0 do not have this bug in warmup.

Additionally, for nmslib, we allow the ef_search parameter to be set after indexing. To do this, we pass the parameter in during loading. In 1.2, we did not pass this parameter in. This will cause default ef_search to be used during warmup. To clean this up a bit, I abstracted generating load parameters into a utility function and used the same one for both search as well as warmup.
 
### Issues Resolved
#255 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
