### PR TITLE
Fix use-after-free bug in nmslib engine query path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Add parent join support for lucene knn [#1182](https://github.com/opensearch-project/k-NN/pull/1182)
 ### Enhancements
-### Bug Fixes 
+### Bug Fixes
+* Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 ### Documentation

--- a/jni/include/nmslib_wrapper.h
+++ b/jni/include/nmslib_wrapper.h
@@ -48,10 +48,10 @@ namespace knn_jni {
         struct IndexWrapper {
             explicit IndexWrapper(const std::string& spaceType) {
                 // Index gets constructed with a reference to data (see above) but is otherwise unused
-                similarity::ObjectVector data;
                 space.reset(similarity::SpaceFactoryRegistry<float>::Instance().CreateSpace(spaceType, similarity::AnyParams()));
                 index.reset(similarity::MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceType, *space, data));
             }
+            similarity::ObjectVector data;
             std::unique_ptr<similarity::Space<float>> space;
             std::unique_ptr<similarity::Index<float>> index;
         };

--- a/jni/tests/nmslib_wrapper_test.cpp
+++ b/jni/tests/nmslib_wrapper_test.cpp
@@ -21,6 +21,17 @@
 using ::testing::NiceMock;
 using ::testing::Return;
 
+TEST(NmslibIndexWrapperSearchTest, BasicAssertions) {
+    similarity::initLibrary();
+    knn_jni::nmslib_wrapper::IndexWrapper indexWrapper = knn_jni::nmslib_wrapper::IndexWrapper("l2");
+    int k = 10;
+    int dim = 2;
+    std::unique_ptr<float> rawQueryvector(new float[dim]);
+    std::unique_ptr<similarity::Object> queryObject(new similarity::Object(-1, -1, dim*sizeof(float), rawQueryvector.get()));
+    similarity::KNNQuery<float> knnQuery(*(indexWrapper.space), queryObject.get(), k);
+    indexWrapper.index->Search((similarity::KNNQuery<float> *)nullptr);
+}
+
 TEST(NmslibCreateIndexTest, BasicAssertions) {
     // Initialize nmslib
     similarity::initLibrary();


### PR DESCRIPTION
### Description
Ties `data` variable to lifetime of `IndexWrapper` by making it struct member as opposed to local constructor variable. This change reflects the structure of `IndexWrapper` before https://github.com/opendistro-for-elasticsearch/k-NN/commit/7640186417fda86d84e0146dd5291d7fe2a81f24.
 
Add unit test. The unit test sometimes reproduces the issue. However, it is difficult to reproduce deterministically. I was able to reproduce on my mac fairly consistently, but not able to reproduce on linux.

### Issues Resolved
#1304 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
