### PR TITLE
Bump byte-buddy version to 1.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+* Bump byte-buddy version to 1.14.3 ([#839](https://github.com/opensearch-project/k-NN/pull/839))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -175,9 +175,9 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version:'30.0-jre'
     api group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.2'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.3'
     testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.2'
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.2'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.3'
 }
 
 


### PR DESCRIPTION
### Description
Bump byte-buddy to follow core and avoid compilation errors like this: https://github.com/opensearch-project/k-NN/actions/runs/4612290817/jobs/8153018668#step:6:154. This is not needed for 2.x
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
