### PR TITLE
Disable sdc table for HNSWPQ read-only indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Optize Faiss Query With Filters: Reduce iteration and memory for id filter [#1402](https://github.com/opensearch-project/k-NN/pull/1402)
 ### Bug Fixes
+* Disable sdc table for HNSWPQ read-only indices [#1518](https://github.com/opensearch-project/k-NN/pull/1518)
 ### Infrastructure
 * Manually install zlib for win CI [#1513](https://github.com/opensearch-project/k-NN/pull/1513)
 ### Documentation

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -213,7 +213,8 @@ jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
     }
 
     std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
-    faiss::Index* indexReader = faiss::read_index(indexPathCpp.c_str(), faiss::IO_FLAG_READ_ONLY);
+    // Skipping IO_FLAG_PQ_SKIP_SDC_TABLE because the index is read only and the sdc table is only used during ingestion
+    faiss::Index* indexReader = faiss::read_index(indexPathCpp.c_str(), faiss::IO_FLAG_READ_ONLY | faiss::IO_FLAG_PQ_SKIP_SDC_TABLE);
     return (jlong) indexReader;
 }
 

--- a/jni/tests/test_util.cpp
+++ b/jni/tests/test_util.cpp
@@ -369,6 +369,22 @@ float test_util::RandomFloat(float min, float max) {
     return distribution(e1);
 }
 
+std::vector<float> test_util::RandomVectors(int dim, int64_t numVectors, float min, float max) {
+    std::vector<float> vectors(dim*numVectors);
+    for (int64_t i = 0; i < dim*numVectors; i++) {
+        vectors[i] = test_util::RandomFloat(min, max);
+    }
+    return vectors;
+}
+
+std::vector<int64_t> test_util::Range(int64_t numElements) {
+    std::vector<int64_t> rangeVector(numElements);
+    for (int64_t i = 0; i < numElements; i++) {
+        rangeVector[i] = i;
+    }
+    return rangeVector;
+}
+
 size_t test_util::bits2words(uint64_t numBits) {
     return ((numBits - 1) >> 6) + 1;
 }

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -155,6 +155,10 @@ namespace test_util {
 
     float RandomFloat(float min, float max);
 
+    std::vector<float> RandomVectors(int dim, int64_t numVectors, float min, float max);
+
+    std::vector<int64_t> Range(int64_t numElements);
+
     // returns the number of 64 bit words it would take to hold numBits
     size_t bits2words(uint64_t numBits);
 


### PR DESCRIPTION
### Description
Passes flag to disable sdc table for the HNSWPQ indices. This table is only used by HNSWPQ during graph creation to compare nodes already present in graph. When we call load index, the graph is read only. Hence, we wont be doing any ingestion and so the table can be disabled to save some memory.

Along with this, added a unit test and a couple test helper methods for generating random data.

### Issues Resolved
#1507 partial

Faiss issue: https://github.com/facebookresearch/faiss/issues/3246.
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
