### PR TITLE
Adding serialization for filter field in KnnQueryBuilder

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFilteringIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/LuceneFilteringIT.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.knn.TestUtils;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
+
+/**
+ * Tests scenarios specific to filtering functionality in k-NN in case Lucene is set as an engine
+ */
+public class LuceneFilteringIT extends AbstractRollingUpgradeTestCase {
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSIONS = 50;
+    private static final int K = 10;
+    private static final int NUM_DOCS = 100;
+    private static final TermQueryBuilder TERM_QUERY = QueryBuilders.termQuery("_id", "100");
+
+    public void testLuceneFiltering() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        float[] queryVector = TestUtils.getQueryVectors(1, DIMENSIONS, NUM_DOCS, true)[0];
+        switch (getClusterType()) {
+            case OLD:
+                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMappingWithLuceneField(TEST_FIELD, DIMENSIONS));
+                bulkAddKnnDocs(testIndex, TEST_FIELD, TestUtils.getIndexVectors(NUM_DOCS, DIMENSIONS, true), NUM_DOCS);
+                validateSearchKNNIndexFailed(testIndex, new KNNQueryBuilder(TEST_FIELD, queryVector, K, TERM_QUERY), K);
+                break;
+            case MIXED:
+                validateSearchKNNIndexFailed(testIndex, new KNNQueryBuilder(TEST_FIELD, queryVector, K, TERM_QUERY), K);
+                break;
+            case UPGRADED:
+                searchKNNIndex(testIndex, new KNNQueryBuilder(TEST_FIELD, queryVector, K, TERM_QUERY), K);
+                deleteKNNIndex(testIndex);
+                break;
+        }
+    }
+
+    protected String createKnnIndexMappingWithLuceneField(final String fieldName, int dimension) throws IOException {
+        return Strings.toString(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(fieldName)
+                .field("type", "knn_vector")
+                .field("dimension", Integer.toString(dimension))
+                .startObject("method")
+                .field("name", "hnsw")
+                .field("engine", "lucene")
+                .field("space_type", "l2")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+        );
+    }
+
+    private void validateSearchKNNIndexFailed(String index, KNNQueryBuilder knnQueryBuilder, int resultSize) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        knnQueryBuilder.doXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject().endObject();
+
+        Request request = new Request("POST", "/" + index + "/_search");
+
+        request.addParameter("size", Integer.toString(resultSize));
+        request.addParameter("explain", Boolean.toString(true));
+        request.addParameter("search_type", "query_then_fetch");
+        request.setJsonEntity(Strings.toString(builder));
+
+        expectThrows(ResponseException.class, () -> client().performRequest(request));
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/KNNClusterContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNClusterContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.collect.ImmutableOpenMap;
+
+/**
+ * Class abstracts information related to underlying OpenSearch cluster
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Log4j2
+public class KNNClusterContext {
+
+    private ClusterService clusterService;
+    private static KNNClusterContext instance;
+
+    /**
+     * Return instance of the cluster context, must be initialized first for proper usage
+     * @return instance of cluster context
+     */
+    public static synchronized KNNClusterContext instance() {
+        if (instance == null) {
+            instance = new KNNClusterContext();
+        }
+        return instance;
+    }
+
+    /**
+     * Initializes instance of cluster context by injecting dependencies
+     * @param clusterService
+     */
+    public void initialize(final ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    /**
+     * Return minimal OpenSearch version based on all nodes currently discoverable in the cluster
+     * @return minimal installed OpenSearch version, default to Version.CURRENT which is typically the latest version
+     */
+    public Version getClusterMinVersion() {
+        Version minVersion = Version.CURRENT;
+        ImmutableOpenMap<String, DiscoveryNode> clusterDiscoveryNodes = ImmutableOpenMap.of();
+        log.debug("Reading cluster min version");
+        try {
+            clusterDiscoveryNodes = this.clusterService.state().getNodes().getNodes();
+        } catch (Exception exception) {
+            log.error("Cannot get cluster nodes", exception);
+        }
+        for (final ObjectCursor<DiscoveryNode> discoveryNodeCursor : clusterDiscoveryNodes.values()) {
+            final Version nodeVersion = discoveryNodeCursor.value.getVersion();
+            if (nodeVersion.before(minVersion)) {
+                minVersion = nodeVersion;
+                log.debug("Update cluster min version to {} based on node {}", nodeVersion, discoveryNodeCursor.value.toString());
+            }
+        }
+        log.debug("Return cluster min version {}", minVersion);
+        return minVersion;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -109,6 +109,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             fieldName = in.readString();
             vector = in.readFloatArray();
             k = in.readInt();
+            if (in.readBoolean()) {
+                filter = in.readNamedWriteable(QueryBuilder.class);
+            }
         } catch (IOException ex) {
             throw new RuntimeException("[KNN] Unable to create KNNQueryBuilder: " + ex);
         }
@@ -181,6 +184,12 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         out.writeString(fieldName);
         out.writeFloatArray(vector);
         out.writeInt(k);
+        if (filter != null) {
+            out.writeBoolean(true);
+            out.writeNamedWriteable(filter);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.query;
 
 import lombok.extern.log4j.Log4j2;
+import org.opensearch.Version;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -109,11 +110,11 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             fieldName = in.readString();
             vector = in.readFloatArray();
             k = in.readInt();
-            if (in.readBoolean()) {
-                filter = in.readNamedWriteable(QueryBuilder.class);
+            if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
+                filter = in.readOptionalNamedWriteable(QueryBuilder.class);
             }
         } catch (IOException ex) {
-            throw new RuntimeException("[KNN] Unable to create KNNQueryBuilder: " + ex);
+            throw new RuntimeException("[KNN] Unable to create KNNQueryBuilder", ex);
         }
     }
 
