### PR TITLE
Backport lucene changes

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920PerFieldKnnVectorsFormat.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.KNN920Codec;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.lucene92.Lucene92HnswVectorsFormat;
+import org.apache.lucene.backward_codecs.lucene92.Lucene92HnswVectorsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.common.KNNConstants;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940Codec.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN940Codec;
+
+import lombok.Builder;
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNNFormatFacade;
+import org.opensearch.knn.index.codec.KNNFormatFactory;
+
+import java.util.Optional;
+
+import static org.opensearch.knn.index.codec.KNNCodecFactory.CodecDelegateFactory.createKNN94DefaultDelegate;
+
+public class KNN940Codec extends FilterCodec {
+    private static final String KNN940 = "KNN940Codec";
+    private final KNNFormatFacade knnFormatFacade;
+    private final PerFieldKnnVectorsFormat perFieldKnnVectorsFormat;
+
+    /**
+     * No arg constructor that uses Lucene94 as the delegate
+     */
+    public KNN940Codec() {
+        this(createKNN94DefaultDelegate(), new KNN940PerFieldKnnVectorsFormat(Optional.empty()));
+    }
+
+    /**
+     * Sole constructor. When subclassing this codec, create a no-arg ctor and pass the delegate codec
+     * and a unique name to this ctor.
+     *
+     * @param delegate codec that will perform all operations this codec does not override
+     * @param knnVectorsFormat per field format for KnnVector
+     */
+    @Builder
+    protected KNN940Codec(Codec delegate, PerFieldKnnVectorsFormat knnVectorsFormat) {
+        super(KNN940, delegate);
+        knnFormatFacade = KNNFormatFactory.createKNN940Format(delegate);
+        perFieldKnnVectorsFormat = knnVectorsFormat;
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        return knnFormatFacade.docValuesFormat();
+    }
+
+    @Override
+    public CompoundFormat compoundFormat() {
+        return knnFormatFacade.compoundFormat();
+    }
+
+    @Override
+    public KnnVectorsFormat knnVectorsFormat() {
+        return perFieldKnnVectorsFormat;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940PerFieldKnnVectorsFormat.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN940Codec;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.lucene94.Lucene94HnswVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Class provides per field format implementation for Lucene Knn vector type
+ */
+@AllArgsConstructor
+@Log4j2
+public class KNN940PerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
+
+    private final Optional<MapperService> mapperService;
+
+    @Override
+    public KnnVectorsFormat getKnnVectorsFormatForField(final String field) {
+        if (isNotKnnVectorFieldType(field)) {
+            log.debug(
+                String.format(
+                    "Initialize KNN vector format for field [%s] with default params [max_connections] = \"%d\" and [beam_width] = \"%d\"",
+                    field,
+                    Lucene94HnswVectorsFormat.DEFAULT_MAX_CONN,
+                    Lucene94HnswVectorsFormat.DEFAULT_BEAM_WIDTH
+                )
+            );
+            return new Lucene94HnswVectorsFormat();
+        }
+        var type = (KNNVectorFieldMapper.KNNVectorFieldType) mapperService.orElseThrow(
+            () -> new IllegalStateException(
+                String.format("Cannot read field type for field [%s] because mapper service is not available", field)
+            )
+        ).fieldType(field);
+        var params = type.getKnnMethodContext().getMethodComponent().getParameters();
+        int maxConnections = getMaxConnections(params);
+        int beamWidth = getBeamWidth(params);
+        log.debug(
+            String.format(
+                "Initialize KNN vector format for field [%s] with params [max_connections] = \"%d\" and [beam_width] = \"%d\"",
+                field,
+                maxConnections,
+                beamWidth
+            )
+        );
+        return new Lucene94HnswVectorsFormat(maxConnections, beamWidth);
+    }
+
+    private boolean isNotKnnVectorFieldType(final String field) {
+        return !mapperService.isPresent() || !(mapperService.get().fieldType(field) instanceof KNNVectorFieldMapper.KNNVectorFieldType);
+    }
+
+    private int getMaxConnections(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_M)) {
+            return (int) params.get(KNNConstants.METHOD_PARAMETER_M);
+        }
+        return Lucene94HnswVectorsFormat.DEFAULT_MAX_CONN;
+    }
+
+    private int getBeamWidth(final Map<String, Object> params) {
+        if (params != null && params.containsKey(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION)) {
+            return (int) params.get(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION);
+        }
+        return Lucene94HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
@@ -8,9 +8,10 @@ import lombok.AllArgsConstructor;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
+import org.apache.lucene.codecs.lucene94.Lucene94Codec;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
-import org.opensearch.knn.index.codec.KNN920Codec.KNN920PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
+import org.opensearch.knn.index.codec.KNN940Codec.KNN940PerFieldKnnVectorsFormat;
 
 import java.util.Optional;
 
@@ -23,9 +24,9 @@ public class KNNCodecFactory {
     private final MapperService mapperService;
 
     public Codec createKNNCodec(final Codec userCodec) {
-        var codec = KNN920Codec.builder()
+        var codec = KNN940Codec.builder()
             .delegate(userCodec)
-            .knnVectorsFormat(new KNN920PerFieldKnnVectorsFormat(Optional.of(mapperService)))
+            .knnVectorsFormat(new KNN940PerFieldKnnVectorsFormat(Optional.of(mapperService)))
             .build();
         return codec;
     }
@@ -41,6 +42,10 @@ public class KNNCodecFactory {
 
         public static Codec createKNN92DefaultDelegate() {
             return new Lucene92Codec();
+        }
+
+        public static Codec createKNN94DefaultDelegate() {
+            return new Lucene94Codec();
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecFactory.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index.codec;
 import lombok.AllArgsConstructor;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
-import org.apache.lucene.codecs.lucene92.Lucene92Codec;
+import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920PerFieldKnnVectorsFormat;

--- a/src/main/java/org/opensearch/knn/index/codec/KNNFormatFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNFormatFactory.java
@@ -38,4 +38,16 @@ public class KNNFormatFactory {
         );
         return knnFormatFacade;
     }
+
+    /**
+     * Return facade class that abstracts format specific to KNN940 codec
+     * @param delegate delegate codec that is wrapped by KNN codec
+     */
+    public static KNNFormatFacade createKNN940Format(final Codec delegate) {
+        final KNNFormatFacade knnFormatFacade = new KNNFormatFacade(
+            new KNN80DocValuesFormat(delegate.docValuesFormat()),
+            new KNN80CompoundFormat(delegate.compoundFormat())
+        );
+        return knnFormatFacade;
+    }
 }

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -4,3 +4,4 @@ org.opensearch.knn.index.codec.KNN86Codec.KNN86Codec
 org.opensearch.knn.index.codec.KNN87Codec.KNN87Codec
 org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec
 org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec
+org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec

--- a/src/test/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN920Codec/KNN920CodecTests.java
@@ -5,15 +5,9 @@
 
 package org.opensearch.knn.index.codec.KNN920Codec;
 
-import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
-
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
 import static org.opensearch.knn.index.codec.KNNCodecFactory.CodecDelegateFactory.createKNN92DefaultDelegate;
 
@@ -25,17 +19,5 @@ public class KNN920CodecTests extends KNNCodecTestCase {
 
     public void testBuildFromModelTemplate() throws InterruptedException, ExecutionException, IOException {
         testBuildFromModelTemplate((KNN920Codec.builder().delegate(createKNN92DefaultDelegate()).build()));
-    }
-
-    public void testKnnVectorIndex() throws Exception {
-        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
-            mapperService) -> new KNN920PerFieldKnnVectorsFormat(Optional.of(mapperService));
-
-        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN920Codec.builder()
-            .delegate(createKNN92DefaultDelegate())
-            .knnVectorsFormat(knnVectorFormat)
-            .build();
-
-        testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN940Codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNNCodecTestCase;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+import static org.opensearch.knn.index.codec.KNNCodecFactory.CodecDelegateFactory.createKNN94DefaultDelegate;
+
+public class KNN940CodecTests extends KNNCodecTestCase {
+
+    public void testMultiFieldsKnnIndex() throws Exception {
+        testMultiFieldsKnnIndex(KNN940Codec.builder().delegate(createKNN94DefaultDelegate()).build());
+    }
+
+    public void testBuildFromModelTemplate() throws InterruptedException, ExecutionException, IOException {
+        testBuildFromModelTemplate((KNN940Codec.builder().delegate(createKNN94DefaultDelegate()).build()));
+    }
+
+    public void testKnnVectorIndex() throws Exception {
+        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
+            mapperService) -> new KNN940PerFieldKnnVectorsFormat(Optional.of(mapperService));
+
+        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN940Codec.builder()
+            .delegate(createKNN94DefaultDelegate())
+            .knnVectorsFormat(knnVectorFormat)
+            .build();
+
+        testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
@@ -8,9 +8,10 @@ package org.opensearch.knn.index.codec;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
+import org.apache.lucene.codecs.lucene94.Lucene94Codec;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
+import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
 
 import static org.mockito.Mockito.mock;
 
@@ -28,12 +29,18 @@ public class KNNCodecFactoryTests extends KNNTestCase {
         assertTrue(knn92DefaultDelegate instanceof Lucene92Codec);
     }
 
+    public void testKNN94DefaultDelegate() {
+        Codec knn94DefaultDelegate = KNNCodecFactory.CodecDelegateFactory.createKNN94DefaultDelegate();
+        assertNotNull(knn94DefaultDelegate);
+        assertTrue(knn94DefaultDelegate instanceof Lucene94Codec);
+    }
+
     public void testKNNDefaultCodec() {
         MapperService mapperService = mock(MapperService.class);
         KNNCodecFactory knnCodecFactory = new KNNCodecFactory(mapperService);
-        Codec knnCodec = knnCodecFactory.createKNNCodec(KNNCodecFactory.CodecDelegateFactory.createKNN92DefaultDelegate());
+        Codec knnCodec = knnCodecFactory.createKNNCodec(KNNCodecFactory.CodecDelegateFactory.createKNN94DefaultDelegate());
         assertNotNull(knnCodec);
-        assertTrue(knnCodec instanceof KNN920Codec);
-        assertEquals("KNN920Codec", knnCodec.getName());
+        assertTrue(knnCodec instanceof KNN940Codec);
+        assertEquals("KNN940Codec", knnCodec.getName());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index.codec;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
-import org.apache.lucene.codecs.lucene92.Lucene92Codec;
+import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -18,8 +18,8 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.MethodComponentContext;
-import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
 import org.opensearch.knn.index.query.KNNQueryFactory;
+import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.KNNSettings;
@@ -79,7 +79,7 @@ import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_LIMIT_SETTIN
  */
 public class KNNCodecTestCase extends KNNTestCase {
 
-    private static final KNN920Codec ACTUAL_CODEC = new KNN920Codec();
+    private static final KNN940Codec ACTUAL_CODEC = new KNN940Codec();
     private static FieldType sampleFieldType;
     static {
         sampleFieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.Directory;
@@ -178,6 +179,7 @@ public class KNNCodecTestUtil {
                 pointIndexDimensionCount,
                 pointNumBytes,
                 vectorDimension,
+                VectorEncoding.FLOAT32,
                 vectorSimilarityFunction,
                 softDeletes
             );

--- a/src/test/java/org/opensearch/knn/index/codec/KNNFormatFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNFormatFactoryTests.java
@@ -36,4 +36,16 @@ public class KNNFormatFactoryTests extends KNNTestCase {
         assertNotNull(knnFormatFacade.compoundFormat());
         assertNotNull(knnFormatFacade.docValuesFormat());
     }
+
+    public void testKNN94Format() {
+        MapperService mapperService = mock(MapperService.class);
+        final Codec lucene94CodecDelegate = KNNCodecFactory.CodecDelegateFactory.createKNN94DefaultDelegate();
+        KNNCodecFactory knnCodecFactory = new KNNCodecFactory(mapperService);
+        final Codec knnCodec = knnCodecFactory.createKNNCodec(lucene94CodecDelegate);
+        KNNFormatFacade knnFormatFacade = KNNFormatFactory.createKNN940Format(knnCodec);
+
+        assertNotNull(knnFormatFacade);
+        assertNotNull(knnFormatFacade.compoundFormat());
+        assertNotNull(knnFormatFacade.docValuesFormat());
+    }
 }


### PR DESCRIPTION
### Description
This PR includes the following changes:

- Backport [package name changes for lucene 92](https://github.com/opensearch-project/k-NN/pull/498/commits/2f6b72a9d1680c4156503c537061f5fe5fb575ce)
- Backport https://github.com/opensearch-project/k-NN/pull/571
- Backport [Lucene 94 changes(Add KNN940Codec)](https://github.com/opensearch-project/k-NN/pull/498/commits/d4e84bce0fd229134fc202989cb3bdcc94d35c6f) 

 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/568
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
