### PR TITLE
[Backport 2.x] Properly designate model state for actively training models when nodes crash or leave cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)
+* Properly designate model state for actively training models when nodes crash or leave cluster [#1317](https://github.com/opensearch-project/k-NN/pull/1317)
+
+>>>>>>> main
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 ### Documentation

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModelIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModelIT.java
@@ -257,6 +257,6 @@ public class ModelIT extends AbstractRestartUpgradeTestCase {
     }
 
     private ModelMetadata getModelMetadata() {
-        return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, ModelState.CREATED, "2021-03-27", "test model", "");
+        return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, ModelState.CREATED, "2021-03-27", "test model", "", "");
     }
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -45,6 +45,7 @@ public class KNNConstants {
     public static final String MODEL_TIMESTAMP = "timestamp";
     public static final String MODEL_DESCRIPTION = "description";
     public static final String MODEL_ERROR = "error";
+    public static final String MODEL_NODE_ASSIGNMENT = "training_node_assignment";
     public static final String PARAM_SIZE = "size";
     public static final Integer SEARCH_MODEL_MIN_SIZE = 1;
     public static final Integer SEARCH_MODEL_MAX_SIZE = 1000;

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -36,12 +36,16 @@ import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 public class IndexUtil {
 
+    public static final String MODEL_NODE_ASSIGNMENT_KEY = KNNConstants.MODEL_NODE_ASSIGNMENT;
+
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_LUCENE_HNSW_FILTER = Version.V_2_4_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_IGNORE_UNMAPPED = Version.V_2_11_0;
-    public static final Map<String, Version> minimalRequiredVersionMap = new HashMap<String, Version>() {
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_NODE_ASSIGNMENT = Version.V_2_12_0;
+    private static final Map<String, Version> minimalRequiredVersionMap = new HashMap<String, Version>() {
         {
             put("filter", MINIMAL_SUPPORTED_VERSION_FOR_LUCENE_HNSW_FILTER);
             put("ignore_unmapped", MINIMAL_SUPPORTED_VERSION_FOR_IGNORE_UNMAPPED);
+            put(MODEL_NODE_ASSIGNMENT_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_NODE_ASSIGNMENT);
         }
     };
 
@@ -252,5 +256,13 @@ public class IndexUtil {
             return false;
         }
         return KNNClusterUtil.instance().getClusterMinVersion().onOrAfter(minimalRequiredVersion);
+    }
+
+    public static boolean isVersionOnOrAfterMinRequiredVersion(Version version, String key) {
+        Version minimalRequiredVersion = minimalRequiredVersionMap.get(key);
+        if (minimalRequiredVersion == null) {
+            return false;
+        }
+        return version.onOrAfter(minimalRequiredVersion);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -41,7 +41,7 @@ public class IndexUtil {
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_LUCENE_HNSW_FILTER = Version.V_2_4_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_IGNORE_UNMAPPED = Version.V_2_11_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_NODE_ASSIGNMENT = Version.V_2_12_0;
-    private static final Map<String, Version> minimalRequiredVersionMap = new HashMap<String, Version>() {
+    public static final Map<String, Version> minimalRequiredVersionMap = new HashMap<String, Version>() {
         {
             put("filter", MINIMAL_SUPPORTED_VERSION_FOR_LUCENE_HNSW_FILTER);
             put("ignore_unmapped", MINIMAL_SUPPORTED_VERSION_FOR_IGNORE_UNMAPPED);

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -287,6 +287,7 @@ public interface ModelDao {
                     put(KNNConstants.MODEL_TIMESTAMP, modelMetadata.getTimestamp());
                     put(KNNConstants.MODEL_DESCRIPTION, modelMetadata.getDescription());
                     put(KNNConstants.MODEL_ERROR, modelMetadata.getError());
+                    put(KNNConstants.MODEL_NODE_ASSIGNMENT, modelMetadata.getNodeAssignment());
                 }
             };
 

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -75,6 +75,7 @@ import org.opensearch.knn.plugin.transport.UpdateModelMetadataAction;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataTransportAction;
 import org.opensearch.knn.plugin.transport.UpdateModelGraveyardAction;
 import org.opensearch.knn.plugin.transport.UpdateModelGraveyardTransportAction;
+import org.opensearch.knn.training.TrainingJobClusterStateListener;
 import org.opensearch.knn.training.TrainingJobRunner;
 import org.opensearch.knn.training.VectorReader;
 import org.opensearch.plugins.ActionPlugin;
@@ -197,10 +198,14 @@ public class KNNPlugin extends Plugin
         ModelDao.OpenSearchKNNModelDao.initialize(client, clusterService, environment.settings());
         ModelCache.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
         TrainingJobRunner.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance());
+        TrainingJobClusterStateListener.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
         KNNQueryBuilder.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         TrainingModelRequest.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
+
+        clusterService.addListener(TrainingJobClusterStateListener.getInstance());
+
         knnStats = new KNNStats();
         return ImmutableList.of(knnStats);
     }

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelTransportAction.java
@@ -26,6 +26,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Transport action that trains a model and serializes it to model system index
@@ -66,7 +67,8 @@ public class TrainingModelTransportAction extends HandledTransportAction<Trainin
             trainingDataEntryContext,
             modelAnonymousEntryContext,
             request.getDimension(),
-            request.getDescription()
+            request.getDescription(),
+            clusterService.localNode().getEphemeralId()
         );
 
         KNNCounter.TRAINING_REQUESTS.increment();
@@ -84,7 +86,7 @@ public class TrainingModelTransportAction extends HandledTransportAction<Trainin
                         wrappedListener::onFailure
                     )
                 );
-        } catch (IOException e) {
+        } catch (IOException | ExecutionException | InterruptedException e) {
             wrappedListener.onFailure(e);
         }
     }

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -65,7 +65,8 @@ public class TrainingJob implements Runnable {
         NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext,
         NativeMemoryEntryContext.AnonymousEntryContext modelAnonymousEntryContext,
         int dimension,
-        String description
+        String description,
+        String nodeAssignment
     ) {
         // Generate random base64 string if one is not provided
         this.modelId = StringUtils.isNotBlank(modelId) ? modelId : UUIDs.randomBase64UUID();
@@ -81,7 +82,8 @@ public class TrainingJob implements Runnable {
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 description,
-                ""
+                "",
+                nodeAssignment
             ),
             null,
             this.modelId

--- a/src/main/java/org/opensearch/knn/training/TrainingJobClusterStateListener.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobClusterStateListener.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterStateListener;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+import org.opensearch.search.SearchHit;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * TrainingJobClusterStateListener is a ClusterStateListener that is used to update models that are still training when a node leaves or the cluster crashes.
+ * This class also sets a flag in TrainingJobRunner to block serialization when a node rejoins a cluster.
+ */
+@Log4j2
+public class TrainingJobClusterStateListener implements ClusterStateListener {
+    private static TrainingJobClusterStateListener INSTANCE;
+
+    private static ModelDao modelDao;
+    private static ThreadPool threadPool;
+    private static ClusterService clusterService;
+    private String oldClusterManagerNodeId = "";
+    private String currentClusterManagerNodeId = "";
+    private boolean clusterManagerNodeRemoved = false;
+
+    /**
+     * Get singleton instance of TrainingJobRunner
+     *
+     * @return singleton instance of TrainingJobRunner
+     */
+    public static synchronized TrainingJobClusterStateListener getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TrainingJobClusterStateListener();
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * Initializes static components.
+     *
+     * @param threadPool threadPool to use to schedule update of models
+     * @param modelDao modelDao used to get modelIds
+     * @param clusterService clusterService used to add a listener
+     */
+    public static synchronized void initialize(ThreadPool threadPool, ModelDao modelDao, ClusterService clusterService) {
+        TrainingJobClusterStateListener.threadPool = threadPool;
+        TrainingJobClusterStateListener.modelDao = modelDao;
+        TrainingJobClusterStateListener.clusterService = clusterService;
+    }
+
+    /**
+     * This method is called whenever the cluster state changes.
+     * It is used to update models that are still training when a node leaves or the cluster crashes.
+     * It is also used to cancel training jobs when a node rejoins the cluster.
+     * @param event the event that changed the cluster change
+     */
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.localNodeClusterManager()) {
+            if (event.isNewCluster()) {
+                // When the cluster is first created, the cluster manager will update models that are still marked as training.
+                threadPool.schedule(() -> {
+                    try {
+                        updateModelsNewCluster();
+                    } catch (IOException | InterruptedException | ExecutionException e) {
+                        throw new RuntimeException(e);
+                    }
+                }, TimeValue.timeValueSeconds(1), ThreadPool.Names.GENERIC);
+            } else if (event.nodesRemoved()) {
+                List<DiscoveryNode> removedNodes = event.nodesDelta().removedNodes();
+                threadPool.schedule(() -> {
+                    try {
+                        updateModelsNodesRemoved(removedNodes);
+                    } catch (IOException | InterruptedException | ExecutionException e) {
+                        throw new RuntimeException(e);
+                    }
+                }, TimeValue.timeValueSeconds(0), ThreadPool.Names.GENERIC);
+            }
+        }
+    }
+
+    protected void updateModelsNewCluster() throws IOException, InterruptedException, ExecutionException {
+        if (modelDao.isCreated()) {
+            List<String> modelIds = searchModelIds();
+            for (String modelId : modelIds) {
+                Model model = modelDao.get(modelId);
+                ModelMetadata modelMetadata = model.getModelMetadata();
+                if (modelMetadata.getState().equals(ModelState.TRAINING)) {
+                    updateModelStateAsFailed(model, "Training failed to complete as cluster crashed");
+                }
+            }
+        }
+    }
+
+    protected void updateModelsNodesRemoved(List<DiscoveryNode> removedNodes) throws IOException, InterruptedException, ExecutionException {
+        if (modelDao.isCreated()) {
+            List<String> modelIds = searchModelIds();
+            for (DiscoveryNode removedNode : removedNodes) {
+                for (String modelId : modelIds) {
+                    Model model = modelDao.get(modelId);
+                    ModelMetadata modelMetadata = model.getModelMetadata();
+                    if (modelMetadata.getNodeAssignment().equals(removedNode.getEphemeralId())
+                        && modelMetadata.getState().equals(ModelState.TRAINING)) {
+                        updateModelStateAsFailed(model, "Training failed to complete as node dropped");
+                    }
+                }
+            }
+        }
+    }
+
+    private List<String> searchModelIds() throws IOException, InterruptedException {
+        List<String> modelIds = new ArrayList<String>();
+        CountDownLatch latch = new CountDownLatch(1);
+        modelDao.search(new SearchRequest(), new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                try {
+                    for (SearchHit searchHit : searchResponse.getHits().getHits()) {
+                        modelIds.add(searchHit.getId());
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                latch.countDown();
+            }
+        });
+        latch.await();
+        return modelIds;
+    }
+
+    private void updateModelStateAsFailed(Model model, String msg) throws IOException {
+        model.getModelMetadata().setState(ModelState.FAILED);
+        model.getModelMetadata().setError(msg);
+        modelDao.update(model, new ActionListener<IndexResponse>() {
+            @Override
+            public void onResponse(IndexResponse indexResponse) {
+                log.info("Model {} marked as {}", model.getModelID(), model.getModelMetadata().getState());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                log.error("Failed to update model state", e);
+            }
+        });
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -61,7 +61,8 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
-            ""
+            "",
+            "test-node"
         );
 
         Model model = new Model(modelMetadata, modelBlob, modelId);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -341,7 +341,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
 
         byte[] modelBytes = JNIService.trainIndex(parameters, dimension, trainingPtr, knnEngine.getName());
         Model model = new Model(
-            new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED, "timestamp", "Empty description", ""),
+            new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED, "timestamp", "Empty description", "", ""),
             modelBytes,
             modelId
         );

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -204,6 +204,7 @@ public class KNNCodecTestCase extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -163,6 +163,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
         builder.modelId.setValue(modelId);
