### PR TITLE
Update Build Script to build libraries with SIMD

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -148,6 +148,20 @@ cd $distributions
 zip -ur $zipPath lib
 cd $work_dir
 
+if [ "$PLATFORM" != "windows" ]; then
+  echo "Building k-NN libraries after enabling SIMD"
+  ./gradlew :buildJniLib -Dsimd.enabled=true
+  mkdir $distributions/lib_simd
+  cp -v $ompPath $distributions/lib_simd
+  cp -v ./jni/release/${libPrefix}* $distributions/lib_simd
+  ls -l $distributions/lib_simd
+
+  # Add lib_simd directory to the k-NN plugin zip
+  cd $distributions
+  zip -ur $zipPath lib_simd
+  cd $work_dir
+fi
+
 echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins
 cp -v ${distributions}/*.zip $OUTPUT/plugins


### PR DESCRIPTION
### Description
Update build script to build and include both the versions of JNI libraries (with and without SIMD optimization) in the final artifact by creating two subdirectories `lib` and `lib_simd`.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4386
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
