### PR TITLE
[Backport 2.x] Tuned default values for ef_search and ef_construction for better indexing and search performance (#1353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add parent join support for lucene knn [#1182](https://github.com/opensearch-project/k-NN/pull/1182)
 ### Enhancements
 * Increase Lucene max dimension limit to 16,000 [#1346](https://github.com/opensearch-project/k-NN/pull/1346)
+* Tuned default values for ef_search and ef_construction for better indexing and search performance for vector search [#1353](https://github.com/opensearch-project/k-NN/pull/1353)
 ### Bug Fixes
 * Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)
 * Properly designate model state for actively training models when nodes crash or leave cluster [#1317](https://github.com/opensearch-project/k-NN/pull/1317)
 
->>>>>>> main
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/KNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethod.java
@@ -63,7 +63,7 @@ public class KNNMethod {
             );
         }
 
-        ValidationException methodValidation = methodComponent.validate(knnMethodContext.getMethodComponent());
+        ValidationException methodValidation = methodComponent.validate(knnMethodContext.getMethodComponentContext());
         if (methodValidation != null) {
             errorMessages.addAll(methodValidation.validationErrors());
         }
@@ -84,7 +84,7 @@ public class KNNMethod {
      * @return true if training is required; false otherwise
      */
     public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
-        return methodComponent.isTrainingRequired(knnMethodContext.getMethodComponent());
+        return methodComponent.isTrainingRequired(knnMethodContext.getMethodComponentContext());
     }
 
     /**
@@ -95,7 +95,7 @@ public class KNNMethod {
      * @return estimate overhead in KB
      */
     public int estimateOverheadInKB(KNNMethodContext knnMethodContext, int dimension) {
-        return methodComponent.estimateOverheadInKB(knnMethodContext.getMethodComponent(), dimension);
+        return methodComponent.estimateOverheadInKB(knnMethodContext.getMethodComponentContext(), dimension);
     }
 
     /**
@@ -105,7 +105,7 @@ public class KNNMethod {
      * @return KNNMethod as a map
      */
     public Map<String, Object> getAsMap(KNNMethodContext knnMethodContext) {
-        Map<String, Object> parameterMap = new HashMap<>(methodComponent.getAsMap(knnMethodContext.getMethodComponent()));
+        Map<String, Object> parameterMap = new HashMap<>(methodComponent.getAsMap(knnMethodContext.getMethodComponentContext()));
         parameterMap.put(KNNConstants.SPACE_TYPE, knnMethodContext.getSpaceType().getValue());
         return parameterMap;
     }

--- a/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethodContext.java
@@ -63,7 +63,7 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
     @NonNull
     private final SpaceType spaceType;
     @NonNull
-    private final MethodComponentContext methodComponent;
+    private final MethodComponentContext methodComponentContext;
 
     /**
      * Constructor from stream.
@@ -74,7 +74,7 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
     public KNNMethodContext(StreamInput in) throws IOException {
         this.knnEngine = KNNEngine.getEngine(in.readString());
         this.spaceType = SpaceType.getSpace(in.readString());
-        this.methodComponent = new MethodComponentContext(in);
+        this.methodComponentContext = new MethodComponentContext(in);
     }
 
     /**
@@ -198,7 +198,7 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(KNN_ENGINE, knnEngine.getName());
         builder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
-        builder = methodComponent.toXContent(builder, params);
+        builder = methodComponentContext.toXContent(builder, params);
         return builder;
     }
 
@@ -211,20 +211,20 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         equalsBuilder.append(knnEngine, other.knnEngine);
         equalsBuilder.append(spaceType, other.spaceType);
-        equalsBuilder.append(methodComponent, other.methodComponent);
+        equalsBuilder.append(methodComponentContext, other.methodComponentContext);
 
         return equalsBuilder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(methodComponent).toHashCode();
+        return new HashCodeBuilder().append(knnEngine).append(spaceType).append(methodComponentContext).toHashCode();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(knnEngine.getName());
         out.writeString(spaceType.getValue());
-        this.methodComponent.writeTo(out);
+        this.methodComponentContext.writeTo(out);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
+++ b/src/main/java/org/opensearch/knn/index/MethodComponentContext.java
@@ -11,8 +11,10 @@
 
 package org.opensearch.knn.index;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -36,12 +38,16 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  *
  * Each component is composed of a name and a map of parameters.
  */
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class MethodComponentContext implements ToXContentFragment, Writeable {
 
     @Getter
     private final String name;
     private final Map<String, Object> parameters;
+
+    @Getter
+    @Setter
+    private Version indexVersion;
 
     /**
      * Constructor from stream.

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -47,7 +47,7 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
                 String.format("Cannot read field type for field [%s] because mapper service is not available", field)
             )
         ).fieldType(field);
-        var params = type.getKnnMethodContext().getMethodComponent().getParameters();
+        var params = type.getKnnMethodContext().getMethodComponentContext().getParameters();
         int maxConnections = getMaxConnections(params);
         int beamWidth = getBeamWidth(params);
         log.debug(

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -44,7 +44,8 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
             input.getCopyTo(),
             input.getIgnoreMalformed(),
             input.isStored(),
-            input.isHasDocValues()
+            input.isHasDocValues(),
+            input.getKnnMethodContext().getMethodComponentContext().getIndexVersion()
         );
 
         vectorDataType = input.getVectorDataType();

--- a/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java
@@ -34,7 +34,16 @@ public class MethodFieldMapper extends KNNVectorFieldMapper {
         KNNMethodContext knnMethodContext
     ) {
 
-        super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
+        super(
+            simpleName,
+            mappedFieldType,
+            multiFields,
+            copyTo,
+            ignoreMalformed,
+            stored,
+            hasDocValues,
+            knnMethodContext.getMethodComponentContext().getIndexVersion()
+        );
 
         this.knnMethod = knnMethodContext;
 

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.FieldType;
+import org.opensearch.Version;
 import org.opensearch.common.Explicit;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.knn.indices.ModelDao;
@@ -29,9 +30,10 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
         boolean stored,
         boolean hasDocValues,
         ModelDao modelDao,
-        String modelId
+        String modelId,
+        Version indexCreatedVersion
     ) {
-        super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues);
+        super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues, indexCreatedVersion);
 
         this.modelId = modelId;
         this.modelDao = modelDao;

--- a/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/AbstractKNNLibrary.java
@@ -35,22 +35,24 @@ public abstract class AbstractKNNLibrary implements KNNLibrary {
 
     @Override
     public ValidationException validateMethod(KNNMethodContext knnMethodContext) {
-        String methodName = knnMethodContext.getMethodComponent().getName();
+        String methodName = knnMethodContext.getMethodComponentContext().getName();
         return getMethod(methodName).validate(knnMethodContext);
     }
 
     @Override
     public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
-        String methodName = knnMethodContext.getMethodComponent().getName();
+        String methodName = knnMethodContext.getMethodComponentContext().getName();
         return getMethod(methodName).isTrainingRequired(knnMethodContext);
     }
 
     @Override
     public Map<String, Object> getMethodAsMap(KNNMethodContext knnMethodContext) {
-        KNNMethod knnMethod = methods.get(knnMethodContext.getMethodComponent().getName());
+        KNNMethod knnMethod = methods.get(knnMethodContext.getMethodComponentContext().getName());
 
         if (knnMethod == null) {
-            throw new IllegalArgumentException(String.format("Invalid method name: %s", knnMethodContext.getMethodComponent().getName()));
+            throw new IllegalArgumentException(
+                String.format("Invalid method name: %s", knnMethodContext.getMethodComponentContext().getName())
+            );
         }
 
         return knnMethod.getAsMap(knnMethodContext);

--- a/src/main/java/org/opensearch/knn/index/util/IndexHyperParametersUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexHyperParametersUtil.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.Version;
+import org.opensearch.knn.index.KNNSettings;
+
+/**
+ * This class acts as an abstraction to get the default hyperparameter values for different parameters used in the
+ * Nearest Neighbor Algorithm across different version of Index.
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IndexHyperParametersUtil {
+
+    private static final int INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION_OLD_VALUE = 512;
+    private static final int INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH_OLD_VALUE = 512;
+
+    /**
+     * Returns the default value of EF Construction that should be used for the input index version. After version 2.12.0
+     * of Opensearch we are have reduced the value of ef_construction in favor of better build times.
+     *
+     * @param indexVersion {@code Version} of the index with which it was created.
+     * @return default value of EF Construction that should be used for the input index version.
+     */
+    public static int getHNSWEFConstructionValue(@NonNull final Version indexVersion) {
+        if (indexVersion.before(Version.V_2_12_0)) {
+            log.debug(
+                "Picking up old values of ef_construction : index version : {}, value: {}",
+                indexVersion,
+                INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION_OLD_VALUE
+            );
+            return INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION_OLD_VALUE;
+        }
+        log.debug(
+            "Picking up new values of ef_construction : index version : {}, value: {}",
+            indexVersion,
+            KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION
+        );
+        return KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION;
+    }
+
+    /**
+     * Returns the default value of EF Search that should be used for the input index version. After version 2.12.0
+     * of Opensearch we are have reduced the value of ef_search in favor of better latency.
+     *
+     * @param indexVersion {@code Version} of the index with which it was created.
+     * @return default value of EF Search that should be used for the input index version.
+     */
+    public static int getHNSWEFSearchValue(@NonNull final Version indexVersion) {
+        if (indexVersion.before(Version.V_2_12_0)) {
+            log.debug(
+                "Picking up old values of ef_search : index version : {}, value: {}",
+                indexVersion,
+                INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH_OLD_VALUE
+            );
+            return INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH_OLD_VALUE;
+        }
+        log.debug(
+            "Picking up new values of ef_search : index version : {}, value: {}",
+            indexVersion,
+            KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH
+        );
+        return KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/util/NativeLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/NativeLibrary.java
@@ -62,7 +62,7 @@ abstract class NativeLibrary extends AbstractKNNLibrary {
 
     @Override
     public int estimateOverheadInKB(KNNMethodContext knnMethodContext, int dimension) {
-        String methodName = knnMethodContext.getMethodComponent().getName();
+        String methodName = knnMethodContext.getMethodComponentContext().getName();
         return getMethod(methodName).estimateOverheadInKB(knnMethodContext, dimension);
     }
 

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
@@ -59,6 +60,7 @@ public class IndexUtilTests extends KNNTestCase {
         Settings settings = Settings.builder().loadFromMap(indexSettings).build();
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
         when(indexMetadata.getSettings()).thenReturn(settings);
+        when(indexMetadata.getCreationVersion()).thenReturn(Version.CURRENT);
         Metadata metadata = mock(Metadata.class);
         when(metadata.index(anyString())).thenReturn(indexMetadata);
         ClusterState clusterState = mock(ClusterState.class);

--- a/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMethodContextTests.java
@@ -66,7 +66,7 @@ public class KNNMethodContextTests extends KNNTestCase {
     public void testGetMethodComponent() {
         MethodComponentContext methodComponent = new MethodComponentContext("test-method", Collections.emptyMap());
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, methodComponent);
-        assertEquals(methodComponent, knnMethodContext.getMethodComponent());
+        assertEquals(methodComponent, knnMethodContext.getMethodComponentContext());
     }
 
     /**
@@ -275,7 +275,7 @@ public class KNNMethodContextTests extends KNNTestCase {
             .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
-        assertTrue(knnMethodContext.getMethodComponent().getParameters().isEmpty());
+        assertTrue(knnMethodContext.getMethodComponentContext().getParameters().isEmpty());
     }
 
     /**
@@ -291,8 +291,8 @@ public class KNNMethodContextTests extends KNNTestCase {
 
         assertEquals(KNNEngine.DEFAULT, knnMethodContext.getKnnEngine());
         assertEquals(SpaceType.DEFAULT, knnMethodContext.getSpaceType());
-        assertEquals(methodName, knnMethodContext.getMethodComponent().getName());
-        assertTrue(knnMethodContext.getMethodComponent().getParameters().isEmpty());
+        assertEquals(methodName, knnMethodContext.getMethodComponentContext().getName());
+        assertTrue(knnMethodContext.getMethodComponentContext().getParameters().isEmpty());
 
         // Method with parameters
         String methodParameterKey1 = "p-1";
@@ -311,8 +311,8 @@ public class KNNMethodContextTests extends KNNTestCase {
         in = xContentBuilderToMap(xContentBuilder);
         knnMethodContext = KNNMethodContext.parse(in);
 
-        assertEquals(methodParameterValue1, knnMethodContext.getMethodComponent().getParameters().get(methodParameterKey1));
-        assertEquals(methodParameterValue2, knnMethodContext.getMethodComponent().getParameters().get(methodParameterKey2));
+        assertEquals(methodParameterValue1, knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey1));
+        assertEquals(methodParameterValue2, knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey2));
 
         // Method with parameter that is a method context paramet
 
@@ -330,12 +330,12 @@ public class KNNMethodContextTests extends KNNTestCase {
         in = xContentBuilderToMap(xContentBuilder);
         knnMethodContext = KNNMethodContext.parse(in);
 
-        assertTrue(knnMethodContext.getMethodComponent().getParameters().get(methodParameterKey1) instanceof MethodComponentContext);
+        assertTrue(knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey1) instanceof MethodComponentContext);
         assertEquals(
             methodParameterValue1,
-            ((MethodComponentContext) knnMethodContext.getMethodComponent().getParameters().get(methodParameterKey1)).getName()
+            ((MethodComponentContext) knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey1)).getName()
         );
-        assertEquals(methodParameterValue2, knnMethodContext.getMethodComponent().getParameters().get(methodParameterKey2));
+        assertEquals(methodParameterValue2, knnMethodContext.getMethodComponentContext().getParameters().get(methodParameterKey2));
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -136,6 +136,41 @@ public class KNNSettingsTests extends KNNTestCase {
         assertWarnings();
     }
 
+    @SneakyThrows
+    public void testGetEfSearch_whenNoValuesProvidedByUsers_thenDefaultSettingsUsed() {
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        mockNode.client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        mockNode.client().admin().indices().create(new CreateIndexRequest(INDEX_NAME)).actionGet();
+        KNNSettings.state().setClusterService(clusterService);
+
+        Integer efSearchValue = KNNSettings.getEfSearchParam(INDEX_NAME);
+        mockNode.close();
+        assertEquals(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH, efSearchValue);
+        assertWarnings();
+    }
+
+    @SneakyThrows
+    public void testGetEfSearch_whenEFSearchValueSetByUser_thenReturnValue() {
+        int userProvidedEfSearch = 300;
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        mockNode.client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        final Settings settings = Settings.builder()
+            .put(KNNSettings.KNN_ALGO_PARAM_EF_SEARCH, userProvidedEfSearch)
+            .put(KNNSettings.KNN_INDEX, true)
+            .build();
+        mockNode.client().admin().indices().create(new CreateIndexRequest(INDEX_NAME, settings)).actionGet();
+        KNNSettings.state().setClusterService(clusterService);
+
+        int efSearchValue = KNNSettings.getEfSearchParam(INDEX_NAME);
+        mockNode.close();
+        assertEquals(userProvidedEfSearch, efSearchValue);
+        assertWarnings();
+    }
+
     private Node createMockNode(Map<String, Object> configSettings) throws IOException {
         Path configDir = createTempDir();
         File configFile = configDir.resolve("opensearch.yml").toFile();

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -18,6 +18,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.opensearch.Version;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -283,6 +284,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
             spaceType,
             new MethodComponentContext(METHOD_HNSW, ImmutableMap.of(METHOD_PARAMETER_M, 16, METHOD_PARAMETER_EF_CONSTRUCTION, 512))
         );
+        knnMethodContext.getMethodComponentContext().setIndexVersion(Version.CURRENT);
 
         String parameterString = XContentFactory.jsonBuilder().map(knnEngine.getMethodAsMap(knnMethodContext)).toString();
 

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -93,7 +93,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     public void testBuilder_getParameters() {
         String fieldName = "test-field-name";
         ModelDao modelDao = mock(ModelDao.class);
-        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(fieldName, modelDao);
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(fieldName, modelDao, CURRENT);
 
         assertEquals(7, builder.getParameters().size());
         List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
@@ -104,7 +104,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     public void testBuilder_build_fromKnnMethodContext() {
         // Check that knnMethodContext takes precedent over both model and legacy
         ModelDao modelDao = mock(ModelDao.class);
-        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao);
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao, CURRENT);
 
         SpaceType spaceType = SpaceType.COSINESIMIL;
         int m = 17;
@@ -141,7 +141,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     public void testBuilder_build_fromModel() {
         // Check that modelContext takes precedent over legacy
         ModelDao modelDao = mock(ModelDao.class);
-        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao);
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao, CURRENT);
 
         SpaceType spaceType = SpaceType.COSINESIMIL;
         int m = 17;
@@ -179,7 +179,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     public void testBuilder_build_fromLegacy() {
         // Check legacy is picked up if model context and method context are not set
         ModelDao modelDao = mock(ModelDao.class);
-        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao);
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder("test-field-name-1", modelDao, CURRENT);
 
         SpaceType spaceType = SpaceType.COSINESIMIL;
         int m = 17;
@@ -237,10 +237,10 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
         builder.build(builderContext);
 
-        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponent().getName());
+        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponentContext().getName());
         assertEquals(
             efConstruction,
-            builder.knnMethodContext.get().getMethodComponent().getParameters().get(METHOD_PARAMETER_EF_CONSTRUCTION)
+            builder.knnMethodContext.get().getMethodComponentContext().getParameters().get(METHOD_PARAMETER_EF_CONSTRUCTION)
         );
         assertTrue(KNNEngine.LUCENE.isInitialized());
 
@@ -260,8 +260,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             buildParserContext(indexName, settings)
         );
 
-        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponent().getName());
-        assertTrue(builderEmptyParams.knnMethodContext.get().getMethodComponent().getParameters().isEmpty());
+        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponentContext().getName());
+        assertTrue(builderEmptyParams.knnMethodContext.get().getMethodComponentContext().getParameters().isEmpty());
 
         XContentBuilder xContentBuilderUnsupportedParam = XContentFactory.jsonBuilder()
             .startObject()
@@ -485,10 +485,10 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             buildParserContext(indexName, settings)
         );
 
-        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponent().getName());
+        assertEquals(METHOD_HNSW, builder.knnMethodContext.get().getMethodComponentContext().getName());
         assertEquals(
             efConstruction,
-            builder.knnMethodContext.get().getMethodComponent().getParameters().get(METHOD_PARAMETER_EF_CONSTRUCTION)
+            builder.knnMethodContext.get().getMethodComponentContext().getParameters().get(METHOD_PARAMETER_EF_CONSTRUCTION)
         );
 
         // Test invalid parameter

--- a/src/test/java/org/opensearch/knn/index/util/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/FaissTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.util;
 
+import org.opensearch.Version;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNTestCase;
@@ -48,6 +49,7 @@ public class FaissTests extends KNNTestCase {
             .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        knnMethodContext.getMethodComponentContext().setIndexVersion(Version.CURRENT);
 
         Map<String, Object> map = Faiss.INSTANCE.getMethodAsMap(knnMethodContext);
 
@@ -76,6 +78,7 @@ public class FaissTests extends KNNTestCase {
             .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        knnMethodContext.getMethodComponentContext().setIndexVersion(Version.CURRENT);
 
         Map<String, Object> map = Faiss.INSTANCE.getMethodAsMap(knnMethodContext);
 

--- a/src/test/java/org/opensearch/knn/index/util/IndexHyperParametersUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/IndexHyperParametersUtilTests.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.util;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.opensearch.Version;
+import org.opensearch.knn.index.KNNSettings;
+
+public class IndexHyperParametersUtilTests extends TestCase {
+
+    public void testLombokNonNull() {
+        Assert.assertThrows(NullPointerException.class, () -> IndexHyperParametersUtil.getHNSWEFConstructionValue(null));
+        Assert.assertThrows(NullPointerException.class, () -> IndexHyperParametersUtil.getHNSWEFSearchValue(null));
+    }
+
+    public void testGetHNSWEFConstructionValue_withDifferentValues_thenSuccess() {
+        Assert.assertEquals(512, IndexHyperParametersUtil.getHNSWEFConstructionValue(Version.V_2_11_0));
+        Assert.assertEquals(512, IndexHyperParametersUtil.getHNSWEFConstructionValue(Version.V_2_3_0));
+        Assert.assertEquals(
+            KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION.intValue(),
+            IndexHyperParametersUtil.getHNSWEFConstructionValue(Version.CURRENT)
+        );
+
+    }
+
+    public void testGetHNSWEFSearchValue_withDifferentValues_thenSuccess() {
+        Assert.assertEquals(512, IndexHyperParametersUtil.getHNSWEFConstructionValue(Version.V_2_11_0));
+        Assert.assertEquals(512, IndexHyperParametersUtil.getHNSWEFConstructionValue(Version.V_2_3_0));
+        Assert.assertEquals(
+            KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH.intValue(),
+            IndexHyperParametersUtil.getHNSWEFConstructionValue(Version.CURRENT)
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -14,6 +14,7 @@ package org.opensearch.knn.jni;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
+import org.opensearch.Version;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNTestCase;
@@ -840,6 +841,7 @@ public class JNIServiceTests extends KNNTestCase {
             .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        knnMethodContext.getMethodComponentContext().setIndexVersion(Version.CURRENT);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
         byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -12,8 +12,9 @@
 package org.opensearch.knn.training;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
@@ -24,6 +25,7 @@ import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
+import org.opensearch.knn.jni.JNIService;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,6 +40,16 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 
 public class TrainingJobTests extends KNNTestCase {
+
+    private final String trainingIndexName = "trainingindexname";
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        DiscoveryNode mockedDiscoveryNode = mock(DiscoveryNode.class);
+        when(clusterService.localNode()).thenReturn(mockedDiscoveryNode);
+        when(mockedDiscoveryNode.getVersion()).thenReturn(Version.CURRENT);
+    }
 
     public void testGetModelId() {
         String modelId = "test-model-id";
@@ -149,6 +161,8 @@ public class TrainingJobTests extends KNNTestCase {
             NativeMemoryEntryContext.TrainingDataEntryContext.class
         );
         when(trainingDataEntryContext.getKey()).thenReturn(tdataKey);
+        when(trainingDataEntryContext.getTrainIndexName()).thenReturn(trainingIndexName);
+        when(trainingDataEntryContext.getClusterService()).thenReturn(clusterService);
 
         when(nativeMemoryCacheManager.get(trainingDataEntryContext, false)).thenReturn(nativeMemoryAllocation);
         doAnswer(invocationOnMock -> {


### PR DESCRIPTION
### Description
Tuned default values for ef_search and ef_construction for better indexing and search performance (#1353)
 
Backport of https://github.com/opensearch-project/k-NN/pull/1353

auto backport failed: https://github.com/opensearch-project/k-NN/pull/1361 due to backward incompatible changes from core 3.0 to 2.x
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1354
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
