### PR TITLE
[BUG FIX] Fix knn index shard to get bwc engine paths

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -138,9 +138,11 @@ public class KNNIndexShard {
 
     protected Map<String, SpaceType> getEnginePaths(Collection<String> files, String segmentName, String fieldName,
                                                    String fileExtension, Path shardPath, SpaceType spaceType) {
+        String prefix = buildEngineFilePrefix(segmentName);
+        String suffix = buildEngineFileSuffix(fieldName, fileExtension);
         return files.stream()
-                .filter(fileName -> fileName.startsWith(buildEngineFilePrefix(segmentName)))
-                .filter(fileName -> fileName.endsWith(buildEngineFileSuffix(fieldName, fileExtension)))
+                .filter(fileName -> fileName.startsWith(prefix))
+                .filter(fileName -> fileName.endsWith(suffix))
                 .map(fileName -> shardPath.resolve(fileName).toString())
                 .collect(Collectors.toMap(fileName -> fileName, fileName -> spaceType));
     }

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -24,7 +24,6 @@ import org.opensearch.knn.index.util.KNNEngine;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -40,13 +40,11 @@ public class KNNCodecUtil {
             }
             docIdList.add(doc);
         }
-        return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new float[][]{}));
+        return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new float[][] {}));
     }
 
-    public static String buildEngineFileName(String segmentName, String latestBuildVersion, String fieldName,
-                                             String extension) {
-        return String.format("%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion,
-                buildEngineFileSuffix(fieldName, extension));
+    public static String buildEngineFileName(String segmentName, String latestBuildVersion, String fieldName, String extension) {
+        return String.format("%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion, buildEngineFileSuffix(fieldName, extension));
     }
 
     public static String buildEngineFilePrefix(String segmentName) {

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -45,6 +45,15 @@ public class KNNCodecUtil {
 
     public static String buildEngineFileName(String segmentName, String latestBuildVersion, String fieldName,
                                              String extension) {
-        return String.format("%s_%s_%s%s", segmentName, latestBuildVersion, fieldName, extension);
+        return String.format("%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion,
+                buildEngineFileSuffix(fieldName, extension));
+    }
+
+    public static String buildEngineFilePrefix(String segmentName) {
+        return String.format("%s_", segmentName);
+    }
+
+    public static String buildEngineFileSuffix(String fieldName, String extension) {
+        return String.format("_%s%s", fieldName, extension);
     }
 }

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -77,7 +77,7 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
      */
     protected void createKnnIndexMapping(String indexName, String fieldName, Integer dimensions) {
         PutMappingRequest request = new PutMappingRequest(indexName);
-        request.source(fieldName, "type=knn_vector,dimension="+dimensions);
+        request.source(fieldName, "type=knn_vector,dimension=" + dimensions);
         OpenSearchAssertions.assertAcked(client().admin().indices().putMapping(request).actionGet());
     }
 
@@ -85,26 +85,19 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
      * Get default k-NN settings for test cases
      */
     protected Settings getKNNDefaultIndexSettings() {
-        return Settings.builder()
-                .put("number_of_shards", 1)
-                .put("number_of_replicas", 0)
-                .put("index.knn", true)
-                .build();
+        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", true).build();
     }
 
     /**
      * Add a k-NN doc to an index
      */
-    protected void addKnnDoc(String index, String docId, String fieldName, Object[] vector)
-            throws IOException, InterruptedException, ExecutionException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .field(fieldName, vector)
-                .endObject();
-        IndexRequest indexRequest = new IndexRequest()
-                .index(index)
-                .id(docId)
-                .source(builder)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+    protected void addKnnDoc(String index, String docId, String fieldName, Object[] vector) throws IOException, InterruptedException,
+        ExecutionException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field(fieldName, vector).endObject();
+        IndexRequest indexRequest = new IndexRequest().index(index)
+            .id(docId)
+            .source(builder)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         IndexResponse response = client().index(indexRequest).get();
         assertEquals(response.status(), RestStatus.CREATED);
@@ -113,16 +106,13 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
     /**
      * Add any document to index
      */
-    protected void addDoc(String index, String docId, String fieldName, String dummyValue)
-            throws IOException, InterruptedException, ExecutionException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .field(fieldName, dummyValue)
-                .endObject();
-        IndexRequest indexRequest = new IndexRequest()
-                .index(index)
-                .id(docId)
-                .source(builder)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+    protected void addDoc(String index, String docId, String fieldName, String dummyValue) throws IOException, InterruptedException,
+        ExecutionException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field(fieldName, dummyValue).endObject();
+        IndexRequest indexRequest = new IndexRequest().index(index)
+            .id(docId)
+            .source(builder)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         IndexResponse response = client().index(indexRequest).get();
         assertEquals(response.status(), RestStatus.CREATED);
@@ -132,18 +122,16 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
      * Run a search against a k-NN index
      */
     protected void searchKNNIndex(String index, String fieldName, float[] vector, int k) {
-        SearchResponse response = client().prepareSearch(index).setQuery(new KNNQueryBuilder(fieldName, vector, k))
-                .get();
+        SearchResponse response = client().prepareSearch(index).setQuery(new KNNQueryBuilder(fieldName, vector, k)).get();
         assertEquals(response.status(), RestStatus.OK);
     }
 
     public Map<String, Object> xContentBuilderToMap(XContentBuilder xContentBuilder) {
-        return XContentHelper.convertToMap(BytesReference.bytes(xContentBuilder), true,
-                xContentBuilder.contentType()).v2();
+        return XContentHelper.convertToMap(BytesReference.bytes(xContentBuilder), true, xContentBuilder.contentType()).v2();
     }
 
-    public void assertTrainingSucceeds(ModelDao modelDao, String modelId, int attempts, int delayInMillis)
-            throws InterruptedException, ExecutionException {
+    public void assertTrainingSucceeds(ModelDao modelDao, String modelId, int attempts, int delayInMillis) throws InterruptedException,
+        ExecutionException {
 
         int attemptNum = 0;
         ModelMetadata modelMetadata;

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -76,7 +76,7 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
      * Create simple k-NN mapping
      */
     protected void createKnnIndexMapping(String indexName, String fieldName, Integer dimensions) {
-        PutMappingRequest request = new PutMappingRequest(indexName).type("_doc");
+        PutMappingRequest request = new PutMappingRequest(indexName);
         request.source(fieldName, "type=knn_vector,dimension="+dimensions);
         OpenSearchAssertions.assertAcked(client().admin().indices().putMapping(request).actionGet());
     }

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
@@ -148,7 +148,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
 
         KNNIndexShard knnIndexShard = new KNNIndexShard(null);
 
-        Path path = Paths.get("").toAbsolutePath();
+        Path path = Paths.get("");
         Map<String, SpaceType> included = knnIndexShard.getEnginePaths(files, segmentName, fieldName, fileExt, path, spaceType);
 
         assertEquals(includedFileNames.size(), included.size());

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 
 import static org.opensearch.knn.index.memory.NativeMemoryCacheManager.GRAPH_COUNT;
 
-
 public class KNNIndexShardTests extends KNNSingleNodeTestCase {
 
     private final String testIndexName = "test-index";
@@ -36,7 +35,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testGetIndexShard() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
-        addKnnDoc(testIndexName, "1", testFieldName, new Float[] {2.5F, 3.5F});
+        addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
         IndexShard indexShard = indexService.iterator().next();
         KNNIndexShard knnIndexShard = new KNNIndexShard(indexShard);
@@ -46,7 +45,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testGetIndexName() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
-        addKnnDoc(testIndexName, "1", testFieldName, new Float[] {2.5F, 3.5F});
+        addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
         IndexShard indexShard = indexService.iterator().next();
         KNNIndexShard knnIndexShard = new KNNIndexShard(indexShard);
@@ -66,9 +65,9 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testWarmup_shardPresentInCache() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
-        addKnnDoc(testIndexName, "1", testFieldName, new Float[] {2.5F, 3.5F});
+        addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
-        searchKNNIndex(testIndexName, testFieldName, new float[] {1.0f, 2.0f}, 1);
+        searchKNNIndex(testIndexName, testFieldName, new float[] { 1.0f, 2.0f }, 1);
         assertEquals(1, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().get(testIndexName).get(GRAPH_COUNT));
 
         IndexShard indexShard = indexService.iterator().next();
@@ -83,7 +82,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         IndexShard indexShard;
         KNNIndexShard knnIndexShard;
 
-        addKnnDoc(testIndexName, "1", testFieldName, new Float[] {2.5F, 3.5F});
+        addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
         client().admin().indices().prepareFlush(testIndexName).execute();
 
         indexShard = indexService.iterator().next();
@@ -91,7 +90,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         knnIndexShard.warmup();
         assertEquals(1, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().get(testIndexName).get(GRAPH_COUNT));
 
-        addKnnDoc(testIndexName, "2", testFieldName, new Float[] {2.5F, 3.5F});
+        addKnnDoc(testIndexName, "2", testFieldName, new Float[] { 2.5F, 3.5F });
         indexShard = indexService.iterator().next();
         knnIndexShard = new KNNIndexShard(indexShard);
         knnIndexShard.warmup();
@@ -114,7 +113,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         assertEquals(0, hnswPaths.size());
         searcher.close();
 
-        addKnnDoc(testIndexName, "1", testFieldName, new Float[] {2.5F, 3.5F});
+        addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
         searcher = indexShard.acquireSearcher("test-hnsw-paths-2");
         hnswPaths = knnIndexShard.getAllEnginePaths(searcher.getIndexReader());
@@ -132,19 +131,18 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         SpaceType spaceType = SpaceType.L2;
 
         Set<String> includedFileNames = ImmutableSet.of(
-                String.format("%s_111_%s%s", segmentName, fieldName, fileExt),
-                String.format("%s_7_%s%s", segmentName, fieldName, fileExt),
-                String.format("%s_53_%s%s", segmentName, fieldName, fileExt)
+            String.format("%s_111_%s%s", segmentName, fieldName, fileExt),
+            String.format("%s_7_%s%s", segmentName, fieldName, fileExt),
+            String.format("%s_53_%s%s", segmentName, fieldName, fileExt)
         );
 
         List<String> excludedFileNames = ImmutableList.of(
-                String.format("_111_%s%s", fieldName, fileExt), // missing segment name
-                String.format("%s_111_%s", segmentName, fileExt), // missing field name
-                String.format("%s_111_%s.invalid", segmentName, fieldName) // missing extension
+            String.format("_111_%s%s", fieldName, fileExt), // missing segment name
+            String.format("%s_111_%s", segmentName, fileExt), // missing field name
+            String.format("%s_111_%s.invalid", segmentName, fieldName) // missing extension
         );
 
-        List<String> files = Stream.concat(includedFileNames.stream(), excludedFileNames.stream())
-                .collect(Collectors.toList());
+        List<String> files = Stream.concat(includedFileNames.stream(), excludedFileNames.stream()).collect(Collectors.toList());
 
         KNNIndexShard knnIndexShard = new KNNIndexShard(null);
 


### PR DESCRIPTION
### Description
Fixes getEnginePaths in KNNIndexShard to retrieve all engine paths, regardless of what version the index was created. Prevents silent failure when warmup completes but doesnt load any segments.

Instead of checking if the engine file that the current version of the plugin would create is in the segment, it just checks the prefix and suffix of the file that would be created. To prevent this failure in the future, a new test was added. Intentionally, the structure is hardcoded. This will ensure that this will be caught in the future if segment file naming conventions change.
 
### Issues Resolved
#308 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
