### PR TITLE
Fix Failing Clear Cache API Test

### DIFF
--- a/src/test/java/org/opensearch/knn/plugin/action/RestClearCacheHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestClearCacheHandlerIT.java
@@ -25,7 +25,6 @@ import static org.opensearch.knn.common.KNNConstants.CLEAR_CACHE;
 public class RestClearCacheHandlerIT extends KNNRestTestCase {
     private static final String TEST_FIELD = "test-field";
     private static final int DIMENSIONS = 2;
-    private static final String ALL_INDICES = "_all";
 
     @SneakyThrows
     public void testNonExistentIndex() {
@@ -81,7 +80,7 @@ public class RestClearCacheHandlerIT extends KNNRestTestCase {
 
         assertEquals(graphCountBefore + 2, getTotalGraphsInCache());
 
-        clearCache(Arrays.asList(ALL_INDICES));
+        clearCache(Arrays.asList(testIndex1, testIndex2));
         assertEquals(graphCountBefore, getTotalGraphsInCache());
     }
 


### PR DESCRIPTION
### Description
Fix failing integration test. If there are any system indices in the cluster, the test will fail during validation as they are non-knn indices.

```
org.opensearch.knn.plugin.action.RestClearCacheHandlerIT > testClearCacheMultipleIndices FAILED
    org.opensearch.client.ResponseException: method [POST], host [https://127.0.0.1:52190/], URI [/_plugins/_knn/clear_cache/_all], status line [HTTP/2.0 500 Internal Server Error]
    {"error":{"root_cause":[{"type":"k_n_n_invalid_indices_exception","reason":"ClearCache request rejected. One or more indices have 'index.knn' set to false."}],"type":"k_n_n_invalid_indices_exception","reason":"ClearCache request rejected. One or more indices have 'index.knn' set to false."},"status":500}
``` 

 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
