### PR TITLE
Update CI to use jdk-21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
   Build-k-NN-Linux:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
 
     name: Build and Test k-NN Plugin on Linux
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
   Build-k-NN-MacOS:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
 
     name: Build and Test k-NN Plugin on MacOS
     needs: Get-CI-Image-Tag
@@ -84,7 +84,7 @@ jobs:
   Build-k-NN-Windows:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
 
     name: Build and Test k-NN Plugin on Windows
     needs: Get-CI-Image-Tag

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -13,7 +13,7 @@ jobs:
   Restart-Upgrade-BWCTests-k-NN:
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17 ]
         os: [ubuntu-latest]
         bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0-SNAPSHOT"]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
@@ -86,7 +86,7 @@ jobs:
   Rolling-Upgrade-BWCTests-k-NN:
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17 ]
         os: [ubuntu-latest]
         bwc_version: [ "2.11.0-SNAPSHOT" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -13,7 +13,7 @@ jobs:
   Restart-Upgrade-BWCTests-k-NN:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
         os: [ubuntu-latest]
         bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0-SNAPSHOT"]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
@@ -86,7 +86,7 @@ jobs:
   Rolling-Upgrade-BWCTests-k-NN:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
         os: [ubuntu-latest]
         bwc_version: [ "2.11.0-SNAPSHOT" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -15,7 +15,7 @@ jobs:
   Build-ad:
     strategy:
       matrix:
-        java: [ 11,17 ]
+        java: [ 11,17,21 ]
         os: [ubuntu-latest]
       fail-fast: true
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
     id 'java-library'
     id 'java-test-fixtures'
     id 'idea'
-    id "com.diffplug.spotless" version "6.3.0" apply false
+    id "com.diffplug.spotless" version "6.20.0" apply false
     id 'io.freefair.lombok' version '8.4'
 }
 

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -654,7 +654,9 @@ public interface ModelDao {
             client.execute(
                 UpdateModelGraveyardAction.INSTANCE,
                 new UpdateModelGraveyardRequest(modelId, true),
-                ActionListener.wrap(acknowledgedResponse -> { throw exceptionFromPreviousStep; }, unblockingFailedException -> {
+                ActionListener.wrap(acknowledgedResponse -> {
+                    throw exceptionFromPreviousStep;
+                }, unblockingFailedException -> {
                     // If it fails to remove the modelId from Model Graveyard, then log the error message and
                     // throw the exception that was passed as a parameter from previous step
                     String errorMessage = String.format("Failed to remove \" %s \" from Model Graveyard", modelId);

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -210,12 +210,9 @@ public class TestUtils {
     public static float computeDistFromSpaceType(SpaceType spaceType, float[] indexVector, float[] queryVector) {
         float dist;
         if (spaceType != null) {
-            dist = KNN_SCORING_SPACE_TYPE.getOrDefault(
-                spaceType,
-                (defaultQueryVector, defaultIndexVector) -> {
-                    throw new IllegalArgumentException(String.format("Invalid SpaceType function: \"%s\"", spaceType));
-                }
-            ).apply(queryVector, indexVector);
+            dist = KNN_SCORING_SPACE_TYPE.getOrDefault(spaceType, (defaultQueryVector, defaultIndexVector) -> {
+                throw new IllegalArgumentException(String.format("Invalid SpaceType function: \"%s\"", spaceType));
+            }).apply(queryVector, indexVector);
         } else {
             throw new NullPointerException("SpaceType is null. Provide a valid SpaceType.");
         }


### PR DESCRIPTION
### Description
This updates the CI system to use jdk-21, which is latest LTS supported version. 
 
### Issues Resolved
Coming from https://github.com/opensearch-project/OpenSearch/issues/10334
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