@@ -184,12 +185,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         out.writeString(fieldName);
         out.writeFloatArray(vector);
         out.writeInt(k);
-        if (filter != null) {
-            out.writeBoolean(true);
-            out.writeNamedWriteable(filter);
-        } else {
-            out.writeBoolean(false);
-        }
+        out.writeOptionalNamedWriteable(filter);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -110,7 +110,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             fieldName = in.readString();
             vector = in.readFloatArray();
             k = in.readInt();
-            if (in.getVersion().onOrAfter(Version.V_2_4_0)) {
+            if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
                 filter = in.readOptionalNamedWriteable(QueryBuilder.class);
             }
         } catch (IOException ex) {

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -11,6 +11,7 @@ import org.opensearch.common.ParseField;
 import org.opensearch.index.codec.CodecServiceFactory;
 import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.knn.index.KNNCircuitBreaker;
+import org.opensearch.knn.index.KNNClusterContext;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
@@ -179,6 +180,7 @@ public class KNNPlugin extends Plugin implements MapperPlugin, SearchPlugin, Act
         NativeMemoryLoadStrategy.TrainingLoadStrategy.initialize(vectorReader);
 
         KNNSettings.state().initialize(client, clusterService);
+        KNNClusterContext.instance().initialize(clusterService);
         ModelDao.OpenSearchKNNModelDao.initialize(client, clusterService, environment.settings());
         ModelCache.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
         TrainingJobRunner.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance());

