### PR TITLE
Fixing the check for max distance computation happening to switch to exact search

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -79,14 +79,7 @@ public class KNNQueryFactory {
 
         if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
             if (filterQuery != null && KNNEngine.getEnginesThatSupportsFilters().contains(createQueryRequest.getKnnEngine())) {
-                log.debug(
-                    String.format(
-                        "Creating custom k-NN query with filters for index: %s \"\", field: %s \"\", " + "k: %d",
-                        indexName,
-                        fieldName,
-                        k
-                    )
-                );
+                log.debug("Creating custom k-NN query with filters for index: {}, field: {} , k: {}", indexName, fieldName, k);
                 return new KNNQuery(fieldName, vector, k, indexName, filterQuery);
             }
             log.debug(String.format("Creating custom k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -124,6 +124,13 @@ public class KNNWeight extends Weight {
                 return null;
             }
             if (canDoExactSearchAfterANNSearch(filterIdsArray.length, annResults.size())) {
+                log.debug(
+                    "Doing ExactSearch after doing ANNSearch as the number of documents returned are less than "
+                        + "K, even when we have more than K filtered Ids. K: {}, ANNResults: {}, filteredIdCount: {}",
+                    knnQuery.getK(),
+                    annResults.size(),
+                    filterIdsArray.length
+                );
                 annResults = doExactSearch(context, filterIdsArray);
             }
             docIdsToScoreMap.putAll(annResults);
@@ -390,7 +397,7 @@ public class KNNWeight extends Weight {
             return filterThresholdValue >= filterIdsCount;
         }
         // if no setting is set, then use the default max distance computation value to see if we can do exact search.
-        return KNNConstants.MAX_DISTANCE_COMPUTATIONS <= filterIdsCount * knnQuery.getQueryVector().length;
+        return KNNConstants.MAX_DISTANCE_COMPUTATIONS >= filterIdsCount * knnQuery.getQueryVector().length;
     }
 
     /**


### PR DESCRIPTION
### Description
Fixing the check for max distance computation happening to switch to exact search. The check got messed up in the older commits. Fixing the check. Also, fixed a log statment.
 
### Issues Resolved
NA
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
