### PR TITLE
Improved the logic to switch to exact search for restrictive filters search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add Clear Cache API [#740](https://github.com/opensearch-project/k-NN/pull/740)
 ### Enhancements
 * Enabled the IVF algorithm to work with Filters of K-NN Query. [#1013](https://github.com/opensearch-project/k-NN/pull/1013)
+* Improved the logic to switch to exact search for restrictive filters search for better recall. [#1059](https://github.com/opensearch-project/k-NN/pull/1059)
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -6,6 +6,10 @@
 package org.opensearch.knn.index;
 
 import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.network.NetworkModule;
@@ -32,6 +36,8 @@ import java.util.Map;
 import static org.opensearch.test.NodeRoles.dataNode;
 
 public class KNNSettingsTests extends KNNTestCase {
+
+    private static final String INDEX_NAME = "myindex";
 
     @SneakyThrows
     public void testGetSettingValueFromConfig() {
@@ -67,6 +73,85 @@ public class KNNSettingsTests extends KNNTestCase {
         // set warning for deprecation of index.store.hybrid.mmap.extensions as expected temporarily, need to work on proper strategy of
         // switching to new setting in core
         // no-jdk distributions expected warning is a workaround for running tests locally
+        assertWarnings();
+    }
+
+    @SneakyThrows
+    public void testFilteredSearchAdvanceSetting_whenNoValuesProvidedByUsers_thenDefaultSettingsUsed() {
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        mockNode.client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        mockNode.client().admin().indices().create(new CreateIndexRequest(INDEX_NAME)).actionGet();
+        KNNSettings.state().setClusterService(clusterService);
+
+        int filteredSearchThresholdPct = KNNSettings.getFilteredExactSearchThresholdPct(INDEX_NAME);
+        int filteredSearchThreshold = KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME);
+        mockNode.close();
+        assertEquals((int) KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_PCT_DEFAULT_VALUE, filteredSearchThresholdPct);
+        assertEquals((int) KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_DEFAULT_VALUE, filteredSearchThreshold);
+        assertWarnings();
+    }
+
+    @SneakyThrows
+    public void testFilteredSearchAdvanceSetting_whenValuesProvidedByUsers_thenValidateSameValues() {
+        int userDefinedPctThreshold = 20;
+        int userDefinedThreshold = 1000;
+        int userDefinedPctThresholdMinValue = 0;
+        int userDefinedThresholdMinValue = 0;
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        mockNode.client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        mockNode.client().admin().indices().create(new CreateIndexRequest(INDEX_NAME)).actionGet();
+        KNNSettings.state().setClusterService(clusterService);
+
+        final Settings filteredSearchAdvanceSettings = Settings.builder()
+            .put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, userDefinedThreshold)
+            .put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_PCT, userDefinedPctThreshold)
+            .build();
+
+        mockNode.client()
+            .admin()
+            .indices()
+            .updateSettings(new UpdateSettingsRequest(filteredSearchAdvanceSettings, INDEX_NAME))
+            .actionGet();
+
+        int filteredSearchThresholdPct = KNNSettings.getFilteredExactSearchThresholdPct(INDEX_NAME);
+        int filteredSearchThreshold = KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME);
+
+        // validate if we are able to set MinValues for the setting
+        final Settings filteredSearchAdvanceSettingsWithMinValues = Settings.builder()
+                .put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, userDefinedThresholdMinValue)
+                .put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_PCT, userDefinedPctThresholdMinValue)
+                .build();
+
+        mockNode.client()
+                .admin()
+                .indices()
+                .updateSettings(new UpdateSettingsRequest(filteredSearchAdvanceSettingsWithMinValues, INDEX_NAME))
+                .actionGet();
+
+        int filteredSearchThresholdPctMinValue = KNNSettings.getFilteredExactSearchThresholdPct(INDEX_NAME);
+        int filteredSearchThresholdMinValue = KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME);
+
+        // Validate if less than MinValues are set then Exception Happens
+        final Settings filteredSearchAdvanceSettingsWithLessThanMinValues = Settings.builder()
+                .put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, -1)
+                .put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_PCT, -1)
+                .build();
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> mockNode.client()
+                .admin()
+                .indices()
+                .updateSettings(new UpdateSettingsRequest(filteredSearchAdvanceSettingsWithLessThanMinValues, INDEX_NAME))
+                .actionGet());
+
+        mockNode.close();
+        assertEquals(userDefinedPctThreshold, filteredSearchThresholdPct);
+        assertEquals(userDefinedThreshold, filteredSearchThreshold);
+        assertEquals(userDefinedPctThresholdMinValue, filteredSearchThresholdPctMinValue);
+        assertEquals(userDefinedThresholdMinValue, filteredSearchThresholdMinValue);
         assertWarnings();
     }
 


### PR DESCRIPTION
### Description
Improved the logic to switch to exact search for restrictive filters search.

This change includes:
* adding 2 extra advanced K-NN settings on when to do exact search for users to tune.

This change doesn't include:
* switching to exact search based on how many distance calculation needs to be done. Once this PR flows I will discuss more on the github issue to see how we want to implement it.

For understanding the details of the change please refer this issue: https://github.com/opensearch-project/k-NN/issues/1049
 
The integration tests are failing as the new backward incompatible changes are not available in snapshot. https://github.com/opensearch-project/OpenSearch/pull/9081#issuecomment-1690751080

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1049
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
