### PR TITLE
Adding clear cache test step

### DIFF
--- a/benchmarks/perf-tool/okpt/test/steps/factory.py
+++ b/benchmarks/perf-tool/okpt/test/steps/factory.py
@@ -9,7 +9,7 @@ from okpt.io.config.parsers.base import ConfigurationError
 from okpt.test.steps.base import Step, StepConfig
 
 from okpt.test.steps.steps import CreateIndexStep, DisableRefreshStep, RefreshIndexStep, DeleteIndexStep, \
-    TrainModelStep, DeleteModelStep, ForceMergeStep, IngestStep, QueryStep
+    TrainModelStep, DeleteModelStep, ForceMergeStep, ClearCacheStep, IngestStep, QueryStep
 
 
 def create_step(step_config: StepConfig) -> Step:
@@ -31,5 +31,7 @@ def create_step(step_config: StepConfig) -> Step:
         return QueryStep(step_config)
     elif step_config.step_name == ForceMergeStep.label:
         return ForceMergeStep(step_config)
+    elif step_config.step_name == ClearCacheStep.label:
+        return ClearCacheStep(step_config)
 
     raise ConfigurationError(f'Invalid step {step_config.step_name}')

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -138,6 +138,28 @@ class ForceMergeStep(OpenSearchStep):
     def _get_measures(self) -> List[str]:
         return ['took']
 
+class ClearCacheStep(OpenSearchStep):
+    """See base class."""
+
+    label = 'clear_cache'
+
+    def __init__(self, step_config: StepConfig):
+        super().__init__(step_config)
+        self.index_name = parse_string_param('index_name', step_config.config,
+                                             {}, None)
+
+    def _action(self):
+        while True:
+            try:
+                self.opensearch.indices.clear_cache(
+                    index=self.index_name)
+                return {}
+            except:
+                pass
+
+    def _get_measures(self) -> List[str]:
+        return ['took']
+
 
 class TrainModelStep(OpenSearchStep):
     """See base class."""


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding clear_cache step to benchmarking tool. It can be used at the beginning of each query run to clean up OpenSearch query cache. This should give more relevant results for test with multiple runs. 

Example of usage:
```
  - name: clear_cache
    index_name: target_index
```

 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