@@ -688,6 +689,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             dimension,
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
             "",
             ""
         );

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -42,6 +42,7 @@ public class ModelCacheTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             "hello".getBytes(),
@@ -76,6 +77,7 @@ public class ModelCacheTests extends KNNTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -133,6 +135,7 @@ public class ModelCacheTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             new byte[size1],
@@ -146,6 +149,7 @@ public class ModelCacheTests extends KNNTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -189,6 +193,7 @@ public class ModelCacheTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             new byte[size1],
@@ -202,6 +207,7 @@ public class ModelCacheTests extends KNNTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -250,6 +256,7 @@ public class ModelCacheTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             "hello".getBytes(),
@@ -293,6 +300,7 @@ public class ModelCacheTests extends KNNTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -361,6 +369,7 @@ public class ModelCacheTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             new byte[modelSize1],
@@ -401,6 +410,7 @@ public class ModelCacheTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             new byte[modelSize1],
@@ -416,6 +426,7 @@ public class ModelCacheTests extends KNNTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -460,6 +471,7 @@ public class ModelCacheTests extends KNNTestCase {
                     dimension,
                     ModelState.CREATED,
                     ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                    "",
                     "",
                     ""
                 ),

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -136,6 +136,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             modelBlob,
@@ -153,6 +154,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.FAILED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -179,6 +181,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -238,6 +241,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -299,6 +303,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             modelBlob,
@@ -333,6 +338,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -370,6 +376,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -420,6 +427,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             modelBlob,
@@ -436,6 +444,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -472,6 +481,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 
@@ -481,7 +491,6 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         final CountDownLatch inProgressLatch1 = new CountDownLatch(1);
         ActionListener<IndexResponse> docCreationListener = ActionListener.wrap(response -> {
             assertEquals(modelId, response.getId());
-
             ModelMetadata modelMetadata1 = modelDao.getMetadata(modelId);
             assertEquals(modelMetadata, modelMetadata1);
 
@@ -548,6 +557,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             modelBlob,
@@ -579,6 +589,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -646,6 +657,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             modelBlob,
@@ -685,6 +697,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 dimension,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),

--- a/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
@@ -38,6 +38,7 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 
@@ -58,6 +59,7 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 
@@ -72,6 +74,7 @@ public class ModelMetadataTests extends KNNTestCase {
             128,
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
             "",
             ""
         );
@@ -88,6 +91,7 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 
@@ -103,6 +107,7 @@ public class ModelMetadataTests extends KNNTestCase {
             modelState,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 
@@ -111,7 +116,7 @@ public class ModelMetadataTests extends KNNTestCase {
 
     public void testGetTimestamp() {
         String timeValue = ZonedDateTime.now(ZoneOffset.UTC).toString();
-        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED, timeValue, "", "");
+        ModelMetadata modelMetadata = new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 12, ModelState.CREATED, timeValue, "", "", "");
 
         assertEquals(timeValue, modelMetadata.getTimestamp());
     }
@@ -125,6 +130,7 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             description,
+            "",
             ""
         );
 
