### PR TITLE
Fix AppSec Findings CWE-22 and CWE-476

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/AbstractRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/AbstractRollingUpgradeTestCase.java
@@ -71,6 +71,9 @@ public abstract class AbstractRollingUpgradeTestCase extends KNNRestTestCase {
     }
 
     protected final ClusterType getClusterType() {
+        if (System.getProperty(BWCSUITE_CLUSTER) == null) {
+            throw new IllegalArgumentException(String.format("[%s] value is null", BWCSUITE_CLUSTER));
+        }
         return ClusterType.instance(System.getProperty(BWCSUITE_CLUSTER));
     }
 

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -466,6 +466,9 @@ public interface ModelDao {
         }
 
         private String getMapping() throws IOException {
+            if (ModelDao.class.getClassLoader() == null) {
+                throw new IllegalStateException("ClassLoader of ModelDao Class is null");
+            }
             URL url = ModelDao.class.getClassLoader().getResource(MODEL_INDEX_MAPPING_PATH);
             if (url == null) {
                 throw new IllegalStateException("Unable to retrieve mapping for \"" + MODEL_INDEX_NAME + "\"");

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -66,6 +66,9 @@ public class FaissIT extends KNNRestTestCase {
 
     @BeforeClass
     public static void setUpClass() throws IOException {
+        if (FaissIT.class.getClassLoader() == null) {
+            throw new IllegalStateException("ClassLoader of FaissIT Class is null");
+        }
         URL testIndexVectors = FaissIT.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
         URL testQueries = FaissIT.class.getClassLoader().getResource("data/test_queries_100x128.csv");
         assert testIndexVectors != null;

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -44,8 +44,11 @@ public class NmslibIT extends KNNRestTestCase {
 
     @BeforeClass
     public static void setUpClass() throws IOException {
-        URL testIndexVectors = FaissIT.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
-        URL testQueries = FaissIT.class.getClassLoader().getResource("data/test_queries_100x128.csv");
+        if (NmslibIT.class.getClassLoader() == null) {
+            throw new IllegalStateException("ClassLoader of NmslibIT Class is null");
+        }
+        URL testIndexVectors = NmslibIT.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
+        URL testQueries = NmslibIT.class.getClassLoader().getResource("data/test_queries_100x128.csv");
         assert testIndexVectors != null;
         assert testQueries != null;
         testData = new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -47,8 +47,11 @@ public class OpenSearchIT extends KNNRestTestCase {
 
     @BeforeClass
     public static void setUpClass() throws IOException {
-        URL testIndexVectors = FaissIT.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
-        URL testQueries = FaissIT.class.getClassLoader().getResource("data/test_queries_100x128.csv");
+        if (OpenSearchIT.class.getClassLoader() == null) {
+            throw new IllegalStateException("ClassLoader of OpenSearchIT Class is null");
+        }
+        URL testIndexVectors = OpenSearchIT.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
+        URL testQueries = OpenSearchIT.class.getClassLoader().getResource("data/test_queries_100x128.csv");
         assert testIndexVectors != null;
         assert testQueries != null;
         testData = new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -65,6 +65,9 @@ public class JNIServiceTests extends KNNTestCase {
 
     @BeforeClass
     public static void setUpClass() throws IOException {
+        if (JNIServiceTests.class.getClassLoader() == null) {
+            throw new IllegalStateException("ClassLoader of JNIServiceTests Class is null");
+        }
         URL testIndexVectors = JNIServiceTests.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
         URL testIndexVectorsNested = JNIServiceTests.class.getClassLoader().getResource("data/test_vectors_nested_1000x128.json");
         URL testQueries = JNIServiceTests.class.getClassLoader().getResource("data/test_queries_100x128.csv");

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -121,6 +121,11 @@ public class KNNRestTestCase extends ODFERestTestCase {
         }
 
         String serverUrl = System.getProperty("jmx.serviceUrl");
+        if (serverUrl == null) {
+            log.error("Failed to dump coverage because JMX Service URL is null");
+            throw new IllegalArgumentException("JMX Service URL is null");
+        }
+
         try (JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(serverUrl))) {
             IProxy proxy = MBeanServerInvocationHandler.newProxyInstance(
                 connector.getMBeanServerConnection(),
@@ -129,7 +134,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
                 false
             );
 
-            Path path = Path.of(jacocoBuildPath, "integTest.exec");
+            Path path = Path.of(Path.of(jacocoBuildPath, "integTest.exec").toFile().getCanonicalPath());
             Files.write(path, proxy.getExecutionData(false));
         } catch (Exception ex) {
             log.error("Failed to dump coverage: ", ex);


### PR DESCRIPTION
### Description
Fix the following AppSec findings:

- CWE-22 is used to identify an "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
weakness. 

- CWE-476 is used to identify a "NULL Pointer Dereference" weakness. 

 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
