### PR TITLE
Fix locale in FaissTests

### DIFF
--- a/src/test/java/org/opensearch/knn/index/util/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/FaissTests.java
@@ -15,6 +15,7 @@ import org.opensearch.knn.index.Parameter;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
@@ -35,7 +36,7 @@ public class FaissTests extends KNNTestCase {
 
     public void testGetMethodAsMap_whenMethodIsHNSWFlat_thenCreateCorrectIndexDescription() throws IOException {
         int mParam = 65;
-        String expectedIndexDescription = String.format("HNSW%d,Flat", mParam);
+        String expectedIndexDescription = String.format(Locale.ROOT, "HNSW%d,Flat", mParam);
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
@@ -57,7 +58,7 @@ public class FaissTests extends KNNTestCase {
     public void testGetMethodAsMap_whenMethodIsHNSWPQ_thenCreateCorrectIndexDescription() throws IOException {
         int hnswMParam = 65;
         int pqMParam = 17;
-        String expectedIndexDescription = String.format("HNSW%d,PQ%d", hnswMParam, pqMParam);
+        String expectedIndexDescription = String.format(Locale.ROOT, "HNSW%d,PQ%d", hnswMParam, pqMParam);
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
@@ -84,7 +85,7 @@ public class FaissTests extends KNNTestCase {
 
     public void testGetMethodAsMap_whenMethodIsIVFFlat_thenCreateCorrectIndexDescription() throws IOException {
         int nlists = 88;
-        String expectedIndexDescription = String.format("IVF%d,Flat", nlists);
+        String expectedIndexDescription = String.format(Locale.ROOT, "IVF%d,Flat", nlists);
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
@@ -107,7 +108,7 @@ public class FaissTests extends KNNTestCase {
         int ivfNlistsParam = 88;
         int pqMParam = 17;
         int pqCodeSizeParam = 53;
-        String expectedIndexDescription = String.format("IVF%d,PQ%dx%d", ivfNlistsParam, pqMParam, pqCodeSizeParam);
+        String expectedIndexDescription = String.format(Locale.ROOT, "IVF%d,PQ%dx%d", ivfNlistsParam, pqMParam, pqCodeSizeParam);
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()


### PR DESCRIPTION
### Description
Related to #1077 failure. Change was introduced in #1074 . Adds locale as root when comparing strings to prevent unexpected string errors.

### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
