### PR TITLE
Refactor knn type and codecs

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethod.java
@@ -29,11 +29,10 @@ import java.util.Set;
  * the KNNMethodContext passed in by the user. It is also used to provide superficial string translations.
  */
 @AllArgsConstructor
+@Getter
 public class KNNMethod {
 
-    @Getter
     private final MethodComponent methodComponent;
-    @Getter
     private final Set<SpaceType> spaces;
 
     /**

--- a/src/main/java/org/opensearch/knn/index/KNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethod.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.knn.index;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
 
@@ -26,30 +28,13 @@ import java.util.Set;
  * KNNMethod is used to define the structure of a method supported by a particular k-NN library. It is used to validate
  * the KNNMethodContext passed in by the user. It is also used to provide superficial string translations.
  */
+@AllArgsConstructor
 public class KNNMethod {
 
+    @Getter
     private final MethodComponent methodComponent;
+    @Getter
     private final Set<SpaceType> spaces;
-
-    /**
-     * KNNMethod Constructor
-     *
-     * @param methodComponent top level method component that is compatible with the underlying library
-     * @param spaces set of valid space types that the method supports
-     */
-    public KNNMethod(MethodComponent methodComponent, Set<SpaceType> spaces) {
-        this.methodComponent = methodComponent;
-        this.spaces = spaces;
-    }
-
-    /**
-     * getMainMethodComponent
-     *
-     * @return mainMethodComponent
-     */
-    public MethodComponent getMethodComponent() {
-        return methodComponent;
-    }
 
     /**
      * Determines whether the provided space is supported for this method
@@ -59,15 +44,6 @@ public class KNNMethod {
      */
     public boolean containsSpace(SpaceType space) {
         return spaces.contains(space);
-    }
-
-    /**
-     * Get all valid spaces for this method
-     *
-     * @return spaces that can be used with this method
-     */
-    public Set<SpaceType> getSpaces() {
-        return spaces;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -41,6 +41,7 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  * It will encompass all parameters necessary to build the index.
  */
 @AllArgsConstructor
+@Getter
 public class KNNMethodContext implements ToXContentFragment, Writeable {
 
     private static KNNMethodContext defaultInstance = null;
@@ -56,11 +57,8 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         return defaultInstance;
     }
 
-    @Getter
     private final KNNEngine knnEngine;
-    @Getter
     private final SpaceType spaceType;
-    @Getter
     private final MethodComponentContext methodComponent;
 
     /**

--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.knn.index;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.opensearch.common.ValidationException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -40,9 +40,8 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  * KNNMethodContext will contain the information necessary to produce a library index from an Opensearch mapping.
  * It will encompass all parameters necessary to build the index.
  */
+@AllArgsConstructor
 public class KNNMethodContext implements ToXContentFragment, Writeable {
-
-    private static final Logger logger = LogManager.getLogger(KNNMethodContext.class);
 
     private static KNNMethodContext defaultInstance = null;
 
@@ -57,22 +56,12 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         return defaultInstance;
     }
 
+    @Getter
     private final KNNEngine knnEngine;
+    @Getter
     private final SpaceType spaceType;
+    @Getter
     private final MethodComponentContext methodComponent;
-
-    /**
-     * Constructor
-     *
-     * @param knnEngine engine that this method uses
-     * @param spaceType space type that this method uses
-     * @param methodComponent MethodComponent describing the main index
-     */
-    public KNNMethodContext(KNNEngine knnEngine, SpaceType spaceType, MethodComponentContext methodComponent) {
-        this.knnEngine = knnEngine;
-        this.spaceType = spaceType;
-        this.methodComponent = methodComponent;
-    }
 
     /**
      * Constructor from stream.
@@ -84,33 +73,6 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         this.knnEngine = KNNEngine.getEngine(in.readString());
         this.spaceType = SpaceType.getSpace(in.readString());
         this.methodComponent = new MethodComponentContext(in);
-    }
-
-    /**
-     * Gets the main method component
-     *
-     * @return methodComponent
-     */
-    public MethodComponentContext getMethodComponent() {
-        return methodComponent;
-    }
-
-    /**
-     * Gets the engine to be used for this context
-     *
-     * @return knnEngine
-     */
-    public KNNEngine getEngine() {
-        return knnEngine;
-    }
-
-    /**
-     * Gets the space type for this context
-     *
-     * @return spaceType
-     */
-    public SpaceType getSpaceType() {
-        return spaceType;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -297,12 +297,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    @Getter
     public static class KNNVectorFieldType extends MappedFieldType {
-        @Getter
         int dimension;
-        @Getter
         String modelId;
-        @Getter
         KNNMethodContext knnMethodContext;
 
         public KNNVectorFieldType(String name, Map<String, String> meta, int dimension) {

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -12,7 +12,6 @@
 package org.opensearch.knn.index;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.opensearch.common.TriFunction;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
@@ -209,7 +208,6 @@ public class MethodComponent {
 
         private String name;
         private Map<String, Parameter<?>> parameters;
-        @Setter
         private BiFunction<MethodComponent, MethodComponentContext, Map<String, Object>> mapGenerator;
         private TriFunction<MethodComponent, MethodComponentContext, Integer, Long> overheadInKBEstimator;
         private boolean requiresTraining;

--- a/src/main/java/org/opensearch/knn/index/MethodComponent.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponent.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.knn.index;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.opensearch.common.TriFunction;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
@@ -26,7 +28,9 @@ import java.util.function.BiFunction;
  */
 public class MethodComponent {
 
+    @Getter
     private String name;
+    @Getter
     private Map<String, Parameter<?>> parameters;
     private BiFunction<MethodComponent, MethodComponentContext, Map<String, Object>> mapGenerator;
     private TriFunction<MethodComponent, MethodComponentContext, Integer, Long> overheadInKBEstimator;
@@ -43,24 +47,6 @@ public class MethodComponent {
         this.mapGenerator = builder.mapGenerator;
         this.overheadInKBEstimator = builder.overheadInKBEstimator;
         this.requiresTraining = builder.requiresTraining;
-    }
-
-    /**
-     * Get the name of the component
-     *
-     * @return name
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Get the parameters for the component
-     *
-     * @return parameters
-     */
-    public Map<String, Parameter<?>> getParameters() {
-        return parameters;
     }
 
     /**
@@ -223,6 +209,7 @@ public class MethodComponent {
 
         private String name;
         private Map<String, Parameter<?>> parameters;
+        @Setter
         private BiFunction<MethodComponent, MethodComponentContext, Map<String, Object>> mapGenerator;
         private TriFunction<MethodComponent, MethodComponentContext, Integer, Long> overheadInKBEstimator;
         private boolean requiresTraining;

--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.knn.index;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.io.stream.Writeable;
@@ -36,23 +36,12 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  *
  * Each component is composed of a name and a map of parameters.
  */
+@AllArgsConstructor
 public class MethodComponentContext implements ToXContentFragment, Writeable {
 
-    private static final Logger logger = LogManager.getLogger(MethodComponentContext.class);
-
+    @Getter
     private final String name;
     private final Map<String, Object> parameters;
-
-    /**
-     * Constructor
-     *
-     * @param name component name
-     * @param parameters component parameters
-     */
-    public MethodComponentContext(String name, Map<String, Object> parameters) {
-        this.name = name;
-        this.parameters = parameters;
-    }
 
     /**
      * Constructor from stream.
@@ -181,15 +170,6 @@ public class MethodComponentContext implements ToXContentFragment, Writeable {
     @Override
     public int hashCode() {
         return new HashCodeBuilder().append(name).append(parameters).toHashCode();
-    }
-
-    /**
-     * Gets the name of the component
-     *
-     * @return name
-     */
-    public String getName() {
-        return name;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
@@ -7,9 +7,9 @@ package org.opensearch.knn.index.codec;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
-import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.util.CodecBuilder;
 
-import java.lang.reflect.Constructor;
 import java.util.Map;
 
 /**
@@ -17,23 +17,26 @@ import java.util.Map;
  */
 public class KNNCodecFactory {
 
-    private static Map<KNNCodecVersion, Class> CODEC_BY_VERSION = ImmutableMap.of(KNNCodecVersion.KNN910, KNN910Codec.class);
+    private final Map<KNNCodecVersion, CodecBuilder> codecByVersion;
 
-    private static KNNCodecVersion LATEST_KNN_CODEC_VERSION = KNNCodecVersion.KNN910;
+    private static final KNNCodecVersion LATEST_KNN_CODEC_VERSION = KNNCodecVersion.KNN910;
 
-    public static Codec createKNNCodec(final Codec userCodec) {
+    public KNNCodecFactory(MapperService mapperService) {
+        codecByVersion = ImmutableMap.of(KNNCodecVersion.KNN910, new CodecBuilder.KNN91CodecBuilder(mapperService));
+    }
+
+    public Codec createKNNCodec(final Codec userCodec) {
         return getCodec(LATEST_KNN_CODEC_VERSION, userCodec);
     }
 
-    public static Codec createKNNCodec(final KNNCodecVersion knnCodecVersion, final Codec userCodec) {
+    public Codec createKNNCodec(final KNNCodecVersion knnCodecVersion, final Codec userCodec) {
         return getCodec(knnCodecVersion, userCodec);
     }
 
-    private static Codec getCodec(final KNNCodecVersion knnCodecVersion, final Codec userCodec) {
+    private Codec getCodec(final KNNCodecVersion knnCodecVersion, final Codec userCodec) {
         try {
-            Constructor<?> constructor = CODEC_BY_VERSION.getOrDefault(knnCodecVersion, CODEC_BY_VERSION.get(LATEST_KNN_CODEC_VERSION))
-                .getConstructor(Codec.class);
-            return (Codec) constructor.newInstance(userCodec);
+            CodecBuilder constructor = codecByVersion.getOrDefault(knnCodecVersion, codecByVersion.get(LATEST_KNN_CODEC_VERSION));
+            return constructor.userCodec(userCodec).build();
         } catch (Exception ex) {
             throw new RuntimeException("Cannot create instance of KNN codec", ex);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
@@ -35,8 +35,8 @@ public class KNNCodecFactory {
 
     private Codec getCodec(final KNNCodecVersion knnCodecVersion, final Codec userCodec) {
         try {
-            CodecBuilder constructor = codecByVersion.getOrDefault(knnCodecVersion, codecByVersion.get(LATEST_KNN_CODEC_VERSION));
-            return constructor.userCodec(userCodec).build();
+            final CodecBuilder codecBuilder = codecByVersion.getOrDefault(knnCodecVersion, codecByVersion.get(LATEST_KNN_CODEC_VERSION));
+            return codecBuilder.userCodec(userCodec).build();
         } catch (Exception ex) {
             throw new RuntimeException("Cannot create instance of KNN codec", ex);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
@@ -14,8 +14,11 @@ import org.opensearch.index.codec.CodecService;
  */
 public class KNNCodecService extends CodecService {
 
+    private final KNNCodecFactory knnCodecFactory;
+
     public KNNCodecService(CodecServiceConfig codecServiceConfig) {
         super(codecServiceConfig.getMapperService(), codecServiceConfig.getLogger());
+        knnCodecFactory = new KNNCodecFactory(codecServiceConfig.getMapperService());
     }
 
     /**
@@ -26,6 +29,6 @@ public class KNNCodecService extends CodecService {
      */
     @Override
     public Codec codec(String name) {
-        return KNNCodecFactory.createKNNCodec(super.codec(name));
+        return knnCodecFactory.createKNNCodec(super.codec(name));
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/util/CodecBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/CodecBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.index.codec.util;
+
+import lombok.AllArgsConstructor;
+import org.apache.lucene.codecs.Codec;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
+
+/**
+ * Abstracts builder logic for plugin codecs
+ */
+public abstract class CodecBuilder {
+    Codec userCodec;
+
+    /**
+     * Set user defined codec for plugin
+     * @param userCodec
+     * @return
+     */
+    public CodecBuilder userCodec(Codec userCodec) {
+        this.userCodec = userCodec;
+        return this;
+    }
+
+    /**
+     * Builds instance of codec, implementation is specific for each codec version
+     * @return
+     */
+    public abstract Codec build();
+
+    /**
+     * Implements builder abstraction for KNN91Codec
+     */
+    @AllArgsConstructor
+    public static class KNN91CodecBuilder extends CodecBuilder {
+        private final MapperService mapperService;
+
+        @Override
+        public Codec build() {
+            return new KNN910Codec(userCodec);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/util/CodecBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/CodecBuilder.java
@@ -10,7 +10,9 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
 
 /**
- * Abstracts builder logic for plugin codecs
+ * Abstracts builder logic for plugin codecs. For each codec we need to set delegate that is typically
+ * Lucene codec implementation and this is made part of the base class. Exact builder implementation may add
+ * additional parameters required to build a codec.
  */
 public abstract class CodecBuilder {
     Codec userCodec;
@@ -27,12 +29,13 @@ public abstract class CodecBuilder {
 
     /**
      * Builds instance of codec, implementation is specific for each codec version
-     * @return
+     * @return instance of codec
      */
     public abstract Codec build();
 
     /**
-     * Implements builder abstraction for KNN91Codec
+     * Implements builder abstraction for KNN91Codec, adds MapperService that may be required to build
+     * per field format based on field mapper type
      */
     @AllArgsConstructor
     public static class KNN91CodecBuilder extends CodecBuilder {

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -75,7 +75,7 @@ public class TrainingJob implements Runnable {
         this.modelAnonymousEntryContext = Objects.requireNonNull(modelAnonymousEntryContext, "AnonymousEntryContext cannot be null.");
         this.model = new Model(
             new ModelMetadata(
-                knnMethodContext.getEngine(),
+                knnMethodContext.getKnnEngine(),
                 knnMethodContext.getSpaceType(),
                 dimension,
                 ModelState.TRAINING,

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -74,7 +74,7 @@ public class KNNMethodContextTests extends KNNTestCase {
     public void testGetEngine() {
         MethodComponentContext methodComponent = new MethodComponentContext("test-method", Collections.emptyMap());
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, methodComponent);
-        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getEngine());
+        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getKnnEngine());
     }
 
     /**
@@ -265,7 +265,7 @@ public class KNNMethodContextTests extends KNNTestCase {
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
 
-        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getEngine());
+        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getKnnEngine());
         assertEquals(SpaceType.DEFAULT, knnMethodContext.getSpaceType());
         assertEquals(methodName, knnMethodContext.getMethodComponent().getName());
         assertTrue(knnMethodContext.getMethodComponent().getParameters().isEmpty());

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
@@ -7,8 +7,11 @@ package org.opensearch.knn.index.codec;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
+
+import static org.mockito.Mockito.mock;
 
 public class KNNCodecFactoryTests extends KNNTestCase {
 
@@ -20,14 +23,18 @@ public class KNNCodecFactoryTests extends KNNTestCase {
 
     public void testKNN91DefaultCodec() {
         Lucene91Codec lucene91CodecDelegate = new Lucene91Codec();
-        Codec knnCodec = KNNCodecFactory.createKNNCodec(lucene91CodecDelegate);
+        MapperService mapperService = mock(MapperService.class);
+        KNNCodecFactory knnCodecFactory = new KNNCodecFactory(mapperService);
+        Codec knnCodec = knnCodecFactory.createKNNCodec(lucene91CodecDelegate);
         assertNotNull(knnCodec);
         assertTrue(knnCodec instanceof KNN910Codec);
     }
 
     public void testKNN91CodecByVersion() {
         Lucene91Codec lucene91CodecDelegate = new Lucene91Codec();
-        Codec knnCodec = KNNCodecFactory.createKNNCodec(KNNCodecFactory.KNNCodecVersion.KNN910, lucene91CodecDelegate);
+        MapperService mapperService = mock(MapperService.class);
+        KNNCodecFactory knnCodecFactory = new KNNCodecFactory(mapperService);
+        Codec knnCodec = knnCodecFactory.createKNNCodec(KNNCodecFactory.KNNCodecVersion.KNN910, lucene91CodecDelegate);
         assertNotNull(knnCodec);
         assertTrue(knnCodec instanceof KNN910Codec);
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNNFormatFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNFormatFactoryTests.java
@@ -6,13 +6,18 @@
 package org.opensearch.knn.index.codec;
 
 import org.apache.lucene.codecs.Codec;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
+
+import static org.mockito.Mockito.mock;
 
 public class KNNFormatFactoryTests extends KNNTestCase {
 
     public void testKNN91Format() {
         final Codec lucene91CodecDelegate = KNNCodecFactory.CodecDelegateFactory.createKNN91DefaultDelegate();
-        final Codec knnCodec = KNNCodecFactory.createKNNCodec(lucene91CodecDelegate);
+        MapperService mapperService = mock(MapperService.class);
+        KNNCodecFactory knnCodecFactory = new KNNCodecFactory(mapperService);
+        final Codec knnCodec = knnCodecFactory.createKNNCodec(lucene91CodecDelegate);
         KNNFormatFacade knnFormatFacade = KNNFormatFactory.createKNN910Format(knnCodec);
 
         assertNotNull(knnFormatFacade);

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -809,7 +809,7 @@ public class JNIServiceTests extends KNNTestCase {
             )
         );
 
-        String description = knnMethodContext.getEngine().getMethodAsMap(knnMethodContext).get(INDEX_DESCRIPTION_PARAMETER).toString();
+        String description = knnMethodContext.getKnnEngine().getMethodAsMap(knnMethodContext).get(INDEX_DESCRIPTION_PARAMETER).toString();
         assertEquals("IVF16,PQ16x8", description);
 
         Map<String, Object> parameters = ImmutableMap.of(

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.KNNVectorFieldMapper;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -25,7 +26,13 @@ public class KNNScoringSpaceTests extends KNNTestCase {
     public void testL2() {
         float[] arrayFloat = new float[] { 1.0f, 2.0f, 3.0f };
         List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
-        KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType("test", Collections.emptyMap(), 3);
+        KNNMethodContext knnMethodContext = KNNMethodContext.getDefault();
+        KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType(
+            "test",
+            Collections.emptyMap(),
+            3,
+            knnMethodContext
+        );
         KNNScoringSpace.L2 l2 = new KNNScoringSpace.L2(arrayListQueryObject, fieldType);
         assertEquals(1F, l2.scoringMethod.apply(arrayFloat, arrayFloat), 0.1F);
 
@@ -40,8 +47,14 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         float[] arrayFloat = new float[] { 1.0f, 2.0f, 3.0f };
         List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
         float[] arrayFloat2 = new float[] { 2.0f, 4.0f, 6.0f };
+        KNNMethodContext knnMethodContext = KNNMethodContext.getDefault();
 
-        KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType("test", Collections.emptyMap(), 3);
+        KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType(
+            "test",
+            Collections.emptyMap(),
+            3,
+            knnMethodContext
+        );
         KNNScoringSpace.CosineSimilarity cosineSimilarity = new KNNScoringSpace.CosineSimilarity(arrayListQueryObject, fieldType);
 
         assertEquals(3F, cosineSimilarity.scoringMethod.apply(arrayFloat2, arrayFloat), 0.1F);
@@ -57,8 +70,14 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         float[] arrayFloat_case1 = new float[] { 1.0f, 2.0f, 3.0f };
         List<Double> arrayListQueryObject_case1 = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
         float[] arrayFloat2_case1 = new float[] { 1.0f, 1.0f, 1.0f };
+        KNNMethodContext knnMethodContext = KNNMethodContext.getDefault();
 
-        KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType("test", Collections.emptyMap(), 3);
+        KNNVectorFieldMapper.KNNVectorFieldType fieldType = new KNNVectorFieldMapper.KNNVectorFieldType(
+            "test",
+            Collections.emptyMap(),
+            3,
+            knnMethodContext
+        );
         KNNScoringSpace.InnerProd innerProd = new KNNScoringSpace.InnerProd(arrayListQueryObject_case1, fieldType);
 
         assertEquals(7.0F, innerProd.scoringMethod.apply(arrayFloat_case1, arrayFloat2_case1), 0.001F);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -42,7 +42,7 @@ public class TrainingJobTests extends KNNTestCase {
     public void testGetModelId() {
         String modelId = "test-model-id";
         KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
-        when(knnMethodContext.getEngine()).thenReturn(KNNEngine.DEFAULT);
+        when(knnMethodContext.getKnnEngine()).thenReturn(KNNEngine.DEFAULT);
         when(knnMethodContext.getSpaceType()).thenReturn(SpaceType.DEFAULT);
 
         TrainingJob trainingJob = new TrainingJob(
@@ -66,7 +66,7 @@ public class TrainingJobTests extends KNNTestCase {
         String error = "";
 
         KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
-        when(knnMethodContext.getEngine()).thenReturn(knnEngine);
+        when(knnMethodContext.getKnnEngine()).thenReturn(knnEngine);
         when(knnMethodContext.getSpaceType()).thenReturn(spaceType);
 
         String modelID = "test-model-id";


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Refactor few things in plugin in order to open possibilities for future extensions required for https://github.com/opensearch-project/k-NN/issues/39

- add KNNMethodContext to KNNVectorFieldType
- pass mapperService to codec implementation, so later we can read type information when initialize codec. We can retrieve knn vector mappedFieldType similar to what is done in POC for core https://github.com/martin-gaievski/OpenSearch/blob/lucene-ann-integ/server/src/main/java/org/opensearch/index/codec/KnnVectorsFormatFactory.java#L33. This is required to initialize per field vector format with _m_ (_max_connections_) and _efConstruction_ (_beam_width_) based on mapping values.
- code cleanup, use lombok syntax where applicable
 
### Issues Resolved
building block for https://github.com/opensearch-project/k-NN/issues/39 
 
### Check List
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
