### PR TITLE
Fixing the backward incompatible changes coming from core in ScoreScript class and index.store.hybrid.mmap.extensions settings

### DIFF
--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.plugin.script;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.knn.index.KNNVectorScriptDocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.index.fielddata.ScriptDocValues;
@@ -32,9 +33,10 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
         String field,
         BiFunction<T, T, Float> scoringMethod,
         SearchLookup lookup,
-        LeafReaderContext leafContext
+        LeafReaderContext leafContext,
+        IndexSearcher searcher
     ) {
-        super(params, lookup, leafContext);
+        super(params, lookup, searcher, leafContext);
         this.queryValue = queryValue;
         this.field = field;
         this.scoringMethod = scoringMethod;
@@ -51,9 +53,10 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
             String field,
             BiFunction<Long, Long, Float> scoringMethod,
             SearchLookup lookup,
-            LeafReaderContext leafContext
+            LeafReaderContext leafContext,
+            IndexSearcher searcher
         ) {
-            super(params, queryValue, field, scoringMethod, lookup, leafContext);
+            super(params, queryValue, field, scoringMethod, lookup, leafContext, searcher);
         }
 
         /**
@@ -84,9 +87,10 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
             String field,
             BiFunction<BigInteger, BigInteger, Float> scoringMethod,
             SearchLookup lookup,
-            LeafReaderContext leafContext
+            LeafReaderContext leafContext,
+            IndexSearcher searcher
         ) {
-            super(params, queryValue, field, scoringMethod, lookup, leafContext);
+            super(params, queryValue, field, scoringMethod, lookup, leafContext, searcher);
         }
 
         /**
@@ -118,9 +122,10 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
             String field,
             BiFunction<float[], float[], Float> scoringMethod,
             SearchLookup lookup,
-            LeafReaderContext leafContext
+            LeafReaderContext leafContext,
+            IndexSearcher searcher
         ) throws IOException {
-            super(params, queryValue, field, scoringMethod, lookup, leafContext);
+            super(params, queryValue, field, scoringMethod, lookup, leafContext, searcher);
         }
 
         /**

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScriptFactory.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScriptFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.plugin.script;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.script.ScoreScript;
@@ -21,13 +22,16 @@ public class KNNScoreScriptFactory implements ScoreScript.LeafFactory {
     private Object query;
     private KNNScoringSpace knnScoringSpace;
 
-    public KNNScoreScriptFactory(Map<String, Object> params, SearchLookup lookup) {
+    private IndexSearcher searcher;
+
+    public KNNScoreScriptFactory(Map<String, Object> params, SearchLookup lookup, IndexSearcher searcher) {
         KNNCounter.SCRIPT_QUERY_REQUESTS.increment();
         this.params = params;
         this.lookup = lookup;
         this.field = getValue(params, "field").toString();
         this.similaritySpace = getValue(params, "space_type").toString();
         this.query = getValue(params, "query_value");
+        this.searcher = searcher;
 
         this.knnScoringSpace = KNNScoringSpaceFactory.create(
             this.similaritySpace,
@@ -60,6 +64,6 @@ public class KNNScoreScriptFactory implements ScoreScript.LeafFactory {
      */
     @Override
     public ScoreScript newInstance(LeafReaderContext ctx) throws IOException {
-        return knnScoringSpace.getScoreScript(params, field, lookup, ctx);
+        return knnScoringSpace.getScoreScript(params, field, lookup, ctx, this.searcher);
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.plugin.script;
 
+import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.apache.lucene.index.LeafReaderContext;
@@ -29,14 +30,16 @@ public interface KNNScoringSpace {
     /**
      * Return the correct scoring script for a given query. The scoring script
      *
-     * @param params Map of parameters
-     * @param field Fieldname
-     * @param lookup SearchLookup
-     * @param ctx ctx LeafReaderContext to be used for scoring documents
+     * @param params   Map of parameters
+     * @param field    Fieldname
+     * @param lookup   SearchLookup
+     * @param ctx      ctx LeafReaderContext to be used for scoring documents
+     * @param searcher IndexSearcher
      * @return ScoreScript for this query
      * @throws IOException throws IOException if ScoreScript cannot be constructed
      */
-    ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx) throws IOException;
+    ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx, IndexSearcher searcher)
+        throws IOException;
 
     class L2 implements KNNScoringSpace {
 
@@ -62,9 +65,14 @@ public interface KNNScoringSpace {
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
         }
 
-        public ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx)
-            throws IOException {
-            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx);
+        public ScoreScript getScoreScript(
+            Map<String, Object> params,
+            String field,
+            SearchLookup lookup,
+            LeafReaderContext ctx,
+            IndexSearcher searcher
+        ) throws IOException {
+            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
         }
     }
 
