### PR TITLE
Adding build.version_qualifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,18 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         knn_bwc_version = System.getProperty("bwc.version", "1.2.0.0-SNAPSHOT")
+        version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_bwc_version = "${knn_bwc_version}" - ".0-SNAPSHOT"
         opensearch_group = "org.opensearch"
+
+        version_with_qualifier = opensearch_version.tokenize('-')[0]
+        if (version_qualifier) {
+            version_with_qualifier += "-${version_qualifier}"
+        }
+        if(opensearch_version.tokenize('-')[1]) {
+            version_with_qualifier += "-${opensearch_version.tokenize('-')[1]}"
+        }
+        opensearch_version = version_with_qualifier
     }
 
     // This isn't applying from repositories.gradle so repeating git diff it here
@@ -71,7 +81,10 @@ ext {
 
 allprojects {
     group = 'org.opensearch'
-    version = "${opensearch_version}" - "-SNAPSHOT" + ".0"
+    version = opensearch_version.tokenize('-')[0] + '.0'
+    if (version_qualifier) {
+        version += "-${version_qualifier}"
+    }
     if (isSnapshot) {
         version += "-SNAPSHOT"
     }


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Added support for property "build.version_qualifier" following the main OpenSearch concept. Property works in a same way for both OpenSearch and kNN artifact versions. Example of settings and results:

1. opensearch_version=2.0.0-SNAPSHOT
   build.version_qualifier not set
result:
   opensearch_version=2.0.0-SNAPSHOT
   opensearch-knn-version=2.0.0.0-SNAPSHOT

2. opensearch_version=2.0.0-SNAPSHOT
   build.version_qualifier=alpha1
result:
   opensearch_version=2.0.0-alpha1-SNAPSHOT
   opensearch-knn-version=2.0.0.0-alpha1-SNAPSHOT

3. opensearch_version=2.0.0
   build.version_qualifier=alpha1
result:
   opensearch_version=2.0.0-alpha1
   opensearch-knn-version=2.0.0.0-alpha1
 
### Issues Resolved
#315 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
