### PR TITLE
Remove k-NN gcc requirements ceiling and not equals 8.3.1 version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -105,25 +105,15 @@ if [ "$JAVA_HOME" = "" ]; then
     echo "SET JAVA_HOME=$JAVA_HOME"
 fi
 
-# Ensure gcc version is above 4.9.0 for faiss 1.7.4+ compilation
+# Ensure gcc version is above 4.9.0 and is not 8.3.1 for faiss 1.7.4+ compilation
 # https://github.com/opensearch-project/k-NN/issues/975
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
 GCC_REQUIRED_VERSION=4.9.0
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ]; then
-    echo "gcc version on this env is older than $GCC_REQUIRED_VERSION, exit 1"
+if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ] || [ "$GCC_VERSION" = "8.3.1" ]; then
+    echo "gcc version on this env is either older than $GCC_REQUIRED_VERSION, or equals 8.3.1, exit 1"
     exit 1
 fi
-
-# Ensure gcc version is below 8.0.0 for faiss 1.7.4+ compilation so it will not crash on arm64 CentOS7
-# https://github.com/opensearch-project/k-NN/issues/975
-GCC_REQUIRED_VERSION_CEILING=8.0.0
-COMPARE_VERSION_CEILING=`echo $GCC_REQUIRED_VERSION_CEILING $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | tail -n 1`
-if [ "$COMPARE_VERSION_CEILING" != "$GCC_REQUIRED_VERSION_CEILING" ] && (echo "$OSTYPE" | grep -i linux); then
-    echo "gcc version on this env is newer than $GCC_REQUIRED_VERSION_CEILING, exit 1"
-    exit 1
-fi
-
 
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir


### PR DESCRIPTION
### Description
Remove k-NN gcc requirements ceiling and not equals 8.3.1 version
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/975
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
