### PR TITLE
Adding OSB index specification json for lucene hnsw

### DIFF
--- a/benchmarks/osb/indices/lucene-index.json
+++ b/benchmarks/osb/indices/lucene-index.json
@@ -1,0 +1,26 @@
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": {{ target_index_primary_shards }},
+      "number_of_replicas": {{ target_index_replica_shards }}
+    }
+  },
+  "mappings": {
+    "properties": {
+      "target_field": {
+        "type": "knn_vector",
+        "dimension": {{ target_index_dimension }},
+        "method": {
+          "name": "hnsw",
+          "space_type": "{{ target_index_space_type }}",
+          "engine": "lucene",
+          "parameters": {
+            "ef_construction": {{ hnsw_ef_construction }},
+            "m": {{ hnsw_m }}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Gives example of index specification in case one need to use OSB to test lucene knn. We do have similar files fornmslib and faiss engines. 
 
### Issues Resolved
Keeping parity between Lucene hnsw and other knn engines
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
