### PR TITLE
Set additional settings at index level for knn enabled indexes

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -362,6 +362,15 @@ public class KNNPlugin extends Plugin
         return List.of(settingProvider);
     }
 
+    private Settings pluginAdditionalSettings(final Settings templateAndRequestSettings) {
+        final var settingsBuilder = Settings.builder();
+        boolean isKnnIndex = Boolean.parseBoolean(templateAndRequestSettings.get(KNNSettings.KNN_INDEX, Boolean.FALSE.toString()));
+        if (isKnnIndex) {
+            additionalMMapFileExtensionsForHybridFs(settingsBuilder);
+        }
+        return settingsBuilder.build();
+    }
+
     private void additionalMMapFileExtensionsForHybridFs(final Settings.Builder settingsBuilder) {
         // We add engine specific extensions to the core list for HybridFS store type. We read existing values
         // and append ours because in core setting will be replaced by override.
@@ -376,14 +385,5 @@ public class KNNPlugin extends Plugin
         ).collect(Collectors.toList());
 
         settingsBuilder.putList(IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getKey(), combinedSettings);
-    }
-
-    private Settings pluginAdditionalSettings(final Settings templateAndRequestSettings) {
-        final var settingsBuilder = Settings.builder();
-        boolean isKnnIndex = Boolean.parseBoolean(templateAndRequestSettings.get(KNNSettings.KNN_INDEX, Boolean.FALSE.toString()));
-        if (isKnnIndex) {
-            additionalMMapFileExtensionsForHybridFs(settingsBuilder);
-        }
-        return settingsBuilder.build();
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/KNNPluginTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/KNNPluginTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.plugin;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexModule;
+import org.opensearch.index.shard.IndexSettingProvider;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.Collection;
+import java.util.List;
+
+public class KNNPluginTests extends KNNTestCase {
+
+    private static final String INDEX_NAME = "test_index";
+
+    public void testMMapFileExtensionsForHybridFs() {
+        final KNNPlugin knnPlugin = new KNNPlugin();
+
+        final Collection<IndexSettingProvider> additionalIndexSettingProviders = knnPlugin.getAdditionalIndexSettingProviders();
+
+        assertEquals(1, additionalIndexSettingProviders.size());
+
+        final IndexSettingProvider indexSettingProvider = additionalIndexSettingProviders.iterator().next();
+        // settings for knn enabled index
+        final Settings knnIndexSettings = indexSettingProvider.getAdditionalIndexSettings(INDEX_NAME, false, getKnnDefaultIndexSettings());
+        final List<String> mmapFileExtensionsForHybridFsKnnIndex = knnIndexSettings.getAsList(
+            IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getKey()
+        );
+
+        assertNotNull(mmapFileExtensionsForHybridFsKnnIndex);
+        assertFalse(mmapFileExtensionsForHybridFsKnnIndex.isEmpty());
+
+        for (KNNEngine engine : KNNEngine.values()) {
+            assertTrue(mmapFileExtensionsForHybridFsKnnIndex.containsAll(engine.mmapFileExtensions()));
+        }
+
+        // settings for index without knn
+        final Settings nonKnnIndexSettings = indexSettingProvider.getAdditionalIndexSettings(INDEX_NAME, false, getNonKnnIndexSettings());
+        final List<String> mmapFileExtensionsForHybridFsNonKnnIndex = nonKnnIndexSettings.getAsList(
+            IndexModule.INDEX_STORE_HYBRID_MMAP_EXTENSIONS.getKey()
+        );
+
+        assertNotNull(mmapFileExtensionsForHybridFsNonKnnIndex);
+        assertTrue(mmapFileExtensionsForHybridFsNonKnnIndex.isEmpty());
+    }
+
+    private Settings getKnnDefaultIndexSettings() {
+        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", true).build();
+    }
+
+    private Settings getNonKnnIndexSettings() {
+        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
With this change we're making k-NN settings specific to an index, and only for case when index is knn enabled (index.knn = true). 
Currently settings override cluster default as per implementation under https://github.com/opensearch-project/k-NN/pull/721. This brings certain confusion because GET `/<index>/_settings` API return core default values without overrides from plugin. 

Setting's semantics didn't change. 

Testing results, k-NN added values are "vec" and "vex".

_After the change:_ 

1. cluster default settings (GET /_cluster/settings?include_defaults=true):
```
            "store": {
                "hybrid": {
                    "mmap": {
                        "extensions": [
                            "nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"
                        ]
                    }
                },
```

2. index specific settings when knn is enabled (GET /<index>/_settings):
```
                "store": {
                    "hybrid": {
                        "mmap": {
                            "extensions": [
                                "nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc", "vec", "vex"
                            ]
                        }
                    }
                },
```

_Before the change:_

1. cluster default settings (GET /_cluster/settings?include_defaults=true):
```
            "store": {
                "hybrid": {
                    "mmap": {
                        "extensions": [
                           "nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc", "vec", "vex"
                        ]
                    }
                },
```
2. index specific settings when knn is enabled (GET /<index>/_settings):
```
                "store": {
                    "hybrid": {
                        "mmap": {
                            "extensions": [
                                "nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc"
                            ]
                        }
                    }
                },
```
### Check List
- [X] New functionality includes testing.
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
