### PR TITLE
Update certifi dependency version

### DIFF
--- a/benchmarks/osb/requirements.txt
+++ b/benchmarks/osb/requirements.txt
@@ -16,7 +16,7 @@ attrs==21.4.0
     #   jsonschema
 cachetools==4.2.4
     # via google-auth
-certifi==2021.10.8
+certifi==2022.12.7
     # via
     #   opensearch-benchmark
     #   opensearch-py

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -8,7 +8,7 @@ cached-property==1.5.2
     # via h5py
 cerberus==1.3.4
     # via -r requirements.in
-certifi==2021.5.30
+certifi==2022.12.7
     # via
     #   opensearch-py
     #   requests


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Update the `certifi` dependency version to "2022.12.7" as per the security recommendation.

Validated the version by compiling the requirements file. Then, tested it by triggering the perf test to make sure there are no version incompatibilities. 
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
