### PR TITLE
Clear settings after rest test case

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -171,7 +171,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
     public void validateKNNIndexingOnUpgrade() throws Exception {
         QUERY_COUNT = NUM_DOCS;
         validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, QUERY_COUNT, K);
-        cleanUpCache();
+        clearCache();
         DOC_ID = NUM_DOCS;
         addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         QUERY_COUNT = QUERY_COUNT + NUM_DOCS;

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -21,7 +21,6 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.opensearch.client.Request;
@@ -131,8 +130,16 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     @Before
-    public void cleanUpCache() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         clearCache();
+        resetDynamicSettings();
+    }
+
+    protected void resetDynamicSettings() throws IOException {
+        for (String setting : KNNSettings.dynamicCacheSettings.keySet()) {
+            updateClusterSettings(setting, null);
+        }
     }
 
     /**
@@ -499,7 +506,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     /**
      * Utility to update  settings
      */
-    protected void updateClusterSettings(String settingKey, Object value) throws Exception {
+    protected void updateClusterSettings(String settingKey, Object value) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("persistent")


### PR DESCRIPTION
### Description
Clears setting values after all rest test cases so that they reset back to the default values. This should prevent flaky integration test failures that might manipulate settings and then not reset them.
 
### Issues Resolved
#734 potentially related to this issue. Have seen failures recently around this test, but they are not deterministically reproducible.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
