### PR TITLE
Fixing the opensearch-build issue happening due to lower version of gcc.

### DIFF
--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -41,9 +41,6 @@ void SetExtraParameters(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env,
 // Train an index with data provided
 void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x);
 
-// Create the SearchParams based on the Index Type
-std::unique_ptr<faiss::SearchParameters> buildSearchParams(const faiss::IndexIDMap *indexReader, faiss::IDSelector* idSelector);
-
 // Helps to choose the right FilterIdsSelectorType for Faiss
 FilterIdsSelectorType getIdSelectorType(const int* filterIds, int filterIdsLength);
 
@@ -249,9 +246,26 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
             buildFilterIdsBitMap(filteredIdsArray, filterIdsLength, bitmap.data());
             idSelector.reset(new faiss::IDSelectorBitmap(filterIdsLength, bitmap.data()));
         }
-        std::unique_ptr<faiss::SearchParameters> searchParameters = buildSearchParams(indexReader, idSelector.get());
+        faiss::SearchParameters *searchParameters;
+        faiss::SearchParametersHNSW hnswParams;
+        faiss::SearchParametersIVF ivfParams;
+        auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
+        if(hnswReader) {
+            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
+            // value of ef_search = 16 which will then be used.
+            hnswParams.efSearch = hnswReader->hnsw.efSearch;
+            hnswParams.sel = idSelector.get();
+            searchParameters = &hnswParams;
+        } else {
+            auto ivfReader = dynamic_cast<const faiss::IndexIVF*>(indexReader->index);
+            auto ivfFlatReader = dynamic_cast<const faiss::IndexIVFFlat*>(indexReader->index);
+            if(ivfReader || ivfFlatReader) {
+                ivfParams.sel = idSelector.get();
+                searchParameters = &ivfParams;
+            }
+        }
         try {
-            indexReader->search(1, rawQueryvector, kJ, dis.data(), ids.data(), searchParameters.get());
+            indexReader->search(1, rawQueryvector, kJ, dis.data(), ids.data(), searchParameters);
         } catch (...) {
             jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
             jniUtil->ReleaseIntArrayElements(env, filterIdsJ, filteredIdsArray, JNI_ABORT);
@@ -474,34 +488,4 @@ void buildFilterIdsBitMap(const int* filterIds, int filterIdsLength, uint8_t* bi
         // (value & 7) equivalent to value % 8
         bitsetVector[bitsetArrayIndex] = bitsetVector[bitsetArrayIndex] |  (1 << (value & 7));
     }
-}
-
-/**
- * Based on the type of the index reader we need to return the SearchParameters. The way we do this by dynamically
- * casting the IndexReader.
- * @param indexReader
- * @param idSelector
- * @return SearchParameters
- */
-std::unique_ptr<faiss::SearchParameters> buildSearchParams(const faiss::IndexIDMap *indexReader, faiss::IDSelector* idSelector) {
-    auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
-    if(hnswReader) {
-        // we need to make this variable unique_ptr so that the scope can be shared with caller function.
-        std::unique_ptr<faiss::SearchParametersHNSW> hnswParams(new faiss::SearchParametersHNSW);
-        // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
-        // value of ef_search = 16 which will then be used.
-        hnswParams->efSearch = hnswReader->hnsw.efSearch;
-        hnswParams->sel = idSelector;
-        return hnswParams;
-    }
-
-    auto ivfReader = dynamic_cast<const faiss::IndexIVF*>(indexReader->index);
-    auto ivfFlatReader = dynamic_cast<const faiss::IndexIVFFlat*>(indexReader->index);
-    if(ivfReader || ivfFlatReader) {
-        // we need to make this variable unique_ptr so that the scope can be shared with caller function.
-        std::unique_ptr<faiss::SearchParametersIVF> ivfParams(new faiss::SearchParametersIVF);
-        ivfParams->sel = idSelector;
-        return ivfParams;
-    }
-    throw std::runtime_error("Invalid Index Type supported for Filtered Search on Faiss");
 }


### PR DESCRIPTION
### Description
Fixing the opensearch-build issue happening due to lower version of gcc.

Jenkins link: https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch/detail/distribution-build-opensearch/8108/pipeline/129/

