### PR TITLE
[Backport 2.x] Do refresh only for non system indices (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Bulk allocate objects for nmslib index creation to avoid malloc fragmentation ([#773](https://github.com/opensearch-project/k-NN/pull/773))
 ### Bug Fixes
 ### Infrastructure
+* Disable index refresh for system indices ([#773](https://github.com/opensearch-project/k-NN/pull/915))
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -55,7 +55,7 @@ public class FaissIT extends KNNRestTestCase {
         testData = new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());
     }
 
-    public void testEndToEnd_fromMethod() throws IOException, InterruptedException {
+    public void testEndToEnd_fromMethod() throws Exception {
         String indexName = "test-index-1";
         String fieldName = "test-field-1";
 
@@ -106,7 +106,7 @@ public class FaissIT extends KNNRestTestCase {
         }
 
         // Assert we have the right number of documents in the index
-        refreshAllIndices();
+        refreshAllNonSystemIndices();
         assertEquals(testData.indexData.docs.length, getDocCount(indexName));
 
         int k = 10;


### PR DESCRIPTION
Backport from https://github.com/opensearch-project/k-NN/pull/915

(cherry picked from commit https://github.com/opensearch-project/k-NN/commit/a5214a3dfe86d5790fe204385bc92af147f98434)
