### PR TITLE
Bump requests version from 2.26.0 to 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Bulk allocate objects for nmslib index creation to avoid malloc fragmentation ([#773](https://github.com/opensearch-project/k-NN/pull/773))
 ### Bug Fixes
 ### Infrastructure
+* Bump requests version from 2.26.0 to 2.31.0 ([#913](https://github.com/opensearch-project/k-NN/pull/913))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -28,7 +28,7 @@ psutil==5.8.0
     # via -r requirements.in
 pyyaml==5.4.1
     # via -r requirements.in
-requests==2.26.0
+requests==2.31.0
     # via -r requirements.in
 urllib3==1.26.6
     # via


### PR DESCRIPTION
### Description
Fix CVE by bumping `requests` dependency version from 2.26.0 to 2.31.0
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/910
 
### Check List
- [x] New functionality includes testing.
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
