### PR TITLE
Skip delete .plugins-ml-config system index during integ test

### DIFF
--- a/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
@@ -51,8 +51,8 @@ import org.junit.After;
 
 import static org.opensearch.knn.TestUtils.KNN_BWC_PREFIX;
 import static org.opensearch.knn.TestUtils.OPENDISTRO_SECURITY;
+import static org.opensearch.knn.TestUtils.ML_PLUGIN_SYSTEM_INDEX_PREFIX;
 import static org.opensearch.knn.TestUtils.OPENSEARCH_SYSTEM_INDEX_PREFIX;
-import static org.opensearch.knn.TestUtils.PLUGINS_ML_CONFIG_INDEX_NAME;
 import static org.opensearch.knn.TestUtils.SECURITY_AUDITLOG_PREFIX;
 import static org.opensearch.knn.TestUtils.SKIP_DELETE_MODEL_INDEX;
 import static org.opensearch.knn.common.KNNConstants.MODELS;
@@ -63,7 +63,12 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
  */
 public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
 
-    private final Set<String> IMMUTABLE_INDEX_PREFIXES = Set.of(KNN_BWC_PREFIX, SECURITY_AUDITLOG_PREFIX, OPENSEARCH_SYSTEM_INDEX_PREFIX);
+    private final Set<String> IMMUTABLE_INDEX_PREFIXES = Set.of(
+        KNN_BWC_PREFIX,
+        SECURITY_AUDITLOG_PREFIX,
+        OPENSEARCH_SYSTEM_INDEX_PREFIX,
+        ML_PLUGIN_SYSTEM_INDEX_PREFIX
+    );
 
     protected boolean isHttps() {
         return Optional.ofNullable(System.getProperty("https")).map("true"::equalsIgnoreCase).orElse(false);
@@ -213,7 +218,6 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
         return indexName == null
             || OPENDISTRO_SECURITY.equals(indexName)
             || IMMUTABLE_INDEX_PREFIXES.stream().anyMatch(indexName::startsWith)
-            || MODEL_INDEX_NAME.equals(indexName)
-            || PLUGINS_ML_CONFIG_INDEX_NAME.equals(indexName);
+            || MODEL_INDEX_NAME.equals(indexName);
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
@@ -52,6 +52,7 @@ import org.junit.After;
 import static org.opensearch.knn.TestUtils.KNN_BWC_PREFIX;
 import static org.opensearch.knn.TestUtils.OPENDISTRO_SECURITY;
 import static org.opensearch.knn.TestUtils.OPENSEARCH_SYSTEM_INDEX_PREFIX;
+import static org.opensearch.knn.TestUtils.PLUGINS_ML_CONFIG_INDEX_NAME;
 import static org.opensearch.knn.TestUtils.SECURITY_AUDITLOG_PREFIX;
 import static org.opensearch.knn.TestUtils.SKIP_DELETE_MODEL_INDEX;
 import static org.opensearch.knn.common.KNNConstants.MODELS;
@@ -212,6 +213,7 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
         return indexName == null
             || OPENDISTRO_SECURITY.equals(indexName)
             || IMMUTABLE_INDEX_PREFIXES.stream().anyMatch(indexName::startsWith)
-            || MODEL_INDEX_NAME.equals(indexName);
+            || MODEL_INDEX_NAME.equals(indexName)
+            || PLUGINS_ML_CONFIG_INDEX_NAME.equals(indexName);
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -99,6 +99,7 @@ public class TestUtils {
     public static final String UPGRADED_CLUSTER = "upgraded_cluster";
     public static final String SECURITY_AUDITLOG_PREFIX = "security-auditlog";
     public static final String OPENSEARCH_SYSTEM_INDEX_PREFIX = ".opensearch";
+    public static final String PLUGINS_ML_CONFIG_INDEX_NAME = ".plugins-ml-config";
 
     // Generating vectors using random function with a seed which makes these vectors standard and generate same vectors for each run.
     public static float[][] randomlyGenerateStandardVectors(int numVectors, int dimensions, int seed) {

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -99,7 +99,7 @@ public class TestUtils {
     public static final String UPGRADED_CLUSTER = "upgraded_cluster";
     public static final String SECURITY_AUDITLOG_PREFIX = "security-auditlog";
     public static final String OPENSEARCH_SYSTEM_INDEX_PREFIX = ".opensearch";
-    public static final String PLUGINS_ML_CONFIG_INDEX_NAME = ".plugins-ml-config";
+    public static final String ML_PLUGIN_SYSTEM_INDEX_PREFIX = ".plugins-ml";
 
     // Generating vectors using random function with a seed which makes these vectors standard and generate same vectors for each run.
     public static float[][] randomlyGenerateStandardVectors(int numVectors, int dimensions, int seed) {


### PR DESCRIPTION
### Description
Skip delete `.plugins-ml-config` system index during integ test.

This PR helps to resolve the error during k-NN build security enabled integ test in release Jenkins concurrent-search-test CI:
```
org.opensearch.client.ResponseException: method [DELETE], host [https://localhost:9200/], URI [/.plugins-ml-config], status line [HTTP/1.1 403 Forbidden]

    {"error":{"root_cause":[{"type":"security_exception","reason":"no permissions for [] and User [name=admin, backend_roles=[admin], requestedTenant=null]"}],"type":"security_exception","reason":"no permissions for [] and User [name=admin, backend_roles=[admin], requestedTenant=null]"},"status":403}

        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:376)
```
 
### Test
With @peterzhuamazon 's help, the Jenkins’s CI build passed  with this code change. Attached logs:
[knn-junqiu-lei-skip-delete-ml-config-gradle.log](https://github.com/opensearch-project/k-NN/files/14058219/knn-junqiu-lei-skip-delete-ml-config-gradle.log)
[2.12.0-concurrent-settings-cluster.log](https://github.com/opensearch-project/k-NN/files/14058220/2.12.0-concurrent-settings-cluster.log)


### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1357, https://github.com/opensearch-project/k-NN/issues/1410, https://github.com/opensearch-project/k-NN/issues/1411, https://github.com/opensearch-project/k-NN/issues/1412
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
