### PR TITLE
Update build script to build JNI lib and gradlew assemble

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,8 +102,8 @@ fi
 
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir
-# Gradle build is used here to replace gradle assemble due to build will also call cmake and make before generating jars
-./gradlew build --no-daemon --refresh-dependencies -x integTest -x test -x jacocoTestReport -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew buildJniLib
+./gradlew assemble --no-daemon --refresh-dependencies -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 # Add lib to zip
 zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)


### PR DESCRIPTION
Signed-off-by: Naveen <navtat@amazon.com>

### Description
Update build script to build JNI libraries separately and then do gradle assemble instead of gradle build
 
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
