### PR TITLE
Use custom plugin to publish zips to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ publishing {
                 developers {
                     developer {
                         name = "OpenSearch"
-                        url = "https://github.com/opensearch-project/opensearch-plugin-template-java"
+                        url = "https://github.com/opensearch-project/k-NN"
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ plugins {
 apply from: 'gradle/formatting.gradle'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.rest-test'
+apply plugin: 'opensearch.pluginzip'
 
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
@@ -77,6 +78,29 @@ allprojects {
         project.licenseFile = rootProject.file('LICENSE.txt')
         project.noticeFile = rootProject.file('NOTICE.txt')
         project.forbiddenApis.ignoreFailures = true
+    }
+}
+
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = "opensearch-knn"
+                description = "OpenSearch k-NN plugin"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/opensearch-plugin-template-java"
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -100,6 +100,7 @@ make opensearchknn_faiss opensearchknn_nmslib
 
 cd $work_dir
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 # Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -119,3 +119,6 @@ cd $work_dir
 echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins
 cp ${distributions}/*.zip $OUTPUT/plugins
+
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,5 @@ rootProject.name = 'opensearch-knn'
 include ":qa"
 include ":qa:rolling-upgrade"
 include ":qa:restart-upgrade"
+
+startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal"]

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,3 @@ include ":qa"
 include ":qa:rolling-upgrade"
 include ":qa:restart-upgrade"
 
-startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal"]


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Follow [campaign](https://github.com/opensearch-project/opensearch-build/issues/1916) and use custom plugin to publish zips to maven
 
### Issues Resolved
#378 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
