### PR TITLE
Remove rc1 build qualifier for 2.0 GA release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
     ext {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
-        version_qualifier = System.getProperty("build.version_qualifier", "rc1")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
     }
 


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Switching to 2.0 main branch after 2.0 rc1 has been released
 
### Issues Resolved
#384 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
