### PR TITLE
Include scripted metric context to allow list

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/script/KNNWhitelistExtension.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNWhitelistExtension.java
@@ -5,22 +5,35 @@
 
 package org.opensearch.knn.plugin.script;
 
+import com.google.common.collect.ImmutableMap;
 import org.opensearch.painless.spi.PainlessExtension;
 import org.opensearch.painless.spi.Whitelist;
 import org.opensearch.painless.spi.WhitelistLoader;
 import org.opensearch.script.ScoreScript;
 import org.opensearch.script.ScriptContext;
+import org.opensearch.script.ScriptedMetricAggContexts;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class KNNWhitelistExtension implements PainlessExtension {
 
-    private static final Whitelist WHITELIST = WhitelistLoader.loadFromResourceFiles(KNNWhitelistExtension.class, "knn_whitelist.txt");
+    private static final Whitelist ALLOW_LIST = WhitelistLoader.loadFromResourceFiles(KNNWhitelistExtension.class, "knn_whitelist.txt");
 
     @Override
     public Map<ScriptContext<?>, List<Whitelist>> getContextWhitelists() {
-        return Collections.singletonMap(ScoreScript.CONTEXT, Collections.singletonList(WHITELIST));
+        final List<Whitelist> allowLists = List.of(ALLOW_LIST);
+        return ImmutableMap.of(
+            ScoreScript.CONTEXT,
+            allowLists,
+            ScriptedMetricAggContexts.InitScript.CONTEXT,
+            allowLists,
+            ScriptedMetricAggContexts.MapScript.CONTEXT,
+            allowLists,
+            ScriptedMetricAggContexts.CombineScript.CONTEXT,
+            allowLists,
+            ScriptedMetricAggContexts.ReduceScript.CONTEXT,
+            allowLists
+        );
     }
 }


### PR DESCRIPTION
### Description
When KNN Vector values are being accessed inside "scripted_metric", following error is observed
```
caused_by":{"type":"illegal_argument_exception","reason":"Illegal list shortcut value [value]."}}}]},"status":400}
```
This is because, ScriptedMetricContext is not added to allow list for doc['knn_vector'].value method to be accessible. 
This PR adds those context that are needed to be included to allow list.
 
### Issues Resolved
#414 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
