### PR TITLE
Fix KNNCodecUtil FieldInfo construction

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -21,6 +21,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.ChecksumIndexInput;
@@ -178,6 +179,7 @@ public class KNNCodecTestUtil {
                 pointIndexDimensionCount,
                 pointNumBytes,
                 vectorDimension,
+                VectorEncoding.FLOAT32,
                 vectorSimilarityFunction,
                 softDeletes
             );


### PR DESCRIPTION
### Description
Fixes constructor for FieldInfo, which changed with Lucene upgrade.

### Issues Resolved
#570 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
