### PR TITLE
Switch spacetype vector similarity function to MAXIMUM_INNER_PRODUCT

### DIFF
--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -76,7 +76,7 @@ public enum SpaceType {
 
         @Override
         public VectorSimilarityFunction getVectorSimilarityFunction() {
-            return VectorSimilarityFunction.DOT_PRODUCT;
+            return VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
         }
     },
     HAMMING_BIT("hammingbit") {

--- a/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
@@ -14,6 +14,10 @@ package org.opensearch.knn.index;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.knn.KNNTestCase;
 
+import java.util.List;
+
+import static org.apache.lucene.util.VectorUtil.scaleMaxInnerProductScore;
+
 public class SpaceTypeTests extends KNNTestCase {
 
     public void testGetVectorSimilarityFunction_l2() {
@@ -22,5 +26,28 @@ public class SpaceTypeTests extends KNNTestCase {
 
     public void testGetVectorSimilarityFunction_invalid() {
         expectThrows(UnsupportedOperationException.class, SpaceType.L1::getVectorSimilarityFunction);
+    }
+
+    public void testGetVectorSimilarityFunction_whenInnerproduct_thenConsistentWithScoreTranslation() {
+        /*
+            For the innerproduct space type, we expect that negative dot product scores will be transformed as follows:
+                if (negativeDotProduct >= 0) {
+                    return 1 / (1 + negativeDotProduct);
+                }
+                return -negativeDotProduct + 1;
+
+            Internally, Lucene uses scaleMaxInnerProductScore to scale the raw dot product into a proper lucene score.
+            See:
+                1. https://github.com/apache/lucene/blob/releases/lucene/9.10.0/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java#L195-L200
+                2. https://github.com/apache/lucene/blob/releases/lucene/9.10.0/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java#L90
+         */
+        List<Float> negativeDotProductScores = List.of(0.0f, -1.0f, -0.5f, -100.0f, 0.5f, 1.0f, 100.0f);
+        for (Float negativeDotProduct : negativeDotProductScores) {
+            assertEquals(
+                SpaceType.INNER_PRODUCT.scoreTranslation(negativeDotProduct),
+                scaleMaxInnerProductScore(-1 * negativeDotProduct),
+                0.0000001
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description
Switches the similarity function for inner product from Lucene's dot product to maximum inner product.  This will allow the filter exact scoring to match results returned by faiss in ANN method.
 
### Issues Resolved
#1396 #1525 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
