### PR TITLE
[Backport 1.3] Update Certifi version to 2022.12.7

### DIFF
--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -8,7 +8,7 @@ cached-property==1.5.2
     # via h5py
 cerberus==1.3.4
     # via -r requirements.in
-certifi==2021.5.30
+certifi==2022.12.7
     # via
     #   opensearch-py
     #   requests


### PR DESCRIPTION
### Description
Manually Backporting https://github.com/opensearch-project/k-NN/pull/817/commits/3292d92e0923f23c2eaa56c3ad63214b9044264a from https://github.com/opensearch-project/k-NN/pull/817
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
