### PR TITLE
Update guava to address CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     compile "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     compile group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
-    compile group: 'com.google.guava', name: 'guava', version:'30.0-jre'
+    compile group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }


### PR DESCRIPTION
### Description
Update guava to address [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976).
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/972
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