--- a/src/test/java/org/opensearch/knn/index/KNNClusterContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNClusterContextTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
+
+public class KNNClusterContextTests extends KNNTestCase {
+
+    public void testSingleNodeCluster() {
+        ClusterService clusterService = mockClusterService(List.of(Version.V_2_4_0));
+
+        final KNNClusterContext knnClusterContext = KNNClusterContext.instance();
+        knnClusterContext.initialize(clusterService);
+
+        final Version minVersion = knnClusterContext.getClusterMinVersion();
+
+        assertTrue(Version.V_2_4_0.equals(minVersion));
+    }
+
+    public void testMultipleNodesCluster() {
+        ClusterService clusterService = mockClusterService(List.of(Version.V_3_0_0, Version.V_2_3_0, Version.V_3_0_0));
+
+        final KNNClusterContext knnClusterContext = KNNClusterContext.instance();
+        knnClusterContext.initialize(clusterService);
+
+        final Version minVersion = knnClusterContext.getClusterMinVersion();
+
+        assertTrue(Version.V_2_3_0.equals(minVersion));
+    }
+
+    public void testWhenErrorOnClusterStateDiscover() {
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenThrow(new RuntimeException("Cluster state is not ready"));
+
+        final KNNClusterContext knnClusterContext = KNNClusterContext.instance();
+        knnClusterContext.initialize(clusterService);
+
+        final Version minVersion = knnClusterContext.getClusterMinVersion();
+
+        assertTrue(Version.CURRENT.equals(minVersion));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/KNNClusterTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/KNNClusterTestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.collect.ImmutableOpenMap;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.test.OpenSearchTestCase.randomAlphaOfLength;
+
+/**
+ * Collection of util methods required for testing and related to OpenSearch cluster setup and functionality
+ */
+public class KNNClusterTestUtils {
+
+    /**
+     * Create new mock for ClusterService
+     * @param versions list of versions for cluster nodes
+     * @return
+     */
+    public static ClusterService mockClusterService(final List<Version> versions) {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+        when(clusterState.getNodes()).thenReturn(discoveryNodes);
+        ImmutableOpenMap.Builder<String, DiscoveryNode> builder = ImmutableOpenMap.builder();
+        for (Version version : versions) {
+            DiscoveryNode clusterNode = mock(DiscoveryNode.class);
+            when(clusterNode.getVersion()).thenReturn(version);
+            builder.put(randomAlphaOfLength(10), clusterNode);
+        }
+        ImmutableOpenMap<String, DiscoveryNode> mapOfNodes = builder.build();
+        when(discoveryNodes.getNodes()).thenReturn(mapOfNodes);
+
+        return clusterService;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -21,6 +21,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.ChecksumIndexInput;
@@ -178,6 +179,7 @@ public class KNNCodecTestUtil {
                 pointIndexDimensionCount,
                 pointNumBytes,
                 vectorDimension,
+                VectorEncoding.BYTE,
                 vectorSimilarityFunction,
                 softDeletes
             );

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -47,7 +47,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
     private static final String FIELD_NAME = "myvector";
     private static final int K = 1;
     private static final TermQueryBuilder TERM_QUERY = QueryBuilders.termQuery("field", "value");
-    private static final float[] QUERY_VECTOR = new float[]{ 1.0f, 2.0f, 3.0f, 4.0f };
+    private static final float[] QUERY_VECTOR = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
 
     public void testInvalidK() {
         float[] queryVector = { 1.0f, 1.0f };
@@ -250,7 +250,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             }
         }
 
-        //test serialization from < 2.4 versions
+        // test serialization from < 2.4 versions
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setVersion(Version.V_2_3_0);
             output.writeNamedWriteable(knnQueryBuilderWithFilter);


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding serialization for filter in Knn query. Without the change multi-node cluster may be in inconsistent state, meaning some shards will execute knn query without the filter and search result will be irrelevant.   

Special case for rolling and restart upgrades. Let's say we do have existing cluster on 2.3 (we call it old) and we want to upgrade to 3.0 (we call it new). Nodes need to handle following cases for success run:

- old -> old        just existing cluster works before the upgrade. This should already work
- old -> new      this is part of restart and rolling upgrades
- new -> old      part of rolling upgrade   
- new -> new    upgraded cluster works

The easiest way to satisfy all criteria is to only write and read filter field in the last case of new->new. In all other cases input stream will be corrupted and logic after knn query will fail. To address this we introducing the cluster min deployed version concept that is set as a lowest out of all versions deployed in the cluster. 

One more added check is for manual k-NN search query, it minimal cluster version is below one that supports filtering feature (3.0.0 for this branch), query will be rejected with 4xx Bad request error. This is to address cluster upgrades, we need to avoid accepting queries with filter until upgrade is completed. Otherwise only some of the cluster nodes will use filter and this affects recall/relevance of the result.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/376 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
