### PR TITLE
Add ability to share IVFPQ-l2 state in JNI

### DIFF
--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -33,8 +33,8 @@ namespace knn_jni {
         // Return a pointer to the loaded index
         jlong LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jstring indexPathJ);
 
-        // Check if a loaded index is an IVFPQ index with l2 space type
-        bool IsIndexIVFPQL2(jlong indexPointerJ);
+        // Check if a loaded index requires shared state
+        bool IsSharedIndexStateRequired(jlong indexPointerJ);
 
         // Initializes the shared index state from an index. Note, this will not set the state for
         // the index pointed to by indexPointerJ. To set it, SetSharedIndexState needs to be called.

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -33,6 +33,18 @@ namespace knn_jni {
         // Return a pointer to the loaded index
         jlong LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jstring indexPathJ);
 
+        // Check if a loaded index is an IVFPQ index with l2 space type
+        bool IsIndexIVFPQL2(jlong indexPointerJ);
+
+        // Initializes the shared index state from an index. Note, this will not set the state for
+        // the index pointed to by indexPointerJ. To set it, SetSharedIndexState needs to be called.
+        //
+        // Return a pointer to the shared index state
+        jlong InitSharedIndexState(jlong indexPointerJ);
+
+        // Sets the sharedIndexState for an index
+        void SetSharedIndexState(jlong indexPointerJ, jlong shareIndexStatePointerJ);
+
         // Execute a query against the index located in memory at indexPointerJ.
         //
         // Return an array of KNNQueryResults
