### PR TITLE
Adding filter type to filtering release configs

### DIFF
--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
@@ -31,3 +31,4 @@ steps:
     neighbors_path: [DATASET_PATH]/sift-128-euclidean-with-filters.hdf5
     neighbors_dataset: neighbors_filter_5
     filter_spec: [INDEX_SPEC_PATH]/relaxed-filter-spec.json
+    filter_type: FILTER

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
@@ -31,3 +31,4 @@ steps:
     neighbors_path: [DATASET_PATH]/sift-128-euclidean-with-filters.hdf5
     neighbors_dataset: neighbors_filter_4
     filter_spec: [INDEX_SPEC_PATH]/restrictive-filter-test.yml
+    filter_type: FILTER


### PR DESCRIPTION
### Description
Current release configs for filtering do not have filter type, this means they we're using default value SCRIPT that is for score scripting with exact k-NN search ([docs on filtering test step](https://github.com/martin-gaievski/k-NN/blob/main/benchmarks/perf-tool/README.md#parameters-10)). This is a gap in initial implementation, intended filter type is FILTER, it uses filtering logic based on Lucene implementation.
 
### Issues Resolved
Identified during k-NN 2.6 release
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
