### PR TITLE
Update performance test with nested field

### DIFF
--- a/benchmarks/perf-tool/add-parent-doc-id-to-dataset.py
+++ b/benchmarks/perf-tool/add-parent-doc-id-to-dataset.py
@@ -116,8 +116,8 @@ class _Dataset:
             possible_colors = ['red', 'green', 'yellow', 'blue', None]
             possible_tastes = ['sweet', 'salty', 'sour', 'bitter', None]
             max_age = 100
-            min_field_size = 1000
-            max_field_size = 10001
+            min_field_size = 10
+            max_field_size = 10
 
             # Copy train and test data
             for key in in_file.keys():

--- a/benchmarks/perf-tool/okpt/test/steps/steps.py
+++ b/benchmarks/perf-tool/okpt/test/steps/steps.py
@@ -759,9 +759,6 @@ class QueryNestedFieldStep(BaseQueryStep):
             }
         }
 
-    def get_exclude_fields(self):
-        return ['nested_field.' + self.field_name]
-
 class GetStatsStep(OpenSearchStep):
     """See base class."""
 

--- a/benchmarks/perf-tool/release-configs/faiss-hnsw/nested/simple/index.json
+++ b/benchmarks/perf-tool/release-configs/faiss-hnsw/nested/simple/index.json
@@ -8,6 +8,9 @@
     }
   },
   "mappings": {
+    "_source": {
+      "excludes": ["nested_field"]
+    },
     "properties": {
       "nested_field": {
         "type": "nested",

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/nested/simple/index.json
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/nested/simple/index.json
@@ -7,6 +7,9 @@
     }
   },
   "mappings": {
+    "_source": {
+      "excludes": ["nested_field"]
+    },
     "properties": {
       "nested_field": {
         "type": "nested",

--- a/benchmarks/perf-tool/release-configs/lucene-hnsw/nested/simple/simple-nested-test.yml
+++ b/benchmarks/perf-tool/release-configs/lucene-hnsw/nested/simple/simple-nested-test.yml
@@ -9,7 +9,7 @@ steps:
     index_name: target_index
   - name: create_index
     index_name: target_index
-    index_spec: release-configs/faiss-hnsw/nested/simple/index.json
+    index_spec: release-configs/lucene-hnsw/nested/simple/index.json
   - name: ingest_nested_field
     index_name: target_index
     field_name: target_field

--- a/benchmarks/perf-tool/release-configs/run_all_tests.sh
+++ b/benchmarks/perf-tool/release-configs/run_all_tests.sh
@@ -68,6 +68,7 @@ curl -X PUT "http://$ENDPOINT:$PORT/_cluster/settings?pretty" -H 'Content-Type: 
 
 TESTS="./release-configs/faiss-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
 ./release-configs/faiss-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
+./release-configs/faiss-hnsw/nested/simple/simple-nested-test.yml
 ./release-configs/faiss-hnsw/test.yml
 ./release-configs/faiss-hnswpq/test.yml
 ./release-configs/faiss-ivf/filtering/relaxed-filter/relaxed-filter-test.yml
@@ -76,6 +77,7 @@ TESTS="./release-configs/faiss-hnsw/filtering/relaxed-filter/relaxed-filter-test
 ./release-configs/faiss-ivfpq/test.yml
 ./release-configs/lucene-hnsw/filtering/relaxed-filter/relaxed-filter-test.yml
 ./release-configs/lucene-hnsw/filtering/restrictive-filter/restrictive-filter-test.yml
+./release-configs/lucene-hnsw/nested/simple/simple-nested-test.yml
 ./release-configs/lucene-hnsw/test.yml
 ./release-configs/nmslib-hnsw/test.yml"
 


### PR DESCRIPTION
### Description
Because the number of items inside nested field is too big(1000, 10001), if it is included in `source`, the query latency becomes around 1s. To have fair comparison with other test case, excluding nested field from being stored in `source`.

## Configurations
### Data Sets
Dataset | Train size | Dimensions | Distance | Format | K
-- | -- | -- | -- | -- | --
sift | 1,000,000(Not document number but total nested fields of entire document) | 128 | L2 | hdf5 | 100

Total Queries: 10,000

### Cluster Configuration

Config item | Value
-- | --
Leader Nodes | 3
Leader Node Type | c5.xlarge
Leader Node Disk Space | 20
Data Nodes | 3
Data Node Type | r5.4xlarge
Data Node Disk Space | 500
Primary Shard Count | 24
Replica Count | 1
AZ | us-east-1

### Client Configuration

Config item | Value
-- | --
OS | Amazon Linux
Instance Type | c5.9xlarge
Count | 1
EBS Size | 800G
AZ | us-east-1


### Faiss (1000 to 10000 items in nested field)
```
{
  "metadata": {
    "test_name": "Faiss HNSW Nested Field Test",
    "test_id": "Faiss HNSW Nested Field Test",
    "date": "02/21/2024 00:06:13",
    "python_version": "3.9.18 (main, Sep 11 2023, 13:41:44) \n[GCC 11.2.0]",
    "os_version": "Linux-4.14.326-245.539.amzn2.x86_64-x86_64-with-glibc2.26",
    "processor": "x86_64, 36 cores",
    "memory": "564981760 (used) / 72506503168 (available) / 73743400960 (total)"
  },
  "results": {
    "test_took": 295325.73138901166,
    "delete_index_took_total": 204.6960236718102,
    "create_index_took_total": 238.805988667688,
    "ingest_nested_field_took_total": 130149.40594166303,
    "refresh_index_store_kb_total": 3009740.120768229,
    "refresh_index_took_total": 28108.197264674043,
    "force_merge_took_total": 67769.72170666461,
    "warmup_operation_took_total": 256.5711303371548,
    "query_nested_field_took_total": 68598.33333333333,
    "query_nested_field_took_p50": 7.0,
    "query_nested_field_took_p90": 8.0,
    "query_nested_field_took_p99": 9.0,
    "query_nested_field_took_p99.9": 13.333333333333334,
    "query_nested_field_took_p100": 886.6666666666666,
    "query_nested_field_client_time_total": 104420.33333333333,
    "query_nested_field_client_time_p50": 10.0,
    "query_nested_field_client_time_p90": 11.0,
    "query_nested_field_client_time_p99": 13.0,
    "query_nested_field_client_time_p99.9": 54.333333333333336,
    "query_nested_field_client_time_p100": 892.0,
    "query_nested_field_memory_kb_total": 1297446.0,
    "query_nested_field_recall@K_total": 0.9989340000000001,
    "query_nested_field_recall@1_total": 1.0
  }
}
```

### Lucene(1000 to 10000 items in nested field per doc)
```
{
  "metadata": {
    "test_name": "Lucene HNSW Nested Field Test",
    "test_id": "Lucene HNSW Nested Field Test",
    "date": "02/21/2024 04:55:09",
    "python_version": "3.9.18 (main, Sep 11 2023, 13:41:44) \n[GCC 11.2.0]",
    "os_version": "Linux-4.14.326-245.539.amzn2.x86_64-x86_64-with-glibc2.26",
    "processor": "x86_64, 36 cores",
    "memory": "581652480 (used) / 72480284672 (available) / 73743400960 (total)"
  },
  "results": {
    "test_took": 3167641.372945001,
    "delete_index_took_total": 171.82520866723885,
    "create_index_took_total": 194.31308500255304,
    "ingest_nested_field_took_total": 1016622.4843550008,
    "refresh_index_store_kb_total": 2798702.498046875,
    "refresh_index_took_total": 838.5021863359725,
    "force_merge_took_total": 146532.57332899375,
    "warmup_operation_took_total": 8.00811433388541,
    "query_nested_field_took_total": 2003273.6666666667,
    "query_nested_field_took_p50": 198.66666666666666,
    "query_nested_field_took_p90": 222.0,
    "query_nested_field_took_p99": 240.66666666666666,
    "query_nested_field_took_p99.9": 254.66666666666666,
    "query_nested_field_took_p100": 984.6666666666666,
    "query_nested_field_client_time_total": 2039660.0,
    "query_nested_field_client_time_p50": 202.0,
    "query_nested_field_client_time_p90": 225.66666666666666,
    "query_nested_field_client_time_p99": 245.0,
    "query_nested_field_client_time_p99.9": 271.3333333333333,
    "query_nested_field_client_time_p100": 990.0,
    "query_nested_field_memory_kb_total": 0.0,
    "query_nested_field_recall@K_total": 0.999981,
    "query_nested_field_recall@1_total": 1.0
  }
}
```

### Faiss(10 items in nested field per doc)
```
{
  "metadata": {
    "test_name": "Faiss HNSW Nested Field Test",
    "test_id": "Faiss HNSW Nested Field Test",
    "date": "02/22/2024 04:45:03",
    "python_version": "3.9.18 (main, Sep 11 2023, 13:41:44) \n[GCC 11.2.0]",
    "os_version": "Linux-4.14.326-245.539.amzn2.x86_64-x86_64-with-glibc2.26",
    "processor": "x86_64, 36 cores",
    "memory": "548995072 (used) / 72500396032 (available) / 73743400960 (total)"
  },
  "results": {
    "test_took": 179865.70236468027,
    "delete_index_took_total": 294.5222413206163,
    "create_index_took_total": 184.65970567194745,
    "ingest_nested_field_took_total": 69229.51351267209,
    "refresh_index_store_kb_total": 3031487.720703125,
    "refresh_index_took_total": 14662.646037681649,
    "force_merge_took_total": 61662.6585573346,
    "warmup_operation_took_total": 351.7023099993821,
    "query_nested_field_took_total": 33480.0,
    "query_nested_field_took_p50": 3.0,
    "query_nested_field_took_p90": 4.0,
    "query_nested_field_took_p99": 4.0,
    "query_nested_field_took_p99.9": 7.0,
    "query_nested_field_took_p100": 671.0,
    "query_nested_field_client_time_total": 63240.666666666664,
    "query_nested_field_client_time_p50": 6.0,
    "query_nested_field_client_time_p90": 7.0,
    "query_nested_field_client_time_p99": 7.0,
    "query_nested_field_client_time_p99.9": 40.333333333333336,
    "query_nested_field_client_time_p100": 677.3333333333334,
    "query_nested_field_memory_kb_total": 1297462.0,
    "query_nested_field_recall@K_total": 0.9992070000000001,
    "query_nested_field_recall@1_total": 1.0
  }
}
```
### Lucene(10 items in nested field per doc)
```
{
  "metadata": {
    "test_name": "Lucene HNSW Nested Field Test",
    "test_id": "Lucene HNSW Nested Field Test",
    "date": "02/22/2024 04:33:25",
    "python_version": "3.9.18 (main, Sep 11 2023, 13:41:44) \n[GCC 11.2.0]",
    "os_version": "Linux-4.14.326-245.539.amzn2.x86_64-x86_64-with-glibc2.26",
    "processor": "x86_64, 36 cores",
    "memory": "11139792896 (used) / 61909598208 (available) / 73743400960 (total)"
  },
  "results": {
    "test_took": 275221.65689366125,
    "delete_index_took_total": 159.45150900127678,
    "create_index_took_total": 192.05309099440151,
    "ingest_nested_field_took_total": 122905.74228100013,
    "refresh_index_store_kb_total": 1845289.30078125,
    "refresh_index_took_total": 416.56529167084955,
    "force_merge_took_total": 65381.89473200085,
    "warmup_operation_took_total": 34.61665566040514,
    "query_nested_field_took_total": 86131.33333333333,
    "query_nested_field_took_p50": 8.0,
    "query_nested_field_took_p90": 10.0,
    "query_nested_field_took_p99": 11.0,
    "query_nested_field_took_p99.9": 15.666666666666666,
    "query_nested_field_took_p100": 1014.3333333333334,
    "query_nested_field_client_time_total": 386889.0,
    "query_nested_field_client_time_p50": 31.333333333333332,
    "query_nested_field_client_time_p90": 34.333333333333336,
    "query_nested_field_client_time_p99": 37.0,
    "query_nested_field_client_time_p99.9": 1372.0,
    "query_nested_field_client_time_p100": 14920.333333333334,
    "query_nested_field_memory_kb_total": 2.0,
    "query_nested_field_recall@K_total": 0.9982586666666666,
    "query_nested_field_recall@1_total": 1.0
  }
}
```
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
