### PR TITLE
Disable index refresh for system indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Bulk allocate objects for nmslib index creation to avoid malloc fragmentation ([#773](https://github.com/opensearch-project/k-NN/pull/773))
 ### Bug Fixes
 ### Infrastructure
+Disable index refresh for system indices ([#773](https://github.com/opensearch-project/k-NN/pull/915))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -106,7 +106,7 @@ public class FaissIT extends KNNRestTestCase {
         }
 
         // Assert we have the right number of documents in the index
-        refreshAllIndices();
+        refreshAllNonSystemIndices();
         assertEquals(testData.indexData.docs.length, getDocCount(indexName));
 
         int k = 10;

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -13,6 +13,9 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
@@ -22,7 +25,6 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.opensearch.client.Request;
@@ -60,6 +62,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -112,6 +115,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     private static final String DOCUMENT_FIELD_FOUND = "found";
     protected static final int DELAY_MILLI_SEC = 1000;
     protected static final int NUM_OF_ATTEMPTS = 30;
+    private static final String SYSTEM_INDEX_PREFIX = ".opendistro";
 
     @AfterClass
     public static void dumpCoverage() throws IOException, MalformedObjectNameException {
@@ -1266,5 +1270,40 @@ public class KNNRestTestCase extends ODFERestTestCase {
         void dump(boolean reset);
 
         void reset();
+    }
+
+    protected void refreshAllNonSystemIndices() throws Exception {
+        Response response = adminClient().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
+        XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType());
+        try (
+            XContentParser parser = xContentType.xContent()
+                .createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    response.getEntity().getContent()
+                )
+        ) {
+            XContentParser.Token token = parser.nextToken();
+            List<Map<String, Object>> parserList;
+            if (token == XContentParser.Token.START_ARRAY) {
+                parserList = parser.listOrderedMap().stream().map(obj -> (Map<String, Object>) obj).collect(Collectors.toList());
+            } else {
+                parserList = Collections.singletonList(parser.mapOrdered());
+            }
+            Set<String> indices = parserList.stream()
+                .map(index -> (String) index.get("index"))
+                .filter(index -> !index.startsWith(SYSTEM_INDEX_PREFIX))
+                .collect(Collectors.toSet());
+            for (String index : indices) {
+                refreshIndex(index);
+            }
+        }
+    }
+
+    protected void refreshIndex(final String index) throws IOException {
+        Request request = new Request("POST", "/" + index + "/_refresh");
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 }


### PR DESCRIPTION
### Description
Standard method refreshAllIndices refreshes all indices including system. This produces error warnings when running integration tests for indices like '.opensearch-knn-models'. In this change we're filtering indices and do refresh only if its name doesn't start with system prefix.  
 
```
Suite: Test class org.opensearch.knn.index.FaissIT
  2> may 25, 2023 8:29:50 PM org.opensearch.client.RestClient logResponse
  2> AVERTISSEMENT: request [POST http://localhost:9200/_refresh?expand_wildcards=open%2Chidden] returned 2 warnings: [299 OpenSearch-2.8.0-4bd47e16e300cd6147d24e329ac05014fd61cb80 "this request accesses system indices: [.opendistro_security], but in a future major version, direct access to system indices will be prevented by default"],[299 OpenSearch-2.8.0-4bd47e16e300cd6147d24e329ac05014fd61cb80 "this request accesses system indices: [.opensearch-knn-models], but in a future major version, direct access to system indices will be prevented by default"]
  2> REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.knn.index.FaissIT.testEndToEnd_fromMethod" -Dtests.seed=BFA60D37E99638AE -Dtests.security.manager=false -Dtests.locale=fr-LU -Dtests.timezone=Europe/Kirov -Druntime.java=17
  2> org.opensearch.client.WarningFailureException: method [POST], host [http://localhost:9200], URI [/_refresh?expand_wildcards=open%2Chidden], status line [HTTP/1.1 200 OK]
    Warnings: [this request accesses system indices: [.opendistro_security], but in a future major version, direct access to system indices will be prevented by default, this request accesses system indices: [.opensearch-knn-models], but in a future major version, direct access to system indices will be prevented by default]
    {"_shards":{"total":6,"successful":4,"failed":0}}
        at __randomizedtesting.SeedInfo.seed([BFA60D37E99638AE:5576685C932D3555]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:371)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:345)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:320)
        at app//org.opensearch.test.rest.OpenSearchRestTestCase.refreshAllIndices(OpenSearchRestTestCase.java:728)
        at app//org.opensearch.knn.index.FaissIT.testEndToEnd_fromMethod(FaissIT.java:109)
  2> NOTE: leaving temporary files on disk at: /tmp/tmpjewtggaq/k-NN/build/testrun/integTes
```

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/914 
 
### Check List
- [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
