### PR TITLE
Update Guava Version to 32.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Update Guava Version to 32.0.1 [#1019](https://github.com/opensearch-project/k-NN/pull/1019)
 ### Refactoring
 * Fix TransportAddress Refactoring Changes in Core [#1020](https://github.com/opensearch-project/k-NN/pull/1020)

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     api group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
-    api group: 'com.google.guava', name: 'guava', version:'30.0-jre'
+    api group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
     api group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.3'


### PR DESCRIPTION
### Description
Update Guava Version to 32.0.1 to address [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976).
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/972
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
