### PR TITLE
Add DocValues Support for Lucene Byte Sized Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Added efficient filtering support for Faiss Engine ([#936](https://github.com/opensearch-project/k-NN/pull/936))
 * Add Indexing Support for Lucene Byte Sized Vector ([#937](https://github.com/opensearch-project/k-NN/pull/937))
 * Add Querying Support for Lucene Byte Sized Vector ([#956](https://github.com/opensearch-project/k-NN/pull/956))
+* Add DocValues Support for Lucene Byte Sized Vector ([#953](https://github.com/opensearch-project/k-NN/pull/953))
+
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
@@ -18,10 +18,12 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
 
     private final LeafReader reader;
     private final String fieldName;
+    private final VectorDataType vectorDataType;
 
-    public KNNVectorDVLeafFieldData(LeafReader reader, String fieldName) {
+    public KNNVectorDVLeafFieldData(LeafReader reader, String fieldName, VectorDataType vectorDataType) {
         this.reader = reader;
         this.fieldName = fieldName;
+        this.vectorDataType = vectorDataType;
     }
 
     @Override
@@ -38,7 +40,7 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
     public ScriptDocValues<float[]> getScriptValues() {
         try {
             BinaryDocValues values = DocValues.getBinary(reader, fieldName);
-            return new KNNVectorScriptDocValues(values, fieldName);
+            return new KNNVectorScriptDocValues(values, fieldName, vectorDataType);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values for knn vector field: " + fieldName, e);
         }

--- a/src/main/java/org/opensearch/knn/index/KNNVectorIndexFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorIndexFieldData.java
@@ -21,10 +21,12 @@ public class KNNVectorIndexFieldData implements IndexFieldData<KNNVectorDVLeafFi
 
     private final String fieldName;
     private final ValuesSourceType valuesSourceType;
+    private final VectorDataType vectorDataType;
 
-    public KNNVectorIndexFieldData(String fieldName, ValuesSourceType valuesSourceType) {
+    public KNNVectorIndexFieldData(String fieldName, ValuesSourceType valuesSourceType, VectorDataType vectorDataType) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
+        this.vectorDataType = vectorDataType;
     }
 
     @Override
@@ -39,7 +41,7 @@ public class KNNVectorIndexFieldData implements IndexFieldData<KNNVectorDVLeafFi
 
     @Override
     public KNNVectorDVLeafFieldData load(LeafReaderContext context) {
-        return new KNNVectorDVLeafFieldData(context.reader(), fieldName);
+        return new KNNVectorDVLeafFieldData(context.reader(), fieldName, vectorDataType);
     }
 
     @Override
@@ -70,15 +72,17 @@ public class KNNVectorIndexFieldData implements IndexFieldData<KNNVectorDVLeafFi
 
         private final String name;
         private final ValuesSourceType valuesSourceType;
+        private final VectorDataType vectorDataType;
 
-        public Builder(String name, ValuesSourceType valuesSourceType) {
+        public Builder(String name, ValuesSourceType valuesSourceType, VectorDataType vectorDataType) {
             this.name = name;
             this.valuesSourceType = valuesSourceType;
+            this.vectorDataType = vectorDataType;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-            return new KNNVectorIndexFieldData(name, valuesSourceType);
+            return new KNNVectorIndexFieldData(name, valuesSourceType, vectorDataType);
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -6,33 +6,21 @@
 package org.opensearch.knn.index;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.util.BytesRef;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.index.fielddata.ScriptDocValues;
-import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
-import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Locale;
 
-import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
-import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
-
+@RequiredArgsConstructor
 public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
 
     private final BinaryDocValues binaryDocValues;
     private final String fieldName;
     @Getter
     private final VectorDataType vectorDataType;
-    private boolean docExists;
-
-    public KNNVectorScriptDocValues(BinaryDocValues binaryDocValues, String fieldName, VectorDataType vectorDataType) {
-        this.binaryDocValues = binaryDocValues;
-        this.fieldName = fieldName;
-        this.vectorDataType = vectorDataType;
-    }
+    private boolean docExists = false;
 
     @Override
     public void setNextDocId(int docId) throws IOException {
@@ -55,31 +43,7 @@ public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
             throw new IllegalStateException(errorMessage);
         }
         try {
-            BytesRef value = binaryDocValues.binaryValue();
-            if (VectorDataType.BYTE.equals(vectorDataType)) {
-                float[] vector = new float[value.length];
-                int i = 0;
-                int j = value.offset;
-
-                while (i < value.length) {
-                    vector[i++] = value.bytes[j++];
-                }
-                return vector;
-            } else if (VectorDataType.FLOAT.equals(vectorDataType)) {
-                ByteArrayInputStream byteStream = new ByteArrayInputStream(value.bytes, value.offset, value.length);
-                final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
-                final float[] vector = vectorSerializer.byteToFloatArray(byteStream);
-                return vector;
-            } else {
-                throw new IllegalArgumentException(
-                    String.format(
-                        Locale.ROOT,
-                        "Invalid value provided for [%s] field. Supported values are [%s]",
-                        VECTOR_DATA_TYPE_FIELD,
-                        SUPPORTED_VECTOR_DATA_TYPES
-                    )
-                );
-            }
+            return vectorDataType.getVectorFromDocValues(binaryDocValues.binaryValue());
         } catch (IOException e) {
             throw ExceptionsHelper.convertToOpenSearchException(e);
         }

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index;
 
+import lombok.Getter;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.ExceptionsHelper;
@@ -14,16 +15,23 @@ import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Locale;
+
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
 public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
 
     private final BinaryDocValues binaryDocValues;
     private final String fieldName;
+    @Getter
+    private final VectorDataType vectorDataType;
     private boolean docExists;
 
-    public KNNVectorScriptDocValues(BinaryDocValues binaryDocValues, String fieldName) {
+    public KNNVectorScriptDocValues(BinaryDocValues binaryDocValues, String fieldName, VectorDataType vectorDataType) {
         this.binaryDocValues = binaryDocValues;
         this.fieldName = fieldName;
+        this.vectorDataType = vectorDataType;
     }
 
     @Override
@@ -48,10 +56,30 @@ public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
         }
         try {
             BytesRef value = binaryDocValues.binaryValue();
-            ByteArrayInputStream byteStream = new ByteArrayInputStream(value.bytes, value.offset, value.length);
-            final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
-            final float[] vector = vectorSerializer.byteToFloatArray(byteStream);
-            return vector;
+            if (VectorDataType.BYTE.equals(vectorDataType)) {
+                float[] vector = new float[value.length];
+                int i = 0;
+                int j = value.offset;
+
+                while (i < value.length) {
+                    vector[i++] = value.bytes[j++];
+                }
+                return vector;
+            } else if (VectorDataType.FLOAT.equals(vectorDataType)) {
+                ByteArrayInputStream byteStream = new ByteArrayInputStream(value.bytes, value.offset, value.length);
+                final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
+                final float[] vector = vectorSerializer.byteToFloatArray(byteStream);
+                return vector;
+            } else {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "Invalid value provided for [%s] field. Supported values are [%s]",
+                        VECTOR_DATA_TYPE_FIELD,
+                        SUPPORTED_VECTOR_DATA_TYPES
+                    )
+                );
+            }
         } catch (IOException e) {
             throw ExceptionsHelper.convertToOpenSearchException(e);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
@@ -18,7 +18,7 @@ public class KNNCodecService extends CodecService {
     private final MapperService mapperService;
 
     public KNNCodecService(CodecServiceConfig codecServiceConfig) {
-        super(codecServiceConfig.getMapperService(), codecServiceConfig.getLogger());
+        super(codecServiceConfig.getMapperService(), codecServiceConfig.getIndexSettings(), codecServiceConfig.getLogger());
         mapperService = codecServiceConfig.getMapperService();
     }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -490,7 +490,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         validateIfKNNPluginEnabled();
         validateIfCircuitBreakerIsNotTriggered();
 
-        if (VectorDataType.BYTE.equals(vectorDataType)) {
+        if (VectorDataType.BYTE == vectorDataType) {
             Optional<byte[]> bytesArrayOptional = getBytesFromContext(context, dimension);
 
             if (!bytesArrayOptional.isPresent()) {
@@ -501,7 +501,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
             context.doc().add(point);
             addStoredFieldForVectorField(context, fieldType, name(), point.toString());
-        } else if (VectorDataType.FLOAT.equals(vectorDataType)) {
+        } else if (VectorDataType.FLOAT == vectorDataType) {
             Optional<float[]> floatsArrayOptional = getFloatsFromContext(context, dimension);
 
             if (!floatsArrayOptional.isPresent()) {

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -96,7 +96,7 @@ public class KNNVectorFieldMapperUtil {
      * @param vectorDataType VectorDataType Parameter
      */
     public static void validateVectorDataTypeWithEngine(ParametrizedFieldMapper.Parameter<VectorDataType> vectorDataType) {
-        if (VectorDataType.FLOAT.equals(vectorDataType.getValue())) {
+        if (VectorDataType.FLOAT == vectorDataType.getValue()) {
             return;
         }
         throw new IllegalArgumentException(
@@ -123,7 +123,7 @@ public class KNNVectorFieldMapperUtil {
         ParametrizedFieldMapper.Parameter<VectorDataType> vectorDataType
     ) {
 
-        if (VectorDataType.FLOAT.equals(vectorDataType.getValue())) {
+        if (VectorDataType.FLOAT == vectorDataType.getValue()) {
             return;
         }
         if (knnIndexSetting) {

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -82,7 +82,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
         validateIfKNNPluginEnabled();
         validateIfCircuitBreakerIsNotTriggered();
 
-        if (VectorDataType.BYTE.equals(vectorDataType)) {
+        if (VectorDataType.BYTE == vectorDataType) {
             Optional<byte[]> bytesArrayOptional = getBytesFromContext(context, dimension);
             if (bytesArrayOptional.isEmpty()) {
                 return;
@@ -96,7 +96,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
             if (hasDocValues && vectorFieldType != null) {
                 context.doc().add(new VectorField(name(), array, vectorFieldType));
             }
-        } else if (VectorDataType.FLOAT.equals(vectorDataType)) {
+        } else if (VectorDataType.FLOAT == vectorDataType) {
             Optional<float[]> floatsArrayOptional = getFloatsFromContext(context, dimension);
 
             if (floatsArrayOptional.isEmpty()) {

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -54,7 +54,11 @@ public interface KNNScoringSpace {
                 throw new IllegalArgumentException("Incompatible field_type for l2 space. The field type must " + "be knn_vector.");
             }
 
-            this.processedQuery = parseToFloatArray(query, ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
+            this.processedQuery = parseToFloatArray(
+                query,
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
+            );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
         }
 
@@ -81,7 +85,11 @@ public interface KNNScoringSpace {
                 throw new IllegalArgumentException("Incompatible field_type for cosine space. The field type must " + "be knn_vector.");
             }
 
-            this.processedQuery = parseToFloatArray(query, ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
+            this.processedQuery = parseToFloatArray(
+                query,
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
+            );
             float qVectorSquaredMagnitude = getVectorMagnitudeSquared(this.processedQuery);
             this.scoringMethod = (float[] q, float[] v) -> 1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude);
         }
@@ -159,7 +167,11 @@ public interface KNNScoringSpace {
                 throw new IllegalArgumentException("Incompatible field_type for l1 space. The field type must " + "be knn_vector.");
             }
 
-            this.processedQuery = parseToFloatArray(query, ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
+            this.processedQuery = parseToFloatArray(
+                query,
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
+            );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
         }
 
@@ -185,7 +197,11 @@ public interface KNNScoringSpace {
                 throw new IllegalArgumentException("Incompatible field_type for l-inf space. The field type must " + "be knn_vector.");
             }
 
-            this.processedQuery = parseToFloatArray(query, ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
+            this.processedQuery = parseToFloatArray(
+                query,
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
+            );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
         }
 
@@ -213,7 +229,11 @@ public interface KNNScoringSpace {
                 );
             }
 
-            this.processedQuery = parseToFloatArray(query, ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension());
+            this.processedQuery = parseToFloatArray(
+                query,
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
+            );
             this.scoringMethod = (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));
         }
 

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -112,7 +112,7 @@ public class KNNScoringSpaceUtil {
             primitiveVector = new float[tmp.size()];
             for (int i = 0; i < primitiveVector.length; i++) {
                 float value = tmp.get(i).floatValue();
-                if (VectorDataType.BYTE.equals(vectorDataType)) {
+                if (VectorDataType.BYTE == vectorDataType) {
                     validateByteVectorValue(value);
                 }
                 primitiveVector[i] = value;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -63,7 +63,7 @@ public class KNNScoringUtil {
         int index = 0;
         for (final Number val : inputVector) {
             float floatValue = val.floatValue();
-            if (VectorDataType.BYTE.equals(vectorDataType)) {
+            if (VectorDataType.BYTE == vectorDataType) {
                 validateByteVectorValue(floatValue);
             }
             value[index++] = floatValue;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -8,10 +8,13 @@ package org.opensearch.knn.plugin.script;
 import org.opensearch.knn.index.KNNVectorScriptDocValues;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.knn.index.VectorDataType;
 
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
+
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVectorValue;
 
 public class KNNScoringUtil {
     private static Logger logger = LogManager.getLogger(KNNScoringUtil.class);
@@ -54,12 +57,16 @@ public class KNNScoringUtil {
         return squaredDistance;
     }
 
-    private static float[] toFloat(List<Number> inputVector) {
+    private static float[] toFloat(List<Number> inputVector, VectorDataType vectorDataType) {
         Objects.requireNonNull(inputVector);
         float[] value = new float[inputVector.size()];
         int index = 0;
         for (final Number val : inputVector) {
-            value[index++] = val.floatValue();
+            float floatValue = val.floatValue();
+            if (VectorDataType.BYTE.equals(vectorDataType)) {
+                validateByteVectorValue(floatValue);
+            }
+            value[index++] = floatValue;
         }
         return value;
     }
@@ -81,7 +88,7 @@ public class KNNScoringUtil {
      * @return L2 score
      */
     public static float l2Squared(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return l2Squared(toFloat(queryVector), docValues.getValue());
+        return l2Squared(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -127,7 +134,11 @@ public class KNNScoringUtil {
      * @return cosine score
      */
     public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues, Number queryVectorMagnitude) {
-        return cosinesimilOptimized(toFloat(queryVector), docValues.getValue(), queryVectorMagnitude.floatValue());
+        return cosinesimilOptimized(
+            toFloat(queryVector, docValues.getVectorDataType()),
+            docValues.getValue(),
+            queryVectorMagnitude.floatValue()
+        );
     }
 
     /**
@@ -172,7 +183,7 @@ public class KNNScoringUtil {
      * @return cosine score
      */
     public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return cosinesimil(toFloat(queryVector), docValues.getValue());
+        return cosinesimil(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -232,7 +243,7 @@ public class KNNScoringUtil {
      * @return L1 score
      */
     public static float l1Norm(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return l1Norm(toFloat(queryVector), docValues.getValue());
+        return l1Norm(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -270,7 +281,7 @@ public class KNNScoringUtil {
      * @return L-inf score
      */
     public static float lInfNorm(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return lInfNorm(toFloat(queryVector), docValues.getValue());
+        return lInfNorm(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -307,6 +318,6 @@ public class KNNScoringUtil {
      * @return inner product score
      */
     public static float innerProduct(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return innerProduct(toFloat(queryVector), docValues.getValue());
+        return innerProduct(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
@@ -62,30 +62,38 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
     }
 
     public void testGetScriptValues() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), MOCK_INDEX_FIELD_NAME);
+        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+            leafReaderContext.reader(),
+            MOCK_INDEX_FIELD_NAME,
+            VectorDataType.FLOAT
+        );
         ScriptDocValues<float[]> scriptValues = leafFieldData.getScriptValues();
         assertNotNull(scriptValues);
         assertTrue(scriptValues instanceof KNNVectorScriptDocValues);
     }
 
     public void testGetScriptValuesWrongFieldName() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "invalid");
+        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "invalid", VectorDataType.FLOAT);
         ScriptDocValues<float[]> scriptValues = leafFieldData.getScriptValues();
         assertNotNull(scriptValues);
     }
 
     public void testGetScriptValuesWrongFieldType() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), MOCK_NUMERIC_INDEX_FIELD_NAME);
+        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+            leafReaderContext.reader(),
+            MOCK_NUMERIC_INDEX_FIELD_NAME,
+            VectorDataType.FLOAT
+        );
         expectThrows(IllegalStateException.class, () -> leafFieldData.getScriptValues());
     }
 
     public void testRamBytesUsed() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "");
+        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "", VectorDataType.FLOAT);
         assertEquals(0, leafFieldData.ramBytesUsed());
     }
 
     public void testGetBytesValues() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "");
+        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "", VectorDataType.FLOAT);
         expectThrows(UnsupportedOperationException.class, () -> leafFieldData.getBytesValues());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNVectorIndexFieldDataTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorIndexFieldDataTests.java
@@ -27,7 +27,7 @@ public class KNNVectorIndexFieldDataTests extends KNNTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        indexFieldData = new KNNVectorIndexFieldData(MOCK_INDEX_FIELD_NAME, CoreValuesSourceType.BYTES);
+        indexFieldData = new KNNVectorIndexFieldData(MOCK_INDEX_FIELD_NAME, CoreValuesSourceType.BYTES, VectorDataType.FLOAT);
         directory = newDirectory();
         createEmptyDocument(directory);
     }

--- a/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
@@ -37,7 +37,8 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
         scriptDocValues = new KNNVectorScriptDocValues(
             leafReaderContext.reader().getBinaryDocValues(MOCK_INDEX_FIELD_NAME),
-            MOCK_INDEX_FIELD_NAME
+            MOCK_INDEX_FIELD_NAME,
+            VectorDataType.FLOAT
         );
     }
 

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -8,19 +8,28 @@ package org.opensearch.knn.index;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.After;
+import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.script.Script;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
@@ -37,6 +46,7 @@ public class VectorDataTypeIT extends KNNRestTestCase {
     private static final String KNN_VECTOR_TYPE = "knn_vector";
     private static final int EF_CONSTRUCTION = 128;
     private static final int M = 16;
+    private static final QueryBuilder MATCH_ALL_QUERY_BUILDER = new MatchAllQueryBuilder();
 
     @After
     @SneakyThrows
@@ -249,6 +259,172 @@ public class VectorDataTypeIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testByteVectorDataTypeWithLegacyFieldMapperKnnIndexSetting() {
+        // Create an index with byte vector data_type and index.knn as true without setting KnnMethodContext,
+        // which should throw an exception because the LegacyFieldMapper will use NMSLIB engine and byte data_type
+        // is not supported for NMSLIB engine.
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION, 2)
+            .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.BYTE.getValue())
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = Strings.toString(builder);
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, mapping));
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    String.format(
+                        Locale.ROOT,
+                        "[%s] field with value [%s] is only supported for [%s] engine",
+                        VECTOR_DATA_TYPE_FIELD,
+                        VectorDataType.BYTE.getValue(),
+                        LUCENE_NAME
+                    )
+                )
+        );
+
+    }
+
+    public void testDocValuesWithByteVectorDataTypeLuceneEngine() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.BYTE.getValue());
+        ingestL2ByteTestData();
+
+        Byte[] queryVector = { 1, 1 };
+        Request request = createScriptQueryRequest(queryVector, SpaceType.L2.getValue(), MATCH_ALL_QUERY_BUILDER);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        validateL2SearchResults(response);
+    }
+
+    public void testDocValuesWithFloatVectorDataTypeLuceneEngine() throws Exception {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
+        ingestL2FloatTestData();
+
+        Byte[] queryVector = { 1, 1 };
+        Request request = createScriptQueryRequest(queryVector, SpaceType.L2.getValue(), MATCH_ALL_QUERY_BUILDER);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        validateL2SearchResults(response);
+    }
+
+    public void testL2ScriptScoreWithByteVectorDataType() throws Exception {
+        createKnnIndexMappingForScripting(2, VectorDataType.BYTE.getValue());
+        ingestL2ByteTestData();
+
+        Byte[] queryVector = { 1, 1 };
+        Request request = createScriptQueryRequest(queryVector, SpaceType.L2.getValue(), MATCH_ALL_QUERY_BUILDER);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        validateL2SearchResults(response);
+    }
+
+    public void testL2ScriptScoreWithFloatVectorDataType() throws Exception {
+        createKnnIndexMappingForScripting(2, VectorDataType.FLOAT.getValue());
+        ingestL2FloatTestData();
+
+        Float[] queryVector = { 1.0f, 1.0f };
+        Request request = createScriptQueryRequest(queryVector, SpaceType.L2.getValue(), MATCH_ALL_QUERY_BUILDER);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        validateL2SearchResults(response);
+    }
+
+    public void testL2PainlessScriptingWithByteVectorDataType() throws Exception {
+        createKnnIndexMappingForScripting(2, VectorDataType.BYTE.getValue());
+        ingestL2ByteTestData();
+
+        String source = String.format("1/(1 + l2Squared([1, 1], doc['%s']))", FIELD_NAME);
+        Request request = constructScriptScoreContextSearchRequest(
+            INDEX_NAME,
+            MATCH_ALL_QUERY_BUILDER,
+            Collections.emptyMap(),
+            Script.DEFAULT_SCRIPT_LANG,
+            source,
+            4
+        );
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        validateL2SearchResults(response);
+    }
+
+    public void testL2PainlessScriptingWithFloatVectorDataType() throws Exception {
+        createKnnIndexMappingForScripting(2, VectorDataType.FLOAT.getValue());
+        ingestL2FloatTestData();
+
+        String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        Request request = constructScriptScoreContextSearchRequest(
+            INDEX_NAME,
+            MATCH_ALL_QUERY_BUILDER,
+            Collections.emptyMap(),
+            Script.DEFAULT_SCRIPT_LANG,
+            source,
+            4
+        );
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        validateL2SearchResults(response);
+    }
+
+    public void testKNNScriptScoreWithInvalidVectorDataType() {
+        // Set an invalid value for data_type field while creating the index for script scoring which should throw an exception
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndexMappingForScripting(2, "invalid_data_type"));
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    String.format(
+                        Locale.ROOT,
+                        "Invalid value provided for [%s] field. Supported values are [%s]",
+                        VECTOR_DATA_TYPE_FIELD,
+                        SUPPORTED_VECTOR_DATA_TYPES
+                    )
+                )
+        );
+    }
+
+    public void testKNNScriptScoreWithInvalidByteQueryVector() throws Exception {
+        // Create an index with byte vector data_type, add docs and run a scoring script query with decimal values
+        // which should throw exception
+        createKnnIndexMappingForScripting(2, VectorDataType.BYTE.getValue());
+
+        Byte[] f1 = { 6, 6 };
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
+
+        Byte[] f2 = { 2, 2 };
+        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f2);
+
+        // Construct Search Request with query vector having decimal values
+        Float[] queryVector = { 10.67f, 19.78f };
+        Request request = createScriptQueryRequest(queryVector, SpaceType.L2.getValue(), MATCH_ALL_QUERY_BUILDER);
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(
+            ex.getMessage()
+                .contains(
+                    String.format(
+                        Locale.ROOT,
+                        "[%s] field was set as [%s] in index mapping. But, KNN vector values are floats instead of byte integers",
+                        VECTOR_DATA_TYPE_FIELD,
+                        VectorDataType.BYTE.getValue()
+                    )
+                )
+        );
+    }
+
+    @SneakyThrows
     private void ingestL2ByteTestData() {
         Byte[] b1 = { 6, 6 };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, b1);
@@ -310,6 +486,40 @@ public class VectorDataTypeIT extends KNNRestTestCase {
 
         String mapping = Strings.toString(builder);
         createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createKnnIndexMappingForScripting(int dimension, String vectorDataType) throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION, dimension)
+            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = Strings.toString(builder);
+        createKnnIndex(INDEX_NAME, Settings.EMPTY, mapping);
+    }
+
+    @SneakyThrows
+    private Request createScriptQueryRequest(Byte[] queryVector, String spaceType, QueryBuilder qb) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("field", FIELD_NAME);
+        params.put("query_value", queryVector);
+        params.put("space_type", spaceType);
+        return constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
+    }
+
+    @SneakyThrows
+    private Request createScriptQueryRequest(Float[] queryVector, String spaceType, QueryBuilder qb) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("field", FIELD_NAME);
+        params.put("query_value", queryVector);
+        params.put("space_type", spaceType);
+        return constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.junit.Assert;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+
+public class VectorDataTypeTests extends KNNTestCase {
+
+    private static final String MOCK_FLOAT_INDEX_FIELD_NAME = "test-float-index-field-name";
+    private static final String MOCK_BYTE_INDEX_FIELD_NAME = "test-byte-index-field-name";
+    private static final float[] SAMPLE_FLOAT_VECTOR_DATA = new float[] { 10.0f, 25.0f };
+    private static final byte[] SAMPLE_BYTE_VECTOR_DATA = new byte[] { 10, 25 };
+    private Directory directory;
+    private DirectoryReader reader;
+
+    @SneakyThrows
+    public void testGetDocValuesWithFloatVectorDataType() {
+        KNNVectorScriptDocValues scriptDocValues = getKNNFloatVectorScriptDocValues();
+
+        scriptDocValues.setNextDocId(0);
+        Assert.assertArrayEquals(SAMPLE_FLOAT_VECTOR_DATA, scriptDocValues.getValue(), 0.1f);
+
+        reader.close();
+        directory.close();
+    }
+
+    @SneakyThrows
+    public void testGetDocValuesWithByteVectorDataType() {
+        KNNVectorScriptDocValues scriptDocValues = getKNNByteVectorScriptDocValues();
+
+        scriptDocValues.setNextDocId(0);
+        Assert.assertArrayEquals(SAMPLE_FLOAT_VECTOR_DATA, scriptDocValues.getValue(), 0.1f);
+
+        reader.close();
+        directory.close();
+    }
+
+    @SneakyThrows
+    private KNNVectorScriptDocValues getKNNFloatVectorScriptDocValues() {
+        directory = newDirectory();
+        createKNNFloatVectorDocument(directory);
+        reader = DirectoryReader.open(directory);
+        LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
+        return new KNNVectorScriptDocValues(
+            leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME),
+            VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME,
+            VectorDataType.FLOAT
+        );
+    }
+
+    @SneakyThrows
+    private KNNVectorScriptDocValues getKNNByteVectorScriptDocValues() {
+        directory = newDirectory();
+        createKNNByteVectorDocument(directory);
+        reader = DirectoryReader.open(directory);
+        LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
+        return new KNNVectorScriptDocValues(
+            leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME),
+            VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME,
+            VectorDataType.BYTE
+        );
+    }
+
+    private void createKNNFloatVectorDocument(Directory directory) throws IOException {
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        IndexWriter writer = new IndexWriter(directory, conf);
+        Document knnDocument = new Document();
+        knnDocument.add(
+            new BinaryDocValuesField(
+                MOCK_FLOAT_INDEX_FIELD_NAME,
+                new VectorField(MOCK_FLOAT_INDEX_FIELD_NAME, SAMPLE_FLOAT_VECTOR_DATA, new FieldType()).binaryValue()
+            )
+        );
+        writer.addDocument(knnDocument);
+        writer.commit();
+        writer.close();
+    }
+
+    private void createKNNByteVectorDocument(Directory directory) throws IOException {
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        IndexWriter writer = new IndexWriter(directory, conf);
+        Document knnDocument = new Document();
+        knnDocument.add(
+            new BinaryDocValuesField(
+                MOCK_BYTE_INDEX_FIELD_NAME,
+                new VectorField(MOCK_BYTE_INDEX_FIELD_NAME, SAMPLE_BYTE_VECTOR_DATA, new FieldType()).binaryValue()
+            )
+        );
+        writer.addDocument(knnDocument);
+        writer.commit();
+        writer.close();
+    }
+}

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -64,11 +65,14 @@ public class KNNScoringSpaceUtilTests extends KNNTestCase {
         KNNVectorFieldMapper.KNNVectorFieldType fieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
 
         when(fieldType.getDimension()).thenReturn(3);
-        assertArrayEquals(arrayFloat, KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject, 3), 0.1f);
+        assertArrayEquals(arrayFloat, KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject, 3, VectorDataType.FLOAT), 0.1f);
 
-        expectThrows(IllegalStateException.class, () -> KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject, 4));
+        expectThrows(
+            IllegalStateException.class,
+            () -> KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject, 4, VectorDataType.FLOAT)
+        );
 
         String invalidObject = "invalidObject";
-        expectThrows(ClassCastException.class, () -> KNNScoringSpaceUtil.parseToFloatArray(invalidObject, 3));
+        expectThrows(ClassCastException.class, () -> KNNScoringSpaceUtil.parseToFloatArray(invalidObject, 3, VectorDataType.FLOAT));
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNVectorScriptDocValues;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -81,7 +82,7 @@ public class KNNScoringUtilTests extends KNNTestCase {
 
     public void testConvertInvalidVectorToPrimitive() {
         float[] primitiveVector = null;
-        assertEquals(primitiveVector, KNNScoringSpaceUtil.convertVectorToPrimitive(primitiveVector));
+        assertEquals(primitiveVector, KNNScoringSpaceUtil.convertVectorToPrimitive(primitiveVector, VectorDataType.FLOAT));
     }
 
     public void testCosineSimilQueryVectorZeroMagnitude() {
@@ -243,7 +244,11 @@ public class KNNScoringUtilTests extends KNNTestCase {
             if (scriptDocValues == null) {
                 reader = DirectoryReader.open(directory);
                 LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-                scriptDocValues = new KNNVectorScriptDocValues(leafReaderContext.reader().getBinaryDocValues(fieldName), fieldName);
+                scriptDocValues = new KNNVectorScriptDocValues(
+                    leafReaderContext.reader().getBinaryDocValues(fieldName),
+                    fieldName,
+                    VectorDataType.FLOAT
+                );
             }
             return scriptDocValues;
         }


### PR DESCRIPTION
### Description
The changes in this PR adds doc values support for fields with byte sized vectors, which helps users to perform script scoring and painless scripting search functionalities on these indices.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/812
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
