### PR TITLE
Fix 2.10 Release Notes

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.10.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.10.0.0.md
@@ -3,7 +3,7 @@
 Compatible with OpenSearch 2.10.0
 
 ### Features
-* Add Clear Cache API ([#740](https://github.com/opensearch-project/k-NN/pull/740))
+* ~~Add Clear Cache API ([#740](https://github.com/opensearch-project/k-NN/pull/740))~~ Feature was mistakenly added to the release notes, although it was not included in the release.
 ### Enhancements
 * Enabled the IVF algorithm to work with Filters of K-NN Query. ([#1013](https://github.com/opensearch-project/k-NN/pull/1013))
 * Improved the logic to switch to exact search for restrictive filters search for better recall. ([#1059](https://github.com/opensearch-project/k-NN/pull/1059))


### PR DESCRIPTION
### Description
Fix the 2.10 release notes where the clear cache API feature was added to it by mistake.
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
