### PR TITLE
Update codec version to 9.5

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -286,10 +286,12 @@ Before adding any new tests to Backward Compatibility Tests, we should be aware 
 
 Starting from 2.0 release the new versioning for codec has been introduced. Two positions will be used to define the version,
 in format 'X.Y', where 'X' corresponds to underlying version of Lucene and 'Y' is the version of the format. 
+Please note that Lucene version along with corresponding Lucene codec is part of the core OpenSearch. KNN codec should be in sync with Lucene codec version from core OpenSearch.
 
 Codec version is used in following classes and methods:
 - org.opensearch.knn.index.codec.KNNXYCodec.KNNXYCodec
-- org.opensearch.knn.index.codec.KNNFormatFactory.createKNNXYFormat
+- org.opensearch.knn.index.codec.KNNXYCodec.KNNXYPerFieldKnnVectorsFormat
+- org.opensearch.knn.index.codec.KNNCodecVersion
 
 These classes and methods are tied directly to Lucene version represented by 'X' part. 
 Other classes use the delegate pattern so no direct tie to Lucene version are related to format and represented by 'Y'

--- a/src/main/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940PerFieldKnnVectorsFormat.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.codec.KNN940Codec;
 
-import org.apache.lucene.codecs.lucene94.Lucene94HnswVectorsFormat;
+import org.apache.lucene.backward_codecs.lucene94.Lucene94HnswVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.BasePerFieldKnnVectorsFormat;
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950Codec.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN950Codec;
+
+import lombok.Builder;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNNCodecVersion;
+import org.opensearch.knn.index.codec.KNNFormatFacade;
+
+public class KNN950Codec extends FilterCodec {
+    private static final KNNCodecVersion VERSION = KNNCodecVersion.V_9_5_0;
+    private final KNNFormatFacade knnFormatFacade;
+    private final PerFieldKnnVectorsFormat perFieldKnnVectorsFormat;
+
+    /**
+     * No arg constructor that uses Lucene95 as the delegate
+     */
+    public KNN950Codec() {
+        this(VERSION.getDefaultCodecDelegate(), VERSION.getPerFieldKnnVectorsFormat());
+    }
+
+    /**
+     * Sole constructor. When subclassing this codec, create a no-arg ctor and pass the delegate codec
+     * and a unique name to this ctor.
+     *
+     * @param delegate codec that will perform all operations this codec does not override
+     * @param knnVectorsFormat per field format for KnnVector
+     */
+    @Builder
+    protected KNN950Codec(Codec delegate, PerFieldKnnVectorsFormat knnVectorsFormat) {
+        super(VERSION.getCodecName(), delegate);
+        knnFormatFacade = VERSION.getKnnFormatFacadeSupplier().apply(delegate);
+        perFieldKnnVectorsFormat = knnVectorsFormat;
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        return knnFormatFacade.docValuesFormat();
+    }
+
+    @Override
+    public CompoundFormat compoundFormat() {
+        return knnFormatFacade.compoundFormat();
+    }
+
+    @Override
+    public KnnVectorsFormat knnVectorsFormat() {
+        return perFieldKnnVectorsFormat;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950PerFieldKnnVectorsFormat.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN950Codec;
+
+import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.BasePerFieldKnnVectorsFormat;
+
+import java.util.Optional;
+
+/**
+ * Class provides per field format implementation for Lucene Knn vector type
+ */
+public class KNN950PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat {
+
+    public KNN950PerFieldKnnVectorsFormat(final Optional<MapperService> mapperService) {
+        super(
+            mapperService,
+            Lucene95HnswVectorsFormat.DEFAULT_MAX_CONN,
+            Lucene95HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
+            () -> new Lucene95HnswVectorsFormat(),
+            (maxConnm, beamWidth) -> new Lucene95HnswVectorsFormat(maxConnm, beamWidth)
+        );
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene94.Lucene94Codec;
+import org.apache.lucene.backward_codecs.lucene94.Lucene94Codec;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
@@ -11,6 +11,7 @@ import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene94.Lucene94Codec;
+import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;
@@ -20,6 +21,8 @@ import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
 import org.opensearch.knn.index.codec.KNN940Codec.KNN940PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNN950Codec.KNN950Codec;
+import org.opensearch.knn.index.codec.KNN950Codec.KNN950PerFieldKnnVectorsFormat;
 
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -74,9 +77,24 @@ public enum KNNCodecVersion {
             .knnVectorsFormat(new KNN940PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService)))
             .build(),
         KNN940Codec::new
+    ),
+
+    V_9_5_0(
+        "KNN950Codec",
+        new Lucene95Codec(),
+        new KNN950PerFieldKnnVectorsFormat(Optional.empty()),
+        (delegate) -> new KNNFormatFacade(
+            new KNN80DocValuesFormat(delegate.docValuesFormat()),
+            new KNN80CompoundFormat(delegate.compoundFormat())
+        ),
+        (userCodec, mapperService) -> KNN950Codec.builder()
+            .delegate(userCodec)
+            .knnVectorsFormat(new KNN950PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService)))
+            .build(),
+        KNN950Codec::new
     );
 
