### PR TITLE
Enabled Inner Product Space Type support for Lucene Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Detect AVX2 Dynamically on the System [#1502](https://github.com/opensearch-project/k-NN/pull/1502)
 * Validate zero vector when using cosine metric [#1501](https://github.com/opensearch-project/k-NN/pull/1501)
 * Persist model definition in model metadata [#1527] (https://github.com/opensearch-project/k-NN/pull/1527)
+* Added Inner Product Space type support for Lucene Engine [#1551](https://github.com/opensearch-project/k-NN/pull/1551)
 ### Bug Fixes
 * Disable sdc table for HNSWPQ read-only indices [#1518](https://github.com/opensearch-project/k-NN/pull/1518)
 * Switch SpaceType.INNERPRODUCT's vector similarity function to MAXIMUM_INNER_PRODUCT [#1532](https://github.com/opensearch-project/k-NN/pull/1532)

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -42,7 +42,7 @@ public class Lucene extends JVMLibrary {
                     )
                 )
                 .build()
-        ).addSpaces(SpaceType.L2, SpaceType.COSINESIMIL).build()
+        ).addSpaces(SpaceType.L2, SpaceType.COSINESIMIL, SpaceType.INNER_PRODUCT).build()
     );
 
     final static Lucene INSTANCE = new Lucene(METHODS, Version.LATEST.toString());

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -12,8 +12,8 @@ import lombok.SneakyThrows;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.VectorUtil;
 import org.junit.After;
-import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -78,36 +78,6 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
     public void testQuery_cosine() throws Exception {
         baseQueryTest(SpaceType.COSINESIMIL);
-    }
-
-    public void testQuery_innerProduct_notSupported() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject(PROPERTIES_FIELD_NAME)
-            .startObject(FIELD_NAME)
-            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(METHOD_HNSW).getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
-            .startObject(KNNConstants.PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, M)
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
-
-        String mapping = builder.toString();
-
-        createIndex(INDEX_NAME, getKNNDefaultIndexSettings());
-
-        Request request = new Request("PUT", "/" + INDEX_NAME + "/_mapping");
-        request.setJsonEntity(mapping);
-
-        expectThrows(ResponseException.class, () -> client().performRequest(request));
     }
 
     public void testQuery_invalidVectorDimensionInQuery() throws Exception {
@@ -448,5 +418,54 @@ public class LuceneEngineIT extends KNNRestTestCase {
                 .collect(Collectors.toList())
                 .containsAll(expectedDocIdsKLimitsFilterResult)
         );
+    }
+
+    @SneakyThrows
+    public void test_whenUsingIP_thenSuccess() {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNEngine.LUCENE.getMethod(KNNConstants.METHOD_HNSW).getMethodComponent().getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        final String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+
+        final List<Float[]> dataVectors = Arrays.asList(new Float[] { -2.0f, 2.0f }, new Float[] { 2.0f, -2.0f });
+        final List<String> ids = Arrays.asList(DOC_ID, DOC_ID_2);
+
+        // Ingest all the documents
+        for (int i = 0; i < dataVectors.size(); i++) {
+            addKnnDoc(INDEX_NAME, ids.get(i), FIELD_NAME, dataVectors.get(i));
+        }
+        refreshIndex(INDEX_NAME);
+
+        float[] queryVector = new float[] { -2.0f, 2.0f };
+        int k = 2;
+        final Response response = searchKNNIndex(
+            INDEX_NAME,
+            new KNNQueryBuilder(FIELD_NAME, queryVector, k, QueryBuilders.matchAllQuery()),
+            k
+        );
+        final String responseBody = EntityUtils.toString(response.getEntity());
+        final List<Float> knnResults = parseSearchResponseScore(responseBody, FIELD_NAME);
+
+        // Check that the expected scores are returned
+        final List<Float> expectedScores = Arrays.asList(
+            VectorUtil.scaleMaxInnerProductScore(8.0f),
+            VectorUtil.scaleMaxInnerProductScore(-8.0f)
+        );
+        assertEquals(expectedScores.size(), knnResults.size());
+        for (int i = 0; i < expectedScores.size(); i++) {
+            assertEquals(expectedScores.get(i), knnResults.get(i), 0.0000001);
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -431,29 +431,6 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             ValidationException.class,
             () -> typeParser.parse(fieldName, xContentBuilderToMap(xContentBuilderL1SpaceType), buildParserContext(indexName, settings))
         );
-
-        XContentBuilder xContentBuilderInnerproductSpaceType = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, dimension)
-            .startObject(KNN_METHOD)
-            .field(NAME, METHOD_HNSW)
-            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
-            .field(KNN_ENGINE, LUCENE_NAME)
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction)
-            .endObject()
-            .endObject()
-            .endObject();
-
-        expectThrows(
-            ValidationException.class,
-            () -> typeParser.parse(
-                fieldName,
-                xContentBuilderToMap(xContentBuilderInnerproductSpaceType),
-                buildParserContext(indexName, settings)
-            )
-        );
     }
 
     public void testTypeParser_parse_fromKnnMethodContext() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/LuceneTests.java
