### PR TITLE
Raise gcc version requirement to 9.0.0 for SIMD Neon support on ARM64

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -105,13 +105,15 @@ if [ "$JAVA_HOME" = "" ]; then
     echo "SET JAVA_HOME=$JAVA_HOME"
 fi
 
-# Ensure gcc version is above 4.9.0 and is not 8.3.1 for faiss 1.7.4+ compilation
+# Ensure gcc version is above 4.9.0 and at least 9.0.0 for faiss 1.7.4+ / SIMD Neon support on ARM64 compilation
 # https://github.com/opensearch-project/k-NN/issues/975
+# https://github.com/opensearch-project/k-NN/issues/1138
+# https://github.com/opensearch-project/opensearch-build/issues/4386
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
-GCC_REQUIRED_VERSION=4.9.0
+GCC_REQUIRED_VERSION=9.0.0
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ] || [ "$GCC_VERSION" = "8.3.1" ]; then
-    echo "gcc version on this env is either older than $GCC_REQUIRED_VERSION, or equals 8.3.1, exit 1"
+if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ]; then
+    echo "gcc version on this env is older than $GCC_REQUIRED_VERSION, exit 1"
     exit 1
 fi
 


### PR DESCRIPTION
### Description
Raise gcc version requirement to 9.0.0 for SIMD Neon support on ARM64
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4386
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
