### PR TITLE
Fix NPE on null script context

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
@@ -9,6 +9,7 @@ import org.opensearch.knn.index.KNNVectorScriptDocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.script.ScoreScript;
+import org.opensearch.script.ScriptContext;
 import org.opensearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
@@ -139,4 +140,6 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
             return this.scoringMethod.apply(this.queryValue, scriptDocValues.getValue());
         }
     }
+
+    public static final ScriptContext<KNNScoreScriptFactory> CONTEXT = new ScriptContext<>("knn_score", KNNScoreScriptFactory.class);
 }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringScriptEngine.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringScriptEngine.java
@@ -10,6 +10,7 @@ import org.opensearch.script.ScoreScript;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptEngine;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,6 +45,6 @@ public class KNNScoringScriptEngine implements ScriptEngine {
 
     @Override
     public Set<ScriptContext<?>> getSupportedContexts() {
-        return null;
+        return Collections.singleton(KNNScoreScript.CONTEXT);
     }
 }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
The REST request GET _script_language lists available script languages.  Implementations of `ScoringEngine.getSupportedContexts()` must provide a set of supported contexts.  This currently returns null, which results in an NPE in response to this REST request.
 
### Issues Resolved
OpenSearch project [#4534](https://github.com/opensearch-project/OpenSearch/issues/4534).
 
### Check List
- ~[ ] New functionality includes testing.~
  - ~[ ] All tests pass~
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
