### PR TITLE
Add ryanbogan as maintainer and codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski
+*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @ryanbogan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,5 +12,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Martin Gaievski         | [martin-gaievski](https://github.com/martin-gaievski) | Amazon      |
 | Naveen Tatikonda        | [naveentatikonda](https://github.com/naveentatikonda) | Amazon      |
 | Navneet Verma           | [navneet1v](https://github.com/navneet1v)             | Amazon      |
+| Ryan Bogan              | [ryanbogan](https://github.com/ryanbogan)             | Amazon      |
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)                 | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      |


### PR DESCRIPTION
### Description
Adds ryanbogan as maintainer and codeowner for k-NN repository.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
