### PR TITLE
Add client setting to ignore warning exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Bump numpy version from 1.22.x to 1.24.2 ([#811](https://github.com/opensearch-project/k-NN/pull/811))
 * Support .opensearch-knn-model index as system index with security enabled ([#827](https://github.com/opensearch-project/k-NN/pull/827))
 * Set gradle dependency scope for common-utils to testFixturesImplementation ([#844](https://github.com/opensearch-project/k-NN/pull/844))
+* Add client setting to ignore warning exceptions ([#850](https://github.com/opensearch-project/k-NN/pull/850))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -383,4 +383,9 @@ public class NmslibIT extends KNNRestTestCase {
         );
         assertThat(ex.getMessage(), containsString("Failed to parse value [-1] for setting [index.knn.algo_param.ef_search]"));
     }
+
+    @Override
+    protected Settings restClientSettings() {
+        return noStrictDeprecationModeSettingsBuilder().build();
+    }
 }


### PR DESCRIPTION
### Description
Fixing integ test, when running in secure cluster it produces WarningException like below. For tests we can ignore such warnings, there is a setting for rest client that needs to be enabled

```
java.lang.AssertionError: Exception not expected as valid index arguements passed: org.opensearch.client.WarningFailureException: method [PUT], host [https://localhost:9200/], URI [/test_index], status line [HTTP/1.1 200 OK]

    Warnings: [[index.knn.algo_param.ef_construction] setting was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation for the next major version.]

    {"acknowledged":true,"shards_acknowledged":true,"index":"test_index"}

        at __randomizedtesting.SeedInfo.seed([B9031256349BA03A:D1B6ED99033EDC32]:0)

        at org.junit.Assert.fail(Assert.java:89)

        at org.opensearch.knn.index.NmslibIT.testCreateIndexWithValidAlgoParams_settings(NmslibIT.java:177)
```
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
