### PR TITLE
Upgrade 2.x to 2.5 manually

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "1.1.0", "1.2.4", "1.3.2", "2.0.0", "2.1.0", "2.2.0" ]
-        opensearch_version : [ "2.4.0-SNAPSHOT" ]
+        bwc_version : [ "1.1.0", "1.2.4", "1.3.2", "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0" ]
+        opensearch_version : [ "2.5.0-SNAPSHOT" ]
 
     name: k-NN Restart-Upgrade BWC Tests
     runs-on: ubuntu-latest
@@ -46,8 +46,8 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "1.3.2", "2.0.0", "2.1.0", "2.2.0" ]
-        opensearch_version: [ "2.4.0-SNAPSHOT" ]
+        bwc_version: [ "1.3.2", "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0" ]
+        opensearch_version: [ "2.5.0-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
-        opensearch_version = System.getProperty("opensearch.version", "2.4.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.5.0-SNAPSHOT")
         version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
     }


### PR DESCRIPTION
### Description
Upgrade 2.x to 2.5 manually as auto workflow failed to update bwc tests (#606)

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
