### PR TITLE
Add query integration tests for Lucene engine

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -13,6 +13,7 @@ package org.opensearch.knn.index;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NonNull;
 import org.opensearch.common.ValidationException;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
@@ -57,8 +58,11 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         return defaultInstance;
     }
 
+    @NonNull
     private final KNNEngine knnEngine;
+    @NonNull
     private final SpaceType spaceType;
+    @NonNull
     private final MethodComponentContext methodComponent;
 
     /**

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.knn.index;
 
+import org.apache.lucene.index.VectorSimilarityFunction;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -104,5 +106,24 @@ public enum SpaceType {
             }
         }
         throw new IllegalArgumentException("Unable to find space: " + spaceTypeName);
+    }
+
+    public static VectorSimilarityFunction spaceTypeToVectorSimilarityFunction(SpaceType spaceType) {
+        if (spaceType == null) {
+            throw new IllegalArgumentException("spaceType cannot be null");
+        }
+
+        switch (spaceType) {
+            case L2:
+                return VectorSimilarityFunction.EUCLIDEAN;
+            case COSINESIMIL:
+                return VectorSimilarityFunction.COSINE;
+            case INNER_PRODUCT:
+                return VectorSimilarityFunction.DOT_PRODUCT;
+            default:
+                throw new IllegalArgumentException(
+                    String.format("Space [%s] does not have a vector similarity function", spaceType.getValue())
+                );
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -28,11 +28,21 @@ public enum SpaceType {
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
         }
+
+        @Override
+        public VectorSimilarityFunction getVectorSimilarityFunction() {
+            return VectorSimilarityFunction.EUCLIDEAN;
+        }
     },
     COSINESIMIL("cosinesimil") {
         @Override
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
+        }
+
+        @Override
+        public VectorSimilarityFunction getVectorSimilarityFunction() {
+            return VectorSimilarityFunction.COSINE;
         }
     },
     L1("l1") {
@@ -63,6 +73,11 @@ public enum SpaceType {
             }
             return -rawScore + 1;
         }
+
+        @Override
+        public VectorSimilarityFunction getVectorSimilarityFunction() {
+            return VectorSimilarityFunction.DOT_PRODUCT;
+        }
     },
     HAMMING_BIT("hammingbit") {
         @Override
@@ -80,6 +95,15 @@ public enum SpaceType {
     }
 
     public abstract float scoreTranslation(float rawScore);
+
+    /**
+     * Get VectorSimilarityFunction that maps to this SpaceType
+     *
+     * @return VectorSimilarityFunction
+     */
+    public VectorSimilarityFunction getVectorSimilarityFunction() {
+        throw new UnsupportedOperationException(String.format("Space [%s] does not have a vector similarity function", getValue()));
+    }
 
     /**
      * Get space type name in engine
@@ -106,24 +130,5 @@ public enum SpaceType {
             }
         }
         throw new IllegalArgumentException("Unable to find space: " + spaceTypeName);
-    }
-
-    public static VectorSimilarityFunction spaceTypeToVectorSimilarityFunction(SpaceType spaceType) {
-        if (spaceType == null) {
-            throw new IllegalArgumentException("spaceType cannot be null");
-        }
-
-        switch (spaceType) {
-            case L2:
-                return VectorSimilarityFunction.EUCLIDEAN;
-            case COSINESIMIL:
-                return VectorSimilarityFunction.COSINE;
-            case INNER_PRODUCT:
-                return VectorSimilarityFunction.DOT_PRODUCT;
-            default:
-                throw new IllegalArgumentException(
-                    String.format("Space [%s] does not have a vector similarity function", spaceType.getValue())
-                );
-        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.mapper;
 
-import com.google.common.collect.ImmutableMap;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -22,14 +21,10 @@ import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.lucene.index.VectorValues.MAX_DIMENSIONS;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
-import static org.opensearch.knn.index.SpaceType.COSINESIMIL;
-import static org.opensearch.knn.index.SpaceType.INNER_PRODUCT;
-import static org.opensearch.knn.index.SpaceType.L2;
 
 /**
  * Field mapper for case when Lucene has been set as an engine.
@@ -40,15 +35,6 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
 
     /** FieldType used for initializing VectorField, which is used for creating binary doc values. **/
     private final FieldType vectorFieldType;