```
Consolidate compiler generated dependencies of target opensearchknn_common

[ 96%] Built target opensearchknn_common

[ 96%] Building CXX object CMakeFiles/opensearchknn_faiss.dir/src/org_opensearch_knn_jni_FaissService.cpp.o

/tmp/tmphvvuwegd/k-NN/jni/src/org_opensearch_knn_jni_FaissService.cpp: In function 'jlong Java_org_opensearch_knn_jni_FaissService_loadIndex(JNIEnv*, jclass, jstring)':

/tmp/tmphvvuwegd/k-NN/jni/src/org_opensearch_knn_jni_FaissService.cpp:75:12: warning: converting to non-pointer type 'long int' from NULL [-Wconversion-null]

     return NULL;

            ^

[100%] Building CXX object CMakeFiles/opensearchknn_faiss.dir/src/faiss_wrapper.cpp.o

/tmp/tmphvvuwegd/k-NN/jni/src/faiss_wrapper.cpp: In function 'std::unique_ptr<faiss::SearchParameters> buildSearchParams(const IndexIDMap*, faiss::IDSelector*)':

/tmp/tmphvvuwegd/k-NN/jni/src/faiss_wrapper.cpp:495:16: error: cannot bind 'std::unique_ptr<faiss::SearchParametersHNSW>' lvalue to 'std::unique_ptr<faiss::SearchParametersHNSW>&&'

         return hnswParams;

                ^

In file included from /usr/include/c++/4.8.2/memory:81:0,

                 from /tmp/tmphvvuwegd/k-NN/jni/external/faiss/faiss/IndexIVF.h:14,

                 from /tmp/tmphvvuwegd/k-NN/jni/external/faiss/faiss/IndexScalarQuantizer.h:17,

                 from /tmp/tmphvvuwegd/k-NN/jni/external/faiss/faiss/IndexHNSW.h:16,

                 from /tmp/tmphvvuwegd/k-NN/jni/src/faiss_wrapper.cpp:18:

/usr/include/c++/4.8.2/bits/unique_ptr.h:169:2: error:   initializing argument 1 of 'std::unique_ptr<_Tp, _Dp>::unique_ptr(std::unique_ptr<_Up, _Ep>&&) [with _Up = faiss::SearchParametersHNSW; _Ep = std::default_delete<faiss::SearchParametersHNSW>; <template-parameter-2-3> = void; _Tp = faiss::SearchParameters; _Dp = std::default_delete<faiss::SearchParameters>]'

  unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept

  ^

/tmp/tmphvvuwegd/k-NN/jni/src/faiss_wrapper.cpp:504:16: error: cannot bind 'std::unique_ptr<faiss::SearchParametersIVF>' lvalue to 'std::unique_ptr<faiss::SearchParametersIVF>&&'

         return ivfParams;

                ^

In file included from /usr/include/c++/4.8.2/memory:81:0,

                 from /tmp/tmphvvuwegd/k-NN/jni/external/faiss/faiss/IndexIVF.h:14,

                 from /tmp/tmphvvuwegd/k-NN/jni/external/faiss/faiss/IndexScalarQuantizer.h:17,

                 from /tmp/tmphvvuwegd/k-NN/jni/external/faiss/faiss/IndexHNSW.h:16,

                 from /tmp/tmphvvuwegd/k-NN/jni/src/faiss_wrapper.cpp:18:

/usr/include/c++/4.8.2/bits/unique_ptr.h:169:2: error:   initializing argument 1 of 'std::unique_ptr<_Tp, _Dp>::unique_ptr(std::unique_ptr<_Up, _Ep>&&) [with _Up = faiss::SearchParametersIVF; _Ep = std::default_delete<faiss::SearchParametersIVF>; <template-parameter-2-3> = void; _Tp = faiss::SearchParameters; _Dp = std::default_delete<faiss::SearchParameters>]'

  unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept

  ^

make[3]: *** [CMakeFiles/opensearchknn_faiss.dir/src/faiss_wrapper.cpp.o] Error 1

make[2]: *** [CMakeFiles/opensearchknn_faiss.dir/all] Error 2

make[1]: *** [CMakeFiles/opensearchknn_faiss.dir/rule] Error 2

make: *** [opensearchknn_faiss] Error 2


```

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/975


 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
