### PR TITLE
Validate zero vector when using cosine metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Optize Faiss Query With Filters: Reduce iteration and memory for id filter [#1402](https://github.com/opensearch-project/k-NN/pull/1402)
 * Detect AVX2 Dynamically on the System [#1502](https://github.com/opensearch-project/k-NN/pull/1502)
+* Validate zero vector when using cosine metric [#1501](https://github.com/opensearch-project/k-NN/pull/1501)
 ### Bug Fixes
 * Disable sdc table for HNSWPQ read-only indices [#1518](https://github.com/opensearch-project/k-NN/pull/1518)
 * Switch SpaceType.INNERPRODUCT's vector similarity function to MAXIMUM_INNER_PRODUCT [#1532](https://github.com/opensearch-project/k-NN/pull/1532)

--- a/src/main/java/org/opensearch/knn/common/KNNValidationUtil.java
+++ b/src/main/java/org/opensearch/knn/common/KNNValidationUtil.java
@@ -14,11 +14,9 @@ package org.opensearch.knn.common;
 import java.util.Locale;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
-import static org.opensearch.knn.common.KNNVectorUtil.isZeroVector;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KNNValidationUtil {
@@ -66,34 +64,6 @@ public class KNNValidationUtil {
                     Byte.MIN_VALUE,
                     Byte.MAX_VALUE
                 )
-            );
-        }
-    }
-
-    /**
-     * Validate if the given byte vector is supported by the given space type
-     *
-     * @param vector     the given vector
-     * @param spaceType  the given space type
-     */
-    public static void validateByteVector(byte[] vector, SpaceType spaceType) {
-        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
-            );
-        }
-    }
-
-    /**
-     * Validate if the given float vector is supported by the given space type
-     *
-     * @param vector     the given vector
-     * @param spaceType  the given space type
-     */
-    public static void validateFloatVector(float[] vector, SpaceType spaceType) {
-        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
             );
         }
     }

