### PR TITLE
Update k-NN build artifact script to enable SIMD on ARM for Faiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add patch to fix arm segfault in nmslib during ingestion [#1541](https://github.com/opensearch-project/k-NN/pull/1541)
 ### Infrastructure
 * Manually install zlib for win CI [#1513](https://github.com/opensearch-project/k-NN/pull/1513)
+* Update k-NN build artifact script to enable SIMD on ARM for Faiss [#1543](https://github.com/opensearch-project/k-NN/pull/1543)
 ### Documentation
 ### Maintenance
 * Bump faiss lib commit to 32f0e8cf92cd2275b60364517bb1cce67aa29a55 [#1443](https://github.com/opensearch-project/k-NN/pull/1443)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,11 +93,9 @@ if [ "$ARCHITECTURE" = "x64" ]; then
     sed -i -e 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
 fi
 
-# For arm, march=native is broken in centos 7. Manually override to lowest version of armv8. Also, disable simd in faiss
-# file. This is broken on centos 7 as well.
+# For arm, march=native is broken in centos 7. Manually override to lowest version of armv8.
 if [ "$ARCHITECTURE" = "arm64" ]; then
     sed -i -e 's/-march=native/-march=armv8-a/g' external/nmslib/similarity_search/CMakeLists.txt
-    sed -i -e 's/__aarch64__/__undefine_aarch64__/g' external/faiss/faiss/utils/distances_simd.cpp
 fi
 
 if [ "$JAVA_HOME" = "" ]; then


### PR DESCRIPTION
### Description
Update k-NN build artifact script to enable SIMD on ARM for Faiss because CentOS is supporting gcc version 9.3.x
```
gcc --version
gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
