### PR TITLE
Add Memory Evaluation For different algorithm

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -187,9 +187,24 @@ if ("${WIN32}" STREQUAL "")
                 tests/faiss_wrapper_test.cpp
                 tests/nmslib_wrapper_test.cpp
                 tests/test_util.cpp)
+        add_executable(
+                jni_memory_test
+                tests/faiss_memory_test.cpp
+                tests/test_util.cpp)
 
         target_link_libraries(
                 jni_test
+                gtest_main
+                gmock_main
+                faiss
+                NonMetricSpaceLib
+                OpenMP::OpenMP_CXX
+                ${TARGET_LIB_FAISS}
+                ${TARGET_LIB_NMSLIB}
+                ${TARGET_LIB_COMMON}
+        )
+        target_link_libraries(
+                jni_memory_test
                 gtest_main
                 gmock_main
                 faiss
@@ -209,9 +224,18 @@ if ("${WIN32}" STREQUAL "")
                 ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include
                 ${gtest_SOURCE_DIR}/include
                 ${gmock_SOURCE_DIR}/include)
-
+        target_include_directories(jni_memory_test PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests
+                ${CMAKE_CURRENT_SOURCE_DIR}/include
+                $ENV{JAVA_HOME}/include
+                $ENV{JAVA_HOME}/include/${JVM_OS_TYPE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss
+                ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib/similarity_search/include
+                ${gtest_SOURCE_DIR}/include
+                ${gmock_SOURCE_DIR}/include)
 
         set_target_properties(jni_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+        set_target_properties(jni_memory_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
     endif ()
 endif()
 

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -189,7 +189,7 @@ if ("${WIN32}" STREQUAL "")
                 tests/test_util.cpp)
         add_executable(
                 jni_memory_test
-                tests/faiss_memory_test.cpp
+                tests/memory_test.cpp
                 tests/test_util.cpp)
 
         target_link_libraries(

--- a/jni/tests/faiss_memory_test.cpp
+++ b/jni/tests/faiss_memory_test.cpp
@@ -1,0 +1,298 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#include "faiss_wrapper.h"
+#include "nmslib_wrapper.h"
+
+#include <vector>
+#include <malloc.h>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "jni_util.h"
+#include "test_util.h"
+#include "faiss/utils/utils.h"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+#define GTEST_COUT std::cerr << "[          ] [ INFO ]"
+
+TEST(FaissHNSWIndexMemoryTest, BasicAssertions) {
+
+    char dataset[] = "dataset/sift/sift_base.fvecs";
+    float* data_load = NULL;
+    unsigned points_num, dim;
+    test_util::load_data(dataset, data_load, points_num, dim);
+
+    GTEST_COUT << "points_num："<< points_num << " data dimension：" << dim << std::endl;
+    float* dataptr = data_load;
+
+    faiss::idx_t numIds = points_num;
+    std::vector<faiss::idx_t> ids(points_num);
+    std::vector<std::vector<float>> vectors;
+    for (int64_t i = 0; i < numIds; ++i) {
+        ids[i] = i;
+
+        std::vector<float> vect;
+        vect.reserve(dim);
+        for (int j = 0; j < dim; ++j) {
+            vect.push_back(*dataptr);
+	    dataptr++;
+        }
+        vectors.push_back(vect);
+    }
+
+    free(data_load);
+    malloc_trim(0);
+
+    std::string indexPath = "tmp/FaissHNSWIndexMemoryTest.faiss";
+    std::string spaceType = knn_jni::L2;
+    std::string index_description = "HNSW32,Flat";  
+    int thread_num = 7;
+    //int efConstruction = 512;
+    //int efSearch = 512;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+    parametersMap[knn_jni::INDEX_DESCRIPTION] = (jobject)&index_description;
+    parametersMap[knn_jni::INDEX_THREAD_QUANTITY] = (jobject)&thread_num;
+    //parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject)&efConstruction;
+    //parametersMap[knn_jni::EF_SEARCH] = (jobject)&efSearch;
+
+    // Set up jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    EXPECT_CALL(mockJNIUtil,
+                GetJavaObjectArrayLength(
+                        jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
+            .WillRepeatedly(Return(vectors.size()));
+
+    // Create the index
+    knn_jni::faiss_wrapper::CreateIndex(
+            &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
+            reinterpret_cast<jobjectArray>(&vectors), (jstring)&indexPath,
+            (jobject)&parametersMap);
+
+    // Make sure index can be loaded
+    // std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
+
+    // Clean up
+    ids.clear();
+    ids.shrink_to_fit();
+    vectors.clear();
+    vectors.shrink_to_fit();
+
+    malloc_trim(0);
+    size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
+
+    GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
+}
+
+TEST(LIBHNSWIndexMemoryTest, BasicAssertions) {
+
+    similarity::initLibrary();
+    char dataset[] = "dataset/sift/sift_base.fvecs";
+    float* data_load = NULL;
+    unsigned points_num, dim;
+    test_util::load_data(dataset, data_load, points_num, dim);
+
+    GTEST_COUT << "points_num："<< points_num << " data dimension：" << dim << std::endl;
+    float* dataptr = data_load;
+
+    faiss::idx_t numIds = points_num;
+    std::vector<int> ids(points_num);
+    std::vector<std::vector<float>> vectors;
+    for (int64_t i = 0; i < numIds; ++i) {
+        ids[i] = i;
+
+        std::vector<float> vect;
+        vect.reserve(dim);
+        for (int j = 0; j < dim; ++j) {
+            vect.push_back(*dataptr);
+	    dataptr++;
+        }
+        vectors.push_back(vect);
+    }
+
+    free(data_load);
+    malloc_trim(0);
+
+    std::string indexPath = "tmp/LibHNSWIndexMemoryTest.faiss";
+    std::string spaceType = knn_jni::L2;
+    int thread_num = 7;
+    int efConstruction = 512;
+    int efSearch = 512;
+    int m = 32;
+
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+    parametersMap[knn_jni::INDEX_THREAD_QUANTITY] = (jobject)&thread_num;
+    parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject)&efConstruction;
+    parametersMap[knn_jni::EF_SEARCH] = (jobject)&efSearch;
+    parametersMap[knn_jni::M] = (jobject)&m;
+
+    // Set up jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    EXPECT_CALL(mockJNIUtil,
+                GetJavaObjectArrayLength(
+                        jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
+            .WillRepeatedly(Return(vectors.size()));
+
+    EXPECT_CALL(mockJNIUtil,
+                GetJavaIntArrayLength(jniEnv, reinterpret_cast<jintArray>(&ids)))
+            .WillRepeatedly(Return(ids.size()));
+    // Create the index
+    knn_jni::nmslib_wrapper::CreateIndex(
+            &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
+            reinterpret_cast<jobjectArray>(&vectors), (jstring)&indexPath,
+            (jobject)&parametersMap);
+
+    // Make sure index can be loaded
+    // std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
+
+    // Clean up
+    ids.clear();
+    ids.shrink_to_fit();
+    vectors.clear();
+    vectors.shrink_to_fit();
+
+    malloc_trim(0);
+    size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
+
+    GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
+}
+
+TEST(FaissNSGIndexMemoryTest, BasicAssertions) {
+
+    char dataset[] = "dataset/sift/sift_base.fvecs";
+    float* data_load = NULL;
+    unsigned points_num, dim;
+    test_util::load_data(dataset, data_load, points_num, dim);
+
+    GTEST_COUT << "points_num："<< points_num << " data dimension：" << dim << std::endl;
+    float* dataptr = data_load;
+
+    faiss::idx_t numIds = points_num;
+    std::vector<faiss::idx_t> ids(points_num);
+    std::vector<std::vector<float>> vectors;
+    for (int64_t i = 0; i < numIds; ++i) {
+        ids[i] = i;
+
+        std::vector<float> vect;
+        vect.reserve(dim);
+        for (int j = 0; j < dim; ++j) {
+            vect.push_back(*dataptr);
+	    dataptr++;
+        }
+        vectors.push_back(vect);
+    }
+
+    free(data_load);
+    malloc_trim(0);
+
+    std::string indexPath = "tmp/FaissNSGIndexMemoryTest.faiss";
+    std::string spaceType = knn_jni::L2;
+    std::string index_description = "NSG64,Flat";
+    int thread_num = 7;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+    parametersMap[knn_jni::INDEX_DESCRIPTION] = (jobject)&index_description;
+    parametersMap[knn_jni::INDEX_THREAD_QUANTITY] = (jobject)&thread_num;
+
+    // Set up jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    EXPECT_CALL(mockJNIUtil,
+                GetJavaObjectArrayLength(
+                        jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
+            .WillRepeatedly(Return(vectors.size()));
+
+    // Create the index
+    knn_jni::faiss_wrapper::CreateIndex(
+            &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
+            reinterpret_cast<jobjectArray>(&vectors), (jstring)&indexPath,
+            (jobject)&parametersMap);
+
+    // Make sure index can be loaded
+    // std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
+
+    // Clean up
+    ids.clear();
+    ids.shrink_to_fit();
+    vectors.clear();
+    vectors.shrink_to_fit();
+
+    malloc_trim(0);
+    size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
+    GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
+}
+
+TEST(FaissNSGQueryMemoryTest, BasicAssertions) {
+
+   std::string indexPath = "tmp/FaissNSGIndexMemoryTest.faiss";
+   std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
+   float queryVector[128];
+   float distance[10];
+   faiss::idx_t ids[10];
+   memset(queryVector, 0, sizeof(queryVector));
+   test_util::FaissQueryIndex(index.get(), queryVector, 10, distance, ids );
+   size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
+   GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
+}
+
+TEST(FaissHNSWQueryMemoryTest, BasicAssertions) {
+
+   std::string indexPath = "tmp/FaissHNSWIndexMemoryTest.faiss";
+   std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
+   float queryVector[128];
+   float distance[10];
+   faiss::idx_t ids[10];
+   memset(queryVector, 0, sizeof(queryVector));
+   test_util::FaissQueryIndex(index.get(), queryVector, 10, distance, ids );
+   size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
+   GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
+}
+
+TEST(LIBHNSWQueryMemoryTest, BasicAssertions) {
+
+    similarity::initLibrary();
+    std::string indexPath = "tmp/LibHNSWIndexMemoryTest2.faiss";
+    std::string spaceType = knn_jni::L2;
+    int thread_num = 7;
+    int efConstruction = 512;
+    int efSearch = 512;
+    int m = 32;
+
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+    parametersMap[knn_jni::INDEX_THREAD_QUANTITY] = (jobject)&thread_num;
+    parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject)&efConstruction;
+    parametersMap[knn_jni::EF_SEARCH] = (jobject)&efSearch;
+    parametersMap[knn_jni::M] = (jobject)&m;
+
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    std::unique_ptr<knn_jni::nmslib_wrapper::IndexWrapper> loadedIndex(
+            reinterpret_cast<knn_jni::nmslib_wrapper::IndexWrapper *>(
+                    knn_jni::nmslib_wrapper::LoadIndex(&mockJNIUtil, jniEnv,
+                                                       (jstring)&indexPath,
+                                                       (jobject)&parametersMap)));
+
+   float queryVector[128];
+   float distance[10];
+   faiss::idx_t ids[10];
+   memset(queryVector, 0, sizeof(queryVector));
+   size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
+   GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
+}

--- a/jni/tests/memory_test.cpp
+++ b/jni/tests/memory_test.cpp
@@ -134,7 +134,6 @@ TEST(NmslibHNSWIndexMemoryTest, BasicAssertions) {
     vectors.clear();
     vectors.shrink_to_fit();
 
-    malloc_trim(0);
     size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
 
     GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
@@ -192,7 +191,6 @@ TEST(FaissNSGIndexMemoryTest, BasicAssertions) {
     vectors.clear();
     vectors.shrink_to_fit();
 
-    malloc_trim(0);
     size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
     GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
 }

--- a/jni/tests/memory_test.cpp
+++ b/jni/tests/memory_test.cpp
@@ -35,37 +35,21 @@ TEST(FaissHNSWIndexMemoryTest, BasicAssertions) {
     GTEST_COUT << "points_num："<< points_num << " data dimension：" << dim << std::endl;
     float* dataptr = data_load;
 
-    faiss::idx_t numIds = points_num;
-    std::vector<faiss::idx_t> ids(points_num);
     std::vector<std::vector<float>> vectors;
-    for (int64_t i = 0; i < numIds; ++i) {
-        ids[i] = i;
-
-        std::vector<float> vect;
-        vect.reserve(dim);
-        for (int j = 0; j < dim; ++j) {
-            vect.push_back(*dataptr);
-	    dataptr++;
-        }
-        vectors.push_back(vect);
-    }
-
+    std::vector<int> ids(points_num);
+    test_util::set_vectors(vectors, ids, points_num, dim, dataptr);
     free(data_load);
-    malloc_trim(0);
 
     std::string indexPath = "tmp/FaissHNSWIndexMemoryTest.faiss";
     std::string spaceType = knn_jni::L2;
     std::string index_description = "HNSW32,Flat";  
     int thread_num = 7;
-    //int efConstruction = 512;
-    //int efSearch = 512;
+    
     std::unordered_map<std::string, jobject> parametersMap;
     parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
     parametersMap[knn_jni::INDEX_DESCRIPTION] = (jobject)&index_description;
     parametersMap[knn_jni::INDEX_THREAD_QUANTITY] = (jobject)&thread_num;
-    //parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject)&efConstruction;
-    //parametersMap[knn_jni::EF_SEARCH] = (jobject)&efSearch;
-
+    
     // Set up jni
     JNIEnv *jniEnv = nullptr;
     NiceMock<test_util::MockJNIUtil> mockJNIUtil;
@@ -75,14 +59,15 @@ TEST(FaissHNSWIndexMemoryTest, BasicAssertions) {
                         jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
             .WillRepeatedly(Return(vectors.size()));
 
+    EXPECT_CALL(mockJNIUtil,
+                GetJavaIntArrayLength(jniEnv, reinterpret_cast<jintArray>(&ids)))
+            .WillRepeatedly(Return(ids.size()));
+
     // Create the index
     knn_jni::faiss_wrapper::CreateIndex(
             &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
             reinterpret_cast<jobjectArray>(&vectors), (jstring)&indexPath,
             (jobject)&parametersMap);
-
-    // Make sure index can be loaded
-    // std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
 
     // Clean up
     ids.clear();
@@ -90,13 +75,12 @@ TEST(FaissHNSWIndexMemoryTest, BasicAssertions) {
     vectors.clear();
     vectors.shrink_to_fit();
 
-    malloc_trim(0);
     size_t mem_usage = faiss::get_mem_usage_kb() / (1 << 10);
 
     GTEST_COUT<<"======Memory Usage:[" << mem_usage << "mb]======" << std::endl;
 }
 
-TEST(LIBHNSWIndexMemoryTest, BasicAssertions) {
+TEST(NmslibHNSWIndexMemoryTest, BasicAssertions) {
 
     similarity::initLibrary();
     char dataset[] = "dataset/sift/sift_base.fvecs";
@@ -107,25 +91,12 @@ TEST(LIBHNSWIndexMemoryTest, BasicAssertions) {
     GTEST_COUT << "points_num："<< points_num << " data dimension：" << dim << std::endl;
     float* dataptr = data_load;
 
-    faiss::idx_t numIds = points_num;
-    std::vector<int> ids(points_num);
     std::vector<std::vector<float>> vectors;
-    for (int64_t i = 0; i < numIds; ++i) {
-        ids[i] = i;
-
-        std::vector<float> vect;
-        vect.reserve(dim);
-        for (int j = 0; j < dim; ++j) {
-            vect.push_back(*dataptr);
-	    dataptr++;
-        }
-        vectors.push_back(vect);
-    }
-
+    std::vector<int> ids(points_num);
+    test_util::set_vectors(vectors, ids, points_num, dim, dataptr);
     free(data_load);
-    malloc_trim(0);
 
-    std::string indexPath = "tmp/LibHNSWIndexMemoryTest.faiss";
+    std::string indexPath = "tmp/NmslibHNSWIndexMemoryTest.hnsw";
     std::string spaceType = knn_jni::L2;
     int thread_num = 7;
     int efConstruction = 512;
@@ -157,9 +128,6 @@ TEST(LIBHNSWIndexMemoryTest, BasicAssertions) {
             reinterpret_cast<jobjectArray>(&vectors), (jstring)&indexPath,
             (jobject)&parametersMap);
 
-    // Make sure index can be loaded
-    // std::unique_ptr<faiss::Index> index(test_util::FaissLoadIndex(indexPath));
-
     // Clean up
     ids.clear();
     ids.shrink_to_fit();
@@ -182,23 +150,10 @@ TEST(FaissNSGIndexMemoryTest, BasicAssertions) {
     GTEST_COUT << "points_num："<< points_num << " data dimension：" << dim << std::endl;
     float* dataptr = data_load;
 
-    faiss::idx_t numIds = points_num;
-    std::vector<faiss::idx_t> ids(points_num);
     std::vector<std::vector<float>> vectors;
-    for (int64_t i = 0; i < numIds; ++i) {
-        ids[i] = i;
-
-        std::vector<float> vect;
-        vect.reserve(dim);
-        for (int j = 0; j < dim; ++j) {
-            vect.push_back(*dataptr);
-	    dataptr++;
-        }
-        vectors.push_back(vect);
-    }
-
+    std::vector<int> ids(points_num);
+    test_util::set_vectors(vectors, ids, points_num, dim, dataptr);
     free(data_load);
-    malloc_trim(0);
 
     std::string indexPath = "tmp/FaissNSGIndexMemoryTest.faiss";
     std::string spaceType = knn_jni::L2;
@@ -217,6 +172,10 @@ TEST(FaissNSGIndexMemoryTest, BasicAssertions) {
                 GetJavaObjectArrayLength(
                         jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
             .WillRepeatedly(Return(vectors.size()));
+
+    EXPECT_CALL(mockJNIUtil,
+                GetJavaIntArrayLength(jniEnv, reinterpret_cast<jintArray>(&ids)))
+            .WillRepeatedly(Return(ids.size()));
 
     // Create the index
     knn_jni::faiss_wrapper::CreateIndex(

--- a/jni/tests/test_util.cpp
+++ b/jni/tests/test_util.cpp
@@ -14,6 +14,7 @@
 #include <jni.h>
 
 #include <random>
+#include <stdio.h>
 #include <utility>
 
 #include "faiss/Index.h"
@@ -346,4 +347,25 @@ float test_util::RandomFloat(float min, float max) {
     std::default_random_engine e1(r());
     std::uniform_real_distribution<float> distribution(min, max);
     return distribution(e1);
+}
+
+void test_util::load_data(char* filename, float*& data, unsigned& num, unsigned& dim) {
+    std::ifstream in(filename, std::ios::binary);
+    if (!in.is_open()) {
+        std::cout << "open file error" << std::endl;
+        exit(-1);
+    }
+    in.read((char*)&dim, 4);
+    in.seekg(0, std::ios::end);
+    std::ios::pos_type ss = in.tellg();
+    size_t fsize = (size_t)ss;
+    num = (unsigned)(fsize / (dim + 1) / 4);
+    data = new float[(size_t)num * (size_t)dim];
+
+    in.seekg(0, std::ios::beg);
+    for (size_t i = 0; i < num; i++) {
+        in.seekg(4, std::ios::cur);
+        in.read((char*)(data + i * dim), dim * 4);
+    }
+    in.close();
 }

--- a/jni/tests/test_util.cpp
+++ b/jni/tests/test_util.cpp
@@ -369,3 +369,20 @@ void test_util::load_data(char* filename, float*& data, unsigned& num, unsigned&
     }
     in.close();
 }
+
+void test_util::set_vectors(std::vector<std::vector<float>>& vectors, 
+                            std::vector<int>& ids, 
+                            int points_num, 
+                            int dim, 
+                            float* dataptr) {
+    ids.resize(points_num);
+    for (int i = 0; i < points_num; ++i) {
+        ids[i] = i;
+        std::vector<float> vect;
+        for (int j = 0; j < dim; ++j) {
+            vect.push_back(*dataptr);
+            dataptr++;
+        }
+        vectors.push_back(vect);
+    }
+}

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -150,6 +150,9 @@ namespace test_util {
 
     float RandomFloat(float min, float max);
 
+    // Read vector file formats
+    void load_data(char* filename, float*& data, unsigned& num, unsigned& dim);
+
 // -------------------------------------------------------------------------------
 }  // namespace test_util
 

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -153,6 +153,13 @@ namespace test_util {
     // Read vector file formats
     void load_data(char* filename, float*& data, unsigned& num, unsigned& dim);
 
+    // asign data into vector
+    void set_vectors(std::vector<std::vector<float>>& vectors, 
+                    std::vector<int>& ids, 
+                    int points_num, 
+                    int dim,
+                    float* dataptr);
+
 // -------------------------------------------------------------------------------
 }  // namespace test_util
 


### PR DESCRIPTION
### Description
When we want to introduce a new algorithm or engine, we prefer to evaluate the performance, memory, disk size. in benchmark tests, we can evaluate the performance as a single node.

But we can not evaluate a engine/algorithm takes how much memory, because in benchmark jvm make it hard to evaluate the memory only in jni layer.

in #946  we try to assess memory usage with different algorithm,  and when using benchmark/intergration tests, java heap memory and other memory usage make it hard to evaluate algorithm real memory usage. 

so i write a memory tests, and only use `faiss_wrapper/nmslib_wrapper`. it can evaluate memory usage, file size.
i use http://corpus-texmex.irisa.fr/ vector file format. and add `test_util::load_data` to read sift.fvecs with SIFT1M datasets.

i do some tests like following report:

`SIFT1M`
| Algotightm | Index RES   | FileSize | Query RES | 
| -----     |  ----  |  ----  | ----  |  
| HNSW32  |  1.8GB |   634MB  |     769MB |
| NSG64 |     3.1GB |   586MB |    752MB |
| NSG32 |     3.1GB |   577MB |    639MB |

`GIST960`
| Algotightm | Index RES   | FileSize | Query RES | 
| -----     |  ----  |  ----  | ----  |  
| HNSW32  |  11.2GB |   3.9GB  |     3944MB |
| NSG64 |     12GB |   3.7GB |    3923MB |
| NSG32 |     12GB |   3.7GB |    3806MB |

Usage:

1.  go to http://corpus-texmex.irisa.fr/, and download SIFT1M dataset, and unzip into a directory like 'dataset/sift/sift_base.fvecs' 

2. and run different tests

`./bin/jni_memory_test --gtest_filter=FaissNSGQueryMemoryTest.*`

### Issues Resolved
#946
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
