### PR TITLE
[Backport 1.3] Bump requests version from 2.26.0 to 2.31.0 (#913)

### DIFF
--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -28,7 +28,7 @@ psutil==5.8.0
     # via -r requirements.in
 pyyaml==5.4.1
     # via -r requirements.in
-requests==2.26.0
+requests==2.31.0
     # via -r requirements.in
 urllib3==1.26.6
     # via


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/k-NN/pull/913 to 1.3
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
