### PR TITLE
Adding integ test for index close/open scenario

### DIFF
--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -346,7 +346,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         }
 
         final float[] searchVector = TEST_QUERY_VECTORS[0];
-        int k = 1;
+        final int k = 1;
 
         validateQueryResultsQty(searchVector, k);
 
@@ -427,11 +427,12 @@ public class LuceneEngineIT extends KNNRestTestCase {
         }
     }
 
-    private void validateQueryResultsQty(float[] searchVector, int k) throws Exception {
-        final Response response = searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, searchVector, k), k);
+    private void validateQueryResultsQty(final float[] searchVector, final int k) throws Exception {
+        final String responseBody = EntityUtils.toString(
+            searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, searchVector, k), k).getEntity()
+        );
+        final List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
 
-        String responseBody = EntityUtils.toString(response.getEntity());
-        List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
         assertEquals(k, knnResults.size());
     }
 }


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding integ test for scenario with index close/open, closing gap in https://github.com/opensearch-project/k-NN/pull/685. In short, for lucene based index with data, index close call caused exception and index became inoperable. 

 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
