### PR TITLE
Replace terminology 'master' with 'cluster manager'

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNCircuitBreaker.java
+++ b/src/main/java/org/opensearch/knn/index/KNNCircuitBreaker.java
@@ -72,7 +72,7 @@ public class KNNCircuitBreaker {
             }
 
             // Leader node untriggers CB if all nodes have not reached their max capacity
-            if (KNNSettings.isCircuitBreakerTriggered() && clusterService.state().nodes().isLocalNodeElectedMaster()) {
+            if (KNNSettings.isCircuitBreakerTriggered() && clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
                 KNNStatsRequest knnStatsRequest = new KNNStatsRequest(KNNStatsConfig.KNN_STATS.keySet());
                 knnStatsRequest.addStat(StatNames.CACHE_CAPACITY_REACHED.getName());
                 knnStatsRequest.timeout(new TimeValue(1000 * 10)); // 10 second timeout

--- a/src/main/java/org/opensearch/knn/indices/ModelGraveyard.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelGraveyard.java
@@ -148,7 +148,7 @@ public class ModelGraveyard implements Metadata.Custom {
 
     /**
      * The ModelGraveyardDiff class compares the previous modelGraveyard object with the current updated modelGraveyard object
-     * and returns only the diff of those 2 objects. So that, whenever there is a change in cluster state, master node only
+     * and returns only the diff of those 2 objects. So that, whenever there is a change in cluster state, clusterManager node only
      * sends the diff to all the data nodes instead of the full cluster state
      */
     public static class ModelGraveyardDiff implements NamedDiff<Metadata.Custom> {

--- a/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportAction.java
@@ -10,7 +10,7 @@ import lombok.extern.log4j.Log4j2;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.action.support.master.TransportMasterNodeAction;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateTaskConfig;
 import org.opensearch.cluster.ClusterStateTaskExecutor;
@@ -38,7 +38,9 @@ import static org.opensearch.knn.common.KNNConstants.PLUGIN_NAME;
  * Transport action used to update model graveyard on the cluster manager node.
  */
 @Log4j2
-public class UpdateModelGraveyardTransportAction extends TransportMasterNodeAction<UpdateModelGraveyardRequest, AcknowledgedResponse> {
+public class UpdateModelGraveyardTransportAction extends TransportClusterManagerNodeAction<
+    UpdateModelGraveyardRequest,
+    AcknowledgedResponse> {
     private UpdateModelGraveyardExecutor updateModelGraveyardExecutor;
 
     @Inject
@@ -72,7 +74,7 @@ public class UpdateModelGraveyardTransportAction extends TransportMasterNodeActi
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         UpdateModelGraveyardRequest request,
         ClusterState clusterState,
         ActionListener<AcknowledgedResponse> actionListener

--- a/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportAction.java
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.master.AcknowledgedResponse;
-import org.opensearch.action.support.master.TransportMasterNodeAction;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateTaskConfig;
 import org.opensearch.cluster.ClusterStateTaskExecutor;
@@ -45,7 +45,9 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_METADATA_FIELD;
 /**
  * Transport action used to update metadata of model's on the cluster manager node.
  */
-public class UpdateModelMetadataTransportAction extends TransportMasterNodeAction<UpdateModelMetadataRequest, AcknowledgedResponse> {
+public class UpdateModelMetadataTransportAction extends TransportClusterManagerNodeAction<
+    UpdateModelMetadataRequest,
+    AcknowledgedResponse> {
 
     public static Logger logger = LogManager.getLogger(UpdateModelMetadataTransportAction.class);
 
@@ -82,7 +84,7 @@ public class UpdateModelMetadataTransportAction extends TransportMasterNodeActio
     }
 
     @Override
-    protected void masterOperation(
+    protected void clusterManagerOperation(
         UpdateModelMetadataRequest request,
         ClusterState clusterState,
         ActionListener<AcknowledgedResponse> actionListener

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
@@ -51,7 +51,7 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
         client().admin().cluster().prepareState().execute(ActionListener.wrap(stateResponse1 -> {
             ClusterState clusterState1 = stateResponse1.getState();
-            updateModelGraveyardTransportAction.masterOperation(
+            updateModelGraveyardTransportAction.clusterManagerOperation(
                 addModelGraveyardRequest,
                 clusterState1,
                 ActionListener.wrap(acknowledgedResponse -> {
@@ -81,7 +81,7 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
         client().admin().cluster().prepareState().execute(ActionListener.wrap(stateResponse1 -> {
             ClusterState clusterState1 = stateResponse1.getState();
-            updateModelGraveyardTransportAction.masterOperation(
+            updateModelGraveyardTransportAction.clusterManagerOperation(
                 addModelGraveyardRequest1,
                 clusterState1,
                 ActionListener.wrap(acknowledgedResponse -> {
@@ -123,7 +123,7 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
         final CountDownLatch inProgressLatch3 = new CountDownLatch(1);
         client().admin().cluster().prepareState().execute(ActionListener.wrap(stateResponse1 -> {
             ClusterState clusterState1 = stateResponse1.getState();
-            updateModelGraveyardTransportAction.masterOperation(
+            updateModelGraveyardTransportAction.clusterManagerOperation(
                 removeModelGraveyardRequest,
                 clusterState1,
                 ActionListener.wrap(acknowledgedResponse -> {

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -79,7 +79,7 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
         client().admin().cluster().prepareState().execute(ActionListener.wrap(stateResponse1 -> {
             ClusterState clusterState1 = stateResponse1.getState();
-            updateModelMetadataTransportAction.masterOperation(
+            updateModelMetadataTransportAction.clusterManagerOperation(
                 updateModelMetadataRequest,
                 clusterState1,
                 ActionListener.wrap(acknowledgedResponse -> {
@@ -114,7 +114,7 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
         final CountDownLatch inProgressLatch2 = new CountDownLatch(1);
         client().admin().cluster().prepareState().execute(ActionListener.wrap(stateResponse1 -> {
             ClusterState clusterState1 = stateResponse1.getState();
-            updateModelMetadataTransportAction.masterOperation(
+            updateModelMetadataTransportAction.clusterManagerOperation(
                 removeModelMetadataRequest,
                 clusterState1,
                 ActionListener.wrap(acknowledgedResponse -> {


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Nomenclature Changes- Replace "master" with "cluster manager"

The below two packages are still not supported by opensearch core and is expected to be ready by 3.0 : 
- org.opensearch.action.support.master.AcknowledgedRequest -> org.opensearch.action.support.clusterManager.AcknowledgedRequest

- org.opensearch.action.support.master.AcknowledgedResponse -> org.opensearch.action.support.clusterManager.AcknowledgedResponse

 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/307
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
