### PR TITLE
Remove 1.0.0 for BWC test

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "1.0.0", "1.1.0", "1.2.4", "1.3.2", "2.0.0", "2.1.0" ]
+        bwc_version : [ "1.1.0", "1.2.4", "1.3.2", "2.0.0", "2.1.0" ]
         opensearch_version : [ "2.2.0-SNAPSHOT" ]
 
     name: k-NN Restart-Upgrade BWC Tests


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
Remove 1.0.0 BWC and switch to version 1.1.0, related issue https://github.com/opensearch-project/OpenSearch/issues/3001
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