@@ -140,7 +146,8 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
-            error
+            error,
+            ""
         );
 
         assertEquals(error, modelMetadata.getError());
@@ -154,6 +161,7 @@ public class ModelMetadataTests extends KNNTestCase {
             12,
             modelState,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
             "",
             ""
         );
@@ -174,7 +182,8 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.TRAINING,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
-            error
+            error,
+            ""
         );
 
         assertEquals(error, modelMetadata.getError());
@@ -192,6 +201,7 @@ public class ModelMetadataTests extends KNNTestCase {
         String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String description = "test-description";
         String error = "test-error";
+        String nodeAssignment = "";
 
         String expected = knnEngine.getName()
             + ","
@@ -205,9 +215,20 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + description
             + ","
-            + error;
+            + error
+            + ","
+            + nodeAssignment;
 
-        ModelMetadata modelMetadata = new ModelMetadata(knnEngine, spaceType, dimension, modelState, timestamp, description, error);
+        ModelMetadata modelMetadata = new ModelMetadata(
+            knnEngine,
+            spaceType,
+            dimension,
+            modelState,
+            timestamp,
+            description,
+            error,
+            nodeAssignment
+        );
 
         assertEquals(expected, modelMetadata.toString());
     }
@@ -217,14 +238,14 @@ public class ModelMetadataTests extends KNNTestCase {
         String time1 = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String time2 = ZonedDateTime.of(2021, 9, 30, 12, 20, 45, 1, ZoneId.systemDefault()).toString();
 
-        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "");
+        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "", "");
 
