### PR TITLE
[Backport 2.x] Adding integ test for index close/open scenario

### DIFF
--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Floats;
 import org.apache.http.util.EntityUtils;
+import org.apache.commons.lang.math.RandomUtils;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.junit.After;
 import org.opensearch.client.Request;
@@ -338,6 +339,28 @@ public class LuceneEngineIT extends KNNRestTestCase {
         );
     }
 
+    public void testIndexReopening() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(DIMENSION, SpaceType.L2);
+
+        for (int j = 0; j < TEST_INDEX_VECTORS.length; j++) {
+            addKnnDoc(INDEX_NAME, Integer.toString(j + 1), FIELD_NAME, TEST_INDEX_VECTORS[j]);
+        }
+
+        final float[] searchVector = TEST_QUERY_VECTORS[0];
+        final int k = 1 + RandomUtils.nextInt(TEST_INDEX_VECTORS.length);
+
+        final List<Float[]> knnResultsBeforeIndexClosure = queryResults(searchVector, k);
+
+        closeIndex(INDEX_NAME);
+        openIndex(INDEX_NAME);
+
+        ensureGreen(INDEX_NAME);
+
+        final List<Float[]> knnResultsAfterIndexClosure = queryResults(searchVector, k);
+
+        assertArrayEquals(knnResultsBeforeIndexClosure.toArray(), knnResultsAfterIndexClosure.toArray());
+    }
+
     private void addKnnDocWithAttributes(String docId, float[] vector, Map<String, String> fieldValues) throws IOException {
         Request request = new Request("POST", "/" + INDEX_NAME + "/_doc/" + docId + "?refresh=true");
 
@@ -405,5 +428,14 @@ public class LuceneEngineIT extends KNNRestTestCase {
                 assertEquals(KNNEngine.LUCENE.score(rawScore, spaceType), actualScores.get(j), 0.0001);
             }
         }
+    }
+
+    private List<Float[]> queryResults(final float[] searchVector, final int k) throws Exception {
+        final String responseBody = EntityUtils.toString(
+            searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, searchVector, k), k).getEntity()
+        );
+        final List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
+        assertNotNull(knnResults);
+        return knnResults.stream().map(KNNResult::getVector).collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
* Adding integ test for index close/open scenario

Backport https://github.com/opensearch-project/k-NN/pull/693

Signed-off-by: Martin Gaievski <gaievski@amazon.com>
(cherry picked from commit https://github.com/opensearch-project/k-NN/commit/54a433ee3681a2f48acee5c1aacf9a3058f85641)

