### PR TITLE
Change initial size of DocIdSetBuilder

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -182,7 +182,10 @@ public class KNNWeight extends Weight {
             .collect(Collectors.toMap(KNNQueryResult::getId, result -> knnEngine.score(result.getScore(), spaceType)));
         int maxDoc = Collections.max(scores.keySet()) + 1;
         DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(maxDoc);
-        DocIdSetBuilder.BulkAdder setAdder = docIdSetBuilder.grow(maxDoc);
+
+        // The docIdSetIterator will contain the docids of the returned results. So, before adding results to
+        // the builder, we can grow to results.length
+        DocIdSetBuilder.BulkAdder setAdder = docIdSetBuilder.grow(results.length);
         Arrays.stream(results).forEach(result -> setAdder.add(result.getId()));
         DocIdSetIterator docIdSetIter = docIdSetBuilder.build().iterator();
         return new KNNScorer(this, docIdSetIter, scores, boost);


### PR DESCRIPTION
### Description
Currently, we grow the size of the DocIDSetBuilder to the maximum id in the results returned by the query. The grow function, however, is intended to take the [number of docs](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/util/DocIdSetBuilder.java#L187) the iterator should have, not the maximum doc id.

Internally, this method has logic to determine whether the iterator should be a sparse set of doc ids, or a dense bit set, where 1 indicates whether a docid is set or not. This can cause problems where the wrong iterator type is created. For instance, assume our results are [200,000,000]. Num docs = 1, but max doc = 200,000,000. This would then cause a bitset of 200,000,000 entries to be created for a single doc. Instead, if we set the length to 1, the iterator would  have a single int in an int array.

This change will allow lucene to pick the best iterator for our use case.

### Issues Resolved
#500 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
