### PR TITLE
[554]Added sample perf-test configs for faiss-ivf, faiss-ivfpq, lucene-hnsw

### DIFF
--- a/benchmarks/perf-tool/release-configs/faiss-ivf/index.json
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/index.json
@@ -1,0 +1,17 @@
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 24,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "target_field": {
+          "type": "knn_vector",
+          "model_id": "test-model"
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-ivf/method-spec.json
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/method-spec.json
@@ -1,0 +1,9 @@
+{
+  "name":"ivf",
+  "engine":"faiss",
+  "space_type": "l2",
+    "parameters":{
+      "nlist": 128,
+      "nprobes": 8
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-ivf/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/test.yml
@@ -1,0 +1,53 @@
+endpoint: [END-POINT]
+test_name: "index-workflow"
+test_id: "index workflow"
+num_runs: 10
+show_runs: false
+setup:
+  - name: delete_index
+    index_name: train_index
+  - name: create_index
+    index_name: train_index
+    index_spec: /home/ec2-user/[PATH]/train-index-spec.json
+  - name: ingest
+    index_name: train_index
+    field_name: train_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/[PATH]/sift-128-euclidean.hdf5
+    doc_count: 50000
+  - name: refresh_index
+    index_name: train_index
+steps:
+  - name: delete_model
+    model_id: test-model
+  - name: delete_index
+    index_name: target_index
+  - name: train_model
+    model_id: test-model
+    train_index: train_index
+    train_field: train_field
+    dimension: 128
+    method_spec: /home/ec2-user/[PATH]/method-spec.json
+    max_training_vector_count: 50000
+  - name: create_index
+    index_name: target_index
+    index_spec: /home/ec2-user/[PATH]/index.json
+  - name: ingest
+    index_name: target_index
+    field_name: target_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+  - name: refresh_index
+    index_name: target_index
+  - name: query
+    k: 100
+    r: 1
+    calculate_recall: true
+    index_name: target_index
+    field_name: target_field
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: /home/ec2-user/data/sift-128-euclidean.hdf5

--- a/benchmarks/perf-tool/release-configs/faiss-ivf/train-index-spec.json
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/train-index-spec.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 24,
+      "number_of_replicas": 0
+    }
+  },
+  "mappings": {
+    "properties": {
+      "train_field": {
+        "type": "knn_vector",
+        "dimension": 128
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-ivfpq/index.json
+++ b/benchmarks/perf-tool/release-configs/faiss-ivfpq/index.json
@@ -1,0 +1,17 @@
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 24,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "target_field": {
+          "type": "knn_vector",
+          "model_id": "test-model"
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-ivfpq/method-spec.json
+++ b/benchmarks/perf-tool/release-configs/faiss-ivfpq/method-spec.json
@@ -1,0 +1,16 @@
+{
+  "name":"ivf",
+  "engine":"faiss",
+  "space_type": "l2",
+    "parameters":{
+      "nlist": 128,
+      "nprobes": 8,
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "m": 16,
+          "code_size": 8
+        }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-ivfpq/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-ivfpq/test.yml
@@ -1,0 +1,53 @@
+endpoint: [ENDPOINT]
+test_name: "index-workflow"
+test_id: "index workflow"
+num_runs: 10
+show_runs: false
+setup:
+  - name: delete_index
+    index_name: train_index
+  - name: create_index
+    index_name: train_index
+    index_spec: /home/ec2-user/[PATH]/train-index-spec.json
+  - name: ingest
+    index_name: train_index
+    field_name: train_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    doc_count: 50000
+  - name: refresh_index
+    index_name: train_index
+steps:
+  - name: delete_model
+    model_id: test-model
+  - name: delete_index
+    index_name: target_index
+  - name: train_model
+    model_id: test-model
+    train_index: train_index
+    train_field: train_field
+    dimension: 128
+    method_spec: /home/ec2-user/[PATH]/method-spec.json
+    max_training_vector_count: 50000
+  - name: create_index
+    index_name: target_index
+    index_spec: /home/ec2-user/[PATH]/index.json
+  - name: ingest
+    index_name: target_index
+    field_name: target_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+  - name: refresh_index
+    index_name: target_index
+  - name: query
+    k: 100
+    r: 1
+    calculate_recall: true
+    index_name: target_index
+    field_name: target_field
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: /home/ec2-user/data/sift-128-euclidean.hdf5

--- a/benchmarks/perf-tool/release-configs/faiss-ivfpq/train-index-spec.json
+++ b/benchmarks/perf-tool/release-configs/faiss-ivfpq/train-index-spec.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 24,
+      "number_of_replicas": 0
+    }
+  },
+  "mappings": {
+    "properties": {
+      "train_field": {
+        "type": "knn_vector",
+        "dimension": 128
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/index.json
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/index.json
@@ -1,0 +1,26 @@
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 24,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "target_field": {
+          "type": "knn_vector",
+          "dimension": 128,
+      	  "method": {
+        		"name": "hnsw",
+        		"space_type": "l2",
+        		"engine": "lucene",
+        		"parameters": {
+          			"ef_construction": 256,
+          			"m": 16
+        		}
+        	}
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/test.yml
@@ -1,0 +1,29 @@
+endpoint: [ENDPOINT]
+test_name: "index-workflow"
+test_id: "Index workflow"
+num_runs: 10
+show_runs: false
+steps:
+  - name: delete_index
+    index_name: target_index
+  - name: create_index
+    index_name: target_index
+    index_spec: /home/ec2-user/[PATH]/index.json
+  - name: ingest
+    index_name: target_index
+    field_name: target_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+  - name: refresh_index
+    index_name: target_index
+  - name: query
+    k: 100
+    r: 1
+    calculate_recall: true
+    index_name: target_index
+    field_name: target_field
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: /home/ec2-user/data/sift-128-euclidean.hdf5

--- a/benchmarks/perf-tool/release-configs/nmslib-hnsw/index.json
+++ b/benchmarks/perf-tool/release-configs/nmslib-hnsw/index.json
@@ -1,0 +1,27 @@
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 24,
+      "number_of_replicas": 1,
+      "knn.algo_param.ef_search": 256
+    }
+  },
+  "mappings": {
+    "properties": {
+      "target_field": {
+          "type": "knn_vector",
+          "dimension": 128,
+      	  "method": {
+        		"name": "hnsw",
+        		"space_type": "l2",
+        		"engine": "nmslib",
+        		"parameters": {
+          			"ef_construction": 256,
+          			"m": 16
+        		}
+        	}
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/nmslib-hnsw/test.yml
+++ b/benchmarks/perf-tool/release-configs/nmslib-hnsw/test.yml
@@ -1,0 +1,29 @@
+endpoint: [ENDPOINT]
+test_name: "index-workflow"
+test_id: "Index workflow"
+num_runs: 10
+show_runs: false
+steps:
+  - name: delete_index
+    index_name: target_index
+  - name: create_index
+    index_name: target_index
+    index_spec: /home/ec2-user/[PATH]/index.json
+  - name: ingest
+    index_name: target_index
+    field_name: target_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+  - name: refresh_index
+    index_name: target_index
+  - name: query
+    k: 100
+    r: 1
+    calculate_recall: true
+    index_name: target_index
+    field_name: target_field
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: /home/ec2-user/data/sift-128-euclidean.hdf5


### PR DESCRIPTION
### Description
Added sample perf-test configs for faiss-ivf, faiss-ivfpq, lucene-hnsw. As offline configs get stale very easily this is a good way to maintain the perf test configs.

Signed-off-by: Navneet Verma <navneev@amazon.com>

 
### Issues Resolved
#554
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
