### PR TITLE
Refactor per field format to a class, add more unit tests

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920Codec.java
@@ -11,15 +11,9 @@ import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.lucene92.Lucene92HnswVectorsFormat;
-import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
-import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.codec.KNNFormatFacade;
 import org.opensearch.knn.index.codec.KNNFormatFactory;
-import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static org.opensearch.knn.index.codec.KNNCodecFactory.CodecDelegateFactory.createKNN92DefaultDelegate;
@@ -33,27 +27,26 @@ public final class KNN920Codec extends FilterCodec {
     private static final String KNN920 = "KNN920Codec";
 
     private final KNNFormatFacade knnFormatFacade;
-    private final Optional<MapperService> mapperService;
     private final KNN920PerFieldKnnVectorsFormat perFieldKnnVectorsFormat;
 
     /**
      * No arg constructor that uses Lucene91 as the delegate
      */
     public KNN920Codec() {
-        this(createKNN92DefaultDelegate(), Optional.empty());
+        this(createKNN92DefaultDelegate(), new KNN920PerFieldKnnVectorsFormat(Optional.empty()));
     }
 
     /**
      * Constructor that takes a Codec delegate to delegate all methods this code does not implement to.
      *
      * @param delegate codec that will perform all operations this codec does not override
+     * @param knnVectorsFormat per field format for KnnVector
      */
     @Builder
-    public KNN920Codec(Codec delegate, Optional<MapperService> mapperService) {
+    public KNN920Codec(Codec delegate, KNN920PerFieldKnnVectorsFormat knnVectorsFormat) {
         super(KNN920, delegate);
-        this.mapperService = mapperService;
         knnFormatFacade = KNNFormatFactory.createKNN920Format(delegate);
-        perFieldKnnVectorsFormat = new KNN920PerFieldKnnVectorsFormat();
+        perFieldKnnVectorsFormat = knnVectorsFormat;
     }
 
     @Override
@@ -69,62 +62,5 @@ public final class KNN920Codec extends FilterCodec {
     @Override
     public KnnVectorsFormat knnVectorsFormat() {
         return perFieldKnnVectorsFormat;
-    }
-
-    /**
-     * Class provides per field format implementation for Lucene Knn vector type
-     */
-    class KNN920PerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
-
-        @Override
-        public KnnVectorsFormat getKnnVectorsFormatForField(final String field) {
-            if (isNotKnnVectorFieldType(field)) {
-                log.debug(
-                    String.format(
-                        "Initialize KNN vector format for field [%s] with default params [max_connections] = \"%d\" and [beam_width] = \"%d\"",
-                        field,
-                        Lucene92HnswVectorsFormat.DEFAULT_MAX_CONN,
-                        Lucene92HnswVectorsFormat.DEFAULT_BEAM_WIDTH
-                    )
-                );
-                return new Lucene92HnswVectorsFormat();
-            }
-            final KNNVectorFieldMapper.KNNVectorFieldType type = (KNNVectorFieldMapper.KNNVectorFieldType) mapperService.orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("Cannot read field type for field [%s] because mapper service is not available", field)
-                )
-            ).fieldType(field);
-            final Map<String, Object> params = type.getKnnMethodContext().getMethodComponent().getParameters();
-            int maxConnections = getMaxConnections(params);
-            int beamWidth = getBeamWidth(params);
-            log.debug(
-                String.format(
-                    "Initialize KNN vector format for field [%s] with params [max_connections] = \"%d\" and [beam_width] = \"%d\"",
-                    field,
-                    maxConnections,
-                    beamWidth
-                )
-            );
-            var luceneHnswVectorsFormat = new Lucene92HnswVectorsFormat(maxConnections, beamWidth);
-            return luceneHnswVectorsFormat;
-        }
-
-        private boolean isNotKnnVectorFieldType(final String field) {
-            return !mapperService.isPresent() || !(mapperService.get().fieldType(field) instanceof KNNVectorFieldMapper.KNNVectorFieldType);
-        }
-
-        private int getMaxConnections(final Map<String, Object> params) {
-            if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_M)) {
-                return (int) params.get(KNNConstants.METHOD_PARAMETER_M);
-            }
-            return Lucene92HnswVectorsFormat.DEFAULT_MAX_CONN;
-        }
-
-        private int getBeamWidth(final Map<String, Object> params) {
-            if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION)) {
-                return (int) params.get(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION);
-            }
-            return Lucene92HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
-        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920PerFieldKnnVectorsFormat.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN920Codec;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene92.Lucene92HnswVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Class provides per field format implementation for Lucene Knn vector type
+ */
+@AllArgsConstructor
+@Log4j2
+public class KNN920PerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
+
+    private final Optional<MapperService> mapperService;
+
+    @Override
+    public KnnVectorsFormat getKnnVectorsFormatForField(final String field) {
+        if (isNotKnnVectorFieldType(field)) {
+            log.debug(
+                String.format(
+                    "Initialize KNN vector format for field [%s] with default params [max_connections] = \"%d\" and [beam_width] = \"%d\"",
+                    field,
+                    Lucene92HnswVectorsFormat.DEFAULT_MAX_CONN,
+                    Lucene92HnswVectorsFormat.DEFAULT_BEAM_WIDTH
+                )
+            );
+            return new Lucene92HnswVectorsFormat();
+        }
+        var type = (KNNVectorFieldMapper.KNNVectorFieldType) mapperService.orElseThrow(
+            () -> new IllegalStateException(
+                String.format("Cannot read field type for field [%s] because mapper service is not available", field)
+            )
+        ).fieldType(field);
+        var params = type.getKnnMethodContext().getMethodComponent().getParameters();
+        int maxConnections = getMaxConnections(params);
+        int beamWidth = getBeamWidth(params);
+        log.debug(
+            String.format(
+                "Initialize KNN vector format for field [%s] with params [max_connections] = \"%d\" and [beam_width] = \"%d\"",
+                field,
+                maxConnections,
+                beamWidth
+            )
+        );
+        var luceneHnswVectorsFormat = new Lucene92HnswVectorsFormat(maxConnections, beamWidth);
+        return luceneHnswVectorsFormat;
+    }
+
+    private boolean isNotKnnVectorFieldType(final String field) {
+        return !mapperService.isPresent() || !(mapperService.get().fieldType(field) instanceof KNNVectorFieldMapper.KNNVectorFieldType);
+    }
+
+    private int getMaxConnections(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_M)) {
+            return (int) params.get(KNNConstants.METHOD_PARAMETER_M);
+        }
+        return Lucene92HnswVectorsFormat.DEFAULT_MAX_CONN;
+    }
+
+    private int getBeamWidth(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION)) {
+            return (int) params.get(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION);
+        }
+        return Lucene92HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920PerFieldKnnVectorsFormat.java
@@ -55,8 +55,7 @@ public class KNN920PerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
                 beamWidth
             )
         );
