### PR TITLE
Throw proper exception to invalid k-NN query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)
 * Properly designate model state for actively training models when nodes crash or leave cluster [#1317](https://github.com/opensearch-project/k-NN/pull/1317)
 * Fix script score queries not getting cached [#1367](https://github.com/opensearch-project/k-NN/pull/1367)
+* Throw proper exception to invalid k-NN query [#1380](https://github.com/opensearch-project/k-NN/pull/1380)
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 * Refactor security testing to install from individual components [#1307](https://github.com/opensearch-project/k-NN/pull/1307)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Increase Lucene max dimension limit to 16,000 [#1346](https://github.com/opensearch-project/k-NN/pull/1346)
 * Tuned default values for ef_search and ef_construction for better indexing and search performance for vector search [#1353](https://github.com/opensearch-project/k-NN/pull/1353)
 * Enabled Filtering on Nested Vector fields with top level filters [#1372](https://github.com/opensearch-project/k-NN/pull/1372)
+* * Throw proper exception to invalid k-NN query [#1380](https://github.com/opensearch-project/k-NN/pull/1380)
 ### Bug Fixes
 * Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)
 * Properly designate model state for actively training models when nodes crash or leave cluster [#1317](https://github.com/opensearch-project/k-NN/pull/1317)
 * Fix script score queries not getting cached [#1367](https://github.com/opensearch-project/k-NN/pull/1367)
-* Throw proper exception to invalid k-NN query [#1380](https://github.com/opensearch-project/k-NN/pull/1380)
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 * Refactor security testing to install from individual components [#1307](https://github.com/opensearch-project/k-NN/pull/1307)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Increase Lucene max dimension limit to 16,000 [#1346](https://github.com/opensearch-project/k-NN/pull/1346)
 * Tuned default values for ef_search and ef_construction for better indexing and search performance for vector search [#1353](https://github.com/opensearch-project/k-NN/pull/1353)
 * Enabled Filtering on Nested Vector fields with top level filters [#1372](https://github.com/opensearch-project/k-NN/pull/1372)
-* * Throw proper exception to invalid k-NN query [#1380](https://github.com/opensearch-project/k-NN/pull/1380)
+* Throw proper exception to invalid k-NN query [#1380](https://github.com/opensearch-project/k-NN/pull/1380)
 ### Bug Fixes
 * Fix use-after-free case on nmslib search path [#1305](https://github.com/opensearch-project/k-NN/pull/1305)
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -100,13 +100,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     }
 
     private static float[] ObjectsToFloats(List<Object> objs) {
-        if (Objects.isNull(objs)) {
-            throw new IllegalArgumentException(String.format("[%s] requires 'vector' to be non-null", NAME));
+        if (Objects.isNull(objs) || objs.isEmpty()) {
+            throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be non-null and non-empty", NAME));
         }
         float[] vec = new float[objs.size()];
         for (int i = 0; i < objs.size(); i++) {
-            if (!(objs.get(i) instanceof Number)) {
-                throw new IllegalArgumentException(String.format("[%s] requires 'vector' to be an array of numbers", NAME));
+            if ((objs.get(i) instanceof Number) == false) {
+                throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be an array of numbers", NAME));
             }
             vec[i] = ((Number) objs.get(i)).floatValue();
         }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -100,8 +100,14 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     }
 
     private static float[] ObjectsToFloats(List<Object> objs) {
+        if (Objects.isNull(objs)) {
+            throw new IllegalArgumentException("[" + NAME + "] requires 'vector' to be non-null");
+        }
         float[] vec = new float[objs.size()];
         for (int i = 0; i < objs.size(); i++) {
+            if (!(objs.get(i) instanceof Number)) {
+                throw new IllegalArgumentException("[" + NAME + "] requires 'vector' to be an array of numbers");
+            }
             vec[i] = ((Number) objs.get(i)).floatValue();
         }
         return vec;

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -101,12 +101,12 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     private static float[] ObjectsToFloats(List<Object> objs) {
         if (Objects.isNull(objs)) {
-            throw new IllegalArgumentException("[" + NAME + "] requires 'vector' to be non-null");
+            throw new IllegalArgumentException(String.format("[%s] requires 'vector' to be non-null", NAME));
         }
         float[] vec = new float[objs.size()];
         for (int i = 0; i < objs.size(); i++) {
             if (!(objs.get(i) instanceof Number)) {
-                throw new IllegalArgumentException("[" + NAME + "] requires 'vector' to be an array of numbers");
+                throw new IllegalArgumentException(String.format("[%s] requires 'vector' to be an array of numbers", NAME));
             }
             vec[i] = ((Number) objs.get(i)).floatValue();
         }

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -426,51 +426,6 @@ public class VectorDataTypeIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testSearchWithInvalidSearchVectorType() {
-        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
-        ingestL2FloatTestData();
-        Request request = new Request("POST", String.format("/%s/_search", INDEX_NAME));
-        request.setJsonEntity(
-            "{\n"
-                + "  \"query\": {\n"
-                + "    \"knn\": {\n"
-                + "      \"test-field-vec-dt\": {\n"
-                + "        \"vector\": [\"a\", \"b\", \"c\", \"d\"],\n"
-                + "        \"k\": 4\n"
-                + "      }\n"
-                + "    }\n"
-                + "  }\n"
-                + "}"
-        );
-
-        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
-        assertTrue(ex.getResponse().getStatusLine().getReasonPhrase().contains("Bad Request"));
-        assertTrue(ex.getMessage().contains(String.format(Locale.ROOT, "[knn] requires 'vector' to be an array of numbers")));
-    }
-
-    @SneakyThrows
-    public void testSearchWithMissingQueryVector() {
-        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
-        ingestL2FloatTestData();
-        Request request = new Request("POST", String.format("/%s/_search", INDEX_NAME));
-        request.setJsonEntity(
-            "{\n"
-                + "  \"query\": {\n"
-                + "    \"knn\": {\n"
-                + "      \"test-field-vec-dt\": {\n"
-                + "        \"k\": 4\n"
-                + "      }\n"
-                + "    }\n"
-                + "  }\n"
-                + "}"
-        );
-
-        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
-        assertTrue(ex.getResponse().getStatusLine().getReasonPhrase().contains("Bad Request"));
-        assertTrue(ex.getMessage().contains(String.format(Locale.ROOT, "[knn] requires 'vector' to be non-null")));
-    }
-
-    @SneakyThrows
     private void ingestL2ByteTestData() {
         Byte[] b1 = { 6, 6 };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, b1);

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -426,6 +426,51 @@ public class VectorDataTypeIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testSearchWithInvalidSearchVectorType() {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
+        ingestL2FloatTestData();
+        Request request = new Request("POST", String.format("/%s/_search", INDEX_NAME));
+        request.setJsonEntity(
+            "{\n"
+                + "  \"query\": {\n"
+                + "    \"knn\": {\n"
+                + "      \"test-field-vec-dt\": {\n"
+                + "        \"vector\": [\"a\", \"b\", \"c\", \"d\"],\n"
+                + "        \"k\": 4\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getResponse().getStatusLine().getReasonPhrase().contains("Bad Request"));
+        assertTrue(ex.getMessage().contains(String.format(Locale.ROOT, "[knn] requires 'vector' to be an array of numbers")));
+    }
+
+    @SneakyThrows
+    public void testSearchWithMissingQueryVector() {
+        createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
+        ingestL2FloatTestData();
+        Request request = new Request("POST", String.format("/%s/_search", INDEX_NAME));
+        request.setJsonEntity(
+            "{\n"
+                + "  \"query\": {\n"
+                + "    \"knn\": {\n"
+                + "      \"test-field-vec-dt\": {\n"
+                + "        \"k\": 4\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}"
+        );
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getResponse().getStatusLine().getReasonPhrase().contains("Bad Request"));
+        assertTrue(ex.getMessage().contains(String.format(Locale.ROOT, "[knn] requires 'vector' to be non-null")));
+    }
+
+    @SneakyThrows
     private void ingestL2ByteTestData() {
         Byte[] b1 = { 6, 6 };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, b1);

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -127,6 +127,43 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         actualBuilder.equals(knnQueryBuilder);
     }
 
+    public void testFromXContent_invalidQueryVectorType() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService);
+
+        String[] invalidTypeQueryVector = { "a", "b", "c", "d" };
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), invalidTypeQueryVector);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        expectThrows(IllegalArgumentException.class, () -> KNNQueryBuilder.fromXContent(contentParser));
+    }
+
+    public void testFromXContent_missingQueryVector() throws Exception {
+        final ClusterService clusterService = mockClusterService(Version.CURRENT);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), K);
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        expectThrows(IllegalArgumentException.class, () -> KNNQueryBuilder.fromXContent(contentParser));
+    }
+
     @Override
     protected NamedXContentRegistry xContentRegistry() {
         List<NamedXContentRegistry.Entry> list = ClusterModule.getNamedXWriteables();

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -144,7 +144,11 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         builder.endObject();
         XContentParser contentParser = createParser(builder);
         contentParser.nextToken();
-        expectThrows(IllegalArgumentException.class, () -> KNNQueryBuilder.fromXContent(contentParser));
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNQueryBuilder.fromXContent(contentParser)
+        );
+        assertTrue(exception.getMessage().contains("[knn] requires 'vector' to be an array of numbers"));
     }
 
     public void testFromXContent_missingQueryVector() throws Exception {
@@ -161,7 +165,11 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         builder.endObject();
         XContentParser contentParser = createParser(builder);
         contentParser.nextToken();
-        expectThrows(IllegalArgumentException.class, () -> KNNQueryBuilder.fromXContent(contentParser));
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNQueryBuilder.fromXContent(contentParser)
+        );
+        assertTrue(exception.getMessage().contains("[knn] requires 'vector' to be non-null"));
     }
 
     @Override


### PR DESCRIPTION
### Description
Throw proper exception to invalid k-NN query in some cases:
1. In case of field “vector” is missing, it will cause NullPointerException;
2. In case of the array of “vector” contains non-number object, it will cause cast exception;
 
After the PR, the response will be:
```
// Case 1
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "[knn] requires 'vector' to be non-null"
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "[knn] requires 'vector' to be non-null"
    },
    "status": 400
}
```

```
// Case 2
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "[knn] requires 'vector' to be an array of numbers"
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "[knn] requires 'vector' to be an array of numbers"
    },
    "status": 400
}
```

### Issues Resolved
Closes https://github.com/opensearch-project/k-NN/issues/1379 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
