### PR TITLE
Add Windows Build.sh Related Changes in k-NN

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -75,7 +75,17 @@ work_dir=$PWD
 git submodule update --init -- jni/external/nmslib
 git submodule update --init -- jni/external/faiss
 
-# Build knn libs
+# Setup compile time dependency for Windows only
+# As Linux version already have OpenBlas in the runner
+if [ "$PLATFORM" = "windows" ]; then
+    openBlasVersion="0.3.21"
+    openBlasFile="openblas_${openBlasVersion}"
+    curl -SL https://github.com/xianyi/OpenBLAS/releases/download/v${openBlasVersion}/OpenBLAS-${openBlasVersion}-x64.zip -o ${openBlasFile}.zip
+    unzip -j -o ${openBlasFile}.zip bin/libopenblas.dll -d ./src/main/resources/windowsDependencies
+    rm -rf ${openBlasFile}.zip
+fi
+
+# Setup knnlib build params for all platforms
 cd jni
 
 # For x64, generalize arch so library is compatible for processors without simd instruction extensions
@@ -95,30 +105,41 @@ if [ "$JAVA_HOME" = "" ]; then
     echo "SET JAVA_HOME=$JAVA_HOME"
 fi
 
-cmake .
-make opensearchknn_faiss opensearchknn_nmslib
-
+# Build k-NN lib and plugin through gradle tasks
 cd $work_dir
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+# Gradle build is used here to replace gradle assemble due to build will also call cmake and make before generating jars
+./gradlew build --no-daemon --refresh-dependencies -x integTest -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 # Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
 mkdir $distributions/lib
-cp ./jni/release/libopensearchknn* $distributions/lib
+libPrefix="libopensearchknn"
+if [ "$PLATFORM" = "windows" ]; then
+    libPrefix="opensearchknn"
+    cp -v ./src/main/resources/windowsDependencies/libopenblas.dll $distributions/lib
 
-# Copy libomp to be packaged with the lib contents
-ompPath=$(ldconfig -p | grep libgomp | cut -d ' ' -f 4)
-cp $ompPath $distributions/lib
+    # Have to define $MINGW_BIN either in ENV VAR or User Provided Var
+    cp -v "$MINGW_BIN/libgcc_s_seh-1.dll" $distributions/lib
+    cp -v "$MINGW_BIN/libwinpthread-1.dll" $distributions/lib
+    cp -v "$MINGW_BIN/libstdc++-6.dll" $distributions/lib
+    cp -v "$MINGW_BIN/libgomp-1.dll" $distributions/lib
+else
+   ompPath=$(ldconfig -p | grep libgomp | cut -d ' ' -f 4)
+   cp -v $ompPath $distributions/lib
+fi
+cp -v ./jni/release/${libPrefix}* $distributions/lib
+ls -l $distributions/lib
 
+# Add lib directory to the k-NN plugin zip
 cd $distributions
 zip -ur $zipPath lib
 cd $work_dir
 
 echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins
-cp ${distributions}/*.zip $OUTPUT/plugins
+cp -v ${distributions}/*.zip $OUTPUT/plugins
 
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
### Description
Add Windows Build.sh Related Changes in k-NN.
Include new changes in windows and streamline linux builds.

This is based on @naveentatikonda 2.x windows support branch.
Needs to be merged only when https://github.com/opensearch-project/k-NN/pull/583 is merged.
We also need the ci repo PR https://github.com/opensearch-project/opensearch-ci/pull/212 to be merged to support `$MINGW_BIN`.

Thanks
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306
#157
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
