### PR TITLE
Increase max dimension to 16k for nmslib and faiss

### DIFF
--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -34,9 +34,9 @@ public enum KNNEngine implements KNNLibrary {
 
     private static Map<KNNEngine, Integer> MAX_DIMENSIONS_BY_ENGINE = Map.of(
         KNNEngine.NMSLIB,
-        10_000,
+        16_000,
         KNNEngine.FAISS,
-        10_000,
+        16_000,
         KNNEngine.LUCENE,
         VectorValues.MAX_DIMENSIONS
     );

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -89,9 +89,13 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
         this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
         int maxDimensions = KNNEngine.getMaxDimensionByEngine(this.knnEngine);
-        if (dimension <= 0 || dimension >= maxDimensions) {
+        if (dimension <= 0 || dimension > maxDimensions) {
             throw new IllegalArgumentException(
-                String.format("Dimension \"%s\" is invalid. Value must be greater than 0 and less than %d", dimension, maxDimensions)
+                String.format(
+                    "Dimension \"%s\" is invalid. Value must be greater than 0 and less than or equal to %d",
+                    dimension,
+                    maxDimensions
+                )
             );
         }
         this.dimension = dimension;


### PR DESCRIPTION
### Description
Increases max dimension to 16k for nmslib and faiss. Lucene has its own limit which we cannot override, so that will not change. 

> Running benchmarks for 16k dimension random data set. Once complete, I will add them to #455 and take PR out of draft mode.

Benchmarks completed. Details can be found https://github.com/opensearch-project/k-NN/issues/455#issuecomment-1204584999.
 
### Issues Resolved
#455 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