@@ -82,6 +82,20 @@ public class LuceneTests extends KNNTestCase {
         in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext4 = KNNMethodContext.parse(in);
         assertNotNull(luceneHNSW.validate(knnMethodContext4));
+
+        // Check INNER_PRODUCT is supported with Lucene Engine
+        xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction)
+            .field(METHOD_PARAMETER_M, m)
+            .endObject()
+            .endObject();
+        in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext5 = KNNMethodContext.parse(in);
+        assertNull(luceneHNSW.validate(knnMethodContext5));
     }
 
     public void testGetExtension() {


### PR DESCRIPTION
### Description
Enabled Inner Product Space Type support for Lucene Engine. Before this change, with IP was not supported with Lucene Engine as it has the potential to give negative scores.

IT and Unit tests are added to validate the scores when dot product is negative and +ve both.

### Manual Testing
#### Create Index
```
PUT hotels-index
{
	"settings": {
		"index": {
			"knn": true,
			"number_of_shards": 1,
			"number_of_replicas": 0
		}
	},
	"mappings": {
		"properties": {
			"location": {
				"type": "knn_vector",
				"dimension": 2,
				"method": {
					"name": "hnsw",
            "space_type": "innerproduct",
					"engine": "lucene"
				}
			}
		}
	}
}
```
#### Ingest Data
```
POST /_bulk?refresh

{ "index": { "_index": "hotels-index", "_id": "3" } }
{ "location": [1, 0], "parking" : "false", "rating" : 5 }
{ "index": { "_index": "hotels-index", "_id": "4" } }
{ "location": [-1, 0], "parking" : "false", "rating" : 5 }
{ "index": { "_index": "hotels-index", "_id": "5" } }
{ "location": [2, 2], "parking" : "false", "rating" : 5 }

```

#### Vector Search
```
{
	"query": {
		"knn": {
			"location": {
				"vector": [
					1,
					1
				],
				"k": 3
			}
		}
	}
}
```
##### Response
```
{
	"took": 3,
	"timed_out": false,
	"_shards": {
		"total": 1,
		"successful": 1,
		"skipped": 0,
		"failed": 0
	},
	"hits": {
		"total": {
			"value": 3,
			"relation": "eq"
		},
		"max_score": 5.0,
		"hits": [
			{
				"_index": "hotels-index",
				"_id": "5",
				"_score": 5.0,
				"_source": {
					"location": [
						2,
						2
					],
					"parking": "false",
					"rating": 5
				}
			},
			{
				"_index": "hotels-index",
				"_id": "3",
				"_score": 2.0,
				"_source": {
					"location": [
						1,
						0
					],
					"parking": "false",
					"rating": 5
				}
			},
			{
				"_index": "hotels-index",
				"_id": "4",
				"_score": 0.5,
				"_source": {
					"location": [
						-1,
						0
					],
					"parking": "false",
					"rating": 5
				}
			}
		]
	}
}
```

#### Filtered Vector Search
```
{
	"query": {
		"knn": {
			"location": {
				"vector": [
					1,
					1
				],
				"k": 3,
				"filter": {
					"term": {
						"parking": "false"
					}
				}
			}
		}
	}
}
```
##### Response
```
{
	"took": 3,
	"timed_out": false,
	"_shards": {
		"total": 1,
		"successful": 1,
		"skipped": 0,
		"failed": 0
	},
	"hits": {
		"total": {
			"value": 3,
			"relation": "eq"
		},
		"max_score": 5.0,
		"hits": [
			{
				"_index": "hotels-index",
				"_id": "5",
				"_score": 5.0,
				"_source": {
					"location": [
						2,
						2
					],
					"parking": "false",
					"rating": 5
				}
			},
			{
				"_index": "hotels-index",
				"_id": "3",
				"_score": 2.0,
				"_source": {
					"location": [
						1,
						0
					],
					"parking": "false",
					"rating": 5
				}
			},
			{
				"_index": "hotels-index",
				"_id": "4",
				"_score": 0.5,
				"_source": {
					"location": [
						-1,
						0
					],
					"parking": "false",
					"rating": 5
				}
			}
		]
	}
}
```
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1550

https://github.com/opensearch-project/k-NN/issues/865
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
