### PR TITLE
Disable warning checks in k-NN test case

### DIFF
--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -53,6 +53,11 @@ public class KNNTestCase extends OpenSearchTestCase {
         openMocks.close();
     }
 
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
     public void resetState() {
         // Reset all of the counters
         for (KNNCounter knnCounter : KNNCounter.values()) {
@@ -80,9 +85,5 @@ public class KNNTestCase extends OpenSearchTestCase {
 
     public Map<String, Object> xContentBuilderToMap(XContentBuilder xContentBuilder) {
         return XContentHelper.convertToMap(BytesReference.bytes(xContentBuilder), true, xContentBuilder.contentType()).v2();
-    }
-
-    protected boolean enableWarningsCheck() {
-        return false;
     }
 }

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -81,4 +81,8 @@ public class KNNTestCase extends OpenSearchTestCase {
     public Map<String, Object> xContentBuilderToMap(XContentBuilder xContentBuilder) {
         return XContentHelper.convertToMap(BytesReference.bytes(xContentBuilder), true, xContentBuilder.contentType()).v2();
     }
+
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
 }

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -55,6 +55,8 @@ public class KNNTestCase extends OpenSearchTestCase {
 
     @Override
     protected boolean enableWarningsCheck() {
+        // Disable warnings check to avoid flaky tests, more details at:
+        // https://github.com/opensearch-project/k-NN/issues/1392
         return false;
     }
 

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -51,7 +51,6 @@ public class KNNSettingsTests extends KNNTestCase {
             .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
         mockNode.close();
         assertEquals(expectedKNNCircuitBreakerLimit, actualKNNCircuitBreakerLimit);
-        assertWarnings();
     }
 
     @SneakyThrows
@@ -69,10 +68,6 @@ public class KNNSettingsTests extends KNNTestCase {
             actualKNNCircuitBreakerLimit
 
         );
-        // set warning for deprecation of index.store.hybrid.mmap.extensions as expected temporarily, need to work on proper strategy of
-        // switching to new setting in core
-        // no-jdk distributions expected warning is a workaround for running tests locally
-        assertWarnings();
     }
 
     @SneakyThrows
@@ -87,7 +82,6 @@ public class KNNSettingsTests extends KNNTestCase {
         Integer filteredSearchThreshold = KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME);
         mockNode.close();
         assertEquals(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_DEFAULT_VALUE, filteredSearchThreshold);
-        assertWarnings();
     }
 
     @SneakyThrows
@@ -129,7 +123,6 @@ public class KNNSettingsTests extends KNNTestCase {
         mockNode.close();
         assertEquals(userDefinedThreshold, filteredSearchThreshold);
         assertEquals(userDefinedThresholdMinValue, filteredSearchThresholdMinValue);
-        assertWarnings();
     }
 
     @SneakyThrows
@@ -144,7 +137,6 @@ public class KNNSettingsTests extends KNNTestCase {
         Integer efSearchValue = KNNSettings.getEfSearchParam(INDEX_NAME);
         mockNode.close();
         assertEquals(KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH, efSearchValue);
-        assertWarnings();
     }
 
     @SneakyThrows
@@ -164,7 +156,6 @@ public class KNNSettingsTests extends KNNTestCase {
         int efSearchValue = KNNSettings.getEfSearchParam(INDEX_NAME);
         mockNode.close();
         assertEquals(userProvidedEfSearch, efSearchValue);
-        assertWarnings();
     }
 
     private Node createMockNode(Map<String, Object> configSettings) throws IOException {
@@ -194,15 +185,5 @@ public class KNNSettingsTests extends KNNTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
             .put(dataNode());
-    }
-
-    private void assertWarnings() {
-        // set warning for deprecation of index.store.hybrid.mmap.extensions as expected temporarily, need to work on proper strategy of
-        // switching to new setting in core
-        // no-jdk distributions expected warning is a workaround for running tests locally
-        assertWarnings(
-            "[index.store.hybrid.mmap.extensions] setting was deprecated in OpenSearch and will be removed in a future release! See the breaking changes documentation for the next major version.",
-            "no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release"
-        );
     }
 }


### PR DESCRIPTION
### Description
This PR followed from https://github.com/opensearch-project/k-NN/issues/1392#issuecomment-1932717537 to disable warnings  check in k-NN tests case and remove warning Assertions in KNNSettingsTests

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1392, https://github.com/opensearch-project/k-NN/issues/1391, https://github.com/opensearch-project/k-NN/issues/1390, https://github.com/opensearch-project/k-NN/issues/1389
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
