### PR TITLE
Dropping support for JDK 14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
   Build-k-NN:
     strategy:
       matrix:
-        java: [11, 14, 17]
+        java: [11, 17]
 
     name: Build and Test k-NN Plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Remove support for JDK 14
 
### Issues Resolved
#342
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
