### PR TITLE
Remove default admin credential references in DEVELOPER_GUIDE

### DIFF
--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -56,4 +56,4 @@ jobs:
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -Dsecurity.enabled=true"
+          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!"

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -56,4 +56,4 @@ jobs:
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!"
+          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -Dsecurity.enabled=true"

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -274,12 +274,12 @@ curl localhost:9200
 
 Additionally, it is also possible to run a cluster with security enabled:
 ```shell script
-./gradlew run -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!
+./gradlew run -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=<admin-password>
 ```
 
 Then, to access the cluster, we can run
 ```bash
-curl https://localhost:9200 --insecure -u admin:myStrongPassword123!
+curl https://localhost:9200 --insecure -u admin:<admin-password>
 
 {
   "name" : "integTest-0",
@@ -327,7 +327,7 @@ Integration tests can be run with remote cluster. For that run the following com
 In case remote cluster is secured it's possible to pass username and password with the following command:
 
 ```
-./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!
+./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=true -Duser=admin -Dpassword=<admin-password>
 ```
 
 ### Debugging

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -274,33 +274,7 @@ curl localhost:9200
 
 Additionally, it is also possible to run a cluster with security enabled:
 ```shell script
-./gradlew run -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=admin
-```
-
-By default, if `-Dsecurity.enabled=true` is passed the following defaults will be used: `https=true`, `user=admin` and
-`password=admin`.
-
-Then, to access the cluster, we can run
-```bash
-curl https://localhost:9200 --insecure -u admin:admin
-
-{
-  "name" : "integTest-0",
-  "cluster_name" : "integTest",
-  "cluster_uuid" : "kLsNk4JDTMyp1yQRqog-3g",
-  "version" : {
-    "distribution" : "opensearch",
-    "number" : "3.0.0-SNAPSHOT",
-    "build_type" : "tar",
-    "build_hash" : "9d85e566894ef53e5f2093618b3d455e4d0a04ce",
-    "build_date" : "2023-10-30T18:34:06.996519Z",
-    "build_snapshot" : true,
-    "lucene_version" : "9.8.0",
-    "minimum_wire_compatibility_version" : "2.12.0",
-    "minimum_index_compatibility_version" : "2.0.0"
-  },
-  "tagline" : "The OpenSearch Project: https://opensearch.org/"
-}
+./gradlew run -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!
 ```
 
 ### Run Multi-node Cluster Locally
@@ -331,7 +305,7 @@ Integration tests can be run with remote cluster. For that run the following com
 In case remote cluster is secured it's possible to pass username and password with the following command:
 
 ```
-./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=true -Duser=admin -Dpassword=admin
+./gradlew :integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="integTest-0" -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!
 ```
 
 ### Debugging

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -277,6 +277,28 @@ Additionally, it is also possible to run a cluster with security enabled:
 ./gradlew run -Dsecurity.enabled=true -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123!
 ```
 
+Then, to access the cluster, we can run
+```bash
+curl https://localhost:9200 --insecure -u admin:myStrongPassword123!
+
+{
+  "name" : "integTest-0",
+  "cluster_name" : "integTest",
+  "cluster_uuid" : "kLsNk4JDTMyp1yQRqog-3g",
+  "version" : {
+    "distribution" : "opensearch",
+    "number" : "3.0.0-SNAPSHOT",
+    "build_type" : "tar",
+    "build_hash" : "9d85e566894ef53e5f2093618b3d455e4d0a04ce",
+    "build_date" : "2023-10-30T18:34:06.996519Z",
+    "build_snapshot" : true,
+    "lucene_version" : "9.8.0",
+    "minimum_wire_compatibility_version" : "2.12.0",
+    "minimum_index_compatibility_version" : "2.0.0"
+  },
+  "tagline" : "The OpenSearch Project: https://opensearch.org/"
+}
+
 ### Run Multi-node Cluster Locally
 
 It can be useful to test and debug on a multi-node cluster. In order to launch a 3 node cluster with the KNN plugin installed, run the following command:

--- a/build.gradle
+++ b/build.gradle
@@ -337,6 +337,13 @@ integTest {
     var user = System.getProperty("user")
     var password = System.getProperty("password")
 
+    if (System.getProperty("security.enabled") != null) {
+        // If security is enabled, set is_https/user/password defaults
+        is_https = is_https == null ? "true" : is_https
+        user = user == null ? "admin" : user
+        password = password == null ? "myStrongPassword123!" : password
+    }
+
     systemProperty("https", is_https)
     systemProperty("user", user)
     systemProperty("password", password)

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        System.setProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "myStrongPassword123!")
 
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
@@ -93,9 +94,9 @@ ext {
         cluster.getNodes().forEach { node ->
             var creds = node.getCredentials()
             if (creds.isEmpty()) {
-                creds.add(Map.of('username', 'admin', 'password', 'myStrongPassword123!'))
+                creds.add(Map.of('username', 'admin', 'password', System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD")))
             } else {
-                creds.get(0).putAll(Map.of('username', 'admin', 'password', 'myStrongPassword123!'))
+                creds.get(0).putAll(Map.of('username', 'admin', 'password', System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD")))
             }
         }
 
@@ -341,7 +342,7 @@ integTest {
         // If security is enabled, set is_https/user/password defaults
         is_https = is_https == null ? "true" : is_https
         user = user == null ? "admin" : user
-        password = password == null ? "myStrongPassword123!" : password
+        password = password == null ? System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD") : password
     }
 
     systemProperty("https", is_https)

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        System.setProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "myStrongPassword123!")
 
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
@@ -94,9 +93,9 @@ ext {
         cluster.getNodes().forEach { node ->
             var creds = node.getCredentials()
             if (creds.isEmpty()) {
-                creds.add(Map.of('username', 'admin', 'password', System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD")))
+                creds.add(Map.of('username', 'admin', 'password', 'admin'))
             } else {
-                creds.get(0).putAll(Map.of('username', 'admin', 'password', System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD")))
+                creds.get(0).putAll(Map.of('username', 'admin', 'password', 'admin'))
             }
         }
 
@@ -342,7 +341,7 @@ integTest {
         // If security is enabled, set is_https/user/password defaults
         is_https = is_https == null ? "true" : is_https
         user = user == null ? "admin" : user
-        password = password == null ? System.getProperty("OPENSEARCH_INITIAL_ADMIN_PASSWORD") : password
+        password = password == null ? "admin" : password
     }
 
     systemProperty("https", is_https)

--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,9 @@ ext {
         cluster.getNodes().forEach { node ->
             var creds = node.getCredentials()
             if (creds.isEmpty()) {
-                creds.add(Map.of('username', 'admin', 'password', 'admin'))
+                creds.add(Map.of('username', 'admin', 'password', 'myStrongPassword123!'))
             } else {
-                creds.get(0).putAll(Map.of('username', 'admin', 'password', 'admin'))
+                creds.get(0).putAll(Map.of('username', 'admin', 'password', 'myStrongPassword123!'))
             }
         }
 
@@ -336,12 +336,7 @@ integTest {
     var is_https = System.getProperty("https")
     var user = System.getProperty("user")
     var password = System.getProperty("password")
-    if (System.getProperty("security.enabled") != null) {
-        // If security is enabled, set is_https/user/password defaults
-        is_https = is_https == null ? "true" : is_https
-        user = user == null ? "admin" : user
-        password = password == null ? "admin" : password
-    }
+
     systemProperty("https", is_https)
     systemProperty("user", user)
     systemProperty("password", password)


### PR DESCRIPTION
### Description
Remove references to admin:admin default security credentials in the developer guide.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1359
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
