### PR TITLE
Upgrade urllib to 1.26.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 ### Maintenance
 * Update developer guide to include M1 Setup [#1222](https://github.com/opensearch-project/k-NN/pull/1222)
+* Upgrade urllib to 1.26.17 [#1278](https://github.com/opensearch-project/k-NN/pull/1278)
 ### Refactoring

--- a/benchmarks/osb/requirements.txt
+++ b/benchmarks/osb/requirements.txt
@@ -85,7 +85,7 @@ tabulate==0.8.7
     # via opensearch-benchmark
 thespian==3.10.1
     # via opensearch-benchmark
-urllib3==1.26.9
+urllib3==1.26.17
     # via opensearch-py
 yappi==1.2.3
     # via opensearch-benchmark

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -30,7 +30,7 @@ pyyaml==5.4.1
     # via -r requirements.in
 requests==2.31.0
     # via -r requirements.in
-urllib3==1.26.6
+urllib3==1.26.17
     # via
     #   opensearch-py
     #   requests


### PR DESCRIPTION
### Description
Upgrades the urllib dependency to version 1.26.17
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1231
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
