### PR TITLE
Update tests for backwards codecs

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
@@ -24,11 +24,7 @@ public class KNN940CodecTests extends KNNCodecTestCase {
 
     // Ensure that the codec is able to return the correct per field knn vectors format for codec
     public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
-        final Codec codec = KNN940Codec.builder()
-            .delegate(V_9_4_0.getDefaultCodecDelegate())
-            .knnVectorsFormat(V_9_4_0.getPerFieldKnnVectorsFormat())
-            .build();
-
+        final Codec codec = new KNN940Codec();
         assertTrue(codec.knnVectorsFormat() instanceof KNN940PerFieldKnnVectorsFormat);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
@@ -6,13 +6,9 @@
 package org.opensearch.knn.index.codec.KNN940Codec;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_4_0;
 
@@ -26,15 +22,13 @@ public class KNN940CodecTests extends KNNCodecTestCase {
         testBuildFromModelTemplate((KNN940Codec.builder().delegate(V_9_4_0.getDefaultCodecDelegate()).build()));
     }
 
-    public void testKnnVectorIndex() throws Exception {
-        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
-            mapperService) -> new KNN940PerFieldKnnVectorsFormat(Optional.of(mapperService));
-
-        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN940Codec.builder()
+    // Ensure that the codec is able to return the correct per field knn vectors format for codec
+    public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
+        final Codec codec = KNN940Codec.builder()
             .delegate(V_9_4_0.getDefaultCodecDelegate())
-            .knnVectorsFormat(knnVectorFormat)
+            .knnVectorsFormat(V_9_4_0.getPerFieldKnnVectorsFormat())
             .build();
 
-        testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+        assertTrue(codec.knnVectorsFormat() instanceof KNN940PerFieldKnnVectorsFormat);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
@@ -9,14 +9,11 @@ import lombok.SneakyThrows;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
-import org.opensearch.knn.index.codec.KNN940Codec.KNN940PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
 
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_4_0;
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_5_0;
 
 public class KNN950CodecTests extends KNNCodecTestCase {
@@ -33,12 +30,8 @@ public class KNN950CodecTests extends KNNCodecTestCase {
 
     // Ensure that the codec is able to return the correct per field knn vectors format for codec
     public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
-        final Codec codec = KNN940Codec.builder()
-            .delegate(V_9_4_0.getDefaultCodecDelegate())
-            .knnVectorsFormat(V_9_4_0.getPerFieldKnnVectorsFormat())
-            .build();
-
-        assertTrue(codec.knnVectorsFormat() instanceof KNN940PerFieldKnnVectorsFormat);
+        final Codec codec = new KNN950Codec();
+        assertTrue(codec.knnVectorsFormat() instanceof KNN950PerFieldKnnVectorsFormat);
     }
 
     // IMPORTANT: When this Codec is moved to a backwards Codec, this test needs to be removed, because it attempts to

--- a/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
@@ -9,11 +9,14 @@ import lombok.SneakyThrows;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
+import org.opensearch.knn.index.codec.KNN940Codec.KNN940PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
 
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_4_0;
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_5_0;
 
 public class KNN950CodecTests extends KNNCodecTestCase {
@@ -28,6 +31,18 @@ public class KNN950CodecTests extends KNNCodecTestCase {
         testBuildFromModelTemplate((KNN950Codec.builder().delegate(V_9_5_0.getDefaultCodecDelegate()).build()));
     }
 
+    // Ensure that the codec is able to return the correct per field knn vectors format for codec
+    public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
+        final Codec codec = KNN940Codec.builder()
+            .delegate(V_9_4_0.getDefaultCodecDelegate())
+            .knnVectorsFormat(V_9_4_0.getPerFieldKnnVectorsFormat())
+            .build();
+
+        assertTrue(codec.knnVectorsFormat() instanceof KNN940PerFieldKnnVectorsFormat);
+    }
+
+    // IMPORTANT: When this Codec is moved to a backwards Codec, this test needs to be removed, because it attempts to
+    // write with a read only codec, which will fail
     @SneakyThrows
     public void testKnnVectorIndex() {
         Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (


### PR DESCRIPTION
### Description
Updates tests for backwards codecs to prevent backwards codecs from writing with a read only codec.

Right now, testKnnVectorIndex requires that the Hnsw Lucene Format have the capability to write. For backwards codecs, however, they are not able to write (see https://github.com/apache/lucene/blob/main/lucene/backward-codecs/src/java/org/apache/lucene/backward_codecs/lucene94/Lucene94HnswVectorsFormat.java#L150). 

To resolve this, we are removing the "testKnnVectorIndex" from backwards compatibility tests. For reading/writing backwards compatibility testing, we will rely on Lucene, where tests can be found in https://github.com/apache/lucene/tree/main/lucene/backward-codecs/src/test/org/apache/lucene/backward_codecs/lucene94.

It adds a test that checks that our custom format is correctly overriden.

### Issues Resolved
https://build.ci.opensearch.org/job/distribution-build-opensearch/6804/ 

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
