### PR TITLE
Get rid of Rachet to fix failing build

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -7,8 +7,7 @@ allprojects {
     project.apply plugin: "com.diffplug.spotless"
     spotless {
         java {
-            ratchetFrom 'origin/1.x'
-            target '**/*.java'
+            target 'src/**/*.java'
             removeUnusedImports()
             eclipse().configFile rootProject.file('buildSrc/formatterConfig.xml')
             trimTrailingWhitespace()

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -21,86 +21,88 @@ import java.util.Set;
  * nmslib calls the inner_product space "negdotprod". This translation should take place in the nmslib's jni layer.
  */
 public enum SpaceType {
-  L2("l2") {
-    @Override
-    public float scoreTranslation(float rawScore) {
-      return 1 / (1 + rawScore);
+    L2("l2") {
+        @Override
+        public float scoreTranslation(float rawScore) {
+            return 1 / (1 + rawScore);
+        }
+    },
+    COSINESIMIL("cosinesimil") {
+        @Override
+        public float scoreTranslation(float rawScore) {
+            return 1 / (1 + rawScore);
+        }
+    },
+    L1("l1") {
+        @Override
+        public float scoreTranslation(float rawScore) {
+            return 1 / (1 + rawScore);
+        }
+    },
+    LINF("linf") {
+        @Override
+        public float scoreTranslation(float rawScore) {
+            return 1 / (1 + rawScore);
+        }
+    },
+    INNER_PRODUCT("innerproduct") {
+        /**
+         * The inner product has a range of [-Float.MAX_VALUE, Float.MAX_VALUE], with a more similar result being
+         * represented by a more negative value. In Lucene, scores have to be in the range of [0, Float.MAX_VALUE],
+         * where a higher score represents a more similar result. So, we convert here.
+         *
+         * @param rawScore score returned from underlying library
+         * @return Lucene scaled score
+         */
+        @Override
+        public float scoreTranslation(float rawScore) {
+            if (rawScore >= 0) {
+                return 1 / (1 + rawScore);
+            }
+            return -rawScore + 1;
+        }
+    },
+    HAMMING_BIT("hammingbit") {
+        @Override
+        public float scoreTranslation(float rawScore) {
+            return 1 / (1 + rawScore);
+        }
+    };
+
+    public static SpaceType DEFAULT = L2;
+
+    private final String value;
+
+    SpaceType(String value) {
+        this.value = value;
     }
-  },
-  COSINESIMIL("cosinesimil") {
-    @Override
-    public float scoreTranslation(float rawScore) {
-      return 1 / (1 + rawScore);
-    }
-  },
-  L1("l1") {
-    @Override
-    public float scoreTranslation(float rawScore) {
-      return 1 / (1 + rawScore);
-    }
-  },
-  LINF("linf") {
-    @Override
-    public float scoreTranslation(float rawScore) {
-      return 1 / (1 + rawScore);
-    }
-  },
-  INNER_PRODUCT("innerproduct") {
+
+    public abstract float scoreTranslation(float rawScore);
+
     /**
-     * The inner product has a range of [-Float.MAX_VALUE, Float.MAX_VALUE], with a more similar result being
-     * represented by a more negative value. In Lucene, scores have to be in the range of [0, Float.MAX_VALUE],
-     * where a higher score represents a more similar result. So, we convert here.
+     * Get space type name in engine
      *
-     * @param rawScore score returned from underlying library
-     * @return Lucene scaled score
+     * @return name
      */
-    @Override
-    public float scoreTranslation(float rawScore) {
-      if (rawScore >= 0) {
-        return 1 / (1 + rawScore);
-      }
-      return -rawScore + 1;
+    public String getValue() {
+        return value;
     }
-  },
-  HAMMING_BIT("hammingbit") {
-    @Override
-    public float scoreTranslation(float rawScore) {
-      return 1 / (1 + rawScore);
+
+    public static Set<String> getValues() {
+        Set<String> values = new HashSet<>();
+
+        for (SpaceType spaceType : SpaceType.values()) {
+            values.add(spaceType.getValue());
+        }
+        return values;
     }
-  };
 
-  public static SpaceType DEFAULT = L2;
-
-  private final String value;
-
-  SpaceType(String value) {
-    this.value = value;
-  }
-
-  public abstract float scoreTranslation(float rawScore);
-
-  /**
-   * Get space type name in engine
-   *
-   * @return name
-   */
-  public String getValue() { return value; }
-
-  public static Set<String> getValues() {
-    Set<String> values = new HashSet<>();
-
-    for (SpaceType spaceType : SpaceType.values()) {
-      values.add(spaceType.getValue());
+    public static SpaceType getSpace(String spaceTypeName) {
+        for (SpaceType currentSpaceType : SpaceType.values()) {
+            if (currentSpaceType.getValue().equalsIgnoreCase(spaceTypeName)) {
+                return currentSpaceType;
+            }
+        }
+        throw new IllegalArgumentException("Unable to find space: " + spaceTypeName);
     }
-    return values;
-  }
-
-  public static SpaceType getSpace(String spaceTypeName) {
-    for (SpaceType currentSpaceType : SpaceType.values()) {
-      if (currentSpaceType.getValue().equalsIgnoreCase(spaceTypeName)) {
-        return currentSpaceType;
-      }
-    }
-    throw new IllegalArgumentException("Unable to find space: " + spaceTypeName);
-  }
 }

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
@@ -87,11 +87,11 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
 
         // Index test document
-        Float[] vector = {6.0f, 6.0f};
+        Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
 
         // First search: Ensure that misses=1
-        float[] qvector = {6.0f, 6.0f};
+        float[] qvector = { 6.0f, 6.0f };
         searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 1), 1);
 
         response = executeKnnStatRequest(Collections.emptyList(), Collections.emptyList(), KNNPlugin.LEGACY_KNN_BASE_URI);
@@ -142,8 +142,10 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      * Test checks that handler correctly returns failure on an invalid metric
      */
     public void testInvalidMetricsStats() {
-        expectThrows(ResponseException.class, () -> executeKnnStatRequest(Collections.emptyList(),
-            Collections.singletonList("invalid_metric"), KNNPlugin.LEGACY_KNN_BASE_URI));
+        expectThrows(
+            ResponseException.class,
+            () -> executeKnnStatRequest(Collections.emptyList(), Collections.singletonList("invalid_metric"), KNNPlugin.LEGACY_KNN_BASE_URI)
+        );
     }
 
     /**
@@ -152,7 +154,11 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      * @throws IOException throws IOException
      */
     public void testValidNodeIdStats() throws IOException {
-        Response response = executeKnnStatRequest(Collections.singletonList("_local"), Collections.emptyList(), KNNPlugin.LEGACY_KNN_BASE_URI);
+        Response response = executeKnnStatRequest(
+            Collections.singletonList("_local"),
+            Collections.emptyList(),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         String responseBody = EntityUtils.toString(response.getEntity());
         List<Map<String, Object>> nodeStats = parseNodeStatsResponse(responseBody);
         assertEquals(1, nodeStats.size());
@@ -164,7 +170,11 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
      * @throws Exception throws Exception
      */
     public void testInvalidNodeIdStats() throws Exception {
-        Response response = executeKnnStatRequest(Collections.singletonList("invalid_node"), Collections.emptyList(), KNNPlugin.LEGACY_KNN_BASE_URI);
+        Response response = executeKnnStatRequest(
+            Collections.singletonList("invalid_node"),
+            Collections.emptyList(),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         String responseBody = EntityUtils.toString(response.getEntity());
         List<Map<String, Object>> nodeStats = parseNodeStatsResponse(responseBody);
         assertEquals(0, nodeStats.size());
@@ -177,11 +187,15 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         clearScriptCache();
 
         // Get initial stats
-        Response response = executeKnnStatRequest(Collections.emptyList(), Arrays.asList(
-            StatNames.SCRIPT_COMPILATIONS.getName(),
-            StatNames.SCRIPT_QUERY_REQUESTS.getName(),
-            StatNames.SCRIPT_QUERY_ERRORS.getName())
-            , KNNPlugin.LEGACY_KNN_BASE_URI);
+        Response response = executeKnnStatRequest(
+            Collections.emptyList(),
+            Arrays.asList(
+                StatNames.SCRIPT_COMPILATIONS.getName(),
+                StatNames.SCRIPT_QUERY_REQUESTS.getName(),
+                StatNames.SCRIPT_QUERY_ERRORS.getName()
+            ),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         List<Map<String, Object>> nodeStats = parseNodeStatsResponse(EntityUtils.toString(response.getEntity()));
         int initialScriptCompilations = (int) (nodeStats.get(0).get(StatNames.SCRIPT_COMPILATIONS.getName()));
         int initialScriptQueryRequests = (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_REQUESTS.getName()));
@@ -189,28 +203,28 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
 
         // Create an index with a single vector
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
-        Float[] vector = {6.0f, 6.0f};
+        Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
 
         // Check l2 query and script compilation stats
         QueryBuilder qb = new MatchAllQueryBuilder();
         Map<String, Object> params = new HashMap<>();
-        float[] queryVector = {1.0f, 1.0f};
+        float[] queryVector = { 1.0f, 1.0f };
         params.put("field", FIELD_NAME);
         params.put("query_value", queryVector);
         params.put("space_type", SpaceType.L2.getValue());
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
         response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
-            RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
-        response = executeKnnStatRequest(Collections.emptyList(), Arrays.asList(
-            StatNames.SCRIPT_COMPILATIONS.getName(),
-            StatNames.SCRIPT_QUERY_REQUESTS.getName()), KNNPlugin.LEGACY_KNN_BASE_URI);
+        response = executeKnnStatRequest(
+            Collections.emptyList(),
+            Arrays.asList(StatNames.SCRIPT_COMPILATIONS.getName(), StatNames.SCRIPT_QUERY_REQUESTS.getName()),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         nodeStats = parseNodeStatsResponse(EntityUtils.toString(response.getEntity()));
         assertEquals((int) (nodeStats.get(0).get(StatNames.SCRIPT_COMPILATIONS.getName())), initialScriptCompilations + 1);
-        assertEquals(initialScriptQueryRequests + 1,
-            (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_REQUESTS.getName())));
+        assertEquals(initialScriptQueryRequests + 1, (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_REQUESTS.getName())));
 
         // Check query error stats
         params = new HashMap<>();
@@ -221,11 +235,13 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         Request finalRequest = request;
         expectThrows(ResponseException.class, () -> client().performRequest(finalRequest));
 
-        response = executeKnnStatRequest(Collections.emptyList(), Collections.singletonList(
-            StatNames.SCRIPT_QUERY_ERRORS.getName()), KNNPlugin.LEGACY_KNN_BASE_URI);
+        response = executeKnnStatRequest(
+            Collections.emptyList(),
+            Collections.singletonList(StatNames.SCRIPT_QUERY_ERRORS.getName()),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         nodeStats = parseNodeStatsResponse(EntityUtils.toString(response.getEntity()));
-        assertEquals(initialScriptQueryErrors + 1,
-            (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_ERRORS.getName())));
+        assertEquals(initialScriptQueryErrors + 1, (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_ERRORS.getName())));
     }
 
     /**
@@ -235,24 +251,28 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         clearScriptCache();
 
         // Get initial stats
-        Response response = executeKnnStatRequest(Collections.emptyList(), Arrays.asList(
-            StatNames.SCRIPT_COMPILATIONS.getName(),
-            StatNames.SCRIPT_QUERY_REQUESTS.getName(),
-            StatNames.SCRIPT_QUERY_ERRORS.getName()), KNNPlugin.LEGACY_KNN_BASE_URI);
+        Response response = executeKnnStatRequest(
+            Collections.emptyList(),
+            Arrays.asList(
+                StatNames.SCRIPT_COMPILATIONS.getName(),
+                StatNames.SCRIPT_QUERY_REQUESTS.getName(),
+                StatNames.SCRIPT_QUERY_ERRORS.getName()
+            ),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         List<Map<String, Object>> nodeStats = parseNodeStatsResponse(EntityUtils.toString(response.getEntity()));
         int initialScriptCompilations = (int) (nodeStats.get(0).get(StatNames.SCRIPT_COMPILATIONS.getName()));
         int initialScriptQueryRequests = (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_REQUESTS.getName()));
         int initialScriptQueryErrors = (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_ERRORS.getName()));
 
         // Create an index with a single vector
-        createKnnIndex(INDEX_NAME, Settings.builder()
-                .put("number_of_shards", 2)
-                .put("number_of_replicas", 0)
-                .put("index.knn", true)
-                .build(),
-            createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(
+            INDEX_NAME,
+            Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 0).put("index.knn", true).build(),
+            createKnnIndexMapping(FIELD_NAME, 2)
+        );
 
-        Float[] vector = {6.0f, 6.0f};
+        Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
         addKnnDoc(INDEX_NAME, "2", FIELD_NAME, vector);
         addKnnDoc(INDEX_NAME, "3", FIELD_NAME, vector);
@@ -261,24 +281,24 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         // Check l2 query and script compilation stats
         QueryBuilder qb = new MatchAllQueryBuilder();
         Map<String, Object> params = new HashMap<>();
-        float[] queryVector = {1.0f, 1.0f};
+        float[] queryVector = { 1.0f, 1.0f };
         params.put("field", FIELD_NAME);
         params.put("query_value", queryVector);
         params.put("space_type", SpaceType.L2.getValue());
         Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
         response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK,
-            RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
-        response = executeKnnStatRequest(Collections.emptyList(), Arrays.asList(
-            StatNames.SCRIPT_COMPILATIONS.getName(),
-            StatNames.SCRIPT_QUERY_REQUESTS.getName()), KNNPlugin.LEGACY_KNN_BASE_URI);
+        response = executeKnnStatRequest(
+            Collections.emptyList(),
+            Arrays.asList(StatNames.SCRIPT_COMPILATIONS.getName(), StatNames.SCRIPT_QUERY_REQUESTS.getName()),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         nodeStats = parseNodeStatsResponse(EntityUtils.toString(response.getEntity()));
         assertEquals((int) (nodeStats.get(0).get(StatNames.SCRIPT_COMPILATIONS.getName())), initialScriptCompilations + 1);
-        //TODO fix the test case. For some reason request count is treated as 4.
+        // TODO fix the test case. For some reason request count is treated as 4.
         // https://github.com/opendistro-for-elasticsearch/k-NN/issues/272
-        assertEquals(initialScriptQueryRequests + 4,
-            (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_REQUESTS.getName())));
+        assertEquals(initialScriptQueryRequests + 4, (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_REQUESTS.getName())));
 
         // Check query error stats
         params = new HashMap<>();
@@ -289,20 +309,20 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         Request finalRequest = request;
         expectThrows(ResponseException.class, () -> client().performRequest(finalRequest));
 
-        response = executeKnnStatRequest(Collections.emptyList(), Collections.singletonList(
-            StatNames.SCRIPT_QUERY_ERRORS.getName()), KNNPlugin.LEGACY_KNN_BASE_URI);
+        response = executeKnnStatRequest(
+            Collections.emptyList(),
+            Collections.singletonList(StatNames.SCRIPT_QUERY_ERRORS.getName()),
+            KNNPlugin.LEGACY_KNN_BASE_URI
+        );
         nodeStats = parseNodeStatsResponse(EntityUtils.toString(response.getEntity()));
-        assertEquals(initialScriptQueryErrors + 2,
-            (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_ERRORS.getName())));
+        assertEquals(initialScriptQueryErrors + 2, (int) (nodeStats.get(0).get(StatNames.SCRIPT_QUERY_ERRORS.getName())));
     }
 
     // Useful settings when debugging to prevent timeouts
     @Override
     protected Settings restClientSettings() {
         if (isDebuggingTest || isDebuggingRemoteCluster) {
-            return Settings.builder()
-                .put(CLIENT_SOCKET_TIMEOUT, TimeValue.timeValueMinutes(10))
-                .build();
+            return Settings.builder().put(CLIENT_SOCKET_TIMEOUT, TimeValue.timeValueMinutes(10)).build();
         } else {
             return super.restClientSettings();
         }

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNWarmupHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNWarmupHandlerIT.java
@@ -55,7 +55,7 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
     public void testSingleIndex() throws IOException {
         int graphCountBefore = getTotalGraphsInCache();
         createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
-        addKnnDoc(testIndexName, "1", testFieldName, new Float[]{6.0f, 6.0f});
+        addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         executeWarmupRequest(Collections.singletonList(testIndexName), KNNPlugin.LEGACY_KNN_BASE_URI);
 
@@ -66,10 +66,10 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
         int graphCountBefore = getTotalGraphsInCache();
 
         createKnnIndex(testIndexName + "1", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
-        addKnnDoc(testIndexName + "1", "1", testFieldName, new Float[]{6.0f, 6.0f});
+        addKnnDoc(testIndexName + "1", "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         createKnnIndex(testIndexName + "2", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
-        addKnnDoc(testIndexName + "2", "1", testFieldName, new Float[]{6.0f, 6.0f});
+        addKnnDoc(testIndexName + "2", "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         executeWarmupRequest(Arrays.asList(testIndexName + "1", testIndexName + "2"), KNNPlugin.LEGACY_KNN_BASE_URI);
 


### PR DESCRIPTION
Signed-off-by: Naveen <navtat@amazon.com>

### Description
Get rid of rachet and apply spotless on every PR before raising it like in main branch. Making this change to fix the OS distribution build failure 

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':spotlessCheck'.
> Could not create task ':spotlessJavaCheck'.
   > Could not create task ':spotlessJava'.
      > No such reference 'origin/1.x'
```
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/647
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
