### PR TITLE
Fix equals and hashCode methods for KNNQuery and KNNQueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Allow nested knn field mapping when train model [#1318](https://github.com/opensearch-project/k-NN/pull/1318)
 * Properly designate model state for actively training models when nodes crash or leave cluster [#1317](https://github.com/opensearch-project/k-NN/pull/1317)
 * Fix script score queries not getting cached [#1367](https://github.com/opensearch-project/k-NN/pull/1367)
+* Fix equals and hashCode methods for KNNQuery and KNNQueryBuilder [#1397](https://github.com/opensearch-project/k-NN/pull/1397)
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 * Refactor security testing to install from individual components [#1307](https://github.com/opensearch-project/k-NN/pull/1307)

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -144,4 +144,4 @@ public class KNNQuery extends Query {
             && Objects.equals(indexName, other.indexName)
             && Objects.equals(filterQuery, other.filterQuery);
     }
-};
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.index.query;
 
+import java.util.Arrays;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.lucene.search.BooleanClause;
@@ -127,7 +129,7 @@ public class KNNQuery extends Query {
 
     @Override
     public int hashCode() {
-        return field.hashCode() ^ queryVector.hashCode() ^ k;
+        return Objects.hash(field, Arrays.hashCode(queryVector), k, indexName, filterQuery);
     }
 
     @Override
@@ -136,6 +138,10 @@ public class KNNQuery extends Query {
     }
 
     private boolean equalsTo(KNNQuery other) {
-        return this.field.equals(other.getField()) && this.queryVector.equals(other.getQueryVector()) && this.k == other.getK();
+        return Objects.equals(field, other.field)
+            && Arrays.equals(queryVector, other.queryVector)
+            && Objects.equals(k, other.k)
+            && Objects.equals(indexName, other.indexName)
+            && Objects.equals(filterQuery, other.filterQuery);
     }
 };

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import java.util.Arrays;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.opensearch.core.common.Strings;
@@ -46,7 +47,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     public static final ParseField K_FIELD = new ParseField("k");
     public static final ParseField FILTER_FIELD = new ParseField("filter");
     public static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
-    public static int K_MAX = 10000;
+    public static final int K_MAX = 10000;
     /**
      * The name for the knn query
      */
@@ -346,12 +347,16 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     @Override
     protected boolean doEquals(KNNQueryBuilder other) {
-        return Objects.equals(fieldName, other.fieldName) && Objects.equals(vector, other.vector) && Objects.equals(k, other.k);
+        return Objects.equals(fieldName, other.fieldName)
+            && Arrays.equals(vector, other.vector)
+            && Objects.equals(k, other.k)
+            && Objects.equals(filter, other.filter)
+            && Objects.equals(ignoreUnmapped, other.ignoreUnmapped);
     }
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(fieldName, vector, k);
+        return Objects.hash(fieldName, Arrays.hashCode(vector), k, filter, ignoreUnmapped);
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -90,7 +90,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         expectThrows(IllegalArgumentException.class, () -> new KNNQueryBuilder(FIELD_NAME, queryVector1, K));
     }
 
-    public void testFromXcontent() throws Exception {
+    public void testFromXContent() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, K);
         XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -103,10 +103,10 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         XContentParser contentParser = createParser(builder);
         contentParser.nextToken();
         KNNQueryBuilder actualBuilder = KNNQueryBuilder.fromXContent(contentParser);
-        actualBuilder.equals(knnQueryBuilder);
+        assertEquals(knnQueryBuilder, actualBuilder);
     }
 
-    public void testFromXcontent_WithFilter() throws Exception {
+    public void testFromXContent_WithFilter() throws Exception {
         final ClusterService clusterService = mockClusterService(Version.CURRENT);
 
         final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
@@ -125,7 +125,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         XContentParser contentParser = createParser(builder);
         contentParser.nextToken();
         KNNQueryBuilder actualBuilder = KNNQueryBuilder.fromXContent(contentParser);
-        actualBuilder.equals(knnQueryBuilder);
+        assertEquals(knnQueryBuilder, actualBuilder);
     }
 
     public void testFromXContent_invalidQueryVectorType() throws Exception {


### PR DESCRIPTION
### Description
The `equals` and `hashCode` implementations of `KNNQuery` and `KNNQueryBuilder` are missing some fields (`indexName` and `filterQuery` for `KNNQuery`, `filter` and `ignoreUnmapped` for `KNNQueryBuilder`) and are not using the correct array comparison/hash method. 

The error in the relevant unit test is as follows:
```
java.lang.AssertionError: expected: org.opensearch.knn.index.query.KNNQueryBuilder<{
  "knn" : {
    "myvector" : {
      "vector" : [
        1.0,
        2.0,
        3.0,
        4.0
      ],
      "k" : 1,
      "filter" : {
        "term" : {
          "field" : {
            "value" : "value",
            "boost" : 1.0
          }
        }
      },
      "boost" : 1.0
    }
  }
}> but was: org.opensearch.knn.index.query.KNNQueryBuilder<{
  "knn" : {
    "myvector" : {
      "vector" : [
        1.0,
        2.0,
        3.0,
        4.0
      ],
      "k" : 1,
      "filter" : {
        "term" : {
          "field" : {
            "value" : "value",
            "boost" : 1.0
          }
        }
      },
      "boost" : 1.0
    }
  }
}>
	at __randomizedtesting.SeedInfo.seed([9EA5DFBEA12B6A22:F50BAC6E9E6B27AA]:0)
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.opensearch.knn.index.query.KNNQueryBuilderTests.testFromXContent_WithFilter(KNNQueryBuilderTests.java:128)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1750)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:938)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:974)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:988)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:817)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:468)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:947)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:832)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:883)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:894)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleStoreClassName$1.evaluate(TestRuleStoreClassName.java:38)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.NoShadowingOrOverridesOnMethodsRule$1.evaluate(NoShadowingOrOverridesOnMethodsRule.java:40)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at org.apache.lucene.tests.util.TestRuleAssertionsRequired$1.evaluate(TestRuleAssertionsRequired.java:53)
	at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
	at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
	at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
	at org.apache.lucene.tests.util.TestRuleIgnoreTestSuites$1.evaluate(TestRuleIgnoreTestSuites.java:47)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:368)
	at java.base/java.lang.Thread.run(Thread.java:832)
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [~] New functionality includes testing.
  - [x] All tests pass
- [~] New functionality has been documented.
  - [~] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