@@ -48,6 +60,9 @@ namespace knn_jni {
 
         // Free the index located in memory at indexPointerJ
         void Free(jlong indexPointer);
+
+        // Free shared index state in memory at shareIndexStatePointerJ
+        void FreeSharedIndexState(jlong shareIndexStatePointerJ);
 
         // Perform initilization operations for the library
         void InitLibrary();

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -44,16 +44,40 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    isIndexIVFPQL2
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isIndexIVFPQL2
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    initSharedIndexState
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initSharedIndexState
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    setSharedIndexState
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setSharedIndexState
+  (JNIEnv *, jclass, jlong, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
  * Method:    queryIndex
- * Signature: (J[FI)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ * Signature: (J[FI[I)[Lorg/opensearch/knn/index/query/KNNQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndex
   (JNIEnv *, jclass, jlong, jfloatArray, jint, jintArray);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
- * Method:    queryIndex_WithFilter
- * Signature: (J[FI[J)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ * Method:    queryIndexWithFilter
+ * Signature: (J[FI[JI[I)[Lorg/opensearch/knn/index/query/KNNQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndexWithFilter
   (JNIEnv *, jclass, jlong, jfloatArray, jint, jlongArray, jint, jintArray);
@@ -64,6 +88,14 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryInd
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_free
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    freeSharedIndexState
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_freeSharedIndexState
   (JNIEnv *, jclass, jlong);
 
 /*

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -44,10 +44,10 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
- * Method:    isIndexIVFPQL2
+ * Method:    isSharedIndexStateRequired
  * Signature: (J)Z
  */
-JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isIndexIVFPQL2
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isSharedIndexStateRequired
   (JNIEnv *, jclass, jlong);
 
 /*

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -228,7 +228,7 @@ jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
     return (jlong) indexReader;
 }
 
-bool knn_jni::faiss_wrapper::IsIndexIVFPQL2(jlong indexPointerJ) {
+bool knn_jni::faiss_wrapper::IsSharedIndexStateRequired(jlong indexPointerJ) {
     auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
     return isIndexIVFPQL2(index);
 }

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -21,6 +21,7 @@
 #include "faiss/MetaIndexes.h"
 #include "faiss/Index.h"
 #include "faiss/impl/IDSelector.h"
+#include "faiss/IndexIVFPQ.h"
 
 #include <algorithm>
 #include <jni.h>
@@ -72,6 +73,13 @@ void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, fa
 void buildFilterIdsBitMap(const int* filterIds, int filterIdsLength, uint8_t* bitsetVector);
 
 std::unique_ptr<faiss::IDGrouperBitmap> buildIDGrouperBitmap(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env, jintArray parentIdsJ, std::vector<uint64_t>* bitmap);
+
+// Check if a loaded index is an IVFPQ index with l2 space type
+bool isIndexIVFPQL2(faiss::Index * index);
+
+// Gets IVFPQ index from a faiss index. For faiss, we wrap the index in the type
+// IndexIDMap which has member that will point to underlying index that stores the data
+faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index);
 
 void knn_jni::faiss_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
                                          jobjectArray vectorsJ, jstring indexPathJ, jobject parametersJ) {
@@ -214,8 +222,58 @@ jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
 
     std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
     // Skipping IO_FLAG_PQ_SKIP_SDC_TABLE because the index is read only and the sdc table is only used during ingestion
-    faiss::Index* indexReader = faiss::read_index(indexPathCpp.c_str(), faiss::IO_FLAG_READ_ONLY | faiss::IO_FLAG_PQ_SKIP_SDC_TABLE);
+    // Skipping IO_PRECOMPUTE_TABLE because it is only needed for IVFPQ-l2 and it leads to high memory consumption if
+    // done for each segment. Instead, we will set it later on with `setSharedIndexState`
+    faiss::Index* indexReader = faiss::read_index(indexPathCpp.c_str(), faiss::IO_FLAG_READ_ONLY | faiss::IO_FLAG_PQ_SKIP_SDC_TABLE | faiss::IO_FLAG_SKIP_PRECOMPUTE_TABLE);
     return (jlong) indexReader;
+}
+
+bool knn_jni::faiss_wrapper::IsIndexIVFPQL2(jlong indexPointerJ) {
+    auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    return isIndexIVFPQL2(index);
+}
+
+jlong knn_jni::faiss_wrapper::InitSharedIndexState(jlong indexPointerJ) {
+    auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    if (!isIndexIVFPQL2(index)) {
+        throw std::runtime_error("Unable to init shared index state from index. index is not of type IVFPQ-l2");
+    }
+
+    auto * indexIVFPQ = extractIVFPQIndex(index);
+    int use_precomputed_table = 0;
+    auto * sharedMemoryAddress = new faiss::AlignedTable<float>();
+    faiss::initialize_IVFPQ_precomputed_table(
+            use_precomputed_table,
+            indexIVFPQ->quantizer,
+            indexIVFPQ->pq,
+            *sharedMemoryAddress,
+            indexIVFPQ->by_residual,
+            indexIVFPQ->verbose);
+    return (jlong) sharedMemoryAddress;
+}
+
+void knn_jni::faiss_wrapper::SetSharedIndexState(jlong indexPointerJ, jlong shareIndexStatePointerJ) {
+    auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    if (!isIndexIVFPQL2(index)) {
+        throw std::runtime_error("Unable to set shared index state from index. index is not of type IVFPQ-l2");
+    }
+    auto * indexIVFPQ = extractIVFPQIndex(index);
+
+    //TODO: Currently, the only shared state is that of the AlignedTable associated with
+    // IVFPQ-l2 index type (see https://github.com/opensearch-project/k-NN/issues/1507). In the future,
+    // this will be generalized and more information will be needed to determine the shared type. But, until then,
+    // this is fine.
+    auto *alignTable = reinterpret_cast<faiss::AlignedTable<float>*>(shareIndexStatePointerJ);
+    // In faiss, usePrecomputedTable can have a couple different values:
+    //  -1  -> dont use the table
+    //   0  -> tell initialize_IVFPQ_precomputed_table to select the best value and change the value
+    //   1  -> default behavior
+    //   2  -> Index is of type "MultiIndexQuantizer"
+    // This index will be of type IndexIVFPQ always. We never create "MultiIndexQuantizer". So, the value we
+    // want is 1.
+    // (ref: https://github.com/facebookresearch/faiss/blob/v1.8.0/faiss/IndexIVFPQ.cpp#L383-L410)
+    int usePrecomputedTable = 1;
+    indexIVFPQ->set_precomputed_table(alignTable, usePrecomputedTable);
 }
 
 jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
@@ -335,6 +393,15 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
 void knn_jni::faiss_wrapper::Free(jlong indexPointer) {
     auto *indexWrapper = reinterpret_cast<faiss::Index*>(indexPointer);
     delete indexWrapper;
+}
+
+void knn_jni::faiss_wrapper::FreeSharedIndexState(jlong shareIndexStatePointerJ) {
+    //TODO: Currently, the only shared state is that of the AlignedTable associated with
+    // IVFPQ-l2 index type (see https://github.com/opensearch-project/k-NN/issues/1507). In the future,
+    // this will be generalized and more information will be needed to determine the shared type. But, until then,
+    // this is fine.
+    auto *alignTable = reinterpret_cast<faiss::AlignedTable<float>*>(shareIndexStatePointerJ);
+    delete alignTable;
 }
 
 void knn_jni::faiss_wrapper::InitLibrary() {
@@ -468,4 +535,36 @@ std::unique_ptr<faiss::IDGrouperBitmap> buildIDGrouperBitmap(knn_jni::JNIUtilInt
     std::unique_ptr<faiss::IDGrouperBitmap> idGrouper = faiss_util::buildIDGrouperBitmap(parentIdsArray, parentIdsLength, bitmap);
     jniUtil->ReleaseIntArrayElements(env, parentIdsJ, parentIdsArray, JNI_ABORT);
     return idGrouper;
+}
+
+bool isIndexIVFPQL2(faiss::Index * index) {
+    faiss::Index * candidateIndex = index;
+    // Unwrap the index if it is wrapped in IndexIDMap. Dynamic cast will "Safely converts pointers and references to
+    // classes up, down, and sideways along the inheritance hierarchy." It will return a nullptr if the
+    // cast fails. (ref: https://en.cppreference.com/w/cpp/language/dynamic_cast)
+    if (auto indexIDMap = dynamic_cast<faiss::IndexIDMap *>(index)) {
+        candidateIndex = indexIDMap->index;
+    }
+
+    // Check if the index is of type IndexIVFPQ. If so, confirm its metric type is
+    // l2.
+    if (auto indexIVFPQ = dynamic_cast<faiss::IndexIVFPQ *>(candidateIndex)) {
+        return faiss::METRIC_L2 == indexIVFPQ->metric_type;
+    }
+
+    return false;
+}
+
+faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index) {
+    faiss::Index * candidateIndex = index;
+    if (auto indexIDMap = dynamic_cast<faiss::IndexIDMap *>(index)) {
+        candidateIndex = indexIDMap->index;
+    }
+
+    faiss::IndexIVFPQ * indexIVFPQ;
+    if ((indexIVFPQ = dynamic_cast<faiss::IndexIVFPQ *>(candidateIndex))) {
+        return indexIVFPQ;
+    }
+
+    throw std::runtime_error("Unable to extract IVFPQ index. IVFPQ index not present.");
 }

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -75,11 +75,11 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex(JNIEn
     return NULL;
 }
 
-JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isIndexIVFPQL2
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isSharedIndexStateRequired
         (JNIEnv * env, jclass cls, jlong indexPointerJ)
 {
     try {
-        return knn_jni::faiss_wrapper::IsIndexIVFPQL2(indexPointerJ);
+        return knn_jni::faiss_wrapper::IsSharedIndexStateRequired(indexPointerJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -75,6 +75,38 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex(JNIEn
     return NULL;
 }
 
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isIndexIVFPQL2
+        (JNIEnv * env, jclass cls, jlong indexPointerJ)
+{
+    try {
+        return knn_jni::faiss_wrapper::IsIndexIVFPQL2(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return NULL;
+}
+
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initSharedIndexState
+        (JNIEnv * env, jclass cls, jlong indexPointerJ)
+{
+    try {
+        return knn_jni::faiss_wrapper::InitSharedIndexState(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return NULL;
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setSharedIndexState
+        (JNIEnv * env, jclass cls, jlong indexPointerJ, jlong shareIndexStatePointerJ)
+{
+    try {
+        knn_jni::faiss_wrapper::SetSharedIndexState(indexPointerJ, shareIndexStatePointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndex(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ, jint kJ, jintArray parentIdsJ)
@@ -104,6 +136,16 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_free(JNIEnv * en
 {
     try {
         return knn_jni::faiss_wrapper::Free(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_freeSharedIndexState
+        (JNIEnv * env, jclass cls, jlong shareIndexStatePointerJ)
+{
+    try {
+        knn_jni::faiss_wrapper::FreeSharedIndexState(shareIndexStatePointerJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -534,7 +534,7 @@ TEST(FaissCreateHnswSQfp16IndexTest, BasicAssertions) {
     std::remove(indexPath.c_str());
 }
 
-TEST(FaissIsIndexIVFPQL2, BasicAssertions) {
+TEST(FaissIsSharedIndexStateRequired, BasicAssertions) {
     int d = 128;
     int hnswM = 16;
     int ivfNlist = 4;
@@ -579,13 +579,13 @@ TEST(FaissIsIndexIVFPQL2, BasicAssertions) {
             ));
     jlong nullAddress = 0;
 
-    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexHNSWL2.get()));
-    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIVFPQIP.get()));
-    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIDMapIVFPQIP.get()));
-    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) nullAddress));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexHNSWL2.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIVFPQIP.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIDMapIVFPQIP.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) nullAddress));
 
-    ASSERT_TRUE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIVFPQL2.get()));
-    ASSERT_TRUE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIDMapIVFPQL2.get()));
+    ASSERT_TRUE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIVFPQL2.get()));
+    ASSERT_TRUE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIDMapIVFPQL2.get()));
 }
 
 TEST(FaissInitAndSetSharedIndexState, BasicAssertions) {

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -18,6 +18,7 @@
 #include "jni_util.h"
 #include "test_util.h"
 #include "faiss/IndexHNSW.h"
+#include "faiss/IndexIVFPQ.h"
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -202,6 +203,37 @@ TEST(FaissLoadIndexTest, HNSWPQDisableSdcTable) {
     auto pqIndex = dynamic_cast<faiss::IndexPQ*>(hnswPQIndex->storage);
     ASSERT_NE(pqIndex, nullptr);
     ASSERT_EQ(0, pqIndex->pq.sdc_table.size());
+}
+
+TEST(FaissLoadIndexTest, IVFPQDisablePrecomputeTable) {
+    faiss::idx_t numIds = 256;
+    int dim = 2;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    std::vector<float> vectors = test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax);
+
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::MetricType metricType = faiss::METRIC_L2;
+    std::string indexDescription = "IVF4,PQ1x4";
+
+    std::unique_ptr<faiss::Index> faissIndex(test_util::FaissCreateIndex(dim, indexDescription, metricType));
+    test_util::FaissTrainIndex(faissIndex.get(), numIds, vectors.data());
+    auto faissIndexWithIDMap = test_util::FaissAddData(faissIndex.get(), ids, vectors);
+    test_util::FaissWriteIndex(&faissIndexWithIDMap, indexPath);
+
+    // Setup jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    std::unique_ptr<faiss::Index> loadedIndexPointer(
+            reinterpret_cast<faiss::Index *>(knn_jni::faiss_wrapper::LoadIndex(
+                    &mockJNIUtil, jniEnv, (jstring)&indexPath)));
+
+    // Cast down until we get to the ivfpq-l2 state
+    auto idMapIndex = dynamic_cast<faiss::IndexIDMap *>(loadedIndexPointer.get());
+    ASSERT_NE(idMapIndex, nullptr);
+    auto ivfpqIndex = dynamic_cast<faiss::IndexIVFPQ *>(idMapIndex->index);
+    ASSERT_NE(ivfpqIndex, nullptr);
+    ASSERT_EQ(0, ivfpqIndex->precomputed_table->size());
 }
 
 TEST(FaissQueryIndexTest, BasicAssertions) {
@@ -500,4 +532,95 @@ TEST(FaissCreateHnswSQfp16IndexTest, BasicAssertions) {
     
     // Clean up
     std::remove(indexPath.c_str());
+}
+
+TEST(FaissIsIndexIVFPQL2, BasicAssertions) {
+    int d = 128;
+    int hnswM = 16;
+    int ivfNlist = 4;
+    int pqM = 1;
+    int pqCodeSize = 8;
+    std::unique_ptr<faiss::IndexHNSW> indexHNSWL2(new faiss::IndexHNSW(d, hnswM, faiss::METRIC_L2));
+    std::unique_ptr<faiss::IndexIVFPQ> indexIVFPQIP(new faiss::IndexIVFPQ(
+                new faiss::IndexFlat(d, faiss::METRIC_INNER_PRODUCT),
+                d,
+                ivfNlist,
+                pqM,
+                pqCodeSize,
+                faiss::METRIC_INNER_PRODUCT
+            ));
+    std::unique_ptr<faiss::IndexIVFPQ> indexIVFPQL2(new faiss::IndexIVFPQ(
+                new faiss::IndexFlat(d, faiss::METRIC_L2),
+                d,
+                ivfNlist,
+                pqM,
+                pqCodeSize,
+                faiss::METRIC_L2
+            ));
+    std::unique_ptr<faiss::IndexIDMap> indexIDMapIVFPQL2(new faiss::IndexIDMap(
+                new faiss::IndexIVFPQ(
+                        new faiss::IndexFlat(d, faiss::METRIC_L2),
+                        d,
+                        ivfNlist,
+                        pqM,
+                        pqCodeSize,
+                        faiss::METRIC_L2
+                )
+            ));
+    std::unique_ptr<faiss::IndexIDMap> indexIDMapIVFPQIP(new faiss::IndexIDMap(
+                new faiss::IndexIVFPQ(
+                        new faiss::IndexFlat(d, faiss::METRIC_INNER_PRODUCT),
+                        d,
+                        ivfNlist,
+                        pqM,
+                        pqCodeSize,
+                        faiss::METRIC_INNER_PRODUCT
+                )
+            ));
+    jlong nullAddress = 0;
+
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexHNSWL2.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIVFPQIP.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIDMapIVFPQIP.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) nullAddress));
+
+    ASSERT_TRUE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIVFPQL2.get()));
+    ASSERT_TRUE(knn_jni::faiss_wrapper::IsIndexIVFPQL2((jlong) indexIDMapIVFPQL2.get()));
+}
+
+TEST(FaissInitAndSetSharedIndexState, BasicAssertions) {
+    faiss::idx_t numIds = 256;
+    int dim = 2;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    std::vector<float> vectors = test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax);
+
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::MetricType metricType = faiss::METRIC_L2;
+    std::string indexDescription = "IVF4,PQ1x4";
+
+    std::unique_ptr<faiss::Index> faissIndex(test_util::FaissCreateIndex(dim, indexDescription, metricType));
+    test_util::FaissTrainIndex(faissIndex.get(), numIds, vectors.data());
+    auto faissIndexWithIDMap = test_util::FaissAddData(faissIndex.get(), ids, vectors);
+    test_util::FaissWriteIndex(&faissIndexWithIDMap, indexPath);
+
+    // Setup jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    std::unique_ptr<faiss::Index> loadedIndexPointer(
+            reinterpret_cast<faiss::Index *>(knn_jni::faiss_wrapper::LoadIndex(
+                    &mockJNIUtil, jniEnv, (jstring)&indexPath)));
+
+    auto idMapIndex = dynamic_cast<faiss::IndexIDMap *>(loadedIndexPointer.get());
+    ASSERT_NE(idMapIndex, nullptr);
+    auto ivfpqIndex = dynamic_cast<faiss::IndexIVFPQ *>(idMapIndex->index);
+    ASSERT_NE(ivfpqIndex, nullptr);
+    ASSERT_EQ(0, ivfpqIndex->precomputed_table->size());
+    jlong sharedModelAddress = knn_jni::faiss_wrapper::InitSharedIndexState((jlong) loadedIndexPointer.get());
+    ASSERT_EQ(0, ivfpqIndex->precomputed_table->size());
+    knn_jni::faiss_wrapper::SetSharedIndexState((jlong) loadedIndexPointer.get(), sharedModelAddress);
+    ASSERT_EQ(sharedModelAddress, (jlong) ivfpqIndex->precomputed_table);
+    ASSERT_NE(0, ivfpqIndex->precomputed_table->size());
+    ASSERT_EQ(1, ivfpqIndex->use_precomputed_table);
+    knn_jni::faiss_wrapper::FreeSharedIndexState(sharedModelAddress);
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -186,7 +186,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             KNNSettings.state().getSettingValue(KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY)
         );
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, parameters, knnEngine.getName());
+            JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, parameters, knnEngine);
             return null;
         });
     }
@@ -228,7 +228,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
 
         // Pass the path for the nms library to save the file
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            JNIService.createIndex(pair.docs, pair.vectors, indexPath, parameters, knnEngine.getName());
+            JNIService.createIndex(pair.docs, pair.vectors, indexPath, parameters, knnEngine);
             return null;
         });
     }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryAllocation.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryAllocation.java
@@ -143,7 +143,7 @@ public interface NativeMemoryAllocation {
 
             // memoryAddress is sometimes initialized to 0. If this is ever the case, freeing will surely fail.
             if (memoryAddress != 0) {
-                JNIService.free(memoryAddress, knnEngine.getName());
+                JNIService.free(memoryAddress, knnEngine);
             }
         }
 

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
@@ -92,7 +92,7 @@ public interface NativeMemoryLoadStrategy<T extends NativeMemoryAllocation, U ex
             fileWatcher.init();
 
             KNNEngine knnEngine = KNNEngine.getEngineNameFromPath(indexPath.toString());
-            long memoryAddress = JNIService.loadIndex(indexPath.toString(), indexEntryContext.getParameters(), knnEngine.getName());
+            long memoryAddress = JNIService.loadIndex(indexPath.toString(), indexEntryContext.getParameters(), knnEngine);
             final WatcherHandle<FileWatcher> watcherHandle = resourceWatcherService.add(fileWatcher);
 
             return new NativeMemoryAllocation.IndexAllocation(

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -280,7 +280,7 @@ public class KNNWeight extends Weight {
                 indexAllocation.getMemoryAddress(),
                 knnQuery.getQueryVector(),
                 knnQuery.getK(),
-                knnEngine.getName(),
+                knnEngine,
                 filterIds,
                 filterType.getValue(),
                 parentIds

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -74,6 +74,31 @@ class FaissService {
     public static native long loadIndex(String indexPath);
 
     /**
+     * Determine if index is IVFPQ with L2 metric. Currently, we cannot do this in the plugin because we
+     * do not store the model definition anywhere.
+     *
+     * @param indexAddr addrees of index to be checked.
+     * @return true if index is of type IVFPQ-l2; false otherwise
+     */
+    public static native boolean isIndexIVFPQL2(long indexAddr);
+
+    /**
+     * Initialize the shared state for an index
+     *
+     * @param indexAddr address of the index to initialize from
+     * @return Address of shared index state address
+     */
+    public static native long initSharedIndexState(long indexAddr);
+
+    /**
+     * Set the index state for an index
+     *
+     * @param indexAddr address of index to set state for
+     * @param shareIndexStateAddr address of shared state to be set
+     */
+    public static native void setSharedIndexState(long indexAddr, long shareIndexStateAddr);
+
+    /**
      * Query an index without filter
      *
      * If the "knn" field is a nested field, each vector value within that nested field will be assigned its
@@ -113,6 +138,13 @@ class FaissService {
      * Free native memory pointer
      */
     public static native void free(long indexPointer);
+
+    /**
+     * Deallocate memory of the shared index state
+     *
+     * @param shareIndexStateAddr address of shared state
+     */
+    public static native void freeSharedIndexState(long shareIndexStateAddr);
 
     /**
      * Initialize library

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -74,13 +74,12 @@ class FaissService {
     public static native long loadIndex(String indexPath);
 
     /**
-     * Determine if index is IVFPQ with L2 metric. Currently, we cannot do this in the plugin because we
-     * do not store the model definition anywhere.
+     * Determine if index contains shared state.
      *
-     * @param indexAddr addrees of index to be checked.
-     * @return true if index is of type IVFPQ-l2; false otherwise
+     * @param indexAddr address of index to be checked.
+     * @return true if index requires shared index state; false otherwise
      */
-    public static native boolean isIndexIVFPQL2(long indexAddr);
+    public static native boolean isSharedIndexStateRequired(long indexAddr);
 
     /**
      * Initialize the shared state for an index

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -42,7 +42,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("CreateIndex not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("CreateIndex not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -68,7 +68,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("CreateIndexFromTemplate not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("CreateIndexFromTemplate not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -88,7 +88,7 @@ public class JNIService {
             return FaissService.loadIndex(indexPath);
         }
 
-        throw new IllegalArgumentException("LoadIndex not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("LoadIndex not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -119,8 +119,7 @@ public class JNIService {
         if (KNNEngine.FAISS.getName().equals(engineName)) {
             return FaissService.initSharedIndexState(indexAddr);
         }
-
-        throw new IllegalArgumentException("InitSharedIndexState not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("InitSharedIndexState not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -136,7 +135,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("SetSharedIndexState not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("SetSharedIndexState not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -173,7 +172,7 @@ public class JNIService {
             }
             return FaissService.queryIndex(indexPointer, queryVector, k, parentIds);
         }
-        throw new IllegalArgumentException("QueryIndex not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("QueryIndex not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -193,7 +192,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("Free not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("Free not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -207,8 +206,7 @@ public class JNIService {
             FaissService.freeSharedIndexState(shareIndexStateAddr);
             return;
         }
-
-        throw new IllegalArgumentException("FreeSharedIndexState not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("FreeSharedIndexState not supported for provided engine : %s", engineName));
     }
 
     /**
@@ -225,7 +223,7 @@ public class JNIService {
             return FaissService.trainIndex(indexParameters, dimension, trainVectorsPointer);
         }
 
-        throw new IllegalArgumentException("TrainIndex not supported for provided engine : " + engineName);
+        throw new IllegalArgumentException(String.format("TrainIndex not supported for provided engine : %s", engineName));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -25,35 +25,35 @@ public class JNIService {
     /**
      * Create an index for the native library
      *
-     * @param ids array of ids mapping to the data passed in
-     * @param data array of float arrays to be indexed
-     * @param indexPath path to save index file to
+     * @param ids        array of ids mapping to the data passed in
+     * @param data       array of float arrays to be indexed
+     * @param indexPath  path to save index file to
      * @param parameters parameters to build index
-     * @param engineName name of engine to build index for
+     * @param knnEngine  engine to build index for
      */
-    public static void createIndex(int[] ids, float[][] data, String indexPath, Map<String, Object> parameters, String engineName) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+    public static void createIndex(int[] ids, float[][] data, String indexPath, Map<String, Object> parameters, KNNEngine knnEngine) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             NmslibService.createIndex(ids, data, indexPath, parameters);
             return;
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.createIndex(ids, data, indexPath, parameters);
             return;
         }
 
-        throw new IllegalArgumentException(String.format("CreateIndex not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(String.format("CreateIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**
      * Create an index for the native library with a provided template index
      *
-     * @param ids array of ids mapping to the data passed in
-     * @param data array of float arrays to be indexed
-     * @param indexPath path to save index file to
+     * @param ids           array of ids mapping to the data passed in
+     * @param data          array of float arrays to be indexed
+     * @param indexPath     path to save index file to
      * @param templateIndex empty template index
-     * @param parameters parameters to build index
-     * @param engineName name of engine to build index for
+     * @param parameters    parameters to build index
+     * @param knnEngine     engine to build index for
      */
     public static void createIndexFromTemplate(
         int[] ids,
@@ -61,34 +61,36 @@ public class JNIService {
         String indexPath,
         byte[] templateIndex,
         Map<String, Object> parameters,
-        String engineName
+        KNNEngine knnEngine
     ) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.createIndexFromTemplate(ids, data, indexPath, templateIndex, parameters);
             return;
         }
 
-        throw new IllegalArgumentException(String.format("CreateIndexFromTemplate not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(
+            String.format("CreateIndexFromTemplate not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Load an index into memory
      *
-     * @param indexPath path to index file
+     * @param indexPath  path to index file
      * @param parameters parameters to be used when loading index
-     * @param engineName name of engine to load index
+     * @param knnEngine  engine to load index
      * @return pointer to location in memory the index resides in
      */
-    public static long loadIndex(String indexPath, Map<String, Object> parameters, String engineName) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+    public static long loadIndex(String indexPath, Map<String, Object> parameters, KNNEngine knnEngine) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             return NmslibService.loadIndex(indexPath, parameters);
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             return FaissService.loadIndex(indexPath);
         }
 
-        throw new IllegalArgumentException(String.format("LoadIndex not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(String.format("LoadIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**
@@ -97,11 +99,11 @@ public class JNIService {
      * return false.
      *
      * @param indexAddr address of index to be checked.
-     * @param engineName name of engine
+     * @param knnEngine engine
      * @return true if index requires shared index state; false otherwise
      */
-    public static boolean isSharedIndexStateRequired(long indexAddr, String engineName) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+    public static boolean isSharedIndexStateRequired(long indexAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
             return FaissService.isSharedIndexStateRequired(indexAddr);
         }
 
@@ -112,40 +114,44 @@ public class JNIService {
      * Initialize the shared state for an index
      *
      * @param indexAddr address of the index to initialize from
-     * @param engineName name of engine
+     * @param knnEngine engine
      * @return Address of shared index state address
      */
-    public static long initSharedIndexState(long indexAddr, String engineName) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+    public static long initSharedIndexState(long indexAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
             return FaissService.initSharedIndexState(indexAddr);
         }
-        throw new IllegalArgumentException(String.format("InitSharedIndexState not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(
+            String.format("InitSharedIndexState not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Set the index state for an index
      *
-     * @param indexAddr address of index to set state for
+     * @param indexAddr           address of index to set state for
      * @param shareIndexStateAddr address of shared state to be set
-     * @param engineName name of engine
+     * @param knnEngine           engine
      */
-    public static void setSharedIndexState(long indexAddr, long shareIndexStateAddr, String engineName) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+    public static void setSharedIndexState(long indexAddr, long shareIndexStateAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.setSharedIndexState(indexAddr, shareIndexStateAddr);
             return;
         }
 
-        throw new IllegalArgumentException(String.format("SetSharedIndexState not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(
+            String.format("SetSharedIndexState not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Query an index
      *
-     * @param indexPointer pointer to index in memory
-     * @param queryVector  vector to be used for query
-     * @param k            neighbors to be returned
-     * @param engineName   name of engine to query index
-     * @param filteredIds  array of ints on which should be used for search.
+     * @param indexPointer  pointer to index in memory
+     * @param queryVector   vector to be used for query
+     * @param k             neighbors to be returned
+     * @param knnEngine     engine to query index
+     * @param filteredIds   array of ints on which should be used for search.
      * @param filterIdsType how to filter ids: Batch or BitMap
      * @return KNNQueryResult array of k neighbors
      */
@@ -153,16 +159,16 @@ public class JNIService {
         long indexPointer,
         float[] queryVector,
         int k,
-        String engineName,
+        KNNEngine knnEngine,
         long[] filteredIds,
         int filterIdsType,
         int[] parentIds
     ) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             return NmslibService.queryIndex(indexPointer, queryVector, k);
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             // This code assumes that if filteredIds == null / filteredIds.length == 0 if filter is specified then empty
             // k-NN results are already returned. Otherwise, it's a filter case and we need to run search with
             // filterIds. FilterIds is coming as empty then its the case where we need to do search with Faiss engine
@@ -172,58 +178,60 @@ public class JNIService {
             }
             return FaissService.queryIndex(indexPointer, queryVector, k, parentIds);
         }
-        throw new IllegalArgumentException(String.format("QueryIndex not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(String.format("QueryIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**
      * Free native memory pointer
      *
      * @param indexPointer location to be freed
-     * @param engineName engine to perform free
+     * @param knnEngine    engine to perform free
      */
-    public static void free(long indexPointer, String engineName) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+    public static void free(long indexPointer, KNNEngine knnEngine) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             NmslibService.free(indexPointer);
             return;
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.free(indexPointer);
             return;
         }
 
-        throw new IllegalArgumentException(String.format("Free not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(String.format("Free not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**
      * Deallocate memory of the shared index state
      *
      * @param shareIndexStateAddr address of shared state
-     * @param engineName name of engine
+     * @param knnEngine           engine
      */
-    public static void freeSharedIndexState(long shareIndexStateAddr, String engineName) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+    public static void freeSharedIndexState(long shareIndexStateAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.freeSharedIndexState(shareIndexStateAddr);
             return;
         }
-        throw new IllegalArgumentException(String.format("FreeSharedIndexState not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(
+            String.format("FreeSharedIndexState not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Train an empty index
      *
-     * @param indexParameters parameters used to build index
-     * @param dimension dimension for the index
+     * @param indexParameters     parameters used to build index
+     * @param dimension           dimension for the index
      * @param trainVectorsPointer pointer to where training vectors are stored in native memory
-     * @param engineName engine to perform the training
+     * @param knnEngine           engine to perform the training
      * @return bytes array of trained template index
      */
-    public static byte[] trainIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer, String engineName) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+    public static byte[] trainIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
             return FaissService.trainIndex(indexParameters, dimension, trainVectorsPointer);
         }
 
-        throw new IllegalArgumentException(String.format("TrainIndex not supported for provided engine : %s", engineName));
+        throw new IllegalArgumentException(String.format("TrainIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -92,6 +92,54 @@ public class JNIService {
     }
 
     /**
+     * Determine if index is IVFPQ with L2 metric. Currently, we cannot do this in the plugin because we
+     * do not store the model definition anywhere. Only faiss supports IVFPQ indices. So for all other engines it will
+     * return false.
+     *
+     * @param indexAddr addrees of index to be checked.
+     * @param engineName name of engine
+     * @return true if index is of type IVFPQ-l2; false otherwise
+     */
+    public static boolean isIndexIVFPQL2(long indexAddr, String engineName) {
+        if (KNNEngine.FAISS.getName().equals(engineName)) {
+            return FaissService.isIndexIVFPQL2(indexAddr);
+        }
+
+        return false;
+    }
+
+    /**
+     * Initialize the shared state for an index
+     *
+     * @param indexAddr address of the index to initialize from
+     * @param engineName name of engine
+     * @return Address of shared index state address
+     */
+    public static long initSharedIndexState(long indexAddr, String engineName) {
+        if (KNNEngine.FAISS.getName().equals(engineName)) {
+            return FaissService.initSharedIndexState(indexAddr);
+        }
+
+        throw new IllegalArgumentException("InitSharedIndexState not supported for provided engine");
+    }
+
+    /**
+     * Set the index state for an index
+     *
+     * @param indexAddr address of index to set state for
+     * @param shareIndexStateAddr address of shared state to be set
+     * @param engineName name of engine
+     */
+    public static void setSharedIndexState(long indexAddr, long shareIndexStateAddr, String engineName) {
+        if (KNNEngine.FAISS.getName().equals(engineName)) {
+            FaissService.setSharedIndexState(indexAddr, shareIndexStateAddr);
+            return;
+        }
+
+        throw new IllegalArgumentException("SetSharedIndexState not supported for provided engine");
+    }
+
+    /**
      * Query an index
      *
      * @param indexPointer pointer to index in memory
@@ -146,6 +194,21 @@ public class JNIService {
         }
 
         throw new IllegalArgumentException("Free not supported for provided engine");
+    }
+
+    /**
+     * Deallocate memory of the shared index state
+     *
+     * @param shareIndexStateAddr address of shared state
+     * @param engineName name of engine
+     */
+    public static void freeSharedIndexState(long shareIndexStateAddr, String engineName) {
+        if (KNNEngine.FAISS.getName().equals(engineName)) {
+            FaissService.freeSharedIndexState(shareIndexStateAddr);
+            return;
+        }
+
+        throw new IllegalArgumentException("FreeSharedIndexState not supported for provided engine");
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -42,7 +42,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("CreateIndex not supported for provided engine");
+        throw new IllegalArgumentException("CreateIndex not supported for provided engine : " + engineName);
     }
 
     /**
@@ -68,7 +68,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("CreateIndexFromTemplate not supported for provided engine");
+        throw new IllegalArgumentException("CreateIndexFromTemplate not supported for provided engine : " + engineName);
     }
 
     /**
@@ -88,21 +88,21 @@ public class JNIService {
             return FaissService.loadIndex(indexPath);
         }
 
-        throw new IllegalArgumentException("LoadIndex not supported for provided engine");
+        throw new IllegalArgumentException("LoadIndex not supported for provided engine : " + engineName);
     }
 
     /**
-     * Determine if index is IVFPQ with L2 metric. Currently, we cannot do this in the plugin because we
-     * do not store the model definition anywhere. Only faiss supports IVFPQ indices. So for all other engines it will
+     * Determine if index contains shared state. Currently, we cannot do this in the plugin because we do not store the
+     * model definition anywhere. Only faiss supports indices that have shared state. So for all other engines it will
      * return false.
      *
-     * @param indexAddr addrees of index to be checked.
+     * @param indexAddr address of index to be checked.
      * @param engineName name of engine
-     * @return true if index is of type IVFPQ-l2; false otherwise
+     * @return true if index requires shared index state; false otherwise
      */
-    public static boolean isIndexIVFPQL2(long indexAddr, String engineName) {
+    public static boolean isSharedIndexStateRequired(long indexAddr, String engineName) {
         if (KNNEngine.FAISS.getName().equals(engineName)) {
-            return FaissService.isIndexIVFPQL2(indexAddr);
+            return FaissService.isSharedIndexStateRequired(indexAddr);
         }
 
         return false;
@@ -120,7 +120,7 @@ public class JNIService {
             return FaissService.initSharedIndexState(indexAddr);
         }
 
-        throw new IllegalArgumentException("InitSharedIndexState not supported for provided engine");
+        throw new IllegalArgumentException("InitSharedIndexState not supported for provided engine : " + engineName);
     }
 
     /**
@@ -136,7 +136,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("SetSharedIndexState not supported for provided engine");
+        throw new IllegalArgumentException("SetSharedIndexState not supported for provided engine : " + engineName);
     }
 
     /**
@@ -173,7 +173,7 @@ public class JNIService {
             }
             return FaissService.queryIndex(indexPointer, queryVector, k, parentIds);
         }
-        throw new IllegalArgumentException("QueryIndex not supported for provided engine");
+        throw new IllegalArgumentException("QueryIndex not supported for provided engine : " + engineName);
     }
 
     /**
@@ -193,7 +193,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("Free not supported for provided engine");
+        throw new IllegalArgumentException("Free not supported for provided engine : " + engineName);
     }
 
     /**
@@ -208,7 +208,7 @@ public class JNIService {
             return;
         }
 
-        throw new IllegalArgumentException("FreeSharedIndexState not supported for provided engine");
+        throw new IllegalArgumentException("FreeSharedIndexState not supported for provided engine : " + engineName);
     }
 
     /**
@@ -225,7 +225,7 @@ public class JNIService {
             return FaissService.trainIndex(indexParameters, dimension, trainVectorsPointer);
         }
 
-        throw new IllegalArgumentException("TrainIndex not supported for provided engine");
+        throw new IllegalArgumentException("TrainIndex not supported for provided engine : " + engineName);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -185,7 +185,7 @@ public class TrainingJob implements Runnable {
                 trainParameters,
                 model.getModelMetadata().getDimension(),
                 trainingDataAllocation.getMemoryAddress(),
-                model.getModelMetadata().getKnnEngine().getName()
+                model.getModelMetadata().getKnnEngine()
             );
 
             // Once training finishes, update model

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -50,7 +50,7 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,
             vectorsPointer,
-            KNNEngine.FAISS.getName()
+            KNNEngine.FAISS
         );
 
         // Setup model

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -341,7 +341,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
             SpaceType.L2.getValue()
         );
 
-        byte[] modelBytes = JNIService.trainIndex(parameters, dimension, trainingPtr, knnEngine.getName());
+        byte[] modelBytes = JNIService.trainIndex(parameters, dimension, trainingPtr, knnEngine);
         Model model = new Model(
             new ModelMetadata(knnEngine, spaceType, dimension, ModelState.CREATED, "timestamp", "Empty description", "", ""),
             modelBytes,

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -197,7 +197,7 @@ public class KNNCodecTestCase extends KNNTestCase {
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,
             vectorsPointer,
-            KNNEngine.FAISS.getName()
+            KNNEngine.FAISS
         );
 
         // Setup model cache

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -334,16 +334,12 @@ public class KNNCodecTestUtil {
     ) {
         String filePath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(state.directory))).getDirectory().toString(), fileName)
             .toString();
-        long indexPtr = JNIService.loadIndex(
-            filePath,
-            Maps.newHashMap(ImmutableMap.of(SPACE_TYPE, spaceType.getValue())),
-            knnEngine.getName()
-        );
+        long indexPtr = JNIService.loadIndex(filePath, Maps.newHashMap(ImmutableMap.of(SPACE_TYPE, spaceType.getValue())), knnEngine);
         int k = 2;
         float[] queryVector = new float[dimension];
-        KNNQueryResult[] results = JNIService.queryIndex(indexPtr, queryVector, k, knnEngine.getName(), null, 0, null);
+        KNNQueryResult[] results = JNIService.queryIndex(indexPtr, queryVector, k, knnEngine, null, 0, null);
         assertTrue(results.length > 0);
-        JNIService.free(indexPtr, knnEngine.getName());
+        JNIService.free(indexPtr, knnEngine);
     }
 
     public static float[][] getRandomVectors(int count, int dimension) {

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
@@ -52,10 +52,10 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
             Arrays.fill(vectors[i], 1f);
         }
         Map<String, Object> parameters = ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.DEFAULT.getValue());
-        JNIService.createIndex(ids, vectors, path, parameters, knnEngine.getName());
+        JNIService.createIndex(ids, vectors, path, parameters, knnEngine);
 
         // Load index into memory
-        long memoryAddress = JNIService.loadIndex(path, parameters, knnEngine.getName());
+        long memoryAddress = JNIService.loadIndex(path, parameters, knnEngine);
 
         @SuppressWarnings("unchecked")
         WatcherHandle<FileWatcher> watcherHandle = (WatcherHandle<FileWatcher>) mock(WatcherHandle.class);

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
@@ -53,7 +53,7 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
             Arrays.fill(vectors[i], 1f);
         }
         Map<String, Object> parameters = ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.DEFAULT.getValue());
-        JNIService.createIndex(ids, vectors, path, parameters, knnEngine.getName());
+        JNIService.createIndex(ids, vectors, path, parameters, knnEngine);
 
         // Setup mock resource manager
         ResourceWatcherService resourceWatcherService = mock(ResourceWatcherService.class);
@@ -74,7 +74,7 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
         // Confirm that the file was loaded by querying
         float[] query = new float[dimension];
         Arrays.fill(query, numVectors + 1);
-        KNNQueryResult[] results = JNIService.queryIndex(indexAllocation.getMemoryAddress(), query, 2, knnEngine.getName(), null, 0, null);
+        KNNQueryResult[] results = JNIService.queryIndex(indexAllocation.getMemoryAddress(), query, 2, knnEngine, null, 0, null);
         assertTrue(results.length > 0);
     }
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -157,7 +157,7 @@ public class KNNWeightTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         final Function<Float, Float> scoreTranslator = spaceType::scoreTranslation;
         final String modelId = "modelId";
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), any()))
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), any()))
             .thenReturn(getKNNQueryResults());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);
@@ -300,7 +300,7 @@ public class KNNWeightTests extends KNNTestCase {
     @SneakyThrows
     public void testEmptyQueryResults() {
         final KNNQueryResult[] knnQueryResults = new KNNQueryResult[] {};
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), any()))
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), any()))
             .thenReturn(knnQueryResults);
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);
@@ -350,7 +350,7 @@ public class KNNWeightTests extends KNNTestCase {
             filterBitSet.set(docId);
         }
         jniServiceMockedStatic.when(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), eq(filterBitSet.getBits()), anyInt(), any())
+            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), eq(filterBitSet.getBits()), anyInt(), any())
         ).thenReturn(getFilteredKNNQueryResults());
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -411,7 +411,7 @@ public class KNNWeightTests extends KNNTestCase {
         assertEquals(FILTERED_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
 
         jniServiceMockedStatic.verify(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), eq(filterBitSet.getBits()), anyInt(), any())
+            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), eq(filterBitSet.getBits()), anyInt(), any())
         );
 
         final List<Integer> actualDocIds = new ArrayList<>();
@@ -677,17 +677,14 @@ public class KNNWeightTests extends KNNTestCase {
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, 1, INDEX_NAME, null, bitSetProducer);
         final KNNWeight knnWeight = new KNNWeight(query, 0.0f, null);
 
-        jniServiceMockedStatic.when(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), eq(parentsFilter))
-        ).thenReturn(getKNNQueryResults());
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), eq(parentsFilter)))
+            .thenReturn(getKNNQueryResults());
 
         // Execute
         Scorer knnScorer = knnWeight.scorer(leafReaderContext);
 
         // Verify
-        jniServiceMockedStatic.verify(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), eq(parentsFilter))
-        );
+        jniServiceMockedStatic.verify(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), eq(parentsFilter)));
         assertNotNull(knnScorer);
         final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
         assertNotNull(docIdSetIterator);
@@ -746,7 +743,7 @@ public class KNNWeightTests extends KNNTestCase {
         final Set<String> segmentFiles,
         final Map<String, String> fileAttributes
     ) throws IOException {
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), any()))
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), any()))
             .thenReturn(getKNNQueryResults());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -54,7 +54,6 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.NAME;
-import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class JNIServiceTests extends KNNTestCase {
@@ -84,7 +83,7 @@ public class JNIServiceTests extends KNNTestCase {
                 new float[][] {},
                 "test",
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                "invalid-engine"
+                KNNEngine.LUCENE
             )
         );
     }
@@ -111,7 +110,7 @@ public class JNIServiceTests extends KNNTestCase {
                 testData.indexData.vectors,
                 "something",
                 Collections.emptyMap(),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -129,7 +128,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors1,
                 tmpFile1.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
@@ -143,7 +142,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors2,
                 tmpFile2.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -161,7 +160,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
@@ -172,7 +171,7 @@ public class JNIServiceTests extends KNNTestCase {
                 null,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
@@ -183,13 +182,13 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 null,
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
         expectThrows(
             Exception.class,
-            () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, KNNEngine.NMSLIB.getName())
+            () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, KNNEngine.NMSLIB)
         );
 
         expectThrows(
@@ -217,7 +216,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, "invalid"),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -235,7 +234,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -259,7 +258,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue(), KNNConstants.PARAMETERS, parametersMap),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -274,7 +273,7 @@ public class JNIServiceTests extends KNNTestCase {
                 testData.indexData.vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertTrue(tmpFile.toFile().length() > 0);
 
@@ -292,7 +291,7 @@ public class JNIServiceTests extends KNNTestCase {
                     KNNConstants.METHOD_PARAMETER_M,
                     12
                 ),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertTrue(tmpFile.toFile().length() > 0);
         }
@@ -310,7 +309,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 "something",
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -328,7 +327,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors1,
                 tmpFile1.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -342,7 +341,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors2,
                 tmpFile2.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -360,7 +359,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -371,7 +370,7 @@ public class JNIServiceTests extends KNNTestCase {
                 null,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -382,11 +381,14 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 null,
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
-        expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, FAISS_NAME));
+        expectThrows(
+            Exception.class,
+            () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, KNNEngine.FAISS)
+        );
 
         expectThrows(
             Exception.class,
@@ -413,7 +415,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, "invalid"),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -431,7 +433,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -449,7 +451,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -467,7 +469,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "invalid", KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -492,7 +494,7 @@ public class JNIServiceTests extends KNNTestCase {
                     KNNConstants.SPACE_TYPE,
                     SpaceType.L2.getValue()
                 ),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -510,11 +512,11 @@ public class JNIServiceTests extends KNNTestCase {
             vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, sqfp16IndexDescription, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
     }
 
@@ -530,21 +532,21 @@ public class JNIServiceTests extends KNNTestCase {
             truncateToFp16Range(testData.indexData.vectors),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, sqfp16IndexDescription, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
 
         for (float[] query : testData.queries) {
-            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null, 0, null);
+            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, null, 0, null);
             assertEquals(k, results.length);
         }
 
         // Filter will result in no ids
         for (float[] query : testData.queries) {
-            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, new long[] { 0 }, 0, null);
+            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, new long[] { 0 }, 0, null);
             assertEquals(0, results.length);
         }
     }
@@ -588,7 +590,7 @@ public class JNIServiceTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -614,7 +616,7 @@ public class JNIServiceTests extends KNNTestCase {
                     KNNConstants.PARAMETERS,
                     ImmutableMap.of(KNNConstants.METHOD_PARAMETER_NPROBES, "14")
                 ),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -632,7 +634,7 @@ public class JNIServiceTests extends KNNTestCase {
                     testData.indexData.vectors,
                     tmpFile1.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertTrue(tmpFile1.toFile().length() > 0);
             }
@@ -640,28 +642,24 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     public void testLoadIndex_invalidEngine() {
-        expectThrows(IllegalArgumentException.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), "invalid-engine"));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), KNNEngine.LUCENE));
     }
 
     public void testLoadIndex_nmslib_invalid_badSpaceType() {
         expectThrows(
             Exception.class,
-            () -> JNIService.loadIndex("test", ImmutableMap.of(KNNConstants.SPACE_TYPE, "invalid"), KNNEngine.NMSLIB.getName())
+            () -> JNIService.loadIndex("test", ImmutableMap.of(KNNConstants.SPACE_TYPE, "invalid"), KNNEngine.NMSLIB)
         );
     }
 
     public void testLoadIndex_nmslib_invalid_noSpaceType() {
-        expectThrows(Exception.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), KNNEngine.NMSLIB.getName()));
+        expectThrows(Exception.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), KNNEngine.NMSLIB));
     }
 
     public void testLoadIndex_nmslib_invalid_fileDoesNotExist() {
         expectThrows(
             Exception.class,
-            () -> JNIService.loadIndex(
-                "invalid",
-                ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
-            )
+            () -> JNIService.loadIndex("invalid", ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), KNNEngine.NMSLIB)
         );
     }
 
@@ -672,7 +670,7 @@ public class JNIServiceTests extends KNNTestCase {
             () -> JNIService.loadIndex(
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -686,27 +684,30 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertNotEquals(0, pointer);
     }
 
     public void testLoadIndex_faiss_invalid_fileDoesNotExist() {
-        expectThrows(Exception.class, () -> JNIService.loadIndex("invalid", Collections.emptyMap(), FAISS_NAME));
+        expectThrows(Exception.class, () -> JNIService.loadIndex("invalid", Collections.emptyMap(), KNNEngine.FAISS));
     }
 
     public void testLoadIndex_faiss_invalid_badFile() throws IOException {
 
         Path tmpFile = createTempFile();
 
-        expectThrows(Exception.class, () -> JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME));
+        expectThrows(
+            Exception.class,
+            () -> JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS)
+        );
     }
 
     public void testLoadIndex_faiss_valid() throws IOException {
@@ -718,24 +719,21 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
     }
 
     public void testQueryIndex_invalidEngine() {
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> JNIService.queryIndex(0L, new float[] {}, 0, "invalid" + "-engine", null, 0, null)
-        );
+        expectThrows(IllegalArgumentException.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.LUCENE, null, 0, null));
     }
 
     public void testQueryIndex_nmslib_invalid_badPointer() {
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.NMSLIB.getName(), null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.NMSLIB, null, 0, null));
     }
 
     public void testQueryIndex_nmslib_invalid_nullQueryVector() throws IOException {
@@ -747,18 +745,18 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertNotEquals(0, pointer);
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.NMSLIB.getName(), null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.NMSLIB, null, 0, null));
     }
 
     public void testQueryIndex_nmslib_valid() throws IOException {
@@ -772,19 +770,19 @@ public class JNIServiceTests extends KNNTestCase {
                 testData.indexData.vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertTrue(tmpFile.toFile().length() > 0);
 
             long pointer = JNIService.loadIndex(
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertNotEquals(0, pointer);
 
             for (float[] query : testData.queries) {
-                KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.NMSLIB.getName(), null, 0, null);
+                KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.NMSLIB, null, 0, null);
                 assertEquals(k, results.length);
             }
         }
@@ -792,7 +790,7 @@ public class JNIServiceTests extends KNNTestCase {
 
     public void testQueryIndex_faiss_invalid_badPointer() {
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, FAISS_NAME, null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.FAISS, null, 0, null));
     }
 
     public void testQueryIndex_faiss_invalid_nullQueryVector() throws IOException {
@@ -804,14 +802,14 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, FAISS_NAME, null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.FAISS, null, 0, null));
     }
 
     public void testQueryIndex_faiss_valid() throws IOException {
@@ -828,25 +826,25 @@ public class JNIServiceTests extends KNNTestCase {
                     testData.indexData.vectors,
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertTrue(tmpFile.toFile().length() > 0);
 
                 long pointer = JNIService.loadIndex(
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertNotEquals(0, pointer);
 
                 for (float[] query : testData.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null, 0, null);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, null, 0, null);
                     assertEquals(k, results.length);
                 }
 
                 // Filter will result in no ids
                 for (float[] query : testData.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, new long[] { 0 }, 0, null);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, new long[] { 0 }, 0, null);
                     assertEquals(0, results.length);
                 }
             }
@@ -869,19 +867,19 @@ public class JNIServiceTests extends KNNTestCase {
                     testDataNested.indexData.vectors,
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertTrue(tmpFile.toFile().length() > 0);
 
                 long pointer = JNIService.loadIndex(
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertNotEquals(0, pointer);
 
                 for (float[] query : testDataNested.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null, 0, parentIds);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, null, 0, parentIds);
                     // Verify there is no more than one result from same parent
                     Set<Integer> parentIdSet = toParentIdSet(results, idToParentIdMap);
                     assertEquals(results.length, parentIdSet.size());
@@ -931,7 +929,7 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     public void testFree_invalidEngine() {
-        expectThrows(IllegalArgumentException.class, () -> JNIService.free(0L, "invalid-engine"));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.free(0L, KNNEngine.LUCENE));
     }
 
     public void testFree_nmslib_valid() throws IOException {
@@ -943,18 +941,18 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertNotEquals(0, pointer);
 
-        JNIService.free(pointer, KNNEngine.NMSLIB.getName());
+        JNIService.free(pointer, KNNEngine.NMSLIB);
     }
 
     public void testFree_faiss_valid() throws IOException {
@@ -966,14 +964,14 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
 
-        JNIService.free(pointer, FAISS_NAME);
+        JNIService.free(pointer, KNNEngine.FAISS);
     }
 
     public void testTransferVectors() {
@@ -1004,7 +1002,7 @@ public class JNIServiceTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1034,7 +1032,7 @@ public class JNIServiceTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1061,7 +1059,7 @@ public class JNIServiceTests extends KNNTestCase {
         knnMethodContext.getMethodComponentContext().setIndexVersion(Version.CURRENT);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1116,7 +1114,7 @@ public class JNIServiceTests extends KNNTestCase {
             spaceType.getValue()
         );
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer1, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer1, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer1);
@@ -1128,11 +1126,11 @@ public class JNIServiceTests extends KNNTestCase {
             tmpFile1.toAbsolutePath().toString(),
             faissIndex,
             ImmutableMap.of(INDEX_THREAD_QTY, 1),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile1.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile1.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile1.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
     }
 
@@ -1147,61 +1145,61 @@ public class JNIServiceTests extends KNNTestCase {
 
         String indexIVFPQPath = createFaissIVFPQIndex(ivfNlist, pqM, pqCodeSize, SpaceType.L2);
 
-        long indexIVFPQIndexTest1 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), FAISS_NAME);
+        long indexIVFPQIndexTest1 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, indexIVFPQIndexTest1);
-        long indexIVFPQIndexTest2 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), FAISS_NAME);
+        long indexIVFPQIndexTest2 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, indexIVFPQIndexTest2);
 
-        long sharedStateAddress = JNIService.initSharedIndexState(indexIVFPQIndexTest1, FAISS_NAME);
-        JNIService.setSharedIndexState(indexIVFPQIndexTest1, sharedStateAddress, FAISS_NAME);
-        JNIService.setSharedIndexState(indexIVFPQIndexTest2, sharedStateAddress, FAISS_NAME);
+        long sharedStateAddress = JNIService.initSharedIndexState(indexIVFPQIndexTest1, KNNEngine.FAISS);
+        JNIService.setSharedIndexState(indexIVFPQIndexTest1, sharedStateAddress, KNNEngine.FAISS);
+        JNIService.setSharedIndexState(indexIVFPQIndexTest2, sharedStateAddress, KNNEngine.FAISS);
 
         assertQueryResultsMatch(testData.queries, k, List.of(indexIVFPQIndexTest1, indexIVFPQIndexTest2));
 
         // Free the first test index 1. This will ensure that the shared state persists after index that initialized
         // shared state is gone.
-        JNIService.free(indexIVFPQIndexTest1, FAISS_NAME);
+        JNIService.free(indexIVFPQIndexTest1, KNNEngine.FAISS);
 
-        long indexIVFPQIndexTest3 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), FAISS_NAME);
+        long indexIVFPQIndexTest3 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, indexIVFPQIndexTest3);
 
-        JNIService.setSharedIndexState(indexIVFPQIndexTest3, sharedStateAddress, FAISS_NAME);
+        JNIService.setSharedIndexState(indexIVFPQIndexTest3, sharedStateAddress, KNNEngine.FAISS);
 
         assertQueryResultsMatch(testData.queries, k, List.of(indexIVFPQIndexTest2, indexIVFPQIndexTest3));
 
         // Ensure everything gets freed
-        JNIService.free(indexIVFPQIndexTest2, FAISS_NAME);
-        JNIService.free(indexIVFPQIndexTest3, FAISS_NAME);
-        JNIService.freeSharedIndexState(sharedStateAddress, FAISS_NAME);
+        JNIService.free(indexIVFPQIndexTest2, KNNEngine.FAISS);
+        JNIService.free(indexIVFPQIndexTest3, KNNEngine.FAISS);
+        JNIService.freeSharedIndexState(sharedStateAddress, KNNEngine.FAISS);
     }
 
     @SneakyThrows
     public void testIsIndexIVFPQL2() {
         long dummyAddress = 0;
-        assertFalse(JNIService.isSharedIndexStateRequired(dummyAddress, NMSLIB_NAME));
+        assertFalse(JNIService.isSharedIndexStateRequired(dummyAddress, KNNEngine.NMSLIB));
 
         String faissIVFPQL2Index = createFaissIVFPQIndex(16, 16, 4, SpaceType.L2);
-        long faissIVFPQL2Address = JNIService.loadIndex(faissIVFPQL2Index, Collections.emptyMap(), FAISS_NAME);
-        assertTrue(JNIService.isSharedIndexStateRequired(faissIVFPQL2Address, FAISS_NAME));
-        JNIService.free(faissIVFPQL2Address, FAISS_NAME);
+        long faissIVFPQL2Address = JNIService.loadIndex(faissIVFPQL2Index, Collections.emptyMap(), KNNEngine.FAISS);
+        assertTrue(JNIService.isSharedIndexStateRequired(faissIVFPQL2Address, KNNEngine.FAISS));
+        JNIService.free(faissIVFPQL2Address, KNNEngine.FAISS);
 
         String faissIVFPQIPIndex = createFaissIVFPQIndex(16, 16, 4, SpaceType.INNER_PRODUCT);
-        long faissIVFPQIPAddress = JNIService.loadIndex(faissIVFPQIPIndex, Collections.emptyMap(), FAISS_NAME);
-        assertFalse(JNIService.isSharedIndexStateRequired(faissIVFPQIPAddress, FAISS_NAME));
-        JNIService.free(faissIVFPQIPAddress, FAISS_NAME);
+        long faissIVFPQIPAddress = JNIService.loadIndex(faissIVFPQIPIndex, Collections.emptyMap(), KNNEngine.FAISS);
+        assertFalse(JNIService.isSharedIndexStateRequired(faissIVFPQIPAddress, KNNEngine.FAISS));
+        JNIService.free(faissIVFPQIPAddress, KNNEngine.FAISS);
 
         String faissHNSWIndex = createFaissHNSWIndex(SpaceType.L2);
-        long faissHNSWAddress = JNIService.loadIndex(faissHNSWIndex, Collections.emptyMap(), FAISS_NAME);
-        assertFalse(JNIService.isSharedIndexStateRequired(faissHNSWAddress, FAISS_NAME));
-        JNIService.free(faissHNSWAddress, FAISS_NAME);
+        long faissHNSWAddress = JNIService.loadIndex(faissHNSWIndex, Collections.emptyMap(), KNNEngine.FAISS);
+        assertFalse(JNIService.isSharedIndexStateRequired(faissHNSWAddress, KNNEngine.FAISS));
+        JNIService.free(faissHNSWAddress, KNNEngine.FAISS);
     }
 
     @SneakyThrows
     public void testFunctionsUnsupportedForEngine_whenEngineUnsupported_thenThrowIllegalArgumentException() {
         int dummyAddress = 0;
-        expectThrows(IllegalArgumentException.class, () -> JNIService.initSharedIndexState(dummyAddress, NMSLIB_NAME));
-        expectThrows(IllegalArgumentException.class, () -> JNIService.setSharedIndexState(dummyAddress, dummyAddress, NMSLIB_NAME));
-        expectThrows(IllegalArgumentException.class, () -> JNIService.freeSharedIndexState(dummyAddress, NMSLIB_NAME));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.initSharedIndexState(dummyAddress, KNNEngine.NMSLIB));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.setSharedIndexState(dummyAddress, dummyAddress, KNNEngine.NMSLIB));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.freeSharedIndexState(dummyAddress, KNNEngine.NMSLIB));
     }
 
     private void assertQueryResultsMatch(float[][] testQueries, int k, List<Long> indexAddresses) {
@@ -1209,7 +1207,7 @@ public class JNIServiceTests extends KNNTestCase {
         for (float[] query : testQueries) {
             KNNQueryResult[][] allResults = new KNNQueryResult[indexAddresses.size()][];
             for (int i = 0; i < indexAddresses.size(); i++) {
-                allResults[i] = JNIService.queryIndex(indexAddresses.get(i), query, k, FAISS_NAME, null, 0, null);
+                allResults[i] = JNIService.queryIndex(indexAddresses.get(i), query, k, KNNEngine.FAISS, null, 0, null);
                 assertEquals(k, allResults[i].length);
             }
 
@@ -1251,7 +1249,7 @@ public class JNIServiceTests extends KNNTestCase {
             spaceType.getValue()
         );
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1262,7 +1260,7 @@ public class JNIServiceTests extends KNNTestCase {
             tmpFile.toAbsolutePath().toString(),
             faissIndex,
             ImmutableMap.of(INDEX_THREAD_QTY, 1),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
@@ -1276,7 +1274,7 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
         return tmpFile.toAbsolutePath().toString();

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -1178,21 +1178,21 @@ public class JNIServiceTests extends KNNTestCase {
     @SneakyThrows
     public void testIsIndexIVFPQL2() {
         long dummyAddress = 0;
-        assertFalse(JNIService.isIndexIVFPQL2(dummyAddress, NMSLIB_NAME));
+        assertFalse(JNIService.isSharedIndexStateRequired(dummyAddress, NMSLIB_NAME));
 
         String faissIVFPQL2Index = createFaissIVFPQIndex(16, 16, 4, SpaceType.L2);
         long faissIVFPQL2Address = JNIService.loadIndex(faissIVFPQL2Index, Collections.emptyMap(), FAISS_NAME);
-        assertTrue(JNIService.isIndexIVFPQL2(faissIVFPQL2Address, FAISS_NAME));
+        assertTrue(JNIService.isSharedIndexStateRequired(faissIVFPQL2Address, FAISS_NAME));
         JNIService.free(faissIVFPQL2Address, FAISS_NAME);
 
         String faissIVFPQIPIndex = createFaissIVFPQIndex(16, 16, 4, SpaceType.INNER_PRODUCT);
         long faissIVFPQIPAddress = JNIService.loadIndex(faissIVFPQIPIndex, Collections.emptyMap(), FAISS_NAME);
-        assertFalse(JNIService.isIndexIVFPQL2(faissIVFPQIPAddress, FAISS_NAME));
+        assertFalse(JNIService.isSharedIndexStateRequired(faissIVFPQIPAddress, FAISS_NAME));
         JNIService.free(faissIVFPQIPAddress, FAISS_NAME);
 
         String faissHNSWIndex = createFaissHNSWIndex(SpaceType.L2);
         long faissHNSWAddress = JNIService.loadIndex(faissHNSWIndex, Collections.emptyMap(), FAISS_NAME);
-        assertFalse(JNIService.isIndexIVFPQL2(faissHNSWAddress, FAISS_NAME));
+        assertFalse(JNIService.isSharedIndexStateRequired(faissHNSWAddress, FAISS_NAME));
         JNIService.free(faissHNSWAddress, FAISS_NAME);
     }
 

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -201,7 +201,7 @@ public class TrainingJobTests extends KNNTestCase {
             indexPath.toString(),
             model.getModelBlob(),
             ImmutableMap.of(INDEX_THREAD_QTY, 1),
-            knnEngine.getName()
+            knnEngine
         );
         assertNotEquals(0, new File(indexPath.toString()).length());
     }


### PR DESCRIPTION
### Description
Adds the set of JNI functions mentioned in https://github.com/opensearch-project/k-NN/issues/1507#issue-2169945763 to allow state to be shared between IVFPQ-l2 based indices. In addition, one more method is added, IsIndexIVFPQL2. This method needs to be added so that from java side we can confirm a particular index needs the shared state or not.

These functions are added assuming that the only state that can be shared is for IVFPQ-l2 index types. In the future, we will generalize this.

Adds unit tests for jni as well as java to test functionality.
 
### Issues Resolved
#1507 - partial
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
