### PR TITLE
Fix FieldInfo Parameters Mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,4 +20,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 ### Maintenance
 * Bump faiss lib commit to 32f0e8cf92cd2275b60364517bb1cce67aa29a55 [#1443](https://github.com/opensearch-project/k-NN/pull/1443)
+* Fix FieldInfo Parameters Mismatch [#1489](https://github.com/opensearch-project/k-NN/pull/1489)
 ### Refactoring

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -71,6 +71,7 @@ public class KNNCodecTestUtil {
         private int vectorDimension;
         private VectorSimilarityFunction vectorSimilarityFunction;
         private boolean softDeletes;
+        private boolean isParentField;
 
         public static FieldInfoBuilder builder(String fieldName) {
             return new FieldInfoBuilder(fieldName);
@@ -92,6 +93,7 @@ public class KNNCodecTestUtil {
             this.vectorDimension = 0;
             this.vectorSimilarityFunction = VectorSimilarityFunction.EUCLIDEAN;
             this.softDeletes = false;
+            this.isParentField = false;
         }
 
         public FieldInfoBuilder fieldNumber(int fieldNumber) {
@@ -164,6 +166,11 @@ public class KNNCodecTestUtil {
             return this;
         }
 
+        public FieldInfoBuilder isParentField(boolean isParentField) {
+            this.isParentField = isParentField;
+            return this;
+        }
+
         public FieldInfo build() {
             return new FieldInfo(
                 fieldName,
@@ -181,7 +188,8 @@ public class KNNCodecTestUtil {
                 vectorDimension,
                 VectorEncoding.FLOAT32,
                 vectorSimilarityFunction,
-                softDeletes
+                softDeletes,
+                isParentField
             );
         }
     }


### PR DESCRIPTION
### Description
Fix the breaking change coming from https://github.com/apache/lucene/pull/12829 which is failing the build due to mismatch in FieldInfo parameters.
 
```
/__w/k-NN/k-NN/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java:168: error: constructor FieldInfo in class FieldInfo cannot be applied to given types;
            return new FieldInfo(
                   ^
  required: String,int,boolean,boolean,boolean,IndexOptions,DocValuesType,long,Map<String,String>,int,int,int,int,VectorEncoding,VectorSimilarityFunction,boolean,boolean
  found: String,int,boolean,boolean,boolean,IndexOptions,DocValuesType,long,Map<String,String>,int,int,int,int,VectorEncoding,VectorSimilarityFunction,boolean
  reason: actual and formal argument lists differ in length
```
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
