### PR TITLE
Fix the BWC Version Bump Issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,10 +322,17 @@ task updateVersion {
             }
         }
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
-        // Extract the oldBWCVersion from the existing OpenSearch Version (oldBWCVersion = major + (minor-1) + patch)
+
         ext.os_version_without_snapshot = opensearch_version.tokenize('-')[0]
-        ext.oldBWCVersion = os_version_without_snapshot.tokenize('.')[0] + '.' + Integer.toString(Integer.valueOf(os_version_without_snapshot.tokenize('.')[1]) - 1) + '.' + os_version_without_snapshot.tokenize('.')[2]
-        // Include the current OpenSearch Version before version bump to the bwc_version matrix
-        ant.replaceregexp(file:".github/workflows/backwards_compatibility_tests_workflow.yml", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
+        ext.os_version_major = os_version_without_snapshot.tokenize('.')[0]
+        ext.os_version_minor = os_version_without_snapshot.tokenize('.')[1]
+        ext.os_version_patch = os_version_without_snapshot.tokenize('.')[2]
+        // This condition will check if the BWC workflow is already updated or not and will run next steps if not updated
+        if (!fileTree(".github/workflows/backwards_compatibility_tests_workflow.yml").getSingleFile().text.contains(os_version_without_snapshot)) {
+            // Extract the oldBWCVersion from the existing OpenSearch Version (oldBWCVersion = major . (minor-1) . patch)
+            ext.oldBWCVersion = os_version_major + '.' + Integer.toString(Integer.valueOf(os_version_minor) - 1) + '.' + os_version_patch
+            // Include the current OpenSearch Version before version bump to the bwc_version matrix
+            ant.replaceregexp(file:".github/workflows/backwards_compatibility_tests_workflow.yml", match: oldBWCVersion, replace: oldBWCVersion + '", "' + opensearch_version.tokenize('-')[0], flags:'g', byline:true)
+        }
     }
 }


### PR DESCRIPTION
### Description
Add a conditional check to make sure the BWC version matrix is not updated before adding new versions to the BWC Matrix. This change will help to avoid creation of unnecessary version bump PRs https://github.com/opensearch-project/k-NN/pull/826 after the version is already incremented.
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
