### PR TITLE
[Backport 2.x] Read BWC Version from Github workflow (#476)

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -52,7 +52,7 @@ jobs:
     name: k-NN Rolling-Upgrade BWC Tests
     runs-on: ubuntu-latest
     env:
-      OPENSEARCH_VERSION_ROLLING_UPGRADE: ${{ matrix.opensearch_version }}
+      BWC_VERSION_ROLLING_UPGRADE: ${{ matrix.bwc_version }}
 
     steps:
       - name: Checkout k-NN
@@ -70,4 +70,4 @@ jobs:
       - name: Run k-NN Rolling-Upgrade BWC Tests from BWCVersion-${{ matrix.bwc_version }} to OpenSearch Version-${{ matrix.opensearch_version }}
         run: |
           echo "Running rolling-upgrade backwards compatibility tests ..."
-          ./gradlew :qa:rolling-upgrade:testRollingUpgrade -Drolling.bwctests.opensearch.version=$OPENSEARCH_VERSION_ROLLING_UPGRADE
+          ./gradlew :qa:rolling-upgrade:testRollingUpgrade -Dtests.bwc.version=$BWC_VERSION_ROLLING_UPGRADE

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -7,15 +7,15 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply from : "$rootDir/qa/build.gradle"
 
-String knn_bwc_version = System.getProperty("bwc.version")
+String default_bwc_version = System.getProperty("bwc.version")
+String knn_bwc_version = System.getProperty("tests.bwc.version", default_bwc_version)
 String baseName = "knnBwcCluster-rolling"
-String opensearch_version_upgraded = System.getProperty("rolling.bwctests.opensearch.version", opensearch_version)
 
 // Creates a test cluster of previous version and loads k-NN plugin of bwcVersion
 testClusters {
     "${baseName}" {
         testDistribution = "ARCHIVE"
-        versions = [knn_bwc_version, opensearch_version_upgraded]
+        versions = [knn_bwc_version, opensearch_version]
         numberOfNodes = 3
         plugin(project.tasks.zipBwcPlugin.archiveFile)
         setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>
(cherry picked from commit 9f71ede43c7d6e7e90156fae65d7d45f676cc39e)

### Description
Backport https://github.com/opensearch-project/k-NN/pull/476/commits/e02557512aa7ea618de23dd087132a2129f8c8e7 from https://github.com/opensearch-project/k-NN/pull/476
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
