### PR TITLE
Updated the BWC workflow to have 2.2.0 as the backward supported version in BWC tests

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "1.1.0", "1.2.4", "1.3.2", "2.0.0", "2.1.0" ]
+        bwc_version : [ "1.1.0", "1.2.4", "1.3.2", "2.0.0", "2.1.0", "2.2.0" ]
         opensearch_version : [ "2.3.0-SNAPSHOT" ]
 
     name: k-NN Restart-Upgrade BWC Tests
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "1.3.2", "2.0.0", "2.1.0" ]
+        bwc_version: [ "1.3.2", "2.0.0", "2.1.0", "2.2.0" ]
         opensearch_version: [ "2.3.0-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests


### PR DESCRIPTION
### Description
Updated the BWC workflow to have 2.2.0 as the backward supported version in BWC tests
 
### Issues Resolved
#524
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
