### PR TITLE
Bumping main version to opensearch core 2.1.0

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "2.0.0" ]
+        bwc_version: [ "1.3.2", "2.0.0" ]
         opensearch_version: [ "2.1.0-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "1.0.0", "1.1.0", "1.2.4", "1.3.2" ]
-        opensearch_version : [ "2.0.0-SNAPSHOT" ]
+        bwc_version : [ "1.0.0", "1.1.0", "1.2.4", "1.3.2", "2.0.0" ]
+        opensearch_version : [ "2.1.0-SNAPSHOT" ]
 
     name: k-NN Restart-Upgrade BWC Tests
     runs-on: ubuntu-latest
@@ -46,8 +46,8 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "1.3.2" ]
-        opensearch_version: [ "2.0.0-rc1-SNAPSHOT", "2.0.0-SNAPSHOT" ]
+        bwc_version: [ "2.0.0" ]
+        opensearch_version: [ "2.1.0-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
         version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
     }
@@ -44,6 +44,7 @@ apply from: 'gradle/formatting.gradle'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.rest-test'
 apply plugin: 'opensearch.pluginzip'
+apply plugin: 'opensearch.repositories'
 
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,8 +5,8 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=c9490e938b221daf0094982288e4038deed954a3f12fb54cbf270ddf4e37d879
+distributionSha256Sum=e6d864e3b5bc05cc62041842b306383fc1fefcec359e70cebb1d470a6094ca82
 

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -51,7 +51,7 @@ testClusters {
         }
 
         // Skip test if version is 1.0, 1.1, 1.2 or 1.3 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.")) {
+        if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.0")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
             }
@@ -94,7 +94,7 @@ testClusters {
         }
 
         // Skip test if version is 1.0, 1.1, 1.2 or 1.3 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.")) {
+        if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.0")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
             }

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
@@ -6,7 +6,7 @@ package org.opensearch.knn.index.codec;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene91.Lucene91Codec;
+import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
 
 import java.lang.reflect.Constructor;

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.codec;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene91.Lucene91Codec;
+import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
 

--- a/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
@@ -122,7 +122,7 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
     @After
     protected void wipeAllODFEIndices() throws IOException {
         Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
-        XContentType xContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
+        XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType().getValue());
         try (
             XContentParser parser = xContentType.xContent()
                 .createParser(


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Upgrade core OpenSearch version to 2.1.0 after 2.0.0 GA release. 

### Issues Resolved
#385 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
