### PR TITLE
Move mappers to separate files

### DIFF
--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -17,6 +17,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -16,6 +16,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterDirectory;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.shard.IndexShard;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;

--- a/src/main/java/org/opensearch/knn/index/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/KNNQueryBuilder.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index;
 
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.plugin.stats.KNNCounter;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterDirectory;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.common.KNNConstants;
 
 import java.io.Closeable;

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesType;
@@ -60,8 +58,6 @@ import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
  * alternative mappings for the same field type.
  */
 public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
-
-    static Logger logger = LogManager.getLogger(KNNVectorFieldMapper.class);
 
     public static final String CONTENT_TYPE = "knn_vector";
     public static final String KNN_FIELD = "knn_field";
@@ -385,7 +381,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
     protected void parseCreateField(ParseContext context, int dimension) throws IOException {
 
         validateIfKNNPluginEnabled();
-        validateIfCircuitBreakerTriggered();
+        validateIfCircuitBreakerIsNotTriggered();
 
         Optional<float[]> arrayOptional = getFloatsFromContext(context, dimension);
 
@@ -402,7 +398,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         context.path().remove();
     }
 
-    void validateIfCircuitBreakerTriggered() {
+    void validateIfCircuitBreakerIsNotTriggered() {
         if (KNNSettings.isCircuitBreakerTriggered()) {
             throw new IllegalStateException(
                 "Indexing knn vector fields is rejected as circuit breaker triggered." + " Check _opendistro/_knn/stats for detailed state"

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -3,12 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index;
+package org.opensearch.knn.index.mapper;
 
 import lombok.Getter;
-import org.opensearch.common.Strings;
 import org.opensearch.common.ValidationException;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.common.KNNConstants;
 
 import org.apache.logging.log4j.LogManager;
@@ -20,7 +18,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.Explicit;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentParser;
@@ -36,9 +33,11 @@ import org.opensearch.index.mapper.TextSearchInfo;
 import org.opensearch.index.mapper.ValueFetcher;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.QueryShardException;
-import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.KNNVectorIndexFieldData;
+import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.indices.ModelDao;
-import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.lookup.SearchLookup;
 
@@ -47,17 +46,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.opensearch.knn.common.KNNConstants.DIMENSION;
-import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_CONSTRUCTION;
-import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_M;
-import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
-import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
-import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
-import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
-import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 /**
  * Field Mapper for KNN vector type.
@@ -69,7 +61,7 @@ import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
  */
 public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
-    private static Logger logger = LogManager.getLogger(KNNVectorFieldMapper.class);
+    static Logger logger = LogManager.getLogger(KNNVectorFieldMapper.class);
 
     public static final String CONTENT_TYPE = "knn_vector";
     public static final String KNN_FIELD = "knn_field";
@@ -392,16 +384,39 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
     protected void parseCreateField(ParseContext context, int dimension) throws IOException {
 
-        if (!KNNSettings.isKNNPluginEnabled()) {
-            throw new IllegalStateException("KNN plugin is disabled. To enable " + "update knn.plugin.enabled setting to true");
-        }
+        validateIfKNNPluginEnabled();
+        validateIfCircuitBreakerTriggered();
 
+        Optional<float[]> arrayOptional = getFloatsFromContext(context, dimension);
+
+        if (!arrayOptional.isPresent()) {
+            return;
+        }
+        final float[] array = arrayOptional.get();
+        VectorField point = new VectorField(name(), array, fieldType);
+
+        context.doc().add(point);
+        if (fieldType.stored()) {
+            context.doc().add(new StoredField(name(), point.toString()));
+        }
+        context.path().remove();
+    }
+
+    void validateIfCircuitBreakerTriggered() {
         if (KNNSettings.isCircuitBreakerTriggered()) {
             throw new IllegalStateException(
                 "Indexing knn vector fields is rejected as circuit breaker triggered." + " Check _opendistro/_knn/stats for detailed state"
             );
         }
+    }
 
+    void validateIfKNNPluginEnabled() {
+        if (!KNNSettings.isKNNPluginEnabled()) {
+            throw new IllegalStateException("KNN plugin is disabled. To enable " + "update knn.plugin.enabled setting to true");
+        }
+    }
+
+    Optional<float[]> getFloatsFromContext(ParseContext context, int dimension) throws IOException {
         context.path().add(simpleName());
 
         ArrayList<Float> vector = new ArrayList<>();
@@ -438,7 +453,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             context.parser().nextToken();
         } else if (token == XContentParser.Token.VALUE_NULL) {
             context.path().remove();
-            return;
+            return Optional.empty();
         }
 
         if (dimension != vector.size()) {
@@ -451,14 +466,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         for (Float f : vector) {
             array[i++] = f;
         }
-
-        VectorField point = new VectorField(name(), array, fieldType);
-
-        context.doc().add(point);
-        if (fieldType.stored()) {
-            context.doc().add(new StoredField(name(), point.toString()));
-        }
-        context.path().remove();
+        return Optional.of(array);
     }
 
     @Override
@@ -503,189 +511,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             FIELD_TYPE.setDocValuesType(DocValuesType.BINARY);
             FIELD_TYPE.putAttribute(KNN_FIELD, "true"); // This attribute helps to determine knn field type
             FIELD_TYPE.freeze();
-        }
-    }
-
-    /**
-     * Field mapper for original implementation
-     */
-    protected static class LegacyFieldMapper extends KNNVectorFieldMapper {
-
-        protected String spaceType;
-        protected String m;
-        protected String efConstruction;
-
-        private LegacyFieldMapper(
-            String simpleName,
-            KNNVectorFieldType mappedFieldType,
-            MultiFields multiFields,
-            CopyTo copyTo,
-            Explicit<Boolean> ignoreMalformed,
-            boolean stored,
-            boolean hasDocValues,
-            String spaceType,
-            String m,
-            String efConstruction
-        ) {
-            super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
-
-            this.spaceType = spaceType;
-            this.m = m;
-            this.efConstruction = efConstruction;
-
-            this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
-
-            this.fieldType.putAttribute(DIMENSION, String.valueOf(dimension));
-            this.fieldType.putAttribute(SPACE_TYPE, spaceType);
-            this.fieldType.putAttribute(KNN_ENGINE, KNNEngine.NMSLIB.getName());
-
-            // These are extra just for legacy
-            this.fieldType.putAttribute(HNSW_ALGO_M, m);
-            this.fieldType.putAttribute(HNSW_ALGO_EF_CONSTRUCTION, efConstruction);
-
-            this.fieldType.freeze();
-        }
-
-        @Override
-        public ParametrizedFieldMapper.Builder getMergeBuilder() {
-            return new KNNVectorFieldMapper.Builder(simpleName(), this.spaceType, this.m, this.efConstruction).init(this);
-        }
-
-        static String getSpaceType(Settings indexSettings) {
-            String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
-            if (spaceType == null) {
-                logger.info(
-                    "[KNN] The setting \""
-                        + METHOD_PARAMETER_SPACE_TYPE
-                        + "\" was not set for the index. "
-                        + "Likely caused by recent version upgrade. Setting the setting to the default value="
-                        + KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE
-                );
-                return KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
-            }
-            return spaceType;
-        }
-
-        static String getM(Settings indexSettings) {
-            String m = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_M_SETTING.getKey());
-            if (m == null) {
-                logger.info(
-                    "[KNN] The setting \""
-                        + HNSW_ALGO_M
-                        + "\" was not set for the index. "
-                        + "Likely caused by recent version upgrade. Setting the setting to the default value="
-                        + KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M
-                );
-                return String.valueOf(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M);
-            }
-            return m;
-        }
-
-        static String getEfConstruction(Settings indexSettings) {
-            String efConstruction = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING.getKey());
-            if (efConstruction == null) {
-                logger.info(
-                    "[KNN] The setting \""
-                        + HNSW_ALGO_EF_CONSTRUCTION
-                        + "\" was not set for"
-                        + " the index. Likely caused by recent version upgrade. Setting the setting to the default value="
-                        + KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION
-                );
-                return String.valueOf(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION);
-            }
-            return efConstruction;
-        }
-    }
-
-    /**
-     * Field mapper for method definition in mapping
-     */
-    protected static class MethodFieldMapper extends KNNVectorFieldMapper {
-
-        private MethodFieldMapper(
-            String simpleName,
-            KNNVectorFieldType mappedFieldType,
-            MultiFields multiFields,
-            CopyTo copyTo,
-            Explicit<Boolean> ignoreMalformed,
-            boolean stored,
-            boolean hasDocValues,
-            KNNMethodContext knnMethodContext
-        ) {
-
-            super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
-
-            this.knnMethod = knnMethodContext;
-
-            this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
-
-            this.fieldType.putAttribute(DIMENSION, String.valueOf(dimension));
-            this.fieldType.putAttribute(SPACE_TYPE, knnMethodContext.getSpaceType().getValue());
-
-            KNNEngine knnEngine = knnMethodContext.getKnnEngine();
-            this.fieldType.putAttribute(KNN_ENGINE, knnEngine.getName());
-
-            try {
-                this.fieldType.putAttribute(
-                    PARAMETERS,
-                    Strings.toString(XContentFactory.jsonBuilder().map(knnEngine.getMethodAsMap(knnMethodContext)))
-                );
-            } catch (IOException ioe) {
-                throw new RuntimeException("Unable to create KNNVectorFieldMapper: " + ioe);
-            }
-
-            this.fieldType.freeze();
-        }
-    }
-
-    /**
-     * Field mapper for model in mapping
-     */
-    protected static class ModelFieldMapper extends KNNVectorFieldMapper {
-
-        private ModelFieldMapper(
-            String simpleName,
-            KNNVectorFieldType mappedFieldType,
-            MultiFields multiFields,
-            CopyTo copyTo,
-            Explicit<Boolean> ignoreMalformed,
-            boolean stored,
-            boolean hasDocValues,
-            ModelDao modelDao,
-            String modelId
-        ) {
-            super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
-
-            this.modelId = modelId;
-            this.modelDao = modelDao;
-
-            this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
-            this.fieldType.putAttribute(MODEL_ID, modelId);
-            this.fieldType.freeze();
-        }
-
-        @Override
-        protected void parseCreateField(ParseContext context) throws IOException {
-            // For the model field mapper, we cannot validate the model during index creation due to
-            // an issue with reading cluster state during mapper creation. So, we need to validate the
-            // model when ingestion starts.
-            ModelMetadata modelMetadata = this.modelDao.getMetadata(modelId);
-
-            if (modelMetadata == null) {
-                throw new IllegalStateException(
-                    "Model \""
-                        + modelId
-                        + "\" from "
-                        + context.mapperService().index().getName()
-                        + "'s mapping does not exist. Because the "
-                        + "\""
-                        + MODEL_ID
-                        + "\" parameter is not updateable, this index will need to "
-                        + "be recreated with a valid model."
-                );
-            }
-
-            parseCreateField(context, modelMetadata.getDimension());
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -87,11 +87,13 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             }
             int value = XContentMapValues.nodeIntegerValue(o);
             if (value > MAX_DIMENSION) {
-                throw new IllegalArgumentException("Dimension value cannot be greater than " + MAX_DIMENSION + " for vector: " + name);
+                throw new IllegalArgumentException(
+                    String.format("Dimension value cannot be greater than %s for vector: %s", MAX_DIMENSION, name)
+                );
             }
 
             if (value <= 0) {
-                throw new IllegalArgumentException("Dimension value must be greater than 0 " + "for vector: " + name);
+                throw new IllegalArgumentException(String.format("Dimension value must be greater than 0 for vector: %s", name));
             }
             return value;
         }, m -> toType(m).dimension);
