### PR TITLE
[Backport 1.2] Allow null value for params in method mappings

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -42,7 +42,7 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  */
 public class KNNMethodContext implements ToXContentFragment, Writeable {
 
-    private static Logger logger = LogManager.getLogger(KNNMethodContext.class);
+    private static final Logger logger = LogManager.getLogger(KNNMethodContext.class);
 
     private static KNNMethodContext defaultInstance = null;
 
@@ -191,6 +191,11 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
 
                 name = (String) value;
             } else if (PARAMETERS.equals(key)) {
+                if (value == null) {
+                    parameters = null;
+                    continue;
+                }
+
                 if (!(value instanceof Map)) {
                     throw new MapperParsingException("Unable to parse parameters for main method component");
                 }

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -262,6 +262,21 @@ public class KNNMethodContextTests extends KNNTestCase {
     }
 
     /**
+     * Test context method parsing when parameters are set to null
+     */
+    public void testParse_nullParameters() throws IOException {
+        String methodName = "test-method";
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, methodName)
+            .field(PARAMETERS, (String) null)
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        assertTrue(knnMethodContext.getMethodComponent().getParameters().isEmpty());
+    }
+
+    /**
      * Test context method parsing when input is valid
      */
     public void testParse_valid() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/MethodComponentContextTests.java
@@ -51,6 +51,13 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext copy = new MethodComponentContext(streamOutput.bytes().streamInput());
 
         assertEquals(original, copy);
+
+        // Check that everything works when streams are null
+        original = new MethodComponentContext(name, null);
+        streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+        copy = new MethodComponentContext(streamOutput.bytes().streamInput());
+        assertEquals(original, copy);
     }
 
     /**
@@ -115,6 +122,25 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext methodContext = new MethodComponentContext(name, params);
         assertEquals(paramVal1, methodContext.getParameters().get(paramKey1));
         assertEquals(paramVal2, methodContext.getParameters().get(paramKey2));
+
+        // When parameters are null, an empty map should be returned
+        methodContext = new MethodComponentContext(name, null);
+        assertTrue(methodContext.getParameters().isEmpty());
+    }
+
+    /**
+     * Test method component context parsing when parameters are set to null
+     */
+    public void testParse_nullParameters() throws IOException {
+        String name = "test-name";
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, name)
+            .field(PARAMETERS, (String) null)
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        MethodComponentContext methodComponentContext = MethodComponentContext.parse(in);
+        assertTrue(methodComponentContext.getParameters().isEmpty());
     }
 
     /**
@@ -213,6 +239,15 @@ public class MethodComponentContextTests extends KNNTestCase {
 
         assertEquals(paramVal1, paramMap.get(paramKey1));
         assertEquals(paramVal2, paramMap.get(paramKey2));
+
+        // Check when parameters are null
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, name).field(PARAMETERS, (String) null).endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        methodContext = MethodComponentContext.parse(in);
+        builder = XContentFactory.jsonBuilder().startObject();
+        builder = methodContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
+        out = xContentBuilderToMap(builder);
+        assertNull(out.get(PARAMETERS));
     }
 
     public void testEquals() {
@@ -233,11 +268,15 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext methodContext1 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext2 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext3 = new MethodComponentContext(name2, parameters2);
+        MethodComponentContext methodContext4 = new MethodComponentContext(name2, null);
+        MethodComponentContext methodContext5 = new MethodComponentContext(name2, null);
 
         assertEquals(methodContext1, methodContext1);
         assertEquals(methodContext1, methodContext2);
         assertNotEquals(methodContext1, methodContext3);
         assertNotEquals(methodContext1, null);
+        assertNotEquals(methodContext2, methodContext4);
+        assertEquals(methodContext4, methodContext5);
     }
 
     public void testHashCode() {
@@ -257,9 +296,13 @@ public class MethodComponentContextTests extends KNNTestCase {
         MethodComponentContext methodContext1 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext2 = new MethodComponentContext(name1, parameters1);
         MethodComponentContext methodContext3 = new MethodComponentContext(name2, parameters2);
+        MethodComponentContext methodContext4 = new MethodComponentContext(name2, null);
+        MethodComponentContext methodContext5 = new MethodComponentContext(name2, null);
 
         assertEquals(methodContext1.hashCode(), methodContext1.hashCode());
         assertEquals(methodContext1.hashCode(), methodContext2.hashCode());
         assertNotEquals(methodContext1.hashCode(), methodContext3.hashCode());
+        assertNotEquals(methodContext1.hashCode(), methodContext4.hashCode());
+        assertEquals(methodContext4.hashCode(), methodContext5.hashCode());
     }
 }


### PR DESCRIPTION
Allow user to input null value for parameters field for KNNMethodContext
and MethodComponentContext. Adds tests to reproduce Mapping Parsing Error when the parameters take
the value null as well as BWC tests.

Backport: #354 

Signed-off-by: John Mazanec <jmazane@amazon.com>
(cherry picked from commit b08127c2c4dcd1844072302e838f44897c8f18f5)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
