### PR TITLE
Add Indexing Support for Lucene Byte Sized Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.8...2.x)
 ### Features
 * Added efficient filtering support for Faiss Engine ([#936](https://github.com/opensearch-project/k-NN/pull/936))
+* Add Indexing Support for Lucene Byte Sized Vector ([#937](https://github.com/opensearch-project/k-NN/pull/937))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -52,8 +52,8 @@ public class KNNConstants {
     public static final String MAX_VECTOR_COUNT_PARAMETER = "max_training_vector_count";
     public static final String SEARCH_SIZE_PARAMETER = "search_size";
 
-    public static final String VECTOR_DATA_TYPE = "data_type";
-    public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE = VectorDataType.FLOAT;
+    public static final String VECTOR_DATA_TYPE_FIELD = "data_type";
+    public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
 
     // Lucene specific constants
     public static final String LUCENE_NAME = "lucene";

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.common;
 
+import org.opensearch.knn.index.VectorDataType;
+
 public class KNNConstants {
     // shared across library constants
     public static final String DIMENSION = "dimension";
@@ -49,6 +51,9 @@ public class KNNConstants {
     public static final String TRAIN_FIELD_PARAMETER = "training_field";
     public static final String MAX_VECTOR_COUNT_PARAMETER = "max_training_vector_count";
     public static final String SEARCH_SIZE_PARAMETER = "search_size";
+
+    public static final String VECTOR_DATA_TYPE = "data_type";
+    public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE = VectorDataType.FLOAT;
 
     // Lucene specific constants
     public static final String LUCENE_NAME = "lucene";

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -5,289 +5,85 @@
 
 package org.opensearch.knn.index;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnVectorField;
-import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.IndexableFieldType;
-import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.opensearch.index.mapper.ParametrizedFieldMapper;
-import org.opensearch.knn.index.util.KNNEngine;
 
-import java.util.HashSet;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE;
-import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
-import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
-import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 /**
  * Enum contains data_type of vectors and right now only supported for lucene engine in k-NN plugin.
  * We have two vector data_types, one is float (default) and the other one is byte.
  */
+@AllArgsConstructor
 public enum VectorDataType {
     BYTE("byte") {
-        /**
-         * @param dimension  Dimension of the vector
-         * @param vectorSimilarityFunction VectorSimilarityFunction for a given spaceType
-         * @return FieldType of type KnnByteVectorField
-         */
+
         @Override
         public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
             return KnnByteVectorField.createFieldType(dimension, vectorSimilarityFunction);
         }
-
-        /**
-         * @param knnEngine KNNEngine
-         * @return DocValues FieldType of type Binary and with BYTE VectorEncoding
-         */
-        @Override
-        public FieldType buildDocValuesFieldType(KNNEngine knnEngine) {
-            IndexableFieldType indexableFieldType = new IndexableFieldType() {
-                @Override
-                public boolean stored() {
-                    return false;
-                }
-
-                @Override
-                public boolean tokenized() {
-                    return true;
-                }
-
-                @Override
-                public boolean storeTermVectors() {
-                    return false;
-                }
-
-                @Override
-                public boolean storeTermVectorOffsets() {
-                    return false;
-                }
-
-                @Override
-                public boolean storeTermVectorPositions() {
-                    return false;
-                }
-
-                @Override
-                public boolean storeTermVectorPayloads() {
-                    return false;
-                }
-
-                @Override
-                public boolean omitNorms() {
-                    return false;
-                }
-
-                @Override
-                public IndexOptions indexOptions() {
-                    return IndexOptions.NONE;
-                }
-
-                @Override
-                public DocValuesType docValuesType() {
-                    return DocValuesType.NONE;
-                }
-
-                @Override
-                public int pointDimensionCount() {
-                    return 0;
-                }
-
-                @Override
-                public int pointIndexDimensionCount() {
-                    return 0;
-                }
-
-                @Override
-                public int pointNumBytes() {
-                    return 0;
-                }
-
-                @Override
-                public int vectorDimension() {
-                    return 0;
-                }
-
-                @Override
-                public VectorEncoding vectorEncoding() {
-                    return VectorEncoding.BYTE;
-                }
-
-                @Override
-                public VectorSimilarityFunction vectorSimilarityFunction() {
-                    return VectorSimilarityFunction.EUCLIDEAN;
-                }
-
-                @Override
-                public Map<String, String> getAttributes() {
-                    return null;
-                }
-            };
-            FieldType field = new FieldType(indexableFieldType);
-            field.putAttribute(KNN_ENGINE, knnEngine.getName());
-            field.setDocValuesType(DocValuesType.BINARY);
-            field.freeze();
-            return field;
-        }
     },
     FLOAT("float") {
-        /**
-         * @param dimension  Dimension of the vector
-         * @param vectorSimilarityFunction VectorSimilarityFunction for a given spaceType
-         * @return  FieldType of type KnnFloatVectorField
-         */
+
         @Override
         public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
             return KnnVectorField.createFieldType(dimension, vectorSimilarityFunction);
         }
 
-        /**
-         * @param knnEngine  KNNEngine
-         * @return  DocValues FieldType of type Binary and with FLOAT32 VectorEncoding
-         */
-        @Override
-        public FieldType buildDocValuesFieldType(KNNEngine knnEngine) {
-            FieldType field = new FieldType();
-            field.putAttribute(KNN_ENGINE, knnEngine.getName());
-            field.setDocValuesType(DocValuesType.BINARY);
-            field.freeze();
-            return field;
-        }
-
     };
 
+    public static final String SUPPORTED_VECTOR_DATA_TYPES = Arrays.stream(VectorDataType.values())
+        .map(VectorDataType::getValue)
+        .collect(Collectors.joining(","));
+    @Getter
     private final String value;
 
-    VectorDataType(String value) {
-        this.value = value;
-    }
-
     /**
-     * Get VectorDataType name
+     * Creates a KnnVectorFieldType based on the VectorDataType using the provided dimension and
+     * VectorSimilarityFunction.
      *
-     * @return  name
+     * @param dimension Dimension of the vector
+     * @param vectorSimilarityFunction VectorSimilarityFunction for a given spaceType
+     * @return FieldType
      */
-    public String getValue() {
-        return value;
-    }
-
     public abstract FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction);
-
-    public abstract FieldType buildDocValuesFieldType(KNNEngine knnEngine);
-
-    /**
-     * @return  Set of names of all the supporting VectorDataTypes
-     */
-    public static Set<String> getValues() {
-        Set<String> values = new HashSet<>();
-
-        for (VectorDataType dataType : VectorDataType.values()) {
-            values.add(dataType.getValue());
-        }
-        return values;
-    }
 
     /**
      * Validates if given VectorDataType is in the list of supported data types.
      * @param vectorDataType VectorDataType
-     * @return  the same VectorDataType if it is in the supported values else throw exception.
+     * @return  the same VectorDataType if it is in the supported values
+     * throws Exception if an invalid value is provided.
      */
     public static VectorDataType get(String vectorDataType) {
-        String supportedTypes = String.join(",", getValues());
         Objects.requireNonNull(
             vectorDataType,
-            String.format("[{}] should not be null. Supported types are [{}]", VECTOR_DATA_TYPE, supportedTypes)
-        );
-        for (VectorDataType currentDataType : VectorDataType.values()) {
-            if (currentDataType.getValue().equalsIgnoreCase(vectorDataType)) {
-                return currentDataType;
-            }
-        }
-        throw new IllegalArgumentException(
             String.format(
-                "[%s] field was set as [%s] in index mapping. But, supported values are [%s]",
-                VECTOR_DATA_TYPE,
-                vectorDataType,
-                supportedTypes
+                Locale.ROOT,
+                "[%s] should not be null. Supported types are [%s]",
+                VECTOR_DATA_TYPE_FIELD,
+                SUPPORTED_VECTOR_DATA_TYPES
             )
         );
-    }
-
-    /**
-     * Validate the float vector values if it is a number and in the finite range.
-     *
-     * @param value  float vector value
-     */
-    public static void validateFloatVectorValues(float value) {
-        if (Float.isNaN(value)) {
-            throw new IllegalArgumentException("KNN vector values cannot be NaN");
-        }
-
-        if (Float.isInfinite(value)) {
-            throw new IllegalArgumentException("KNN vector values cannot be infinity");
-        }
-    }
-
-    /**
-     * Validate the float vector value in the byte range if it is a finite number,
-     * with no decimal values and in the byte range of [-128 to 127].
-     *
-     * @param value  float value in byte range
-     */
-    public static void validateByteVectorValues(float value) {
-        validateFloatVectorValues(value);
-        if (value % 1 != 0) {
-            throw new IllegalArgumentException(
-                "[data_type] field was set as [byte] in index mapping. But, KNN vector values are floats instead of byte integers"
-            );
-        }
-        if ((int) value < Byte.MIN_VALUE || (int) value > Byte.MAX_VALUE) {
+        try {
+            return VectorDataType.valueOf(vectorDataType.toUpperCase(Locale.ROOT));
+        } catch (Exception e) {
             throw new IllegalArgumentException(
                 String.format(
-                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are not within in the byte range [{}, {}]",
-                    VECTOR_DATA_TYPE,
-                    VectorDataType.BYTE.getValue(),
-                    Byte.MIN_VALUE,
-                    Byte.MAX_VALUE
+                    Locale.ROOT,
+                    "Invalid value provided for [%s] field. Supported values are [%s]",
+                    VECTOR_DATA_TYPE_FIELD,
+                    SUPPORTED_VECTOR_DATA_TYPES
                 )
             );
-        }
-    }
-
-    /**
-     * Validate if the given vector size matches with the dimension provided in mapping.
-     *
-     * @param dimension dimension of vector
-     * @param vectorSize size of the vector
-     */
-    public static void validateVectorDimension(int dimension, int vectorSize) {
-        if (dimension != vectorSize) {
-            String errorMessage = String.format("Vector dimension mismatch. Expected: %d, Given: %d", dimension, vectorSize);
-            throw new IllegalArgumentException(errorMessage);
-        }
-
-    }
-
-    /**
-     * Validates and throws exception if data_type field is set in the index mapping
-     * using any VectorDataType (other than float, which is default) with any engine (except lucene).
-     *
-     * @param knnMethodContext KNNMethodContext Parameter
-     * @param vectorDataType VectorDataType Parameter
-     */
-    public static void validateVectorDataType_Engine(
-        ParametrizedFieldMapper.Parameter<KNNMethodContext> knnMethodContext,
-        ParametrizedFieldMapper.Parameter<VectorDataType> vectorDataType
-    ) {
-        if (vectorDataType.getValue() != DEFAULT_VECTOR_DATA_TYPE
-            && (knnMethodContext.get() == null || knnMethodContext.getValue().getKnnEngine() != KNNEngine.LUCENE)) {
-            throw new IllegalArgumentException(String.format("[%s] is only supported for [%s] engine", VECTOR_DATA_TYPE, LUCENE_NAME));
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE;
+
+/**
+ * Enum contains data_type of vectors and right now only supported for lucene engine in k-NN plugin.
+ * We have two vector data_types, one is float (default) and the other one is byte.
+ */
+public enum VectorDataType {
+    BYTE("byte") {
+        /**
+         * @param dimension  Dimension of the vector
+         * @param vectorSimilarityFunction VectorSimilarityFunction for a given spaceType
+         * @return FieldType of type KnnByteVectorField
+         */
+        @Override
+        public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
+            return KnnByteVectorField.createFieldType(dimension, vectorSimilarityFunction);
+        }
+
+        /**
+         * @param knnEngine KNNEngine
+         * @return DocValues FieldType of type Binary and with BYTE VectorEncoding
+         */
+        @Override
+        public FieldType buildDocValuesFieldType(KNNEngine knnEngine) {
+            IndexableFieldType indexableFieldType = new IndexableFieldType() {
+                @Override
+                public boolean stored() {
+                    return false;
+                }
+
+                @Override
+                public boolean tokenized() {
+                    return true;
+                }
+
+                @Override
+                public boolean storeTermVectors() {
+                    return false;
+                }
+
+                @Override
+                public boolean storeTermVectorOffsets() {
+                    return false;
+                }
+
+                @Override
+                public boolean storeTermVectorPositions() {
+                    return false;
+                }
+
+                @Override
+                public boolean storeTermVectorPayloads() {
+                    return false;
+                }
+
+                @Override
+                public boolean omitNorms() {
+                    return false;
+                }
+
+                @Override
+                public IndexOptions indexOptions() {
+                    return IndexOptions.NONE;
+                }
+
+                @Override
+                public DocValuesType docValuesType() {
+                    return DocValuesType.NONE;
+                }
+
+                @Override
+                public int pointDimensionCount() {
+                    return 0;
+                }
+
+                @Override
+                public int pointIndexDimensionCount() {
+                    return 0;
+                }
+
+                @Override
+                public int pointNumBytes() {
+                    return 0;
+                }
+
+                @Override
+                public int vectorDimension() {
+                    return 0;
+                }
+
+                @Override
+                public VectorEncoding vectorEncoding() {
+                    return VectorEncoding.BYTE;
+                }
+
+                @Override
+                public VectorSimilarityFunction vectorSimilarityFunction() {
+                    return VectorSimilarityFunction.EUCLIDEAN;
+                }
+
+                @Override
+                public Map<String, String> getAttributes() {
+                    return null;
+                }
+            };
+            FieldType field = new FieldType(indexableFieldType);
+            field.putAttribute(KNN_ENGINE, knnEngine.getName());
+            field.setDocValuesType(DocValuesType.BINARY);
+            field.freeze();
+            return field;
+        }
+    },
+    FLOAT("float") {
+        /**
+         * @param dimension  Dimension of the vector
+         * @param vectorSimilarityFunction VectorSimilarityFunction for a given spaceType
+         * @return  FieldType of type KnnFloatVectorField
+         */
+        @Override
+        public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
+            return KnnVectorField.createFieldType(dimension, vectorSimilarityFunction);
+        }
+
+        /**
+         * @param knnEngine  KNNEngine
+         * @return  DocValues FieldType of type Binary and with FLOAT32 VectorEncoding
+         */
+        @Override
+        public FieldType buildDocValuesFieldType(KNNEngine knnEngine) {
+            FieldType field = new FieldType();
+            field.putAttribute(KNN_ENGINE, knnEngine.getName());
+            field.setDocValuesType(DocValuesType.BINARY);
+            field.freeze();
+            return field;
+        }
+
+    };
+
+    private final String value;
+
+    VectorDataType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Get VectorDataType name
+     *
+     * @return  name
+     */
+    public String getValue() {
+        return value;
+    }
+
+    public abstract FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction);
+
+    public abstract FieldType buildDocValuesFieldType(KNNEngine knnEngine);
+
+    /**
+     * @return  Set of names of all the supporting VectorDataTypes
+     */
+    public static Set<String> getValues() {
+        Set<String> values = new HashSet<>();
+
+        for (VectorDataType dataType : VectorDataType.values()) {
+            values.add(dataType.getValue());
+        }
+        return values;
+    }
+
+    /**
+     * Validates if given VectorDataType is in the list of supported data types.
+     * @param vectorDataType VectorDataType
+     * @return  the same VectorDataType if it is in the supported values else throw exception.
+     */
+    public static VectorDataType get(String vectorDataType) {
+        String supportedTypes = String.join(",", getValues());
+        Objects.requireNonNull(
+            vectorDataType,
+            String.format("[{}] should not be null. Supported types are [{}]", VECTOR_DATA_TYPE, supportedTypes)
+        );
+        for (VectorDataType currentDataType : VectorDataType.values()) {
+            if (currentDataType.getValue().equalsIgnoreCase(vectorDataType)) {
+                return currentDataType;
+            }
+        }
+        throw new IllegalArgumentException(
+            String.format(
+                "[%s] field was set as [%s] in index mapping. But, supported values are [%s]",
+                VECTOR_DATA_TYPE,
+                vectorDataType,
+                supportedTypes
+            )
+        );
+    }
+
+    /**
+     * Validate the float vector values if it is a number and in the finite range.
+     *
+     * @param value  float vector value
+     */
+    public static void validateFloatVectorValues(float value) {
+        if (Float.isNaN(value)) {
+            throw new IllegalArgumentException("KNN vector values cannot be NaN");
+        }
+
+        if (Float.isInfinite(value)) {
+            throw new IllegalArgumentException("KNN vector values cannot be infinity");
+        }
+    }
+
+    /**
+     * Validate the float vector value in the byte range if it is a finite number,
+     * with no decimal values and in the byte range of [-128 to 127].
+     *
+     * @param value  float value in byte range
+     */
+    public static void validateByteVectorValues(float value) {
+        validateFloatVectorValues(value);
+        if (value % 1 != 0) {
+            throw new IllegalArgumentException(
+                "[data_type] field was set as [byte] in index mapping. But, KNN vector values are floats instead of byte integers"
+            );
+        }
+        if ((int) value < Byte.MIN_VALUE || (int) value > Byte.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are not within in the byte range [{}, {}]",
+                    VECTOR_DATA_TYPE,
+                    VectorDataType.BYTE.getValue(),
+                    Byte.MIN_VALUE,
+                    Byte.MAX_VALUE
+                )
+            );
+        }
+    }
+
+    /**
+     * Validate if the given vector size matches with the dimension provided in mapping.
+     *
+     * @param dimension dimension of vector
+     * @param vectorSize size of the vector
+     */
+    public static void validateVectorDimension(int dimension, int vectorSize) {
+        if (dimension != vectorSize) {
+            String errorMessage = String.format("Vector dimension mismatch. Expected: %d, Given: %d", dimension, vectorSize);
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+    }
+
+    /**
+     * Validates and throws exception if data_type field is set in the index mapping
+     * using any VectorDataType (other than float, which is default) with any engine (except lucene).
+     *
+     * @param knnMethodContext KNNMethodContext Parameter
+     * @param vectorDataType VectorDataType Parameter
+     */
+    public static void validateVectorDataType_Engine(
+        ParametrizedFieldMapper.Parameter<KNNMethodContext> knnMethodContext,
+        ParametrizedFieldMapper.Parameter<VectorDataType> vectorDataType
+    ) {
+        if (vectorDataType.getValue() != DEFAULT_VECTOR_DATA_TYPE
+            && (knnMethodContext.get() == null || knnMethodContext.getValue().getKnnEngine() != KNNEngine.LUCENE)) {
+            throw new IllegalArgumentException(String.format("[%s] is only supported for [%s] engine", VECTOR_DATA_TYPE, LUCENE_NAME));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/VectorField.java
+++ b/src/main/java/org/opensearch/knn/index/VectorField.java
@@ -34,7 +34,7 @@ public class VectorField extends Field {
         try {
             this.setBytesValue(value);
         } catch (Exception e) {
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException(e);
         }
 
     }

--- a/src/main/java/org/opensearch/knn/index/VectorField.java
+++ b/src/main/java/org/opensearch/knn/index/VectorField.java
@@ -23,4 +23,19 @@ public class VectorField extends Field {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * @param name FieldType name
+     * @param value an array of byte vector values
+     * @param type FieldType to build DocValues
+     */
+    public VectorField(String name, byte[] value, IndexableFieldType type) {
+        super(name, new BytesRef(), type);
+        try {
+            this.setBytesValue(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -35,6 +35,7 @@ import org.opensearch.index.query.QueryShardException;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.KNNVectorIndexFieldData;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
@@ -49,7 +50,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE;
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE;
+import static org.opensearch.knn.index.VectorDataType.validateByteVectorValues;
+import static org.opensearch.knn.index.VectorDataType.validateFloatVectorValues;
+import static org.opensearch.knn.index.VectorDataType.validateVectorDataType_Engine;
+import static org.opensearch.knn.index.VectorDataType.validateVectorDimension;
 
 /**
  * Field Mapper for KNN vector type.
@@ -95,6 +102,18 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             }
             return value;
         }, m -> toType(m).dimension);
+
+        /**
+         * data_type which defines the datatype of the vector values. This is an optional parameter and
+         * this is right now only relevant for lucene engine. The default value is float.
+         */
+        protected final Parameter<VectorDataType> vectorDataType = new Parameter<>(
+            VECTOR_DATA_TYPE,
+            false,
+            () -> DEFAULT_VECTOR_DATA_TYPE,
+            (n, c, o) -> VectorDataType.get((String) o),
+            m -> toType(m).vectorDataType
+        );
 
         /**
          * modelId provides a way for a user to generate the underlying library indices from an already serialized
@@ -168,7 +187,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         protected List<Parameter<?>> getParameters() {
-            return Arrays.asList(stored, hasDocValues, dimension, meta, knnMethodContext, modelId);
+            return Arrays.asList(stored, hasDocValues, dimension, vectorDataType, meta, knnMethodContext, modelId);
         }
 
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
@@ -203,7 +222,8 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                     buildFullName(context),
                     metaValue,
                     dimension.getValue(),
-                    knnMethodContext
+                    knnMethodContext,
+                    vectorDataType.getValue()
                 );
                 if (knnMethodContext.getKnnEngine() == KNNEngine.LUCENE) {
                     log.debug(String.format("Use [LuceneFieldMapper] mapper for field [%s]", name));
@@ -216,6 +236,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                             .ignoreMalformed(ignoreMalformed)
                             .stored(stored.get())
                             .hasDocValues(hasDocValues.get())
+                            .vectorDataType(vectorDataType.getValue())
                             .knnMethodContext(knnMethodContext)
                             .build();
                     return new LuceneFieldMapper(createLuceneFieldMapperInput);
@@ -327,6 +348,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 throw new IllegalArgumentException(String.format("Dimension value missing for vector: %s", name));
             }
 
+            // Validates and throws exception if data_type field is set in the index mapping
+            // using any VectorDataType (other than float, which is default) with any engine (except lucene).
+            validateVectorDataType_Engine(builder.knnMethodContext, builder.vectorDataType);
+
             return builder;
         }
     }
@@ -336,20 +361,43 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         int dimension;
         String modelId;
         KNNMethodContext knnMethodContext;
+        VectorDataType vectorDataType;
 
         public KNNVectorFieldType(String name, Map<String, String> meta, int dimension) {
-            this(name, meta, dimension, null, null);
+            this(name, meta, dimension, null, null, DEFAULT_VECTOR_DATA_TYPE);
         }
 
         public KNNVectorFieldType(String name, Map<String, String> meta, int dimension, KNNMethodContext knnMethodContext) {
-            this(name, meta, dimension, knnMethodContext, null);
+            this(name, meta, dimension, knnMethodContext, null, DEFAULT_VECTOR_DATA_TYPE);
         }
 
         public KNNVectorFieldType(String name, Map<String, String> meta, int dimension, KNNMethodContext knnMethodContext, String modelId) {
+            this(name, meta, dimension, knnMethodContext, modelId, DEFAULT_VECTOR_DATA_TYPE);
+        }
+
+        public KNNVectorFieldType(
+            String name,
+            Map<String, String> meta,
+            int dimension,
+            KNNMethodContext knnMethodContext,
+            VectorDataType vectorDataType
+        ) {
+            this(name, meta, dimension, knnMethodContext, null, vectorDataType);
+        }
+
+        public KNNVectorFieldType(
+            String name,
+            Map<String, String> meta,
+            int dimension,
+            KNNMethodContext knnMethodContext,
+            String modelId,
+            VectorDataType vectorDataType
+        ) {
             super(name, false, false, true, TextSearchInfo.NONE, meta);
             this.dimension = dimension;
             this.modelId = modelId;
             this.knnMethodContext = knnMethodContext;
+            this.vectorDataType = vectorDataType;
         }
 
         @Override
@@ -386,6 +434,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
     protected boolean stored;
     protected boolean hasDocValues;
     protected Integer dimension;
+    protected VectorDataType vectorDataType;
     protected ModelDao modelDao;
 
     // These members map to parameters in the builder. They need to be declared in the abstract class due to the
@@ -408,6 +457,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         this.stored = stored;
         this.hasDocValues = hasDocValues;
         this.dimension = mappedFieldType.getDimension();
+        this.vectorDataType = mappedFieldType.getVectorDataType();
         updateEngineStats();
     }
 
@@ -459,6 +509,41 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         }
     }
 
+    // Returns an optional array of byte values where each value in the vector is parsed as a float and validated
+    // if it is a finite number without any decimals and within the byte range of [-128 to 127].
+    Optional<byte[]> getBytesFromContext(ParseContext context, int dimension) throws IOException {
+        context.path().add(simpleName());
+
+        ArrayList<Byte> vector = new ArrayList<>();
+        XContentParser.Token token = context.parser().currentToken();
+        float value;
+
+        if (token == XContentParser.Token.START_ARRAY) {
+            token = context.parser().nextToken();
+            while (token != XContentParser.Token.END_ARRAY) {
+                value = context.parser().floatValue();
+                validateByteVectorValues(value);
+                vector.add((byte) value);
+                token = context.parser().nextToken();
+            }
+        } else if (token == XContentParser.Token.VALUE_NUMBER) {
+            value = context.parser().floatValue();
+            validateByteVectorValues(value);
+            vector.add((byte) value);
+            context.parser().nextToken();
+        } else if (token == XContentParser.Token.VALUE_NULL) {
+            context.path().remove();
+            return Optional.empty();
+        }
+        validateVectorDimension(dimension, vector.size());
+        byte[] array = new byte[vector.size()];
+        int i = 0;
+        for (Byte f : vector) {
+            array[i++] = f;
+        }
+        return Optional.of(array);
+    }
+
     Optional<float[]> getFloatsFromContext(ParseContext context, int dimension) throws IOException {
         context.path().add(simpleName());
 
@@ -469,40 +554,20 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             token = context.parser().nextToken();
             while (token != XContentParser.Token.END_ARRAY) {
                 value = context.parser().floatValue();
-
-                if (Float.isNaN(value)) {
-                    throw new IllegalArgumentException("KNN vector values cannot be NaN");
-                }
-
-                if (Float.isInfinite(value)) {
-                    throw new IllegalArgumentException("KNN vector values cannot be infinity");
-                }
-
+                validateFloatVectorValues(value);
                 vector.add(value);
                 token = context.parser().nextToken();
             }
         } else if (token == XContentParser.Token.VALUE_NUMBER) {
             value = context.parser().floatValue();
-
-            if (Float.isNaN(value)) {
-                throw new IllegalArgumentException("KNN vector values cannot be NaN");
-            }
-
-            if (Float.isInfinite(value)) {
-                throw new IllegalArgumentException("KNN vector values cannot be infinity");
-            }
-
+            validateFloatVectorValues(value);
             vector.add(value);
             context.parser().nextToken();
         } else if (token == XContentParser.Token.VALUE_NULL) {
             context.path().remove();
             return Optional.empty();
         }
-
-        if (dimension != vector.size()) {
-            String errorMessage = String.format("Vector dimension mismatch. Expected: %d, Given: %d", dimension, vector.size());
-            throw new IllegalArgumentException(errorMessage);
-        }
+        validateVectorDimension(dimension, vector.size());
 
         float[] array = new float[vector.size()];
         int i = 0;

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DocValuesType;
+import org.opensearch.index.mapper.ParametrizedFieldMapper;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.Locale;
+
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
+public class KNNVectorFieldMapperUtil {
+    /**
+     * Validate the float vector value and throw exception if it is not a number or not in the finite range.
+     *
+     * @param value  float vector value
+     */
+    public static void validateFloatVectorValue(float value) {
+        if (Float.isNaN(value)) {
+            throw new IllegalArgumentException("KNN vector values cannot be NaN");
+        }
+
+        if (Float.isInfinite(value)) {
+            throw new IllegalArgumentException("KNN vector values cannot be infinity");
+        }
+    }
+
+    /**
+     * Validate the float vector value in the byte range if it is a finite number,
+     * with no decimal values and in the byte range of [-128 to 127]. If not throw IllegalArgumentException.
+     *
+     * @param value  float value in byte range
+     */
+    public static void validateByteVectorValue(float value) {
+        validateFloatVectorValue(value);
+        if (value % 1 != 0) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are floats instead of byte integers",
+                    VECTOR_DATA_TYPE_FIELD,
+                    VectorDataType.BYTE.getValue()
+                )
+
+            );
+        }
+        if ((int) value < Byte.MIN_VALUE || (int) value > Byte.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are not within in the byte range [%d, %d]",
+                    VECTOR_DATA_TYPE_FIELD,
+                    VectorDataType.BYTE.getValue(),
+                    Byte.MIN_VALUE,
+                    Byte.MAX_VALUE
+                )
+            );
+        }
+    }
+
+    /**
+     * Validate if the given vector size matches with the dimension provided in mapping.
+     *
+     * @param dimension dimension of vector
+     * @param vectorSize size of the vector
+     */
+    public static void validateVectorDimension(int dimension, int vectorSize) {
+        if (dimension != vectorSize) {
+            String errorMessage = String.format(Locale.ROOT, "Vector dimension mismatch. Expected: %d, Given: %d", dimension, vectorSize);
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+    }
+
+    /**
+     * Validates and throws exception if data_type field is set in the index mapping
+     * using any VectorDataType (other than float, which is default) with any engine (except lucene).
+     *
+     * @param knnMethodContext KNNMethodContext Parameter
+     * @param vectorDataType VectorDataType Parameter
+     */
+    public static void validateVectorDataTypeWithEngine(
+        ParametrizedFieldMapper.Parameter<KNNMethodContext> knnMethodContext,
+        ParametrizedFieldMapper.Parameter<VectorDataType> vectorDataType
+    ) {
+        if (vectorDataType.getValue() == DEFAULT_VECTOR_DATA_TYPE_FIELD) {
+            return;
+        }
+        if ((knnMethodContext.getValue() == null && KNNEngine.DEFAULT != KNNEngine.LUCENE)
+            || knnMethodContext.getValue().getKnnEngine() != KNNEngine.LUCENE) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] field with value [%s] is only supported for [%s] engine",
+                    VECTOR_DATA_TYPE_FIELD,
+                    vectorDataType.getValue().getValue(),
+                    LUCENE_NAME
+                )
+            );
+        }
+    }
+
+    /**
+     * @param knnEngine  KNNEngine
+     * @return  DocValues FieldType of type Binary
+     */
+    public static FieldType buildDocValuesFieldType(KNNEngine knnEngine) {
+        FieldType field = new FieldType();
+        field.putAttribute(KNN_ENGINE, knnEngine.getName());
+        field.setDocValuesType(DocValuesType.BINARY);
+        field.freeze();
+        return field;
+    }
+
+    public static void addStoredFieldForVectorField(
+        ParseContext context,
+        FieldType fieldType,
+        String mapperName,
+        String vectorFieldAsString
+    ) {
+        if (fieldType.stored()) {
+            context.doc().add(new StoredField(mapperName, vectorFieldAsString));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.junit.After;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.Strings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE;
+import static org.opensearch.knn.index.VectorDataType.getValues;
+
+public class VectorDataTypeIT extends KNNRestTestCase {
+    private static final String INDEX_NAME = "test-index-vec-dt";
+    private static final String FIELD_NAME = "test-field-vec-dt";
+    private static final String PROPERTIES_FIELD = "properties";
+    private static final String DOC_ID = "doc1";
+    private static final String TYPE_FIELD_NAME = "type";
+    private static final String KNN_VECTOR_TYPE = "knn_vector";
+    private static final int EF_CONSTRUCTION = 128;
+    private static final int M = 16;
+
+    @After
+    public final void cleanUp() throws IOException {
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    // Validate if we are able to create an index by setting data_type field as byte and add a doc to it
+    public void testAddDocWithByteVector() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue());
+        Byte[] vector = { 6, 6 };
+        addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector);
+
+        refreshAllIndices();
+        assertEquals(1, getDocCount(INDEX_NAME));
+    }
+
+    // Validate by creating an index by setting data_type field as byte, add a doc to it and update it later.
+    public void testUpdateDocWithByteVector() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue());
+        Byte[] vector = { -36, 78 };
+        addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector);
+
+        Byte[] updatedVector = { 89, -8 };
+        updateKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, updatedVector);
+
+        refreshAllIndices();
+        assertEquals(1, getDocCount(INDEX_NAME));
+    }
+
+    // Validate by creating an index by setting data_type field as byte, add a doc to it and delete it later.
+    public void testDeleteDocWithByteVector() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue());
+        Byte[] vector = { 35, -46 };
+        addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector);
+
+        deleteKnnDoc(INDEX_NAME, DOC_ID);
+        refreshAllIndices();
+
+        assertEquals(0, getDocCount(INDEX_NAME));
+    }
+
+    // Set an invalid value for data_type field while creating the index which should throw an exception
+    public void testInvalidVectorDataType() {
+        String vectorDataType = "invalidVectorType";
+        String supportedTypes = String.join(",", getValues());
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, vectorDataType)
+        );
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    String.format(
+                        "[%s] field was set as [%s] in index mapping. But, supported values are [%s]",
+                        VECTOR_DATA_TYPE,
+                        vectorDataType,
+                        supportedTypes
+                    )
+                )
+        );
+    }
+
+    // Set null value for data_type field while creating the index which should throw an exception
+    public void testVectorDataTypeAsNull() {
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, null));
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    String.format(
+                        "[%s] on mapper [%s] of type [%s] must not have a [null] value",
+                        VECTOR_DATA_TYPE,
+                        FIELD_NAME,
+                        KNN_VECTOR_TYPE
+                    )
+                )
+        );
+    }
+
+    // Create an index with byte vector data_type and add a doc with decimal values which should throw exception
+    public void testInvalidVectorData() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue());
+        Float[] vector = { -10.76f, 15.89f };
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector));
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    "[data_type] field was set as [byte] in index mapping. But, KNN vector values are floats instead of byte integers"
+                )
+        );
+    }
+
+    // Create an index with byte vector data_type and add a doc with values out of byte range which should throw exception
+    public void testInvalidByteVectorRange() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue());
+        Float[] vector = { -1000f, 155f };
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector));
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    String.format(
+                        "[%s] field was set as [%s] in index mapping. But, KNN vector values are not within in the byte range [{}, {}]",
+                        VECTOR_DATA_TYPE,
+                        VectorDataType.BYTE.getValue(),
+                        Byte.MIN_VALUE,
+                        Byte.MAX_VALUE
+                    )
+                )
+        );
+    }
+
+    // Create an index with byte vector data_type using nmslib engine which should throw an exception
+    public void testByteVectorDataTypeWithNmslibEngine() {
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> createKnnIndexMappingWithNmslibEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue())
+        );
+        assertTrue(ex.getMessage().contains(String.format("[%s] is only supported for [%s] engine", VECTOR_DATA_TYPE, LUCENE_NAME)));
+    }
+
+    private void createKnnIndexMappingWithNmslibEngine(int dimension, SpaceType spaceType, String vectorDataType) throws Exception {
+        createKnnIndexMappingWithCustomEngine(dimension, spaceType, vectorDataType, KNNEngine.NMSLIB.getName());
+    }
+
+    private void createKnnIndexMappingWithLuceneEngine(int dimension, SpaceType spaceType, String vectorDataType) throws Exception {
+        createKnnIndexMappingWithCustomEngine(dimension, spaceType, vectorDataType, KNNEngine.LUCENE.getName());
+    }
+
+    private void createKnnIndexMappingWithCustomEngine(int dimension, SpaceType spaceType, String vectorDataType, String engine)
+        throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION, dimension)
+            .field(VECTOR_DATA_TYPE, vectorDataType)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, engine)
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = Strings.toString(builder);
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+}


### PR DESCRIPTION
### Description
This PR contains changes which adds indexing support to lucene byte sized vector and corresponding tests to validate it. It helps users to index vectors as byte sized vectors(which theoretically saves 75% of memory when compared to float vectors) by setting the optional `data_type` field as `byte` while creating the index. As we are not adding support for Quantization Techniques, users are expected to index vectors that are in the byte range [-128 to 127] without any decimal values. Also, right now this feature is only supported for lucene engine.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/812 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
