### PR TITLE
Remove lucene 95 upgrade from release notes

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.5.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.5.0.0.md
@@ -30,6 +30,5 @@ Compatible with OpenSearch 2.5.0
 
 * Fix the codec94 version import statements ([#684](https://github.com/opensearch-project/k-NN/pull/684))
 * Add integ test for index close/open scenario ([#693](https://github.com/opensearch-project/k-NN/pull/693))
-* Add Lucene 9.5 codec and make it new default ([#700](https://github.com/opensearch-project/k-NN/pull/700))
 * Make version of lucene k-nn engine match lucene current version ([#691](https://github.com/opensearch-project/k-NN/pull/691))
 * Increment version to 2.5.0-SNAPSHOT ([#632](https://github.com/opensearch-project/k-NN/pull/632))


### PR DESCRIPTION
### Description
In 2.5, we accidentally included #700 in our release notes. However, this did not get backported to 2.5 and does not make sense because Lucene 95 has not yet been released. This PR removes it from the release notes.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
