### PR TITLE
Fixing unit test for Faiss due to faiss upgrade.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -56,11 +56,11 @@ In addition to this, the plugin has been tested with JDK 17, and this JDK versio
 
 #### CMake
 
-The plugin requires that cmake >= 3.23.1 is installed in order to build the JNI libraries.
+The plugin requires that cmake >= 3.23.3 is installed in order to build the JNI libraries.
 
 One easy way to install on mac or linux is to use pip:
 ```bash
-pip install cmake==3.23.1
+pip install cmake==3.23.3
 ```
 
 #### Faiss Dependencies

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -23,8 +23,8 @@ using ::testing::Return;
 
 TEST(FaissCreateIndexTest, BasicAssertions) {
     // Define the data
-    faiss::Index::idx_t numIds = 200;
-    std::vector<faiss::Index::idx_t> ids;
+    faiss::idx_t numIds = 200;
+    std::vector<faiss::idx_t> ids;
     std::vector<std::vector<float>> vectors;
     int dim = 2;
     for (int64_t i = 0; i < numIds; ++i) {
@@ -70,8 +70,8 @@ TEST(FaissCreateIndexTest, BasicAssertions) {
 
 TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
     // Define the data
-    faiss::Index::idx_t numIds = 100;
-    std::vector<faiss::Index::idx_t> ids;
+    faiss::idx_t numIds = 100;
+    std::vector<faiss::idx_t> ids;
     std::vector<std::vector<float>> vectors;
     int dim = 2;
     for (int64_t i = 0; i < numIds; ++i) {
@@ -122,8 +122,8 @@ TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
 
 TEST(FaissLoadIndexTest, BasicAssertions) {
     // Define the data
-    faiss::Index::idx_t numIds = 100;
-    std::vector<faiss::Index::idx_t> ids;
+    faiss::idx_t numIds = 100;
+    std::vector<faiss::idx_t> ids;
     std::vector<float> vectors;
     int dim = 2;
     for (int64_t i = 0; i < numIds; i++) {
@@ -174,8 +174,8 @@ TEST(FaissLoadIndexTest, BasicAssertions) {
 
 TEST(FaissQueryIndexTest, BasicAssertions) {
     // Define the index data
-    faiss::Index::idx_t numIds = 100;
-    std::vector<faiss::Index::idx_t> ids;
+    faiss::idx_t numIds = 100;
+    std::vector<faiss::idx_t> ids;
     std::vector<float> vectors;
     int dim = 16;
     for (int64_t i = 0; i < numIds; i++) {

--- a/jni/tests/test_util.cpp
+++ b/jni/tests/test_util.cpp
@@ -234,7 +234,7 @@ faiss::Index *test_util::FaissLoadFromSerializedIndex(
 }
 
 faiss::IndexIDMap test_util::FaissAddData(faiss::Index *index,
-                                          std::vector<faiss::Index::idx_t> ids,
+                                          std::vector<faiss::idx_t> ids,
                                           std::vector<float> dataset) {
     faiss::IndexIDMap idMap = faiss::IndexIDMap(index);
     idMap.add_with_ids(ids.size(), dataset.data(), ids.data());
@@ -251,11 +251,11 @@ faiss::Index *test_util::FaissLoadIndex(const std::string &indexPath) {
 }
 
 void test_util::FaissQueryIndex(faiss::Index *index, float *query, int k,
-                                float *distances, faiss::Index::idx_t *ids) {
+                                float *distances, faiss::idx_t *ids) {
     index->search(1, query, k, distances, ids);
 }
 
-void test_util::FaissTrainIndex(faiss::Index *index, faiss::Index::idx_t n,
+void test_util::FaissTrainIndex(faiss::Index *index, faiss::idx_t n,
                                 const float *x) {
     if (auto *indexIvf = dynamic_cast<faiss::IndexIVF *>(index)) {
         if (indexIvf->quantizer_trains_alone == 2) {

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -108,7 +108,7 @@ namespace test_util {
     faiss::Index* FaissLoadFromSerializedIndex(std::vector<uint8_t>* indexSerial);
 
     faiss::IndexIDMap FaissAddData(faiss::Index* index,
-                                   std::vector<faiss::Index::idx_t> ids,
+                                   std::vector<faiss::idx_t> ids,
                                    std::vector<float> dataset);
 
     void FaissWriteIndex(faiss::Index* index, const std::string& indexPath);
@@ -116,9 +116,9 @@ namespace test_util {
     faiss::Index* FaissLoadIndex(const std::string& indexPath);
 
     void FaissQueryIndex(faiss::Index* index, float* query, int k, float* distances,
-                         faiss::Index::idx_t* ids);
+                         faiss::idx_t* ids);
 
-    void FaissTrainIndex(faiss::Index* index, faiss::Index::idx_t n,
+    void FaissTrainIndex(faiss::Index* index, faiss::idx_t n,
                          const float* x);
 
 // -------------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Fixing unit test for Faiss due to faiss upgrade.
 
### Issues Resolved
NA

```
16:51 ~/workplace/k-NN/jni faiss-unit$ ./bin/jni_test
Running main() from /Users/navneev/workplace/k-NN/jni/googletest-src/googletest/src/gtest_main.cc
[==========] Running 12 tests from 12 test suites.
[----------] Global test environment set-up.
[----------] 1 test from FaissCreateIndexTest
[ RUN      ] FaissCreateIndexTest.BasicAssertions
[       OK ] FaissCreateIndexTest.BasicAssertions (11 ms)
[----------] 1 test from FaissCreateIndexTest (11 ms total)

[----------] 1 test from FaissCreateIndexFromTemplateTest
[ RUN      ] FaissCreateIndexFromTemplateTest.BasicAssertions
[       OK ] FaissCreateIndexFromTemplateTest.BasicAssertions (5 ms)
[----------] 1 test from FaissCreateIndexFromTemplateTest (5 ms total)

[----------] 1 test from FaissLoadIndexTest
[ RUN      ] FaissLoadIndexTest.BasicAssertions
[       OK ] FaissLoadIndexTest.BasicAssertions (6 ms)
[----------] 1 test from FaissLoadIndexTest (6 ms total)

[----------] 1 test from FaissQueryIndexTest
[ RUN      ] FaissQueryIndexTest.BasicAssertions
[       OK ] FaissQueryIndexTest.BasicAssertions (93 ms)
[----------] 1 test from FaissQueryIndexTest (93 ms total)

[----------] 1 test from FaissFreeTest
[ RUN      ] FaissFreeTest.BasicAssertions
[       OK ] FaissFreeTest.BasicAssertions (0 ms)
[----------] 1 test from FaissFreeTest (0 ms total)

[----------] 1 test from FaissInitLibraryTest
[ RUN      ] FaissInitLibraryTest.BasicAssertions
[       OK ] FaissInitLibraryTest.BasicAssertions (0 ms)
[----------] 1 test from FaissInitLibraryTest (0 ms total)

[----------] 1 test from FaissTrainIndexTest
[ RUN      ] FaissTrainIndexTest.BasicAssertions
[       OK ] FaissTrainIndexTest.BasicAssertions (19 ms)
[----------] 1 test from FaissTrainIndexTest (19 ms total)

[----------] 1 test from NmslibCreateIndexTest
[ RUN      ] NmslibCreateIndexTest.BasicAssertions
[       OK ] NmslibCreateIndexTest.BasicAssertions (9 ms)
[----------] 1 test from NmslibCreateIndexTest (9 ms total)

[----------] 1 test from NmslibLoadIndexTest
[ RUN      ] NmslibLoadIndexTest.BasicAssertions
[       OK ] NmslibLoadIndexTest.BasicAssertions (8 ms)
[----------] 1 test from NmslibLoadIndexTest (8 ms total)

[----------] 1 test from NmslibQueryIndexTest
[ RUN      ] NmslibQueryIndexTest.BasicAssertions
[       OK ] NmslibQueryIndexTest.BasicAssertions (17 ms)
[----------] 1 test from NmslibQueryIndexTest (17 ms total)

[----------] 1 test from NmslibFreeTest
[ RUN      ] NmslibFreeTest.BasicAssertions
[       OK ] NmslibFreeTest.BasicAssertions (7 ms)
[----------] 1 test from NmslibFreeTest (7 ms total)

[----------] 1 test from NmslibInitLibraryTest
[ RUN      ] NmslibInitLibraryTest.BasicAssertions
[       OK ] NmslibInitLibraryTest.BasicAssertions (0 ms)
[----------] 1 test from NmslibInitLibraryTest (0 ms total)

[----------] Global test environment tear-down
[==========] 12 tests from 12 test suites ran. (179 ms total)
[  PASSED  ] 12 tests.
```
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