--- a/src/main/java/org/opensearch/knn/common/KNNValidationUtil.java
+++ b/src/main/java/org/opensearch/knn/common/KNNValidationUtil.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.common;
+
+import java.util.Locale;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNVectorUtil.isZeroVector;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KNNValidationUtil {
+    /**
+     * Validate the float vector value and throw exception if it is not a number or not in the finite range.
+     *
+     * @param value  float vector value
+     */
+    public static void validateFloatVectorValue(float value) {
+        if (Float.isNaN(value)) {
+            throw new IllegalArgumentException("KNN vector values cannot be NaN");
+        }
+
+        if (Float.isInfinite(value)) {
+            throw new IllegalArgumentException("KNN vector values cannot be infinity");
+        }
+    }
+
+    /**
+     * Validate the float vector value in the byte range if it is a finite number,
+     * with no decimal values and in the byte range of [-128 to 127]. If not throw IllegalArgumentException.
+     *
+     * @param value  float value in byte range
+     */
+    public static void validateByteVectorValue(float value) {
+        validateFloatVectorValue(value);
+        if (value % 1 != 0) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are floats instead of byte integers",
+                    VECTOR_DATA_TYPE_FIELD,
+                    VectorDataType.BYTE.getValue()
+                )
+
+            );
+        }
+        if ((int) value < Byte.MIN_VALUE || (int) value > Byte.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are not within in the byte range [%d, %d]",
+                    VECTOR_DATA_TYPE_FIELD,
+                    VectorDataType.BYTE.getValue(),
+                    Byte.MIN_VALUE,
+                    Byte.MAX_VALUE
+                )
+            );
+        }
+    }
+
+    /**
+     * Validate if the given byte vector is supported by the given space type
+     *
+     * @param vector     the given vector
+     * @param spaceType  the given space type
+     */
+    public static void validateByteVector(byte[] vector, SpaceType spaceType) {
+        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
+            );
+        }
+    }
+
+    /**
+     * Validate if the given float vector is supported by the given space type
+     *
+     * @param vector     the given vector
+     * @param spaceType  the given space type
+     */
+    public static void validateFloatVector(float[] vector, SpaceType spaceType) {
+        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
+            );
+        }
+    }
+
+    /**
+     * Validate if the given vector size matches with the dimension provided in mapping.
+     *
+     * @param dimension dimension of vector
+     * @param vectorSize size of the vector
+     */
+    public static void validateVectorDimension(int dimension, int vectorSize) {
+        if (dimension != vectorSize) {
+            String errorMessage = String.format(Locale.ROOT, "Vector dimension mismatch. Expected: %d, Given: %d", dimension, vectorSize);
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
+++ b/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common;
+
+public class KNNVectorUtil {
+    private KNNVectorUtil() {}
+
+    /**
+     * Check if all the elements of a given vector are zero
+     *
+     * @param vector the vector
+     * @return true if yes; otherwise false
+     */
+    public static boolean isZeroVector(byte[] vector) {
+        for (byte e : vector) {
+            if (e != (byte) 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check if all the elements of a given vector are zero
+     *
+     * @param vector the vector
+     * @return true if yes; otherwise false
+     */
+    public static boolean isZeroVector(float[] vector) {
+        for (float e : vector) {
+            if (e != 0f) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
+++ b/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
@@ -5,9 +5,12 @@
 
 package org.opensearch.knn.common;
 
-public class KNNVectorUtil {
-    private KNNVectorUtil() {}
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KNNVectorUtil {
     /**
      * Check if all the elements of a given vector are zero
      *
@@ -15,6 +18,7 @@ public class KNNVectorUtil {
      * @return true if yes; otherwise false
      */
     public static boolean isZeroVector(byte[] vector) {
+        Objects.requireNonNull(vector, "vector must not be null");
         for (byte e : vector) {
             if (e != 0) {
                 return false;
@@ -30,6 +34,7 @@ public class KNNVectorUtil {
      * @return true if yes; otherwise false
      */
     public static boolean isZeroVector(float[] vector) {
+        Objects.requireNonNull(vector, "vector must not be null");
         for (float e : vector) {
             if (e != 0f) {
                 return false;

--- a/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
+++ b/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
@@ -16,7 +16,7 @@ public class KNNVectorUtil {
      */
     public static boolean isZeroVector(byte[] vector) {
         for (byte e : vector) {
-            if (e != (byte) 0) {
+            if (e != 0) {
                 return false;
             }
         }

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -11,10 +11,13 @@
 
 package org.opensearch.knn.index;
 
+import java.util.Locale;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.opensearch.knn.common.KNNVectorUtil.isZeroVector;
 
 /**
  * Enum contains spaces supported for approximate nearest neighbor search in the k-NN plugin. Each engine's methods are
@@ -43,6 +46,24 @@ public enum SpaceType {
         @Override
         public VectorSimilarityFunction getVectorSimilarityFunction() {
             return VectorSimilarityFunction.COSINE;
+        }
+
+        @Override
+        public void validateVector(byte[] vector) {
+            if (isZeroVector(vector)) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", getValue())
+                );
+            }
+        }
+
+        @Override
+        public void validateVector(float[] vector) {
+            if (isZeroVector(vector)) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", getValue())
+                );
+            }
         }
     },
     L1("l1") {
@@ -103,6 +124,24 @@ public enum SpaceType {
      */
     public VectorSimilarityFunction getVectorSimilarityFunction() {
         throw new UnsupportedOperationException(String.format("Space [%s] does not have a vector similarity function", getValue()));
+    }
+
+    /**
+     * Validate if the given byte vector is supported by this space type
+     *
+     * @param vector     the given vector
+     */
+    public void validateVector(byte[] vector) {
+        // do nothing
+    }
+
+    /**
+     * Validate if the given float vector is supported by this space type
+     *
+     * @param vector     the given vector
+     */
+    public void validateVector(float[] vector) {
+        // do nothing
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -57,14 +57,14 @@ import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FI
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVector;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateVectorDataTypeWithEngine;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateVectorDataTypeWithKnnIndexSetting;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.addStoredFieldForVectorField;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVectorValue;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVectorValue;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateVectorDimension;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
+import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVectorValue;
+import static org.opensearch.knn.common.KNNValidationUtil.validateVectorDimension;
 
 /**
  * Field Mapper for KNN vector type.

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -11,12 +11,13 @@
 
 package org.opensearch.knn.index.mapper;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesType;
 import org.opensearch.index.mapper.ParametrizedFieldMapper;
 import org.opensearch.index.mapper.ParseContext;
-import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
@@ -25,98 +26,9 @@ import java.util.Locale;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
-import static org.opensearch.knn.common.KNNVectorUtil.isZeroVector;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KNNVectorFieldMapperUtil {
-    /**
-     * Validate the float vector value and throw exception if it is not a number or not in the finite range.
-     *
-     * @param value  float vector value
-     */
-    public static void validateFloatVectorValue(float value) {
-        if (Float.isNaN(value)) {
-            throw new IllegalArgumentException("KNN vector values cannot be NaN");
-        }
-
-        if (Float.isInfinite(value)) {
-            throw new IllegalArgumentException("KNN vector values cannot be infinity");
-        }
-    }
-
-    /**
-     * Validate the float vector value in the byte range if it is a finite number,
-     * with no decimal values and in the byte range of [-128 to 127]. If not throw IllegalArgumentException.
-     *
-     * @param value  float value in byte range
-     */
-    public static void validateByteVectorValue(float value) {
-        validateFloatVectorValue(value);
-        if (value % 1 != 0) {
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are floats instead of byte integers",
-                    VECTOR_DATA_TYPE_FIELD,
-                    VectorDataType.BYTE.getValue()
-                )
-
-            );
-        }
-        if ((int) value < Byte.MIN_VALUE || (int) value > Byte.MAX_VALUE) {
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "[%s] field was set as [%s] in index mapping. But, KNN vector values are not within in the byte range [%d, %d]",
-                    VECTOR_DATA_TYPE_FIELD,
-                    VectorDataType.BYTE.getValue(),
-                    Byte.MIN_VALUE,
-                    Byte.MAX_VALUE
-                )
-            );
-        }
-    }
-
-    /**
-     * Validate if the given byte vector is supported by the given space type
-     *
-     * @param vector     the given vector
-     * @param spaceType  the given space type
-     */
-    public static void validateByteVector(byte[] vector, SpaceType spaceType) {
-        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
-            );
-        }
-    }
-
-    /**
-     * Validate if the given float vector is supported by the given space type
-     *
-     * @param vector     the given vector
-     * @param spaceType  the given space type
-     */
-    public static void validateFloatVector(float[] vector, SpaceType spaceType) {
-        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
-            );
-        }
-    }
-
-    /**
-     * Validate if the given vector size matches with the dimension provided in mapping.
-     *
-     * @param dimension dimension of vector
-     * @param vectorSize size of the vector
-     */
-    public static void validateVectorDimension(int dimension, int vectorSize) {
-        if (dimension != vectorSize) {
-            String errorMessage = String.format(Locale.ROOT, "Vector dimension mismatch. Expected: %d, Given: %d", dimension, vectorSize);
-            throw new IllegalArgumentException(errorMessage);
-        }
-    }
-
     /**
      * Validates and throws exception if data_type field is set in the index mapping
      * using any VectorDataType (other than float, which is default) because other

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -16,6 +16,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesType;
 import org.opensearch.index.mapper.ParametrizedFieldMapper;
 import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
@@ -24,6 +25,7 @@ import java.util.Locale;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNVectorUtil.isZeroVector;
 
 public class KNNVectorFieldMapperUtil {
     /**
@@ -75,6 +77,34 @@ public class KNNVectorFieldMapperUtil {
     }
 
     /**
+     * Validate if the given byte vector is supported by the given space type
+     *
+     * @param vector     the given vector
+     * @param spaceType  the given space type
+     */
+    public static void validateByteVector(byte[] vector, SpaceType spaceType) {
+        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
+            );
+        }
+    }
+
+    /**
+     * Validate if the given float vector is supported by the given space type
+     *
+     * @param vector     the given vector
+     * @param spaceType  the given space type
+     */
+    public static void validateFloatVector(float[] vector, SpaceType spaceType) {
+        if (spaceType == SpaceType.COSINESIMIL && isZeroVector(vector)) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", spaceType.getValue())
+            );
+        }
+    }
+
+    /**
      * Validate if the given vector size matches with the dimension provided in mapping.
      *
      * @param dimension dimension of vector
@@ -85,7 +115,6 @@ public class KNNVectorFieldMapperUtil {
             String errorMessage = String.format(Locale.ROOT, "Vector dimension mismatch. Expected: %d, Given: %d", dimension, vectorSize);
             throw new IllegalArgumentException(errorMessage);
         }
-
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.common.Explicit;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -26,6 +27,8 @@ import java.util.Optional;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.addStoredFieldForVectorField;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVector;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
 
 /**
  * Field mapper for case when Lucene has been set as an engine.
@@ -75,7 +78,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
     }
 
     @Override
-    protected void parseCreateField(ParseContext context, int dimension) throws IOException {
+    protected void parseCreateField(ParseContext context, int dimension, SpaceType spaceType) throws IOException {
 
         validateIfKNNPluginEnabled();
         validateIfCircuitBreakerIsNotTriggered();
@@ -86,6 +89,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
                 return;
             }
             final byte[] array = bytesArrayOptional.get();
+            validateByteVector(array, spaceType);
             KnnByteVectorField point = new KnnByteVectorField(name(), array, fieldType);
 
             context.doc().add(point);
@@ -101,7 +105,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
                 return;
             }
             final float[] array = floatsArrayOptional.get();
-
+            validateFloatVector(array, spaceType);
             KnnVectorField point = new KnnVectorField(name(), array, fieldType);
 
             context.doc().add(point);

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.knn.index.mapper;
 
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -20,15 +23,9 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.util.KNNEngine;
 
-import java.io.IOException;
-import java.util.Locale;
-import java.util.Optional;
-
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.addStoredFieldForVectorField;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
-import static org.opensearch.knn.common.KNNValidationUtil.validateByteVector;
-import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 
 /**
  * Field mapper for case when Lucene has been set as an engine.
@@ -89,7 +86,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
                 return;
             }
             final byte[] array = bytesArrayOptional.get();
-            validateByteVector(array, spaceType);
+            spaceType.validateVector(array);
             KnnByteVectorField point = new KnnByteVectorField(name(), array, fieldType);
 
             context.doc().add(point);
@@ -105,7 +102,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
                 return;
             }
             final float[] array = floatsArrayOptional.get();
-            validateFloatVector(array, spaceType);
+            spaceType.validateVector(array);
             KnnVectorField point = new KnnVectorField(name(), array, fieldType);
 
             context.doc().add(point);

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.addStoredFieldForVectorField;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVector;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 
 /**
  * Field mapper for case when Lucene has been set as an engine.

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -61,6 +61,6 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
             );
         }
 
-        parseCreateField(context, modelMetadata.getDimension());
+        parseCreateField(context, modelMetadata.getDimension(), modelMetadata.getSpaceType());
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -35,9 +35,9 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.opensearch.knn.index.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVector;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVectorValue;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
+import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 
 /**
  * Helper class to build the KNN query
@@ -290,8 +290,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         SpaceType spaceType = knnVectorFieldType.getSpaceType();
 
         if (fieldDimension == -1) {
+            if (spaceType != null) {
+                throw new IllegalStateException("Space type should be null when the field uses a model");
+            }
             // If dimension is not set, the field uses a model and the information needs to be retrieved from there
-            assert spaceType == null;
             ModelMetadata modelMetadata = getModelMetadataForField(knnVectorFieldType);
             fieldDimension = modelMetadata.getDimension();
             knnEngine = modelMetadata.getKnnEngine();

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -5,12 +5,25 @@
 
 package org.opensearch.knn.index.query;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
+import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -19,25 +32,9 @@ import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.plugin.stats.KNNCounter;
-import org.apache.lucene.search.Query;
-import org.opensearch.core.ParseField;
-import org.opensearch.core.common.ParsingException;
-import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.mapper.MappedFieldType;
-import org.opensearch.index.query.AbstractQueryBuilder;
-import org.opensearch.index.query.QueryShardContext;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-
-import static org.opensearch.knn.index.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
-import static org.opensearch.knn.common.KNNValidationUtil.validateByteVector;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
-import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
+import static org.opensearch.knn.index.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
 
 /**
  * Helper class to build the KNN query
@@ -316,9 +313,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 validateByteVectorValue(vector[i]);
                 byteVector[i] = (byte) vector[i];
             }
-            validateByteVector(byteVector, spaceType);
+            spaceType.validateVector(byteVector);
         } else {
-            validateFloatVector(vector, spaceType);
+            spaceType.validateVector(vector);
         }
 
         if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine)

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.plugin.script;
 
 import org.apache.lucene.search.IndexSearcher;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.apache.lucene.index.LeafReaderContext;
@@ -18,6 +19,7 @@ import java.math.BigInteger;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.getVectorMagnitudeSquared;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isKNNVectorFieldType;
@@ -90,7 +92,7 @@ public interface KNNScoringSpace {
          */
         public CosineSimilarity(Object query, MappedFieldType fieldType) {
             if (!isKNNVectorFieldType(fieldType)) {
-                throw new IllegalArgumentException("Incompatible field_type for cosine space. The field type must " + "be knn_vector.");
+                throw new IllegalArgumentException("Incompatible field_type for cosine space. The field type must be knn_vector.");
             }
 
             this.processedQuery = parseToFloatArray(
@@ -98,6 +100,7 @@ public interface KNNScoringSpace {
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
+            validateFloatVector(processedQuery, SpaceType.COSINESIMIL);
             float qVectorSquaredMagnitude = getVectorMagnitudeSquared(this.processedQuery);
             this.scoringMethod = (float[] q, float[] v) -> 1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude);
         }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -19,7 +19,6 @@ import java.math.BigInteger;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.getVectorMagnitudeSquared;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isKNNVectorFieldType;
@@ -100,7 +99,7 @@ public interface KNNScoringSpace {
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
-            validateFloatVector(processedQuery, SpaceType.COSINESIMIL);
+            SpaceType.COSINESIMIL.validateVector(processedQuery);
             float qVectorSquaredMagnitude = getVectorMagnitudeSquared(this.processedQuery);
             this.scoringMethod = (float[] q, float[] v) -> 1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude);
         }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -19,7 +19,7 @@ import java.math.BigInteger;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.getVectorMagnitudeSquared;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isKNNVectorFieldType;

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -17,7 +17,7 @@ import java.math.BigInteger;
 import java.util.Base64;
 
 import static org.opensearch.index.mapper.NumberFieldMapper.NumberType.LONG;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVectorValue;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
 
 public class KNNScoringSpaceUtil {
 

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.plugin.script;
 
+import java.util.List;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.plugin.stats.KNNCounter;
@@ -13,7 +14,6 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Base64;
 
 import static org.opensearch.index.mapper.NumberFieldMapper.NumberType.LONG;
@@ -108,7 +108,7 @@ public class KNNScoringSpaceUtil {
     public static float[] convertVectorToPrimitive(Object vector, VectorDataType vectorDataType) {
         float[] primitiveVector = null;
         if (vector != null) {
-            final ArrayList<Number> tmp = (ArrayList<Number>) vector;
+            final List<Number> tmp = (List<Number>) vector;
             primitiveVector = new float[tmp.size()];
             for (int i = 0; i < primitiveVector.length; i++) {
                 float value = tmp.get(i).floatValue();

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -5,18 +5,16 @@
 
 package org.opensearch.knn.plugin.script;
 
-import org.opensearch.knn.index.KNNVectorScriptDocValues;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.VectorDataType;
-
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.knn.index.KNNVectorScriptDocValues;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
-import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 
 public class KNNScoringUtil {
     private static Logger logger = LogManager.getLogger(KNNScoringUtil.class);
@@ -137,7 +135,7 @@ public class KNNScoringUtil {
      */
     public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues, Number queryVectorMagnitude) {
         float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
-        validateFloatVector(inputVector, SpaceType.COSINESIMIL);
+        SpaceType.COSINESIMIL.validateVector(inputVector);
         return cosinesimilOptimized(inputVector, docValues.getValue(), queryVectorMagnitude.floatValue());
     }
 
@@ -184,7 +182,7 @@ public class KNNScoringUtil {
      */
     public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
         float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
-        validateFloatVector(inputVector, SpaceType.COSINESIMIL);
+        SpaceType.COSINESIMIL.validateVector(inputVector);
         return cosinesimil(inputVector, docValues.getValue());
     }
 

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.plugin.script;
 import org.opensearch.knn.index.KNNVectorScriptDocValues;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 
 import java.math.BigInteger;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVectorValue;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
 
 public class KNNScoringUtil {
     private static Logger logger = LogManager.getLogger(KNNScoringUtil.class);
@@ -134,11 +136,9 @@ public class KNNScoringUtil {
      * @return cosine score
      */
     public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues, Number queryVectorMagnitude) {
-        return cosinesimilOptimized(
-            toFloat(queryVector, docValues.getVectorDataType()),
-            docValues.getValue(),
-            queryVectorMagnitude.floatValue()
-        );
+        float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
+        validateFloatVector(inputVector, SpaceType.COSINESIMIL);
+        return cosinesimilOptimized(inputVector, docValues.getValue(), queryVectorMagnitude.floatValue());
     }
 
     /**
@@ -183,7 +183,9 @@ public class KNNScoringUtil {
      * @return cosine score
      */
     public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return cosinesimil(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
+        float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
+        validateFloatVector(inputVector, SpaceType.COSINESIMIL);
+        return cosinesimil(inputVector, docValues.getValue());
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -15,8 +15,8 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateByteVectorValue;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateFloatVector;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
+import static org.opensearch.knn.common.KNNValidationUtil.validateFloatVector;
 
 public class KNNScoringUtil {
     private static Logger logger = LogManager.getLogger(KNNScoringUtil.class);

--- a/src/test/java/org/opensearch/knn/common/KNNVectorUtilTests.java
+++ b/src/test/java/org/opensearch/knn/common/KNNVectorUtilTests.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.common;
+
+import org.opensearch.knn.KNNTestCase;
+
+public class KNNVectorUtilTests extends KNNTestCase {
+    public void testByteZeroVector() {
+        assertTrue(KNNVectorUtil.isZeroVector(new byte[] { 0, 0, 0 }));
+        assertFalse(KNNVectorUtil.isZeroVector(new byte[] { 1, 1, 1 }));
+    }
+
+    public void testFloatZeroVector() {
+        assertTrue(KNNVectorUtil.isZeroVector(new float[] { 0.0f, 0.0f, 0.0f }));
+        assertFalse(KNNVectorUtil.isZeroVector(new float[] { 1.0f, 1.0f, 1.0f }));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -71,21 +71,21 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 public class KNNVectorFieldMapperTests extends KNNTestCase {
 
-    private final static String TEST_FIELD_NAME = "test-field-name";
+    private static final String TEST_FIELD_NAME = "test-field-name";
 
-    private final static int TEST_DIMENSION = 17;
+    private static final int TEST_DIMENSION = 17;
 
-    private final static float TEST_VECTOR_VALUE = 1.5f;
+    private static final float TEST_VECTOR_VALUE = 1.5f;
 
-    private final static float[] TEST_VECTOR = createInitializedFloatArray(TEST_DIMENSION, TEST_VECTOR_VALUE);
+    private static final float[] TEST_VECTOR = createInitializedFloatArray(TEST_DIMENSION, TEST_VECTOR_VALUE);
 
-    private final static byte TEST_BYTE_VECTOR_VALUE = 10;
-    private final static byte[] TEST_BYTE_VECTOR = createInitializedByteArray(TEST_DIMENSION, TEST_BYTE_VECTOR_VALUE);
+    private static final byte TEST_BYTE_VECTOR_VALUE = 10;
+    private static final byte[] TEST_BYTE_VECTOR = createInitializedByteArray(TEST_DIMENSION, TEST_BYTE_VECTOR_VALUE);
 
-    private final static BytesRef TEST_VECTOR_BYTES_REF = new BytesRef(
+    private static final BytesRef TEST_VECTOR_BYTES_REF = new BytesRef(
         KNNVectorSerializerFactory.getDefaultSerializer().floatToByteArray(TEST_VECTOR)
     );
-    private final static BytesRef TEST_BYTE_VECTOR_BYTES_REF = new BytesRef(TEST_BYTE_VECTOR);
+    private static final BytesRef TEST_BYTE_VECTOR_BYTES_REF = new BytesRef(TEST_BYTE_VECTOR);
     private static final String DIMENSION_FIELD_NAME = "dimension";
     private static final String KNN_VECTOR_TYPE = "knn_vector";
     private static final String TYPE_FIELD_NAME = "type";
@@ -757,8 +757,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         doReturn(Optional.of(TEST_VECTOR)).when(luceneFieldMapper).getFloatsFromContext(parseContext, TEST_DIMENSION);
         doNothing().when(luceneFieldMapper).validateIfCircuitBreakerIsNotTriggered();
         doNothing().when(luceneFieldMapper).validateIfKNNPluginEnabled();
-
-        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION);
+        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION, luceneFieldMapper.fieldType().spaceType);
 
         // Document should have 2 fields: one for VectorField (binary doc values) and one for KnnVectorField
         List<IndexableField> fields = document.getFields();
@@ -796,7 +795,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         doNothing().when(luceneFieldMapper).validateIfCircuitBreakerIsNotTriggered();
         doNothing().when(luceneFieldMapper).validateIfKNNPluginEnabled();
 
-        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION);
+        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION, luceneFieldMapper.fieldType().spaceType);
 
         // Document should have 1 field: one for KnnVectorField
         fields = document.getFields();
@@ -825,7 +824,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         doNothing().when(luceneFieldMapper).validateIfCircuitBreakerIsNotTriggered();
         doNothing().when(luceneFieldMapper).validateIfKNNPluginEnabled();
 
-        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION);
+        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION, luceneFieldMapper.fieldType().spaceType);
 
         // Document should have 2 fields: one for VectorField (binary doc values) and one for KnnByteVectorField
         List<IndexableField> fields = document.getFields();
@@ -862,7 +861,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         doNothing().when(luceneFieldMapper).validateIfCircuitBreakerIsNotTriggered();
         doNothing().when(luceneFieldMapper).validateIfKNNPluginEnabled();
 
-        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION);
+        luceneFieldMapper.parseCreateField(parseContext, TEST_DIMENSION, luceneFieldMapper.fieldType().spaceType);
 
         // Document should have 1 field: one for KnnByteVectorField
         fields = document.getFields();

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -303,6 +303,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         ModelMetadata modelMetadata = mock(ModelMetadata.class);
         when(modelMetadata.getDimension()).thenReturn(4);
         when(modelMetadata.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+        when(modelMetadata.getSpaceType()).thenReturn(SpaceType.COSINESIMIL);
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
         KNNQueryBuilder.initialize(modelDao);

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.query;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -222,6 +223,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.L2);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         KNNQuery query = (KNNQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
         assertEquals(knnQueryBuilder.getK(), query.getK());
@@ -238,6 +240,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.L2);
         MethodComponentContext methodComponentContext = new MethodComponentContext(METHOD_HNSW, ImmutableMap.of());
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
@@ -255,6 +258,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.L2);
         MethodComponentContext methodComponentContext = new MethodComponentContext(METHOD_HNSW, ImmutableMap.of());
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, methodComponentContext);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
@@ -272,6 +276,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.L2);
         MethodComponentContext methodComponentContext = new MethodComponentContext(METHOD_HNSW, ImmutableMap.of());
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.NMSLIB, SpaceType.L2, methodComponentContext);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
@@ -332,6 +337,48 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockNumberField);
         expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testDoToQuery_InvalidZeroFloatVector() {
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, K);
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.COSINESIMIL);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> knnQueryBuilder.doToQuery(mockQueryShardContext)
+        );
+        assertEquals(
+            String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", SpaceType.COSINESIMIL.getValue()),
+            exception.getMessage()
+        );
+    }
+
+    public void testDoToQuery_InvalidZeroByteVector() {
+        float[] queryVector = { 0.0f, 0.0f, 0.0f, 0.0f };
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, K);
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.BYTE);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.COSINESIMIL);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> knnQueryBuilder.doToQuery(mockQueryShardContext)
+        );
+        assertEquals(
+            String.format(Locale.ROOT, "zero vector is not supported when space type is [%s]", SpaceType.COSINESIMIL.getValue()),
+            exception.getMessage()
+        );
     }
 
     public void testSerialization() throws Exception {

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
@@ -10,20 +10,21 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.index.mapper.NumberFieldMapper;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KNNScoringSpaceFactoryTests extends KNNTestCase {
     public void testValidSpaces() {
 
         KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldType.getDimension()).thenReturn(3);
         NumberFieldMapper.NumberFieldType numberFieldType = new NumberFieldMapper.NumberFieldType(
             "field",
             NumberFieldMapper.NumberType.LONG
         );
-        List<Float> floatQueryObject = new ArrayList<>();
+        List<Float> floatQueryObject = List.of(1.0f, 1.0f, 1.0f);
         Long longQueryObject = 0L;
 
         assertTrue(

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -17,6 +17,7 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
@@ -331,6 +332,28 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .startObject("method")
             .field("name", algoName)
             .field("engine", knnEngine)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    /**
+     * Utility to create a Knn Index Mapping with specific algorithm, engine and spaceType
+     */
+    protected String createKnnIndexMapping(String fieldName, Integer dimensions, String algoName, String knnEngine, String spaceType)
+        throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(KNNConstants.DIMENSION, dimensions.toString())
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, algoName)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType)
+            .field(KNNConstants.KNN_ENGINE, knnEngine)
             .endObject()
             .endObject()
             .endObject()


### PR DESCRIPTION
### Description
Validate the vector passed by the user during querying or indexing, if the vector is zero vector and the space type of index is cosine, an exception will be thrown.

**Examples**
1. When we use cosine space type and index a zero vector through bulk api, the response returned will be as follows:
```
{
    "took": 2,
    "errors": true,
    "items": [
        {
            "index": {
                "_index": "products-shirts",
                "_id": "1",
                "status": 400,
                "error": {
                    "type": "mapper_parsing_exception",
                    "reason": "failed to parse field [item_vector] of type [knn_vector] in document with id '1'. Preview of field's value: 'null'",
                    "caused_by": {
                        "type": "illegal_argument_exception",
                        "reason": "zero vector is not supported when space type is [cosinesimil]"
                    }
                }
            }
        }
    ]
}
```
2. If we use cosine metric and query index is a zero vector, the response returned will be as following:
```
{
    "error": {
        "root_cause": [
            {
                "type": "query_shard_exception",
                "reason": "failed to create query: zero vector is not supported when space type is [cosinesimil]",
                "index": "products-shirts",
                "index_uuid": "5ccs3V8rRceXFOaMAvDtMw"
            }
        ],
        "type": "search_phase_execution_exception",
        "reason": "all shards failed",
        "phase": "query",
        "grouped": true,
        "failed_shards": [
            {
                "shard": 0,
                "index": "products-shirts",
                "node": "Fq1_A7lHSAu25Beapfb5-A",
                "reason": {
                    "type": "query_shard_exception",
                    "reason": "failed to create query: zero vector is not supported when space type is [cosinesimil]",
                    "index": "products-shirts",
                    "index_uuid": "5ccs3V8rRceXFOaMAvDtMw",
                    "caused_by": {
                        "type": "illegal_argument_exception",
                        "reason": "zero vector is not supported when space type is [cosinesimil]"
                    }
                }
            }
        ]
    },
    "status": 400
}
```

3. When we use euclidean space type and index a zero vector through bulk api, the response returned will be as follows:
```
{
    "took": 301,
    "errors": false,
    "items": [
        {
            "index": {
                "_index": "products-shirts",
                "_id": "12",
                "_version": 1,
                "result": "created",
                "_shards": {
                    "total": 1,
                    "successful": 1,
                    "failed": 0
                },
                "_seq_no": 11,
                "_primary_term": 1,
                "status": 201
            }
        }
    ]
}
```

4. If we use euclidean metric and query index is a zero vector, the response returned will be as following:
```
{
    "took": 2,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 2,
            "relation": "eq"
        },
        "max_score": 1.0,
        "hits": [
            {
                "_index": "products-shirts",
                "_id": "12",
                "_score": 1.0,
                "_source": {
                    "item_vector": [
                        0,
                        0,
                        0
                    ],
                    "size": "large",
                    "rating": 3
                }
            },
            {
                "_index": "products-shirts",
                "_id": "11",
                "_score": 0.055555556,
                "_source": {
                    "item_vector": [
                        3,
                        2,
                        2
                    ],
                    "size": "large",
                    "rating": 6
                }
            }
        ]
    }
}
```
 
### Issues Resolved
#1461
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
