### PR TITLE
Fixed the github actions to use the image used by OpenSearch-build repo for building the distribution

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       image: public.ecr.aws/opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+      # need to add this option so that docker image can be pulled and run.
       options: --user root
 
     steps:
@@ -36,6 +37,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Run build
+        # switching the user, as OpenSearch cluster cannot be started as root.
         run: |
           chown -R opensearch.opensearch ./* `pwd`
           su opensearch -c "whoami && java -version && ./gradlew build"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,8 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
       image: public.ecr.aws/opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
-      # need to add this option so that docker image can be pulled and run.
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
     steps:
@@ -37,9 +38,9 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Run build
-        # switching the user, as OpenSearch cluster cannot be started as root.
+        # switching the user, as OpenSearch cluster cannot only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
-          chown -R opensearch.opensearch ./* `pwd`
+          chown -R opensearch.opensearch `pwd`
           su opensearch -c "whoami && java -version && ./gradlew build"
 
       - name: Upload Coverage Report

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Run build
-        # switching the user, as OpenSearch cluster cannot only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
+        # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           chown -R opensearch.opensearch `pwd`
           su opensearch -c "whoami && java -version && ./gradlew build"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,7 @@ jobs:
 
       - name: Run build
         run: |
-          pwd
           chown -R opensearch.opensearch ./* `pwd`
-          ls -l ./ ../
           su opensearch -c "whoami && java -version && ./gradlew build"
 
       - name: Upload Coverage Report

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Run build
         run: |
-          ./gradlew build
+          pwd
+          chown -R opensearch.opensearch ./* `pwd`
+          ls -l ./ ../
+          su opensearch -c "whoami && java -version && ./gradlew build"
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,10 +16,41 @@ jobs:
     strategy:
       matrix:
         java: [11, 17]
-        os: [ubuntu-latest, macos-latest]
 
-    name: Build and Test k-NN Plugin
-    runs-on: ${{ matrix.os }}
+    name: Build and Test k-NN Plugin on Ubnutu
+    runs-on: ubuntu-latest
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      image: public.ecr.aws/opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+      options: --user root
+
+    steps:
+      - name: Checkout k-NN
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Run build
+        run: |
+          ./gradlew build
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  Build-k-NN-MacOS:
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+
+    name: Build and Test k-NN Plugin on MacOS
+    runs-on: macos-latest
 
     steps:
       - name: Checkout k-NN
@@ -30,13 +61,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      - name: Install dependencies on ubuntu
-        if: startsWith(matrix.os,'ubuntu')
-        run: |
-          sudo apt-get install libopenblas-dev gfortran -y
-
       - name: Install dependencies on macos
-        if: startsWith(matrix.os, 'macos')
         run: |
           brew reinstall gcc
           export FC=/usr/local/Cellar/gcc/12.2.0/bin/gfortran
@@ -44,12 +69,6 @@ jobs:
       - name: Run build
         run: |
           ./gradlew build
-
-      - name: Upload Coverage Report
-        if: startsWith(matrix.os,'ubuntu')
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   Build-k-NN-Windows:
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         java: [11, 17]
 
-    name: Build and Test k-NN Plugin on Ubnutu
+    name: Build and Test k-NN Plugin on Linux
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution


### PR DESCRIPTION
### Description
Fixed the github actions to use the image used by OpenSearch-build repo for building the distribution
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1042
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
