### PR TITLE
Adding stat for query with filter

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -158,6 +158,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                         String tokenName = parser.currentName();
                         if (FILTER_FIELD.getPreferredName().equals(tokenName)) {
                             log.debug(String.format("Start parsing filter for field [%s]", fieldName));
+                            KNNCounter.KNN_QUERY_WITH_FILTER_REQUESTS.increment();
                             if (isClusterOnOrAfterMinRequiredVersion()) {
                                 filter = parseInnerQueryBuilder(parser);
                             } else {

--- a/src/main/java/org/opensearch/knn/plugin/stats/KNNCounter.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/KNNCounter.java
@@ -21,7 +21,8 @@ public enum KNNCounter {
     SCRIPT_QUERY_REQUESTS("script_query_requests"),
     SCRIPT_QUERY_ERRORS("script_query_errors"),
     TRAINING_REQUESTS("training_requests"),
-    TRAINING_ERRORS("training_errors");
+    TRAINING_ERRORS("training_errors"),
+    KNN_QUERY_WITH_FILTER_REQUESTS("knn_query_with_filter_requests");
 
     private String name;
     private AtomicLong count;

--- a/src/main/java/org/opensearch/knn/plugin/stats/KNNStatsConfig.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/KNNStatsConfig.java
@@ -55,6 +55,10 @@ public class KNNStatsConfig {
         .put(StatNames.CIRCUIT_BREAKER_TRIGGERED.getName(), new KNNStat<>(true, new KNNCircuitBreakerSupplier()))
         .put(StatNames.MODEL_INDEX_STATUS.getName(), new KNNStat<>(true, new ModelIndexStatusSupplier<>(ModelDao::getHealthStatus)))
         .put(StatNames.KNN_QUERY_REQUESTS.getName(), new KNNStat<>(false, new KNNCounterSupplier(KNNCounter.KNN_QUERY_REQUESTS)))
+        .put(
+            StatNames.KNN_QUERY_WITH_FILTER_REQUESTS.getName(),
+            new KNNStat<>(false, new KNNCounterSupplier(KNNCounter.KNN_QUERY_WITH_FILTER_REQUESTS))
+        )
         .put(StatNames.SCRIPT_COMPILATIONS.getName(), new KNNStat<>(false, new KNNCounterSupplier(KNNCounter.SCRIPT_COMPILATIONS)))
         .put(
             StatNames.SCRIPT_COMPILATION_ERRORS.getName(),

--- a/src/main/java/org/opensearch/knn/plugin/stats/StatNames.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/StatNames.java
@@ -40,7 +40,8 @@ public enum StatNames {
     TRAINING_ERRORS(KNNCounter.TRAINING_ERRORS.getName()),
     TRAINING_MEMORY_USAGE("training_memory_usage"),
     TRAINING_MEMORY_USAGE_PERCENTAGE("training_memory_usage_percentage"),
-    SCRIPT_QUERY_ERRORS(KNNCounter.SCRIPT_QUERY_ERRORS.getName());
+    SCRIPT_QUERY_ERRORS(KNNCounter.SCRIPT_QUERY_ERRORS.getName()),
+    KNN_QUERY_WITH_FILTER_REQUESTS(KNNCounter.KNN_QUERY_WITH_FILTER_REQUESTS.getName());
 
     private String name;
 


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding counter stat "knn_query_with_filter_requests" for queries with filter field. Example of response with new stat
 
```
    "nodes": {
        "gIsW_7cBQwqSeZ2sr5knEw": {
            "graph_memory_usage_percentage": 0.0,
            "graph_query_requests": 0,
            "graph_memory_usage": 0,
            "cache_capacity_reached": false,
            "load_success_count": 0,
            "training_memory_usage": 0,
            "indices_in_cache": {},
            "script_query_errors": 0,
            "hit_count": 0,
            "knn_query_requests": 2,
            "total_load_time": 0,
            "miss_count": 0,
            "knn_query_with_filter_requests": 1,
            "training_memory_usage_percentage": 0.0,
            "lucene_initialized": true,
            "graph_index_requests": 0,
            "faiss_initialized": false,
            "load_exception_count": 0,
            "training_errors": 0,
            "eviction_count": 0,
            "nmslib_initialized": false,
            "script_compilations": 0,
            "script_query_requests": 0,
            "graph_query_errors": 0,
            "indexing_from_model_degraded": false,
            "graph_index_errors": 0,
            "training_requests": 0,
            "script_compilation_errors": 0
        }
    }
```

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/376
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
