### PR TITLE
[2.x] Switch from XContentType to MediaType to fix compilation errors

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModelIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModelIT.java
@@ -15,7 +15,7 @@ import org.opensearch.common.Strings;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelMetadata;
@@ -186,7 +186,7 @@ public class ModelIT extends AbstractRestartUpgradeTestCase {
             String responseBody = EntityUtils.toString(response.getEntity());
             assertNotNull(responseBody);
 
-            XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+            XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
             SearchResponse searchResponse = SearchResponse.fromXContent(parser);
             assertNotNull(searchResponse);
             assertEquals(EXP_NUM_OF_MODELS, searchResponse.getHits().getHits().length);
@@ -203,7 +203,7 @@ public class ModelIT extends AbstractRestartUpgradeTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
         assertEquals(modelId, responseMap.get(MODEL_ID));
         assertTrainingSucceeds(modelId, NUM_OF_ATTEMPTS, DELAY_MILLI_SEC);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -10,7 +10,7 @@ import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.knn.index.KNNSettings;
@@ -176,7 +176,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             parameters.put(PARAMETERS, algoParams);
         } else {
             parameters.putAll(
-                XContentFactory.xContent(XContentType.JSON)
+                XContentFactory.xContent(MediaTypeParserRegistry.getDefaultMediaType())
                     .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, parametersString)
                     .map()
             );

--- a/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
@@ -17,7 +17,7 @@ import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.rest.RestStatus;
@@ -62,7 +62,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getModelResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 
@@ -99,7 +99,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getModelResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 
@@ -205,7 +205,7 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
@@ -16,7 +16,7 @@ import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.rest.RestStatus;
@@ -74,7 +74,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(response.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
         assertEquals(modelId, responseMap.get(MODEL_ID));
         assertEquals(modelDescription, responseMap.get(MODEL_DESCRIPTION));
         assertEquals(FAISS.getName(), responseMap.get(KNN_ENGINE));
@@ -106,7 +106,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(response.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertTrue(responseMap.size() == filteredPath.size());
         assertEquals(modelId, responseMap.get(MODEL_ID));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -19,7 +19,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -347,7 +347,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
 
             final Response response = getKnnStats(Collections.emptyList(), Arrays.asList(modelIndexStatusName));
             final String responseBody = EntityUtils.toString(response.getEntity());
-            final Map<String, Object> statsMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+            final Map<String, Object> statsMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
             // Check that model health status is null since model index is not created to system yet
             assertNull(statsMap.get(StatNames.MODEL_INDEX_STATUS.getName()));
@@ -358,7 +358,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
         Response response = getKnnStats(Collections.emptyList(), Arrays.asList(modelIndexStatusName));
 
         final String responseBody = EntityUtils.toString(response.getEntity());
-        final Map<String, Object> statsMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        final Map<String, Object> statsMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         // Check that model health status is not null
         assertNotNull(statsMap.get(modelIndexStatusName));
@@ -452,7 +452,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
         assertEquals(modelId, responseMap.get(MODEL_ID));
         assertTrainingSucceeds(modelId, NUM_OF_ATTEMPTS, DELAY_MILLI_SEC);
     }

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -17,7 +17,7 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -73,7 +73,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(response.getEntity());
         assertNotNull(responseBody);
 
-        XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+        XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
         SearchResponse searchResponse = SearchResponse.fromXContent(parser);
         assertNotNull(searchResponse);
         assertEquals(searchResponse.getHits().getHits().length, 0);
@@ -133,7 +133,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
             String responseBody = EntityUtils.toString(response.getEntity());
             assertNotNull(responseBody);
 
-            XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+            XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
             SearchResponse searchResponse = SearchResponse.fromXContent(parser);
             assertNotNull(searchResponse);
 
@@ -177,7 +177,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
             String responseBody = EntityUtils.toString(response.getEntity());
             assertNotNull(responseBody);
 
-            XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+            XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
             SearchResponse searchResponse = SearchResponse.fromXContent(parser);
             assertNotNull(searchResponse);
 
@@ -225,7 +225,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
             String responseBody = EntityUtils.toString(response.getEntity());
             assertNotNull(responseBody);
 
-            XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+            XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
             SearchResponse searchResponse = SearchResponse.fromXContent(parser);
             assertNotNull(searchResponse);
 
@@ -277,7 +277,7 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
             String responseBody = EntityUtils.toString(response.getEntity());
             assertNotNull(responseBody);
 
-            XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+            XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
             SearchResponse searchResponse = SearchResponse.fromXContent(parser);
             assertNotNull(searchResponse);
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -15,7 +15,7 @@ import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.rest.RestStatus;
 
@@ -97,7 +97,8 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
         assertNotNull(trainResponseBody);
 
-        Map<String, Object> trainResponseMap = createParser(XContentType.JSON.xContent(), trainResponseBody).map();
+        Map<String, Object> trainResponseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), trainResponseBody)
+            .map();
         String modelId = (String) trainResponseMap.get(MODEL_ID);
         assertNotNull(modelId);
 
@@ -106,7 +107,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 
@@ -177,7 +178,8 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
         assertNotNull(trainResponseBody);
 
