### PR TITLE
Fix a bug on sqfp16 test

### DIFF
--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -57,7 +57,8 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class JNIServiceTests extends KNNTestCase {
-
+    static final int FP16_MAX = 65504;
+    static final int FP16_MIN = -65504;
     static TestUtils.TestData testData;
     static TestUtils.TestData testDataNested;
     private String faissMethod = "HNSW32,Flat";
@@ -553,9 +554,9 @@ public class JNIServiceTests extends KNNTestCase {
         for (int i = 0; i < data.length; i++) {
             for (int j = 0; j < data[i].length; j++) {
                 float value = data[i][j];
-                if (value < Float.MIN_VALUE || value > Float.MAX_VALUE) {
+                if (value < FP16_MIN || value > FP16_MAX) {
                     // If value is outside of the range, set it to the maximum or minimum value
-                    result[i][j] = value < 0 ? -Float.MAX_VALUE : Float.MAX_VALUE;
+                    result[i][j] = value < 0 ? FP16_MIN : FP16_MAX;
                 } else {
                     result[i][j] = value;
                 }


### PR DESCRIPTION
### Description
Fix a bug in https://github.com/opensearch-project/k-NN/pull/1474 where invalid max/min value of fp16 is used
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
