### PR TITLE
Add engine specific validation for max dimensions

### DIFF
--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.util;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.lucene.index.VectorValues;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -30,6 +31,15 @@ public enum KNNEngine implements KNNLibrary {
     public static final KNNEngine DEFAULT = NMSLIB;
 
     private static final Set<KNNEngine> CUSTOM_SEGMENT_FILE_ENGINES = ImmutableSet.of(KNNEngine.NMSLIB, KNNEngine.FAISS);
+
+    private static Map<KNNEngine, Integer> MAX_DIMENSIONS_BY_ENGINE = Map.of(
+        KNNEngine.NMSLIB,
+        10_000,
+        KNNEngine.FAISS,
+        10_000,
+        KNNEngine.LUCENE,
+        VectorValues.MAX_DIMENSIONS
+    );
 
     /**
      * Constructor for KNNEngine
@@ -92,6 +102,15 @@ public enum KNNEngine implements KNNLibrary {
      */
     public static Set<KNNEngine> getEnginesThatCreateCustomSegmentFiles() {
         return CUSTOM_SEGMENT_FILE_ENGINES;
+    }
+
+    /**
+     * Return number of max allowed dimensions per single vector based on the knn engine
+     * @param knnEngine knn engine to check max dimensions value
+     * @return
+     */
+    public static int getMaxDimensionByEngine(KNNEngine knnEngine) {
+        return MAX_DIMENSIONS_BY_ENGINE.getOrDefault(knnEngine, MAX_DIMENSIONS_BY_ENGINE.get(KNNEngine.DEFAULT));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -34,7 +34,6 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ERROR;
 import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_TIMESTAMP;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.MAX_DIMENSION;
 
 public class ModelMetadata implements Writeable, ToXContentObject {
 
@@ -89,9 +88,10 @@ public class ModelMetadata implements Writeable, ToXContentObject {
     ) {
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
         this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
-        if (dimension <= 0 || dimension >= MAX_DIMENSION) {
+        int maxDimensions = KNNEngine.getMaxDimensionByEngine(this.knnEngine);
+        if (dimension <= 0 || dimension >= maxDimensions) {
             throw new IllegalArgumentException(
-                "Dimension \"" + dimension + "\" is invalid. Value must be greater " + "than 0 and less than " + MAX_DIMENSION
+                String.format("Dimension \"%s\" is invalid. Value must be greater than 0 and less than %d", dimension, maxDimensions)
             );
         }
         this.dimension = dimension;

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -27,7 +27,6 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
@@ -288,11 +287,20 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         Exception ex = expectThrows(
             ResponseException.class,
-            () -> createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, KNNVectorFieldMapper.MAX_DIMENSION + 1))
+            () -> createKnnIndex(
+                INDEX_NAME,
+                settings,
+                createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT) + 1)
+            )
         );
         assertThat(
             ex.getMessage(),
-            containsString("Dimension value cannot be greater than " + KNNVectorFieldMapper.MAX_DIMENSION + " for vector: " + FIELD_NAME)
+            containsString(
+                "Dimension value cannot be greater than "
+                    + KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT)
+                    + " for vector: "
+                    + FIELD_NAME
+            )
         );
     }
 

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -283,7 +283,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             IllegalArgumentException.class,
             () -> builderInvalidDimension.build(new Mapper.BuilderContext(settings, new ContentPath()))
         );
-        assertEquals("Dimension value cannot be greater than [1024] but got [2000] for vector [test-field-name]", ex.getMessage());
+        assertEquals("Dimension value cannot be greater than 1024 for vector: test-field-name", ex.getMessage());
 
         XContentBuilder xContentBuilderUnsupportedParam = XContentFactory.jsonBuilder()
             .startObject()

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -21,8 +21,6 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.MAX_DIMENSION;
-
 public class ModelTests extends KNNTestCase {
 
     public void testNullConstructor() {
@@ -87,7 +85,7 @@ public class ModelTests extends KNNTestCase {
                 new ModelMetadata(
                     KNNEngine.DEFAULT,
                     SpaceType.DEFAULT,
-                    MAX_DIMENSION + 1,
+                    KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT) + 1,
                     ModelState.CREATED,
                     ZonedDateTime.now(ZoneOffset.UTC).toString(),
                     "",


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Re-write validation for max dimensions to make it engine specific comparing to one global validation. 
 
### Issues Resolved
building block for #380 
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
