### PR TITLE
Fix Spotless Transitive Dependency and bump aiohttp to fix CVE

### DIFF
--- a/benchmarks/osb/requirements.txt
+++ b/benchmarks/osb/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-aiohttp==3.8.5
+aiohttp==3.8.6
     # via opensearch-py
 aiosignal==1.2.0
     # via aiohttp

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ buildscript {
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
+        configurations.all {
+            resolutionStrategy {
+                force("org.eclipse.platform:org.eclipse.core.runtime:3.29.0") // for spotless transitive dependency CVE (for 3.26.100)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Description
The Spotless Gradle Plugin brings in a transitive dependency on Eclipse Core Runtime 3.26.100. That version is impacted by a CVE. This forces the newest version, currently 3.29.0.

Also, bump the aiohttp dependency from 3.8.5 to 3.8.6 to fix CVE.  
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1321
https://github.com/opensearch-project/k-NN/issues/1320
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