-        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING, time1, "", "");
-        ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time2, "", "");
+        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING, time1, "", "", "");
+        ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time2, "", "", "");
         ModelMetadata modelMetadata8 = new ModelMetadata(
             KNNEngine.FAISS,
             SpaceType.L2,
@@ -232,9 +253,19 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             time1,
             "diff descript",
+            "",
             ""
         );
-        ModelMetadata modelMetadata9 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "diff error");
+        ModelMetadata modelMetadata9 = new ModelMetadata(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            128,
+            ModelState.CREATED,
+            time1,
+            "",
+            "diff error",
+            ""
+        );
 
         assertEquals(modelMetadata1, modelMetadata1);
         assertEquals(modelMetadata1, modelMetadata2);
@@ -254,14 +285,14 @@ public class ModelMetadataTests extends KNNTestCase {
         String time1 = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String time2 = ZonedDateTime.of(2021, 9, 30, 12, 20, 45, 1, ZoneId.systemDefault()).toString();
 
-        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "");
+        ModelMetadata modelMetadata1 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata2 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "", "");
 
-        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED, time1, "", "");
-        ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING, time1, "", "");
-        ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time2, "", "");
+        ModelMetadata modelMetadata3 = new ModelMetadata(KNNEngine.NMSLIB, SpaceType.L2, 128, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata4 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L1, 128, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata5 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 129, ModelState.CREATED, time1, "", "", "");
+        ModelMetadata modelMetadata6 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.TRAINING, time1, "", "", "");
+        ModelMetadata modelMetadata7 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time2, "", "", "");
         ModelMetadata modelMetadata8 = new ModelMetadata(
             KNNEngine.FAISS,
             SpaceType.L2,
@@ -269,9 +300,19 @@ public class ModelMetadataTests extends KNNTestCase {
             ModelState.CREATED,
             time1,
             "diff descript",
+            "",
             ""
         );
-        ModelMetadata modelMetadata9 = new ModelMetadata(KNNEngine.FAISS, SpaceType.L2, 128, ModelState.CREATED, time1, "", "diff error");
+        ModelMetadata modelMetadata9 = new ModelMetadata(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            128,
+            ModelState.CREATED,
+            time1,
+            "",
+            "diff error",
+            ""
+        );
 
         assertEquals(modelMetadata1.hashCode(), modelMetadata1.hashCode());
         assertEquals(modelMetadata1.hashCode(), modelMetadata2.hashCode());
@@ -294,6 +335,7 @@ public class ModelMetadataTests extends KNNTestCase {
         String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String description = "test-description";
         String error = "test-error";
+        String nodeAssignment = "test-node";
 
         String stringRep1 = knnEngine.getName()
             + ","
@@ -307,12 +349,42 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + description
             + ","
+            + error
+            + ","
+            + nodeAssignment;
+
+        String stringRep2 = knnEngine.getName()
+            + ","
+            + spaceType.getValue()
+            + ","
+            + dimension
+            + ","
+            + modelState.getName()
+            + ","
+            + timestamp
+            + ","
+            + description
+            + ","
             + error;
 
-        ModelMetadata expected = new ModelMetadata(knnEngine, spaceType, dimension, modelState, timestamp, description, error);
-        ModelMetadata fromString1 = ModelMetadata.fromString(stringRep1);
+        ModelMetadata expected1 = new ModelMetadata(
+            knnEngine,
+            spaceType,
+            dimension,
+            modelState,
+            timestamp,
+            description,
+            error,
+            nodeAssignment
+        );
 
-        assertEquals(expected, fromString1);
+        ModelMetadata expected2 = new ModelMetadata(knnEngine, spaceType, dimension, modelState, timestamp, description, error, "");
+
+        ModelMetadata fromString1 = ModelMetadata.fromString(stringRep1);
+        ModelMetadata fromString2 = ModelMetadata.fromString(stringRep2);
+
+        assertEquals(expected1, fromString1);
+        assertEquals(expected2, fromString2);
 
         expectThrows(IllegalArgumentException.class, () -> ModelMetadata.fromString("invalid"));
     }
@@ -325,8 +397,19 @@ public class ModelMetadataTests extends KNNTestCase {
         String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String description = "test-description";
         String error = "test-error";
+        String nodeAssignment = "test-node";
 
-        ModelMetadata expected = new ModelMetadata(knnEngine, spaceType, dimension, modelState, timestamp, description, error);
+        ModelMetadata expected = new ModelMetadata(
+            knnEngine,
+            spaceType,
+            dimension,
+            modelState,
+            timestamp,
+            description,
+            error,
+            nodeAssignment
+        );
+        ModelMetadata expected2 = new ModelMetadata(knnEngine, spaceType, dimension, modelState, timestamp, description, error, "");
         Map<String, Object> metadataAsMap = new HashMap<>();
         metadataAsMap.put(KNNConstants.KNN_ENGINE, knnEngine.getName());
         metadataAsMap.put(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
@@ -335,8 +418,13 @@ public class ModelMetadataTests extends KNNTestCase {
         metadataAsMap.put(KNNConstants.MODEL_TIMESTAMP, timestamp);
         metadataAsMap.put(KNNConstants.MODEL_DESCRIPTION, description);
         metadataAsMap.put(KNNConstants.MODEL_ERROR, error);
+        metadataAsMap.put(KNNConstants.MODEL_NODE_ASSIGNMENT, nodeAssignment);
 
         ModelMetadata fromMap = ModelMetadata.getMetadataFromSourceMap(metadataAsMap);
         assertEquals(expected, fromMap);
+
+        metadataAsMap.put(KNNConstants.MODEL_NODE_ASSIGNMENT, null);
+        assertEquals(expected2, fromMap);
+
     }
 }

--- a/src/test/java/org/opensearch/knn/indices/ModelStateTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelStateTests.java
@@ -31,5 +31,8 @@ public class ModelStateTests extends KNNTestCase {
 
     public void testGetModelState() {
         assertEquals(ModelState.CREATED, ModelState.getModelState(ModelState.CREATED.getName()));
+        assertEquals(ModelState.TRAINING, ModelState.getModelState(ModelState.TRAINING.getName()));
+        assertEquals(ModelState.FAILED, ModelState.getModelState(ModelState.FAILED.getName()));
+        expectThrows(IllegalArgumentException.class, () -> ModelState.getModelState("throw-exception"));
     }
 }

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -38,6 +38,7 @@ public class ModelTests extends KNNTestCase {
                     ModelState.FAILED,
                     ZonedDateTime.now(ZoneOffset.UTC).toString(),
                     "",
+                    "",
                     ""
                 ),
                 null,
@@ -57,6 +58,7 @@ public class ModelTests extends KNNTestCase {
                     ModelState.CREATED,
                     ZonedDateTime.now(ZoneOffset.UTC).toString(),
                     "",
+                    "",
                     ""
                 ),
                 new byte[16],
@@ -73,6 +75,7 @@ public class ModelTests extends KNNTestCase {
                     ModelState.CREATED,
                     ZonedDateTime.now(ZoneOffset.UTC).toString(),
                     "",
+                    "",
                     ""
                 ),
                 new byte[16],
@@ -88,6 +91,7 @@ public class ModelTests extends KNNTestCase {
                     KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT) + 1,
                     ModelState.CREATED,
                     ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                    "",
                     "",
                     ""
                 ),
@@ -106,6 +110,7 @@ public class ModelTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
         Model model = new Model(modelMetadata, new byte[16], "test-model");
@@ -121,6 +126,7 @@ public class ModelTests extends KNNTestCase {
                 2,
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
                 "",
                 ""
             ),
@@ -140,6 +146,7 @@ public class ModelTests extends KNNTestCase {
                 ModelState.CREATED,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             new byte[size],
@@ -155,6 +162,7 @@ public class ModelTests extends KNNTestCase {
                 ModelState.TRAINING,
                 ZonedDateTime.now(ZoneOffset.UTC).toString(),
                 "",
+                "",
                 ""
             ),
             null,
@@ -166,7 +174,16 @@ public class ModelTests extends KNNTestCase {
     public void testSetModelBlob() {
         byte[] blob1 = "Hello blob 1".getBytes();
         Model model = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, ZonedDateTime.now(ZoneOffset.UTC).toString(), "", ""),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L1,
+                2,
+                ModelState.CREATED,
+                ZonedDateTime.now(ZoneOffset.UTC).toString(),
+                "",
+                "",
+                ""
+            ),
             blob1,
             "test-model"
         );
@@ -182,17 +199,17 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", ""),
             new byte[16],
             "test-model-1"
         );
         Model model2 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", ""),
             new byte[16],
             "test-model-1"
         );
         Model model3 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED, time, "", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED, time, "", "", ""),
             new byte[16],
             "test-model-2"
         );
