### PR TITLE
Rename knnlib to lib in zip artifact

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -75,7 +75,7 @@ work_dir=$PWD
 git submodule update --init -- jni/external/nmslib
 git submodule update --init -- jni/external/faiss
 
-# Build knnlib
+# Build knn libs
 cd jni
 
 # For x64, generalize arch so library is compatible for processors without simd instruction extensions
@@ -101,18 +101,18 @@ make opensearchknn_faiss opensearchknn_nmslib
 cd $work_dir
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
-# Add knnlib to zip
+# Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
-mkdir $distributions/knnlib
-cp ./jni/release/libopensearchknn* $distributions/knnlib
+mkdir $distributions/lib
+cp ./jni/release/libopensearchknn* $distributions/lib
 
-# Copy libomp to be packaged with the knnlib contents
+# Copy libomp to be packaged with the lib contents
 ompPath=$(ldconfig -p | grep libgomp | cut -d ' ' -f 4)
-cp $ompPath $distributions/knnlib
+cp $ompPath $distributions/lib
 
 cd $distributions
-zip -ur $zipPath knnlib
+zip -ur $zipPath lib
 cd $work_dir
 
 echo "COPY ${distributions}/*.zip"


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Renames knnlib to lib in produced zip artifact. 
 
### Issues Resolved
#314 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
