### PR TITLE
Allow null value for params in method mappings

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -42,7 +42,7 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  */
 public class KNNMethodContext implements ToXContentFragment, Writeable {
 
-    private static Logger logger = LogManager.getLogger(KNNMethodContext.class);
+    private static final Logger logger = LogManager.getLogger(KNNMethodContext.class);
 
     private static KNNMethodContext defaultInstance = null;
 
@@ -194,6 +194,10 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
 
                 name = (String) value;
             } else if (PARAMETERS.equals(key)) {
+                if (value == null) {
+                    continue;
+                }
+
                 if (!(value instanceof Map)) {
                     throw new MapperParsingException("Unable to parse parameters for main method component");
                 }

--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -195,6 +195,7 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
                 name = (String) value;
             } else if (PARAMETERS.equals(key)) {
                 if (value == null) {
+                    parameters = null;
                     continue;
                 }
 

--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -37,10 +37,10 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  */
 public class MethodComponentContext implements ToXContentFragment, Writeable {
 
-    private static Logger logger = LogManager.getLogger(MethodComponentContext.class);
+    private static final Logger logger = LogManager.getLogger(MethodComponentContext.class);
 
-    private String name;
-    private Map<String, Object> parameters;
+    private final String name;
+    private final Map<String, Object> parameters;
 
     /**
      * Constructor
@@ -93,6 +93,10 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
                 }
                 name = (String) value;
             } else if (PARAMETERS.equals(key)) {
+                if (value == null) {
+                    continue;
+                }
+
                 if (!(value instanceof Map)) {
                     throw new MapperParsingException("Unable to parse parameters for  method component");
                 }

--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -21,6 +21,7 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.MapperParsingException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,7 +62,15 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
      */
     public MethodComponentContext(StreamInput in) throws IOException {
         this.name = in.readString();
-        this.parameters = in.readMap(StreamInput::readString, new ParameterMapValueReader());
+
+        // Due to backwards compatibility issue, parameters could be null. To prevent any null pointer exceptions,
+        // do not read if their are no bytes left is null. Make sure this is in sync with the fellow read method. For
+        // more information, refer to https://github.com/opensearch-project/k-NN/issues/353.
+        if (in.available() > 0) {
+            this.parameters = in.readMap(StreamInput::readString, new ParameterMapValueReader());
+        } else {
+            this.parameters = null;
+        }
     }
 
     /**
@@ -94,6 +103,7 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
                 name = (String) value;
             } else if (PARAMETERS.equals(key)) {
                 if (value == null) {
+                    parameters = null;
                     continue;
                 }
 
@@ -129,22 +139,30 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(NAME, name);
-        builder.startObject(PARAMETERS);
-        parameters.forEach((key, value) -> {
-            try {
-                if (value instanceof MethodComponentContext) {
-                    builder.startObject(key);
-                    ((MethodComponentContext) value).toXContent(builder, params);
-                    builder.endObject();
-                } else {
-                    builder.field(key, value);
+        // Due to backwards compatibility issue, parameters could be null. To prevent any null pointer exceptions,
+        // we just create the null field. If parameters are not null, we created a nested structure. For more
+        // information, refer to https://github.com/opensearch-project/k-NN/issues/353.
+        if (parameters == null) {
+            builder.field(PARAMETERS, (String) null);
+        } else {
+            builder.startObject(PARAMETERS);
+            parameters.forEach((key, value) -> {
+                try {
+                    if (value instanceof MethodComponentContext) {
+                        builder.startObject(key);
+                        ((MethodComponentContext) value).toXContent(builder, params);
+                        builder.endObject();
+                    } else {
+                        builder.field(key, value);
+                    }
+                } catch (IOException ioe) {
+                    throw new RuntimeException("Unable to generate xcontent for method component");
                 }
-            } catch (IOException ioe) {
-                throw new RuntimeException("Unable to generate xcontent for method component");
-            }
 
-        });
-        builder.endObject();
+            });
+            builder.endObject();
+        }
+
         return builder;
     }
 
@@ -180,13 +198,25 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
      * @return parameters
      */
     public Map<String, Object> getParameters() {
+        // Due to backwards compatibility issue, parameters could be null. To prevent any null pointer exceptions,
+        // return an empty map if parameters is null. For more information, refer to
+        // https://github.com/opensearch-project/k-NN/issues/353.
+        if (parameters == null) {
+            return Collections.emptyMap();
+        }
         return parameters;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(this.name);
-        out.writeMap(this.parameters, StreamOutput::writeString, new ParameterMapValueWriter());
+
+        // Due to backwards compatibility issue, parameters could be null. To prevent any null pointer exceptions,
+        // do not write if parameters is null. Make sure this is in sync with the fellow read method. For more
+        // information, refer to https://github.com/opensearch-project/k-NN/issues/353.
+        if (this.parameters != null) {
+            out.writeMap(this.parameters, StreamOutput::writeString, new ParameterMapValueWriter());
+        }
     }
 
     // Because the generic StreamOutput writeMap method can only write generic values, we need to create a custom one

--- a/src/test/java/org/opensearch/knn/bwc/KNNBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/knn/bwc/KNNBackwardsCompatibilityIT.java
@@ -242,6 +242,14 @@ public class KNNBackwardsCompatibilityIT extends KNNRestTestCase {
     }
 
     public void testNullParametersOnUpgrade() throws Exception {
+
+        // Skip test if version is 1.2 or 1.3
+        // systemProperty 'tests.plugin_bwc_version', knn_bwc_version
+        String bwcVersion = System.getProperty("tests.plugin_bwc_version", null);
+        if (bwcVersion == null || bwcVersion.startsWith("1.2") || bwcVersion.startsWith("1.3")) {
+            return;
+        }
+
         // Confirm cluster is green before starting
         Request waitForGreen = new Request("GET", "/_cluster/health");
         waitForGreen.addParameter("wait_for_nodes", "3");

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -245,10 +245,10 @@ public class KNNMethodContextTests extends KNNTestCase {
     public void testParse_nullParameters() throws IOException {
         String methodName = "test-method";
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, methodName)
-                .field(PARAMETERS, (String) null)
-                .endObject();
+            .startObject()
+            .field(NAME, methodName)
+            .field(PARAMETERS, (String) null)
+            .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         assertTrue(knnMethodContext.getMethodComponent().getParameters().isEmpty());

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -240,6 +240,21 @@ public class KNNMethodContextTests extends KNNTestCase {
     }
 
     /**
+     * Test context method parsing when parameters are set to null
+     */
+    public void testParse_nullParameters() throws IOException {
+        String methodName = "test-method";
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, methodName)
+                .field(PARAMETERS, (String) null)
+                .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        assertTrue(knnMethodContext.getMethodComponent().getParameters().isEmpty());
+    }
+
+    /**
      * Test context method parsing when input is valid
      */
     public void testParse_valid() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -47,6 +47,13 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext copy = new MethodComponentContext(streamOutput.bytes().streamInput());
 
         assertEquals(original, copy);
+
+        // Check that everything works when streams are null
+        original = new MethodComponentContext(name, null);
+        streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+        copy = new MethodComponentContext(streamOutput.bytes().streamInput());
+        assertEquals(original, copy);
     }
 
     /**
@@ -105,6 +112,10 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext methodContext = new MethodComponentContext(name, params);
         assertEquals(paramVal1, methodContext.getParameters().get(paramKey1));
         assertEquals(paramVal2, methodContext.getParameters().get(paramKey2));
+
+        // When parameters are null, an empty map should be returned
+        methodContext = new MethodComponentContext(name, null);
+        assertTrue(methodContext.getParameters().isEmpty());
     }
 
     /**
@@ -215,6 +226,15 @@ public class MethodComponentContextTests extends KNNTestCase {
 
         assertEquals(paramVal1, paramMap.get(paramKey1));
         assertEquals(paramVal2, paramMap.get(paramKey2));
+
+        // Check when parameters are null
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, name).field(PARAMETERS, (String) null).endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        methodContext = MethodComponentContext.parse(in);
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder = methodContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+        out = xContentBuilderToMap(builder);
+        assertNull(out.get(PARAMETERS));
     }
 
     public void testEquals() {
@@ -229,11 +249,15 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext methodContext1 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext2 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext3 = new MethodComponentContext(name2, parameters2);
+        MethodComponentContext methodContext4 = new MethodComponentContext(name2, null);
+        MethodComponentContext methodContext5 = new MethodComponentContext(name2, null);
 
         assertEquals(methodContext1, methodContext1);
         assertEquals(methodContext1, methodContext2);
         assertNotEquals(methodContext1, methodContext3);
         assertNotEquals(methodContext1, null);
+        assertNotEquals(methodContext2, methodContext4);
+        assertEquals(methodContext4, methodContext5);
     }
 
     public void testHashCode() {
@@ -248,9 +272,13 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext methodContext1 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext2 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext3 = new MethodComponentContext(name2, parameters2);
+        MethodComponentContext methodContext4 = new MethodComponentContext(name2, null);
+        MethodComponentContext methodContext5 = new MethodComponentContext(name2, null);
 
         assertEquals(methodContext1.hashCode(), methodContext1.hashCode());
         assertEquals(methodContext1.hashCode(), methodContext2.hashCode());
         assertNotEquals(methodContext1.hashCode(), methodContext3.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext4.hashCode());
+        assertEquals(methodContext4.hashCode(), methodContext5.hashCode());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -108,6 +108,21 @@ public class MethodComponentContextTests extends KNNTestCase {
     }
 
     /**
+     * Test method component context parsing when parameters are set to null
+     */
+    public void testParse_nullParameters() throws IOException {
+        String name = "test-name";
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, name)
+                .field(PARAMETERS, (String) null)
+                .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
+        assertTrue(methodComponentContext.getParameters().isEmpty());
+    }
+
+    /**
      * Test parse where input is valid
      */
     public void testParse_valid() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -113,10 +113,10 @@ public class MethodComponentContextTests extends KNNTestCase {
     public void testParse_nullParameters() throws IOException {
         String name = "test-name";
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, name)
-                .field(PARAMETERS, (String) null)
-                .endObject();
+            .startObject()
+            .field(NAME, name)
+            .field(PARAMETERS, (String) null)
+            .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
         assertTrue(methodComponentContext.getParameters().isEmpty());


### PR DESCRIPTION
### Description
By default, in OpenSearch 1.0 and 1.1, if parameters were not set for method definitions, they were assigned a value of null. This causes an issue on upgrade to 1.2+, where null values for parameters are not accepted and throw a MappingParsingException.

The fix is to skip parsing the parameter value as a map in the input JSON if it is null.
 
### Issues Resolved
#353 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
