### PR TITLE
Disable Code Coverage for Windows and Mac Platforms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,7 @@ jobs:
           ./gradlew build
 
       - name: Upload Coverage Report
+        if: startsWith(matrix.os,'ubuntu')
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -91,10 +92,6 @@ jobs:
       - name: Run build
         run: |
           ./gradlew.bat build
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
 #      - name: Pull and Run Docker for security tests
 #        run: |


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Disable code coverage for mac and windows platforms in CI to avoid duplicate reports.
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
