### PR TITLE
Add Lucene specific file extensions to core HybridFS 

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.5.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.5.0.0.md
@@ -5,6 +5,7 @@ Compatible with OpenSearch 2.5.0
 ### Enhancements
 
 * Extend SystemIndexPlugin for k-NN model system index ([#630](https://github.com/opensearch-project/k-NN/pull/630))
+* Add Lucene specific file extensions to core HybridFS ([#721](https://github.com/opensearch-project/k-NN/pull/721))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -12,6 +12,7 @@ import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.SpaceType;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -175,5 +176,10 @@ public enum KNNEngine implements KNNLibrary {
     @Override
     public void setInitialized(Boolean isInitialized) {
         knnLibrary.setInitialized(isInitialized);
+    }
+
+    @Override
+    public List<String> mmapFileExtensions() {
+        return knnLibrary.mmapFileExtensions();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -16,6 +16,8 @@ import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.SpaceType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -113,4 +115,13 @@ public interface KNNLibrary {
      * @param isInitialized whether library has been initialized
      */
     void setInitialized(Boolean isInitialized);
+
+    /**
+     * Getter for mmap file extensions
+     *
+     * @return list of file extensions that will be read/write with mmap
+     */
+    default List<String> mmapFileExtensions() {
+        return Collections.EMPTY_LIST;
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -77,6 +77,6 @@ public class Lucene extends JVMLibrary {
 
     @Override
     public List<String> mmapFileExtensions() {
-        return List.of("vec", "vem");
+        return List.of("vec", "vex");
     }
 }

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -13,6 +13,7 @@ import org.opensearch.knn.index.MethodComponent;
 import org.opensearch.knn.index.Parameter;
 import org.opensearch.knn.index.SpaceType;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -72,5 +73,10 @@ public class Lucene extends JVMLibrary {
         // actually invert the distance score so that a higher number is a better score. So, we can just return the
         // score provided.
         return rawScore;
+    }
+
+    @Override
+    public List<String> mmapFileExtensions() {
+        return List.of("vec", "vem");
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.codec.KNNCodecService;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
+import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelGraveyard;
 import org.opensearch.knn.indices.ModelCache;
 import org.opensearch.knn.indices.ModelDao;
@@ -104,6 +105,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.knn.common.KNNConstants.KNN_THREAD_POOL_PREFIX;
@@ -337,5 +340,17 @@ public class KNNPlugin extends Plugin
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
         return ImmutableList.of(new SystemIndexDescriptor(MODEL_INDEX_NAME, "Index for storing models used for k-NN indices"));
+    }
+
+    @Override
+    public Settings additionalSettings() {
+        final List<String> engineSettings = Arrays.stream(KNNEngine.values())
+            .flatMap(engine -> engine.mmapFileExtensions().stream())
+            .collect(Collectors.toList());
+        final List<String> combinedSettings = Stream.concat(
+            IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getDefault(Settings.EMPTY).stream(),
+            engineSettings.stream()
+        ).collect(Collectors.toList());
+        return Settings.builder().putList(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getKey(), combinedSettings).build();
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -342,8 +342,17 @@ public class KNNPlugin extends Plugin
         return ImmutableList.of(new SystemIndexDescriptor(MODEL_INDEX_NAME, "Index for storing models used for k-NN indices"));
     }
 
+    /**
+     * Plugin can provide additional node settings, that includes new settings or overrides for existing one from core.
+     *
+     * @return settings that are set by plugin
+     */
     @Override
     public Settings additionalSettings() {
+        // We add engine specific extensions to the core list for HybridFS store type. We read existing values
+        // and append ours because in core setting will be replaced by override.
+        // Values are set as cluster defaults and are used at index creation time. Index specific overrides will take priority over values
+        // that are set here.
         final List<String> engineSettings = Arrays.stream(KNNEngine.values())
             .flatMap(engine -> engine.mmapFileExtensions().stream())
             .collect(Collectors.toList());

--- a/src/test/java/org/opensearch/knn/index/util/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/KNNEngineTests.java
@@ -57,7 +57,7 @@ public class KNNEngineTests extends KNNTestCase {
             .flatMap(engine -> engine.mmapFileExtensions().stream())
             .collect(Collectors.toList());
         assertNotNull(mmapExtensions);
-        final List<String> expectedSettings = List.of("vem", "vec");
+        final List<String> expectedSettings = List.of("vex", "vec");
         assertTrue(expectedSettings.containsAll(mmapExtensions));
         assertTrue(mmapExtensions.containsAll(expectedSettings));
     }

--- a/src/test/java/org/opensearch/knn/index/util/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/KNNEngineTests.java
@@ -8,6 +8,10 @@ package org.opensearch.knn.index.util;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class KNNEngineTests extends KNNTestCase {
     /**
      * Check that version from engine and library match
@@ -46,5 +50,15 @@ public class KNNEngineTests extends KNNTestCase {
 
         String invalidPath = "test.invalid";
         expectThrows(IllegalArgumentException.class, () -> KNNEngine.getEngineNameFromPath(invalidPath));
+    }
+
+    public void testMmapFileExtensions() {
+        final List<String> mmapExtensions = Arrays.stream(KNNEngine.values())
+            .flatMap(engine -> engine.mmapFileExtensions().stream())
+            .collect(Collectors.toList());
+        assertNotNull(mmapExtensions);
+        final List<String> expectedSettings = List.of("vem", "vec");
+        assertTrue(expectedSettings.containsAll(mmapExtensions));
+        assertTrue(mmapExtensions.containsAll(expectedSettings));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
@@ -15,6 +15,7 @@ import org.opensearch.knn.index.SpaceType;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -113,5 +114,13 @@ public class LuceneTests extends KNNTestCase {
     public void testVersion() {
         Lucene luceneInstance = Lucene.INSTANCE;
         assertEquals(Version.LATEST.toString(), luceneInstance.getVersion());
+    }
+
+    public void testMmapFileExtensions() {
+        final List<String> luceneMmapExtensions = Lucene.INSTANCE.mmapFileExtensions();
+        assertNotNull(luceneMmapExtensions);
+        final List<String> expectedSettings = List.of("vem", "vec");
+        assertTrue(expectedSettings.containsAll(luceneMmapExtensions));
+        assertTrue(luceneMmapExtensions.containsAll(expectedSettings));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
@@ -119,7 +119,7 @@ public class LuceneTests extends KNNTestCase {
     public void testMmapFileExtensions() {
         final List<String> luceneMmapExtensions = Lucene.INSTANCE.mmapFileExtensions();
         assertNotNull(luceneMmapExtensions);
-        final List<String> expectedSettings = List.of("vem", "vec");
+        final List<String> expectedSettings = List.of("vex", "vec");
         assertTrue(expectedSettings.containsAll(luceneMmapExtensions));
         assertTrue(luceneMmapExtensions.containsAll(expectedSettings));
     }


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
We're including file extensions for vector value files from Lucene 9.4 to the list of extensions that Core OpenSearch will use with HybridFS store type and MMap file I/O. This increases performance for both data ingestion and queries for p99. Setting is abstracted at engine level with specific implementation for Lucene. Setting is set at cluster defaults level, index specific overrides will take priority over it.  

Tested locally on 1M dataset

Before change (baseline):
data ingestion
```
  "results": {
    "test_took": 2706990.31884,
    "create_index_took_total": 2702.2581160000004,
    "ingest_took_total": 513438.04862599995,
    "refresh_index_store_kb_total": 2810943.876953125,
    "refresh_index_took_total": 641.9670379999616,
    "force_merge_took_total": 2190208.04506
  }
```
query
```
  "results": {
    "test_took": 347624.7275845,
    "clear_cache_took_total": 22.227584499987294,
    "query_took_total": 347602.5,
    "query_took_p50": 32.5,
    "query_took_p90": 45.5,
    "query_took_p99": 83.0,
    "query_memory_kb_total": 0.0,
    "query_recall@K_total": 0.991061,
    "query_recall@1_total": 1.0
  }
```

With the change
data ingestion
```
  "results": {
    "test_took": 748055.190353,
    "create_index_took_total": 2722.189422,
    "ingest_took_total": 535081.281891,
    "refresh_index_store_kb_total": 2814413.49609375,
    "refresh_index_took_total": 1110.5574829999796,
    "force_merge_took_total": 209141.16155700004
  }
```
query
```
  "results": {
    "test_took": 111353.221852,
    "clear_cache_took_total": 110.22185199999768,
    "query_took_total": 111243.0,
    "query_took_p50": 9.5,
    "query_took_p90": 16.0,
    "query_took_p99": 28.5,
    "query_memory_kb_total": 0.0,
    "query_recall@K_total": 0.990751,
    "query_recall@1_total": 1.0
  }
```
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/637
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
