### PR TITLE
Enabled Filtering on Nested Vector fields with top level filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 ### Refactoring
 
-## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.11...2.x)
+## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.12...2.x)
 ### Features
 * Add parent join support for lucene knn [#1182](https://github.com/opensearch-project/k-NN/pull/1182)
 ### Enhancements
 * Increase Lucene max dimension limit to 16,000 [#1346](https://github.com/opensearch-project/k-NN/pull/1346)
 * Tuned default values for ef_search and ef_construction for better indexing and search performance for vector search [#1353](https://github.com/opensearch-project/k-NN/pull/1353)
+* Enabled Filtering on Nested Vector fields with top level filters [#1372](https://github.com/opensearch-project/k-NN/pull/1372)
 ### Bug Fixes
 * Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)

--- a/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
+++ b/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
@@ -1,0 +1,550 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.Assert;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.NestedKnnDocBuilder;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.K;
+import static org.opensearch.knn.common.KNNConstants.KNN;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PATH;
+import static org.opensearch.knn.common.KNNConstants.QUERY;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.common.KNNConstants.TYPE_NESTED;
+import static org.opensearch.knn.common.KNNConstants.VECTOR;
+
+/**
+ * This class contains the IT for some advanced and tricky use-case of filters.
+ * <a href="https://github.com/opensearch-project/k-NN/issues/1356">Github issue</a>
+ */
+public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
+
+    private static final String INDEX_NAME = "advanced_filtering_test_index";
+
+    private static final String FIELD_NAME_NESTED = "test_nested";
+
+    private static final String FIELD_NAME_VECTOR = "test_vector";
+
+    private static final String PROPERTIES_FIELD = "properties";
+
+    private static final String FILTER_FIELD = "filter";
+
+    private static final String TERM_FIELD = "term";
+
+    private static final int k = 20;
+
+    private static final String FIELD_NAME_METADATA = "parking";
+
+    private static final int NUM_DOCS = 50;
+
+    private static final int DOCUMENT_IN_RESPONSE = 10;
+
+    private static final Float[] QUERY_VECTOR = { 5f };
+
+    private static final List<String> enginesToTest = KNNEngine.getEnginesThatSupportsFilters()
+        .stream()
+        .map(KNNEngine::getName)
+        .collect(Collectors.toList());
+
+    /**
+     * {
+     *     "query": {
+     *         "nested": {
+     *             "path": "test_nested",
+     *             "query": {
+     *                 "knn": {
+     *                     "test_nested.test_vector": {
+     *                         "vector": [
+     *                             3
+     *                         ],
+     *                         "k": 20,
+     *                         "filter": {
+     *                             "nested": {
+     *                                 "path": "test_nested",
+     *                                 "query": {
+     *                                     "term": {
+     *                                         "test_nested.parking": "false"
+     *                                     }
+     *                                 }
+     *                             }
+     *                         }
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testFiltering_whenNestedKNNAndFilterFieldWithNestedQueries_thenSuccess() {
+        for (final String engine : enginesToTest) {
+            // Set up the index with nested k-nn and metadata fields
+            createKnnIndex(INDEX_NAME, createNestedMappings(1, engine));
+            for (int i = 1; i <= NUM_DOCS; i++) {
+                // making sure that only 2 documents have valid filters
+                final String metadataFieldValue = i % 2 == 0 ? "false" : "true";
+                String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+                    .addVectors(FIELD_NAME_VECTOR, new Float[] { (float) i + 1 })
+                    .addVectorWithMetadata(FIELD_NAME_VECTOR, new Float[] { (float) i }, FIELD_NAME_METADATA, metadataFieldValue)
+                    .build();
+                addKnnDoc(INDEX_NAME, String.valueOf(i), doc);
+            }
+            refreshIndex(INDEX_NAME);
+            forceMergeKnnIndex(INDEX_NAME);
+
+            // Build the query with both k-nn and filters as nested fields. The filter should also have a nested context
+            final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(QUERY);
+            builder.startObject(TYPE_NESTED);
+            builder.field(PATH, FIELD_NAME_NESTED);
+            builder.startObject(QUERY).startObject(KNN).startObject(FIELD_NAME_NESTED + "." + FIELD_NAME_VECTOR);
+            builder.field(VECTOR, QUERY_VECTOR);
+            builder.field(K, k);
+            builder.startObject(FILTER_FIELD);
+            builder.startObject(TYPE_NESTED);
+            builder.field(PATH, FIELD_NAME_NESTED);
+            builder.startObject(QUERY);
+            builder.startObject(TERM_FIELD);
+            builder.field(FIELD_NAME_NESTED + "." + FIELD_NAME_METADATA, "false");
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject().endObject().endObject().endObject().endObject().endObject();
+
+            validateFilterSearch(builder.toString(), engine);
+            // cleanup
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    /**
+     * {
+     *     "query": {
+     *         "nested": {
+     *             "path": "test_nested",
+     *             "query": {
+     *                 "knn": {
+     *                     "test_nested.test_vector": {
+     *                         "vector": [
+     *                             3
+     *                         ],
+     *                         "k": 20,
+     *                         "filter": {
+     *                             "term": {
+     *                                 "test_nested.parking": "false"
+     *                             }
+     *                         }
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testFiltering_whenNestedKNNAndFilterFieldWithNoNestedContextInFilterQuery_thenSuccess() {
+        for (final String engine : enginesToTest) {
+            // Set up the index with nested k-nn and metadata fields
+            createKnnIndex(INDEX_NAME, createNestedMappings(1, engine));
+            for (int i = 1; i <= NUM_DOCS; i++) {
+                // making sure that only 2 documents have valid filters
+                final String metadataFieldValue = i % 2 == 0 ? "false" : "true";
+                String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+                    .addVectors(FIELD_NAME_VECTOR, new Float[] { (float) i + 1 })
+                    .addVectorWithMetadata(FIELD_NAME_VECTOR, new Float[] { (float) i }, FIELD_NAME_METADATA, metadataFieldValue)
+                    .build();
+                addKnnDoc(INDEX_NAME, String.valueOf(i), doc);
+            }
+            refreshIndex(INDEX_NAME);
+            forceMergeKnnIndex(INDEX_NAME);
+
+            // Build the query with both k-nn and filters as nested fields but a single nested context
+            final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(QUERY);
+            builder.startObject(TYPE_NESTED);
+            builder.field(PATH, FIELD_NAME_NESTED);
+            builder.startObject(QUERY).startObject(KNN).startObject(FIELD_NAME_NESTED + "." + FIELD_NAME_VECTOR);
+            builder.field(VECTOR, QUERY_VECTOR);
+            builder.field(K, k);
+            builder.startObject(FILTER_FIELD);
+            builder.startObject(TERM_FIELD);
+            builder.field(FIELD_NAME_NESTED + "." + FIELD_NAME_METADATA, "false");
+            builder.endObject();
+            builder.endObject();
+            builder.endObject().endObject().endObject().endObject().endObject().endObject();
+
+            validateFilterSearch(builder.toString(), engine);
+
+            // cleanup
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    /**
+     * {
+     * 	"query": {
+     * 		"nested": {
+     * 			"path": "test_nested",
+     * 			"query": {
+     * 				"knn": {
+     * 					"test_nested.test_vector": {
+     * 						"vector": [
+     * 							3
+     * 						],
+     * 						"k": 20,
+     * 						"filter": {
+     * 							"term": {
+     * 								"parking": "false"
+     *                          }
+     *                      }
+     * 					}
+     * 				}
+     * 			}
+     * 		}
+     * 	 }
+     * }
+     *
+     */
+    @SneakyThrows
+    public void testFiltering_whenNestedKNNAndNonNestedFilterFieldWithNonNestedFilterQuery_thenSuccess() {
+        for (final String engine : enginesToTest) {
+            // Set up the index with nested k-nn and metadata fields
+            createKnnIndex(INDEX_NAME, createNestedMappings(1, engine));
+            for (int i = 1; i <= NUM_DOCS; i++) {
+                final String metadataFieldValue = i % 2 == 0 ? "false" : "true";
+                String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+                    .addVectors(FIELD_NAME_VECTOR, new Float[] { (float) i + 1 }, new Float[] { (float) i })
+                    .addTopLevelField(FIELD_NAME_METADATA, metadataFieldValue)
+                    .build();
+                addKnnDoc(INDEX_NAME, String.valueOf(i), doc);
+            }
+            refreshIndex(INDEX_NAME);
+            forceMergeKnnIndex(INDEX_NAME);
+
+            // Build the query with k-nn field as nested query and filter on the top level fields
+            final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(QUERY);
+            builder.startObject(TYPE_NESTED);
+            builder.field(PATH, FIELD_NAME_NESTED);
+            builder.startObject(QUERY).startObject(KNN).startObject(FIELD_NAME_NESTED + "." + FIELD_NAME_VECTOR);
+            builder.field(VECTOR, QUERY_VECTOR);
+            builder.field(K, k);
+            builder.startObject(FILTER_FIELD);
+            builder.startObject(TERM_FIELD);
+            builder.field(FIELD_NAME_METADATA, "false");
+            builder.endObject();
+            builder.endObject();
+            builder.endObject().endObject().endObject().endObject().endObject().endObject();
+
+            validateFilterSearch(builder.toString(), engine);
+
+            // cleanup
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    /**
+     * {
+     *     "query": {
+     *         "knn": {
+     *             "test_vector": {
+     *                 "vector": [
+     *                     3
+     *                 ],
+     *                 "k": 20,
+     *                 "filter": {
+     *                     "bool": {
+     *                         "should": [
+     *                             {
+     *                                 "nested": {
+     *                                     "path": "test_nested",
+     *                                     "query": {
+     *                                         "term": {
+     *                                             "test_nested.parking": "false"
+     *                                         }
+     *                                     }
+     *                                 }
+     *                             }
+     *                         ]
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    public void testFiltering_whenNonNestedKNNAndNestedFilterFieldWithNestedFilterQuery_thenSuccess() {
+        for (final String engine : enginesToTest) {
+            // Set up the index with nested k-nn and metadata fields
+            createKnnIndex(INDEX_NAME, createVectorNonNestedMappings(1, engine));
+            for (int i = 1; i <= NUM_DOCS; i++) {
+                final String metadataFieldValue = i % 2 == 0 ? "false" : "true";
+                String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+                    .addMetadata(ImmutableMap.of(FIELD_NAME_METADATA, metadataFieldValue))
+                    .addTopLevelField(FIELD_NAME_VECTOR, new Float[] { (float) i })
+                    .build();
+                addKnnDoc(INDEX_NAME, String.valueOf(i), doc);
+            }
+            refreshIndex(INDEX_NAME);
+            forceMergeKnnIndex(INDEX_NAME);
+
+            // Build the query when filters are nested with nested path and k-NN field is non nested.
+            final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(QUERY);
+            builder.startObject(KNN).startObject(FIELD_NAME_VECTOR);
+            builder.field(VECTOR, QUERY_VECTOR);
+            builder.field(K, k);
+            builder.startObject(FILTER_FIELD);
+            builder.startObject("bool");
+            builder.startArray("should");
+            builder.startObject();
+
+            builder.startObject(TYPE_NESTED);
+            builder.field(PATH, FIELD_NAME_NESTED);
+
+            builder.startObject(QUERY);
+            builder.startObject(TERM_FIELD);
+            builder.field(FIELD_NAME_NESTED + "." + FIELD_NAME_METADATA, "false");
+            builder.endObject();
+            builder.endObject();
+
+            builder.endObject();
+
+            builder.endObject();
+            builder.endArray();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+
+            validateFilterSearch(builder.toString(), engine);
+            // cleanup
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    /**
+     * {
+     * 	"query": {
+     * 		"knn": {
+     * 			"test_vector": {
+     * 				"vector": [
+     * 					5
+     * 				],
+     * 				"k": 20,
+     * 				"filter": {
+     * 					"bool": {
+     * 						"must": [
+     *                           {
+     * 								"nested": {
+     * 									"path": "test_nested",
+     * 									"query": {
+     * 										"term": {
+     * 											"test_nested.parking": "false"
+     *                                        }
+     *                                    }
+     *                                }
+     *                            },
+     *                            {
+     * 								"term": {
+     * 									"parking": "false"
+     *                                }
+     *                            }
+     * 						]
+     * 					}
+     * 				}
+     * 			}
+     * 		}
+     * 	}
+     * }
+     */
+    @SneakyThrows
+    public void testFiltering_whenNonNestedKNNAndNestedFilterAndNonNestedFieldWithNestedAndNonNestedFilterQuery_thenSuccess() {
+        for (final String engine : enginesToTest) {
+            // Set up the index with nested k-nn and metadata fields
+            createKnnIndex(INDEX_NAME, createVectorNonNestedMappings(1, engine));
+            for (int i = 1; i <= NUM_DOCS; i++) {
+                final String metadataFieldValue = i % 2 == 0 ? "false" : "true";
+                String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+                    .addMetadata(ImmutableMap.of(FIELD_NAME_METADATA, metadataFieldValue))
+                    .addTopLevelField(FIELD_NAME_VECTOR, new Float[] { (float) i })
+                    .addTopLevelField(FIELD_NAME_METADATA, metadataFieldValue)
+                    .build();
+                addKnnDoc(INDEX_NAME, String.valueOf(i), doc);
+            }
+            refreshIndex(INDEX_NAME);
+            forceMergeKnnIndex(INDEX_NAME);
+
+            // Build the query when filters are nested with nested path and k-NN field is non nested.
+            final XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(QUERY);
+            builder.startObject(KNN).startObject(FIELD_NAME_VECTOR);
+            builder.field(VECTOR, QUERY_VECTOR);
+            builder.field(K, k);
+            builder.startObject(FILTER_FIELD);
+            builder.startObject("bool");
+            builder.startArray("must");
+            builder.startObject();
+            builder.startObject(TERM_FIELD);
+            builder.field(FIELD_NAME_METADATA, "false");
+            builder.endObject();
+            builder.endObject();
+
+            builder.startObject();
+
+            builder.startObject(TYPE_NESTED);
+            builder.field(PATH, FIELD_NAME_NESTED);
+
+            builder.startObject(QUERY);
+            builder.startObject(TERM_FIELD);
+            builder.field(FIELD_NAME_NESTED + "." + FIELD_NAME_METADATA, "false");
+            builder.endObject();
+            builder.endObject();
+
+            builder.endObject();
+
+            builder.endObject();
+            builder.endArray();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+
+            validateFilterSearch(builder.toString(), engine);
+            // cleanup
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    private void validateFilterSearch(final String query, final String engine) throws IOException, ParseException {
+        String response = EntityUtils.toString(performSearch(INDEX_NAME, query).getEntity());
+        // Validate number of documents returned as the expected number of documents
+        Assert.assertEquals("For engine " + engine + " : ", DOCUMENT_IN_RESPONSE, parseHits(response));
+        if (KNNEngine.getEngine(engine) == KNNEngine.FAISS) {
+            // Update the filter threshold to 0 to ensure that we are hitting ANN Search use case for FAISS
+            updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 0));
+            response = EntityUtils.toString(performSearch(INDEX_NAME, query).getEntity());
+
+            // Validate number of documents returned as the expected number of documents
+            Assert.assertEquals("For engine " + engine + " with ANN search :", DOCUMENT_IN_RESPONSE, parseHits(response));
+        }
+    }
+
+    /**
+     * Sample return
+     * {
+     *     "properties": {
+     *         "test_nested": {
+     *             "type": "nested",
+     *             "properties": {
+     *                 "test_vector": {
+     *                     "type": "knn_vector",
+     *                     "dimension": 1,
+     *                     "method": {
+     *                         "name": "hnsw",
+     *                         "space_type": "l2",
+     *                         "engine": "lucene"
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    private String createNestedMappings(final int dimension, final String engine) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME_NESTED)
+            .field(TYPE, TYPE_NESTED)
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME_VECTOR)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, engine)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        return builder.toString();
+    }
+
+    /**
+     * Sample return
+     * {
+     *     "properties": {
+     *         "test_vector": {
+     *             "type": "knn_vector",
+     *             "dimension": 1,
+     *             "method": {
+     *                 "name": "hnsw",
+     *                 "space_type": "l2",
+     *                 "engine": "lucene"
+     *             }
+     *         },
+     *         "test_nested": {
+     *             "type": "nested"
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    private String createVectorNonNestedMappings(final int dimension, final String engine) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME_NESTED)
+            .field(TYPE, TYPE_NESTED)
+            .endObject()
+            .startObject(FIELD_NAME_VECTOR)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, engine)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        return builder.toString();
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -222,6 +222,15 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return response;
     }
 
+    protected Response performSearch(final String indexName, final String query) throws IOException {
+        Request request = new Request("POST", "/" + indexName + "/_search");
+        request.setJsonEntity(query);
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+        return response;
+    }
+
     /**
      * Parse the response of KNN search into a List of KNNResults
      */
@@ -502,6 +511,15 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Adds a doc where document is represented as a string.
+     */
+    protected void addKnnDoc(final String index, final String docId, final String document) throws IOException {
+        Request request = new Request("POST", "/" + index + "/_doc/" + docId);
+        request.setJsonEntity(document);
+        client().performRequest(request);
+    }
+
+    /**
      * Add a single numeric field Doc to an index
      */
     protected void addDocWithNumericField(String index, String docId, String fieldName, long value) throws IOException {
@@ -693,6 +711,14 @@ public class KNNRestTestCase extends ODFERestTestCase {
         ).map().get("hits");
 
         return (int) ((Map<String, Object>) responseMap.get("total")).get("value");
+    }
+
+    protected int parseHits(String searchResponseBody) throws IOException {
+        Map<String, Object> responseMap = (Map<String, Object>) createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            searchResponseBody
+        ).map().get("hits");
+        return ((List) responseMap.get("hits")).size();
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/knn/NestedKnnDocBuilder.java
+++ b/src/testFixtures/java/org/opensearch/knn/NestedKnnDocBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class NestedKnnDocBuilder {
+    private XContentBuilder builder;
+    private boolean isNestedFieldBuildCompleted;
+
+    public NestedKnnDocBuilder(final String fieldName) throws IOException {
+        isNestedFieldBuildCompleted = false;
+        builder = XContentFactory.jsonBuilder().startObject().startArray(fieldName);
+    }
+
+    public static NestedKnnDocBuilder create(final String fieldName) throws IOException {
+        return new NestedKnnDocBuilder(fieldName);
+    }
+
+    public NestedKnnDocBuilder addVectors(final String fieldName, final Object[]... vectors) throws IOException {
+        for (Object[] vector : vectors) {
+            builder.startObject();
+            builder.field(fieldName, vector);
+            builder.endObject();
+        }
+        return this;
+    }
+
+    public NestedKnnDocBuilder addVectorWithMetadata(
+        final String fieldName,
+        final Object[] vectorValue,
+        final String metadataFieldName,
+        final Object metadataValue
+    ) throws IOException {
+        builder.startObject();
+        builder.field(fieldName, vectorValue);
+        builder.field(metadataFieldName, metadataValue);
+        builder.endObject();
+        return this;
+    }
+
+    public NestedKnnDocBuilder addMetadata(final Map<String, Object> metadata) throws IOException {
+        builder.startObject();
+        metadata.forEach((k, v) -> {
+            try {
+                builder.field(k, v);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        builder.endObject();
+        return this;
+    }
+
+    /**
+     * Use this function when you want to add top level fields in the document that contains nested fields. Once you
+     * run this function you cannot add anything in the nested field.
+     */
+    public NestedKnnDocBuilder addTopLevelField(final String fieldName, final Object value) throws IOException {
+        if (isNestedFieldBuildCompleted == false) {
+            // Making sure that we close the building of nested field.
+            isNestedFieldBuildCompleted = true;
+            builder.endArray();
+        }
+        builder.field(fieldName, value);
+        return this;
+    }
+
+    public String build() throws IOException {
+        if (isNestedFieldBuildCompleted) {
+            builder.endObject();
+        } else {
+            builder.endArray().endObject();
+        }
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
### Description
Enabled Filtering on Nested Vector fields with top level filters.

After this change, below use case for filtering is supported with vector search(both Lucene and Faiss). The change is BWC.:
1. When vector field is nested and filters are applied on non-nested fields.
2. When vector field is nested and filters are applied nested fields.
3. When vector field is nested and filters are applied on nested fields with nested path provided in filters.
4. When vector field is non-nested and filters are applied on nested fields with nested path provided in filters.

To ensure that any further changes in the filter code we are able to catch the bugs, I added a new IT test class `AdvancedFilteringUseCasesIT` which has integration tests for all the above use-cases.

**Context**
There was feature gap in the efficient filter for both Faiss and Lucene engine, where the filtering was not working with vector search when vector field is a nested field and filter query has the top level fields. 

Please refer #1356 for more details.
 
### Issues Resolved

https://github.com/opensearch-project/k-NN/issues/1356

### Testing
Apart from IT, I did the manual testing for all the below cases. Please check the [#1356](https://github.com/opensearch-project/k-NN/issues/1356#issuecomment-1876731658) for more details the query payloads.


Sr No. | Case Type | KNN engine | KNN Field | Meta data field | KNN Query | Filter Query | Manual Testing Status
-- | -- | -- | -- | -- | -- | -- | --
1 | Base Case | Faiss | Nested | Nested | Nested | Query contains the nested field, but filter query has no nested field context | Working
2 |   | Faiss | Nested | Nested | Nested | Nested Query clause wrapped in Bool query | Working
3 |   | Faiss | Nested | Nested | Nested | nested query clause | Working
  |   |   |   |   |   |   |  
4 | Reported which was not working | Faiss | Nested | Non Nested | Nested | Non Nested | Working
  |   |   |   |   |   |   |  
5 |   | Faiss | Non Nested | Nested | Non Nested | nested query clause | Working
6 |   | Faiss | Non Nested | Nested | Non Nested | Nested Query clause wrapped in Bool query | Working
  |   |   |   |   |   |   |  
  |   |   |   |   |   |   |  
7 | Base Case | Faiss | Non Nested | Non Nested | Non Nested | Non Nested | Working
  |   |   |   |   |   |   |  
  |   |   |   |   |   |   |  
8 | Base Case | Lucene | Nested | Nested | Nested | Query contains the nested field, but filter query has no nested field context | Working
9 |   | Lucene | Nested | Nested | Nested | Nested Query clause wrapped in Bool query | Working
10 |   | Lucene | Nested | Nested | Nested | nested query clause | Working
  |   |   |   |   |   |   |  
11 | Reported which was not working | Lucene | Nested | Non Nested | Nested | Non Nested | Working
  |   |   |   |   |   |   |  
12 |   | Lucene | Non Nested | Nested | Non Nested | nested query clause | Working
13 |   | Lucene | Non Nested | Nested | Non Nested | Nested Query clause wrapped in Bool query | Working
  |   |   |   |   |   |   |  
14 | Base Case | Lucene | Non Nested | Non Nested | Non Nested | Non Nested | Working


### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