@@ -94,9 +102,14 @@ public interface KNNScoringSpace {
             this.scoringMethod = (float[] q, float[] v) -> 1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude);
         }
 
-        public ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx)
-            throws IOException {
-            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx);
+        public ScoreScript getScoreScript(
+            Map<String, Object> params,
+            String field,
+            SearchLookup lookup,
+            LeafReaderContext ctx,
+            IndexSearcher searcher
+        ) throws IOException {
+            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
         }
     }
 
@@ -127,8 +140,13 @@ public interface KNNScoringSpace {
         }
 
         @SuppressWarnings("unchecked")
-        public ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx)
-            throws IOException {
+        public ScoreScript getScoreScript(
+            Map<String, Object> params,
+            String field,
+            SearchLookup lookup,
+            LeafReaderContext ctx,
+            IndexSearcher searcher
+        ) throws IOException {
             if (this.processedQuery instanceof Long) {
                 return new KNNScoreScript.LongType(
                     params,
@@ -136,7 +154,8 @@ public interface KNNScoringSpace {
                     field,
                     (BiFunction<Long, Long, Float>) this.scoringMethod,
                     lookup,
-                    ctx
+                    ctx,
+                    searcher
                 );
             }
 
@@ -146,7 +165,8 @@ public interface KNNScoringSpace {
                 field,
                 (BiFunction<BigInteger, BigInteger, Float>) this.scoringMethod,
                 lookup,
-                ctx
+                ctx,
+                searcher
             );
         }
     }
@@ -175,9 +195,14 @@ public interface KNNScoringSpace {
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
         }
 
-        public ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx)
-            throws IOException {
-            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx);
+        public ScoreScript getScoreScript(
+            Map<String, Object> params,
+            String field,
+            SearchLookup lookup,
+            LeafReaderContext ctx,
+            IndexSearcher searcher
+        ) throws IOException {
+            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
         }
     }
 
@@ -205,9 +230,14 @@ public interface KNNScoringSpace {
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
         }
 
-        public ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx)
-            throws IOException {
-            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx);
+        public ScoreScript getScoreScript(
+            Map<String, Object> params,
+            String field,
+            SearchLookup lookup,
+            LeafReaderContext ctx,
+            IndexSearcher searcher
+        ) throws IOException {
+            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
         }
     }
 
@@ -238,9 +268,14 @@ public interface KNNScoringSpace {
         }
 
         @Override
-        public ScoreScript getScoreScript(Map<String, Object> params, String field, SearchLookup lookup, LeafReaderContext ctx)
-            throws IOException {
-            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx);
+        public ScoreScript getScoreScript(
+            Map<String, Object> params,
+            String field,
+            SearchLookup lookup,
+            LeafReaderContext ctx,
+            IndexSearcher searcher
+        ) throws IOException {
+            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
         }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -46,6 +46,7 @@ public class KNNSettingsTests extends KNNTestCase {
             .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
         mockNode.close();
         assertEquals(expectedKNNCircuitBreakerLimit, actualKNNCircuitBreakerLimit);
+        assertWarnings();
     }
 
     @SneakyThrows
@@ -63,6 +64,10 @@ public class KNNSettingsTests extends KNNTestCase {
             actualKNNCircuitBreakerLimit
 
         );
+        // set warning for deprecation of index.store.hybrid.mmap.extensions as expected temporarily, need to work on proper strategy of
+        // switching to new setting in core
+        // no-jdk distributions expected warning is a workaround for running tests locally
+        assertWarnings();
     }
 
     private Node createMockNode(Map<String, Object> configSettings) throws IOException {
@@ -92,5 +97,15 @@ public class KNNSettingsTests extends KNNTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
             .put(dataNode());
+    }
+
+    private void assertWarnings() {
+        // set warning for deprecation of index.store.hybrid.mmap.extensions as expected temporarily, need to work on proper strategy of
+        // switching to new setting in core
+        // no-jdk distributions expected warning is a workaround for running tests locally
+        assertWarnings(
+            "[index.store.hybrid.mmap.extensions] setting was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation for the next major version.",
+            "no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release"
+        );
     }
 }


### PR DESCRIPTION
Fixing the backward incompatible changes coming from core in ScoreScript class and index.store.hybrid.mmap.extensions setting

### Description
The change includes:
1. Fixing the backward incompatible changes in ScoreScript class. https://github.com/opensearch-project/OpenSearch/pull/9081
2. index.store.hybrid.mmap.extensions settings is deprecated. Hence it is adding warnings and failing the unit tests. Added a workaround which is already added in the [2.x branch](https://github.com/opensearch-project/k-NN/commit/67df3aee57601ceeab81cf8b159749422c155468). This will ensure that main is unblocked. Will work on fixing this deprecated settings in future PRs.
 
### Issues Resolved
NA
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
