### PR TITLE
Update bwc version after 2.8 release

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java: [ 11, 17 ]
         os: [ubuntu-latest]
-        bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0-SNAPSHOT" ]
+        bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0-SNAPSHOT" ]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
         exclude:
           - os: windows-latest
@@ -88,7 +88,7 @@ jobs:
       matrix:
         java: [ 11, 17 ]
         os: [ubuntu-latest]
-        bwc_version: [ "2.8.0-SNAPSHOT" ]
+        bwc_version: [ "2.9.0-SNAPSHOT" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests


### PR DESCRIPTION
### Description
Update versions after 2.8 release: change 2.8.0-SNAPSHOT to 2.8.0, add 2.9.0-SNAPSHOT, it's routine maintenance similar to what is done for every version ([ref for 2.7->2.8](https://github.com/opensearch-project/k-NN/commit/5a0b20d81b48874f995f8295919c62b5460602e4)) 
 
### Check List
- [ ] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
