### PR TITLE
Replacing BaseNodeRequest by TransportRequest

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModelIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModelIT.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.bwc;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.AfterClass;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;
@@ -141,7 +141,7 @@ public class ModelIT extends AbstractRestartUpgradeTestCase {
     }
 
     // KNN Delete Model test for model in Training State
-    public void testDeleteTrainingModel() throws IOException, InterruptedException {
+    public void testDeleteTrainingModel() throws Exception {
         byte[] testModelBlob = "hello".getBytes();
         ModelMetadata testModelMetadata = getModelMetadata();
         testModelMetadata.setState(ModelState.TRAINING);
@@ -193,7 +193,7 @@ public class ModelIT extends AbstractRestartUpgradeTestCase {
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 
-    public void searchKNNModel(String testModelID) throws IOException {
+    public void searchKNNModel(String testModelID) throws Exception {
         String restURI = String.join("/", KNNPlugin.KNN_BASE_URI, MODELS, "_search");
 
         for (String method : Arrays.asList("GET", "POST")) {
@@ -217,7 +217,7 @@ public class ModelIT extends AbstractRestartUpgradeTestCase {
     }
 
     // Confirm that the model gets created using Get Model API
-    public void validateModelCreated(String modelId) throws IOException, InterruptedException {
+    public void validateModelCreated(String modelId) throws Exception {
         Response getResponse = getModel(modelId, null);
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ScriptScoringIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ScriptScoringIT.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.bwc;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.index.query.MatchAllQueryBuilder;

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.knn.bwc;
 
-import java.io.IOException;
-
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
 
 public class IndexingIT extends AbstractRollingUpgradeTestCase {
@@ -49,7 +47,7 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
     }
 
     // validation steps for indexing after upgrading each node from old version to new version
-    public void validateKNNIndexingOnUpgrade(int totalDocsCount, int docId) throws IOException {
+    public void validateKNNIndexingOnUpgrade(int totalDocsCount, int docId) throws Exception {
         validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, totalDocsCount, K);
         addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docId, NUM_DOCS);
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/StatsIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/StatsIT.java
@@ -5,12 +5,11 @@
 
 package org.opensearch.knn.bwc;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.knn.plugin.stats.KNNStats;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +20,7 @@ public class StatsIT extends AbstractRollingUpgradeTestCase {
     private KNNStats knnStats = new KNNStats(KNN_STATS);
 
     // Validate if all the KNN Stats metrics from old version are present in new version
-    public void testAllMetricStatsReturned() throws IOException {
+    public void testAllMetricStatsReturned() throws Exception {
         Response response = getKnnStats(Collections.emptyList(), Collections.emptyList());
         String responseBody = EntityUtils.toString(response.getEntity());
         Map<String, Object> clusterStats = parseClusterStatsResponse(responseBody);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.bwc;
 
-import java.io.IOException;
 import java.util.Collections;
 
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
@@ -47,7 +46,7 @@ public class WarmupIT extends AbstractRollingUpgradeTestCase {
     }
 
     // validation steps for KNN Warmup after upgrading each node from old version to new version
-    public void validateKNNWarmupOnUpgrade(int totalDocsCount, int docId) throws IOException {
+    public void validateKNNWarmupOnUpgrade(int totalDocsCount, int docId) throws Exception {
         int graphCount = getTotalGraphsInCache();
         knnWarmup(Collections.singletonList(testIndex));
         assertTrue(getTotalGraphsInCache() > graphCount);

--- a/src/main/java/org/opensearch/knn/plugin/transport/KNNStatsNodeRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/KNNStatsNodeRequest.java
@@ -5,16 +5,16 @@
 
 package org.opensearch.knn.plugin.transport;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
 
 /**
  *  KNNStatsNodeRequest represents the request to an individual node
  */
-public class KNNStatsNodeRequest extends BaseNodeRequest {
+public class KNNStatsNodeRequest extends TransportRequest {
     private KNNStatsRequest request;
 
     /**

--- a/src/main/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheNodeRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheNodeRequest.java
@@ -11,16 +11,16 @@
 
 package org.opensearch.knn.plugin.transport;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
 
 /**
  * Request sent to each to tell it to evict a given model from the cache.
  */
-public class RemoveModelFromCacheNodeRequest extends BaseNodeRequest {
+public class RemoveModelFromCacheNodeRequest extends TransportRequest {
 
     private final String modelId;
 

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouteDecisionInfoNodeRequest.java
@@ -11,8 +11,8 @@
 
 package org.opensearch.knn.plugin.transport;
 
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.transport.TransportRequest;
 
 import java.io.IOException;
 
@@ -20,7 +20,7 @@ import java.io.IOException;
  * Request sent to each node to gather info that will be used to determine where to route a job. Right now,
  * this is fairly simple. However, in the future, we could add different filter parameters here.
  */
-public class TrainingJobRouteDecisionInfoNodeRequest extends BaseNodeRequest {
+public class TrainingJobRouteDecisionInfoNodeRequest extends TransportRequest {
 
     /**
      * Constructor

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -13,7 +13,7 @@ package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -55,7 +55,7 @@ public class FaissIT extends KNNRestTestCase {
         testData = new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());
     }
 
-    public void testEndToEnd_fromMethod() throws IOException, InterruptedException {
+    public void testEndToEnd_fromMethod() throws Exception {
         String indexName = "test-index-1";
         String fieldName = "test-field-1";
 
@@ -213,7 +213,7 @@ public class FaissIT extends KNNRestTestCase {
         deleteKnnDoc(INDEX_NAME, "1");
     }
 
-    public void testEndToEnd_fromModel() throws IOException, InterruptedException {
+    public void testEndToEnd_fromModel() throws Exception {
         String modelId = "test-model";
         int dimension = 128;
 

--- a/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index;
 
 import org.opensearch.knn.KNNRestTestCase;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.index.query.KNNQueryBuilder;

--- a/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.stats.StatNames;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.settings.Settings;
@@ -118,7 +118,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testCacheRebuiltAfterUpdateIndexSettings() throws IOException {
+    public void testCacheRebuiltAfterUpdateIndexSettings() throws Exception {
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
 
         Float[] vector = { 6.0f, 6.0f };

--- a/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index;
 
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Response;

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Floats;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.junit.After;
 import org.opensearch.client.Request;
@@ -134,7 +134,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         validateQueries(spaceType, FIELD_NAME);
     }
 
-    public void testQuery_multipleEngines() throws IOException {
+    public void testQuery_multipleEngines() throws Exception {
         String luceneField = "lucene-field";
         SpaceType luceneSpaceType = SpaceType.COSINESIMIL;
         String nmslibField = "nmslib-field";
@@ -187,7 +187,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         validateQueries(nmslibSpaceType, nmslibField);
     }
 
-    public void testAddDoc() throws IOException {
+    public void testAddDoc() throws Exception {
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
         List<Integer> efConstructionValues = ImmutableList.of(16, 32, 64, 128);
 
@@ -280,7 +280,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         validateQueries(spaceType, FIELD_NAME);
     }
 
-    private void validateQueries(SpaceType spaceType, String fieldName) throws IOException {
+    private void validateQueries(SpaceType spaceType, String fieldName) throws Exception {
 
         int k = LuceneEngineIT.TEST_INDEX_VECTORS.length;
         for (float[] queryVector : TEST_QUERY_VECTORS) {

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -13,7 +13,7 @@ package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -52,7 +52,7 @@ public class NmslibIT extends KNNRestTestCase {
         testData = new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());
     }
 
-    public void testEndToEnd() throws IOException, InterruptedException {
+    public void testEndToEnd() throws Exception {
         String indexName = "test-index-1";
         String fieldName = "test-field-1";
 

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -16,7 +16,7 @@ import com.google.common.primitives.Floats;
 import org.junit.BeforeClass;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -55,7 +55,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         testData = new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());
     }
 
-    public void testEndToEnd() throws IOException, InterruptedException {
+    public void testEndToEnd() throws Exception {
         String indexName = "test-index-1";
         KNNEngine knnEngine1 = KNNEngine.NMSLIB;
         KNNEngine knnEngine2 = KNNEngine.FAISS;
@@ -365,7 +365,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         updateKnnDoc(INDEX_NAME, "1", f5, vector1);
     }
 
-    public void testExistsQuery() throws IOException {
+    public void testExistsQuery() throws Exception {
         String field1 = "field1";
         String field2 = "field2";
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList(field1, field2), Arrays.asList(2, 2)));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.knn.plugin.action;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -27,7 +27,6 @@ import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.DeleteModelResponse;
 import org.opensearch.rest.RestStatus;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
@@ -52,7 +51,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, ModelState.CREATED, "2021-03-27", "test model", "");
     }
 
-    public void testDeleteModelExists() throws IOException {
+    public void testDeleteModelExists() throws Exception {
         createModelSystemIndex();
         String testModelID = "test-model-id";
         byte[] testModelBlob = "hello".getBytes();
@@ -70,7 +69,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         assertEquals(0, getDocCount(MODEL_INDEX_NAME));
     }
 
-    public void testDeleteTrainingModel() throws IOException {
+    public void testDeleteTrainingModel() throws Exception {
         createModelSystemIndex();
         String testModelID = "test-model-id";
         byte[] testModelBlob = "hello".getBytes();
@@ -100,7 +99,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         assertEquals(errorMessage, responseMap.get(DeleteModelResponse.ERROR_MSG));
     }
 
-    public void testDeleteModelFailsInvalid() throws IOException {
+    public void testDeleteModelFailsInvalid() throws Exception {
         String modelId = "invalid-model-id";
         createModelSystemIndex();
         String restURI = String.join("/", KNNPlugin.KNN_BASE_URI, MODELS, modelId);
@@ -111,7 +110,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
     }
 
     // Test Train Model -> Delete Model -> Train Model with same modelId
-    public void testTrainingDeletedModel() throws IOException, InterruptedException {
+    public void testTrainingDeletedModel() throws Exception {
         String modelId = "test-model-id1";
         String trainingIndexName1 = "train-index-1";
         String trainingIndexName2 = "train-index-2";
@@ -134,8 +133,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         trainModel(modelId, trainingIndexName2, trainingFieldName, dimension);
     }
 
-    private void trainModel(String modelId, String trainingIndexName, String trainingFieldName, int dimension) throws IOException,
-        InterruptedException {
+    private void trainModel(String modelId, String trainingIndexName, String trainingFieldName, int dimension) throws Exception {
 
         // Create a training index and randomly ingest data into it
         createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);

--- a/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
@@ -12,7 +12,7 @@
 package org.opensearch.knn.plugin.action;
 
 import joptsimple.internal.Strings;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -50,7 +50,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, ModelState.CREATED, "2021-03-27", "test model", "");
     }
 
-    public void testGetModelExists() throws IOException {
+    public void testGetModelExists() throws Exception {
         createModelSystemIndex();
         String testModelID = "test-model-id";
         byte[] testModelBlob = "hello".getBytes();
@@ -79,7 +79,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         assertEquals(testModelMetadata.getTimestamp(), responseMap.get(MODEL_TIMESTAMP));
     }
 
-    public void testGetModelExistsWithFilter() throws IOException {
+    public void testGetModelExistsWithFilter() throws Exception {
         createModelSystemIndex();
         String testModelID = "test-model-id";
         byte[] testModelBlob = "hello".getBytes();

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.plugin.action;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Before;
@@ -85,7 +85,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testCorrectStatsReturned() throws IOException {
+    public void testCorrectStatsReturned() throws Exception {
         Response response = getKnnStats(Collections.emptyList(), Collections.emptyList());
         String responseBody = EntityUtils.toString(response.getEntity());
         Map<String, Object> clusterStats = parseClusterStatsResponse(responseBody);
@@ -99,7 +99,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testStatsValueCheck() throws IOException {
+    public void testStatsValueCheck() throws Exception {
         Response response = getKnnStats(Collections.emptyList(), Collections.emptyList());
         String responseBody = EntityUtils.toString(response.getEntity());
 
@@ -147,7 +147,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testValidMetricsStats() throws IOException {
+    public void testValidMetricsStats() throws Exception {
         // Create request that only grabs two of the possible metrics
         String metric1 = StatNames.HIT_COUNT.getName();
         String metric2 = StatNames.MISS_COUNT.getName();
@@ -174,7 +174,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testValidNodeIdStats() throws IOException {
+    public void testValidNodeIdStats() throws Exception {
         Response response = getKnnStats(Collections.singletonList("_local"), Collections.emptyList());
         String responseBody = EntityUtils.toString(response.getEntity());
         List<Map<String, Object>> nodeStats = parseNodeStatsResponse(responseBody);
@@ -319,7 +319,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
         assertEquals(initialScriptQueryErrors + 2, (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_ERRORS.getName())));
     }
 
-    public void testModelIndexHealthMetricsStats() throws IOException {
+    public void testModelIndexHealthMetricsStats() throws Exception {
         // Create request that filters only model index
         String modelIndexStatusName = StatNames.MODEL_INDEX_STATUS.getName();
 
@@ -350,7 +350,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testModelIndexingDegradedMetricsStats() throws IOException {
+    public void testModelIndexingDegradedMetricsStats() throws Exception {
         // Create request that only grabs model indexing degraded stats alone
         String statName = StatNames.INDEXING_FROM_MODEL_DEGRADED.getName();
 
@@ -424,7 +424,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
         assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
     }
 
-    public void validateModelCreated(String modelId) throws IOException, InterruptedException {
+    public void validateModelCreated(String modelId) throws Exception {
         Response getResponse = getModel(modelId, null);
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNWarmupHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNWarmupHandlerIT.java
@@ -36,7 +36,7 @@ public class RestKNNWarmupHandlerIT extends KNNRestTestCase {
         knnWarmup(Collections.singletonList("not-knn-index"));
     }
 
-    public void testEmptyIndex() throws IOException {
+    public void testEmptyIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
         createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
 
@@ -45,7 +45,7 @@ public class RestKNNWarmupHandlerIT extends KNNRestTestCase {
         assertEquals(graphCountBefore, getTotalGraphsInCache());
     }
 
-    public void testSingleIndex() throws IOException {
+    public void testSingleIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
         createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 6.0f, 6.0f });
@@ -55,7 +55,7 @@ public class RestKNNWarmupHandlerIT extends KNNRestTestCase {
         assertEquals(graphCountBefore + 1, getTotalGraphsInCache());
     }
 
-    public void testMultipleIndices() throws IOException {
+    public void testMultipleIndices() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
 
         createKnnIndex(testIndexName + "1", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
@@ -17,7 +17,7 @@ import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.stats.KNNStats;
 import org.opensearch.knn.plugin.stats.StatNames;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Before;
@@ -61,7 +61,7 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testCorrectStatsReturned() throws IOException {
+    public void testCorrectStatsReturned() throws Exception {
         Response response = executeKnnStatRequest(Collections.emptyList(), Collections.emptyList(), KNNPlugin.LEGACY_KNN_BASE_URI);
         String responseBody = EntityUtils.toString(response.getEntity());
         Map<String, Object> clusterStats = parseClusterStatsResponse(responseBody);
@@ -75,7 +75,7 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testStatsValueCheck() throws IOException {
+    public void testStatsValueCheck() throws Exception {
         Response response = executeKnnStatRequest(Collections.emptyList(), Collections.emptyList(), KNNPlugin.LEGACY_KNN_BASE_URI);
         String responseBody = EntityUtils.toString(response.getEntity());
 
@@ -123,7 +123,7 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testValidMetricsStats() throws IOException {
+    public void testValidMetricsStats() throws Exception {
         // Create request that only grabs two of the possible metrics
         String metric1 = StatNames.HIT_COUNT.getName();
         String metric2 = StatNames.MISS_COUNT.getName();
@@ -153,7 +153,7 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      *
      * @throws IOException throws IOException
      */
-    public void testValidNodeIdStats() throws IOException {
+    public void testValidNodeIdStats() throws Exception {
         Response response = executeKnnStatRequest(
             Collections.singletonList("_local"),
             Collections.emptyList(),

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNWarmupHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNWarmupHandlerIT.java
@@ -43,7 +43,7 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
         executeWarmupRequest(Collections.singletonList("not-knn-index"), KNNPlugin.LEGACY_KNN_BASE_URI);
     }
 
-    public void testEmptyIndex() throws IOException {
+    public void testEmptyIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
         createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
 
@@ -52,7 +52,7 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
         assertEquals(graphCountBefore, getTotalGraphsInCache());
     }
 
-    public void testSingleIndex() throws IOException {
+    public void testSingleIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
         createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 6.0f, 6.0f });
@@ -62,7 +62,7 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
         assertEquals(graphCountBefore + 1, getTotalGraphsInCache());
     }
 
-    public void testMultipleIndices() throws IOException {
+    public void testMultipleIndices() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
 
         createKnnIndex(testIndexName + "1", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.knn.plugin.action;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -60,7 +60,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
         expectThrows(ResponseException.class, () -> client().performRequest(request));
     }
 
-    public void testNoModelExists() throws IOException {
+    public void testNoModelExists() throws Exception {
         createModelSystemIndex();
         String restURI = String.join("/", KNNPlugin.KNN_BASE_URI, MODELS, "_search");
         Request request = new Request("GET", restURI);
@@ -96,7 +96,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
 
     }
 
-    public void testSearchModelExists() throws IOException {
+    public void testSearchModelExists() throws Exception {
         createModelSystemIndex();
         createIndex("irrelevant-index", Settings.EMPTY);
         addDocWithBinaryField("irrelevant-index", "id1", "field-name", "value");
@@ -134,7 +134,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
         }
     }
 
-    public void testSearchModelWithoutSource() throws IOException {
+    public void testSearchModelWithoutSource() throws Exception {
         createModelSystemIndex();
         createIndex("irrelevant-index", Settings.EMPTY);
         addDocWithBinaryField("irrelevant-index", "id1", "field-name", "value");
@@ -172,7 +172,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
         }
     }
 
-    public void testSearchModelWithSourceFilteringIncludes() throws IOException {
+    public void testSearchModelWithSourceFilteringIncludes() throws Exception {
         createModelSystemIndex();
         createIndex("irrelevant-index", Settings.EMPTY);
         addDocWithBinaryField("irrelevant-index", "id1", "field-name", "value");
@@ -221,7 +221,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
         }
     }
 
-    public void testSearchModelWithSourceFilteringExcludes() throws IOException {
+    public void testSearchModelWithSourceFilteringExcludes() throws Exception {
         createModelSystemIndex();
         createIndex("irrelevant-index", Settings.EMPTY);
         addDocWithBinaryField("irrelevant-index", "id1", "field-name", "value");

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -11,7 +11,7 @@
 
 package org.opensearch.knn.plugin.action;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -19,7 +19,6 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.rest.RestStatus;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
@@ -34,7 +33,7 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
-    public void testTrainModel_fail_notEnoughData() throws IOException, InterruptedException {
+    public void testTrainModel_fail_notEnoughData() throws Exception {
 
         // Check that training fails properly when there is not enough data
 
@@ -193,7 +192,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         assertTrainingFails(modelId, 30, 1000);
     }
 
-    public void testTrainModel_success_withId() throws IOException, InterruptedException {
+    public void testTrainModel_success_withId() throws Exception {
         // Test checks that training when passing in an id succeeds
 
         String modelId = "test-model-id";
@@ -265,7 +264,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         assertTrainingSucceeds(modelId, 30, 1000);
     }
 
-    public void testTrainModel_success_noId() throws IOException, InterruptedException {
+    public void testTrainModel_success_noId() throws Exception {
         // Test to check if training succeeds when no id is passed in
 
         String trainingIndexName = "train-index";

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.plugin.script;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.SpaceType;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;

--- a/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
@@ -13,7 +13,7 @@ import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -9,6 +9,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.google.common.primitives.Floats;
 import org.apache.commons.lang.StringUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.index.query.MatchAllQueryBuilder;
@@ -20,7 +21,7 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.opensearch.client.Request;
@@ -344,7 +345,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * @return index mapping a map
      */
     @SuppressWarnings("unchecked")
-    public Map<String, Object> getIndexMappingAsMap(String index) throws IOException {
+    public Map<String, Object> getIndexMappingAsMap(String index) throws Exception {
         Request request = new Request("GET", "/" + index + "/_mapping");
 
         Response response = client().performRequest(request);
@@ -358,7 +359,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return (Map<String, Object>) ((Map<String, Object>) responseMap.get(index)).get("mappings");
     }
 
-    public int getDocCount(String indexName) throws IOException {
+    public int getDocCount(String indexName) throws Exception {
         Request request = new Request("GET", "/" + indexName + "/_count");
 
         Response response = client().performRequest(request);
@@ -479,7 +480,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     /**
      * Retrieve document by index and document id
      */
-    protected Map<String, Object> getKnnDoc(final String index, final String docId) throws IOException {
+    protected Map<String, Object> getKnnDoc(final String index, final String docId) throws Exception {
         final Request request = new Request("GET", "/" + index + "/_doc/" + docId);
         final Response response = client().performRequest(request);
 
@@ -598,7 +599,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Get the total number of graphs in the cache across all nodes
      */
     @SuppressWarnings("unchecked")
-    protected int getTotalGraphsInCache() throws IOException {
+    protected int getTotalGraphsInCache() throws Exception {
         Response response = getKnnStats(Collections.emptyList(), Collections.emptyList());
         String responseBody = EntityUtils.toString(response.getEntity());
 
@@ -838,7 +839,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     // Method that returns index vectors of the documents that were added before into the index
-    public float[][] getIndexVectorsFromIndex(String testIndex, String testField, int docCount, int dimensions) throws IOException {
+    public float[][] getIndexVectorsFromIndex(String testIndex, String testField, int docCount, int dimensions) throws Exception {
         float[][] vectors = new float[docCount][dimensions];
 
         QueryBuilder qb = new MatchAllQueryBuilder();
@@ -866,7 +867,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     // Method that performs bulk search for multiple queries and stores the resulting documents ids into list
-    public List<List<String>> bulkSearch(String testIndex, String testField, float[][] queryVectors, int k) throws IOException {
+    public List<List<String>> bulkSearch(String testIndex, String testField, float[][] queryVectors, int k) throws Exception {
         List<List<String>> searchResults = new ArrayList<>();
         List<String> kVectors;
 
@@ -904,7 +905,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     // Validate KNN search on a KNN index by generating the query vector from the number of documents in the index
-    public void validateKNNSearch(String testIndex, String testField, int dimension, int numDocs, int k) throws IOException {
+    public void validateKNNSearch(String testIndex, String testField, int dimension, int numDocs, int k) throws Exception {
         float[] queryVector = new float[dimension];
         Arrays.fill(queryVector, (float) numDocs);
 
@@ -1116,7 +1117,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return client().performRequest(request);
     }
 
-    public void assertTrainingSucceeds(String modelId, int attempts, int delayInMillis) throws InterruptedException, IOException {
+    public void assertTrainingSucceeds(String modelId, int attempts, int delayInMillis) throws InterruptedException, Exception {
         int attemptNum = 0;
         Response response;
         Map<String, Object> responseMap;
@@ -1140,7 +1141,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         fail("Training did not succeed after " + attempts + " attempts with a delay of " + delayInMillis + " ms.");
     }
 
-    public void assertTrainingFails(String modelId, int attempts, int delayInMillis) throws InterruptedException, IOException {
+    public void assertTrainingFails(String modelId, int attempts, int delayInMillis) throws Exception {
         int attemptNum = 0;
         Response response;
         Map<String, Object> responseMap;


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Remove usage of deprecated BaseNodeRequest (https://github.com/opensearch-project/OpenSearch/pull/4702). For now no need in downport as core PR is for 3.0.0. 
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
