### PR TITLE
Refactor integ tests that access model index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 * Refactor security testing to install from individual components [#1307](https://github.com/opensearch-project/k-NN/pull/1307)
+* Refactor integ tests that access model index [#1423](https://github.com/opensearch-project/k-NN/pull/1423)
 ### Documentation
 ### Maintenance
 * Update developer guide to include M1 Setup [#1222](https://github.com/opensearch-project/k-NN/pull/1222)

--- a/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
@@ -42,7 +42,8 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class RestDeleteModelHandlerIT extends KNNRestTestCase {
 
-    public void testDelete_whenModelExists_thenDeletionSucceeds() throws Exception {
+    @SneakyThrows
+    public void testDelete_whenModelExists_thenDeletionSucceeds() {
         String modelId = "test-model-id";
         String trainingIndexName = "train-index";
         String trainingFieldName = "train-field";

--- a/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.plugin.action;
 
+import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;

--- a/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestDeleteModelHandlerIT.java
@@ -88,7 +88,8 @@ public class RestDeleteModelHandlerIT extends KNNRestTestCase {
     }
 
     // Test Train Model -> Delete Model -> Train Model with same modelId
-    public void testTraining_whenModelHasBeenDeleted_thenSucceedTrainingModelWithSameID() throws Exception {
+    @SneakyThrows
+    public void testTraining_whenModelHasBeenDeleted_thenSucceedTrainingModelWithSameID() {
         String modelId = "test-model-id1";
         String trainingIndexName1 = "train-index-1";
         String trainingIndexName2 = "train-index-2";

--- a/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
@@ -21,7 +21,6 @@ import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.core.rest.RestStatus;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -44,9 +43,7 @@ import static org.opensearch.knn.index.util.KNNEngine.FAISS;
 
 public class RestGetModelHandlerIT extends KNNRestTestCase {
 
-    public void testGetModelExists() throws Exception {
-        createModelSystemIndex();
-
+    public void testGetModel_whenModelIdExists_thenSucceed() throws Exception {
         String modelId = "test-model-id";
         String trainingIndexName = "train-index";
         String trainingFieldName = "train-field";
@@ -81,8 +78,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         assertEquals(L2.getValue(), responseMap.get(METHOD_PARAMETER_SPACE_TYPE));
     }
 
-    public void testGetModelExistsWithFilter() throws Exception {
-        createModelSystemIndex();
+    public void testGetModel_whenFilterApplied_thenReturnExpectedFields() throws Exception {
         String modelId = "test-model-id";
         String trainingIndexName = "train-index";
         String trainingFieldName = "train-field";
@@ -118,8 +114,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         assertFalse(responseMap.containsKey(MODEL_STATE));
     }
 
-    public void testGetModelFailsInvalid() throws IOException {
-        createModelSystemIndex();
+    public void testGetModel_whenModelIDIsInValid_thenFail() {
         String restURI = String.join("/", KNNPlugin.KNN_BASE_URI, MODELS, "invalid-model-id");
         Request request = new Request("GET", restURI);
 
@@ -127,8 +122,7 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         assertTrue(ex.getMessage().contains("\"invalid-model-id\""));
     }
 
-    public void testGetModelFailsBlank() throws IOException {
-        createModelSystemIndex();
+    public void testGetModel_whenIDIsBlank_thenFail() {
         String restURI = String.join("/", KNNPlugin.KNN_BASE_URI, MODELS, " ");
         Request request = new Request("GET", restURI);
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.plugin.action;
 
 import joptsimple.internal.Strings;
+import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;

--- a/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
@@ -79,7 +79,8 @@ public class RestGetModelHandlerIT extends KNNRestTestCase {
         assertEquals(L2.getValue(), responseMap.get(METHOD_PARAMETER_SPACE_TYPE));
     }
 
-    public void testGetModel_whenFilterApplied_thenReturnExpectedFields() throws Exception {
+    @SneakyThrows
+    public void testGetModel_whenFilterApplied_thenReturnExpectedFields() {
         String modelId = "test-model-id";
         String trainingIndexName = "train-index";
         String trainingFieldName = "train-field";

--- a/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestGetModelHandlerIT.java
@@ -43,7 +43,8 @@ import static org.opensearch.knn.index.util.KNNEngine.FAISS;
 
 public class RestGetModelHandlerIT extends KNNRestTestCase {
 
-    public void testGetModel_whenModelIdExists_thenSucceed() throws Exception {
+    @SneakyThrows
+    public void testGetModel_whenModelIdExists_thenSucceed() {
         String modelId = "test-model-id";
         String trainingIndexName = "train-index";
         String trainingFieldName = "train-field";

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -339,7 +339,6 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
     }
 
     public void testModelIndexHealthMetricsStats() throws Exception {
-        // Create request that filters only model index
         String modelIndexStatusName = StatNames.MODEL_INDEX_STATUS.getName();
         // index can be created in one of previous tests, and as we do not delete it each test the check below became optional
         if (!systemIndexExists(MODEL_INDEX_NAME)) {
@@ -351,7 +350,11 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
             // Check that model health status is null since model index is not created to system yet
             assertNull(statsMap.get(StatNames.MODEL_INDEX_STATUS.getName()));
 
-            createModelSystemIndex();
+            // Train a model so that the system index will get created
+            createBasicKnnIndex(TRAINING_INDEX, TRAINING_FIELD, DIMENSION);
+            bulkIngestRandomVectors(TRAINING_INDEX, TRAINING_FIELD, NUM_DOCS, DIMENSION);
+            trainKnnModel(TEST_MODEL_ID, TRAINING_INDEX, TRAINING_FIELD, DIMENSION, MODEL_DESCRIPTION);
+            validateModelCreated(TEST_MODEL_ID);
         }
 
         Response response = getKnnStats(Collections.emptyList(), Arrays.asList(modelIndexStatusName));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.plugin.action;
 
+import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Request;

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -95,7 +95,8 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
 
     }
 
-    public void testSearch_whenModelExists_thenSuccess() throws Exception {
+    @SneakyThrows
+    public void testSearch_whenModelExists_thenSuccess() {
         String trainingIndex = "irrelevant-index";
         String trainingFieldName = "train-field";
         int dimension = 8;

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -52,7 +52,8 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
         expectThrows(ResponseException.class, () -> client().performRequest(request));
     }
 
-    public void testSearch_whenNoModelExists_thenReturnEmptyResults() throws Exception {
+    @SneakyThrows
+    public void testSearch_whenNoModelExists_thenReturnEmptyResults() {
         // Currently, if the model index exists, we will return empty hits. If it does not exist, we will
         // throw an exception. This is somewhat of a bug considering that the model index is supposed to be
         // an implementation detail abstracted away from the user. However, in order to test, we need to handle

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.knn;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
 import com.google.common.primitives.Floats;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
@@ -22,7 +20,6 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
@@ -51,7 +48,6 @@ import javax.management.remote.JMXServiceURL;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -77,8 +73,6 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
-import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_MAPPING_PATH;
-import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
 import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
@@ -778,20 +772,6 @@ public class KNNRestTestCase extends ODFERestTestCase {
             }
             Map<String, Object> userSettings = (Map<String, Object>) settings.get("settings");
             return (String) (userSettings.get(settingName) == null ? defaultSettings.get(settingName) : userSettings.get(settingName));
-        }
-    }
-
-    protected void createModelSystemIndex() throws IOException {
-        URL url = ModelDao.class.getClassLoader().getResource(MODEL_INDEX_MAPPING_PATH);
-        if (url == null) {
-            throw new IllegalStateException("Unable to retrieve mapping for \"" + MODEL_INDEX_NAME + "\"");
-        }
-
-        String mapping = Resources.toString(url, Charsets.UTF_8);
-        mapping = mapping.substring(1, mapping.length() - 1);
-
-        if (!systemIndexExists(MODEL_INDEX_NAME)) {
-            createIndex(MODEL_INDEX_NAME, Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).build(), mapping);
         }
     }
 


### PR DESCRIPTION
### Description
Refactors integration tests that directly access the model system index. End users should not be directly accessing the model system index. It is supposed to be an implementation detail. We have written restful integration tests that directly access the model system index in order to initialize the cluster state. However, we should not do this because users should not be able to interact with it through restful APIs. In fact, in some cluster configurations, it should not be possible.

That being said, some of this implementation detail leaks out through the interface. For instance, in k-NN stats we have a stat that is the model system index status. So, in order to test this, we do need direct access to the system index. Similarly, for search, we execute the search against the system index and directly return the results. This is probably a bug - but we still need to test it. So, for these cases, we check if the index exists.

Additionally, I deleted the test `RestDeleteModelHandlerIT.testDeleteTrainingModel`. This test had an inherit race condition that model that was got trained did not complete until a few lines later. This will lead to flakiness, so I deleted it. This functionality is also already unit tested in ModelDaoTests.

Along with this, I did some test renaming to make test logic more clear using test*_when*_then* convention.
 
### Issues Resolved
#1365 , #888
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
