### PR TITLE
Fixing the BWC test which is failing due to 2.10.0-snapshot present in the bwc versions

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java: [ 11, 17 ]
         os: [ubuntu-latest]
-        bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0-SNAPSHOT"]
+        bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0-SNAPSHOT"]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
         exclude:
           - os: windows-latest


### PR DESCRIPTION
### Description
Fixing the BWC test which is failing due to 2.10.0-snapshot present in the bwc versions
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
