### PR TITLE
Making version of lucene k-nn engine match lucene current version

### DIFF
--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -44,7 +44,7 @@ public class Lucene extends JVMLibrary {
         ).addSpaces(SpaceType.L2, SpaceType.COSINESIMIL).build()
     );
 
-    final static Lucene INSTANCE = new Lucene(METHODS, Version.LUCENE_9_2_0.toString());
+    final static Lucene INSTANCE = new Lucene(METHODS, Version.LATEST.toString());
 
     /**
      * Constructor

--- a/src/test/java/org/opensearch/knn/index/util/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/KNNEngineTests.java
@@ -14,6 +14,8 @@ public class KNNEngineTests extends KNNTestCase {
      */
     public void testDelegateLibraryFunctions() {
         assertEquals(Nmslib.INSTANCE.getVersion(), KNNEngine.NMSLIB.getVersion());
+        assertEquals(Faiss.INSTANCE.getVersion(), KNNEngine.FAISS.getVersion());
+        assertEquals(Lucene.INSTANCE.getVersion(), KNNEngine.LUCENE.getVersion());
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
@@ -108,4 +108,9 @@ public class LuceneTests extends KNNTestCase {
         luceneLibrary.setInitialized(true);
         assertTrue(luceneLibrary.isInitialized());
     }
+
+    public void testVersion() {
+        Lucene luceneInstance = Lucene.INSTANCE;
+        assertEquals("9.5.0", luceneInstance.getVersion());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.util;
 
+import org.apache.lucene.util.Version;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNTestCase;
@@ -111,6 +112,6 @@ public class LuceneTests extends KNNTestCase {
 
     public void testVersion() {
         Lucene luceneInstance = Lucene.INSTANCE;
-        assertEquals("9.5.0", luceneInstance.getVersion());
+        assertEquals(Version.LATEST.toString(), luceneInstance.getVersion());
     }
 }


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Update version of Lucene kNN engine, it matches version of Lucene that is coming with core OpenSearch. Currently it's used as engine text description, it shouldn't cause bwc issues. 
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
