### PR TITLE
Update Certifi version to 2022.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+* Update Certifi version to 2022.12.7 ([#817](https://github.com/opensearch-project/k-NN/pull/817))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -8,7 +8,7 @@ cached-property==1.5.2
     # via h5py
 cerberus==1.3.4
     # via -r requirements.in
-certifi==2021.5.30
+certifi==2022.12.7
     # via
     #   opensearch-py
     #   requests


### PR DESCRIPTION
### Description
Update Certifi version to 2022.12.7 to fix the failing whitesource security check
https://github.com/opensearch-project/k-NN/pull/809/checks?check_run_id=12067423521
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
