### PR TITLE
Replace Forum link in k-NN plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build and Test k-NN](https://github.com/opensearch-project/k-NN/actions/workflows/CI.yml/badge.svg)](https://github.com/opensearch-project/k-NN/actions/workflows/CI.yml)
 [![codecov](https://codecov.io/gh/opensearch-project/k-NN/branch/main/graph/badge.svg?token=PYQO2GW39S)](https://codecov.io/gh/opensearch-project/k-NN)
 [![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://opensearch.org/docs/search-plugins/knn/index/)
-[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/k-NN/)
+[![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/k-nn/48)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
 # OpenSearch k-NN
@@ -21,7 +21,7 @@
 * [Project Website](https://opensearch.org/)
 * [Downloads](https://opensearch.org/downloads.html).
 * [Documentation](https://opensearch.org/docs/search-plugins/knn/index/)
-* Need help? Try [Forums](https://discuss.opendistrocommunity.dev/c/k-nn/)
+* Need help? Try the [Forum](https://forum.opensearch.org/c/plugins/k-nn/48)
 * [Project Principles](https://opensearch.org/#principles)
 * [Contributing to OpenSearch k-NN](CONTRIBUTING.md)
 * [Maintainer Responsibilities](MAINTAINERS.md)


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Replaced the link to the Forum discussion in the README.md file so that it points to the OpenSearch forum rather than the defunct Open Distro forum.
 
### Issues Resolved
This fixes the issue for the k-NN plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
