### PR TITLE
Switch spacetype similarity function to MAXIMUM_INNER_PRODUCT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optize Faiss Query With Filters: Reduce iteration and memory for id filter [#1402](https://github.com/opensearch-project/k-NN/pull/1402)
 ### Bug Fixes
 * Disable sdc table for HNSWPQ read-only indices [#1518](https://github.com/opensearch-project/k-NN/pull/1518)
+* Switch SpaceType.INNERPRODUCT's vector similarity function to MAXIMUM_INNER_PRODUCT [#1532](https://github.com/opensearch-project/k-NN/pull/1532)
 ### Infrastructure
 * Manually install zlib for win CI [#1513](https://github.com/opensearch-project/k-NN/pull/1513)
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -76,7 +76,7 @@ public enum SpaceType {
 
         @Override
         public VectorSimilarityFunction getVectorSimilarityFunction() {
-            return VectorSimilarityFunction.DOT_PRODUCT;
+            return VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
         }
     },
     HAMMING_BIT("hammingbit") {

--- a/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
@@ -13,6 +13,10 @@ package org.opensearch.knn.index;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class SpaceTypeTests extends KNNTestCase {
 
@@ -22,5 +26,39 @@ public class SpaceTypeTests extends KNNTestCase {
 
     public void testGetVectorSimilarityFunction_invalid() {
         expectThrows(UnsupportedOperationException.class, SpaceType.L1::getVectorSimilarityFunction);
+    }
+
+    public void testGetVectorSimilarityFunction_whenInnerproduct_thenConsistentWithScoreTranslation() {
+        /*
+            For the innerproduct space type, we expect that negative dot product scores will be transformed as follows:
+                if (negativeDotProduct >= 0) {
+                    return 1 / (1 + negativeDotProduct);
+                }
+                return -negativeDotProduct + 1;
+
+            Internally, Lucene uses scaleMaxInnerProductScore to scale the raw dot product into a proper lucene score.
+            See:
+                1. https://github.com/apache/lucene/blob/releases/lucene/9.10.0/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java#L195-L200
+                2. https://github.com/apache/lucene/blob/releases/lucene/9.10.0/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java#L90
+         */
+        final List<float[]> dataVectors = Arrays.asList(
+            new float[] { 0.0f, 0.0f },
+            new float[] { 0.25f, -0.25f },
+            new float[] { 0.125f, -0.125f },
+            new float[] { 25.0f, -25.0f },
+            new float[] { -0.125f, 0.125f },
+            new float[] { -0.25f, 0.25f },
+            new float[] { -25.0f, 25.0f }
+        );
+        float[] queryVector = new float[] { -2.0f, 2.0f };
+        List<Float> dotProducts = List.of(0.0f, -1.0f, -0.5f, -100.0f, 0.5f, 1.0f, 100.0f);
+
+        for (int i = 0; i < dataVectors.size(); i++) {
+            assertEquals(
+                KNNEngine.FAISS.score(dotProducts.get(i), SpaceType.INNER_PRODUCT),
+                SpaceType.INNER_PRODUCT.getVectorSimilarityFunction().compare(queryVector, dataVectors.get(i)),
+                0.0000001
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description
Switches the similarity function for inner product from Lucene's dot product to maximum inner product. This will allow the filter exact scoring to match results returned by faiss in ANN method.

(Retrying #1530 due to GH issue)
 
### Issues Resolved
#1396 #1525 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