-        Map<String, Object> trainResponseMap = createParser(XContentType.JSON.xContent(), trainResponseBody).map();
+        Map<String, Object> trainResponseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), trainResponseBody)
+            .map();
         String modelId = (String) trainResponseMap.get(MODEL_ID);
         assertNotNull(modelId);
 
@@ -186,7 +188,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 
@@ -257,7 +259,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 
@@ -327,7 +329,8 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
         assertNotNull(trainResponseBody);
 
-        Map<String, Object> trainResponseMap = createParser(XContentType.JSON.xContent(), trainResponseBody).map();
+        Map<String, Object> trainResponseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), trainResponseBody)
+            .map();
         String modelId = (String) trainResponseMap.get(MODEL_ID);
         assertNotNull(modelId);
 
@@ -336,7 +339,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -17,7 +17,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
@@ -390,8 +390,10 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 
         String responseBody = EntityUtils.toString(response.getEntity());
-        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody).map()
-            .get("hits")).get("hits");
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("hits")).get("hits");
 
         List<String> docIds = hits.stream().map(hit -> {
             String id = ((String) ((Map<String, Object>) hit).get("_id"));
@@ -456,8 +458,10 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(request1.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response1.getStatusLine().getStatusCode()));
 
         String responseBody1 = EntityUtils.toString(response1.getEntity());
-        List<Object> hits1 = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody1).map()
-            .get("hits")).get("hits");
+        List<Object> hits1 = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody1
+        ).map().get("hits")).get("hits");
 
         List<String> docIds1 = hits1.stream().map(hit -> ((String) ((Map<String, Object>) hit).get("_id"))).collect(Collectors.toList());
 
@@ -494,8 +498,10 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(request2.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response2.getStatusLine().getStatusCode()));
 
         String responseBody2 = EntityUtils.toString(response2.getEntity());
-        List<Object> hits2 = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody2).map()
-            .get("hits")).get("hits");
+        List<Object> hits2 = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody2
+        ).map().get("hits")).get("hits");
 
         List<String> docIds2 = hits2.stream().map(hit -> ((String) ((Map<String, Object>) hit).get("_id"))).collect(Collectors.toList());
 
@@ -563,8 +569,10 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(request1.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response1.getStatusLine().getStatusCode()));
 
         String responseBody1 = EntityUtils.toString(response1.getEntity());
-        List<Object> hits1 = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody1).map()
-            .get("hits")).get("hits");
+        List<Object> hits1 = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody1
+        ).map().get("hits")).get("hits");
 
         List<String> docIds1 = hits1.stream().map(hit -> ((String) ((Map<String, Object>) hit).get("_id"))).collect(Collectors.toList());
 
@@ -601,8 +609,10 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(request2.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response2.getStatusLine().getStatusCode()));
 
         String responseBody2 = EntityUtils.toString(response2.getEntity());
-        List<Object> hits2 = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody2).map()
-            .get("hits")).get("hits");
+        List<Object> hits2 = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody2
+        ).map().get("hits")).get("hits");
 
         List<String> docIds2 = hits2.stream().map(hit -> ((String) ((Map<String, Object>) hit).get("_id"))).collect(Collectors.toList());
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/DeleteModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/DeleteModelResponseTests.java
@@ -15,7 +15,7 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.KNNTestCase;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ public class DeleteModelResponseTests extends KNNTestCase {
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         deleteModelResponse.writeTo(streamOutput);
         String expectedResponseString = "{\"model_id\":\"test-model\",\"result\":\"deleted\"}";
-        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(MediaTypeParserRegistry.getDefaultMediaType());
         deleteModelResponse.toXContent(xContentBuilder, null);
         assertEquals(expectedResponseString, Strings.toString(xContentBuilder));
     }

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -15,7 +15,7 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -49,7 +49,7 @@ public class GetModelResponseTests extends KNNTestCase {
         GetModelResponse getModelResponse = new GetModelResponse(model);
         String expectedResponseString =
             "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\"}";
-        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(MediaTypeParserRegistry.getDefaultMediaType());
         getModelResponse.toXContent(xContentBuilder, null);
         assertEquals(expectedResponseString, Strings.toString(xContentBuilder));
     }
@@ -60,7 +60,7 @@ public class GetModelResponseTests extends KNNTestCase {
         GetModelResponse getModelResponse = new GetModelResponse(model);
         String expectedResponseString =
             "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\"}";
-        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+        XContentBuilder xContentBuilder = XContentFactory.contentBuilder(MediaTypeParserRegistry.getDefaultMediaType());
         getModelResponse.toXContent(xContentBuilder, null);
         assertEquals(expectedResponseString, Strings.toString(xContentBuilder));
     }

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -30,10 +30,10 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
@@ -227,8 +227,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
      */
     protected List<KNNResult> parseSearchResponse(String responseBody, String fieldName) throws IOException {
         @SuppressWarnings("unchecked")
-        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody).map()
-            .get("hits")).get("hits");
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("hits")).get("hits");
 
         @SuppressWarnings("unchecked")
         List<KNNResult> knnSearchResponses = hits.stream().map(hit -> {
@@ -244,8 +246,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
     protected List<Float> parseSearchResponseScore(String responseBody, String fieldName) throws IOException {
         @SuppressWarnings("unchecked")
-        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody).map()
-            .get("hits")).get("hits");
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("hits")).get("hits");
 
         @SuppressWarnings("unchecked")
         List<Float> knnSearchResponses = hits.stream()
