### PR TITLE
Bump jinja2 dependency from 2.11.3 to 3.1.3

### DIFF
--- a/benchmarks/osb/requirements.txt
+++ b/benchmarks/osb/requirements.txt
@@ -38,7 +38,7 @@ ijson==2.6.1
     # via opensearch-benchmark
 importlib-metadata==4.11.3
     # via jsonschema
-jinja2==2.11.3
+jinja2==3.1.3
     # via opensearch-benchmark
 jsonschema==3.1.1
     # via opensearch-benchmark


### PR DESCRIPTION
### Description
Fix jinja2 dependency CVE by bumping it from 2.11.3 to 3.1.3
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1385
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
