### PR TITLE
Update jacoco version to 0.8.7 to support JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ if (!usingRemoteCluster) {
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.7"
 }
 
 check.dependsOn spotlessCheck


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Update jacoco version to 0.8.7 for JDK17 support. Current version gives error:
  ` Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 61`
 
### Issues Resolved
#299 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
