### PR TITLE
Change minimum supported JDK version from 8 to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ allprojects {
     }
     apply from: 'build-tools/repositories.gradle'
     plugins.withId('java') {
-        sourceCompatibility = targetCompatibility = "1.8"
+        sourceCompatibility = targetCompatibility = "11"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Removing support for JDK8 to be in sync with main OpenSearch. 
 
### Issues Resolved
#311 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
