### PR TITLE
Change imports to align with core lucene upgrade

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Optional;
 
-import static org.apache.lucene.index.VectorValues.MAX_DIMENSIONS;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.addStoredFieldForVectorField;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
@@ -33,7 +33,7 @@ import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocV
  */
 public class LuceneFieldMapper extends KNNVectorFieldMapper {
 
-    private static final int LUCENE_MAX_DIMENSION = MAX_DIMENSIONS;
+    private static final int LUCENE_MAX_DIMENSION = KnnVectorsFormat.DEFAULT_MAX_DIMENSIONS;
 
     /** FieldType used for initializing VectorField, which is used for creating binary doc values. **/
     private final FieldType vectorFieldType;

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.util;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.KNNMethod;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -40,7 +40,7 @@ public enum KNNEngine implements KNNLibrary {
         KNNEngine.FAISS,
         16_000,
         KNNEngine.LUCENE,
-        VectorValues.MAX_DIMENSIONS
+        KnnVectorsFormat.DEFAULT_MAX_DIMENSIONS
     );
 
     /**


### PR DESCRIPTION
### Description
OpenSearch core recently updated the lucene version, rendering some constants used in k-NN obsolete.  This PR updates to the new versions of those constants.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
