### PR TITLE
Make sure not hardcoding user name when switching to uid 1000 on CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
-          chown -R opensearch.opensearch `pwd`
-          su opensearch -c "whoami && java -version && ./gradlew build"
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "whoami && java -version && ./gradlew build"
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
### Description
Make sure not hardcoding user name when switching to uid 1000 on CI.yml
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1042
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
