### PR TITLE
[Backport 2.x] Bump requests version from 2.26.0 to 2.31.0 (#913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Bulk allocate objects for nmslib index creation to avoid malloc fragmentation ([#773](https://github.com/opensearch-project/k-NN/pull/773))
 ### Bug Fixes
 ### Infrastructure
+* Bump requests version from 2.26.0 to 2.31.0 ([#913](https://github.com/opensearch-project/k-NN/pull/913))
 * Disable index refresh for system indices ([#773](https://github.com/opensearch-project/k-NN/pull/915))
 ### Documentation
 ### Maintenance

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -28,7 +28,7 @@ psutil==5.8.0
     # via -r requirements.in
 pyyaml==5.4.1
     # via -r requirements.in
-requests==2.26.0
+requests==2.31.0
     # via -r requirements.in
 urllib3==1.26.6
     # via


### PR DESCRIPTION
Backport from #913 

(cherry picked from commit 15319e2e57aace412809abed0ac4e29e6d18a4ad)

