### PR TITLE
Adding auto delete workflow for backport branches

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,0 +1,15 @@
+name: Delete merged branch of the backport PRs
+on: 
+  pull_request:
+    types:
+      - closed
+  
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    steps:
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Workflow to automatically delete the branches created by the [backport action ](https://github.com/opensearch-project/k-NN/blob/main/.github/workflows/backport.yml)of type `backport/*`.

This PR needs to be backported to release branches so that the auto delete runs on backport PRs created for those branches.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
