### PR TITLE
Handle multi-vector in exact search scenario

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIterator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.filtered;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
+import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * Inspired by DiversifyingChildrenFloatKnnVectorQuery in lucene
+ * https://github.com/apache/lucene/blob/7b8aece125aabff2823626d5b939abf4747f63a7/lucene/join/src/java/org/apache/lucene/search/join/DiversifyingChildrenFloatKnnVectorQuery.java#L162
+ *
+ * The class is used in KNNWeight to score filtered KNN field by iterating filterIdsArray.
+ */
+public class FilteredIdsKNNIterator {
+    // Array of doc ids to iterate
+    protected final int[] filterIdsArray;
+    protected final float[] queryVector;
+    protected final BinaryDocValues binaryDocValues;
+    protected final SpaceType spaceType;
+    protected float currentScore = Float.NEGATIVE_INFINITY;
+    protected int currentPos = 0;
+
+    public FilteredIdsKNNIterator(
+        final int[] filterIdsArray,
+        final float[] queryVector,
+        final BinaryDocValues binaryDocValues,
+        final SpaceType spaceType
+    ) {
+        this.filterIdsArray = filterIdsArray;
+        this.queryVector = queryVector;
+        this.binaryDocValues = binaryDocValues;
+        this.spaceType = spaceType;
+    }
+
+    /**
+     * Advance to the next doc and update score value with score of the next doc.
+     * DocIdSetIterator.NO_MORE_DOCS is returned when there is no more docs
+     *
+     * @return next doc id
+     */
+    public int nextDoc() throws IOException {
+        if (currentPos >= filterIdsArray.length) {
+            return DocIdSetIterator.NO_MORE_DOCS;
+        }
+        int docId = binaryDocValues.advance(filterIdsArray[currentPos]);
+        currentScore = computeScore();
+        currentPos++;
+        return docId;
+    }
+
+    public float score() {
+        return currentScore;
+    }
+
+    protected float computeScore() throws IOException {
+        final BytesRef value = binaryDocValues.binaryValue();
+        final ByteArrayInputStream byteStream = new ByteArrayInputStream(value.bytes, value.offset, value.length);
+        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
+        final float[] vector = vectorSerializer.byteToFloatArray(byteStream);
+        // Calculates a similarity score between the two vectors with a specified function. Higher similarity
+        // scores correspond to closer vectors.
+        return spaceType.getVectorSimilarityFunction().compare(queryVector, vector);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIterator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.filtered;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BitSet;
+import org.opensearch.knn.index.SpaceType;
+
+import java.io.IOException;
+
+/**
+ * This iterator iterates filterIdsArray to score. However, it dedupe docs per each parent doc
+ * of which ID is set in parentBitSet and only return best child doc with the highest score.
+ */
+public class NestedFilteredIdsKNNIterator extends FilteredIdsKNNIterator {
+    private final BitSet parentBitSet;
+
+    public NestedFilteredIdsKNNIterator(
+        final int[] filterIdsArray,
+        final float[] queryVector,
+        final BinaryDocValues values,
+        final SpaceType spaceType,
+        final BitSet parentBitSet
+    ) {
+        super(filterIdsArray, queryVector, values, spaceType);
+        this.parentBitSet = parentBitSet;
+    }
+
+    /**
+     * Advance to the next best child doc per parent and update score with the best score among child docs from the parent.
+     * DocIdSetIterator.NO_MORE_DOCS is returned when there is no more docs
+     *
+     * @return next best child doc id
+     */
+    @Override
+    public int nextDoc() throws IOException {
+        if (currentPos >= filterIdsArray.length) {
+            return DocIdSetIterator.NO_MORE_DOCS;
+        }
+        currentScore = Float.NEGATIVE_INFINITY;
+        int currentParent = parentBitSet.nextSetBit(filterIdsArray[currentPos]);
+        int bestChild = -1;
+        while (currentPos < filterIdsArray.length && filterIdsArray[currentPos] < currentParent) {
+            binaryDocValues.advance(filterIdsArray[currentPos]);
+            float score = computeScore();
+            if (score > currentScore) {
+                bestChild = filterIdsArray[currentPos];
+                currentScore = score;
+            }
+            currentPos++;
+        }
+
+        return bestChild;
+    }
+}

--- a/src/test/java/org/opensearch/knn/common/Constants.java
+++ b/src/test/java/org/opensearch/knn/common/Constants.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common;
+
+public class Constants {
+    public static final String FIELD_FILTER = "filter";
+    public static final String FIELD_TERM = "term";
+}

--- a/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIteratorTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.filtered;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.util.KNNVectorAsArraySerializer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FilteredIdsKNNIteratorTests extends KNNTestCase {
+    @SneakyThrows
+    public void testNextDoc_whenCalled_IterateAllDocs() {
+        final SpaceType spaceType = SpaceType.L2;
+        final float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        final int[] filterIds = { 1, 2, 3 };
+        final List<float[]> dataVectors = Arrays.asList(
+            new float[] { 11.0f, 12.0f, 13.0f },
+            new float[] { 14.0f, 15.0f, 16.0f },
+            new float[] { 17.0f, 18.0f, 19.0f }
+        );
+        final List<Float> expectedScores = dataVectors.stream()
+            .map(vector -> spaceType.getVectorSimilarityFunction().compare(queryVector, vector))
+            .collect(Collectors.toList());
+
+        BinaryDocValues values = mock(BinaryDocValues.class);
+        final List<BytesRef> byteRefs = dataVectors.stream()
+            .map(vector -> new BytesRef(new KNNVectorAsArraySerializer().floatToByteArray(vector)))
+            .collect(Collectors.toList());
+        when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
+
+        for (int id : filterIds) {
+            when(values.advance(id)).thenReturn(id);
+        }
+
+        // Execute and verify
+        FilteredIdsKNNIterator iterator = new FilteredIdsKNNIterator(filterIds, queryVector, values, spaceType);
+        for (int i = 0; i < filterIds.length; i++) {
+            assertEquals(filterIds[i], iterator.nextDoc());
+            assertEquals(expectedScores.get(i), (Float) iterator.score());
+        }
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIteratorTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.filtered;
+
+import junit.framework.TestCase;
+import lombok.SneakyThrows;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.util.KNNVectorAsArraySerializer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NestedFilteredIdsKNNIteratorTests extends TestCase {
+    @SneakyThrows
+    public void testNextDoc_whenIterate_ReturnBestChildDocsPerParent() {
+        final SpaceType spaceType = SpaceType.L2;
+        final float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        final int[] filterIds = { 0, 2, 3 };
+        // Parent id for 0 -> 1
+        // Parent id for 2, 3 -> 4
+        // In bit representation, it is 10010. In long, it is 18.
+        final BitSet parentBitSet = new FixedBitSet(new long[] { 18 }, 5);
+        final List<float[]> dataVectors = Arrays.asList(
+            new float[] { 11.0f, 12.0f, 13.0f },
+            new float[] { 17.0f, 18.0f, 19.0f },
+            new float[] { 14.0f, 15.0f, 16.0f }
+        );
+        final List<Float> expectedScores = dataVectors.stream()
+            .map(vector -> spaceType.getVectorSimilarityFunction().compare(queryVector, vector))
+            .collect(Collectors.toList());
+
+        BinaryDocValues values = mock(BinaryDocValues.class);
+        final List<BytesRef> byteRefs = dataVectors.stream()
+            .map(vector -> new BytesRef(new KNNVectorAsArraySerializer().floatToByteArray(vector)))
+            .collect(Collectors.toList());
+        when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
+
+        for (int id : filterIds) {
+            when(values.advance(id)).thenReturn(id);
+        }
+
+        // Execute and verify
+        NestedFilteredIdsKNNIterator iterator = new NestedFilteredIdsKNNIterator(filterIds, queryVector, values, spaceType, parentBitSet);
+        assertEquals(filterIds[0], iterator.nextDoc());
+        assertEquals(expectedScores.get(0), iterator.score());
+        assertEquals(filterIds[2], iterator.nextDoc());
+        assertEquals(expectedScores.get(2), iterator.score());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -721,6 +721,16 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return ((List) responseMap.get("hits")).size();
     }
 
+    protected List<String> parseIds(String searchResponseBody) throws IOException {
+        @SuppressWarnings("unchecked")
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            searchResponseBody
+        ).map().get("hits")).get("hits");
+
+        return hits.stream().map(hit -> (String) ((Map<String, Object>) hit).get("_id")).collect(Collectors.toList());
+    }
+
     /**
      * Get the total number of graphs in the cache across all nodes
      */


### PR DESCRIPTION
### Description
When filter query is provided using Faiss engine, knn search can be run in exact search mode instead of ANN mode based on few conditions. One of the condition is when k is larger than the size of list of filtered IDs.
This PR handles multi-vector in the exact search mode with Faiss engine.

 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1065
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
