### PR TITLE
Add Querying Support to Lucene Byte Sized Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Added efficient filtering support for Faiss Engine ([#936](https://github.com/opensearch-project/k-NN/pull/936))
 * Add Indexing Support for Lucene Byte Sized Vector ([#937](https://github.com/opensearch-project/k-NN/pull/937))
+* Add Querying Support for Lucene Byte Sized Vector ([#956](https://github.com/opensearch-project/k-NN/pull/956))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -257,7 +257,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
 
         byte[] byteVector = new byte[0];
-        if (VectorDataType.BYTE.equals(vectorDataType)) {
+        if (VectorDataType.BYTE == vectorDataType) {
             byteVector = new byte[vector.length];
             for (int i = 0; i < vector.length; i++) {
                 validateByteVectorValue(vector[i]);
@@ -274,8 +274,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             .knnEngine(knnEngine)
             .indexName(indexName)
             .fieldName(this.fieldName)
-            .vector(VectorDataType.FLOAT.equals(vectorDataType) ? this.vector : null)
-            .byteVector(VectorDataType.BYTE.equals(vectorDataType) ? byteVector : null)
+            .vector(VectorDataType.FLOAT == vectorDataType ? this.vector : null)
+            .byteVector(VectorDataType.BYTE == vectorDataType ? byteVector : null)
             .vectorDataType(vectorDataType)
             .k(this.k)
             .filter(this.filter)

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -93,31 +93,10 @@ public class KNNQueryFactory {
             return new KNNQuery(fieldName, vector, k, indexName);
         }
 
-        if (filterQuery != null) {
-            log.debug(
-                String.format("Creating Lucene k-NN query with filters for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k)
-            );
-            if (VectorDataType.BYTE.equals(vectorDataType)) {
-                return new KnnByteVectorQuery(fieldName, byteVector, k, filterQuery);
-            } else if (VectorDataType.FLOAT.equals(vectorDataType)) {
-                return new KnnFloatVectorQuery(fieldName, vector, k, filterQuery);
-            } else {
-                throw new IllegalArgumentException(
-                    String.format(
-                        Locale.ROOT,
-                        "Invalid value provided for [%s] field. Supported values are [%s]",
-                        VECTOR_DATA_TYPE_FIELD,
-                        SUPPORTED_VECTOR_DATA_TYPES
-                    )
-                );
-            }
-
-        }
-        log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
-        if (VectorDataType.BYTE.equals(vectorDataType)) {
-            return new KnnByteVectorQuery(fieldName, byteVector, k);
-        } else if (VectorDataType.FLOAT.equals(vectorDataType)) {
-            return new KnnFloatVectorQuery(fieldName, vector, k);
+        if (VectorDataType.BYTE == vectorDataType) {
+            return getKnnByteVectorQuery(indexName, fieldName, byteVector, k, filterQuery);
+        } else if (VectorDataType.FLOAT == vectorDataType) {
+            return getKnnFloatVectorQuery(indexName, fieldName, vector, k, filterQuery);
         } else {
             throw new IllegalArgumentException(
                 String.format(
@@ -128,6 +107,40 @@ public class KNNQueryFactory {
                 )
             );
         }
+    }
+
+    private static Query getKnnByteVectorQuery(String indexName, String fieldName, byte[] byteVector, int k, Query filterQuery) {
+        if (filterQuery != null) {
+            log.debug(
+                String.format(
+                    Locale.ROOT,
+                    "Creating Lucene k-NN query with filters for index: %s \"\", field: %s \"\", k: %d",
+                    indexName,
+                    fieldName,
+                    k
+                )
+            );
+            return new KnnByteVectorQuery(fieldName, byteVector, k, filterQuery);
+        }
+        log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
+        return new KnnByteVectorQuery(fieldName, byteVector, k);
+    }
+
+    private static Query getKnnFloatVectorQuery(String indexName, String fieldName, float[] floatVector, int k, Query filterQuery) {
+        if (filterQuery != null) {
+            log.debug(
+                String.format(
+                    Locale.ROOT,
+                    "Creating Lucene k-NN query with filters for index: %s \"\", field: %s \"\", k: %d",
+                    indexName,
+                    fieldName,
+                    k
+                )
+            );
+            return new KnnFloatVectorQuery(fieldName, floatVector, k, filterQuery);
+        }
+        log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
+        return new KnnFloatVectorQuery(fieldName, floatVector, k);
     }
 
     private static Query getFilterQuery(CreateQueryRequest createQueryRequest) {

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -227,7 +227,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         Float[] vector = new Float[] { 2.0f, 4.5f, 6.5f };
         addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, vector);
 
-        refreshAllIndices();
+        refreshIndex(INDEX_NAME);
         assertEquals(1, getDocCount(INDEX_NAME));
     }
 
@@ -239,7 +239,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         Float[] updatedVector = { 8.0f, 8.0f };
         updateKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, updatedVector);
 
-        refreshAllIndices();
+        refreshIndex(INDEX_NAME);
         assertEquals(1, getDocCount(INDEX_NAME));
     }
 
@@ -250,7 +250,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
         deleteKnnDoc(INDEX_NAME, DOC_ID);
 
-        refreshAllIndices();
+        refreshIndex(INDEX_NAME);
         assertEquals(0, getDocCount(INDEX_NAME));
     }
 
@@ -265,7 +265,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         addKnnDocWithAttributes(DOC_ID_2, new float[] { 3.2f, 2.1f, 4.8f }, ImmutableMap.of(COLOR_FIELD_NAME, "green"));
         addKnnDocWithAttributes(DOC_ID_3, new float[] { 4.1f, 5.0f, 7.1f }, ImmutableMap.of(COLOR_FIELD_NAME, "red"));
 
-        refreshAllIndices();
+        refreshIndex(INDEX_NAME);
 
         final float[] searchVector = { 6.0f, 6.0f, 4.1f };
         List<String> expectedDocIdsKGreaterThanFilterResult = Arrays.asList(DOC_ID, DOC_ID_3);
@@ -281,7 +281,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         addKnnDocWithAttributes(DOC_ID_2, new float[] { 3.0f, 2.0f, 4.0f }, ImmutableMap.of(COLOR_FIELD_NAME, "green"));
         addKnnDocWithAttributes(DOC_ID_3, new float[] { 4.0f, 5.0f, 7.0f }, ImmutableMap.of(COLOR_FIELD_NAME, "red"));
 
-        refreshAllIndices();
+        refreshIndex(INDEX_NAME);
 
         final float[] searchVector = { 6.0f, 6.0f, 4.0f };
         List<String> expectedDocIdsKGreaterThanFilterResult = Arrays.asList(DOC_ID, DOC_ID_3);

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -69,6 +69,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.Version.CURRENT;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_CONSTRUCTION;
 import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_M;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
@@ -338,7 +339,14 @@ public class KNNCodecTestCase extends KNNTestCase {
         verify(perFieldKnnVectorsFormatSpy, atLeastOnce()).getKnnVectorsFormatForField(eq(FIELD_NAME_ONE));
 
         IndexSearcher searcher = new IndexSearcher(reader);
-        Query query = KNNQueryFactory.create(KNNEngine.LUCENE, "dummy", FIELD_NAME_ONE, new float[] { 1.0f, 0.0f, 0.0f }, 1);
+        Query query = KNNQueryFactory.create(
+            KNNEngine.LUCENE,
+            "dummy",
+            FIELD_NAME_ONE,
+            new float[] { 1.0f, 0.0f, 0.0f },
+            1,
+            DEFAULT_VECTOR_DATA_TYPE_FIELD
+        );
 
         assertEquals(1, searcher.count(query));
 
@@ -365,7 +373,14 @@ public class KNNCodecTestCase extends KNNTestCase {
         verify(perFieldKnnVectorsFormatSpy, atLeastOnce()).getKnnVectorsFormatForField(eq(FIELD_NAME_TWO));
 
         IndexSearcher searcher1 = new IndexSearcher(reader1);
-        Query query1 = KNNQueryFactory.create(KNNEngine.LUCENE, "dummy", FIELD_NAME_TWO, new float[] { 1.0f, 0.0f }, 1);
+        Query query1 = KNNQueryFactory.create(
+            KNNEngine.LUCENE,
+            "dummy",
+            FIELD_NAME_TWO,
+            new float[] { 1.0f, 0.0f },
+            1,
+            DEFAULT_VECTOR_DATA_TYPE_FIELD
+        );
 
         assertEquals(1, searcher1.count(query1));
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -30,6 +30,7 @@ import org.opensearch.knn.index.KNNClusterUtil;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
@@ -153,6 +154,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         KNNQuery query = (KNNQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
         assertEquals(knnQueryBuilder.getK(), query.getK());
@@ -168,6 +170,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         MethodComponentContext methodComponentContext = new MethodComponentContext(METHOD_HNSW, ImmutableMap.of());
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
@@ -187,6 +190,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
         // Dimension is -1. In this case, model metadata will need to provide dimension
         when(mockKNNVectorField.getDimension()).thenReturn(-K);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(null);
         String modelId = "test-model-id";
         when(mockKNNVectorField.getModelId()).thenReturn(modelId);

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FIELD;
 
 public class KNNQueryFactoryTests extends KNNTestCase {
     private static final String FILTER_FILED_NAME = "foo";
@@ -38,7 +39,14 @@ public class KNNQueryFactoryTests extends KNNTestCase {
 
     public void testCreateCustomKNNQuery() {
         for (KNNEngine knnEngine : KNNEngine.getEnginesThatCreateCustomSegmentFiles()) {
-            Query query = KNNQueryFactory.create(knnEngine, testIndexName, testFieldName, testQueryVector, testK);
+            Query query = KNNQueryFactory.create(
+                knnEngine,
+                testIndexName,
+                testFieldName,
+                testQueryVector,
+                testK,
+                DEFAULT_VECTOR_DATA_TYPE_FIELD
+            );
             assertTrue(query instanceof KNNQuery);
 
             assertEquals(testIndexName, ((KNNQuery) query).getIndexName());
@@ -53,7 +61,14 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             .filter(knnEngine -> !KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine))
             .collect(Collectors.toList());
         for (KNNEngine knnEngine : luceneDefaultQueryEngineList) {
-            Query query = KNNQueryFactory.create(knnEngine, testIndexName, testFieldName, testQueryVector, testK);
+            Query query = KNNQueryFactory.create(
+                knnEngine,
+                testIndexName,
+                testFieldName,
+                testQueryVector,
+                testK,
+                DEFAULT_VECTOR_DATA_TYPE_FIELD
+            );
             assertTrue(query.getClass().isAssignableFrom(KnnFloatVectorQuery.class));
         }
     }
@@ -71,6 +86,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
                 .indexName(testIndexName)
                 .fieldName(testFieldName)
                 .vector(testQueryVector)
+                .vectorDataType(DEFAULT_VECTOR_DATA_TYPE_FIELD)
                 .k(testK)
                 .context(mockQueryShardContext)
                 .filter(FILTER_QUERY_BUILDER)


### PR DESCRIPTION
### Description
The changes in this PR adds querying support to lucene byte sized vector.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/812
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
