### PR TITLE
Reduce number of test run from 10 to 3

### DIFF
--- a/benchmarks/perf-tool/release-configs/faiss-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss HNSW Relaxed Filter Test"
 test_id: "Faiss HNSW Relaxed Filter Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss HNSW Restrictive Filter Test"
 test_id: "Faiss HNSW Restrictive Filter Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-hnsw/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-hnsw/test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss HNSW Test"
 test_id: "Faiss HNSW Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-hnswpq/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-hnswpq/test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss HNSW PQ Test"
 test_id: "Faiss HNSW PQ Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 setup:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-ivf/filtering/relaxed-filter/relaxed-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/filtering/relaxed-filter/relaxed-filter-test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss IVF Relaxed Filter Test"
 test_id: "Faiss IVF Relaxed Filter Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 setup:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-ivf/filtering/restrictive-filter/restrictive-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/filtering/restrictive-filter/restrictive-filter-test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss IVF restrictive Filter Test"
 test_id: "Faiss IVF restrictive Filter Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 setup:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-ivf/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-ivf/test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss IVF"
 test_id: "Faiss IVF"
-num_runs: 10
+num_runs: 3
 show_runs: false
 setup:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/faiss-ivfpq/test.yml
+++ b/benchmarks/perf-tool/release-configs/faiss-ivfpq/test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Faiss IVF PQ Test"
 test_id: "Faiss IVF PQ Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 setup:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Lucene HNSW Relaxed Filter Test"
 test_id: "Lucene HNSW Relaxed Filter Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Lucene HNSW Restrictive Filter Test"
 test_id: "Lucene HNSW Restrictive Filter Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Lucene HNSW"
 test_id: "Lucene HNSW"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index

--- a/benchmarks/perf-tool/release-configs/nmslib-hnsw/test.yml
+++ b/benchmarks/perf-tool/release-configs/nmslib-hnsw/test.yml
@@ -2,7 +2,7 @@ endpoint: [ENDPOINT]
 port: [PORT]
 test_name: "Nmslib HNSW Test"
 test_id: "Nmslib HNSW Test"
-num_runs: 10
+num_runs: 3
 show_runs: false
 steps:
   - name: delete_index


### PR DESCRIPTION

### Description
No much difference was found between the two configuration. Therefore, reduce the number of test run to make test to complete faster.

#### Test time
1 run = 46 minutes
3 runs = 2.3 hours
10 runs = 7.6 hours

#### Ingest(ms)

  | 10 runs(base) | 10 runs | 3 runs | 1 run | Diff 10 runs(%) | Diff 3 runs(%) | Diff 1 run(%)
-- | -- | -- | -- | -- | -- | -- | --
Faiss_HNSW_PQ_Test | 61312 | 58170 | 57856 | 56119 | 5.12461 | 5.63674 | 8.46979
Faiss_HNSW_Relaxed_Filter_Test | 60404 | 62387 | 59828 | 61827 | -3.2829 | 0.95358 | -2.3558
Faiss_HNSW_Restrictive_Filter_Test | 59952 | 61615 | 60726 | 61266 | -2.77389 | -1.29103 | -2.19175
Faiss_HNSW_Test | 57546 | 58018 | 55960 | 56531 | -0.82021 | 2.75606 | 1.76381
Faiss_IVF | 57185 | 55504 | 58951 | 56165 | 2.93958 | -3.08822 | 1.78368
Faiss_IVF_PQ_Test | 57879 | 55794 | 58157 | 58190 | 3.60234 | -0.48031 | -0.53733
Faiss_IVF_Relaxed_Filter_Test | 60062 | 59434 | 60195 | 59795 | 1.04559 | -0.22144 | 0.44454
Faiss_IVF_restrictive_Filter_Test | 59496 | 58800 | 61211 | 59742 | 1.16983 | -2.88255 | -0.41347
Lucene_HNSW | 223573 | 170942 | 198416 | 199510 | 23.54086 | 11.25225 | 10.76293
Lucene_HNSW_Relaxed_Filter_Test | 216788 | 173679 | 207515 | 230482 | 19.88533 | 4.27745 | -6.31677
Lucen_HNSW_Restrictive_Filter_Test | 186928 | 183281 | 203776 | 199627 | 1.95102 | -9.0131 | -6.79352
Nmslib_HNSW_Test | 56569 | 58571 | 57717 | 58369 | -3.53904 | -2.02938 | -3.18195



