### PR TITLE
[feature/lucene-knn] Add Lucene as a KNNEngine

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -50,6 +50,9 @@ public class KNNConstants {
     public static final String MAX_VECTOR_COUNT_PARAMETER = "max_training_vector_count";
     public static final String SEARCH_SIZE_PARAMETER = "search_size";
 
+    // Lucene specific constants
+    public static final String LUCENE_NAME = "lucene";
+
     // nmslib specific constants
     public static final String NMSLIB_NAME = "nmslib";
     public static final String SPACE_TYPE = "spaceType"; // used as field info key

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -109,7 +109,7 @@ public class KNNIndexShard {
      */
     public Map<String, SpaceType> getAllEnginePaths(IndexReader indexReader) throws IOException {
         Map<String, SpaceType> engineFiles = new HashMap<>();
-        for (KNNEngine knnEngine : KNNEngine.values()) {
+        for (KNNEngine knnEngine : KNNEngine.getEnginesThatCreateCustomSegmentFiles()) {
             engineFiles.putAll(getEnginePaths(indexReader, knnEngine));
         }
         return engineFiles;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
@@ -47,7 +47,10 @@ public class KNN80CompoundFormat extends CompoundFormat {
     @Override
     public void write(Directory dir, SegmentInfo si, IOContext context) throws IOException {
         for (KNNEngine knnEngine : KNNEngine.values()) {
-            writeEngineFiles(dir, si, context, knnEngine.getExtension());
+            // Lucene is a special case. All engine writes are completely handled by it so we can skip it.
+            if (knnEngine != KNNEngine.LUCENE) {
+                writeEngineFiles(dir, si, context, knnEngine.getExtension());
+            }
         }
         delegate.write(dir, si, context);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
@@ -46,11 +46,8 @@ public class KNN80CompoundFormat extends CompoundFormat {
 
     @Override
     public void write(Directory dir, SegmentInfo si, IOContext context) throws IOException {
-        for (KNNEngine knnEngine : KNNEngine.values()) {
-            // Lucene is a special case. All engine writes are completely handled by it so we can skip it.
-            if (knnEngine != KNNEngine.LUCENE) {
-                writeEngineFiles(dir, si, context, knnEngine.getExtension());
-            }
+        for (KNNEngine knnEngine : KNNEngine.getEnginesThatCreateCustomSegmentFiles()) {
+            writeEngineFiles(dir, si, context, knnEngine.getExtension());
         }
         delegate.write(dir, si, context);
     }

--- a/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
@@ -26,7 +26,11 @@ public abstract class AbstractKNNLibrary implements KNNLibrary {
 
     @Override
     public KNNMethod getMethod(String methodName) {
-        return this.methods.get(methodName);
+        KNNMethod method = methods.get(methodName);
+        if (method == null) {
+            throw new IllegalArgumentException(String.format("Invalid method name: %s", methodName));
+        }
+        return method;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.knn.index.util;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -14,26 +17,12 @@ import java.util.Map;
 /**
  * AbstractKNNLibrary implements common functionality shared between libraries
  */
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public abstract class AbstractKNNLibrary implements KNNLibrary {
 
     protected final Map<String, KNNMethod> methods;
+    @Getter
     protected final String version;
-
-    /**
-     * Constructor
-     *
-     * @param methods Map of k-NN methods that the library supports
-     * @param version String representing version of library
-     */
-    AbstractKNNLibrary(Map<String, KNNMethod> methods, String version) {
-        this.methods = methods;
-        this.version = version;
-    }
-
-    @Override
-    public String getVersion() {
-        return this.version;
-    }
 
     @Override
     public KNNMethod getMethod(String methodName) {

--- a/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.util;
+
+import org.opensearch.common.ValidationException;
+import org.opensearch.knn.index.KNNMethod;
+import org.opensearch.knn.index.KNNMethodContext;
+
+import java.util.Map;
+
+/**
+ * AbstractKNNLibrary implements common functionality shared between libraries
+ */
+public abstract class AbstractKNNLibrary implements KNNLibrary {
+
+    protected final Map<String, KNNMethod> methods;
+    protected final String version;
+
+    /**
+     * Constructor
+     *
+     * @param methods Map of k-NN methods that the library supports
+     * @param version String representing version of library
+     */
+    AbstractKNNLibrary(Map<String, KNNMethod> methods, String version) {
+        this.methods = methods;
+        this.version = version;
+    }
+
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public KNNMethod getMethod(String methodName) {
+        return this.methods.get(methodName);
+    }
+
+    @Override
+    public ValidationException validateMethod(KNNMethodContext knnMethodContext) {
+        String methodName = knnMethodContext.getMethodComponent().getName();
+        return getMethod(methodName).validate(knnMethodContext);
+    }
+
+    @Override
+    public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
+        String methodName = knnMethodContext.getMethodComponent().getName();
+        return getMethod(methodName).isTrainingRequired(knnMethodContext);
+    }
+
+    @Override
+    public Map<String, Object> getMethodAsMap(KNNMethodContext knnMethodContext) {
+        KNNMethod knnMethod = methods.get(knnMethodContext.getMethodComponent().getName());
+
+        if (knnMethod == null) {
+            throw new IllegalArgumentException(String.format("Invalid method name: %s", knnMethodContext.getMethodComponent().getName()));
+        }
+
+        return knnMethod.getAsMap(knnMethodContext);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/util/JVMLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/JVMLibrary.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.util;
+
+import org.opensearch.knn.index.KNNMethod;
+import org.opensearch.knn.index.KNNMethodContext;
+
+import java.util.Map;
+
+/**
+ * Abstract class for JVM based KNN libraries
+ */
+public abstract class JVMLibrary extends AbstractKNNLibrary {
+
+    /**
+     * Constructor
+     *
+     * @param methods Map of k-NN methods that the library supports
+     * @param version String representing version of library
+     */
+    JVMLibrary(Map<String, KNNMethod> methods, String version) {
+        super(methods, version);
+    }
+
+    @Override
+    public int estimateOverheadInKB(KNNMethodContext knnMethodContext, int dimension) {
+        throw new UnsupportedOperationException("Estimating overhead is not supported for JVM based libraries.");
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -10,7 +10,10 @@ import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.SpaceType;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
@@ -79,6 +82,15 @@ public enum KNNEngine implements KNNLibrary {
         }
 
         throw new IllegalArgumentException("No engine matches the path's suffix");
+    }
+
+    /**
+     * Returns all engines that create custom segment files. This will be all engines except for Lucene
+     *
+     * @return List of all engines that create custom segment files.
+     */
+    public static List<KNNEngine> getEnginesThatCreateCustomSegmentFiles() {
+        return Arrays.stream(KNNEngine.values()).filter(knnEngine -> knnEngine != KNNEngine.LUCENE).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -13,6 +13,7 @@ import org.opensearch.knn.index.SpaceType;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
 import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 
 /**
@@ -21,7 +22,8 @@ import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
  */
 public enum KNNEngine implements KNNLibrary {
     NMSLIB(NMSLIB_NAME, Nmslib.INSTANCE),
-    FAISS(FAISS_NAME, Faiss.INSTANCE);
+    FAISS(FAISS_NAME, Faiss.INSTANCE),
+    LUCENE(LUCENE_NAME, Lucene.INSTANCE);
 
     public static final KNNEngine DEFAULT = NMSLIB;
 
@@ -52,6 +54,10 @@ public enum KNNEngine implements KNNLibrary {
 
         if (FAISS.getName().equals(name)) {
             return FAISS;
+        }
+
+        if (LUCENE.getName().equals(name)) {
+            return LUCENE;
         }
 
         throw new IllegalArgumentException(String.format("Invalid engine type: %s", name));

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -52,11 +52,11 @@ public enum KNNEngine implements KNNLibrary {
             return NMSLIB;
         }
 
-        if (FAISS.getName().equals(name)) {
+        if (FAISS.getName().equalsIgnoreCase(name)) {
             return FAISS;
         }
 
-        if (LUCENE.getName().equals(name)) {
+        if (LUCENE.getName().equalsIgnoreCase(name)) {
             return LUCENE;
         }
 

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -58,12 +58,12 @@ public class Lucene extends JVMLibrary {
 
     @Override
     public String getExtension() {
-        throw new UnsupportedOperationException("Unable to get extension for Lucene.");
+        throw new UnsupportedOperationException("Getting extension for Lucene is not supported");
     }
 
     @Override
     public String getCompoundExtension() {
-        throw new UnsupportedOperationException("Unable to get compound extension for Lucene.");
+        throw new UnsupportedOperationException("Getting compound extension for Lucene is not supported");
     }
 
     @Override
@@ -81,6 +81,6 @@ public class Lucene extends JVMLibrary {
 
     @Override
     public void setInitialized(Boolean isInitialized) {
-        throw new UnsupportedOperationException("Lucene is automatically initialized.");
+        throw new UnsupportedOperationException("Setting Lucene as initialized is not supported");
     }
 }

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.util.Version;
+import org.opensearch.knn.index.KNNMethod;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.MethodComponent;
+import org.opensearch.knn.index.Parameter;
+import org.opensearch.knn.index.SpaceType;
+
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+
+/**
+ * KNN Library for Lucene
+ */
+public class Lucene extends JVMLibrary {
+
+    final static Map<String, KNNMethod> METHODS = ImmutableMap.of(
+        METHOD_HNSW,
+        KNNMethod.Builder.builder(
+            MethodComponent.Builder.builder(METHOD_HNSW)
+                .addParameter(
+                    METHOD_PARAMETER_M,
+                    new Parameter.IntegerParameter(METHOD_PARAMETER_M, KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_M, v -> v > 0)
+                )
+                .addParameter(
+                    METHOD_PARAMETER_EF_CONSTRUCTION,
+                    new Parameter.IntegerParameter(
+                        METHOD_PARAMETER_EF_CONSTRUCTION,
+                        KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION,
+                        v -> v > 0
+                    )
+                )
+                .build()
+        ).addSpaces(SpaceType.L2, SpaceType.COSINESIMIL, SpaceType.INNER_PRODUCT).build()
+    );
+
+    final static Lucene INSTANCE = new Lucene(METHODS, Version.LUCENE_9_2_0.toString());
+
+    /**
+     * Constructor
+     *
+     * @param methods Map of k-NN methods that the library supports
+     * @param version String representing version of library
+     */
+    Lucene(Map<String, KNNMethod> methods, String version) {
+        super(methods, version);
+    }
+
+    @Override
+    public String getExtension() {
+        throw new UnsupportedOperationException("Unable to get extension for Lucene.");
+    }
+
+    @Override
+    public String getCompoundExtension() {
+        throw new UnsupportedOperationException("Unable to get compound extension for Lucene.");
+    }
+
+    @Override
+    public float score(float rawScore, SpaceType spaceType) {
+        // The score returned by Lucene follows the higher the score, the better the result convention. It will
+        // actually invert the distance score so that a higher number is a better score. So, we can just return the
+        // score provided.
+        return rawScore;
+    }
+
+    @Override
+    public Boolean isInitialized() {
+        return true;
+    }
+
+    @Override
+    public void setInitialized(Boolean isInitialized) {
+        throw new UnsupportedOperationException("Lucene is automatically initialized.");
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/util/NativeLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/NativeLibrary.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.util;
 
+import lombok.Getter;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -21,6 +22,7 @@ import java.util.function.Function;
  */
 abstract class NativeLibrary extends AbstractKNNLibrary {
     private final Map<SpaceType, Function<Float, Float>> scoreTranslation;
+    @Getter
     private final String extension;
     private final AtomicBoolean initialized;
 
@@ -42,11 +44,6 @@ abstract class NativeLibrary extends AbstractKNNLibrary {
         this.scoreTranslation = scoreTranslation;
         this.extension = extension;
         this.initialized = new AtomicBoolean(false);
-    }
-
-    @Override
-    public String getExtension() {
-        return this.extension;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/util/NativeLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/NativeLibrary.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.util;
 
-import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -20,10 +19,8 @@ import java.util.function.Function;
  * Abstract implementation of KNNLibrary. It contains several default methods and fields that
  * are common across different underlying libraries.
  */
-abstract class NativeLibrary implements KNNLibrary {
-    protected Map<String, KNNMethod> methods;
+abstract class NativeLibrary extends AbstractKNNLibrary {
     private final Map<SpaceType, Function<Float, Float>> scoreTranslation;
-    private final String currentVersion;
     private final String extension;
     private final AtomicBoolean initialized;
 
@@ -32,25 +29,19 @@ abstract class NativeLibrary implements KNNLibrary {
      *
      * @param methods map of methods the native library supports
      * @param scoreTranslation Map of translation of space type to scores returned by the library
-     * @param currentVersion String representation of current version of the library
+     * @param version String representation of version of the library
      * @param extension String representing the extension that library files should use
      */
     NativeLibrary(
         Map<String, KNNMethod> methods,
         Map<SpaceType, Function<Float, Float>> scoreTranslation,
-        String currentVersion,
+        String version,
         String extension
     ) {
-        this.methods = methods;
+        super(methods, version);
         this.scoreTranslation = scoreTranslation;
-        this.currentVersion = currentVersion;
         this.extension = extension;
         this.initialized = new AtomicBoolean(false);
-    }
-
-    @Override
-    public String getVersion() {
-        return this.currentVersion;
     }
 
     @Override
@@ -64,15 +55,6 @@ abstract class NativeLibrary implements KNNLibrary {
     }
 
     @Override
-    public KNNMethod getMethod(String methodName) {
-        KNNMethod method = methods.get(methodName);
-        if (method != null) {
-            return method;
-        }
-        throw new IllegalArgumentException(String.format("Invalid method name: %s", methodName));
-    }
-
-    @Override
     public float score(float rawScore, SpaceType spaceType) {
         if (this.scoreTranslation.containsKey(spaceType)) {
             return this.scoreTranslation.get(spaceType).apply(rawScore);
@@ -82,32 +64,9 @@ abstract class NativeLibrary implements KNNLibrary {
     }
 
     @Override
-    public ValidationException validateMethod(KNNMethodContext knnMethodContext) {
-        String methodName = knnMethodContext.getMethodComponent().getName();
-        return getMethod(methodName).validate(knnMethodContext);
-    }
-
-    @Override
-    public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
-        String methodName = knnMethodContext.getMethodComponent().getName();
-        return getMethod(methodName).isTrainingRequired(knnMethodContext);
-    }
-
-    @Override
     public int estimateOverheadInKB(KNNMethodContext knnMethodContext, int dimension) {
         String methodName = knnMethodContext.getMethodComponent().getName();
         return getMethod(methodName).estimateOverheadInKB(knnMethodContext, dimension);
-    }
-
-    @Override
-    public Map<String, Object> getMethodAsMap(KNNMethodContext knnMethodContext) {
-        KNNMethod knnMethod = methods.get(knnMethodContext.getMethodComponent().getName());
-
-        if (knnMethod == null) {
-            throw new IllegalArgumentException(String.format("Invalid method name: %s", knnMethodContext.getMethodComponent().getName()));
-        }
-
-        return knnMethod.getAsMap(knnMethodContext);
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/util/AbstractKNNLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/AbstractKNNLibraryTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.common.ValidationException;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNMethod;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.MethodComponent;
+import org.opensearch.knn.index.MethodComponentContext;
+import org.opensearch.knn.index.SpaceType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class AbstractKNNLibraryTests extends KNNTestCase {
+
+    public void testGetVersion() {
+        String testVersion = "test-version";
+        TestAbstractKNNLibrary testAbstractKNNLibrary = new TestAbstractKNNLibrary(Collections.emptyMap(), testVersion);
+        assertEquals(testVersion, testAbstractKNNLibrary.getVersion());
+    }
+
+    public void testGetMethod() {
+        String methodName1 = "test-method-1";
+        KNNMethod knnMethod1 = KNNMethod.Builder.builder(MethodComponent.Builder.builder(methodName1).build()).build();
+
+        String methodName2 = "test-method-2";
+        KNNMethod knnMethod2 = KNNMethod.Builder.builder(MethodComponent.Builder.builder(methodName2).build()).build();
+
+        Map<String, KNNMethod> knnMethodMap = ImmutableMap.of(methodName1, knnMethod1, methodName2, knnMethod2);
+
+        TestAbstractKNNLibrary testAbstractKNNLibrary = new TestAbstractKNNLibrary(knnMethodMap, "");
+        assertEquals(knnMethod1, testAbstractKNNLibrary.getMethod(methodName1));
+        assertEquals(knnMethod2, testAbstractKNNLibrary.getMethod(methodName2));
+        expectThrows(IllegalArgumentException.class, () -> testAbstractKNNLibrary.getMethod("invalid"));
+    }
+
+    public void testValidateMethod() throws IOException {
+        // Invalid - method not supported
+        String methodName1 = "test-method-1";
+        KNNMethod knnMethod1 = KNNMethod.Builder.builder(MethodComponent.Builder.builder(methodName1).build()).build();
+
+        Map<String, KNNMethod> methodMap = ImmutableMap.of(methodName1, knnMethod1);
+        TestAbstractKNNLibrary testAbstractKNNLibrary1 = new TestAbstractKNNLibrary(methodMap, "");
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, "invalid").endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext1 = KNNMethodContext.parse(in);
+        expectThrows(IllegalArgumentException.class, () -> testAbstractKNNLibrary1.validateMethod(knnMethodContext1));
+
+        // Invalid - method validation
+        String methodName2 = "test-method-2";
+        KNNMethod knnMethod2 = new KNNMethod(MethodComponent.Builder.builder(methodName2).build(), Collections.emptySet()) {
+            @Override
+            public ValidationException validate(KNNMethodContext knnMethodContext) {
+                return new ValidationException();
+            }
+        };
+
+        methodMap = ImmutableMap.of(methodName2, knnMethod2);
+        TestAbstractKNNLibrary testAbstractKNNLibrary2 = new TestAbstractKNNLibrary(methodMap, "");
+        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName2).endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext2 = KNNMethodContext.parse(in);
+        assertNotNull(testAbstractKNNLibrary2.validateMethod(knnMethodContext2));
+    }
+
+    public void testGetMethodAsMap() {
+        String methodName = "test-method-1";
+        SpaceType spaceType = SpaceType.DEFAULT;
+        Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-param");
+        MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
+            .setMapGenerator(((methodComponent1, methodComponentContext) -> generatedMap))
+            .build();
+        KNNMethod knnMethod = KNNMethod.Builder.builder(methodComponent).build();
+
+        TestAbstractKNNLibrary testAbstractKNNLibrary = new TestAbstractKNNLibrary(ImmutableMap.of(methodName, knnMethod), "");
+
+        // Check that map is expected
+        Map<String, Object> expectedMap = new HashMap<>(generatedMap);
+        expectedMap.put(KNNConstants.SPACE_TYPE, spaceType.getValue());
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.DEFAULT,
+            spaceType,
+            new MethodComponentContext(methodName, Collections.emptyMap())
+        );
+        assertEquals(expectedMap, testAbstractKNNLibrary.getMethodAsMap(knnMethodContext));
+
+        // Check when invalid method is passed in
+        KNNMethodContext invalidKnnMethodContext = new KNNMethodContext(
+            KNNEngine.DEFAULT,
+            spaceType,
+            new MethodComponentContext("invalid", Collections.emptyMap())
+        );
+        expectThrows(IllegalArgumentException.class, () -> testAbstractKNNLibrary.getMethodAsMap(invalidKnnMethodContext));
+    }
+
+    private static class TestAbstractKNNLibrary extends AbstractKNNLibrary {
+        public TestAbstractKNNLibrary(Map<String, KNNMethod> methods, String currentVersion) {
+            super(methods, currentVersion);
+        }
+
+        @Override
+        public String getExtension() {
+            return null;
+        }
+
+        @Override
+        public String getCompoundExtension() {
+            return null;
+        }
+
+        @Override
+        public float score(float rawScore, SpaceType spaceType) {
+            return 0;
+        }
+
+        @Override
+        public int estimateOverheadInKB(KNNMethodContext knnMethodContext, int dimension) {
+            return 0;
+        }
+
+        @Override
+        public Boolean isInitialized() {
+            return null;
+        }
+
+        @Override
+        public void setInitialized(Boolean isInitialized) {
+
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.util;
+
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNMethod;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.SpaceType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+
+public class LuceneTests extends KNNTestCase {
+
+    public void testLucenHNSWMethod() throws IOException {
+        KNNMethod luceneHNSW = Lucene.INSTANCE.getMethod(METHOD_HNSW);
+        assertNotNull(luceneHNSW);
+
+        int efConstruction = 100;
+        int m = 17;
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction)
+            .field(METHOD_PARAMETER_M, m)
+            .endObject()
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext1 = KNNMethodContext.parse(in);
+        assertNull(luceneHNSW.validate(knnMethodContext1));
+
+        // Invalid parameter
+        String invalidParameter = "invalid";
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .startObject(PARAMETERS)
+            .field(invalidParameter, 10)
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext2 = KNNMethodContext.parse(in);
+        assertNotNull(luceneHNSW.validate(knnMethodContext2));
+
+        // Valid parameter, invalid value
+        int invalidEfConstruction = -1;
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, invalidEfConstruction)
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext3 = KNNMethodContext.parse(in);
+        assertNotNull(luceneHNSW.validate(knnMethodContext3));
+
+        // Unsupported space type
+        SpaceType invalidSpaceType = SpaceType.LINF; // Not currently supported
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, invalidSpaceType.getValue())
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext4 = KNNMethodContext.parse(in);
+        assertNotNull(luceneHNSW.validate(knnMethodContext4));
+    }
+
+    public void testGetExtension() {
+        Lucene luceneLibrary = new Lucene(Collections.emptyMap(), "");
+        expectThrows(UnsupportedOperationException.class, luceneLibrary::getExtension);
+    }
+
+    public void testGetCompundExtension() {
+        Lucene luceneLibrary = new Lucene(Collections.emptyMap(), "");
+        expectThrows(UnsupportedOperationException.class, luceneLibrary::getCompoundExtension);
+    }
+
+    public void testScore() {
+        Lucene luceneLibrary = new Lucene(Collections.emptyMap(), "");
+        float rawScore = 10.0f;
+        assertEquals(rawScore, luceneLibrary.score(rawScore, SpaceType.DEFAULT), 0.001);
+    }
+
+    public void testIsInitialized() {
+        Lucene luceneLibrary = new Lucene(Collections.emptyMap(), "");
+        assertTrue(luceneLibrary.isInitialized());
+    }
+
+    public void testSetInitialized() {
+        Lucene luceneLibrary = new Lucene(Collections.emptyMap(), "");
+        expectThrows(UnsupportedOperationException.class, () -> luceneLibrary.setInitialized(true));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/util/NativeLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/NativeLibraryTests.java
@@ -6,34 +6,15 @@
 package org.opensearch.knn.index.util;
 
 import com.google.common.collect.ImmutableMap;
-import org.opensearch.common.ValidationException;
-import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethod;
-import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.MethodComponent;
-import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 
-import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.opensearch.knn.common.KNNConstants.NAME;
-
 public class NativeLibraryTests extends KNNTestCase {
-    /**
-     * Test native library version getter
-     */
-    public void testGetVersion() {
-        String latestBuildVersion = "test-build-version";
-        TestNativeLibrary testNativeLibrary = new TestNativeLibrary(Collections.emptyMap(), Collections.emptyMap(), latestBuildVersion, "");
-        assertEquals(latestBuildVersion, testNativeLibrary.getVersion());
-    }
 
     /**
      * Test native library extension getter
@@ -54,24 +35,6 @@ public class NativeLibraryTests extends KNNTestCase {
     }
 
     /**
-     * Test native library compound extension getter
-     */
-    public void testGetMethod() {
-        String methodName1 = "test-method-1";
-        KNNMethod knnMethod1 = KNNMethod.Builder.builder(MethodComponent.Builder.builder(methodName1).build()).build();
-
-        String methodName2 = "test-method-2";
-        KNNMethod knnMethod2 = KNNMethod.Builder.builder(MethodComponent.Builder.builder(methodName2).build()).build();
-
-        Map<String, KNNMethod> knnMethodMap = ImmutableMap.of(methodName1, knnMethod1, methodName2, knnMethod2);
-
-        TestNativeLibrary testNativeLibrary = new TestNativeLibrary(knnMethodMap, Collections.emptyMap(), "", "");
-        assertEquals(knnMethod1, testNativeLibrary.getMethod(methodName1));
-        assertEquals(knnMethod2, testNativeLibrary.getMethod(methodName2));
-        expectThrows(IllegalArgumentException.class, () -> testNativeLibrary.getMethod("invalid"));
-    }
-
-    /**
      * Test native library scoring override
      */
     public void testScore() {
@@ -82,69 +45,6 @@ public class NativeLibraryTests extends KNNTestCase {
 
         // Test non-override
         assertEquals(SpaceType.L1.scoreTranslation(1f), testNativeLibrary.score(1f, SpaceType.L1), 0.0001);
-    }
-
-    /**
-     * Test native library method validation
-     */
-    public void testValidateMethod() throws IOException {
-        // Invalid - method not supported
-        String methodName1 = "test-method-1";
-        KNNMethod knnMethod1 = KNNMethod.Builder.builder(MethodComponent.Builder.builder(methodName1).build()).build();
-
-        Map<String, KNNMethod> methodMap = ImmutableMap.of(methodName1, knnMethod1);
-        TestNativeLibrary testNativeLibrary1 = new TestNativeLibrary(methodMap, Collections.emptyMap(), "", "");
-
-        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, "invalid").endObject();
-        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
-        KNNMethodContext knnMethodContext1 = KNNMethodContext.parse(in);
-        expectThrows(IllegalArgumentException.class, () -> testNativeLibrary1.validateMethod(knnMethodContext1));
-
-        // Invalid - method validation
-        String methodName2 = "test-method-2";
-        KNNMethod knnMethod2 = new KNNMethod(MethodComponent.Builder.builder(methodName2).build(), Collections.emptySet()) {
-            @Override
-            public ValidationException validate(KNNMethodContext knnMethodContext) {
-                return new ValidationException();
-            }
-        };
-
-        methodMap = ImmutableMap.of(methodName2, knnMethod2);
-        TestNativeLibrary testNativeLibrary2 = new TestNativeLibrary(methodMap, Collections.emptyMap(), "", "");
-        xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName2).endObject();
-        in = xContentBuilderToMap(xContentBuilder);
-        KNNMethodContext knnMethodContext2 = KNNMethodContext.parse(in);
-        assertNotNull(testNativeLibrary2.validateMethod(knnMethodContext2));
-    }
-
-    public void testGetMethodAsMap() {
-        String methodName = "test-method-1";
-        SpaceType spaceType = SpaceType.DEFAULT;
-        Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-param");
-        MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
-            .setMapGenerator(((methodComponent1, methodComponentContext) -> generatedMap))
-            .build();
-        KNNMethod knnMethod = KNNMethod.Builder.builder(methodComponent).build();
-
-        TestNativeLibrary testNativeLibrary = new TestNativeLibrary(ImmutableMap.of(methodName, knnMethod), Collections.emptyMap(), "", "");
-
-        // Check that map is expected
-        Map<String, Object> expectedMap = new HashMap<>(generatedMap);
-        expectedMap.put(KNNConstants.SPACE_TYPE, spaceType.getValue());
-        KNNMethodContext knnMethodContext = new KNNMethodContext(
-            KNNEngine.DEFAULT,
-            spaceType,
-            new MethodComponentContext(methodName, Collections.emptyMap())
-        );
-        assertEquals(expectedMap, testNativeLibrary.getMethodAsMap(knnMethodContext));
-
-        // Check when invalid method is passed in
-        KNNMethodContext invalidKnnMethodContext = new KNNMethodContext(
-            KNNEngine.DEFAULT,
-            spaceType,
-            new MethodComponentContext("invalid", Collections.emptyMap())
-        );
-        expectThrows(IllegalArgumentException.class, () -> testNativeLibrary.getMethodAsMap(invalidKnnMethodContext));
     }
 
     static class TestNativeLibrary extends NativeLibrary {


### PR DESCRIPTION
### Description
Adds lucene as another k-NN engine that can be used. Adds one supported method to the engine, "hnsw", with parameters "ef_construction" and "m". In addition, adds some layers of abstraction to reduce code deduplication.

### Issues Resolved
Related #380 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