-
-    private static final Map<SpaceType, VectorSimilarityFunction> SPACE_TYPE_TO_VECTOR_SIMILARITY_FUNCTION = ImmutableMap.of(
-        L2,
-        VectorSimilarityFunction.EUCLIDEAN,
-        COSINESIMIL,
-        VectorSimilarityFunction.COSINE,
-        INNER_PRODUCT,
-        VectorSimilarityFunction.DOT_PRODUCT
-    );
 
     LuceneFieldMapper(final CreateLuceneFieldMapperInput input) {
         super(
@@ -64,7 +50,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
         this.knnMethod = input.getKnnMethodContext();
         final SpaceType spaceType = this.knnMethod.getSpaceType();
         final VectorSimilarityFunction vectorSimilarityFunction = Optional.ofNullable(
-            SPACE_TYPE_TO_VECTOR_SIMILARITY_FUNCTION.get(spaceType)
+            SpaceType.spaceTypeToVectorSimilarityFunction(spaceType)
         ).orElseThrow(() -> new IllegalArgumentException(String.format("Space type [%s] is not supported for Lucene engine", spaceType)));
 
         final int dimension = input.getMappedFieldType().getDimension();

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -16,7 +16,6 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.common.Explicit;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.util.KNNEngine;
 
@@ -48,11 +47,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
         );
 
         this.knnMethod = input.getKnnMethodContext();
-        final SpaceType spaceType = this.knnMethod.getSpaceType();
-        final VectorSimilarityFunction vectorSimilarityFunction = Optional.ofNullable(spaceType.getVectorSimilarityFunction())
-            .orElseThrow(
-                () -> new IllegalArgumentException(String.format("Space type [%s] is not supported for Lucene engine", spaceType))
-            );
+        final VectorSimilarityFunction vectorSimilarityFunction = this.knnMethod.getSpaceType().getVectorSimilarityFunction();
 
         final int dimension = input.getMappedFieldType().getDimension();
         if (dimension > LUCENE_MAX_DIMENSION) {

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -49,9 +49,10 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
 
         this.knnMethod = input.getKnnMethodContext();
         final SpaceType spaceType = this.knnMethod.getSpaceType();
-        final VectorSimilarityFunction vectorSimilarityFunction = Optional.ofNullable(
-            SpaceType.spaceTypeToVectorSimilarityFunction(spaceType)
-        ).orElseThrow(() -> new IllegalArgumentException(String.format("Space type [%s] is not supported for Lucene engine", spaceType)));
+        final VectorSimilarityFunction vectorSimilarityFunction = Optional.ofNullable(spaceType.getVectorSimilarityFunction())
+            .orElseThrow(
+                () -> new IllegalArgumentException(String.format("Space type [%s] is not supported for Lucene engine", spaceType))
+            );
 
         final int dimension = input.getMappedFieldType().getDimension();
         if (dimension > LUCENE_MAX_DIMENSION) {

--- a/src/test/java/org/opensearch/knn/index/KNNMethodTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodTests.java
@@ -98,7 +98,7 @@ public class KNNMethodTests extends KNNTestCase {
         String methodName = "test-method";
         Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-value");
         MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
-            .setMapGenerator(((methodComponent1, methodComponentContext) -> generatedMap))
+            .setMapGenerator(((methodComponent1, methodComponentContext) -> methodComponentContext.getParameters()))
             .build();
 
         KNNMethod knnMethod = KNNMethod.Builder.builder(methodComponent).build();
@@ -106,7 +106,10 @@ public class KNNMethodTests extends KNNTestCase {
         Map<String, Object> expectedMap = new HashMap<>(generatedMap);
         expectedMap.put(KNNConstants.SPACE_TYPE, spaceType.getValue());
 
-        assertEquals(expectedMap, knnMethod.getAsMap(new KNNMethodContext(KNNEngine.DEFAULT, spaceType, null)));
+        assertEquals(
+            expectedMap,
+            knnMethod.getAsMap(new KNNMethodContext(KNNEngine.DEFAULT, spaceType, new MethodComponentContext(methodName, generatedMap)))
+        );
     }
 
     public void testBuilder() {

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
-public class LuceneIT extends KNNRestTestCase {
+public class LuceneEngineIT extends KNNRestTestCase {
 
     private static final int DIMENSION = 3;
     private static final String DOC_ID = "doc1";
@@ -60,7 +60,7 @@ public class LuceneIT extends KNNRestTestCase {
         baseQueryTest(SpaceType.INNER_PRODUCT);
     }
 
-    public void testQuery_invalidParameters() throws Exception {
+    public void testQuery_invalidVectorDimensionInQuery() throws Exception {
 
         createKnnIndexMappingWithLuceneEngine(DIMENSION, SpaceType.L2);
         for (int j = 0; j < TEST_INDEX_VECTORS.length; j++) {
@@ -239,7 +239,7 @@ public class LuceneIT extends KNNRestTestCase {
 
     private void validateQueries(SpaceType spaceType, String fieldName) throws IOException {
 
-        int k = LuceneIT.TEST_INDEX_VECTORS.length;
+        int k = LuceneEngineIT.TEST_INDEX_VECTORS.length;
         for (float[] queryVector : TEST_QUERY_VECTORS) {
             Response response = searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(fieldName, queryVector, k), k);
             String responseBody = EntityUtils.toString(response.getEntity());

--- a/src/test/java/org/opensearch/knn/index/LuceneIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneIT.java
@@ -250,7 +250,7 @@ public class LuceneIT extends KNNRestTestCase {
             for (int j = 0; j < k; j++) {
                 float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
                 float distance = TestUtils.computeDistFromSpaceType(spaceType, primitiveArray, queryVector);
-                float rawScore = SpaceType.spaceTypeToVectorSimilarityFunction(spaceType).convertToScore(distance);
+                float rawScore = spaceType.getVectorSimilarityFunction().convertToScore(distance);
                 assertEquals(KNNEngine.LUCENE.score(rawScore, spaceType), actualScores.get(j), 0.0001);
             }
         }

--- a/src/test/java/org/opensearch/knn/index/LuceneIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneIT.java
@@ -6,17 +6,29 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Floats;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.common.Strings;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 public class LuceneIT extends KNNRestTestCase {
 
@@ -27,7 +39,112 @@ public class LuceneIT extends KNNRestTestCase {
     private static final String FIELD_NAME = "test-field-1";
     private static final int M = 16;
 
-    public void test_addDoc() throws IOException {
+    private static final Float[][] TEST_INDEX_VECTORS = { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
+
+    private static final float[][] TEST_QUERY_VECTORS = { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
+
+    @After
+    public final void cleanUp() throws IOException {
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testQuery_l2() throws Exception {
+        baseQueryTest(SpaceType.L2);
+    }
+
+    public void testQuery_cosine() throws Exception {
+        baseQueryTest(SpaceType.COSINESIMIL);
+    }
+
+    public void testQuery_innerProduct() throws Exception {
+        baseQueryTest(SpaceType.INNER_PRODUCT);
+    }
+
+    public void testQuery_invalidParameters() throws Exception {
+
+        createKnnIndexMappingWithLuceneEngine(DIMENSION, SpaceType.L2);
+        for (int j = 0; j < TEST_INDEX_VECTORS.length; j++) {
+            addKnnDoc(INDEX_NAME, Integer.toString(j + 1), FIELD_NAME, TEST_INDEX_VECTORS[j]);
+        }
+
+        float[] invalidQuery = new float[DIMENSION - 1];
+        int validK = 1;
+        expectThrows(
+            ResponseException.class,
+            () -> searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, invalidQuery, validK), validK)
+        );
+    }
+
+    public void testQuery_documentsMissingField() throws Exception {
+
+        SpaceType spaceType = SpaceType.L2;
+
+        createKnnIndexMappingWithLuceneEngine(DIMENSION, spaceType);
+        for (int j = 0; j < TEST_INDEX_VECTORS.length; j++) {
+            addKnnDoc(INDEX_NAME, Integer.toString(j + 1), FIELD_NAME, TEST_INDEX_VECTORS[j]);
+        }
+
+        // Add a doc without the lucene field set
+        String secondField = "field-2";
+        addDocWithNumericField(INDEX_NAME, Integer.toString(TEST_INDEX_VECTORS.length + 1), secondField, 0L);
+
+        validateQueries(spaceType, FIELD_NAME);
+    }
+
+    public void testQuery_multipleEngines() throws IOException {
+        String luceneField = "lucene-field";
+        SpaceType luceneSpaceType = SpaceType.COSINESIMIL;
+        String nmslibField = "nmslib-field";
+        SpaceType nmslibSpaceType = SpaceType.L2;
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(luceneField)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, luceneSpaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .startObject(nmslibField)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, nmslibSpaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.NMSLIB.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        String mapping = Strings.toString(builder);
+        createKnnIndex(INDEX_NAME, mapping);
+
+        for (int i = 0; i < TEST_INDEX_VECTORS.length; i++) {
+            addKnnDoc(
+                INDEX_NAME,
+                Integer.toString(i + 1),
+                ImmutableList.of(luceneField, nmslibField),
+                ImmutableList.of(TEST_INDEX_VECTORS[i], TEST_INDEX_VECTORS[i])
+            );
+        }
+
+        validateQueries(luceneSpaceType, luceneField);
+        validateQueries(nmslibSpaceType, nmslibField);
+    }
+
+    public void testAddDoc() throws IOException {
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
         List<Integer> efConstructionValues = ImmutableList.of(16, 32, 64, 128);
 
@@ -38,7 +155,7 @@ public class LuceneIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", DIMENSION)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(KNNConstants.METHOD_HNSW).getMethodComponent().getName())
+            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .startObject(KNNConstants.PARAMETERS)
@@ -61,12 +178,10 @@ public class LuceneIT extends KNNRestTestCase {
 
         refreshAllIndices();
         assertEquals(1, getDocCount(INDEX_NAME));
-
-        deleteKNNIndex(INDEX_NAME);
     }
 
-    public void test_updateDoc() throws Exception {
-        createKnnIndexMappingWithLuceneEngine(2);
+    public void testUpdateDoc() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2);
         Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector);
 
@@ -75,12 +190,10 @@ public class LuceneIT extends KNNRestTestCase {
 
         refreshAllIndices();
         assertEquals(1, getDocCount(INDEX_NAME));
-
-        deleteKNNIndex(INDEX_NAME);
     }
 
-    public void test_deleteDoc() throws Exception {
-        createKnnIndexMappingWithLuceneEngine(2);
+    public void testDeleteDoc() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2);
         Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector);
 
@@ -88,11 +201,9 @@ public class LuceneIT extends KNNRestTestCase {
 
         refreshAllIndices();
         assertEquals(0, getDocCount(INDEX_NAME));
-
-        deleteKNNIndex(INDEX_NAME);
     }
 
-    private void createKnnIndexMappingWithLuceneEngine(int dimension) throws Exception {
+    private void createKnnIndexMappingWithLuceneEngine(int dimension, SpaceType spaceType) throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -100,8 +211,8 @@ public class LuceneIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(KNNConstants.METHOD_HNSW).getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
             .startObject(KNNConstants.PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, M)
@@ -114,5 +225,34 @@ public class LuceneIT extends KNNRestTestCase {
 
         String mapping = Strings.toString(builder);
         createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void baseQueryTest(SpaceType spaceType) throws Exception {
+
+        createKnnIndexMappingWithLuceneEngine(DIMENSION, spaceType);
+        for (int j = 0; j < TEST_INDEX_VECTORS.length; j++) {
+            addKnnDoc(INDEX_NAME, Integer.toString(j + 1), FIELD_NAME, TEST_INDEX_VECTORS[j]);
+        }
+
+        validateQueries(spaceType, FIELD_NAME);
+    }
+
+    private void validateQueries(SpaceType spaceType, String fieldName) throws IOException {
+
+        int k = LuceneIT.TEST_INDEX_VECTORS.length;
+        for (float[] queryVector : TEST_QUERY_VECTORS) {
+            Response response = searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(fieldName, queryVector, k), k);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
+            assertEquals(k, knnResults.size());
+
+            List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
+            for (int j = 0; j < k; j++) {
+                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float distance = TestUtils.computeDistFromSpaceType(spaceType, primitiveArray, queryVector);
+                float rawScore = SpaceType.spaceTypeToVectorSimilarityFunction(spaceType).convertToScore(distance);
+                assertEquals(KNNEngine.LUCENE.score(rawScore, spaceType), actualScores.get(j), 0.0001);
+            }
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.opensearch.knn.KNNTestCase;
+
+public class SpaceTypeTests extends KNNTestCase {
+
+    public void testSpaceTypeToVectorSimilarityFunction_l2() {
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN, SpaceType.spaceTypeToVectorSimilarityFunction(SpaceType.L2));
+    }
+
+    public void testSpaceTypeToVectorSimilarityFunction_invalid() {
+        expectThrows(IllegalArgumentException.class, () -> SpaceType.spaceTypeToVectorSimilarityFunction(SpaceType.L1));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
@@ -17,10 +17,10 @@ import org.opensearch.knn.KNNTestCase;
 public class SpaceTypeTests extends KNNTestCase {
 
     public void testSpaceTypeToVectorSimilarityFunction_l2() {
-        assertEquals(VectorSimilarityFunction.EUCLIDEAN, SpaceType.spaceTypeToVectorSimilarityFunction(SpaceType.L2));
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getVectorSimilarityFunction());
     }
 
     public void testSpaceTypeToVectorSimilarityFunction_invalid() {
-        expectThrows(IllegalArgumentException.class, () -> SpaceType.spaceTypeToVectorSimilarityFunction(SpaceType.L1));
+        expectThrows(UnsupportedOperationException.class, SpaceType.L1::getVectorSimilarityFunction);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
@@ -16,11 +16,11 @@ import org.opensearch.knn.KNNTestCase;
 
 public class SpaceTypeTests extends KNNTestCase {
 
-    public void testSpaceTypeToVectorSimilarityFunction_l2() {
+    public void testGetVectorSimilarityFunction_l2() {
         assertEquals(VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getVectorSimilarityFunction());
     }
 
-    public void testSpaceTypeToVectorSimilarityFunction_invalid() {
+    public void testGetVectorSimilarityFunction_invalid() {
         expectThrows(UnsupportedOperationException.class, SpaceType.L1::getVectorSimilarityFunction);
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -66,7 +66,11 @@ public class TestUtils {
         SpaceType.L2,
         KNNScoringUtil::l2Squared,
         SpaceType.LINF,
-        KNNScoringUtil::lInfNorm
+        KNNScoringUtil::lInfNorm,
+        SpaceType.COSINESIMIL,
+        KNNScoringUtil::cosinesimil,
+        SpaceType.INNER_PRODUCT,
+        KNNScoringUtil::innerProduct
     );
 
     public static final String KNN_BWC_PREFIX = "knn-bwc-";


### PR DESCRIPTION
### Description
Adds query integration tests for the lucene engine. Moves spacetype to
lucene vectorsimilarityfunction translation to SpaceType enum for
testability.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
