### PR TITLE
Remove latestSettings cache from KNNSettings

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -24,12 +24,12 @@ import org.opensearch.monitor.jvm.JvmInfo;
 import org.opensearch.monitor.os.OsProbe;
 
 import java.security.InvalidParameterException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,16 +41,15 @@ import static org.opensearch.common.unit.MemorySizeValue.parseBytesSizeValueOrHe
 
 /**
  * This class defines
- * 1. KNN settings to hold the HNSW algorithm parameters.
- * https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md
+ * 1. KNN settings to hold the <a href="https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md">HNSW algorithm parameters</a>.
  * 2. KNN settings to enable/disable plugin, circuit breaker settings
  * 3. KNN settings to manage graphs loaded in native memory
  */
 public class KNNSettings {
 
-    private static Logger logger = LogManager.getLogger(KNNSettings.class);
+    private static final Logger logger = LogManager.getLogger(KNNSettings.class);
     private static KNNSettings INSTANCE;
-    private static OsProbe osProbe = OsProbe.getInstance();
+    private static final OsProbe osProbe = OsProbe.getInstance();
 
     private static final int INDEX_THREAD_QTY_MAX = 32;
 
@@ -85,6 +84,7 @@ public class KNNSettings {
     public static final Integer KNN_DEFAULT_CIRCUIT_BREAKER_UNSET_PERCENTAGE = 75;
     public static final Integer KNN_DEFAULT_MODEL_CACHE_SIZE_LIMIT_PERCENTAGE = 10; // By default, set aside 10% of the JVM for the limit
     public static final Integer KNN_MAX_MODEL_CACHE_SIZE_LIMIT_PERCENTAGE = 25; // Model cache limit cannot exceed 25% of the JVM heap
+    public static final String KNN_DEFAULT_MEMORY_CIRCUIT_BREAKER_LIMIT = "50%";
 
     /**
      * Settings Definition
@@ -233,7 +233,13 @@ public class KNNSettings {
             put(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, Setting.boolSetting(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, true, NodeScope, Dynamic));
             put(
                 KNN_MEMORY_CIRCUIT_BREAKER_LIMIT,
-                knnMemoryCircuitBreakerSetting(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT, "50%", NodeScope, Dynamic)
+                new Setting<>(
+                    KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT,
+                    KNNSettings.KNN_DEFAULT_MEMORY_CIRCUIT_BREAKER_LIMIT,
+                    (s) -> parseknnMemoryCircuitBreakerValue(s, KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT),
+                    NodeScope,
+                    Dynamic
+                )
             );
 
             /**
@@ -247,9 +253,6 @@ public class KNNSettings {
         }
     };
 
-    /** Latest setting value for each registered key. Thread-safe is required. */
-    private final Map<String, Object> latestSettings = new ConcurrentHashMap<>();
-
     private ClusterService clusterService;
     private Client client;
 
@@ -262,35 +265,33 @@ public class KNNSettings {
         return INSTANCE;
     }
 
-    public void setSettingsUpdateConsumers() {
-        for (Setting<?> setting : dynamicCacheSettings.values()) {
-            clusterService.getClusterSettings().addSettingsUpdateConsumer(setting, newVal -> {
-                logger.debug("The value of setting [{}] changed to [{}]", setting.getKey(), newVal);
-                latestSettings.put(setting.getKey(), newVal);
+    private void setSettingsUpdateConsumers() {
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(updatedSettings -> {
+            // When any of the dynamic settings are updated, rebuild the cache with the updated values. Use the current
+            // cluster settings values as defaults.
+            boolean isCircuitBreakerEnabled = updatedSettings.getAsBoolean(
+                KNN_MEMORY_CIRCUIT_BREAKER_ENABLED,
+                getSettingValue(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED)
+            );
 
-                // Rebuild the cache with updated limit
-                NativeMemoryCacheManager.getInstance().rebuildCache();
-            });
-        }
+            ByteSizeValue maxCacheWeight = getSettingValue(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT);
+            if (updatedSettings.hasValue(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)) {
+                maxCacheWeight = (ByteSizeValue) getSetting(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT).get(updatedSettings);
+            }
 
-        /**
-         * We do not have to rebuild the cache for below settings
-         */
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                KNN_CIRCUIT_BREAKER_TRIGGERED_SETTING,
-                newVal -> { latestSettings.put(KNN_CIRCUIT_BREAKER_TRIGGERED, newVal); }
+            boolean isCacheExpiryEnabled = updatedSettings.getAsBoolean(
+                KNN_CACHE_ITEM_EXPIRY_ENABLED,
+                getSettingValue(KNN_CACHE_ITEM_EXPIRY_ENABLED)
             );
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                KNN_CIRCUIT_BREAKER_UNSET_PERCENTAGE_SETTING,
-                newVal -> { latestSettings.put(KNN_CIRCUIT_BREAKER_UNSET_PERCENTAGE, newVal); }
-            );
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING,
-                newVal -> { latestSettings.put(KNN_ALGO_PARAM_INDEX_THREAD_QTY, newVal); }
-            );
+
+            long expiryTimeInMinutes = updatedSettings.getAsTime(
+                KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES,
+                getSettingValue(KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES)
+            ).getMinutes();
+
+            NativeMemoryCacheManager.getInstance()
+                .rebuildCache(isCircuitBreakerEnabled, maxCacheWeight.getKb(), isCacheExpiryEnabled, expiryTimeInMinutes);
+        }, new ArrayList<>(dynamicCacheSettings.values()));
     }
 
     /**
@@ -302,10 +303,10 @@ public class KNNSettings {
      */
     @SuppressWarnings("unchecked")
     public <T> T getSettingValue(String key) {
-        return (T) latestSettings.getOrDefault(key, getSetting(key).getDefault(Settings.EMPTY));
+        return (T) clusterService.getClusterSettings().get(getSetting(key));
     }
 
-    public Setting<?> getSetting(String key) {
+    private Setting<?> getSetting(String key) {
         if (dynamicCacheSettings.containsKey(key)) {
             return dynamicCacheSettings.get(key);
         }
@@ -362,19 +363,6 @@ public class KNNSettings {
         this.client = client;
         this.clusterService = clusterService;
         setSettingsUpdateConsumers();
-    }
-
-    /**
-     * Creates a setting which specifies a circuit breaker memory limit. This can either be
-     * specified as an absolute bytes value or as a percentage.
-     *
-     * @param key the key for the setting
-     * @param defaultValue the default value for this setting
-     * @param properties properties properties for this setting like scope, filtering...
-     * @return the setting object
-     */
-    public static Setting<ByteSizeValue> knnMemoryCircuitBreakerSetting(String key, String defaultValue, Setting.Property... properties) {
-        return new Setting<>(key, defaultValue, (s) -> parseknnMemoryCircuitBreakerValue(s, key), properties);
     }
 
     public static ByteSizeValue parseknnMemoryCircuitBreakerValue(String sValue, String settingName) {
@@ -436,24 +424,11 @@ public class KNNSettings {
      * @return efSearch value
      */
     public static int getEfSearchParam(String index) {
-        return getIndexSettingValue(index, KNN_ALGO_PARAM_EF_SEARCH, 512);
-    }
-
-    /**
-     *
-     * @param index Name of the index
-     * @return spaceType name in KNN plugin
-     */
-    public static String getSpaceType(String index) {
         return KNNSettings.state().clusterService.state()
             .getMetadata()
             .index(index)
             .getSettings()
-            .get(KNN_SPACE_TYPE, SpaceType.DEFAULT.getValue());
-    }
-
-    public static int getIndexSettingValue(String index, String settingName, int defaultValue) {
-        return KNNSettings.state().clusterService.state().getMetadata().index(index).getSettings().getAsInt(settingName, defaultValue);
+            .getAsInt(KNNSettings.KNN_ALGO_PARAM_EF_SEARCH, 512);
     }
 
     public void setClusterService(ClusterService clusterService) {
@@ -475,7 +450,6 @@ public class KNNSettings {
     public void onIndexModule(IndexModule module) {
         module.addSettingsUpdateConsumer(INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING, newVal -> {
             logger.debug("The value of [KNN] setting [{}] changed to [{}]", KNN_ALGO_PARAM_EF_SEARCH, newVal);
-            latestSettings.put(KNN_ALGO_PARAM_EF_SEARCH, newVal);
             // TODO: replace cache-rebuild with index reload into the cache
             NativeMemoryCacheManager.getInstance().rebuildCache();
         });

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerDto.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerDto.java
@@ -6,13 +6,13 @@
 package org.opensearch.knn.index.memory;
 
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Value;
 
-@Getter
+@Value
 @Builder
 public class NativeMemoryCacheManagerDto {
-    private final boolean isWeightLimited;
-    private final long maxWeight;
-    private final boolean isExpirationLimited;
-    private final long expiryTimeInMin;
+    boolean isWeightLimited;
+    long maxWeight;
+    boolean isExpirationLimited;
+    long expiryTimeInMin;
 }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerDto.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerDto.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.memory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NativeMemoryCacheManagerDto {
+    private final boolean isWeightLimited;
+    private final long maxWeight;
+    private final boolean isExpirationLimited;
+    private final long expiryTimeInMin;
+}

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -5,6 +5,11 @@
 
 package org.opensearch.knn;
 
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 import org.opensearch.common.bytes.BytesReference;
@@ -12,7 +17,13 @@ import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Base class for integration tests for KNN plugin. Contains several methods for testing KNN ES functionality.
@@ -29,6 +40,18 @@ public class KNNTestCase extends OpenSearchTestCase {
         for (KNNCounter knnCounter : KNNCounter.values()) {
             knnCounter.set(0L);
         }
+
+        ClusterService clusterService = mock(ClusterService.class);
+        Set<Setting<?>> defaultClusterSettings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        defaultClusterSettings.addAll(
+            KNNSettings.state()
+                .getSettings()
+                .stream()
+                .filter(s -> s.getProperties().contains(Setting.Property.NodeScope))
+                .collect(Collectors.toList())
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(Settings.EMPTY, defaultClusterSettings));
+        KNNSettings.state().setClusterService(clusterService);
 
         // Clean up the cache
         NativeMemoryCacheManager.getInstance().invalidateAll();

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn;
 
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
@@ -22,26 +24,36 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * Base class for integration tests for KNN plugin. Contains several methods for testing KNN ES functionality.
  */
 public class KNNTestCase extends OpenSearchTestCase {
+
+    @Mock
+    protected ClusterService clusterService;
+    private AutoCloseable openMocks;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        openMocks = MockitoAnnotations.openMocks(this);
+    }
+
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
         resetState();
+        openMocks.close();
     }
 
-    public static void resetState() {
+    public void resetState() {
         // Reset all of the counters
         for (KNNCounter knnCounter : KNNCounter.values()) {
             knnCounter.set(0L);
         }
 
-        ClusterService clusterService = mock(ClusterService.class);
         Set<Setting<?>> defaultClusterSettings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         defaultClusterSettings.addAll(
             KNNSettings.state()

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.knn.index;

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -45,7 +45,7 @@ public class KNNSettingsTests extends KNNTestCase {
         long actualKNNCircuitBreakerLimit = ((ByteSizeValue) KNNSettings.state()
             .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
         mockNode.close();
-        assertEquals(actualKNNCircuitBreakerLimit, expectedKNNCircuitBreakerLimit);
+        assertEquals(expectedKNNCircuitBreakerLimit, actualKNNCircuitBreakerLimit);
     }
 
     @SneakyThrows
@@ -58,9 +58,10 @@ public class KNNSettingsTests extends KNNTestCase {
             .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
         mockNode.close();
         assertEquals(
-            actualKNNCircuitBreakerLimit,
             ((ByteSizeValue) KNNSettings.dynamicCacheSettings.get(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT).getDefault(Settings.EMPTY))
-                .getKb()
+                .getKb(),
+            actualKNNCircuitBreakerLimit
+
         );
     }
 

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import lombok.SneakyThrows;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.network.NetworkModule;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.ByteSizeValue;
+import org.opensearch.env.Environment;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.plugin.KNNPlugin;
+import org.opensearch.node.MockNode;
+import org.opensearch.node.Node;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.test.InternalTestCluster;
+import org.opensearch.test.MockHttpTransport;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.test.NodeRoles.dataNode;
+
+public class KNNSettingsTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testGetSettingValueFromConfig() {
+        long expectedKNNCircuitBreakerLimit = 13;
+        Node mockNode = createMockNode(
+            Map.of(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT, "\"" + expectedKNNCircuitBreakerLimit + "kb\"")
+        );
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        long actualKNNCircuitBreakerLimit = ((ByteSizeValue) KNNSettings.state()
+            .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
+        mockNode.close();
+        assertEquals(actualKNNCircuitBreakerLimit, expectedKNNCircuitBreakerLimit);
+    }
+
+    @SneakyThrows
+    public void testGetSettingValueDefault() {
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        long actualKNNCircuitBreakerLimit = ((ByteSizeValue) KNNSettings.state()
+            .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
+        mockNode.close();
+        assertEquals(
+            actualKNNCircuitBreakerLimit,
+            ((ByteSizeValue) KNNSettings.dynamicCacheSettings.get(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT).getDefault(Settings.EMPTY))
+                .getKb()
+        );
+    }
+
+    private Node createMockNode(Map<String, Object> configSettings) throws IOException {
+        Path configDir = createTempDir();
+        File configFile = configDir.resolve("opensearch.yml").toFile();
+        FileWriter configFileWriter = new FileWriter(configFile);
+
+        for (Map.Entry<String, Object> setting : configSettings.entrySet()) {
+            configFileWriter.write("\"" + setting.getKey() + "\": " + setting.getValue());
+        }
+        configFileWriter.close();
+        return new MockNode(baseSettings().build(), basePlugins(), configDir, true);
+    }
+
+    private List<Class<? extends Plugin>> basePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>();
+        plugins.add(getTestTransportPlugin());
+        plugins.add(MockHttpTransport.TestPlugin.class);
+        plugins.add(KNNPlugin.class);
+        return plugins;
+    }
+
+    private static Settings.Builder baseSettings() {
+        final Path tempDir = createTempDir();
+        return Settings.builder()
+            .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
+            .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
+            .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
+            .put(dataNode());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
@@ -51,8 +52,10 @@ import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -95,6 +98,15 @@ public class KNNCodecTestCase extends KNNTestCase {
         ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
         Settings settings = Settings.Builder.EMPTY_SETTINGS;
         when(clusterService.state().getMetadata().index(Mockito.anyString()).getSettings()).thenReturn(settings);
+        Set<Setting<?>> defaultClusterSettings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        defaultClusterSettings.addAll(
+            KNNSettings.state()
+                .getSettings()
+                .stream()
+                .filter(s -> s.getProperties().contains(Setting.Property.NodeScope))
+                .collect(Collectors.toList())
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(Settings.EMPTY, defaultClusterSettings));
         KNNSettings.state().setClusterService(clusterService);
     }
 


### PR DESCRIPTION
### Description
Removes the latestSettings cache from the KNNSettings class. latestSettings cache gets updated in a consumer when the particular settings are updated.

[KNNSettings.getSettingValue](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/KNNSettings.java#L305) would pull from this cache and then fallback to the default if it is not present. However, in the case when the settings are set via opensearch.yml config file, the settings get set before any functions can be registered. So the config values never get put in the cache. This leads to getSettingValue to always return the default instead of the value specified in the config file.

To fix this, this change refactors getSettingValue to pull from the cluster settings and removes the latestSetting cache. However, because the dynamicCacheSettings have [consumers](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/KNNSettings.java#L269) that rebuild the NativeMemoryCacheManager cache when they are changed, the logic for passing the parameters to rebuild this cache had to change as well. Initially, the NativeMemoryCacheManager gets its [parameters](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java#L77) from the settings. However, because we are switching "getSettingValue" to get the values from the ClusterSettings, the new cluster settings will not yet be committed to the cluster state when the settings update consumer is called (it gets called in this chain starting [here](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/cluster/settings/SettingsUpdater.java#L158)). To workaround this, this change refactors the cache to accept parameters as args.

In addition to this, I added a couple tests units tests and did some refactoring to get tests to pass.

### Issues Resolved
#585 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
