### PR TITLE
Fix flaky model tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade gradle to 8.4 [1289](https://github.com/opensearch-project/k-NN/pull/1289)
 * Refactor security testing to install from individual components [#1307](https://github.com/opensearch-project/k-NN/pull/1307)
 * Refactor integ tests that access model index [#1423](https://github.com/opensearch-project/k-NN/pull/1423)
+* Fix flaky model tests [#1429](https://github.com/opensearch-project/k-NN/pull/1429)
 ### Documentation
 ### Maintenance
 * Update developer guide to include M1 Setup [#1222](https://github.com/opensearch-project/k-NN/pull/1222)

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -11,7 +11,8 @@
 
 package org.opensearch.knn.indices;
 
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.mockito.MockedStatic;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
@@ -59,7 +60,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.opensearch.cluster.metadata.Metadata.builder;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
@@ -84,7 +87,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         trainingJobClusterStateListenerMockedStatic = mockStatic(TrainingJobClusterStateListener.class);
         final TrainingJobClusterStateListener trainingJobClusterStateListener = mock(TrainingJobClusterStateListener.class);
         doNothing().when(trainingJobClusterStateListener).clusterChanged(any(ClusterChangedEvent.class));
-        trainingJobClusterStateListenerMockedStatic.when(TrainingJobClusterStateListener::getInstance).thenReturn(trainingJobClusterStateListener);
+        trainingJobClusterStateListenerMockedStatic.when(TrainingJobClusterStateListener::getInstance)
+            .thenReturn(trainingJobClusterStateListener);
     }
 
     @AfterClass

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.indices;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.mockito.MockedStatic;
 import org.opensearch.ExceptionsHelper;


### PR DESCRIPTION
### Description
Since `ModelDaoTests` extends `KNNSingleNodeTestCase`, a node is started at the beginning of each test and stopped at the end of each test.  The `TrainingJobClusterStateListenerClass` contains a `clusterChanged` method that is called each time a new cluster is started.  Within this method, a separate thread runs through all existing models and marks any that are stuck in training as failed.  This can result in a scenario that causes flaky tests.

In this scenario, a node is started at the beginning of a test, calling the `clusterChanged` method.  The test creates a model (or multiple), verifies the expected behavior, and then stops the node.  Meanwhile, the other thread is in the process of looping through any existing models and potentially updating their model state parameter.  If the node stops before this process is complete, an exception will be thrown saying that the model index (.opensearch-knn-models) does not exist.

To fix the flaky test situation, the `TrainingJobClusterStateListener` class has been mocked to no-op the `clusterChanged` method in the setup for the class.  This means that there will be no separate thread accessing the models for the entire `ModelDaoTests` class.  In the teardown after the class, the mocked static is closed so it will not affect any other test classes.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1376
https://github.com/opensearch-project/k-NN/issues/1413
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
