### PR TITLE
Fixed failing unit test

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -57,12 +57,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.Version.CURRENT;
@@ -321,7 +320,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         IndexReader reader = writer.getReader();
         writer.close();
 
-        verify(perFieldKnnVectorsFormatSpy).getKnnVectorsFormatForField(anyString());
+        verify(perFieldKnnVectorsFormatSpy, atLeastOnce()).getKnnVectorsFormatForField(eq(FIELD_NAME_ONE));
 
         IndexSearcher searcher = new IndexSearcher(reader);
         Query query = KNNQueryFactory.create(KNNEngine.LUCENE, "dummy", FIELD_NAME_ONE, new float[] { 1.0f, 0.0f, 0.0f }, 1);
@@ -348,7 +347,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         ResourceWatcherService resourceWatcherService = createDisabledResourceWatcherService();
         NativeMemoryLoadStrategy.IndexLoadStrategy.initialize(resourceWatcherService);
 
-        verify(perFieldKnnVectorsFormatSpy, times(2)).getKnnVectorsFormatForField(anyString());
+        verify(perFieldKnnVectorsFormatSpy, atLeastOnce()).getKnnVectorsFormatForField(eq(FIELD_NAME_TWO));
 
         IndexSearcher searcher1 = new IndexSearcher(reader1);
         Query query1 = KNNQueryFactory.create(KNNEngine.LUCENE, "dummy", FIELD_NAME_TWO, new float[] { 1.0f, 0.0f }, 1);


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Fixed flaky unit tests, narrow assertion logic and adjust for test runs with multi node mock cluster

Rolling upgrades are failing, presumable due to issue with security plugin https://github.com/opensearch-project/security/issues/2228

Repro for certain seeds:
```
./gradlew ':test' --tests "org.opensearch.knn.index.codec.KNN940Codec.KNN940CodecTests.testKnnVectorIndex" -Dtests.seed=B5E0DC7BF07CBCC1 -Dtests.security.manager=false -Dtests.locale=el-CY -Dtests.timezone=America/Mendoza -Druntime.java=17

org.opensearch.knn.index.codec.KNN940Codec.KNN940CodecTests > testKnnVectorIndex FAILED
    org.mockito.exceptions.verification.TooManyActualInvocations:
    kNN940PerFieldKnnVectorsFormat.getKnnVectorsFormatForField(
        <any string>
    );
``` 
After change test runs are succesful:
```
./gradlew ':test' -Dtests.seed=B5E0DC7BF07CBCC1

BUILD SUCCESSFUL in 1m 35s
15 actionable tasks: 6 executed, 9 up-to-date
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
