### PR TITLE
Add gcc version ceiling verification before building k-NN on arm64

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -114,6 +114,15 @@ if [ ! "$COMPARE_VERSION" = "$GCC_REQUIRED_VERSION" ]; then
     exit 1
 fi
 
+# Ensure gcc version is below 8.0.0 for faiss 1.7.4+ compilation so it will not crash on arm64 CentOS7
+GCC_REQUIRED_VERSION_CEILING=8.0.0
+COMPARE_VERSION_CEILING=`echo $GCC_REQUIRED_VERSION_CEILING $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | tail -n 1`
+if [ ! "$COMPARE_VERSION_CEILING" = "$GCC_REQUIRED_VERSION_CEILING" ]; then
+    echo "gcc version on this env is newer than $GCC_REQUIRED_VERSION_CEILING, exit 1"
+    exit 1
+fi
+
+
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir
 # Gradle build is used here to replace gradle assemble due to build will also call cmake and make before generating jars

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,6 +106,7 @@ if [ "$JAVA_HOME" = "" ]; then
 fi
 
 # Ensure gcc version is above 4.9.0 for faiss 1.7.4+ compilation
+# https://github.com/opensearch-project/k-NN/issues/975
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
 GCC_REQUIRED_VERSION=4.9.0
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
@@ -115,6 +116,7 @@ if [ ! "$COMPARE_VERSION" = "$GCC_REQUIRED_VERSION" ]; then
 fi
 
 # Ensure gcc version is below 8.0.0 for faiss 1.7.4+ compilation so it will not crash on arm64 CentOS7
+# https://github.com/opensearch-project/k-NN/issues/975
 GCC_REQUIRED_VERSION_CEILING=8.0.0
 COMPARE_VERSION_CEILING=`echo $GCC_REQUIRED_VERSION_CEILING $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | tail -n 1`
 if [ ! "$COMPARE_VERSION_CEILING" = "$GCC_REQUIRED_VERSION_CEILING" ]; then


### PR DESCRIPTION
### Description
Add gcc version ceiling verification before building k-NN on arm64
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/975
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
