### PR TITLE
Update CVE-affected dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Update developer guide to include M1 Setup [#1222](https://github.com/opensearch-project/k-NN/pull/1222)
 * Upgrade urllib to 1.26.17 [#1278](https://github.com/opensearch-project/k-NN/pull/1278)
+* Upgrade urllib to 1.26.18 [#1319](https://github.com/opensearch-project/k-NN/pull/1319)
+* Upgrade guava to 32.1.3 [#1319](https://github.com/opensearch-project/k-NN/pull/1319)
 ### Refactoring

--- a/benchmarks/osb/requirements.txt
+++ b/benchmarks/osb/requirements.txt
@@ -85,7 +85,7 @@ tabulate==0.8.7
     # via opensearch-benchmark
 thespian==3.10.1
     # via opensearch-benchmark
-urllib3==1.26.17
+urllib3==1.26.18
     # via opensearch-py
 yappi==1.2.3
     # via opensearch-benchmark

--- a/benchmarks/perf-tool/requirements.txt
+++ b/benchmarks/perf-tool/requirements.txt
@@ -30,7 +30,7 @@ pyyaml==5.4.1
     # via -r requirements.in
 requests==2.31.0
     # via -r requirements.in
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   opensearch-py
     #   requests

--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ dependencies {
     api "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     api group: 'com.google.guava', name: 'failureaccess', version:'1.0.1'
-    api group: 'com.google.guava', name: 'guava', version:'32.0.1-jre'
+    api group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     api group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.7'


### PR DESCRIPTION
### Description

Updates Guava and urllib3 versions.
 
### Issues Resolved

https://nvd.nist.gov/vuln/detail/CVE-2023-2976
https://nvd.nist.gov/vuln/detail/CVE-2023-45803
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