@@ -207,17 +224,17 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", ""),
             new byte[16],
             "test-model-1"
         );
         Model model2 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", ""),
             new byte[16],
             "test-model-1"
         );
         Model model3 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", ""),
             new byte[16],
             "test-model-2"
         );
@@ -236,8 +253,18 @@ public class ModelTests extends KNNTestCase {
         String timestamp = ZonedDateTime.now(ZoneOffset.UTC).toString();
         String description = "test-description";
         String error = "test-error";
+        String nodeAssignment = "test-node";
 
-        ModelMetadata metadata = new ModelMetadata(knnEngine, spaceType, dimension, modelState, timestamp, description, error);
+        ModelMetadata metadata = new ModelMetadata(
+            knnEngine,
+            spaceType,
+            dimension,
+            modelState,
+            timestamp,
+            description,
+            error,
+            nodeAssignment
+        );
         Map<String, Object> modelAsMap = new HashMap<>();
         modelAsMap.put(KNNConstants.MODEL_ID, modelID);
         modelAsMap.put(KNNConstants.KNN_ENGINE, knnEngine.getName());
@@ -247,6 +274,7 @@ public class ModelTests extends KNNTestCase {
         modelAsMap.put(KNNConstants.MODEL_TIMESTAMP, timestamp);
         modelAsMap.put(KNNConstants.MODEL_DESCRIPTION, description);
         modelAsMap.put(KNNConstants.MODEL_ERROR, error);
+        modelAsMap.put(KNNConstants.MODEL_NODE_ASSIGNMENT, nodeAssignment);
         modelAsMap.put(KNNConstants.MODEL_BLOB_PARAMETER, "aGVsbG8=");
 
         byte[] blob1 = "hello".getBytes();

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -48,7 +48,7 @@ import static org.opensearch.knn.index.util.KNNEngine.FAISS;
 public class RestSearchModelHandlerIT extends KNNRestTestCase {
 
     private ModelMetadata getModelMetadata() {
-        return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, ModelState.CREATED, "2021-03-27", "test model", "");
+        return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, ModelState.CREATED, "2021-03-27", "test model", "", "");
     }
 
     public void testNotSupportedParams() throws IOException {

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public class GetModelResponseTests extends KNNTestCase {
 
     private ModelMetadata getModelMetadata(ModelState state) {
-        return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, state, "2021-03-27 10:15:30 AM +05:30", "test model", "");
+        return new ModelMetadata(KNNEngine.DEFAULT, SpaceType.DEFAULT, 4, state, "2021-03-27 10:15:30 AM +05:30", "test model", "", "");
     }
 
     public void testStreams() throws IOException {
@@ -47,7 +47,7 @@ public class GetModelResponseTests extends KNNTestCase {
         Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
         GetModelResponse getModelResponse = new GetModelResponse(model);
         String expectedResponseString =
-            "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\"}";
+            "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\"}";
         XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
         getModelResponse.toXContent(xContentBuilder, null);
         assertEquals(expectedResponseString, xContentBuilder.toString());
@@ -58,7 +58,7 @@ public class GetModelResponseTests extends KNNTestCase {
         Model model = new Model(getModelMetadata(ModelState.FAILED), null, modelId);
         GetModelResponse getModelResponse = new GetModelResponse(model);
         String expectedResponseString =
-            "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\"}";
+            "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\"}";
         XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
         getModelResponse.toXContent(xContentBuilder, null);
         assertEquals(expectedResponseString, xContentBuilder.toString());

--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -68,7 +68,7 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
         ModelDao modelDao = mock(ModelDao.class);
         String modelId = "test-model-id";
         Model model = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 16, ModelState.CREATED, "timestamp", "description", ""),
+            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 16, ModelState.CREATED, "timestamp", "description", "", ""),
             new byte[128],
             modelId
         );

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
@@ -167,6 +167,7 @@ public class TrainingModelRequestTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
@@ -39,6 +39,7 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest(modelId, isRemoveRequest, modelMetadata);
@@ -61,6 +62,7 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             128,
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
             "",
             ""
         );
@@ -99,6 +101,7 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             128,
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
             "",
             ""
         );

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -65,6 +65,7 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
             ModelState.CREATED,
             ZonedDateTime.now(ZoneOffset.UTC).toString(),
             "",
