### PR TITLE
Add more unit-tests for Lucene Byte Vector

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.mapper;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.common.ValidationException;
@@ -110,7 +111,8 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
          * data_type which defines the datatype of the vector values. This is an optional parameter and
          * this is right now only relevant for lucene engine. The default value is float.
          */
-        private final Parameter<VectorDataType> vectorDataType = new Parameter<>(
+        @VisibleForTesting
+        protected final Parameter<VectorDataType> vectorDataType = new Parameter<>(
             VECTOR_DATA_TYPE_FIELD,
             false,
             () -> DEFAULT_VECTOR_DATA_TYPE_FIELD,

--- a/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
@@ -61,15 +61,12 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
         directory.close();
     }
 
-    public void testGetScriptValues() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
-            leafReaderContext.reader(),
-            MOCK_INDEX_FIELD_NAME,
-            VectorDataType.FLOAT
-        );
-        ScriptDocValues<float[]> scriptValues = leafFieldData.getScriptValues();
-        assertNotNull(scriptValues);
-        assertTrue(scriptValues instanceof KNNVectorScriptDocValues);
+    public void testGetScriptValuesFloatVectorDataType() {
+        validateGetScriptValuesWithVectorDataType(VectorDataType.FLOAT);
+    }
+
+    public void testGetScriptValuesByteVectorDataType() {
+        validateGetScriptValuesWithVectorDataType(VectorDataType.BYTE);
     }
 
     public void testGetScriptValuesWrongFieldName() {
@@ -85,6 +82,17 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
             VectorDataType.FLOAT
         );
         expectThrows(IllegalStateException.class, () -> leafFieldData.getScriptValues());
+    }
+
+    private void validateGetScriptValuesWithVectorDataType(VectorDataType vectorDataType) {
+        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+            leafReaderContext.reader(),
+            MOCK_INDEX_FIELD_NAME,
+            vectorDataType
+        );
+        ScriptDocValues<float[]> scriptValues = leafFieldData.getScriptValues();
+        assertNotNull(scriptValues);
+        assertTrue(scriptValues instanceof KNNVectorScriptDocValues);
     }
 
     public void testRamBytesUsed() {

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -7,8 +7,10 @@ package org.opensearch.knn.index.mapper;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.BytesRef;
@@ -218,6 +220,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             .startObject()
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
             .field(DIMENSION_FIELD_NAME, dimension)
+            .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.BYTE.getValue())
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
@@ -237,6 +240,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         builder.build(builderContext);
 
         assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponent().getName());
+        assertEquals(VectorDataType.BYTE.getValue(), builder.vectorDataType.getValue().getValue());
         assertEquals(
             efConstruction,
             builder.knnMethodContext.get().getMethodComponent().getParameters().get(METHOD_PARAMETER_EF_CONSTRUCTION)
@@ -869,6 +873,13 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         assertTrue(field instanceof KnnByteVectorField);
         knnByteVectorField = (KnnByteVectorField) field;
         assertArrayEquals(TEST_BYTE_VECTOR, knnByteVectorField.vectorValue());
+    }
+
+    public void testBuildDocValuesFieldType() {
+        FieldType fieldType = KNNVectorFieldMapperUtil.buildDocValuesFieldType(KNNEngine.LUCENE);
+        assertNotNull(fieldType);
+        assertEquals(KNNEngine.LUCENE.getName(), fieldType.getAttributes().get(KNN_ENGINE));
+        assertEquals(DocValuesType.BINARY, fieldType.docValuesType());
     }
 
     private LuceneFieldMapper.CreateLuceneFieldMapperInput.CreateLuceneFieldMapperInputBuilder createLuceneFieldMapperInputBuilder(

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -15,6 +16,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.util.Arrays;
@@ -71,6 +73,24 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             );
             assertTrue(query.getClass().isAssignableFrom(KnnFloatVectorQuery.class));
         }
+    }
+
+    public void testCreateLuceneQueryByteVectorDataType() {
+        byte[] byteQueryVector = { 1, 2, 3, 4 };
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNQueryFactory.CreateQueryRequest createQueryRequest = KNNQueryFactory.CreateQueryRequest.builder()
+            .knnEngine(KNNEngine.LUCENE)
+            .indexName(testIndexName)
+            .fieldName(testFieldName)
+            .vector(null)
+            .byteVector(byteQueryVector)
+            .vectorDataType(VectorDataType.BYTE)
+            .k(testK)
+            .filter(null)
+            .context(mockQueryShardContext)
+            .build();
+        Query query = KNNQueryFactory.create(createQueryRequest);
+        assertTrue(query.getClass().isAssignableFrom(KnnByteVectorQuery.class));
     }
 
     public void testCreateLuceneQueryWithFilter() {

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
@@ -75,4 +75,27 @@ public class KNNScoringSpaceUtilTests extends KNNTestCase {
         String invalidObject = "invalidObject";
         expectThrows(ClassCastException.class, () -> KNNScoringSpaceUtil.parseToFloatArray(invalidObject, 3, VectorDataType.FLOAT));
     }
+
+    public void testParseKNNVectorQueryByteVectorDataType() {
+        float[] arrayFloat = new float[] { 1.0f, 2.0f, 3.0f };
+        List<Number> arrayListQueryObject = new ArrayList<>(Arrays.asList(1, 2, 3));
+        KNNVectorFieldMapper.KNNVectorFieldType fieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(fieldType.getDimension()).thenReturn(3);
+        // Query vector is a byte vector, so test should succeed
+        assertArrayEquals(arrayFloat, KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject, 3, VectorDataType.BYTE), 0.1f);
+
+        // Query vector is a float vector for byte vector data type, so test should throw IllegalArgumentException
+        List<Double> arrayListQueryObject1 = new ArrayList<>(Arrays.asList(1.1, 2.56, 3.67));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject1, 3, VectorDataType.BYTE)
+        );
+
+        // Query vector is not within the byte range for byte vector data type, so test should throw IllegalArgumentException
+        List<Number> arrayListQueryObject2 = new ArrayList<>(Arrays.asList(1000, 2, 3));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNScoringSpaceUtil.parseToFloatArray(arrayListQueryObject2, 3, VectorDataType.BYTE)
+        );
+    }
 }


### PR DESCRIPTION
### Description
Add more unit-tests to improve test coverage for Lucene Byte Vector
 
### Check List
- [x] All tests pass
- [x] New functionality has been documented.
- [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