@@ -273,12 +275,12 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             // is done before any mappers are built. Therefore, validation should be done during parsing
             // so that it can fail early.
             if (builder.knnMethodContext.get() != null && builder.modelId.get() != null) {
-                throw new IllegalArgumentException("Method and model can not be both specified in the mapping: " + name);
+                throw new IllegalArgumentException(String.format("Method and model can not be both specified in the mapping: %s", name));
             }
 
             // Dimension should not be null unless modelId is used
             if (builder.dimension.getValue() == -1 && builder.modelId.get() == null) {
-                throw new IllegalArgumentException("Dimension value missing for vector: " + name);
+                throw new IllegalArgumentException(String.format("Dimension value missing for vector: %s", name));
             }
 
             return builder;
@@ -325,7 +327,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         public Query termQuery(Object value, QueryShardContext context) {
             throw new QueryShardException(
                 context,
-                "KNN vector do not support exact searching, use KNN queries " + "instead: [" + name() + "]"
+                String.format("KNN vector do not support exact searching, use KNN queries instead: [%s]", name())
             );
         }
 
@@ -401,14 +403,14 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
     void validateIfCircuitBreakerIsNotTriggered() {
         if (KNNSettings.isCircuitBreakerTriggered()) {
             throw new IllegalStateException(
-                "Indexing knn vector fields is rejected as circuit breaker triggered." + " Check _opendistro/_knn/stats for detailed state"
+                "Indexing knn vector fields is rejected as circuit breaker triggered. Check _opendistro/_knn/stats for detailed state"
             );
         }
     }
 
     void validateIfKNNPluginEnabled() {
         if (!KNNSettings.isKNNPluginEnabled()) {
-            throw new IllegalStateException("KNN plugin is disabled. To enable " + "update knn.plugin.enabled setting to true");
+            throw new IllegalStateException("KNN plugin is disabled. To enable update knn.plugin.enabled setting to true");
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.mapper;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.FieldType;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.settings.Settings;
@@ -22,6 +23,7 @@ import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 /**
  * Field mapper for original implementation
  */
+@Log4j2
 public class LegacyFieldMapper extends KNNVectorFieldMapper {
 
     protected String spaceType;
@@ -67,7 +69,7 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
     static String getSpaceType(Settings indexSettings) {
         String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
         if (spaceType == null) {
-            logger.info(
+            log.info(
                 "[KNN] The setting \""
                     + METHOD_PARAMETER_SPACE_TYPE
                     + "\" was not set for the index. "
@@ -82,7 +84,7 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
     static String getM(Settings indexSettings) {
         String m = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_M_SETTING.getKey());
         if (m == null) {
-            logger.info(
+            log.info(
                 "[KNN] The setting \""
                     + HNSW_ALGO_M
                     + "\" was not set for the index. "
@@ -97,7 +99,7 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
     static String getEfConstruction(Settings indexSettings) {
         String efConstruction = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING.getKey());
         if (efConstruction == null) {
-            logger.info(
+            log.info(
                 "[KNN] The setting \""
                     + HNSW_ALGO_EF_CONSTRUCTION
                     + "\" was not set for"

--- a/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.FieldType;
+import org.opensearch.common.Explicit;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_M;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+
+/**
+ * Field mapper for original implementation
+ */
+public class LegacyFieldMapper extends KNNVectorFieldMapper {
+
+    protected String spaceType;
+    protected String m;
+    protected String efConstruction;
+
+    LegacyFieldMapper(
+        String simpleName,
+        KNNVectorFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        Explicit<Boolean> ignoreMalformed,
+        boolean stored,
+        boolean hasDocValues,
+        String spaceType,
+        String m,
+        String efConstruction
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
+
+        this.spaceType = spaceType;
+        this.m = m;
+        this.efConstruction = efConstruction;
+
+        this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
+
+        this.fieldType.putAttribute(DIMENSION, String.valueOf(dimension));
+        this.fieldType.putAttribute(SPACE_TYPE, spaceType);
+        this.fieldType.putAttribute(KNN_ENGINE, KNNEngine.NMSLIB.getName());
+
+        // These are extra just for legacy
+        this.fieldType.putAttribute(HNSW_ALGO_M, m);
+        this.fieldType.putAttribute(HNSW_ALGO_EF_CONSTRUCTION, efConstruction);
+
+        this.fieldType.freeze();
+    }
+
+    @Override
+    public ParametrizedFieldMapper.Builder getMergeBuilder() {
+        return new KNNVectorFieldMapper.Builder(simpleName(), this.spaceType, this.m, this.efConstruction).init(this);
+    }
+
+    static String getSpaceType(Settings indexSettings) {
+        String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
+        if (spaceType == null) {
+            logger.info(
+                "[KNN] The setting \""
+                    + METHOD_PARAMETER_SPACE_TYPE
+                    + "\" was not set for the index. "
+                    + "Likely caused by recent version upgrade. Setting the setting to the default value="
+                    + KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE
+            );
+            return KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
+        }
+        return spaceType;
+    }
+
+    static String getM(Settings indexSettings) {
+        String m = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_M_SETTING.getKey());
+        if (m == null) {
+            logger.info(
+                "[KNN] The setting \""
+                    + HNSW_ALGO_M
+                    + "\" was not set for the index. "
+                    + "Likely caused by recent version upgrade. Setting the setting to the default value="
+                    + KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M
+            );
+            return String.valueOf(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M);
+        }
+        return m;
+    }
+
+    static String getEfConstruction(Settings indexSettings) {
+        String efConstruction = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING.getKey());
+        if (efConstruction == null) {
+            logger.info(
+                "[KNN] The setting \""
+                    + HNSW_ALGO_EF_CONSTRUCTION
+                    + "\" was not set for"
+                    + " the index. Likely caused by recent version upgrade. Setting the setting to the default value="
+                    + KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION
+            );
+            return String.valueOf(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION);
+        }
+        return efConstruction;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
@@ -21,7 +21,14 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 /**
- * Field mapper for original implementation
+ * Field mapper for original implementation. It defaults to using nmslib as the engine and retrieves parameters from index settings.
+ *
+ * Example of this mapper output:
+ *
+ *   {
+ *    "type": "knn_vector",
+ *    "dimension": 128
+ *   }
  */
 @Log4j2
 public class LegacyFieldMapper extends KNNVectorFieldMapper {
@@ -70,11 +77,11 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
         String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
         if (spaceType == null) {
             log.info(
-                "[KNN] The setting \""
-                    + METHOD_PARAMETER_SPACE_TYPE
-                    + "\" was not set for the index. "
-                    + "Likely caused by recent version upgrade. Setting the setting to the default value="
-                    + KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE
+                String.format(
+                    "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value=%s",
+                    METHOD_PARAMETER_SPACE_TYPE,
+                    KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE
+                )
             );
             return KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
         }
@@ -85,11 +92,11 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
         String m = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_M_SETTING.getKey());
         if (m == null) {
             log.info(
-                "[KNN] The setting \""
-                    + HNSW_ALGO_M
-                    + "\" was not set for the index. "
-                    + "Likely caused by recent version upgrade. Setting the setting to the default value="
-                    + KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M
+                String.format(
+                    "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value=%s",
+                    HNSW_ALGO_M,
+                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M
+                )
             );
             return String.valueOf(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M);
         }
@@ -100,11 +107,11 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
         String efConstruction = indexSettings.get(KNNSettings.INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING.getKey());
         if (efConstruction == null) {
             log.info(
-                "[KNN] The setting \""
-                    + HNSW_ALGO_EF_CONSTRUCTION
-                    + "\" was not set for"
-                    + " the index. Likely caused by recent version upgrade. Setting the setting to the default value="
-                    + KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION
+                String.format(
+                    "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value=%s",
+                    HNSW_ALGO_EF_CONSTRUCTION,
+                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION
+                )
             );
             return String.valueOf(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION);
         }

--- a/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java
@@ -53,7 +53,7 @@ public class MethodFieldMapper extends KNNVectorFieldMapper {
                 Strings.toString(XContentFactory.jsonBuilder().map(knnEngine.getMethodAsMap(knnMethodContext)))
             );
         } catch (IOException ioe) {
-            throw new RuntimeException("Unable to create KNNVectorFieldMapper: " + ioe);
+            throw new RuntimeException(String.format("Unable to create KNNVectorFieldMapper: %s", ioe));
         }
 
         this.fieldType.freeze();

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.FieldType;
+import org.opensearch.common.Explicit;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+
+/**
+ * Field mapper for model in mapping
+ */
+public class ModelFieldMapper extends KNNVectorFieldMapper {
+
+    ModelFieldMapper(
+        String simpleName,
+        KNNVectorFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        Explicit<Boolean> ignoreMalformed,
+        boolean stored,
+        boolean hasDocValues,
+        ModelDao modelDao,
+        String modelId
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
+
+        this.modelId = modelId;
+        this.modelDao = modelDao;
+
+        this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
+        this.fieldType.putAttribute(MODEL_ID, modelId);
+        this.fieldType.freeze();
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) throws IOException {
+        // For the model field mapper, we cannot validate the model during index creation due to
+        // an issue with reading cluster state during mapper creation. So, we need to validate the
+        // model when ingestion starts.
+        ModelMetadata modelMetadata = this.modelDao.getMetadata(modelId);
+
+        if (modelMetadata == null) {
+            throw new IllegalStateException(
+                "Model \""
+                    + modelId
+                    + "\" from "
+                    + context.mapperService().index().getName()
+                    + "'s mapping does not exist. Because the "
+                    + "\""
+                    + MODEL_ID
+                    + "\" parameter is not updateable, this index will need to "
+                    + "be recreated with a valid model."
+            );
+        }
+
+        parseCreateField(context, modelMetadata.getDimension());
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -50,15 +50,12 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
 
         if (modelMetadata == null) {
             throw new IllegalStateException(
-                "Model \""
-                    + modelId
-                    + "\" from "
-                    + context.mapperService().index().getName()
-                    + "'s mapping does not exist. Because the "
-                    + "\""
-                    + MODEL_ID
-                    + "\" parameter is not updateable, this index will need to "
-                    + "be recreated with a valid model."
+                String.format(
+                    "Model \"%s\" from %s's mapping does not exist. Because the \"%s\" parameter is not updatable, this index will need to be recreated with a valid model.",
+                    modelId,
+                    context.mapperService().index().getName(),
+                    MODEL_ID
+                )
             );
         }
 

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -34,7 +34,7 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ERROR;
 import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_TIMESTAMP;
-import static org.opensearch.knn.index.KNNVectorFieldMapper.MAX_DIMENSION;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.MAX_DIMENSION;
 
 public class ModelMetadata implements Writeable, ToXContentObject {
 

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -10,7 +10,7 @@ import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.knn.index.KNNCircuitBreaker;
 import org.opensearch.knn.index.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 
 import org.opensearch.knn.index.KNNWeight;
 import org.opensearch.knn.index.codec.KNNCodecService;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.plugin.script;
 
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.KNNWeight;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.index.mapper.MappedFieldType;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.plugin.script;
 
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;

--- a/src/test/java/org/opensearch/knn/index/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNQueryBuilderTests.java
@@ -12,6 +12,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.index.Index;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -27,6 +27,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 import org.opensearch.rest.RestStatus;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -26,7 +26,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.KNN87Codec.KNN87Codec;

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -15,7 +15,7 @@ import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.KNNQuery;
 import org.opensearch.knn.index.KNNSettings;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.KNNWeight;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorField;

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1,9 +1,15 @@
 /*
- * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
  */
 
-package org.opensearch.knn.index;
+package org.opensearch.knn.index.mapper;
 
 import com.google.common.collect.ImmutableMap;
 import org.opensearch.knn.KNNTestCase;
@@ -17,6 +23,10 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.ContentPath;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.MethodComponentContext;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
@@ -79,7 +89,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
         KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
-        assertTrue(knnVectorFieldMapper instanceof KNNVectorFieldMapper.MethodFieldMapper);
+        assertTrue(knnVectorFieldMapper instanceof MethodFieldMapper);
         assertNotNull(knnVectorFieldMapper.knnMethod);
         assertNull(knnVectorFieldMapper.modelId);
     }
@@ -116,7 +126,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
         when(modelDao.getMetadata(modelId)).thenReturn(mockedModelMetadata);
         KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
-        assertTrue(knnVectorFieldMapper instanceof KNNVectorFieldMapper.ModelFieldMapper);
+        assertTrue(knnVectorFieldMapper instanceof ModelFieldMapper);
         assertNotNull(knnVectorFieldMapper.modelId);
         assertNull(knnVectorFieldMapper.knnMethod);
     }
@@ -140,7 +150,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
         KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
-        assertTrue(knnVectorFieldMapper instanceof KNNVectorFieldMapper.LegacyFieldMapper);
+        assertTrue(knnVectorFieldMapper instanceof LegacyFieldMapper);
 
         assertNull(knnVectorFieldMapper.modelId);
         assertNull(knnVectorFieldMapper.knnMethod);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.knn.index.mapper;

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -21,7 +21,7 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.opensearch.knn.index.KNNVectorFieldMapper.MAX_DIMENSION;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.MAX_DIMENSION;
 
 public class ModelTests extends KNNTestCase {
 

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
 

--- a/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
@@ -25,7 +25,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
This is in preparation for new LuceneField mapper to keep size of KNNVectorFieldMapper manageable and to structure project better.
Extract mapper classes from file with abstract class KNNVectorFieldMapper to separate files, created new "mapper" package for new classes.

 
### Issues Resolved
building block for #39 
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
