### PR TITLE
Add more description about running OpenSearch on MAC M1 to developer guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -127,7 +127,7 @@ Next, obtain a minimum distribution tarball of the k-NN version you want to buil
 4. You should see a opensearch-min-<version>-SNAPSHOT-darwin-x64.tar.gz file present in distribution/archives/darwin-tar/build/distributions/
 5. Build k-NN by passing the OpenSearch distribution path in `./gradlew <integTest/run> -PcustomDistributionUrl="<Full path to .tar.gz file you noted above>"`
 
-If you want to start OpenSearch directly on Mac M1, make sure JDK for ARM is used, if not you will see 'mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')'. And it's better to start OpenSearch by running `bash opensearch-tar-install.sh`, if you want to run `./bin/opensearch`, the environment variable `JAVA_LIBRARY_PATH` should be set correctly so that OpenSearch can find the JNI library:
+If you want to start OpenSearch directly on Mac M1, make sure to use JDK for ARM. Otherwise, you will see the following error: `mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')`. It is better to start OpenSearch by running `bash opensearch-tar-install.sh` instead of `./bin/opensearch`. To run `./bin/opensearch`, the environment variable `JAVA_LIBRARY_PATH` needs to be set correctly so that OpenSearch can find the JNI library:
 
 ```
 export OPENSEARCH_HOME=the directory of opensearch...

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -127,6 +127,13 @@ Next, obtain a minimum distribution tarball of the k-NN version you want to buil
 4. You should see a opensearch-min-<version>-SNAPSHOT-darwin-x64.tar.gz file present in distribution/archives/darwin-tar/build/distributions/
 5. Build k-NN by passing the OpenSearch distribution path in `./gradlew <integTest/run> -PcustomDistributionUrl="<Full path to .tar.gz file you noted above>"`
 
+If you want to start OpenSearch directly on Mac M1, make sure JDK for ARM is used, if not you will see 'mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')'. And it's better to start OpenSearch by running `bash opensearch-tar-install.sh`, if you want to run `./bin/opensearch`, the environment variable `JAVA_LIBRARY_PATH` should be set correctly so that OpenSearch can find the JNI library:
+
+```
+export OPENSEARCH_HOME=the directory of opensearch...
+export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/lib
+```
+
 #### Environment
 
 Currently, the plugin only supports Linux on x64 and arm platforms.


### PR DESCRIPTION
### Description

When running OpenSearch with knn plugin on MAC M1, we need to build the JNI library such as faiss, nmslib manually, but if we don't use JDK for ARM, then we can see the error `mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')` when executing knn search. And if we start OpenSearch by running `./bin/opensearch` directly on MAC M1 and do not set the environment variable `JAVA_LIBRARY_PATH`, then OpenSearch cannot find the JNI library. We need to add more description about how to run OpenSearchon MAC M1 to make it clear for users.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/580
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