+            "",
             ""
         );
 

--- a/src/test/java/org/opensearch/knn/training/TrainingJobClusterStateListenerTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobClusterStateListenerTests.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.indices.Model;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
+
+public class TrainingJobClusterStateListenerTests extends KNNTestCase {
+    public void testClusterChanged() throws InterruptedException {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        TrainingJobClusterStateListener trainingJobClusterStateListener = TrainingJobClusterStateListener.getInstance();
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+        doAnswer(invocationOnMock -> { return null; }).when(threadPool)
+            .schedule(any(Runnable.class), any(TimeValue.class), any(String.class));
+
+        ModelDao modelDao = mock(ModelDao.class);
+        ClusterChangedEvent clusterChangedEvent = mock(ClusterChangedEvent.class);
+        when(clusterChangedEvent.localNodeClusterManager()).thenReturn(true);
+        when(clusterChangedEvent.isNewCluster()).thenReturn(true);
+
+        TrainingJobClusterStateListener.initialize(threadPool, modelDao, clusterService);
+
+        trainingJobClusterStateListener.clusterChanged(clusterChangedEvent);
+
+        verify(threadPool, times(1)).schedule(any(Runnable.class), any(TimeValue.class), any(String.class));
+
+        when(clusterChangedEvent.isNewCluster()).thenReturn(false);
+        when(clusterChangedEvent.nodesRemoved()).thenReturn(true);
+        DiscoveryNodes.Delta delta = mock(DiscoveryNodes.Delta.class);
+        List<DiscoveryNode> nodes = new ArrayList<>();
+        when(clusterChangedEvent.nodesDelta()).thenReturn(delta);
+        when(delta.removedNodes()).thenReturn(nodes);
+
+        trainingJobClusterStateListener.clusterChanged(clusterChangedEvent);
+
+        verify(threadPool, times(2)).schedule(any(Runnable.class), any(TimeValue.class), any(String.class));
+        verify(clusterChangedEvent, times(1)).nodesDelta();
+
+        when(clusterChangedEvent.nodesRemoved()).thenReturn(false);
+        trainingJobClusterStateListener.clusterChanged(clusterChangedEvent);
+        verify(threadPool, times(2)).schedule(any(Runnable.class), any(TimeValue.class), any(String.class));
+
+        when(clusterChangedEvent.localNodeClusterManager()).thenReturn(false);
+        trainingJobClusterStateListener.clusterChanged(clusterChangedEvent);
+        verify(threadPool, times(2)).schedule(any(Runnable.class), any(TimeValue.class), any(String.class));
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    public void testUpdateModelsNewCluster() throws IOException, InterruptedException, ExecutionException {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        TrainingJobClusterStateListener trainingJobClusterStateListener = TrainingJobClusterStateListener.getInstance();
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+
+        String modelId = "test-model-id";
+        Model model = mock(Model.class);
+        ModelMetadata modelMetadata = mock(ModelMetadata.class);
+        when(modelMetadata.getState()).thenReturn(ModelState.TRAINING);
+        when(model.getModelMetadata()).thenReturn(modelMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        when(modelDao.isCreated()).thenReturn(true);
+        when(modelDao.get(modelId)).thenReturn(model);
+        doAnswer(invocationOnMock -> {
+            SearchResponse searchResponse = mock(SearchResponse.class);
+            SearchHits searchHits = mock(SearchHits.class);
+            when(searchResponse.getHits()).thenReturn(searchHits);
+            SearchHit searchHit = mock(SearchHit.class);
+            when(searchHit.getId()).thenReturn(modelId);
+            SearchHit[] searchHitArray = new SearchHit[1];
+            searchHitArray[0] = searchHit;
+            when(searchHits.getHits()).thenReturn(searchHitArray);
+            ((ActionListener<SearchResponse>) invocationOnMock.getArguments()[1]).onResponse(searchResponse);
+            return null;
+        }).when(modelDao).search(any(SearchRequest.class), any(ActionListener.class));
+        doAnswer(invocationOnMock -> { return null; }).when(modelDao).update(any(Model.class), any(ActionListener.class));
+
+        TrainingJobClusterStateListener.initialize(threadPool, modelDao, clusterService);
+
+        trainingJobClusterStateListener.updateModelsNewCluster();
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        verify(modelMetadata, times(1)).setState(ModelState.FAILED);
+        verify(modelMetadata, times(1)).setError("Training failed to complete as cluster crashed");
+        verify(modelDao, times(1)).update(any(Model.class), any(ActionListener.class));
+    }
+
+    public void testUpdateModelsNodesRemoved() throws IOException, InterruptedException, ExecutionException {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        TrainingJobClusterStateListener trainingJobClusterStateListener = TrainingJobClusterStateListener.getInstance();
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(TRAIN_THREAD_POOL)).thenReturn(executorService);
+
+        String modelId = "test-model-id";
+        Model model = mock(Model.class);
+        ModelMetadata modelMetadata = mock(ModelMetadata.class);
+        when(modelMetadata.getState()).thenReturn(ModelState.TRAINING);
+        when(modelMetadata.getNodeAssignment()).thenReturn("test-node-model-match");
+        when(model.getModelMetadata()).thenReturn(modelMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        when(modelDao.isCreated()).thenReturn(true);
+        when(modelDao.get(modelId)).thenReturn(model);
+        DiscoveryNode node1 = mock(DiscoveryNode.class);
+        when(node1.getEphemeralId()).thenReturn("test-node-model-match");
+        DiscoveryNode node2 = mock(DiscoveryNode.class);
+        when(node2.getEphemeralId()).thenReturn("test-node-not-model-match");
+        List<DiscoveryNode> nodes = new ArrayList<DiscoveryNode>();
+        nodes.add(node1);
+        nodes.add(node2);
+        doAnswer(invocationOnMock -> {
+            SearchResponse searchResponse = mock(SearchResponse.class);
+            SearchHits searchHits = mock(SearchHits.class);
+            when(searchResponse.getHits()).thenReturn(searchHits);
+            SearchHit searchHit = mock(SearchHit.class);
+            when(searchHit.getId()).thenReturn(modelId);
+            SearchHit[] searchHitArray = new SearchHit[1];
+            searchHitArray[0] = searchHit;
+            when(searchHits.getHits()).thenReturn(searchHitArray);
+            ((ActionListener<SearchResponse>) invocationOnMock.getArguments()[1]).onResponse(searchResponse);
+            return null;
+        }).when(modelDao).search(any(SearchRequest.class), any(ActionListener.class));
+        doAnswer(invocationOnMock -> { return null; }).when(modelDao).update(any(Model.class), any(ActionListener.class));
+
+        TrainingJobClusterStateListener.initialize(threadPool, modelDao, clusterService);
+
+        trainingJobClusterStateListener.updateModelsNodesRemoved(nodes);
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        verify(modelMetadata, times(1)).setState(ModelState.FAILED);
+        verify(modelMetadata, times(1)).setError("Training failed to complete as node dropped");
+        verify(modelDao, times(1)).update(any(Model.class), any(ActionListener.class));
+    }
+}

--- a/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
@@ -17,13 +17,12 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -37,7 +36,7 @@ import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
 public class TrainingJobRunnerTests extends KNNTestCase {
 
     @SuppressWarnings("unchecked")
-    public void testExecute_success() throws IOException, InterruptedException {
+    public void testExecute_success() throws IOException, InterruptedException, ExecutionException {
         // Test makes sure the correct execution logic follows on successful run
         ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -48,6 +47,9 @@ public class TrainingJobRunnerTests extends KNNTestCase {
 
         String modelId = "test-model-id";
         Model model = mock(Model.class);
+        ModelMetadata modelMetadata = mock(ModelMetadata.class);
+        when(modelMetadata.getState()).thenReturn(ModelState.TRAINING);
+        when(model.getModelMetadata()).thenReturn(modelMetadata);
         TrainingJob trainingJob = mock(TrainingJob.class);
         when(trainingJob.getModelId()).thenReturn(modelId);
         when(trainingJob.getModel()).thenReturn(model);
@@ -63,6 +65,7 @@ public class TrainingJobRunnerTests extends KNNTestCase {
         // After put finishes, it should call the onResponse function that will call responseListener and then kickoff
         // training.
         ModelDao modelDao = mock(ModelDao.class);
+        when(modelDao.get(modelId)).thenReturn(model);
         doAnswer(invocationOnMock -> {
             assertEquals(1, trainingJobRunner.getJobCount()); // Make sure job count is correct
             IndexResponse indexResponse = new IndexResponse(new ShardId(MODEL_INDEX_NAME, "uuid", 0), modelId, 0, 0, 0, true);
@@ -88,7 +91,7 @@ public class TrainingJobRunnerTests extends KNNTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testExecute_failure_rejected() throws IOException, InterruptedException {
+    public void testExecute_failure_rejected() throws IOException, InterruptedException, ExecutionException {
         // This test makes sure we reject another request when one is ongoing. To do this, we call
         // trainingJobRunner.execute(trainingJob, responseListener) in the mocked modeldao.update. At this point,
         // the call should produce a failure because a training job is already ongoing.
@@ -100,6 +103,9 @@ public class TrainingJobRunnerTests extends KNNTestCase {
 
         String modelId = "test-model-id";
         Model model = mock(Model.class);
+        ModelMetadata modelMetadata = mock(ModelMetadata.class);
+        when(modelMetadata.getState()).thenReturn(ModelState.TRAINING);
+        when(model.getModelMetadata()).thenReturn(modelMetadata);
         TrainingJob trainingJob = mock(TrainingJob.class);
         when(trainingJob.getModelId()).thenReturn(modelId);
         when(trainingJob.getModel()).thenReturn(model);
@@ -115,6 +121,7 @@ public class TrainingJobRunnerTests extends KNNTestCase {
         // After put finishes, it should call the onResponse function that will call responseListener and then kickoff
         // training.
         ModelDao modelDao = mock(ModelDao.class);
+        when(modelDao.get(modelId)).thenReturn(model);
         doAnswer(invocationOnMock -> {
             IndexResponse indexResponse = new IndexResponse(new ShardId(MODEL_INDEX_NAME, "uuid", 0), modelId, 0, 0, 0, true);
             ((ActionListener<IndexResponse>) invocationOnMock.getArguments()[1]).onResponse(indexResponse);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -52,7 +52,8 @@ public class TrainingJobTests extends KNNTestCase {
             mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
             mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
             10,
-            ""
+            "",
+            "test-node"
         );
 
         assertEquals(modelId, trainingJob.getModelId());
@@ -62,8 +63,9 @@ public class TrainingJobTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.INNER_PRODUCT;
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         int dimension = 10;
-        String desciption = "test description";
+        String description = "test description";
         String error = "";
+        String nodeAssignment = "test-node";
 
         KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
         when(knnMethodContext.getKnnEngine()).thenReturn(knnEngine);
@@ -77,7 +79,8 @@ public class TrainingJobTests extends KNNTestCase {
             mock(NativeMemoryEntryContext.TrainingDataEntryContext.class),
             mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
             dimension,
-            desciption
+            description,
+            nodeAssignment
         );
 
         Model model = new Model(
@@ -87,8 +90,9 @@ public class TrainingJobTests extends KNNTestCase {
                 dimension,
                 ModelState.TRAINING,
                 trainingJob.getModel().getModelMetadata().getTimestamp(),
-                desciption,
-                error
+                description,
+                error,
+                nodeAssignment
             ),
             null,
             modelID
@@ -159,7 +163,9 @@ public class TrainingJobTests extends KNNTestCase {
             trainingDataEntryContext,
             modelContext,
             dimension,
-            ""
+            "",
+            "test-node"
+
         );
 
         trainingJob.run();
@@ -235,7 +241,9 @@ public class TrainingJobTests extends KNNTestCase {
             trainingDataEntryContext,
             modelContext,
             dimension,
-            ""
+            "",
+
+            "test-node"
         );
 
         trainingJob.run();
@@ -301,7 +309,9 @@ public class TrainingJobTests extends KNNTestCase {
             trainingDataEntryContext,
             modelContext,
             dimension,
-            ""
+            "",
+
+            "test-node"
         );
 
         trainingJob.run();
@@ -366,7 +376,8 @@ public class TrainingJobTests extends KNNTestCase {
             trainingDataEntryContext,
             mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
             dimension,
-            ""
+            "",
+            "test-node"
         );
 
         trainingJob.run();
@@ -438,7 +449,8 @@ public class TrainingJobTests extends KNNTestCase {
             trainingDataEntryContext,
             modelContext,
             dimension,
-            ""
+            "",
+            "test-node"
         );
 
         trainingJob.run();

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -77,6 +77,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE
 import static org.opensearch.knn.common.KNNConstants.MODEL_BLOB_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ERROR;
+import static org.opensearch.knn.common.KNNConstants.MODEL_NODE_ASSIGNMENT;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_MAPPING_PATH;
 import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
@@ -735,6 +736,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .field(MODEL_TIMESTAMP, modelMetadata.getTimestamp())
             .field(MODEL_DESCRIPTION, modelMetadata.getDescription())
             .field(MODEL_ERROR, modelMetadata.getError())
+            .field(MODEL_NODE_ASSIGNMENT, modelMetadata.getNodeAssignment())
             .endObject();
 
         request.setJsonEntity(builder.toString());


### PR DESCRIPTION
### Description
There is currently a bug where models will be stuck in the state TRAINING when a node crashes or leaves the cluster. Since there is a write block on training models, they cannot be removed even though they are not actually training. This PR marks the models as their proper state (either ZOMBIE or FAILED) when a node crashes or leaves the cluster, so that the zombie models can be deleted.

Backport of https://github.com/opensearch-project/k-NN/pull/1317
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/837
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
