### PR TITLE
Change validation error for dimension value

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -82,8 +82,14 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             if (o == null) {
                 throw new IllegalArgumentException("Dimension cannot be null");
             }
-            int value = XContentMapValues.nodeIntegerValue(o);
-
+            int value;
+            try {
+                value = XContentMapValues.nodeIntegerValue(o);
+            } catch (Exception exception) {
+                throw new IllegalArgumentException(
+                    String.format("Unable to parse [dimension] from provided value [%s] for vector [%s]", o, name)
+                );
+            }
             if (value <= 0) {
                 throw new IllegalArgumentException(String.format("Dimension value must be greater than 0 for vector: %s", name));
             }


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Address appsec finding related to expose of extra info and returning response code 500. Catching error on parsing and throw IllegalArgumentException error that results in error code 400. 
```
Problem Details
When some field key names or dimension values are submitted to the /<INDEX_‐
NAME>/_mapping API, the service responds with a HTTP 500 error response.

dimension Integer Overflow
The k-NN plugin does not allow knn_vector fields with a dimension greater than 1024.
Values of dimension between 1025 and 2,147,483,647 (i.e., 231 − 1) return a 400 error as

1. Create an example index.
curl -X PUT "http://<cluster_host>/example_index"
2. Attempt to create a kNN field with a dimension of 2,147,483,648 or greater.
curl -v -X PUT "http://<cluster_host>/example_index/_mapping" -H "Content-Type: application/json" -d '
{
 "properties": {
 "example_vector": {
 "type": "knn_vector",
 "dimension": 2147483648,
 "method": {
 "name": "hnsw",
 "space_type": "l2",
 "engine": "lucene"
 }
 }
 }
}
'
3. Observe that a 500 error is returned. Additionally note the verbose error message.
* Trying <REDACTED>:80...
* Connected to <cluster_host>
(<REDACTED>) port 80 (#0)
> PUT /example_index/_mapping HTTP/1.1
> Host: <cluster_host>
> User-Agent: curl/7.79.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 253
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< Date: <date>
< Content-Type: application/json; charset=UTF-8
< Content-Length: 201
< Connection: keep-alive
<
* Connection #0 to host <cluster_host> left intact
{"error":{"root_cause":
[{"type":"arithmetic_exception","reason":"arithmetic_exception: integer
overflow"}],"type":"arithmetic_exception","reason":"arithmetic_exception:
integer overflow"},"status":500}
```
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/380
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
