### PR TITLE
[Backport 2.1] Increase max dimension to 16k for nmslib and faiss 

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorFieldMapper.java
@@ -77,7 +77,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
      * Define the max dimension a knn_vector mapping can have. This limit is somewhat arbitrary. In the future, we
      * should make this configurable.
      */
-    public static final int MAX_DIMENSION = 10000;
+    public static final int MAX_DIMENSION = 16000;
 
     private static KNNVectorFieldMapper toType(FieldMapper in) {
         return (KNNVectorFieldMapper) in;


### PR DESCRIPTION
### Description
Backport #490 to 2.1
 
### Issues Resolved
#455 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
