### PR TITLE
Allow mapping service to be null for scenarios of shard recovery from translog

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
@@ -56,7 +56,7 @@ public enum KNNCodecVersion {
         ),
         (userCodec, mapperService) -> KNN920Codec.builder()
             .delegate(userCodec)
-            .knnVectorsFormat(new KNN920PerFieldKnnVectorsFormat(Optional.of(mapperService)))
+            .knnVectorsFormat(new KNN920PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService)))
             .build(),
         KNN920Codec::new
     ),
@@ -71,7 +71,7 @@ public enum KNNCodecVersion {
         ),
         (userCodec, mapperService) -> KNN940Codec.builder()
             .delegate(userCodec)
-            .knnVectorsFormat(new KNN940PerFieldKnnVectorsFormat(Optional.of(mapperService)))
+            .knnVectorsFormat(new KNN940PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService)))
             .build(),
         KNN940Codec::new
     );

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecServiceTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecServiceTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.Index;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.codec.CodecServiceConfig;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.KNNTestCase;
+
+import org.apache.logging.log4j.Logger;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for KNNCodecService class with focus on codec by name lookup
+ */
+public class KNNCodecServiceTests extends KNNTestCase {
+    private static final String TEST_INDEX = "test-index";
+    private static final int NUM_OF_SHARDS = 1;
+    private static final UUID INDEX_UUID = UUID.randomUUID();
+
+    private IndexSettings indexSettings;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.getIndex()).thenReturn(new Index(TEST_INDEX, INDEX_UUID.toString()));
+        when(indexMetadata.getSettings()).thenReturn(Settings.EMPTY);
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, Integer.toString(NUM_OF_SHARDS)).build();
+        indexSettings = new IndexSettings(indexMetadata, settings);
+    }
+
+    public void testGetCodecByName() {
+        MapperService mapperService = mock(MapperService.class);
+        Logger loggerMock = mock(Logger.class);
+        CodecServiceConfig codecServiceConfig = new CodecServiceConfig(indexSettings, mapperService, loggerMock);
+        KNNCodecService knnCodecService = new KNNCodecService(codecServiceConfig);
+        Codec codec = knnCodecService.codec(KNNCodecVersion.current().getCodecName());
+        assertNotNull(codec);
+    }
+
+    /**
+     * This test case covers scenarios when MapperService is null, for instance this may happen during index.close operation.
+     * In such scenario codec is not really required but is created as part of engine initialization, please check code references below:
+     * @see <a href="https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/EngineConfig.java#L378">EngineConfig.java</a>
+     * @see <a href="https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/shard/IndexShard.java#L3315">IndexShard.java</a>
+     * @see <a href="https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/Engine.java#L906">Engine.java</a>
+     */
+    public void testGetCodecByNameWithNoMapperService() {
+        Logger loggerMock = mock(Logger.class);
+        CodecServiceConfig codecServiceConfig = new CodecServiceConfig(indexSettings, null, loggerMock);
+        KNNCodecService knnCodecService = new KNNCodecService(codecServiceConfig);
+        Codec codec = knnCodecService.codec(KNNCodecVersion.current().getCodecName());
+        assertNotNull(codec);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
In certain scenarios codec can be initialized as part of recovery process for shard (e.g. index close and open operations). In such cases mapperService can be passed as null, but currently this causes NPE exception on kNN side with below stacktrace. It's ok to allow null value as codec is not actually required and is initialized just to create new engine and read segment information. In addition to that we do have another check for null references in [kNN code](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java#L45-L47) 
 
```
[WARN ][o.o.i.c.IndicesClusterStateService] [integTest-0] [target_index][5] marking and sending shard failed due to [failed recovery]
org.opensearch.indices.recovery.RecoveryFailedException: [target_index][5]: Recovery failed on {integTest-0}{eHellPqISveDSsP3t1W3kw}{V5PeDGWOQK-xl0mUnKEnuQ}{127.0.0.1}{127.0.0.1:9300}{dimr}{testattr=test, shard_indexing_pressure_enabled=true}
        at org.opensearch.index.shard.IndexShard.lambda$executeRecovery$25(IndexShard.java:3181) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.ActionListener$1.onFailure(ActionListener.java:88) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.lambda$recoveryListener$7(StoreRecovery.java:436) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.ActionListener$1.onFailure(ActionListener.java:88) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.ActionListener.completeWith(ActionListener.java:345) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.recoverFromStore(StoreRecovery.java:111) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.recoverFromStore(IndexShard.java:2303) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:88) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:806) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: org.opensearch.index.shard.IndexShardRecoveryException: failed recovery
        ... 11 more
Caused by: java.lang.NullPointerException
        at java.util.Objects.requireNonNull(Objects.java:208) ~[?:?]
        at java.util.Optional.of(Optional.java:113) ~[?:?]
        at org.opensearch.knn.index.codec.KNNCodecVersion.lambda$static$5(KNNCodecVersion.java:74) ~[?:?]
        at org.opensearch.knn.index.codec.KNNCodecService.codec(KNNCodecService.java:33) ~[?:?]
        at org.opensearch.index.engine.EngineConfig.getCodec(EngineConfig.java:378) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.Engine.getSegmentFileSizes(Engine.java:916) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.Engine.fillSegmentStats(Engine.java:906) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.NoOpEngine.<init>(NoOpEngine.java:82) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.innerOpenEngineAndTranslog(IndexShard.java:2036) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.openEngineAndRecoverFromTranslog(IndexShard.java:1999) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.internalRecoverFromStore(StoreRecovery.java:584) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.lambda$recoverFromStore$0(StoreRecovery.java:113) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.ActionListener.completeWith(ActionListener.java:342) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
```

Issue can be replicated with following steps:
- create index with knn field
- ingest some vector data
- call `POST /index/close`

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