#### Query 50(ms)

  | 10 runs(base) | 10 runs | 3 runs | 1 run | Diff 10 runs(%) | Diff 3 runs(%) | Diff 1 run(%)
-- | -- | -- | -- | -- | -- | -- | --
Faiss_HNSW_PQ_Test | 4.8 | 4 | 4.67 | 5 | 16.66667 | 2.70833 | -4.16667
Faiss_HNSW_Relaxed_Filter_Test | 8.9 | 7.6 | 8.3 | 8 | 14.60674 | 6.74157 | 10.11236
Faiss_HNSW_Restrictive_Filter_Test | 4 | 4 | 4 | 4 | 0 | 0 | 0
Faiss_HNSW_Test | 6.3 | 5 | 5.7 | 6 | 20.63492 | 9.52381 | 4.7619
Faiss_IVF | 3 | 3 | 3 | 3 | 0 | 0 | 0
Faiss_IVF_PQ_Test | 3 | 2.8 | 3 | 3 | 6.66667 | 0 | 0
Faiss_IVF_Relaxed_Filter_Test | 5 | 4.1 | 5 | 5 | 18 | 0 | 0
Faiss_IVF_restrictive_Filter_Test | 4 | 4 | 4.7 | 4 | 0 | -17.5 | 0
Lucene_HNSW | 4.9 | 4.2 | 5 | 5 | 14.28571 | -2.04082 | -2.04082
Lucene_HNSW_Relaxed_Filter_Test | 7.3 | 7 | 7.7 | 8 | 4.10959 | -5.47945 | -9.58904
Lucen_HNSW_Restrictive_Filter_Test | 6.1 | 5.8 | 6 | 6 | 4.91803 | 1.63934 | 1.63934
Nmslib_HNSW_Test | 3.3 | 3 | 4 | 3 | 9.09091 | -21.21212 | 9.09091



#### Query P90(ms)
  | 10 runs(base) | 10 runs | 3 runs | 1 run | Diff 10 runs(%) | Diff 3 runs(%) | Diff 1 run(%)
-- | -- | -- | -- | -- | -- | -- | --
Faiss_HNSW_PQ_Test | 5.4 | 4.7 | 5 | 5 | 12.96296 | 7.40741 | 7.40741
Faiss_HNSW_Relaxed_Filter_Test | 11 | 9.4 | 10.3 | 10 | 14.54545 | 6.36364 | 9.09091
Faiss_HNSW_Restrictive_Filter_Test | 4 | 4.4 | 4.7 | 5 | -10 | -17.5 | -25
Faiss_HNSW_Test | 7.7 | 5.8 | 6.7 | 7 | 24.67532 | 12.98701 | 9.09091
Faiss_IVF | 3.5 | 3 | 3.7 | 4 | 14.28571 | -5.71429 | -14.28571
Faiss_IVF_PQ_Test | 3 | 3 | 3 | 3 | 0 | 0 | 0
Faiss_IVF_Relaxed_Filter_Test | 6 | 5.1 | 6 | 6 | 15 | 0 | 0
Faiss_IVF_restrictive_Filter_Test | 4.2 | 4 | 5 | 5 | 4.7619 | -19.04762 | -19.04762
Lucene_HNSW | 5.7 | 5 | 5.7 | 6 | 12.2807 | 0 | -5.26316
Lucene_HNSW_Relaxed_Filter_Test | 9 | 8.1 | 9 | 9 | 10 | 0 | 0
Lucen_HNSW_Restrictive_Filter_Test | 6.3 | 6 | 6 | 7 | 4.7619 | 4.7619 | -11.11111
Nmslib_HNSW_Test | 3.3 | 3 | 4.3 | 4 | 9.09091 | -30.30303 | -21.21212


 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
