### PR TITLE
Add fix to fromXContent and toXContent in ModelGraveyard

### DIFF
--- a/src/main/java/org/opensearch/knn/indices/ModelGraveyard.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelGraveyard.java
@@ -81,11 +81,11 @@ public class ModelGraveyard implements Metadata.Custom {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        Iterator modelIds = getModelIds().iterator();
+        Iterator model_ids = getModelIds().iterator();
 
-        builder.startArray("MODEL_GRAVEYARD");
-        while (modelIds.hasNext()) {
-            builder.value(modelIds.next());
+        builder.startArray("model_ids");
+        while (model_ids.hasNext()) {
+            builder.value(model_ids.next());
         }
         builder.endArray();
         return builder;

--- a/src/test/java/org/opensearch/knn/indices/ModelGraveyardTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelGraveyardTests.java
@@ -6,6 +6,9 @@
 package org.opensearch.knn.indices;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
@@ -55,6 +58,24 @@ public class ModelGraveyardTests extends OpenSearchTestCase {
         assertEquals(testModelGraveyard.size(), testModelGraveyardCopy.size());
         assertTrue(testModelGraveyard.contains(testModelId));
         assertTrue(testModelGraveyardCopy.contains(testModelId));
+    }
+
+    public void testXContentBuilder() throws IOException {
+        Set<String> modelIds = new HashSet<>();
+        String testModelId = "test-model-id";
+        String testModelId1 = "test-model-id1";
+        modelIds.add(testModelId);
+        modelIds.add(testModelId1);
+        ModelGraveyard testModelGraveyard = new ModelGraveyard(modelIds);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        XContentBuilder builder = testModelGraveyard.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        ModelGraveyard testModelGraveyard2 = ModelGraveyard.fromXContent(createParser(builder));
+        assertTrue(testModelGraveyard2.contains(testModelId));
+        assertTrue(testModelGraveyard2.contains(testModelId1));
     }
 
     public void testDiffStreams() throws IOException {

--- a/src/test/java/org/opensearch/knn/indices/ModelGraveyardTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelGraveyardTests.java
@@ -62,10 +62,10 @@ public class ModelGraveyardTests extends OpenSearchTestCase {
 
     public void testXContentBuilder() throws IOException {
         Set<String> modelIds = new HashSet<>();
-        String testModelId = "test-model-id";
         String testModelId1 = "test-model-id1";
-        modelIds.add(testModelId);
+        String testModelId2 = "test-model-id2";
         modelIds.add(testModelId1);
+        modelIds.add(testModelId2);
         ModelGraveyard testModelGraveyard = new ModelGraveyard(modelIds);
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
@@ -74,8 +74,9 @@ public class ModelGraveyardTests extends OpenSearchTestCase {
         builder.endObject();
 
         ModelGraveyard testModelGraveyard2 = ModelGraveyard.fromXContent(createParser(builder));
-        assertTrue(testModelGraveyard2.contains(testModelId));
+        assertEquals(2, testModelGraveyard2.size());
         assertTrue(testModelGraveyard2.contains(testModelId1));
+        assertTrue(testModelGraveyard2.contains(testModelId2));
     }
 
     public void testDiffStreams() throws IOException {


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Add fix to fromXContent and toXContent in ModelGraveyard, where before adding this fix it will fail to bootup after a node drop or if cluster is killed.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/619
 
### Check List
- [x] New functionality includes testing.
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
