### PR TITLE
Remove overallocation in faiss query path

### DIFF
--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -192,9 +192,8 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniU
         throw std::runtime_error("Invalid pointer to index");
     }
 
-    int dim	= jniUtil->GetJavaFloatArrayLength(env, queryVectorJ);
-    std::vector<float> dis(kJ * dim);
-    std::vector<faiss::Index::idx_t> ids(kJ * dim);
+    std::vector<float> dis(kJ);
+    std::vector<faiss::Index::idx_t> ids(kJ);
     float* rawQueryvector = jniUtil->GetFloatArrayElements(env, queryVectorJ, nullptr);
 
     try {

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -192,6 +192,8 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniU
         throw std::runtime_error("Invalid pointer to index");
     }
 
+    // The ids vector will hold the top k ids from the search and the dis vector will hold the top k distances from
+    // the query point
     std::vector<float> dis(kJ);
     std::vector<faiss::Index::idx_t> ids(kJ);
     float* rawQueryvector = jniUtil->GetFloatArrayElements(env, queryVectorJ, nullptr);


### PR DESCRIPTION
### Description
Removes overallocation of 2 c++ vectors in faiss querying functionality.
Performance results can be viewed in [497](https://github.com/opensearch-project/k-NN/issues/497#issuecomment-1208643311).
 In general, this change could provide a small improvement in memory
 footprint during search workloads.
 
### Issues Resolved
#497 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