-        var luceneHnswVectorsFormat = new Lucene92HnswVectorsFormat(maxConnections, beamWidth);
-        return luceneHnswVectorsFormat;
+        return new Lucene92HnswVectorsFormat(maxConnections, beamWidth);
     }
 
     private boolean isNotKnnVectorFieldType(final String field) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
@@ -10,6 +10,7 @@ import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.apache.lucene.codecs.lucene92.Lucene92Codec;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
+import org.opensearch.knn.index.codec.KNN920Codec.KNN920PerFieldKnnVectorsFormat;
 
 import java.util.Optional;
 
@@ -22,7 +23,10 @@ public class KNNCodecFactory {
     private final MapperService mapperService;
 
     public Codec createKNNCodec(final Codec userCodec) {
-        var codec = KNN920Codec.builder().delegate(userCodec).mapperService(Optional.of(mapperService)).build();
+        var codec = KNN920Codec.builder()
+            .delegate(userCodec)
+            .knnVectorsFormat(new KNN920PerFieldKnnVectorsFormat(Optional.of(mapperService)))
+            .build();
         return codec;
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -45,8 +45,11 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -409,4 +412,21 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         verify(delegate, times(1)).close();
     }
 
+    public void testAddBinaryField_luceneEngine_noInvocations_addKNNBinary() throws IOException {
+        var fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test-field")
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .addAttribute(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .build();
+        DocValuesProducer docValuesProducer = mock(DocValuesProducer.class);
+
+        var delegate = mock(DocValuesConsumer.class);
+        doNothing().when(delegate).addBinaryField(fieldInfo, docValuesProducer);
+
+        var knn80DocValuesConsumer = spy(new KNN80DocValuesConsumer(delegate, null));
+
+        knn80DocValuesConsumer.addBinaryField(fieldInfo, docValuesProducer);
+
+        verify(delegate, times(1)).addBinaryField(fieldInfo, docValuesProducer);
+        verify(knn80DocValuesConsumer, never()).addKNNBinaryField(any(), any());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -264,7 +264,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             .field("dimension", dimension)
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
-            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L1)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
             .field(KNN_ENGINE, LUCENE_NAME)
             .startObject(PARAMETERS)
             .field("RANDOM_PARAM", 0)

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -154,7 +154,6 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     }
 
     public void testBuilder_parse_fromKnnMethodContext_luceneEngine() throws IOException {
-        // Check that knnMethodContext is set
         String fieldName = "test-field-name";
         String indexName = "test-index-name";
 
@@ -191,6 +190,25 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             efConstruction,
             builder.knnMethodContext.get().getMethodComponent().getParameters().get(METHOD_PARAMETER_EF_CONSTRUCTION)
         );
+
+        XContentBuilder xContentBuilderEmptyParams = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
+            .field(KNN_ENGINE, LUCENE_NAME)
+            .endObject()
+            .endObject();
+        KNNVectorFieldMapper.Builder builderEmptyParams = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilderEmptyParams),
+            buildParserContext(indexName, settings)
+        );
+
+        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponent().getName());
+        assertTrue(builderEmptyParams.knnMethodContext.get().getMethodComponent().getParameters().isEmpty());
 
         XContentBuilder xContentBuilderInvalidSpaceType = XContentFactory.jsonBuilder()
             .startObject()
@@ -239,6 +257,29 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             () -> builderInvalidDimension.build(new Mapper.BuilderContext(settings, new ContentPath()))
         );
         assertEquals("Dimension value cannot be greater than [1024] but got [2000] for vector [test-field-name]", ex.getMessage());
+
+        XContentBuilder xContentBuilderUnsupportedParam = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L1)
+            .field(KNN_ENGINE, LUCENE_NAME)
+            .startObject(PARAMETERS)
+            .field("RANDOM_PARAM", 0)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        expectThrows(
+            ValidationException.class,
+            () -> typeParser.parse(
+                fieldName,
+                xContentBuilderToMap(xContentBuilderUnsupportedParam),
+                buildParserContext(indexName, settings)
+            )
+        );
     }
 
     public void testTypeParser_parse_fromKnnMethodContext() throws IOException {


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Added more unit tests around Lucene hnsw, refactor KNN920PerFieldKnnVectorsFormat into a public class (mainly to improve testability)
 
### Issues Resolved
part of https://github.com/opensearch-project/k-NN/issues/380
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
