### PR TITLE
Update build script to publish to maven local

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
 
 allprojects {
 
-    group = 'org.opensearch'
+    group = 'org.opensearch.plugin'
     version = opensearch_version.tokenize('-')[0] + '.0'
     if (version_qualifier) {
         version += "-${version_qualifier}"

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
 
 allprojects {
 
-    group = 'org.opensearch.plugin'
+    group = 'org.opensearch'
     version = opensearch_version.tokenize('-')[0] + '.0'
     if (version_qualifier) {
         version += "-${version_qualifier}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -101,6 +101,7 @@ make opensearchknn_faiss opensearchknn_nmslib
 cd $work_dir
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew :publishToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 # Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -101,7 +101,7 @@ make opensearchknn_faiss opensearchknn_nmslib
 cd $work_dir
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
-./gradlew publishPluginZipPublicationToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishPluginZipPublicationToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Dopensearch.version=$VERSION
 
 # Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -101,7 +101,7 @@ make opensearchknn_faiss opensearchknn_nmslib
 cd $work_dir
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
-./gradlew :publishToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishPluginZipPublicationToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 # Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)


### PR DESCRIPTION
### Description
Updates build script to publish zip to local maven. This allows plugins like neural search to pick up the zip as a dependency.

Fixes bug in build script where group was being set to org.opensearch as opposed to org.opensearch.plugin.

Publish to maven passed:
```
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.5/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 1 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.

BUILD SUCCESSFUL in 16s
38 actionable tasks: 38 executed

Tried with variety
./gradlew :publishToMavenLocal -Dbuild.snapshot=true -Dbuild.version_qualifier=rc1
./gradlew :publishToMavenLocal -Dbuild.snapshot=true
./gradlew :publishToMavenLocal -Dbuild.snapshot=false

ls ~/.m2/repository/org/opensearch/plugin/opensearch-knn/
3.0.0.0				3.0.0.0-SNAPSHOT		3.0.0.0-rc1-SNAPSHOT		maven-metadata-local.xml
```
 
### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/31
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
