### PR TITLE
Add HNSW PQ configuration to perf tests

### DIFF
--- a/benchmarks/perf-tool/release-configs/faiss-hnswpq/index.json
+++ b/benchmarks/perf-tool/release-configs/faiss-hnswpq/index.json
@@ -1,0 +1,17 @@
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 24,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "target_field": {
+          "type": "knn_vector",
+          "model_id": "test-model"
+      }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-hnswpq/method-spec.json
+++ b/benchmarks/perf-tool/release-configs/faiss-hnswpq/method-spec.json
@@ -1,0 +1,15 @@
+{
+  "name":"hnsw",
+  "engine":"faiss",
+  "space_type": "l2",
+    "parameters":{
+      "ef_construction": 256,
+      "m": 16,
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "m": 16
+        }
+    }
+  }
+}

--- a/benchmarks/perf-tool/release-configs/faiss-hnswpq/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-hnswpq/test.yml
@@ -1,0 +1,53 @@
+endpoint: [ENDPOINT]
+test_name: "index-workflow"
+test_id: "index workflow"
+num_runs: 10
+show_runs: false
+setup:
+  - name: delete_index
+    index_name: train_index
+  - name: create_index
+    index_name: train_index
+    index_spec: /home/ec2-user/[PATH]/train-index-spec.json
+  - name: ingest
+    index_name: train_index
+    field_name: train_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    doc_count: 50000
+  - name: refresh_index
+    index_name: train_index
+steps:
+  - name: delete_model
+    model_id: test-model
+  - name: delete_index
+    index_name: target_index
+  - name: train_model
+    model_id: test-model
+    train_index: train_index
+    train_field: train_field
+    dimension: 128
+    method_spec: /home/ec2-user/[PATH]/method-spec.json
+    max_training_vector_count: 50000
+  - name: create_index
+    index_name: target_index
+    index_spec: /home/ec2-user/[PATH]/index.json
+  - name: ingest
+    index_name: target_index
+    field_name: target_field
+    bulk_size: 500
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+  - name: refresh_index
+    index_name: target_index
+  - name: query
+    k: 100
+    r: 1
+    calculate_recall: true
+    index_name: target_index
+    field_name: target_field
+    dataset_format: hdf5
+    dataset_path: /home/ec2-user/data/sift-128-euclidean.hdf5
+    neighbors_format: hdf5
+    neighbors_path: /home/ec2-user/data/sift-128-euclidean.hdf5

--- a/benchmarks/perf-tool/release-configs/faiss-hnswpq/train-index-spec.json
+++ b/benchmarks/perf-tool/release-configs/faiss-hnswpq/train-index-spec.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 24,
+      "number_of_replicas": 0
+    }
+  },
+  "mappings": {
+    "properties": {
+      "train_field": {
+        "type": "knn_vector",
+        "dimension": 128
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
Adds HNSW PQ perf test config to release configs.

Ran on my own machine and got the following results:
```
  "results": {
    "test_took": 293816.24999604654,
    "delete_model_took_total": 74.6723180054687,
    "delete_index_took_total": 91.5388090070337,
    "train_model_took_total": 98810.09195902152,
    "create_index_took_total": 447.3603710066527,
    "ingest_took_total": 67643.88565102126,
    "refresh_index_store_kb_total": 969579.529296875,
    "refresh_index_took_total": 25093.700887984596,
    "query_took_total": 101655.0,
    "query_took_p50": 10.0,
    "query_took_p90": 11.0,
    "query_took_p99": 12.0,
    "query_took_p99.9": 13.0,
    "query_took_p100": 99.0,
    "query_client_time_total": 121304.0,
    "query_client_time_p50": 12.0,
    "query_client_time_p90": 13.0,
    "query_client_time_p99": 14.0,
    "query_client_time_p99.9": 41.0,
    "query_client_time_p100": 228.0,
    "query_memory_kb_total": 172384.0,
    "query_recall@K_total": 0.629275,
    "query_recall@1_total": 0.9948
  }
```
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