-    private static final KNNCodecVersion CURRENT = V_9_4_0;
+    private static final KNNCodecVersion CURRENT = V_9_5_0;
 
     private final String codecName;
     private final Codec defaultCodecDelegate;

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -5,3 +5,4 @@ org.opensearch.knn.index.codec.KNN87Codec.KNN87Codec
 org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec
 org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec
 org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec
+org.opensearch.knn.index.codec.KNN950Codec.KNN950Codec

--- a/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN940Codec/KNN940CodecTests.java
@@ -6,13 +6,9 @@
 package org.opensearch.knn.index.codec.KNN940Codec;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_4_0;
 
@@ -26,15 +22,9 @@ public class KNN940CodecTests extends KNNCodecTestCase {
         testBuildFromModelTemplate((KNN940Codec.builder().delegate(V_9_4_0.getDefaultCodecDelegate()).build()));
     }
 
-    public void testKnnVectorIndex() throws Exception {
-        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
-            mapperService) -> new KNN940PerFieldKnnVectorsFormat(Optional.of(mapperService));
-
-        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN940Codec.builder()
-            .delegate(V_9_4_0.getDefaultCodecDelegate())
-            .knnVectorsFormat(knnVectorFormat)
-            .build();
-
-        testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+    // Ensure that the codec is able to return the correct per field knn vectors format for codec
+    public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
+        final Codec codec = new KNN940Codec();
+        assertTrue(codec.knnVectorsFormat() instanceof KNN940PerFieldKnnVectorsFormat);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
@@ -28,6 +28,14 @@ public class KNN950CodecTests extends KNNCodecTestCase {
         testBuildFromModelTemplate((KNN950Codec.builder().delegate(V_9_5_0.getDefaultCodecDelegate()).build()));
     }
 
+    // Ensure that the codec is able to return the correct per field knn vectors format for codec
+    public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
+        final Codec codec = new KNN950Codec();
+        assertTrue(codec.knnVectorsFormat() instanceof KNN950PerFieldKnnVectorsFormat);
+    }
+
+    // IMPORTANT: When this Codec is moved to a backwards Codec, this test needs to be removed, because it attempts to
+    // write with a read only codec, which will fail
     @SneakyThrows
     public void testKnnVectorIndex() {
         Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (

--- a/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN950Codec/KNN950CodecTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN950Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNNCodecTestCase;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_5_0;
+
+public class KNN950CodecTests extends KNNCodecTestCase {
+
+    @SneakyThrows
+    public void testMultiFieldsKnnIndex() {
+        testMultiFieldsKnnIndex(KNN950Codec.builder().delegate(V_9_5_0.getDefaultCodecDelegate()).build());
+    }
+
+    @SneakyThrows
+    public void testBuildFromModelTemplate() {
+        testBuildFromModelTemplate((KNN950Codec.builder().delegate(V_9_5_0.getDefaultCodecDelegate()).build()));
+    }
+
+    @SneakyThrows
+    public void testKnnVectorIndex() {
+        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
+            mapperService) -> new KNN950PerFieldKnnVectorsFormat(Optional.of(mapperService));
+
+        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN950Codec.builder()
+            .delegate(V_9_5_0.getDefaultCodecDelegate())
+            .knnVectorsFormat(knnVectorFormat)
+            .build();
+
+        testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec;
 import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
-import org.apache.lucene.codecs.lucene94.Lucene94Codec;
+import org.apache.lucene.backward_codecs.lucene94.Lucene94Codec;
 import org.opensearch.knn.KNNTestCase;
 
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_1_0;

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecFactoryTests.java
@@ -9,11 +9,13 @@ import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene91.Lucene91Codec;
 import org.apache.lucene.backward_codecs.lucene94.Lucene94Codec;
+import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.opensearch.knn.KNNTestCase;
 
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_1_0;
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_2_0;
 import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_4_0;
+import static org.opensearch.knn.index.codec.KNNCodecVersion.V_9_5_0;
 
 public class KNNCodecFactoryTests extends KNNTestCase {
 
@@ -33,6 +35,12 @@ public class KNNCodecFactoryTests extends KNNTestCase {
         assertDelegateForVersion(V_9_4_0, Lucene94Codec.class);
         assertNotNull(V_9_4_0.getPerFieldKnnVectorsFormat());
         assertNotNull(V_9_4_0.getKnnFormatFacadeSupplier().apply(V_9_4_0.getDefaultCodecDelegate()));
+    }
+
+    public void testKNN950Codec() {
+        assertDelegateForVersion(V_9_5_0, Lucene95Codec.class);
+        assertNotNull(V_9_5_0.getPerFieldKnnVectorsFormat());
+        assertNotNull(V_9_5_0.getKnnFormatFacadeSupplier().apply(V_9_5_0.getDefaultCodecDelegate()));
     }
 
     private void assertDelegateForVersion(final KNNCodecVersion codecVersion, final Class expectedCodecClass) {


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
This PR includes the following changes:

- Update lucene94 package name to backward_codecs
- Add Lucene95 codec and make it default (Cherry-picked 4f9a8b296241c316bbc2d7dbfe67f20a59893302 from https://github.com/opensearch-project/k-NN/pull/700)
- Update tests for backwards codecs (Cherry-picked 8b168311d345228c30408bbb8078943b13477823 from https://github.com/opensearch-project/k-NN/pull/710)

 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/745
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
