### PR TITLE
Adding JDK 17 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   Build-k-NN:
     strategy:
       matrix:
-        java: [11, 14]
+        java: [11, 14, 17]
 
     name: Build and Test k-NN Plugin
     runs-on: ubuntu-latest

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -48,6 +48,7 @@ sdk use java 11.0.2-open
 ```
 
 Team has to replace minimum JDK version 14 as it was not an LTS release. JDK 14 should still work for most scenarios.
+In addition to this, the plugin has been tested with JDK 17, and this JDK version is fully supported.
 
 #### CMake
 


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding JDK17 support - added JDK17 to CI matrix, updated developer guide with note of support
 
### Issues Resolved
#312 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
