### PR TITLE
Replace KnnQueryVector by KnnFloatVectorQuery for Lucene knn

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.search.KnnVectorQuery;
+import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryShardContext;
@@ -73,13 +73,13 @@ public class KNNQueryFactory {
             );
             try {
                 final Query filterQuery = createQueryRequest.getFilter().get().toQuery(queryShardContext);
-                return new KnnVectorQuery(fieldName, vector, k, filterQuery);
+                return new KnnFloatVectorQuery(fieldName, vector, k, filterQuery);
             } catch (IOException e) {
                 throw new RuntimeException("Cannot create knn query with filter", e);
             }
         }
         log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
-        return new KnnVectorQuery(fieldName, vector, k);
+        return new KnnFloatVectorQuery(fieldName, vector, k);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.query;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.lucene.search.KnnVectorQuery;
+import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterModule;
@@ -174,7 +174,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         Query query = knnQueryBuilder.doToQuery(mockQueryShardContext);
         assertNotNull(query);
-        assertTrue(query instanceof KnnVectorQuery);
+        assertTrue(query.getClass().isAssignableFrom(KnnFloatVectorQuery.class));
     }
 
     public void testDoToQuery_FromModel() {

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
-import org.apache.lucene.search.KnnVectorQuery;
+import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.QueryBuilder;
@@ -47,7 +47,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             .collect(Collectors.toList());
         for (KNNEngine knnEngine : luceneDefaultQueryEngineList) {
             Query query = KNNQueryFactory.create(knnEngine, testIndexName, testFieldName, testQueryVector, testK);
-            assertTrue(query instanceof KnnVectorQuery);
+            assertTrue(query.getClass().isAssignableFrom(KnnFloatVectorQuery.class));
         }
     }
 
@@ -70,7 +70,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
                 .filter(filter)
                 .build();
             Query query = KNNQueryFactory.create(createQueryRequest);
-            assertTrue(query instanceof KnnVectorQuery);
+            assertTrue(query.getClass().isAssignableFrom(KnnFloatVectorQuery.class));
         }
     }
 }


### PR DESCRIPTION
### Description
KnnQueryVector has been [marked as deprecated in Lucene 9.5](https://github.com/apache/lucene/blob/branch_9_5/lucene/core/src/java/org/apache/lucene/search/KnnVectorQuery.java#L35) and new implementation created instead. We need to follow Lucene path as we do return their implementation directly. 
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/766
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
