### PR TITLE
Enabled the efficient filtering support for Faiss Engine

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -56,11 +56,11 @@ In addition to this, the plugin has been tested with JDK 17, and this JDK versio
 
 #### CMake
 
-The plugin requires that cmake >= 3.17.2 is installed in order to build the JNI libraries.
+The plugin requires that cmake >= 3.23.1 is installed in order to build the JNI libraries.
 
 One easy way to install on mac or linux is to use pip:
 ```bash
-pip install cmake==3.17.2
+pip install cmake==3.23.1
 ```
 
 #### Faiss Dependencies

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.23.1)
 
 project(KNNPlugin_JNI)
 
@@ -95,7 +95,7 @@ if (${CONFIG_NMSLIB} STREQUAL ON OR ${CONFIG_ALL} STREQUAL ON OR ${CONFIG_TEST} 
     set_target_properties(${TARGET_LIB_NMSLIB} PROPERTIES SUFFIX ${LIB_EXT})
     set_target_properties(${TARGET_LIB_NMSLIB} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-    if (WIN32)
+    if (NOT "${WIN32}" STREQUAL "")
     # Use RUNTIME_OUTPUT_DIRECTORY, to build the target library (opensearchknn_nmslib) in the specified directory at runtime.
         set_target_properties(${TARGET_LIB_NMSLIB} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/release)
     else()

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -40,6 +40,12 @@ namespace knn_jni {
         jobjectArray QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
                                 jfloatArray queryVectorJ, jint kJ);
 
+        // Execute a query against the index located in memory at indexPointerJ along with Filters
+        //
+        // Return an array of KNNQueryResults
+        jobjectArray QueryIndex_WithFilter(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
+                                                                jfloatArray queryVectorJ, jint kJ, jintArray filterIdsJ);
+
         // Free the index located in memory at indexPointerJ
         void Free(jlong indexPointer);
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -52,6 +52,14 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryInd
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    queryIndex_WithFilter
+ * Signature: (J[FI[J)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ */
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndexWithFilter
+  (JNIEnv *, jclass, jlong, jfloatArray, jint, jintArray);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
  * Method:    free
  * Signature: (J)V
  */

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -18,12 +18,18 @@
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexIVFFlat.h"
 #include "faiss/MetaIndexes.h"
+#include "faiss/Index.h"
+#include "faiss/impl/IDSelector.h"
 
 #include <algorithm>
 #include <jni.h>
 #include <string>
 #include <vector>
 
+// Defines type of IDSelector
+enum FilterIdsSelectorType{
+    BITMAP, BATCH
+};
 
 // Translate space type to faiss metric
 faiss::MetricType TranslateSpaceToMetric(const std::string& spaceType);
@@ -33,7 +39,19 @@ void SetExtraParameters(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env,
                         const std::unordered_map<std::string, jobject>& parametersCpp, faiss::Index * index);
 
 // Train an index with data provided
-void InternalTrainIndex(faiss::Index * index, faiss::Index::idx_t n, const float* x);
+void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x);
+
+// Create the SearchParams based on the Index Type
+std::unique_ptr<faiss::SearchParameters> buildSearchParams(const faiss::IndexIDMap *indexReader, faiss::IDSelector* idSelector);
+
+// Helps to choose the right FilterIdsSelectorType for Faiss
+FilterIdsSelectorType getIdSelectorType(const int* filterIds, int filterIdsLength);
+
+// Converts the int FilterIds to Faiss ids type array.
+void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, faiss::idx_t* convertedFilterIds);
+
+// Concerts the FilterIds to BitMap
+void buildFilterIdsBitMap(const int* filterIds, int filterIdsLength, uint8_t* bitsetVector);
 
 void knn_jni::faiss_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
                                          jobjectArray vectorsJ, jstring indexPathJ, jobject parametersJ) {
@@ -181,12 +199,17 @@ jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
 
 jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
                                                 jfloatArray queryVectorJ, jint kJ) {
+    return knn_jni::faiss_wrapper::QueryIndex_WithFilter(jniUtil, env, indexPointerJ, queryVectorJ, kJ, nullptr);
+}
+
+jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
+                                                jfloatArray queryVectorJ, jint kJ, jintArray filterIdsJ) {
 
     if (queryVectorJ == nullptr) {
         throw std::runtime_error("Query Vector cannot be null");
     }
 
-    auto *indexReader = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    auto *indexReader = reinterpret_cast<faiss::IndexIDMap *>(indexPointerJ);
 
     if (indexReader == nullptr) {
         throw std::runtime_error("Invalid pointer to index");
@@ -195,14 +218,50 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniU
     // The ids vector will hold the top k ids from the search and the dis vector will hold the top k distances from
     // the query point
     std::vector<float> dis(kJ);
-    std::vector<faiss::Index::idx_t> ids(kJ);
+    std::vector<faiss::idx_t> ids(kJ);
     float* rawQueryvector = jniUtil->GetFloatArrayElements(env, queryVectorJ, nullptr);
-
-    try {
-        indexReader->search(1, rawQueryvector, kJ, dis.data(), ids.data());
-    } catch (...) {
-        jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
-        throw;
+    // create the filterSearch params if the filterIdsJ is not a null pointer
+    if(filterIdsJ != nullptr) {
+        int *filteredIdsArray = jniUtil->GetIntArrayElements(env, filterIdsJ, nullptr);
+        int filterIdsLength = env->GetArrayLength(filterIdsJ);
+        std::unique_ptr<faiss::IDSelector> idSelector;
+        FilterIdsSelectorType idSelectorType = getIdSelectorType(filteredIdsArray, filterIdsLength);
+        // start with empty vectors for 2 different types of empty Selectors. We need define them here to avoid copying of data
+        // during the returns. We could have used pass by reference, but we choose pointers. Returning reference to local
+        // vector is also an option which can be efficient than copying during returns but it requires upto date C++ compilers.
+        // To avoid all those confusions, its better to work with pointers here. Ref: https://cplusplus.com/forum/general/56177/
+        std::vector<faiss::idx_t> convertedIds;
+        std::vector<uint8_t> bitmap;
+        // Choose a selector which suits best
+        if(idSelectorType == BATCH) {
+            convertedIds.resize(filterIdsLength);
+            convertFilterIdsToFaissIdType(filteredIdsArray, filterIdsLength, convertedIds.data());
+            idSelector.reset(new faiss::IDSelectorBatch(convertedIds.size(), convertedIds.data()));
+        } else {
+            int maxIdValue = filteredIdsArray[filterIdsLength - 1];
+            // >> 3 is equivalent to value / 8
+            const int bitsetArraySize = (maxIdValue >> 3) + 1;
+            bitmap.resize(bitsetArraySize, 0);
+            buildFilterIdsBitMap(filteredIdsArray, filterIdsLength, bitmap.data());
+            idSelector.reset(new faiss::IDSelectorBitmap(filterIdsLength, bitmap.data()));
+        }
+        std::unique_ptr<faiss::SearchParameters> searchParameters = buildSearchParams(indexReader, idSelector.get());
+        try {
+            indexReader->search(1, rawQueryvector, kJ, dis.data(), ids.data(), searchParameters.get());
+        } catch (...) {
+            jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
+            jniUtil->ReleaseIntArrayElements(env, filterIdsJ, filteredIdsArray, JNI_ABORT);
+            throw;
+        }
+        jniUtil->ReleaseIntArrayElements(env, filterIdsJ, filteredIdsArray, JNI_ABORT);
+    } else {
+        try {
+            std::cout << "Doing query" << std::endl;
+            indexReader->search(1, rawQueryvector, kJ, dis.data(), ids.data());
+        } catch (...) {
+            jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
+            throw;
+        }
     }
     jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
 
@@ -225,6 +284,33 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniU
         jniUtil->SetObjectArrayElement(env, results, i, result);
     }
     return results;
+}
+
+/**
+ * Based on the type of the index reader we need to return the SearchParameters. The way we do this by dynamically
+ * casting the IndexReader.
+ * @param indexReader
+ * @param idSelector
+ * @return SearchParameters
+ */
+std::unique_ptr<faiss::SearchParameters> buildSearchParams(const faiss::IndexIDMap *indexReader, faiss::IDSelector* idSelector) {
+    auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
+    if(hnswReader) {
+        // we need to make this variable unique_ptr so that the scope can be shared with caller function.
+        std::unique_ptr<faiss::SearchParametersHNSW> hnswParams(new faiss::SearchParametersHNSW);
+        hnswParams->sel = idSelector;
+        return hnswParams;
+    }
+
+    auto ivfReader = dynamic_cast<const faiss::IndexIVF*>(indexReader->index);
+    auto ivfFlatReader = dynamic_cast<const faiss::IndexIVFFlat*>(indexReader->index);
+    if(ivfReader || ivfFlatReader) {
+        // we need to make this variable unique_ptr so that the scope can be shared with caller function.
+        std::unique_ptr<faiss::SearchParametersIVF> ivfParams(new faiss::SearchParametersIVF);
+        ivfParams->sel = idSelector;
+        return ivfParams;
+    }
+    throw std::runtime_error("Invalid Index Type supported for Filtered Search on Faiss");
 }
 
 void knn_jni::faiss_wrapper::Free(jlong indexPointer) {
@@ -344,7 +430,7 @@ void SetExtraParameters(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env,
     }
 }
 
-void InternalTrainIndex(faiss::Index * index, faiss::Index::idx_t n, const float* x) {
+void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x) {
     if (auto * indexIvf = dynamic_cast<faiss::IndexIVF*>(index)) {
         if (indexIvf->quantizer_trains_alone == 2) {
             InternalTrainIndex(indexIvf->quantizer, n, x);
@@ -354,5 +440,62 @@ void InternalTrainIndex(faiss::Index * index, faiss::Index::idx_t n, const float
 
     if (!index->is_trained) {
         index->train(n, x);
+    }
+}
+
+/**
+ * This function takes a call on what ID Selector to use:
+ * https://github.com/facebookresearch/faiss/wiki/Setting-search-parameters-for-one-query#idselectorarray-idselectorbatch-and-idselectorbitmap
+ *
+ * class	       storage	lookup     construction(Opensearch + Faiss)
+ * IDSelectorArray	O(k)	O(k)          O(2k)
+ * IDSelectorBatch	O(k)	O(1)          O(2k)
+ * IDSelectorBitmap	O(n/8)	O(1)          O(k) -> n is the max value of id in the index
+ *
+ * TODO: We need to ideally decide when we can take another hit of K iterations in latency. Some facts:
+ * an OpenSearch Index can have max segment size as 5GB which, which on a vector with dimension of 128 boils down to
+ * 7.5M vectors.
+ * Ref: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#hnsw-memory-estimation
+ * M = 16
+ * Dimension = 128
+ * (1.1 * ( 4 * 128 + 8 * 16) * 7500000)/(1024*1024*1024) ~ 4.9GB
+ * Ids are sequential in a Segment which means for IDSelectorBitmap total size if the max ID has value of 7.5M will be
+ * 7500000/(8*1024) = 915KBs in worst case. But with larger dimensions this worst case value will decrease.
+ *
+ * With 915KB how many ids can be represented as an array of 64-bit longs : 117,120 ids
+ * So iterating on 117k ids for 1 single pass is also time consuming. So, we are currently concluding to consider only size
+ * as factor. We need to improve on this.
+ *
+ * TODO: Best way is to implement a SparseBitSet in C++. This can be done by extending the IDSelector Interface of Faiss.
+ *
+ * @param filterIds
+ * @param filterIdsLength
+ * @return std::string
+ */
+FilterIdsSelectorType getIdSelectorType(const int* filterIds, int filterIdsLength) {
+    int maxIdValue = filterIds[filterIdsLength - 1];
+    if(filterIdsLength * sizeof(faiss::idx_t) * 8 <= maxIdValue ) {
+        return BATCH;
+    }
+    return BITMAP;
+}
+
+void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, faiss::idx_t* convertedFilterIds) {
+    for (int i = 0; i < filterIdsLength; i++) {
+        convertedFilterIds[i] = filterIds[i];
+    }
+}
+
+void buildFilterIdsBitMap(const int* filterIds, int filterIdsLength, uint8_t* bitsetVector) {
+    /**
+     * Coming from Faiss IDSelectorBitmap::is_member function bitmap id will be selected
+     * iff id / 8 < n and bit number (i%8) of bitmap[floor(i / 8)] is 1.
+     */
+    for(int i = 0 ; i < filterIdsLength ; i ++) {
+        int value = filterIds[i];
+        // / , % are expensive operation. Hence, using BitShift operation as they are fast.
+        int bitsetArrayIndex = value >> 3 ; // is equivalent to value / 8
+        // (value & 7) equivalent to value % 8
+        bitsetVector[bitsetArrayIndex] = bitsetVector[bitsetArrayIndex] |  (1 << (value & 7));
     }
 }

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -88,6 +88,18 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryInd
     return nullptr;
 }
 
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndexWithFilter
+  (JNIEnv * env, jclass cls, jlong indexPointerJ, jfloatArray queryVectorJ, jint kJ, jintArray filteredIdsJ) {
+
+      try {
+          return knn_jni::faiss_wrapper::QueryIndex_WithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, kJ, filteredIdsJ);
+      } catch (...) {
+          jniUtil.CatchCppExceptionAndThrowJava(env);
+      }
+      return nullptr;
+
+}
+
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_free(JNIEnv * env, jclass cls, jlong indexPointerJ)
 {
     try {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -283,7 +283,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             );
         }
 
-        if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine) && filter != null) {
+        if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine) && filter != null && knnEngine != KNNEngine.FAISS) {
             throw new IllegalArgumentException(String.format("Engine [%s] does not support filters", knnEngine));
         }
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNScorer.java
@@ -56,4 +56,37 @@ public class KNNScorer extends Scorer {
     public int docID() {
         return docIdsIter.docID();
     }
+
+    /**
+     * Returns the Empty Scorer implementation. We use this scorer to short circuit the actual search when it is not
+     * required.
+     * @param knnWeight {@link KNNWeight}
+     * @return {@link KNNScorer}
+     */
+    public static Scorer emptyScorer(KNNWeight knnWeight) {
+        return new Scorer(knnWeight) {
+            private final DocIdSetIterator docIdsIter = DocIdSetIterator.empty();
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return docIdsIter;
+            }
+
+            @Override
+            public float getMaxScore(int upTo) throws IOException {
+                return 0;
+            }
+
+            @Override
+            public float score() throws IOException {
+                assert docID() != DocIdSetIterator.NO_MORE_DOCS;
+                return 0;
+            }
+
+            @Override
+            public int docID() {
+                return docIdsIter.docID();
+            }
+        };
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -32,6 +32,7 @@ public enum KNNEngine implements KNNLibrary {
     public static final KNNEngine DEFAULT = NMSLIB;
 
     private static final Set<KNNEngine> CUSTOM_SEGMENT_FILE_ENGINES = ImmutableSet.of(KNNEngine.NMSLIB, KNNEngine.FAISS);
+    private static final Set<KNNEngine> ENGINES_SUPPORTING_FILTERS = ImmutableSet.of(KNNEngine.LUCENE, KNNEngine.FAISS);
 
     private static Map<KNNEngine, Integer> MAX_DIMENSIONS_BY_ENGINE = Map.of(
         KNNEngine.NMSLIB,
@@ -103,6 +104,10 @@ public enum KNNEngine implements KNNLibrary {
      */
     public static Set<KNNEngine> getEnginesThatCreateCustomSegmentFiles() {
         return CUSTOM_SEGMENT_FILE_ENGINES;
+    }
+
+    public static Set<KNNEngine> getEnginesThatSupportsFilters() {
+        return ENGINES_SUPPORTING_FILTERS;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -122,6 +122,6 @@ public interface KNNLibrary {
      * @return list of file extensions that will be read/write with mmap
      */
     default List<String> mmapFileExtensions() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -24,7 +24,7 @@ import java.util.Map;
  *
  * In order to compile C++ header file, run:
  * javac -h jni/include src/main/java/org/opensearch/knn/jni/FaissService.java
- *      src/main/java/org/opensearch/knn/index/KNNQueryResult.java
+ *      src/main/java/org/opensearch/knn/index/query/KNNQueryResult.java
  *      src/main/java/org/opensearch/knn/common/KNNConstants.java
  */
 class FaissService {
@@ -82,6 +82,8 @@ class FaissService {
      * @return KNNQueryResult array of k neighbors
      */
     public static native KNNQueryResult[] queryIndex(long indexPointer, float[] queryVector, int k);
+
+    public static native KNNQueryResult[] queryIndexWithFilter(long indexPointer, float[] queryVector, int k, int[] filterIds);
 
     /**
      * Free native memory pointer

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestGetModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestGetModelHandler.java
@@ -12,8 +12,8 @@
 package org.opensearch.knn.plugin.rest;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.common.Strings;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.GetModelAction;
 import org.opensearch.knn.plugin.transport.GetModelRequest;
@@ -50,7 +50,7 @@ public class RestGetModelHandler extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String modelID = restRequest.param(MODEL_ID);
-        if (!Strings.hasText(modelID)) {
+        if (StringUtils.isBlank(modelID)) {
             throw new IllegalArgumentException("model ID cannot be empty");
         }
 

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestKNNStatsHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestKNNStatsHandler.java
@@ -6,12 +6,12 @@
 package org.opensearch.knn.plugin.rest;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang.StringUtils;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.KNNStatsAction;
 import org.opensearch.knn.plugin.transport.KNNStatsRequest;
 import com.google.common.collect.ImmutableList;
 import org.opensearch.client.node.NodeClient;
-import org.opensearch.common.Strings;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestActions;
@@ -83,7 +83,7 @@ public class RestKNNStatsHandler extends BaseRestHandler {
         // parse the nodes the user wants to query
         String[] nodeIdsArr = null;
         String nodesIdsStr = request.param("nodeId");
-        if (!Strings.isEmpty(nodesIdsStr)) {
+        if (StringUtils.isNotEmpty(nodesIdsStr)) {
             nodeIdsArr = nodesIdsStr.split(",");
         }
 
@@ -93,7 +93,7 @@ public class RestKNNStatsHandler extends BaseRestHandler {
         // parse the stats the customer wants to see
         Set<String> statsSet = null;
         String statsStr = request.param("stat");
-        if (!Strings.isEmpty(statsStr)) {
+        if (StringUtils.isNotEmpty(statsStr)) {
             statsSet = new HashSet<>(Arrays.asList(statsStr.split(",")));
         }
 

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestKNNWarmupHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestKNNWarmupHandler.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.plugin.rest;
 
+import org.apache.commons.lang.StringUtils;
 import org.opensearch.knn.common.exception.KNNInvalidIndicesException;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.KNNWarmupAction;
@@ -15,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.Index;
 import org.opensearch.rest.BaseRestHandler;
@@ -81,7 +81,7 @@ public class RestKNNWarmupHandler extends BaseRestHandler {
     }
 
     private KNNWarmupRequest createKNNWarmupRequest(RestRequest request) {
-        String[] indexNames = Strings.splitStringByCommaToArray(request.param("index"));
+        String[] indexNames = StringUtils.split(request.param("index"), ",");
         Index[] indices = indexNameExpressionResolver.concreteIndices(clusterService.state(), strictExpandOpen(), indexNames);
         List<String> invalidIndexNames = new ArrayList<>();
 

--- a/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/DeleteModelRequest.java
@@ -11,9 +11,9 @@
 
 package org.opensearch.knn.plugin.transport;
 
+import org.apache.commons.lang.StringUtils;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
-import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 
@@ -43,7 +43,7 @@ public class DeleteModelRequest extends ActionRequest {
 
     @Override
     public ActionRequestValidationException validate() {
-        if (Strings.hasText(modelID)) {
+        if (StringUtils.isNotBlank(modelID)) {
             return null;
         }
         return addValidationError("Model id cannot be empty ", null);

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.plugin.transport;
 
+import org.apache.commons.lang.StringUtils;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.search.SearchRequest;
@@ -19,7 +20,6 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.Strings;
 import org.opensearch.common.ValidationException;
 import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.inject.Inject;
@@ -107,7 +107,7 @@ public class TrainingJobRouterTransportAction extends HandledTransportAction<Tra
             if (response.getTrainingJobCount() < 1) {
                 selectedNode = currentNode;
                 // Return right away if the user didnt pass a preferred node or this is the preferred node
-                if (Strings.isEmpty(preferredNode) || selectedNode.getId().equals(preferredNode)) {
+                if (StringUtils.isEmpty(preferredNode) || selectedNode.getId().equals(preferredNode)) {
                     return selectedNode;
                 }
             }

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -11,9 +11,9 @@
 
 package org.opensearch.knn.training;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.common.Strings;
 import org.opensearch.common.UUIDs;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
@@ -68,7 +68,7 @@ public class TrainingJob implements Runnable {
         String description
     ) {
         // Generate random base64 string if one is not provided
-        this.modelId = Strings.hasText(modelId) ? modelId : UUIDs.randomBase64UUID();
+        this.modelId = StringUtils.isNotBlank(modelId) ? modelId : UUIDs.randomBase64UUID();
         this.knnMethodContext = Objects.requireNonNull(knnMethodContext, "MethodContext cannot be null.");
         this.nativeMemoryCacheManager = Objects.requireNonNull(nativeMemoryCacheManager, "NativeMemoryCacheManager cannot be null.");
         this.trainingDataEntryContext = Objects.requireNonNull(trainingDataEntryContext, "TrainingDataEntryContext cannot be null.");

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -333,7 +333,7 @@ public class KNNCodecTestUtil {
         );
         int k = 2;
         float[] queryVector = new float[dimension];
-        KNNQueryResult[] results = JNIService.queryIndex(indexPtr, queryVector, k, knnEngine.getName());
+        KNNQueryResult[] results = JNIService.queryIndex(indexPtr, queryVector, k, knnEngine.getName(), null);
         assertTrue(results.length > 0);
         JNIService.free(indexPtr, knnEngine.getName());
     }

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
@@ -74,7 +74,7 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
         // Confirm that the file was loaded by querying
         float[] query = new float[dimension];
         Arrays.fill(query, numVectors + 1);
-        KNNQueryResult[] results = JNIService.queryIndex(indexAllocation.getMemoryAddress(), query, 2, knnEngine.getName());
+        KNNQueryResult[] results = JNIService.queryIndex(indexAllocation.getMemoryAddress(), query, 2, knnEngine.getName(), null);
         assertTrue(results.length > 0);
     }
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -133,7 +133,8 @@ public class KNNWeightTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         final Function<Float, Float> scoreTranslator = spaceType::scoreTranslation;
         final String modelId = "modelId";
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString())).thenReturn(getKNNQueryResults());
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any()))
+            .thenReturn(getKNNQueryResults());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME);
 
@@ -272,7 +273,8 @@ public class KNNWeightTests extends KNNTestCase {
     @SneakyThrows
     public void testEmptyQueryResults() {
         final KNNQueryResult[] knnQueryResults = new KNNQueryResult[] {};
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString())).thenReturn(knnQueryResults);
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any()))
+            .thenReturn(knnQueryResults);
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME);
         final KNNWeight knnWeight = new KNNWeight(query, 0.0f);
@@ -316,7 +318,8 @@ public class KNNWeightTests extends KNNTestCase {
         final Set<String> segmentFiles,
         final Map<String, String> fileAttributes
     ) throws IOException {
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString())).thenReturn(getKNNQueryResults());
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any()))
+            .thenReturn(getKNNQueryResults());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME);
         final KNNWeight knnWeight = new KNNWeight(query, 0.0f);

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -583,12 +583,12 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     public void testQueryIndex_invalidEngine() {
-        expectThrows(IllegalArgumentException.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, "invalid-engine"));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, "invalid" + "-engine", null));
     }
 
     public void testQueryIndex_nmslib_invalid_badPointer() {
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.NMSLIB.getName()));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.NMSLIB.getName(), null));
     }
 
     public void testQueryIndex_nmslib_invalid_nullQueryVector() throws IOException {
@@ -611,7 +611,7 @@ public class JNIServiceTests extends KNNTestCase {
         );
         assertNotEquals(0, pointer);
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.NMSLIB.getName()));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.NMSLIB.getName(), null));
     }
 
     public void testQueryIndex_nmslib_valid() throws IOException {
@@ -637,7 +637,7 @@ public class JNIServiceTests extends KNNTestCase {
             assertNotEquals(0, pointer);
 
             for (float[] query : testData.queries) {
-                KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.NMSLIB.getName());
+                KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.NMSLIB.getName(), null);
                 assertEquals(k, results.length);
             }
         }
@@ -645,7 +645,7 @@ public class JNIServiceTests extends KNNTestCase {
 
     public void testQueryIndex_faiss_invalid_badPointer() {
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, FAISS_NAME));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, FAISS_NAME, null));
     }
 
     public void testQueryIndex_faiss_invalid_nullQueryVector() throws IOException {
@@ -664,7 +664,7 @@ public class JNIServiceTests extends KNNTestCase {
         long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
         assertNotEquals(0, pointer);
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, FAISS_NAME));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, FAISS_NAME, null));
     }
 
     public void testQueryIndex_faiss_valid() throws IOException {
@@ -693,7 +693,7 @@ public class JNIServiceTests extends KNNTestCase {
                 assertNotEquals(0, pointer);
 
                 for (float[] query : testData.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null);
                     assertEquals(k, results.length);
                 }
             }


### PR DESCRIPTION
### Description
This is an initial PR for enabling the pre-filtering support for Faiss Engine.

#### Changes include:
1. Upgrading the Faiss to commit id: https://github.com/facebookresearch/faiss/commit/3219e3d12e6fc36dfdfe17d4cf238ef70bf89568
2. Doing an optimization to select when to use IDArraySelector and IDBitMapSelector.
3. Don't run Faiss search if no docIds are returned from filters.


## Next Steps:
1. Optimize the JNI interfaces to have single query interface.
2. Write Unit tests for both java and c++ code.
3. Write ITs for filtering.
5. Do perf testing, compare with lucene and share the results on the github issue.
6. Figure out better way to select IDSelector Map.
7. Implement Exact search optimization when filterIds < k


### Issues Resolved
#903 

###Testing
Tested the code using the example mentioned here: https://opensearch.org/docs/latest/search-plugins/knn/filter-search-knn/#using-a-lucene-k-nn-filter for lucene


### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
