### PR TITLE
[Backport 1.2] [BUG FIX] Add space type default and ef search parameter in warmup

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/KNNWeight.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 
 /**
@@ -134,24 +135,13 @@ public class KNNWeight extends Weight {
             KNNCounter.GRAPH_QUERY_REQUESTS.increment();
 
             // We need to first get index allocation
-            NativeMemoryAllocation indexAllocation = null;
-
-            Map<String, Object> loadParameters = new HashMap<String, Object>() {{
-                put(SPACE_TYPE, spaceType.getValue());
-            }};
-
-            // For nmslib, we set efSearch from an index setting. This has the advantage of being able to dynamically
-            // update this value, which we cannot do at the moment for mapping parameters.
-            if (knnEngine.equals(KNNEngine.NMSLIB)) {
-                loadParameters.put(KNNConstants.HNSW_ALGO_EF_SEARCH, KNNSettings.getEfSearchParam(knnQuery.getIndexName()));
-            }
-
+            NativeMemoryAllocation indexAllocation;
             try {
                 indexAllocation = nativeMemoryCacheManager.get(
                         new NativeMemoryEntryContext.IndexEntryContext(
                                 indexPath.toString(),
                                 NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
-                                loadParameters,
+                                getParametersAtLoading(spaceType, knnEngine, knnQuery.getIndexName()),
                                 knnQuery.getIndexName()
                         ), true);
             } catch (ExecutionException e) {

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
+
+public class IndexUtilTests extends KNNTestCase {
+    public void testGetLoadParameters() {
+        // Test faiss to ensure that space type gets set properly
+        SpaceType spaceType1 = SpaceType.COSINESIMIL;
+        KNNEngine knnEngine1 = KNNEngine.FAISS;
+        String indexName = "my-test-index";
+
+        Map<String, Object> loadParameters = getParametersAtLoading(spaceType1, knnEngine1, indexName);
+        assertEquals(1, loadParameters.size());
+        assertEquals(spaceType1.getValue(), loadParameters.get(SPACE_TYPE));
+
+        // Test nmslib to ensure both space type and ef search are properly set
+        SpaceType spaceType2 = SpaceType.L1;
+        KNNEngine knnEngine2 = KNNEngine.NMSLIB;
+        int efSearchValue = 413;
+
+        // We use the constant for the setting here as opposed to the identifier of efSearch in nmslib jni
+        Map<String, Object> indexSettings = ImmutableMap.of(
+                KNN_ALGO_PARAM_EF_SEARCH, efSearchValue
+        );
+
+        // Because ef search comes from an index setting, we need to mock the long line of calls to get those
+        // index settings
+        Settings settings = Settings.builder().loadFromMap(indexSettings).build();
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.getSettings()).thenReturn(settings);
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.index(anyString())).thenReturn(indexMetadata);
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        KNNSettings.state().setClusterService(clusterService);
+
+        loadParameters = getParametersAtLoading(spaceType2, knnEngine2, indexName);
+        assertEquals(2, loadParameters.size());
+        assertEquals(spaceType2.getValue(), loadParameters.get(SPACE_TYPE));
+        assertEquals(efSearchValue, loadParameters.get(HNSW_ALGO_EF_SEARCH));
+    }
+}


### PR DESCRIPTION
### Description
Sets the default value of space type to L2 in KNNIndexShard.
KNNIndexShard is used during warmup to load segments into memory. For
indices created in ES 7.1 and 7.4, they will not have this value set
because the only space we supported was l2. So, we need to hardcode the
defaults here.

For nmslib, the ef_search parameter is configurable at load time. So, it
needs to be passed as a parameter in both the search load phase as well
as warmup. This commit adds it to the warmup phase and abstracts load
parameters to a helper function so that it can be consistent for both
search and warmup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
