### PR TITLE
Make innerproduct similarity not supported

### DIFF
--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -41,7 +41,7 @@ public class Lucene extends JVMLibrary {
                     )
                 )
                 .build()
-        ).addSpaces(SpaceType.L2, SpaceType.COSINESIMIL, SpaceType.INNER_PRODUCT).build()
+        ).addSpaces(SpaceType.L2, SpaceType.COSINESIMIL).build()
     );
 
     final static Lucene INSTANCE = new Lucene(METHODS, Version.LUCENE_9_2_0.toString());

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -23,7 +23,6 @@ import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.util.KNNEngine;
-import org.opensearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -56,6 +55,10 @@ public class LuceneEngineIT extends KNNRestTestCase {
         VectorSimilarityFunction.COSINE,
         (similarity) -> (1 + similarity) / 2
     );
+    private static final String DIMENSION_FIELD_NAME = "dimension";
+    private static final String KNN_VECTOR_TYPE = "knn_vector";
+    private static final String PROPERTIES_FIELD_NAME = "properties";
+    private static final String TYPE_FIELD_NAME = "type";
 
     @After
     public final void cleanUp() throws IOException {
@@ -72,23 +75,23 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
     public void testQuery_innerProduct_notSupported() throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("properties")
-                .startObject(FIELD_NAME)
-                .field("type", "knn_vector")
-                .field("dimension", DIMENSION)
-                .startObject(KNNConstants.KNN_METHOD)
-                .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
-                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
-                .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
-                .startObject(KNNConstants.PARAMETERS)
-                .field(KNNConstants.METHOD_PARAMETER_M, M)
-                .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .startObject(PROPERTIES_FIELD_NAME)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, DIMENSION)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         String mapping = Strings.toString(builder);
 
@@ -139,10 +142,10 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("properties")
+            .startObject(PROPERTIES_FIELD_NAME)
             .startObject(luceneField)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, DIMENSION)
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, luceneSpaceType.getValue())
@@ -154,8 +157,8 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .endObject()
             .endObject()
             .startObject(nmslibField)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, DIMENSION)
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, nmslibSpaceType.getValue())
@@ -190,10 +193,10 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("properties")
+            .startObject(PROPERTIES_FIELD_NAME)
             .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, DIMENSION)
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
@@ -246,10 +249,10 @@ public class LuceneEngineIT extends KNNRestTestCase {
     private void createKnnIndexMappingWithLuceneEngine(int dimension, SpaceType spaceType) throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("properties")
+            .startObject(PROPERTIES_FIELD_NAME)
             .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", dimension)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Remove Inner product (or Dot product) from list of supported similarity functions for Lucene engine. This is due to specifics of [Lucene implementation of Dot product](https://github.com/apache/lucene/blob/branch_9_2/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java#L72-L74), score can be negative which violates OpenSearch concept. Tested by following test case. Plan is to test/address this issue properly and then open support in later versions.

for 2 vectors ```[-10.0, -10.0]``` and ```[10.0, 10.0]```  and search request ```[10, 10]``` here is the response

```
{
    "took": 1,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 2,
            "relation": "eq"
        },
        "max_score": 100.5,
        "hits": [
            {
                "_index": "my_index",
                "_id": "2",
                "_score": 100.5,
                "_source": {
                    "my_vector": [
                        10,
                        10
                    ]
                }
            },
            {
                "_index": "my_index",
                "_id": "1",
                "_score": -99.5,
                "_source": {
                    "my_vector": [
                        -10,
                        -10
                    ]
                }
            }
        ]
    }
}
``` 
 
### Issues Resolved
#380 
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
