### PR TITLE
Add gcc version verification before building k-NN

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -105,6 +105,15 @@ if [ "$JAVA_HOME" = "" ]; then
     echo "SET JAVA_HOME=$JAVA_HOME"
 fi
 
+# Ensure gcc version is above 4.9.0 for faiss 1.7.4+ compilation
+GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
+GCC_REQUIRED_VERSION=4.9.0
+COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+if [ ! "$COMPARE_VERSION" = "$GCC_REQUIRED_VERSION" ]; then
+    echo "gcc version on this env is older than $GCC_REQUIRED_VERSION, exit 1"
+    exit 1
+fi
+
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir
 # Gradle build is used here to replace gradle assemble due to build will also call cmake and make before generating jars


### PR DESCRIPTION
### Description
Add gcc version verification before building k-NN
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/975
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
