### PR TITLE
Restore assemble behavior by removing unittests for Windows during Jenkins build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,7 +108,7 @@ fi
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir
 # Gradle build is used here to replace gradle assemble due to build will also call cmake and make before generating jars
-./gradlew build --no-daemon --refresh-dependencies -x integTest -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew build --no-daemon --refresh-dependencies -x integTest -x test -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew publishPluginZipPublicationToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Dopensearch.version=$VERSION
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Restore assemble behavior by removing unittests for Windows during Jenkins build.
Initially we are running `gradle assemble` which does not run integTest or unittest during compiling.

Now due to integrate with multiple tasks such as windowsscript as well as running cmake through gradle, we have to switch to `gradle build` which cause the entire build to take around 1 hour plus to complete, compares to the original compile time 30min-40min.

By removing unittest during compilation this restored the original behavior of KNN build on Jenkins, while allowing gradle to take over the trigger of cmake/make.

Thanks.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
