### PR TITLE
Adding p99.9, p100 and num_of_segments metrics to perf-tool

### DIFF
--- a/benchmarks/perf-tool/README.md
+++ b/benchmarks/perf-tool/README.md
@@ -272,12 +272,12 @@ Runs a set of queries against an index.
 
 ##### Metrics
 
-| Metric Name | Description | Unit |  
-| ----------- | ----------- | ----------- |
-| took | Took times returned per query aggregated as total, p50, p90 and p99 (when applicable) | ms |
-| memory_kb | Native memory k-NN is using at the end of the query workload | KB |
+| Metric Name | Description                                                                                             | Unit |  
+| ----------- |---------------------------------------------------------------------------------------------------------| ----------- |
+| took | Took times returned per query aggregated as total, p50, p90, p99, p99.9 and p100 (when applicable)      | ms |
+| memory_kb | Native memory k-NN is using at the end of the query workload                                            | KB |
 | recall@R | ratio of top R results from the ground truth neighbors that are in the K results returned by the plugin | float 0.0-1.0 |
-| recall@K | ratio of results returned that were ground truth nearest neighbors  | float 0.0-1.0 |
+| recall@K | ratio of results returned that were ground truth nearest neighbors                                      | float 0.0-1.0 |
 
 #### query_with_filter
 
@@ -310,6 +310,23 @@ Runs a set of queries with filter against an index.
 | memory_kb | Native memory k-NN is using at the end of the query workload | KB |
 | recall@R | ratio of top R results from the ground truth neighbors that are in the K results returned by the plugin | float 0.0-1.0 |
 | recall@K | ratio of results returned that were ground truth nearest neighbors  | float 0.0-1.0 |
+
+#### get_stats
+
+Gets the index stats.
+
+##### Parameters
+
+| Parameter Name | Description                                                                                                                                                                                                                               | Default              |  
+| ----------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------| 
+| index_name | Name of index to search                                                                                                                                                                                                                   | No default           |
+
+##### Metrics
+
+| Metric Name | Description                                     | Unit       |  
+| ----------- |-------------------------------------------------|------------|
+| num_of_committed_segments | Total number of commited segments in the index  | integer >= 0 |
+| num_of_search_segments | Total number of search segments in the index    | integer >= 0 |
 
 ### Data sets
 

--- a/benchmarks/perf-tool/okpt/test/steps/factory.py
+++ b/benchmarks/perf-tool/okpt/test/steps/factory.py
@@ -9,7 +9,8 @@ from okpt.io.config.parsers.base import ConfigurationError
 from okpt.test.steps.base import Step, StepConfig
 
 from okpt.test.steps.steps import CreateIndexStep, DisableRefreshStep, RefreshIndexStep, DeleteIndexStep, \
-    TrainModelStep, DeleteModelStep, ForceMergeStep, ClearCacheStep, IngestStep, IngestMultiFieldStep, QueryStep, QueryWithFilterStep
+    TrainModelStep, DeleteModelStep, ForceMergeStep, ClearCacheStep, IngestStep, IngestMultiFieldStep, \
+    QueryStep, QueryWithFilterStep, GetStatsStep
 
 
 def create_step(step_config: StepConfig) -> Step:
@@ -37,5 +38,7 @@ def create_step(step_config: StepConfig) -> Step:
         return ForceMergeStep(step_config)
     elif step_config.step_name == ClearCacheStep.label:
         return ClearCacheStep(step_config)
+    elif step_config.step_name == GetStatsStep.label:
+        return GetStatsStep(step_config)
 
     raise ConfigurationError(f'Invalid step {step_config.step_name}')

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -618,12 +618,12 @@ class GetStatsStep(OpenSearchStep):
                 num_of_committed_segments += segment["num_committed_segments"]
                 num_of_search_segments += segment["num_search_segments"]
 
-        results['num_of_committed_segments'] = num_of_committed_segments
-        results['num_of_search_segments'] = num_of_search_segments
+        results['committed_segments'] = num_of_committed_segments
+        results['search_segments'] = num_of_search_segments
         return results
 
     def _get_measures(self) -> List[str]:
-        return ['num_of_committed_segments', 'num_of_search_segments']
+        return ['committed_segments', 'search_segments']
 
 # Helper functions - (AKA not steps)
 def bulk_transform(partition: np.ndarray, field_name: str, action,

--- a/benchmarks/perf-tool/okpt/test/test.py
+++ b/benchmarks/perf-tool/okpt/test/test.py
@@ -53,6 +53,8 @@ def _pxx(values: List[Any], p: float):
     if p < 0 or p > 1:
         return -1.0
     elif p < lowest_percentile or p > highest_percentile:
+        if p == 1.0 and len(values) > 1:
+            return float(values[len(values) - 1])
         return -1.0
     else:
         return float(values[floor(len(values) * p)])
@@ -137,6 +139,12 @@ def _aggregate_steps(step_results: List[Dict[str, Any]],
         p99 = _pxx(step_measure, 0.99)
         if p99 != -1:
             aggregate[step_measure_label + '_p99'] = p99
+        p99_9 = _pxx(step_measure, 0.999)
+        if p99_9 != -1:
+            aggregate[step_measure_label + '_p99.9'] = p99_9
+        p100 = _pxx(step_measure, 1.00)
+        if p100 != -1:
+            aggregate[step_measure_label + '_p100'] = p100
 
     return aggregate
 

--- a/benchmarks/perf-tool/okpt/test/test.py
+++ b/benchmarks/perf-tool/okpt/test/test.py
@@ -107,7 +107,7 @@ def _aggregate_steps(step_results: List[Dict[str, Any]],
         for measure_label in step_measure_labels:
 
             step_measure = step[measure_label]
-            step_measure_label = f'{step_label}_{measure_label}'
+            step_measure_label = f'{measure_label}' if step_label == 'get_stats' else f'{step_label}_{measure_label}'
 
             # Add cumulative test measures from steps to test measures
             if measure_label in measure_labels:


### PR DESCRIPTION
Signed-off-by: Martin Gaievski <gaievski@amazon.com>

### Description
Adding few metrics to perf tool, I used them while working on vec file io improvements for lucene knn. One is total number of segments in index, search and committed. Second added is p99.9 and p100 for query latencies, this allows to get info on a data tail.

This is example of test run result with num of segments and p99.9/p100. 

```
  "results": {
    "test_took": 46429.944159499944,
    "get_stats_num_of_committed_segments_total": 8.0,
    "get_stats_num_of_search_segments_total": 8.0,
    "get_stats_took_total": 186.8456724999713,
    "clear_cache_took_total": 164.59848699996982,
    "query_took_total": 46078.5,
    "query_took_p50": 4.5,
    "query_took_p90": 6.0,
    "query_took_p99": 7.0,
    "query_took_p99.9": 7.0,
    "query_took_p100": 11.5,
    "query_memory_kb_total": 0.0,
    "query_recall@K_total": 0.99167,
    "query_recall@1_total": 1.0
  }
```
 

### Check List
- [X] New functionality has been documented.
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
