### PR TITLE
Nomenclature changes from master to cluster manager

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportAction.java
@@ -43,7 +43,7 @@ import static org.opensearch.knn.common.KNNConstants.PLUGIN_NAME;
 import static org.opensearch.knn.common.KNNConstants.MODEL_METADATA_FIELD;
 
 /**
- * Transport action used to update metadata of model's on the master node.
+ * Transport action used to update metadata of model's on the cluster manager node.
  */
 public class UpdateModelMetadataTransportAction extends TransportMasterNodeAction<UpdateModelMetadataRequest, AcknowledgedResponse> {
 
@@ -87,7 +87,7 @@ public class UpdateModelMetadataTransportAction extends TransportMasterNodeActio
         ClusterState clusterState,
         ActionListener<AcknowledgedResponse> actionListener
     ) {
-        // Master updates model metadata based on request parameters
+        // ClusterManager updates model metadata based on request parameters
         clusterService.submitStateUpdateTask(
             PLUGIN_NAME,
             new UpdateModelMetaDataTask(request.getModelId(), request.getModelMetadata(), request.isRemoveRequest()),

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -173,7 +173,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
             assertEquals(modelId, response.getId());
 
-            // We need to use executor service here so master thread does not block
+            // We need to use executor service here so main thread does not block
             modelGetterExecutor.submit(() -> {
                 try {
                     assertEquals(model, modelDao.get(modelId));
@@ -232,7 +232,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
             assertEquals(modelId, response.getId());
 
-            // We need to use executor service here so master thread does not block
+            // We need to use executor service here so main thread does not block
             modelGetterExecutor.submit(() -> {
                 try {
                     assertEquals(model, modelDao.get(modelId));
@@ -327,7 +327,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
             assertEquals(modelId, response.getId());
 
-            // We need to use executor service here so master thread does not block
+            // We need to use executor service here so main thread does not block
             modelGetterExecutor.submit(() -> {
                 try {
                     assertEquals(model, modelDao.get(modelId));
@@ -363,7 +363,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         ActionListener<IndexResponse> updateListener = ActionListener.wrap(response -> {
             assertEquals(modelId, response.getId());
 
-            // We need to use executor service here so master thread does not block
+            // We need to use executor service here so main thread does not block
             modelGetterExecutor.submit(() -> {
                 try {
                     assertEquals(updatedModel, modelDao.get(modelId));

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -52,7 +52,7 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
         assertEquals(acknowledgedResponse, acknowledgedResponse1);
     }
 
-    public void testMasterOperation() throws InterruptedException {
+    public void testClusterManagerOperation() throws InterruptedException {
         // Setup the Model system index
         createIndex(MODEL_INDEX_NAME);
 


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Change `master` nomenclature to `cluster manager`. Still there are few changes(package names, method names) which needs to be done. Will make those changes after those changes are implemented in opensearch core.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/307
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
