### PR TITLE
Applying build qualifier only to knn plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,24 +9,13 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        // for opensearch that is used by plugin following version schema is in use:
-        //    "<opensearch_version before first '-'>-<build.version_qualifier>-<SNAPSHOT optional>"
-        // for plugin artifacts produced by this script the version schema is very similar except for additional '0' as a minor version:
-        //    "<opensearch_version before first '-'>.0-<build.version_qualifier>-<SNAPSHOT optional>"
+        // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
+        // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-alpha1-SNAPSHOT
         opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         knn_bwc_version = System.getProperty("bwc.version", "1.2.0.0-SNAPSHOT")
         version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_bwc_version = "${knn_bwc_version}" - ".0-SNAPSHOT"
         opensearch_group = "org.opensearch"
-
-        version_with_qualifier = opensearch_version.tokenize('-')[0]
-        if (version_qualifier) {
-            version_with_qualifier += "-${version_qualifier}"
-        }
-        if(opensearch_version.tokenize('-')[1]) {
-            version_with_qualifier += "-${opensearch_version.tokenize('-')[1]}"
-        }
-        opensearch_version = version_with_qualifier
     }
 
     // This isn't applying from repositories.gradle so repeating git diff it here


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
We need to apply build.version_qualifier parameter only to plugin artifacts. For base OpneSearch the version with its qualifier has to be set explicitly via opensearch.version. 
Base [on this reply](https://github.com/opensearch-project/k-NN/pull/329#issuecomment-1075820345)
 
### Issues Resolved
#315
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
