### PR TITLE
Fix sha256 on gradle 7.6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,8 +5,8 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionSha256Sum=518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description
Fixes checksum for gradle 7.6.1

Related: https://github.com/opensearch-project/k-NN/actions/runs/4931642285/jobs/8813885647

Checksums can be found here.

Command to generate:
```
./gradlew wrapper --gradle-version 7.6.1 --gradle-distribution-sha256-sum 518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2 --distribution-type all
```

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
