### PR TITLE
[Backport 1.3] Update Guava Version to 32.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     compile "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     compile group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
-    compile group: 'com.google.guava', name: 'guava', version:'30.0-jre'
+    compile group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }


### PR DESCRIPTION
Backport https://github.com/opensearch-project/k-NN/commit/478d87c19a43dd2ebaaeae36b2599a86bed9b7bd from https://github.com/opensearch-project/k-NN/pull/1019
