### PR TITLE
Fix the filter_spec file name in restrictive-filter-test

### DIFF
--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
@@ -30,5 +30,5 @@ steps:
     neighbors_format: hdf5
     neighbors_path: [DATASET_PATH]/sift-128-euclidean-with-filters.hdf5
     neighbors_dataset: neighbors_filter_4
-    filter_spec: [INDEX_SPEC_PATH]/restrictive-filter-test.yml
+    filter_spec: [INDEX_SPEC_PATH]/restrictive-filter-spec.json
     filter_type: FILTER


### PR DESCRIPTION
### Description
Fix the filter_spec file name in restrictive-filter-test.yml
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
