### PR TITLE
Fix OnDiskInvertedLists file path for windows patching

### DIFF
--- a/scripts/windowsScript.ps1
+++ b/scripts/windowsScript.ps1
@@ -26,7 +26,7 @@ git submodule update --init -- jni/external/faiss
 #  #ifndef __MINGW32__
 #    #include <sys/mman.h>
 #  #endif
-(Get-Content jni/external/faiss/faiss/OnDiskInvertedLists.cpp).replace('#include <sys/mman.h>', "#ifndef __MINGW32__`n#include <sys/mman.h>`n#endif") | Set-Content jni/external/faiss/faiss/OnDiskInvertedLists.cpp
+(Get-Content jni/external/faiss/faiss/invlists/OnDiskInvertedLists.cpp).replace('#include <sys/mman.h>', "#ifndef __MINGW32__`n#include <sys/mman.h>`n#endif") | Set-Content jni/external/faiss/faiss/invlists/OnDiskInvertedLists.cpp
 # intrin.h function like __builtin_ctz, __builtin_clzll is not available in MINGW32. So, adding condition to include it if not running on Windows
 # Replace '#include <intrin.h>' with
 #  #ifndef __MINGW32__


### PR DESCRIPTION
### Description
Fix OnDiskInvertedLists.cpp file path to apply patching on Windows OS

```
> Task :windowsPatches
Get-Content : Cannot find path
'C:\Users\Administrator\AppData\Local\Temp\2\tmp0ado2fyq\k-NN\jni\external\faiss\faiss\OnDiskInvertedLists.cpp'
because it does not exist.
At C:\Users\Administrator\AppData\Local\Temp\2\tmp0ado2fyq\k-NN\scripts\windowsScript.ps1:29 char:2
+ (Get-Content jni/external/faiss/faiss/OnDiskInvertedLists.cpp).replac ...
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\Admini...vertedLists.cpp:String) [Get-Content], ItemNotFoundEx
   ception
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand

You cannot call a method on a null-valued expression.
At C:\Users\Administrator\AppData\Local\Temp\2\tmp0ado2fyq\k-NN\scripts\windowsScript.ps1:29 char:1
+ (Get-Content jni/external/faiss/faiss/OnDiskInvertedLists.cpp).replac ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull
```
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1040
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