@@ -260,8 +264,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
      */
     protected Double parseAggregationResponse(String responseBody, String aggregationName) throws IOException {
         @SuppressWarnings("unchecked")
-        Map<String, Object> aggregations = ((Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody).map()
-            .get("aggregations"));
+        Map<String, Object> aggregations = ((Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("aggregations"));
 
         final Map<String, Object> values = (Map<String, Object>) aggregations.get(aggregationName);
         return Double.valueOf(String.valueOf(values.get("value")));
@@ -366,7 +372,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         String responseBody = EntityUtils.toString(response.getEntity());
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
 
         return (Map<String, Object>) ((Map<String, Object>) responseMap.get(index)).get("mappings");
     }
@@ -380,7 +386,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         String responseBody = EntityUtils.toString(response.getEntity());
 
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
         return (Integer) responseMap.get("count");
     }
 
@@ -496,8 +502,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
         final Request request = new Request("GET", "/" + index + "/_doc/" + docId);
         final Response response = client().performRequest(request);
 
-        final Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity()))
-            .map();
+        final Map<String, Object> responseMap = createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            EntityUtils.toString(response.getEntity())
+        ).map();
 
         assertNotNull(responseMap);
         assertTrue((Boolean) responseMap.get(DOCUMENT_FIELD_FOUND));
@@ -573,7 +581,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Parse KNN Cluster stats from response
      */
     protected Map<String, Object> parseClusterStatsResponse(String responseBody) throws IOException {
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody).map();
         responseMap.remove("cluster_name");
         responseMap.remove("_nodes");
         responseMap.remove("nodes");
@@ -585,7 +593,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
      */
     protected List<Map<String, Object>> parseNodeStatsResponse(String responseBody) throws IOException {
         @SuppressWarnings("unchecked")
-        Map<String, Object> responseMap = (Map<String, Object>) createParser(XContentType.JSON.xContent(), responseBody).map().get("nodes");
+        Map<String, Object> responseMap = (Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("nodes");
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> nodeResponses = responseMap.keySet()
@@ -601,8 +612,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
      */
     @SuppressWarnings("unchecked")
     protected int parseTotalSearchHits(String searchResponseBody) throws IOException {
-        Map<String, Object> responseMap = (Map<String, Object>) createParser(XContentType.JSON.xContent(), searchResponseBody).map()
-            .get("hits");
+        Map<String, Object> responseMap = (Map<String, Object>) createParser(
+            MediaTypeParserRegistry.getDefaultMediaType().xContent(),
+            searchResponseBody
+        ).map().get("hits");
 
         return (int) ((Map<String, Object>) responseMap.get("total")).get("value");
     }
@@ -1142,7 +1155,8 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
             response = getModel(modelId, null);
 
-            responseMap = createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity())).map();
+            responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), EntityUtils.toString(response.getEntity()))
+                .map();
 
             modelState = ModelState.getModelState((String) responseMap.get(MODEL_STATE));
             if (modelState == ModelState.CREATED) {
@@ -1166,7 +1180,8 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
             response = getModel(modelId, null);
 
-            responseMap = createParser(XContentType.JSON.xContent(), EntityUtils.toString(response.getEntity())).map();
+            responseMap = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), EntityUtils.toString(response.getEntity()))
+                .map();
 
             modelState = ModelState.getModelState((String) responseMap.get(MODEL_STATE));
             if (modelState == ModelState.FAILED) {

--- a/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
@@ -31,7 +31,7 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.commons.rest.SecureRestClientBuilder;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.rest.RestStatus;
@@ -211,7 +211,7 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
         final String responseBody = EntityUtils.toString(response.getEntity());
         assertNotNull(responseBody);
 
-        final XContentParser parser = createParser(XContentType.JSON.xContent(), responseBody);
+        final XContentParser parser = createParser(MediaTypeParserRegistry.getDefaultMediaType().xContent(), responseBody);
         final SearchResponse searchResponse = SearchResponse.fromXContent(parser);
 
         return Arrays.stream(searchResponse.getHits().getHits()).map(SearchHit::getId).collect(Collectors.toList());

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -9,7 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.MediaTypeParserRegistry;
 import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -252,7 +252,7 @@ public class TestUtils {
             BufferedReader reader = new BufferedReader(new FileReader(path));
             String line = reader.readLine();
             while (line != null) {
-                Map<String, Object> doc = XContentFactory.xContent(XContentType.JSON)
+                Map<String, Object> doc = XContentFactory.xContent(MediaTypeParserRegistry.getDefaultMediaType())
                     .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, line)
                     .map();
                 idsList.add((Integer) doc.get("id"));


### PR DESCRIPTION
### Description
Switch from XContentType to MediaType to fix compilation errors from core refactor

### Issue
https://github.com/opensearch-project/k-NN/issues/1005
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
