### PR TITLE
Integrate index state sharing into mem management

### DIFF
--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -274,7 +274,7 @@ public class IndexUtil {
      * @return true if state can be shared; false otherwise
      */
     public static boolean isSharedIndexStateRequired(KNNEngine knnEngine, String modelId, long indexAddr) {
-        if (StringUtils.isEmpty(modelId) || KNNEngine.FAISS != knnEngine) {
+        if (StringUtils.isEmpty(modelId)) {
             return false;
         }
         return JNIService.isSharedIndexStateRequired(indexAddr, knnEngine);

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.jni.JNIService;
 
 import java.io.File;
 import java.util.Collections;
@@ -262,5 +263,20 @@ public class IndexUtil {
             return false;
         }
         return version.onOrAfter(minimalRequiredVersion);
+    }
+
+    /**
+     * Checks if index requires shared state
+     *
+     * @param knnEngine The knnEngine associated with the index
+     * @param modelId The modelId associated with the index
+     * @param indexAddr Address to check if loaded index requires shared state
+     * @return true if state can be shared; false otherwise
+     */
+    public static boolean isSharedIndexStateRequired(KNNEngine knnEngine, String modelId, long indexAddr) {
+        if (StringUtils.isEmpty(modelId) || KNNEngine.FAISS != knnEngine) {
+            return false;
+        }
+        return JNIService.isSharedIndexStateRequired(indexAddr, knnEngine);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index.memory;
 
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.IndexUtil;
 
 import java.io.IOException;
@@ -63,6 +64,8 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         private final NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy;
         private final String openSearchIndexName;
         private final Map<String, Object> parameters;
+        @Nullable
+        private final String modelId;
 
         /**
          * Constructor
@@ -78,10 +81,30 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             Map<String, Object> parameters,
             String openSearchIndexName
         ) {
+            this(indexPath, indexLoadStrategy, parameters, openSearchIndexName, null);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param indexPath path to index file. Also used as key in cache.
+         * @param indexLoadStrategy strategy to load index into memory
+         * @param parameters load time parameters
+         * @param openSearchIndexName opensearch index associated with index
+         * @param modelId model to be loaded. If none available, pass null
+         */
+        public IndexEntryContext(
+            String indexPath,
+            NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy,
+            Map<String, Object> parameters,
+            String openSearchIndexName,
+            String modelId
+        ) {
             super(indexPath);
             this.indexLoadStrategy = indexLoadStrategy;
             this.openSearchIndexName = openSearchIndexName;
             this.parameters = parameters;
+            this.modelId = modelId;
         }
 
         @Override
@@ -110,6 +133,15 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
          */
         public Map<String, Object> getParameters() {
             return parameters;
+        }
+
+        /**
+         * Getter
+         *
+         * @return return model ID for the index. null if no model is in use
+         */
+        public String getModelId() {
+            return modelId;
         }
 
         private static class IndexSizeCalculator implements Function<IndexEntryContext, Integer> {

--- a/src/main/java/org/opensearch/knn/index/memory/SharedIndexState.java
+++ b/src/main/java/org/opensearch/knn/index/memory/SharedIndexState.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.memory;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.knn.index.util.KNNEngine;
+
+/**
+ * Class stores information about the shared memory allocations between loaded native indices.
+ */
+@RequiredArgsConstructor
+@Getter
+public class SharedIndexState {
+    private final long sharedIndexStateAddress;
+    private final String modelId;
+    private final KNNEngine knnEngine;
+}

--- a/src/main/java/org/opensearch/knn/index/memory/SharedIndexStateManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/SharedIndexStateManager.java
@@ -97,15 +97,14 @@ class SharedIndexStateManager {
         this.readWriteLock.writeLock().lock();
 
         try {
-            if (!sharedIndexStateCache.containsKey(sharedIndexState.getModelId())) {
+            SharedIndexStateEntry sharedIndexStateEntry;
+            if ((sharedIndexStateEntry = sharedIndexStateCache.get(sharedIndexState.getModelId())) == null) {
                 // This should not happen. Will log the error and return to prevent crash
                 log.error("Attempting to evict model from cache but it is not present: {}", sharedIndexState.getModelId());
-                this.readWriteLock.writeLock().unlock();
                 return;
             }
 
-            long refCount = sharedIndexStateCache.get(sharedIndexState.getModelId()).decRef();
-            if (refCount <= 0) {
+            if (sharedIndexStateEntry.decRef() <= 0) {
                 log.info("Evicting entry from shared index state cache for key {}", sharedIndexState.getModelId());
                 sharedIndexStateCache.remove(sharedIndexState.getModelId());
                 JNIService.freeSharedIndexState(sharedIndexState.getSharedIndexStateAddress(), sharedIndexState.getKnnEngine());

--- a/src/main/java/org/opensearch/knn/index/memory/SharedIndexStateManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/SharedIndexStateManager.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.memory;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.jni.JNIService;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Class manages allocations that can be shared between native indices. No locking is required.
+ * Once a caller obtain an instance of a {@link org.opensearch.knn.index.memory.SharedIndexState}, it is guaranteed to
+ * be valid until it is returned. {@link org.opensearch.knn.index.memory.SharedIndexState} are reference counted
+ * internally. Once the reference count goes to 0, it will be freed.
+ */
+@Log4j2
+class SharedIndexStateManager {
+    // Map storing the shared index state with key being the modelId.
+    private final ConcurrentHashMap<String, SharedIndexStateEntry> sharedIndexStateCache;
+    private final ReadWriteLock readWriteLock;
+
+    private static SharedIndexStateManager INSTANCE;
+
+    // TODO: Going to refactor away from doing this in the future. For now, keeping for simplicity.
+    public static synchronized SharedIndexStateManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SharedIndexStateManager();
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * Constructor
+     */
+    @VisibleForTesting
+    SharedIndexStateManager() {
+        this.sharedIndexStateCache = new ConcurrentHashMap<>();
+        this.readWriteLock = new ReentrantReadWriteLock();
+    }
+
+    /**
+     * Return a {@link SharedIndexState} associated with the key. If no value exists, it will attempt to create it.
+     * Once returned, the {@link SharedIndexState} will be valid until
+     * {@link SharedIndexStateManager#release(SharedIndexState)} is called. Caller must ensure that this is
+     * called after it is done using it.
+     *
+     * In order to create the shared state, it will use the indexAddress passed in to create the shared state from
+     * using {@link org.opensearch.knn.jni.JNIService#initSharedIndexState(long, KNNEngine)}.
+     *
+     * @param indexAddress Address of index to initialize the shared state from
+     * @param knnEngine engine index belongs to
+     * @return ShareModelContext
+     */
+    public SharedIndexState get(long indexAddress, String modelId, KNNEngine knnEngine) {
+        this.readWriteLock.readLock().lock();
+        try {
+            // This can be done safely with readLock because the ConcurrentHasMap.computeIfAbsent guarantees:
+            //
+            // "If the specified key is not already associated with a value, attempts to compute its value using the given
+            // mapping function and enters it into this map unless null. The entire method invocation is performed
+            // atomically, so the function is applied at most once per key. Some attempted update operations on this map
+            // by other threads may be blocked while computation is in progress, so the computation should be short and
+            // simple, and must not attempt to update any other mappings of this map."
+            //
+            // Ref:
+            // https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#computeIfAbsent-K-java.util.function.Function-
+            SharedIndexStateEntry entry = sharedIndexStateCache.computeIfAbsent(modelId, m -> {
+                log.info("Loading entry to shared index state cache for model {}", modelId);
+                long sharedIndexStateAddress = JNIService.initSharedIndexState(indexAddress, knnEngine);
+                return new SharedIndexStateEntry(new SharedIndexState(sharedIndexStateAddress, modelId, knnEngine));
+            });
+            entry.incRef();
+            return entry.getSharedIndexState();
+        } finally {
+            this.readWriteLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Indicate that the {@link SharedIndexState} is no longer being used. If nothing else is using it, it will be
+     * removed from the cache and evicted.
+     *
+     * After calling this method, {@link SharedIndexState} should no longer be used by calling thread.
+     *
+     * @param sharedIndexState to return to the system.
+     */
+    public void release(SharedIndexState sharedIndexState) {
+        this.readWriteLock.writeLock().lock();
+
+        try {
+            if (!sharedIndexStateCache.containsKey(sharedIndexState.getModelId())) {
+                // This should not happen. Will log the error and return to prevent crash
+                log.error("Attempting to evict model from cache but it is not present: {}", sharedIndexState.getModelId());
+                this.readWriteLock.writeLock().unlock();
+                return;
+            }
+
+            long refCount = sharedIndexStateCache.get(sharedIndexState.getModelId()).decRef();
+            if (refCount <= 0) {
+                log.info("Evicting entry from shared index state cache for key {}", sharedIndexState.getModelId());
+                sharedIndexStateCache.remove(sharedIndexState.getModelId());
+                JNIService.freeSharedIndexState(sharedIndexState.getSharedIndexStateAddress(), sharedIndexState.getKnnEngine());
+            }
+        } finally {
+            this.readWriteLock.writeLock().unlock();
+        }
+    }
+
+    private static final class SharedIndexStateEntry {
+        @Getter
+        private final SharedIndexState sharedIndexState;
+        private final AtomicLong referenceCount;
+
+        /**
+         * Constructor
+         *
+         * @param sharedIndexState sharedIndexStateContext being wrapped
+         */
+        private SharedIndexStateEntry(SharedIndexState sharedIndexState) {
+            this.sharedIndexState = sharedIndexState;
+            this.referenceCount = new AtomicLong(0);
+        }
+
+        /**
+         * Increases reference count by 1
+         *
+         * @return ++referenceCount
+         */
+        private long incRef() {
+            return referenceCount.incrementAndGet();
+        }
+
+        /**
+         * Decrease reference count by 1
+         *
+         * @return --referenceCount
+         */
+        private long decRef() {
+            return referenceCount.decrementAndGet();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -256,7 +256,8 @@ public class KNNWeight extends Weight {
                     indexPath.toString(),
                     NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
                     getParametersAtLoading(spaceType, knnEngine, knnQuery.getIndexName()),
-                    knnQuery.getIndexName()
+                    knnQuery.getIndexName(),
+                    modelId
                 ),
                 true
             );

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -39,6 +39,7 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
@@ -50,6 +51,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.NAME;
@@ -491,6 +493,116 @@ public class FaissIT extends KNNRestTestCase {
         }
 
         fail("Graphs are not getting evicted");
+    }
+
+    /**
+     * This test confirms that sharing index state for IVFPQ-l2 indices functions properly. The main functionality that
+     * needs to be confirmed is that once an index gets deleted, it will not cause a failure for the non-deleted index.
+     *
+     * The workflow will be:
+     * 1. Create a model
+     * 2. Create two indices index from the model
+     * 3. Load the native index files from the first index
+     * 4. Assert search works
+     * 5. Load the native index files (which will reuse the shared state from the initial index)
+     * 6. Assert search works on the second index
+     * 7. Delete the first index and wait
+     * 8. Assert search works on the second index
+     */
+    @SneakyThrows
+    public void testSharedIndexState_whenOneIndexDeleted_thenSecondIndexIsStillSearchable() {
+        String firstIndexName = "test-index-1";
+        String secondIndexName = "test-index-2";
+        String trainingIndexName = "training-index";
+
+        String modelId = "test-model";
+        String modelDescription = "ivfpql2 model for testing shared state";
+
+        int dimension = testData.indexData.vectors[0].length;
+        SpaceType spaceType = SpaceType.L2;
+        int ivfNlist = 4;
+        int ivfNprobes = 4;
+        int pqCodeSize = 8;
+        int pqM = 1;
+        int docCount = 100;
+
+        // training data needs to be at least equal to the number of centroids for PQ
+        // which is 2^8 = 256. 8 because thats the only valid code_size for HNSWPQ
+        int trainingDataCount = 256;
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_IVF)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NPROBES, ivfNprobes)
+            .field(METHOD_PARAMETER_NLIST, ivfNlist)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_PQ)
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_M, pqCodeSize)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, pqM)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        createBasicKnnIndex(trainingIndexName, FIELD_NAME, dimension);
+        ingestDataAndTrainModel(modelId, trainingIndexName, FIELD_NAME, dimension, modelDescription, in, trainingDataCount);
+        assertTrainingSucceeds(modelId, 360, 1000);
+
+        createIndexFromModelAndIngestDocuments(firstIndexName, modelId, docCount);
+        createIndexFromModelAndIngestDocuments(secondIndexName, modelId, docCount);
+
+        doKnnWarmup(List.of(firstIndexName));
+        validateSearchWorkflow(firstIndexName, testData.queries, 10);
+        doKnnWarmup(List.of(secondIndexName));
+        validateSearchWorkflow(secondIndexName, testData.queries, 10);
+        deleteKNNIndex(firstIndexName);
+        // wait for all index files to be cleaned up from original index. empirically determined to take 25 seconds.
+        // will give 15 second buffer from that
+        Thread.sleep(1000 * 45);
+        validateSearchWorkflow(secondIndexName, testData.queries, 10);
+        deleteModel(modelId);
+    }
+
+    @SneakyThrows
+    private void createIndexFromModelAndIngestDocuments(String indexName, String modelId, int docCount) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("model_id", modelId)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Map<String, Object> mappingMap = xContentBuilderToMap(builder);
+        String mapping = builder.toString();
+        createKnnIndex(indexName, mapping);
+        assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
+
+        for (int i = 0; i < Math.min(testData.indexData.docs.length, docCount); i++) {
+            addKnnDoc(
+                indexName,
+                Integer.toString(testData.indexData.docs[i]),
+                FIELD_NAME,
+                Floats.asList(testData.indexData.vectors[i]).toArray()
+            );
+        }
+        refreshAllNonSystemIndices();
+        assertEquals(Math.min(testData.indexData.docs.length, docCount), getDocCount(indexName));
+    }
+
+    @SneakyThrows
+    private void validateSearchWorkflow(String indexName, float[][] queries, int k) {
+        for (float[] query : queries) {
+            Response response = searchKNNIndex(indexName, new KNNQueryBuilder(FIELD_NAME, query, k), k);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
+            assertEquals(k, knnResults.size());
+        }
     }
 
     public void testDocUpdate() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -228,12 +228,6 @@ public class IndexUtilTests extends KNNTestCase {
         assertFalse(IndexUtil.isSharedIndexStateRequired(knnEngine, modelId, TEST_INDEX_ADDRESS));
     }
 
-    public void testIsShareableStateContainedInIndex_whenEngineIsNotFaiss_thenReturnFalse() {
-        String modelId = "test-model";
-        KNNEngine knnEngine = KNNEngine.NMSLIB;
-        assertFalse(IndexUtil.isSharedIndexStateRequired(knnEngine, modelId, TEST_INDEX_ADDRESS));
-    }
-
     public void testIsShareableStateContainedInIndex_whenFaissHNSWIsUsed_thenReturnFalse() {
         jniServiceMockedStatic.when(() -> JNIService.isSharedIndexStateRequired(anyLong(), any())).thenReturn(false);
         String modelId = "test-model";

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
@@ -17,9 +17,7 @@ import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -98,38 +96,35 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         assertEquals(2, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().get(testIndexName).get(GRAPH_COUNT));
     }
 
-    public void testGetHNSWPaths() throws IOException, ExecutionException, InterruptedException {
+    public void testGetAllEngineFileContexts() throws IOException, ExecutionException, InterruptedException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
-        IndexShard indexShard;
-        KNNIndexShard knnIndexShard;
-        Engine.Searcher searcher;
-        Map<String, SpaceType> hnswPaths;
 
-        indexShard = indexService.iterator().next();
-        knnIndexShard = new KNNIndexShard(indexShard);
+        IndexShard indexShard = indexService.iterator().next();
+        KNNIndexShard knnIndexShard = new KNNIndexShard(indexShard);
 
-        searcher = indexShard.acquireSearcher("test-hnsw-paths-1");
-        hnswPaths = knnIndexShard.getAllEnginePaths(searcher.getIndexReader());
-        assertEquals(0, hnswPaths.size());
+        Engine.Searcher searcher = indexShard.acquireSearcher("test-hnsw-paths-1");
+        List<KNNIndexShard.EngineFileContext> engineFileContexts = knnIndexShard.getAllEngineFileContexts(searcher.getIndexReader());
+        assertEquals(0, engineFileContexts.size());
         searcher.close();
 
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
         searcher = indexShard.acquireSearcher("test-hnsw-paths-2");
-        hnswPaths = knnIndexShard.getAllEnginePaths(searcher.getIndexReader());
-        assertEquals(1, hnswPaths.size());
-        List<String> paths = new ArrayList<>(hnswPaths.keySet());
+        engineFileContexts = knnIndexShard.getAllEngineFileContexts(searcher.getIndexReader());
+        assertEquals(1, engineFileContexts.size());
+        List<String> paths = engineFileContexts.stream().map(KNNIndexShard.EngineFileContext::getIndexPath).collect(Collectors.toList());
         assertTrue(paths.get(0).contains("hnsw") || paths.get(0).contains("hnswc"));
         searcher.close();
     }
 
-    public void testGetEnginePaths() {
+    public void testGetEngineFileContexts() {
         // Check that the correct engine paths are being returned by the KNNIndexShard
         String segmentName = "_0";
         String fieldName = "test_field";
         String fileExt = ".test";
         SpaceType spaceType = SpaceType.L2;
+        String modelId = "test-model";
 
         Set<String> includedFileNames = ImmutableSet.of(
             String.format("%s_111_%s%s", segmentName, fieldName, fileExt),
@@ -148,10 +143,18 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         KNNIndexShard knnIndexShard = new KNNIndexShard(null);
 
         Path path = Paths.get("");
-        Map<String, SpaceType> included = knnIndexShard.getEnginePaths(files, segmentName, fieldName, fileExt, path, spaceType);
+        List<KNNIndexShard.EngineFileContext> included = knnIndexShard.getEngineFileContexts(
+            files,
+            segmentName,
+            fieldName,
+            fileExt,
+            path,
+            spaceType,
+            modelId
+        );
 
         assertEquals(includedFileNames.size(), included.size());
-        included.keySet().forEach(o -> assertTrue(includedFileNames.contains(o)));
+        included.stream().map(KNNIndexShard.EngineFileContext::getIndexPath).forEach(o -> assertTrue(includedFileNames.contains(o)));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateManagerTests.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.memory;
+
+import org.junit.BeforeClass;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.jni.JNIService;
+
+import static org.mockito.Mockito.mockStatic;
+
+public class SharedIndexStateManagerTests extends KNNTestCase {
+    private static MockedStatic<JNIService> jniServiceMockedStatic;
+    private final static long TEST_SHARED_TABLE_ADDRESS = 123;
+    private final static long TEST_INDEX_ADDRESS = 1234;
+    private final static String TEST_MODEL_ID = "test-model-id";
+    private final static KNNEngine TEST_KNN_ENGINE = KNNEngine.DEFAULT;
+
+    @BeforeClass
+    public static void setUpClass() {
+        jniServiceMockedStatic = mockStatic(JNIService.class);
+        jniServiceMockedStatic.when(() -> JNIService.freeSharedIndexState(TEST_SHARED_TABLE_ADDRESS, TEST_KNN_ENGINE))
+            .then(invocation -> null);
+        jniServiceMockedStatic.when(() -> JNIService.initSharedIndexState(TEST_INDEX_ADDRESS, TEST_KNN_ENGINE))
+            .thenReturn(TEST_SHARED_TABLE_ADDRESS);
+    }
+
+    public void testGet_whenNormalWorkfloatApplied_thenSucceed() {
+        SharedIndexStateManager sharedIndexStateManager = new SharedIndexStateManager();
+        SharedIndexState firstSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        assertEquals(TEST_SHARED_TABLE_ADDRESS, firstSharedIndexStateRetrieved.getSharedIndexStateAddress());
+        assertEquals(TEST_MODEL_ID, firstSharedIndexStateRetrieved.getModelId());
+        assertEquals(TEST_KNN_ENGINE, firstSharedIndexStateRetrieved.getKnnEngine());
+
+        SharedIndexState secondSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        assertEquals(TEST_SHARED_TABLE_ADDRESS, secondSharedIndexStateRetrieved.getSharedIndexStateAddress());
+        assertEquals(TEST_MODEL_ID, secondSharedIndexStateRetrieved.getModelId());
+        assertEquals(TEST_KNN_ENGINE, secondSharedIndexStateRetrieved.getKnnEngine());
+    }
+
+    public void testRelease_whenNormalWorkflowApplied_thenSucceed() {
+        SharedIndexStateManager sharedIndexStateManager = new SharedIndexStateManager();
+        SharedIndexState firstSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        SharedIndexState secondSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+
+        sharedIndexStateManager.release(firstSharedIndexStateRetrieved);
+        jniServiceMockedStatic.verify(() -> JNIService.freeSharedIndexState(TEST_SHARED_TABLE_ADDRESS, TEST_KNN_ENGINE), Mockito.times(0));
+        sharedIndexStateManager.release(secondSharedIndexStateRetrieved);
+        jniServiceMockedStatic.verify(() -> JNIService.freeSharedIndexState(TEST_SHARED_TABLE_ADDRESS, TEST_KNN_ENGINE), Mockito.times(1));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.memory;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+
+public class SharedIndexStateTests extends KNNTestCase {
+
+    private static final String TEST_MODEL_ID = "test-model";
+    private static final long TEST_SHARED_INDEX_STATE_ADDRESS = 22L;
+    private static final KNNEngine TEST_KNN_ENGINE = KNNEngine.DEFAULT;
+
+    public void testSharedIndexState() {
+        SharedIndexState sharedIndexState = new SharedIndexState(TEST_SHARED_INDEX_STATE_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        assertEquals(TEST_MODEL_ID, sharedIndexState.getModelId());
+        assertEquals(TEST_SHARED_INDEX_STATE_ADDRESS, sharedIndexState.getSharedIndexStateAddress());
+        assertEquals(TEST_KNN_ENGINE, sharedIndexState.getKnnEngine());
+    }
+}

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -11,54 +11,520 @@
 
 package org.opensearch.knn.recall;
 
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY;
 import static org.opensearch.knn.index.KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED;
 
+/**
+ * Tests confirm that for the different supported configurations, recall is sound. The recall thresholds are
+ * conservatively and empirically determined to prevent flakiness.
+ *
+ * This test suite can take a long time to run. The primary reason is that training can take a long time for PQ.
+ * The parameters for PQ have been reduced significantly, but it still takes time.
+ */
 public class RecallTestsIT extends KNNRestTestCase {
 
-    private final String testFieldName = "test-field";
-    private final int dimensions = 50;
-    private final int docCount = 10000;
-    private final int queryCount = 100;
-    private final int k = 5;
-    private final double expRecallValue = 1.0;
+    private static final String PROPERTIES_FIELD = "properties";
+    private final static String TEST_INDEX_PREFIX_NAME = "test_index";
+    private final static String TEST_FIELD_NAME = "test_field";
+    private final static String TRAIN_INDEX_NAME = "train_index";
+    private final static String TRAIN_FIELD_NAME = "train_field";
+    private final static String TEST_MODEL_ID = "test_model_id";
+    private final static int TEST_DIMENSION = 32;
+    private final static int DOC_COUNT = 500;
+    private final static int QUERY_COUNT = 100;
+    private final static int TEST_K = 100;
+    private final static double PERFECT_RECALL = 1.0;
+    private final static int SHARD_COUNT = 1;
+    private final static int REPLICA_COUNT = 0;
+    private final static int MAX_SEGMENT_COUNT = 10;
 
-    public void testRecallL2StandardData() throws Exception {
-        String testIndexStandard = "test-index-standard";
+    // Standard algorithm parameters
+    private final static int HNSW_M = 16;
+    private final static int HNSW_EF_CONSTRUCTION = 100;
+    private final static int HNSW_EF_SEARCH = TEST_K; // For consistency with lucene
+    private final static int IVF_NLIST = 4;
+    private final static int IVF_NPROBES = IVF_NLIST; // This equates to essentially a brute force search
+    private final static int PQ_CODE_SIZE = 8; // This is low and going to produce bad recall, but reduces build time
+    private final static int PQ_M = TEST_DIMENSION / 8; // Will give low recall, but required for test time
 
-        addDocs(testIndexStandard, testFieldName, dimensions, docCount, true);
-        float[][] indexVectors = getIndexVectorsFromIndex(testIndexStandard, testFieldName, docCount, dimensions);
-        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, docCount, true);
-        List<Set<String>> groundTruthValues = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, k);
-        List<List<String>> searchResults = bulkSearch(testIndexStandard, testFieldName, queryVectors, k);
-        double recallValue = TestUtils.calculateRecallValue(searchResults, groundTruthValues, k);
-        assertEquals(expRecallValue, recallValue, 0.2);
-    }
+    // Setup ground truth for all tests once
+    private final static float[][] INDEX_VECTORS = TestUtils.getIndexVectors(DOC_COUNT, TEST_DIMENSION, true);
+    private final static float[][] QUERY_VECTORS = TestUtils.getQueryVectors(QUERY_COUNT, TEST_DIMENSION, DOC_COUNT, true);
+    private final static Map<SpaceType, List<Set<String>>> GROUND_TRUTH = Map.of(
+        SpaceType.L2,
+        TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.L2, TEST_K),
+        SpaceType.COSINESIMIL,
+        TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.COSINESIMIL, TEST_K),
+        SpaceType.INNER_PRODUCT,
+        TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.INNER_PRODUCT, TEST_K)
+    );
 
-    public void testRecallL2RandomData() throws Exception {
-        String testIndexRandom = "test-index-random";
-
-        addDocs(testIndexRandom, testFieldName, dimensions, docCount, false);
-        float[][] indexVectors = getIndexVectorsFromIndex(testIndexRandom, testFieldName, docCount, dimensions);
-        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, docCount, false);
-        List<Set<String>> groundTruthValues = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, k);
-        List<List<String>> searchResults = bulkSearch(testIndexRandom, testFieldName, queryVectors, k);
-        double recallValue = TestUtils.calculateRecallValue(searchResults, groundTruthValues, k);
-        assertEquals(expRecallValue, recallValue, 0.2);
-    }
-
-    private void addDocs(String testIndex, String testField, int dimensions, int docCount, boolean isStandard) throws Exception {
-        createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(testField, dimensions));
-
+    @SneakyThrows
+    @Before
+    public void setupClusterSettings() {
         updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, 2);
         updateClusterSettings(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, true);
-
-        bulkAddKnnDocs(testIndex, testField, TestUtils.getIndexVectors(docCount, dimensions, isStandard), docCount);
     }
 
+    /**
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"nmslib",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH}
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenNmslibHnswFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.COSINESIMIL, SpaceType.INNER_PRODUCT);
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.NMSLIB, spaceType);
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(TEST_FIELD_NAME)
+                .field(TYPE, TYPE_KNN_VECTOR)
+                .field(DIMENSION, TEST_DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .field(KNN_ENGINE, KNNEngine.NMSLIB.getName())
+                .field(NAME, METHOD_HNSW)
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createIndexAndIngestDocs(
+                indexName,
+                TEST_FIELD_NAME,
+                Settings.builder()
+                    .put("number_of_shards", SHARD_COUNT)
+                    .put("number_of_replicas", REPLICA_COUNT)
+                    .put("index.knn", true)
+                    .put(KNN_ALGO_PARAM_EF_SEARCH, HNSW_EF_SEARCH)
+                    .build(),
+                builder.toString()
+            );
+            assertRecall(indexName, spaceType, 0.25f);
+        }
+    }
+
+    /**
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"lucene",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION}
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenLuceneHnswFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.COSINESIMIL);
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.LUCENE, spaceType);
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(TEST_FIELD_NAME)
+                .field(TYPE, TYPE_KNN_VECTOR)
+                .field(DIMENSION, TEST_DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+                .field(NAME, METHOD_HNSW)
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), builder.toString());
+            assertRecall(indexName, spaceType, 0.25f);
+        }
+    }
+
+    /**
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {TEST_DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"faiss",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH},
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissHnswFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(TEST_FIELD_NAME)
+                .field(TYPE, TYPE_KNN_VECTOR)
+                .field(DIMENSION, TEST_DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+                .field(NAME, METHOD_HNSW)
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .field(METHOD_PARAMETER_EF_SEARCH, HNSW_EF_SEARCH)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), builder.toString());
+            assertRecall(indexName, spaceType, 0.25f);
+        }
+    }
+
+    /**
+     * Train context:
+     * {
+     *  "method": {
+     *      "name":"ivf",
+     *      "engine":"faiss",
+     *      "space_type": "{SPACE_TYPE}",
+     *      "parameters":{
+     *          "nlist":{IVF_NLIST},
+     *          "nprobes": {IVF_NPROBES}
+     *      }
+     *   }
+     * }
+     *
+     * Index Mapping:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "model_id": {MODEL_ID}
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissIVFFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        setupTrainingIndex();
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+
+            // Train the model
+            XContentBuilder trainingBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, METHOD_IVF)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, IVF_NLIST)
+                .field(METHOD_PARAMETER_NPROBES, IVF_NPROBES)
+                .endObject()
+                .endObject();
+            trainModel(
+                TEST_MODEL_ID,
+                TRAIN_INDEX_NAME,
+                TRAIN_FIELD_NAME,
+                TEST_DIMENSION,
+                xContentBuilderToMap(trainingBuilder),
+                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+            );
+            assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
+
+            // Build the index
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), getModelMapping());
+            assertRecall(indexName, spaceType, 0.25f);
+
+            // Delete the model
+            deleteModel(TEST_MODEL_ID);
+        }
+    }
+
+    /**
+     * Train context:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {TEST_DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"faiss",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH},
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     *
+     * Index Mapping:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "model_id": {MODEL_ID}
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissIVFPQFP32_thenRecallAbove50percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        setupTrainingIndex();
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+
+            // Train the model
+            XContentBuilder trainingBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, METHOD_IVF)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, IVF_NLIST)
+                .field(METHOD_PARAMETER_NPROBES, IVF_NPROBES)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_PQ)
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, PQ_CODE_SIZE)
+                .field(ENCODER_PARAMETER_PQ_M, PQ_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            trainModel(
+                TEST_MODEL_ID,
+                TRAIN_INDEX_NAME,
+                TRAIN_FIELD_NAME,
+                TEST_DIMENSION,
+                xContentBuilderToMap(trainingBuilder),
+                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+            );
+            assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
+
+            // Build the index
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), getModelMapping());
+            assertRecall(indexName, spaceType, 0.5f);
+
+            // Delete the model
+            deleteModel(TEST_MODEL_ID);
+        }
+    }
+
+    /**
+     * Train context:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {TEST_DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"faiss",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH},
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     *
+     * Index Mapping:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "model_id": {MODEL_ID}
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissHNSWPQFP32_thenRecallAbove50percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        setupTrainingIndex();
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+
+            // Train the model
+            XContentBuilder trainingBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, METHOD_HNSW)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .field(METHOD_PARAMETER_EF_SEARCH, HNSW_EF_SEARCH)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_PQ)
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, PQ_CODE_SIZE)
+                .field(ENCODER_PARAMETER_PQ_M, PQ_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            trainModel(
+                TEST_MODEL_ID,
+                TRAIN_INDEX_NAME,
+                TRAIN_FIELD_NAME,
+                TEST_DIMENSION,
+                xContentBuilderToMap(trainingBuilder),
+                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+            );
+            assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
+
+            // Build the index
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), getModelMapping());
+            assertRecall(indexName, spaceType, 0.5f);
+
+            // Delete the model
+            deleteModel(TEST_MODEL_ID);
+        }
+    }
+
+    @SneakyThrows
+    private void assertRecall(String testIndexName, SpaceType spaceType, float acceptableRecallFromPerfect) {
+        List<List<String>> searchResults = bulkSearch(testIndexName, TEST_FIELD_NAME, QUERY_VECTORS, TEST_K);
+        double recallValue = TestUtils.calculateRecallValue(searchResults, GROUND_TRUTH.get(spaceType), TEST_K);
+        logger.info("Recall value = {}", recallValue);
+        assertEquals(PERFECT_RECALL, recallValue, acceptableRecallFromPerfect);
+    }
+
+    private String createIndexName(KNNEngine knnEngine, SpaceType spaceType) {
+        return String.format("%s_%s_%s", TEST_INDEX_PREFIX_NAME, knnEngine.getName(), spaceType.getValue());
+    }
+
+    @SneakyThrows
+    private void createIndexAndIngestDocs(String indexName, String fieldName, Settings settings, String mapping) {
+        createKnnIndex(indexName, settings, mapping);
+        bulkAddKnnDocs(indexName, fieldName, INDEX_VECTORS, DOC_COUNT);
+        forceMergeKnnIndex(indexName, MAX_SEGMENT_COUNT);
+    }
+
+    @SneakyThrows
+    private void setupTrainingIndex() {
+        XContentBuilder trainingIndexBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(TRAIN_FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, TEST_DIMENSION)
+            .endObject()
+            .endObject()
+            .endObject();
+        createIndexAndIngestDocs(
+            TRAIN_INDEX_NAME,
+            TRAIN_FIELD_NAME,
+            Settings.builder().put("number_of_shards", SHARD_COUNT).put("number_of_replicas", REPLICA_COUNT).build(),
+            trainingIndexBuilder.toString()
+        );
+    }
+
+    @SneakyThrows
+    private String getModelMapping() {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(TEST_FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(MODEL_ID, TEST_MODEL_ID)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    private Settings getSettings() {
+        return Settings.builder()
+            .put("number_of_shards", SHARD_COUNT)
+            .put("number_of_replicas", REPLICA_COUNT)
+            .put("index.knn", true)
+            .build();
+    }
 }

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn;
 
 import com.google.common.primitives.Floats;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -427,6 +428,13 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Force merge KNN index segments
      */
     protected void forceMergeKnnIndex(String index) throws Exception {
+        forceMergeKnnIndex(index, 1);
+    }
+
+    /**
+     * Force merge KNN index segments
+     */
+    protected void forceMergeKnnIndex(String index, int maxSegments) throws Exception {
         Request request = new Request("POST", "/" + index + "/_refresh");
 
         Response response = client().performRequest(request);
@@ -434,7 +442,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         request = new Request("POST", "/" + index + "/_forcemerge");
 
-        request.addParameter("max_num_segments", "1");
+        request.addParameter("max_num_segments", String.valueOf(maxSegments));
         request.addParameter("flush", "true");
         response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
@@ -635,6 +643,12 @@ public class KNNRestTestCase extends ODFERestTestCase {
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
         return response;
+    }
+
+    @SneakyThrows
+    protected void doKnnWarmup(List<String> indices) {
+        Response response = knnWarmup(indices);
+        assertEquals(response.getStatusLine().getStatusCode(), 200);
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -143,6 +143,12 @@ public class TestUtils {
             pq = new PriorityQueue<>(k, new DistComparator());
             for (int j = 0; j < indexVectors.length; j++) {
                 float dist = computeDistFromSpaceType(spaceType, indexVectors[j], queryVectors[i]);
+
+                // Need to invert distance for IP or COSINE because higher is better in these cases
+                if (spaceType == SpaceType.INNER_PRODUCT || spaceType == SpaceType.COSINESIMIL) {
+                    dist *= -1;
+                }
+
                 pq = insertWithOverflow(pq, k, dist, j);
             }
 
@@ -203,6 +209,11 @@ public class TestUtils {
         for (int id = 0; id < numDocs; id++) {
             float[] indexVector = idVectorProducer.getVector(id);
             float dist = computeDistFromSpaceType(spaceType, indexVector, queryVector);
+            // Need to invert distance for IP or COSINE because higher is better in these cases
+            if (spaceType == SpaceType.INNER_PRODUCT || spaceType == SpaceType.COSINESIMIL) {
+                dist *= -1;
+            }
+
             pq = insertWithOverflow(pq, k, dist, id);
         }
         return pq;


### PR DESCRIPTION
### Description
Last PR in series to fix #1507 

Adds the ability to share index state amongst indices during index load operations into the plugins memory management system. Introduces a manager of the shared state that will properly manage the lifecycle of the shared state.

Additionally, there was a bug in clear cache that had to be fixed to get this change working as well. Previously, only one index file per clear cache would be freed. This fixes that logic to clear everything.

Added unit tests and an integration test to confirm functionality. In addition, modified recall integration tests to get more coverage on the different algo configs. Along with this, had to fix a few things around the computation of recall for non-l2 space types.

Note - the addition of these integration tests will increase the CI time. Its a tradeoff that can be discussed. In future, we can take some items to reduce this time (such as #1540 to decouple CI for lib tests and plugin tests)

Once merged, I will create a PR to merge the feature branch into main so it can be released in 2.13.
 
### Issues Resolved
#1507
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
