### PR TITLE
[FLAKY TEST] Fix codec test causing CI to fail

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -109,7 +109,8 @@ public class  KNNCodecTestCase extends KNNTestCase {
         doc.add(vectorField);
         writer.addDocument(doc);
 
-        NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(createDisabledResourceWatcherService());
+        ResourceWatcherService resourceWatcherService = createDisabledResourceWatcherService();
+        NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(resourceWatcherService);
         IndexReader reader = writer.getReader();
         LeafReaderContext lrc = reader.getContext().leaves().iterator().next(); // leaf reader context
         SegmentReader segmentReader = (SegmentReader) FilterLeafReader.unwrap(lrc.reader());
@@ -131,6 +132,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
         reader.close();
         writer.close();
         dir.close();
+        resourceWatcherService.close();
     }
 
     public void testMultiFieldsKnnIndex(Codec codec) throws Exception {
@@ -165,7 +167,8 @@ public class  KNNCodecTestCase extends KNNTestCase {
         writer.addDocument(doc1);
         IndexReader reader = writer.getReader();
         writer.close();
-        NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(createDisabledResourceWatcherService());
+        ResourceWatcherService resourceWatcherService = createDisabledResourceWatcherService();
+        NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(resourceWatcherService);
         List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
 
         // there should be 2 hnsw index files created. one for test_vector and one for my_vector
@@ -186,6 +189,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         reader.close();
         dir.close();
+        resourceWatcherService.close();
     }
 
     public void testBuildFromModelTemplate(Codec codec) throws IOException, ExecutionException, InterruptedException {
@@ -257,7 +261,8 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         // Make sure that search returns the correct results
         KNNWeight.initialize(modelDao);
-        NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(createDisabledResourceWatcherService());
+        ResourceWatcherService resourceWatcherService = createDisabledResourceWatcherService();
+        NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(resourceWatcherService);
         float [] query = {10.0f, 10.0f, 10.0f};
         IndexSearcher searcher = new IndexSearcher(reader);
         TopDocs topDocs = searcher.search(new KNNQuery(fieldName, query, 4, "dummy"), 10);
@@ -269,6 +274,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
 
         reader.close();
         dir.close();
+        resourceWatcherService.close();
     }
 }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -133,6 +133,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
         writer.close();
         dir.close();
         resourceWatcherService.close();
+        NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance().close();
     }
 
     public void testMultiFieldsKnnIndex(Codec codec) throws Exception {
@@ -190,6 +191,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
         reader.close();
         dir.close();
         resourceWatcherService.close();
+        NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance().close();
     }
 
     public void testBuildFromModelTemplate(Codec codec) throws IOException, ExecutionException, InterruptedException {
@@ -275,6 +277,7 @@ public class  KNNCodecTestCase extends KNNTestCase {
         reader.close();
         dir.close();
         resourceWatcherService.close();
+        NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance().close();
     }
 }
 


### PR DESCRIPTION
### Description
CI keeps failing because of our Codec tests: https://github.com/opensearch-project/k-NN/actions/runs/1820922609. It is due to threads leaking. This PR closes a 2 closeables that were causing an issue:  IndexLoadStrategy, resourceWatcherService.

CI was able to pass on my fork: https://github.com/jmazanec15/k-NN-1/actions/runs/1821011151.

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
