### PR TITLE
[Manually backport 2.x] Allow nested knn field mapping when train model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 * Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
+* Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 ### Documentation

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -14,13 +14,18 @@ package org.opensearch.knn.index;
 import com.google.common.collect.ImmutableMap;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.ValidationException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -66,5 +71,137 @@ public class IndexUtilTests extends KNNTestCase {
         assertEquals(2, loadParameters.size());
         assertEquals(spaceType2.getValue(), loadParameters.get(SPACE_TYPE));
         assertEquals(efSearchValue, loadParameters.get(HNSW_ALGO_EF_SEARCH));
+    }
+
+    public void testValidateKnnField_NestedField() {
+        Map<String, Object> deepFieldValues = Map.of("type", "knn_vector", "dimension", 8);
+        Map<String, Object> deepField = Map.of("train-field", deepFieldValues);
+        Map<String, Object> deepFieldProperties = Map.of("properties", deepField);
+        Map<String, Object> nest_b = Map.of("b", deepFieldProperties);
+        Map<String, Object> nest_b_properties = Map.of("properties", nest_b);
+        Map<String, Object> nest_a = Map.of("a", nest_b_properties);
+        Map<String, Object> properties = Map.of("properties", nest_a);
+
+        String field = "a.b.train-field";
+        int dimension = 8;
+
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(properties);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        assertNull(e);
+    }
+
+    public void testValidateKnnField_NonNestedField() {
+        Map<String, Object> fieldValues = Map.of("type", "knn_vector", "dimension", 8);
+        Map<String, Object> top_level_field = Map.of("top_level_field", fieldValues);
+        Map<String, Object> properties = Map.of("properties", top_level_field);
+        String field = "top_level_field";
+        int dimension = 8;
+
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(properties);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        assertNull(e);
+    }
+
+    public void testValidateKnnField_NonKnnField() {
+        Map<String, Object> fieldValues = Map.of("type", "text");
+        Map<String, Object> top_level_field = Map.of("top_level_field", fieldValues);
+        Map<String, Object> properties = Map.of("properties", top_level_field);
+        String field = "top_level_field";
+        int dimension = 8;
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(properties);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        assert Objects.requireNonNull(e).getMessage().matches("Validation Failed: 1: Field \"" + field + "\" is not of type knn_vector.;");
+    }
+
+    public void testValidateKnnField_WrongFieldPath() {
+        Map<String, Object> deepFieldValues = Map.of("type", "knn_vector", "dimension", 8);
+        Map<String, Object> deepField = Map.of("train-field", deepFieldValues);
+        Map<String, Object> deepFieldProperties = Map.of("properties", deepField);
+        Map<String, Object> nest_b = Map.of("b", deepFieldProperties);
+        Map<String, Object> nest_b_properties = Map.of("properties", nest_b);
+        Map<String, Object> nest_a = Map.of("a", nest_b_properties);
+        Map<String, Object> properties = Map.of("properties", nest_a);
+        String field = "a.train-field";
+        int dimension = 8;
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(properties);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        assert (Objects.requireNonNull(e).getMessage().matches("Validation Failed: 1: Field \"" + field + "\" does not exist.;"));
+    }
+
+    public void testValidateKnnField_EmptyField() {
+        Map<String, Object> deepFieldValues = Map.of("type", "knn_vector", "dimension", 8);
+        Map<String, Object> deepField = Map.of("train-field", deepFieldValues);
+        Map<String, Object> deepFieldProperties = Map.of("properties", deepField);
+        Map<String, Object> nest_b = Map.of("b", deepFieldProperties);
+        Map<String, Object> nest_b_properties = Map.of("properties", nest_b);
+        Map<String, Object> nest_a = Map.of("a", nest_b_properties);
+        Map<String, Object> properties = Map.of("properties", nest_a);
+        String field = "";
+        int dimension = 8;
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(properties);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        System.out.println(Objects.requireNonNull(e).getMessage());
+
+        assert (Objects.requireNonNull(e).getMessage().matches("Validation Failed: 1: Field path is empty.;"));
+    }
+
+    public void testValidateKnnField_EmptyIndexMetadata() {
+        String field = "a.b.train-field";
+        int dimension = 8;
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(null);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        assert (Objects.requireNonNull(e).getMessage().matches("Validation Failed: 1: Invalid index. Index does not contain a mapping;"));
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -342,4 +342,74 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
         assertTrainingSucceeds(modelId, 30, 1000);
     }
+
+    // Test to checks when user tries to train a model with nested fields
+    public void testTrainModel_success_nestedField() throws Exception {
+        String modelId = "test-model-id";
+        String trainingIndexName = "train-index";
+        String nestedFieldPath = "a.b.train-field";
+        int dimension = 8;
+
+        // Create a training index and randomly ingest data into it
+        String mapping = createKnnIndexNestedMapping(dimension, nestedFieldPath);
+        createKnnIndex(trainingIndexName, mapping);
+        int trainingDataCount = 200;
+        bulkIngestRandomVectorsWithNestedField(trainingIndexName, nestedFieldPath, trainingDataCount, dimension);
+
+        // Call the train API with this definition:
+        /*
+            {
+                "training_index": "train_index",
+                "training_field": "a.b.train_field",
+                "dimension": 8,
+                "description": "this should be allowed to be null",
+                "method": {
+                    "name":"ivf",
+                    "engine":"faiss",
+                    "space_type": "l2",
+                    "parameters":{
+                        "nlist":1,
+                        "encoder":{
+                            "name":"pq",
+                            "parameters":{
+                                "code_size":2,
+                                "m": 2
+                            }
+                        }
+                    }
+                }
+             }
+         */
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Map<String, Object> method = xContentBuilderToMap(builder);
+
+        Response trainResponse = trainModel(modelId, trainingIndexName, nestedFieldPath, dimension, method, "dummy description");
+
+        assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
+
+        Response getResponse = getModel(modelId, null);
+        String responseBody = EntityUtils.toString(getResponse.getEntity());
+        assertNotNull(responseBody);
+
+        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
+
+        assertEquals(modelId, responseMap.get(MODEL_ID));
+
+        assertTrainingSucceeds(modelId, 30, 1000);
+    }
 }


### PR DESCRIPTION
### Description
Manually backport #1318 into 2.x branch to replace failed auto backport PR #1338 

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
