### PR TITLE
Remove hardcoding of version in knn CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run build
         run: |
-          ./gradlew build -Dopensearch.version=2.0.0-alpha1-SNAPSHOT
+          ./gradlew build
 
       - name: Run k-NN Backwards Compatibility Tests
         run: |


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove hardcoding of version in knn CI.
The value should be taken from build.gradle.
Thanks.

 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/1632
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
