### PR TITLE
Remove version from CMakeLists.txt

### DIFF
--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -18,7 +18,7 @@ h5py==3.3.0
     # via -r requirements.in
 idna==3.2
     # via requests
-numpy==1.22.0
+numpy==1.22.1
     # via
     #   -r requirements.in
     #   h5py

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ opensearch_tmp_dir.mkdirs()
 
 task cmakeJniLib(type:Exec) {
     workingDir 'jni'
-    commandLine 'cmake', '.'
+    commandLine 'cmake', '.', "-DKNN_PLUGIN_VERSION=${opensearch_version}"
 }
 
 task buildJniLib(type:Exec) {

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -39,8 +39,9 @@ else()
     message(FATAL_ERROR "Unable to run on system: ${CMAKE_SYSTEM_NAME}")
 endif()
 
+# By default, set to 0.0.0
 if(NOT KNN_PLUGIN_VERSION)
-    set(KNN_PLUGIN_VERSION "1.3.0.0")
+    set(KNN_PLUGIN_VERSION "0.0.0")
 endif()
 
 # Set architecture specific variables


### PR DESCRIPTION
### Description
Removes setting of versions in CMake and pushed them to build.gradle. Version is used in CMake for building RPM/DEB with CPack. Currently, the CPack logic is not used in the OpenSearch project. Not removing because it may be used by others that build the plugin separately.

In addition, PR bumps numpy to fix whitesource failures. This is in line with 1.x branch.
 
### Issues Resolved
#82 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
