### PR TITLE
[Backport 2.x] Bump numpy from 1.22.x to 1.24.2 (#811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Bump byte-buddy version from 1.12.22 to 1.14.2 ([#804](https://github.com/opensearch-project/k-NN/pull/804))
 * Add 2.6.0 to BWC Version Matrix ([#810](https://github.com/opensearch-project/k-NN/pull/810))
 * Update BWC Version with OpenSearch Version Bump ([#813](https://github.com/opensearch-project/k-NN/pull/813))
+* Bump numpy version from 1.22.x to 1.24.2 ([#811](https://github.com/opensearch-project/k-NN/pull/811))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/benchmarks/osb/requirements.txt
+++ b/benchmarks/osb/requirements.txt
@@ -52,7 +52,7 @@ multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
-numpy==1.22.3
+numpy==1.24.2
     # via
     #   -r requirements.in
     #   h5py

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -18,7 +18,7 @@ h5py==3.3.0
     # via -r requirements.in
 idna==3.2
     # via requests
-numpy==1.22.1
+numpy==1.24.2
     # via
     #   -r requirements.in
     #   h5py


### PR DESCRIPTION
Backport (cherry picked from commit f7f12022fdecad7f8fa0dbf1f9727480b91b392c) from #811 

