### PR TITLE
[Backport 2.x] Share ivfpq-l2 table allocations across indices on load

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
           rm ../../patches/faiss/0001-Custom-patch-to-support-multi-vector.patch
           git apply --ignore-space-change --ignore-whitespace --3way ../../patches/faiss/0002-Custom-patch-to-support-AVX2-Linux-CI.patch
           rm ../../patches/faiss/0002-Custom-patch-to-support-AVX2-Linux-CI.patch
+          git apply --ignore-space-change --ignore-whitespace --3way ../../patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch
+          rm ../../patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch
           cd ../nmslib
           git apply --ignore-space-change --ignore-whitespace --3way ../../patches/nmslib/0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch
           rm ../../patches/nmslib/0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -47,6 +47,8 @@ jobs:
           rm ../../patches/faiss/0001-Custom-patch-to-support-multi-vector.patch
           git apply --ignore-space-change --ignore-whitespace --3way ../../patches/faiss/0002-Custom-patch-to-support-AVX2-Linux-CI.patch
           rm ../../patches/faiss/0002-Custom-patch-to-support-AVX2-Linux-CI.patch
+          git apply --ignore-space-change --ignore-whitespace --3way ../../patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch
+          rm ../../patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch
           cd ../nmslib
           git apply --ignore-space-change --ignore-whitespace --3way ../../patches/nmslib/0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch
           rm ../../patches/nmslib/0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Disable sdc table for HNSWPQ read-only indices [#1518](https://github.com/opensearch-project/k-NN/pull/1518)
 * Switch SpaceType.INNERPRODUCT's vector similarity function to MAXIMUM_INNER_PRODUCT [#1532](https://github.com/opensearch-project/k-NN/pull/1532)
 * Add patch to fix arm segfault in nmslib during ingestion [#1541](https://github.com/opensearch-project/k-NN/pull/1541)
+* Share ivfpq-l2 table allocations across indices on load [#1558](https://github.com/opensearch-project/k-NN/pull/1558)
 ### Infrastructure
 * Manually install zlib for win CI [#1513](https://github.com/opensearch-project/k-NN/pull/1513)
 * Update k-NN build artifact script to enable SIMD on ARM for Faiss [#1543](https://github.com/opensearch-project/k-NN/pull/1543)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -168,13 +168,13 @@ if (${CONFIG_FAISS} STREQUAL ON OR ${CONFIG_ALL} STREQUAL ON OR ${CONFIG_TEST} S
     endif ()
 
     # Check if patch exist, this is to skip git apply during CI build. See CI.yml with ubuntu.
-    find_path(PATCH_FILE NAMES 0001-Custom-patch-to-support-multi-vector.patch PATHS ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss NO_DEFAULT_PATH)
+    find_path(PATCH_FILE NAMES 0001-Custom-patch-to-support-multi-vector.patch 0003-Enable-precomp-table-to-be-shared-ivfpq.patch PATHS ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss NO_DEFAULT_PATH)
 
     # If it exists, apply patches
     if (EXISTS ${PATCH_FILE})
         message(STATUS "Applying custom patches.")
         execute_process(COMMAND git apply --ignore-space-change --ignore-whitespace --3way ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
-
+        execute_process(COMMAND git apply --ignore-space-change --ignore-whitespace --3way ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
         if(RESULT_CODE)
             message(FATAL_ERROR "Failed to apply patch:\n${ERROR_MSG}")
         endif()

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -33,6 +33,18 @@ namespace knn_jni {
         // Return a pointer to the loaded index
         jlong LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jstring indexPathJ);
 
+        // Check if a loaded index requires shared state
+        bool IsSharedIndexStateRequired(jlong indexPointerJ);
+
+        // Initializes the shared index state from an index. Note, this will not set the state for
+        // the index pointed to by indexPointerJ. To set it, SetSharedIndexState needs to be called.
+        //
+        // Return a pointer to the shared index state
+        jlong InitSharedIndexState(jlong indexPointerJ);
+
+        // Sets the sharedIndexState for an index
+        void SetSharedIndexState(jlong indexPointerJ, jlong shareIndexStatePointerJ);
+
         // Execute a query against the index located in memory at indexPointerJ.
         //
         // Return an array of KNNQueryResults
@@ -48,6 +60,9 @@ namespace knn_jni {
 
         // Free the index located in memory at indexPointerJ
         void Free(jlong indexPointer);
+
+        // Free shared index state in memory at shareIndexStatePointerJ
+        void FreeSharedIndexState(jlong shareIndexStatePointerJ);
 
         // Perform initilization operations for the library
         void InitLibrary();

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -44,16 +44,40 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    isSharedIndexStateRequired
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isSharedIndexStateRequired
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    initSharedIndexState
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initSharedIndexState
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    setSharedIndexState
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setSharedIndexState
+  (JNIEnv *, jclass, jlong, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
  * Method:    queryIndex
- * Signature: (J[FI)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ * Signature: (J[FI[I)[Lorg/opensearch/knn/index/query/KNNQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndex
   (JNIEnv *, jclass, jlong, jfloatArray, jint, jintArray);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
- * Method:    queryIndex_WithFilter
- * Signature: (J[FI[J)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ * Method:    queryIndexWithFilter
+ * Signature: (J[FI[JI[I)[Lorg/opensearch/knn/index/query/KNNQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndexWithFilter
   (JNIEnv *, jclass, jlong, jfloatArray, jint, jlongArray, jint, jintArray);
@@ -64,6 +88,14 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryInd
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_free
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    freeSharedIndexState
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_freeSharedIndexState
   (JNIEnv *, jclass, jlong);
 
 /*

--- a/jni/patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch
+++ b/jni/patches/faiss/0003-Enable-precomp-table-to-be-shared-ivfpq.patch
@@ -1,0 +1,512 @@
+From c5ca07299b427dedafc738b98bd20f8f286f6783 Mon Sep 17 00:00:00 2001
+From: John Mazanec <jmazane@amazon.com>
+Date: Wed, 21 Feb 2024 15:34:15 -0800
+Subject: [PATCH] Enable precomp table to be shared ivfpq
+
+Changes IVFPQ and IVFPQFastScan indices to be able to share the
+precomputed table amongst other instances. Switches var to a pointer and
+add necessary functions to set them correctly.
+
+Adds a tests to validate the behavior.
+
+Signed-off-by: John Mazanec <jmazane@amazon.com>
+---
+ faiss/IndexIVFPQ.cpp                 |  47 +++++++-
+ faiss/IndexIVFPQ.h                   |  16 ++-
+ faiss/IndexIVFPQFastScan.cpp         |  47 ++++++--
+ faiss/IndexIVFPQFastScan.h           |  11 +-
+ tests/CMakeLists.txt                 |   1 +
+ tests/test_disable_pq_sdc_tables.cpp |   4 +-
+ tests/test_ivfpq_share_table.cpp     | 173 +++++++++++++++++++++++++++
+ 7 files changed, 284 insertions(+), 15 deletions(-)
+ create mode 100644 tests/test_ivfpq_share_table.cpp
+
+diff --git a/faiss/IndexIVFPQ.cpp b/faiss/IndexIVFPQ.cpp
+index 0b7f4d05..07bc7e83 100644
+--- a/faiss/IndexIVFPQ.cpp
++++ b/faiss/IndexIVFPQ.cpp
+@@ -59,6 +59,29 @@ IndexIVFPQ::IndexIVFPQ(
+     polysemous_training = nullptr;
+     do_polysemous_training = false;
+     polysemous_ht = 0;
++    precomputed_table = new AlignedTable<float>();
++    owns_precomputed_table = true;
++}
++
++IndexIVFPQ::IndexIVFPQ(const IndexIVFPQ& orig) : IndexIVF(orig), pq(orig.pq) {
++    code_size = orig.pq.code_size;
++    invlists->code_size = code_size;
++    is_trained = orig.is_trained;
++    by_residual = orig.by_residual;
++    use_precomputed_table = orig.use_precomputed_table;
++    scan_table_threshold = orig.scan_table_threshold;
++
++    polysemous_training = orig.polysemous_training;
++    do_polysemous_training = orig.do_polysemous_training;
++    polysemous_ht = orig.polysemous_ht;
++    precomputed_table = new AlignedTable<float>(*orig.precomputed_table);
++    owns_precomputed_table = true;
++}
++
++IndexIVFPQ::~IndexIVFPQ() {
++    if (owns_precomputed_table) {
++        delete precomputed_table;
++    }
+ }
+ 
+ /****************************************************************
+@@ -466,11 +489,23 @@ void IndexIVFPQ::precompute_table() {
+             use_precomputed_table,
+             quantizer,
+             pq,
+-            precomputed_table,
++            *precomputed_table,
+             by_residual,
+             verbose);
+ }
+ 
++void IndexIVFPQ::set_precomputed_table(
++        AlignedTable<float>* _precompute_table,
++        int _use_precomputed_table) {
++    // Clean up old pre-computed table
++    if (owns_precomputed_table) {
++        delete precomputed_table;
++    }
++    owns_precomputed_table = false;
++    precomputed_table = _precompute_table;
++    use_precomputed_table = _use_precomputed_table;
++}
++
+ namespace {
+ 
+ #define TIC t0 = get_cycles()
+@@ -650,7 +685,7 @@ struct QueryTables {
+ 
+             fvec_madd(
+                     pq.M * pq.ksub,
+-                    ivfpq.precomputed_table.data() + key * pq.ksub * pq.M,
++                    ivfpq.precomputed_table->data() + key * pq.ksub * pq.M,
+                     -2.0,
+                     sim_table_2,
+                     sim_table);
+@@ -679,7 +714,7 @@ struct QueryTables {
+                 k >>= cpq.nbits;
+ 
+                 // get corresponding table
+-                const float* pc = ivfpq.precomputed_table.data() +
++                const float* pc = ivfpq.precomputed_table->data() +
+                         (ki * pq.M + cm * Mf) * pq.ksub;
+ 
+                 if (polysemous_ht == 0) {
+@@ -709,7 +744,7 @@ struct QueryTables {
+             dis0 = coarse_dis;
+ 
+             const float* s =
+-                    ivfpq.precomputed_table.data() + key * pq.ksub * pq.M;
++                    ivfpq.precomputed_table->data() + key * pq.ksub * pq.M;
+             for (int m = 0; m < pq.M; m++) {
+                 sim_table_ptrs[m] = s;
+                 s += pq.ksub;
+@@ -729,7 +764,7 @@ struct QueryTables {
+                 int ki = k & ((uint64_t(1) << cpq.nbits) - 1);
+                 k >>= cpq.nbits;
+ 
+-                const float* pc = ivfpq.precomputed_table.data() +
++                const float* pc = ivfpq.precomputed_table->data() +
+                         (ki * pq.M + cm * Mf) * pq.ksub;
+ 
+                 for (int m = m0; m < m0 + Mf; m++) {
+@@ -1346,6 +1381,8 @@ IndexIVFPQ::IndexIVFPQ() {
+     do_polysemous_training = false;
+     polysemous_ht = 0;
+     polysemous_training = nullptr;
++    precomputed_table = new AlignedTable<float>();
++    owns_precomputed_table = true;
+ }
+ 
+ struct CodeCmp {
+diff --git a/faiss/IndexIVFPQ.h b/faiss/IndexIVFPQ.h
+index d5d21da4..850bbe44 100644
+--- a/faiss/IndexIVFPQ.h
++++ b/faiss/IndexIVFPQ.h
+@@ -48,7 +48,8 @@ struct IndexIVFPQ : IndexIVF {
+ 
+     /// if use_precompute_table
+     /// size nlist * pq.M * pq.ksub
+-    AlignedTable<float> precomputed_table;
++    bool owns_precomputed_table;
++    AlignedTable<float>* precomputed_table;
+ 
+     IndexIVFPQ(
+             Index* quantizer,
+@@ -58,6 +59,10 @@ struct IndexIVFPQ : IndexIVF {
+             size_t nbits_per_idx,
+             MetricType metric = METRIC_L2);
+ 
++    IndexIVFPQ(const IndexIVFPQ& orig);
++
++    ~IndexIVFPQ();
++
+     void encode_vectors(
+             idx_t n,
+             const float* x,
+@@ -139,6 +144,15 @@ struct IndexIVFPQ : IndexIVF {
+     /// build precomputed table
+     void precompute_table();
+ 
++    /**
++     * Initialize the precomputed table
++     * @param precompute_table
++     * @param _use_precomputed_table
++     */
++    void set_precomputed_table(
++            AlignedTable<float>* precompute_table,
++            int _use_precomputed_table);
++
+     IndexIVFPQ();
+ };
+ 
+diff --git a/faiss/IndexIVFPQFastScan.cpp b/faiss/IndexIVFPQFastScan.cpp
+index d069db13..09a335ff 100644
+--- a/faiss/IndexIVFPQFastScan.cpp
++++ b/faiss/IndexIVFPQFastScan.cpp
+@@ -46,6 +46,8 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(
+         : IndexIVFFastScan(quantizer, d, nlist, 0, metric), pq(d, M, nbits) {
+     by_residual = false; // set to false by default because it's faster
+ 
++    precomputed_table = new AlignedTable<float>();
++    owns_precomputed_table = true;
+     init_fastscan(M, nbits, nlist, metric, bbs);
+ }
+ 
+@@ -53,6 +55,17 @@ IndexIVFPQFastScan::IndexIVFPQFastScan() {
+     by_residual = false;
+     bbs = 0;
+     M2 = 0;
++    precomputed_table = new AlignedTable<float>();
++    owns_precomputed_table = true;
++}
++
++IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQFastScan& orig)
++        : IndexIVFFastScan(orig), pq(orig.pq) {
++    by_residual = orig.by_residual;
++    bbs = orig.bbs;
++    M2 = orig.M2;
++    precomputed_table = new AlignedTable<float>(*orig.precomputed_table);
++    owns_precomputed_table = true;
+ }
+ 
+ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
+@@ -71,13 +84,15 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
+     ntotal = orig.ntotal;
+     is_trained = orig.is_trained;
+     nprobe = orig.nprobe;
++    precomputed_table = new AlignedTable<float>();
++    owns_precomputed_table = true;
+ 
+-    precomputed_table.resize(orig.precomputed_table.size());
++    precomputed_table->resize(orig.precomputed_table->size());
+ 
+-    if (precomputed_table.nbytes() > 0) {
+-        memcpy(precomputed_table.get(),
+-               orig.precomputed_table.data(),
+-               precomputed_table.nbytes());
++    if (precomputed_table->nbytes() > 0) {
++        memcpy(precomputed_table->get(),
++               orig.precomputed_table->data(),
++               precomputed_table->nbytes());
+     }
+ 
+     for (size_t i = 0; i < nlist; i++) {
+@@ -102,6 +117,12 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
+     orig_invlists = orig.invlists;
+ }
+ 
++IndexIVFPQFastScan::~IndexIVFPQFastScan() {
++    if (owns_precomputed_table) {
++        delete precomputed_table;
++    }
++}
++
+ /*********************************************************
+  * Training
+  *********************************************************/
+@@ -127,11 +148,23 @@ void IndexIVFPQFastScan::precompute_table() {
+             use_precomputed_table,
+             quantizer,
+             pq,
+-            precomputed_table,
++            *precomputed_table,
+             by_residual,
+             verbose);
+ }
+ 
++void IndexIVFPQFastScan::set_precomputed_table(
++        AlignedTable<float>* _precompute_table,
++        int _use_precomputed_table) {
++    // Clean up old pre-computed table
++    if (owns_precomputed_table) {
++        delete precomputed_table;
++    }
++    owns_precomputed_table = false;
++    precomputed_table = _precompute_table;
++    use_precomputed_table = _use_precomputed_table;
++}
++
+ /*********************************************************
+  * Code management functions
+  *********************************************************/
+@@ -229,7 +262,7 @@ void IndexIVFPQFastScan::compute_LUT(
+                     if (cij >= 0) {
+                         fvec_madd_simd(
+                                 dim12,
+-                                precomputed_table.get() + cij * dim12,
++                                precomputed_table->get() + cij * dim12,
+                                 -2,
+                                 ip_table.get() + i * dim12,
+                                 tab);
+diff --git a/faiss/IndexIVFPQFastScan.h b/faiss/IndexIVFPQFastScan.h
+index 00dd2f11..91f35a6e 100644
+--- a/faiss/IndexIVFPQFastScan.h
++++ b/faiss/IndexIVFPQFastScan.h
+@@ -38,7 +38,8 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
+     /// precomputed tables management
+     int use_precomputed_table = 0;
+     /// if use_precompute_table size (nlist, pq.M, pq.ksub)
+-    AlignedTable<float> precomputed_table;
++    bool owns_precomputed_table;
++    AlignedTable<float>* precomputed_table;
+ 
+     IndexIVFPQFastScan(
+             Index* quantizer,
+@@ -51,6 +52,10 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
+ 
+     IndexIVFPQFastScan();
+ 
++    IndexIVFPQFastScan(const IndexIVFPQFastScan& orig);
++
++    ~IndexIVFPQFastScan();
++
+     // built from an IndexIVFPQ
+     explicit IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs = 32);
+ 
+@@ -60,6 +65,10 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
+ 
+     /// build precomputed table, possibly updating use_precomputed_table
+     void precompute_table();
++    /// Pass in externally a precomputed
++    void set_precomputed_table(
++            AlignedTable<float>* precompute_table,
++            int _use_precomputed_table);
+ 
+     /// same as the regular IVFPQ encoder. The codes are not reorganized by
+     /// blocks a that point
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 9017edc5..0889bf72 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -33,6 +33,7 @@ set(FAISS_TEST_SRC
+   test_partitioning.cpp
+   test_fastscan_perf.cpp
+   test_disable_pq_sdc_tables.cpp
++  test_ivfpq_share_table.cpp
+ )
+ 
+ add_executable(faiss_test ${FAISS_TEST_SRC})
+diff --git a/tests/test_disable_pq_sdc_tables.cpp b/tests/test_disable_pq_sdc_tables.cpp
+index b211a5c4..a27973d5 100644
+--- a/tests/test_disable_pq_sdc_tables.cpp
++++ b/tests/test_disable_pq_sdc_tables.cpp
+@@ -15,7 +15,9 @@
+ #include "faiss/index_io.h"
+ #include "test_util.h"
+ 
+-pthread_mutex_t temp_file_mutex = PTHREAD_MUTEX_INITIALIZER;
++namespace {
++    pthread_mutex_t temp_file_mutex = PTHREAD_MUTEX_INITIALIZER;
++}
+ 
+ TEST(IO, TestReadHNSWPQ_whenSDCDisabledFlagPassed_thenDisableSDCTable) {
+     Tempfilename index_filename(&temp_file_mutex, "/tmp/faiss_TestReadHNSWPQ");
+diff --git a/tests/test_ivfpq_share_table.cpp b/tests/test_ivfpq_share_table.cpp
+new file mode 100644
+index 00000000..f827315d
+--- /dev/null
++++ b/tests/test_ivfpq_share_table.cpp
+@@ -0,0 +1,173 @@
++/**
++ * Copyright (c) Facebook, Inc. and its affiliates.
++ *
++ * This source code is licensed under the MIT license found in the
++ * LICENSE file in the root directory of this source tree.
++ */
++
++#include <gtest/gtest.h>
++
++#include <random>
++
++#include "faiss/Index.h"
++#include "faiss/IndexHNSW.h"
++#include "faiss/IndexIVFPQFastScan.h"
++#include "faiss/index_factory.h"
++#include "faiss/index_io.h"
++#include "test_util.h"
++
++namespace {
++    pthread_mutex_t temp_file_mutex = PTHREAD_MUTEX_INITIALIZER;
++}
++
++std::vector<float> generate_data(
++        int d,
++        int n,
++        std::default_random_engine rng,
++        std::uniform_real_distribution<float> u) {
++    std::vector<float> vectors(n * d);
++    for (size_t i = 0; i < n * d; i++) {
++        vectors[i] = u(rng);
++    }
++    return vectors;
++}
++
++void assert_float_vectors_almost_equal(
++        std::vector<float> a,
++        std::vector<float> b) {
++    float margin = 0.000001;
++    ASSERT_EQ(a.size(), b.size());
++    for (int i = 0; i < a.size(); i++) {
++        ASSERT_NEAR(a[i], b[i], margin);
++    }
++}
++
++/// Test case test precomputed table sharing for IVFPQ indices.
++template <typename T> /// T represents class cast to use for index
++void test_ivfpq_table_sharing(
++        const std::string& index_description,
++        const std::string& filename,
++        faiss::MetricType metric) {
++    // Setup the index:
++    // 1. Build an index
++    // 2. ingest random data
++    // 3. serialize to disk
++    int d = 32, n = 1000;
++    std::default_random_engine rng(
++            std::chrono::system_clock::now().time_since_epoch().count());
++    std::uniform_real_distribution<float> u(0, 100);
++
++    std::vector<float> index_vectors = generate_data(d, n, rng, u);
++    std::vector<float> query_vectors = generate_data(d, n, rng, u);
++
++    Tempfilename index_filename(&temp_file_mutex, filename);
++    {
++        std::unique_ptr<faiss::Index> index_writer(
++                faiss::index_factory(d, index_description.c_str(), metric));
++
++        index_writer->train(n, index_vectors.data());
++        index_writer->add(n, index_vectors.data());
++        faiss::write_index(index_writer.get(), index_filename.c_str());
++    }
++
++    // Load index from disk. Confirm that the sdc table is equal to 0 when
++    // disable sdc is set
++    std::unique_ptr<faiss::AlignedTable<float>> sharedAlignedTable(
++            new faiss::AlignedTable<float>());
++    int shared_use_precomputed_table = 0;
++    int k = 10;
++    std::vector<float> distances_test_a(k * n);
++    std::vector<faiss::idx_t> labels_test_a(k * n);
++    {
++        std::vector<float> distances_baseline(k * n);
++        std::vector<faiss::idx_t> labels_baseline(k * n);
++
++        std::unique_ptr<T> index_read_pq_table_enabled(
++                dynamic_cast<T*>(faiss::read_index(
++                        index_filename.c_str(), faiss::IO_FLAG_READ_ONLY)));
++        std::unique_ptr<T> index_read_pq_table_disabled(
++                dynamic_cast<T*>(faiss::read_index(
++                        index_filename.c_str(),
++                        faiss::IO_FLAG_READ_ONLY |
++                                faiss::IO_FLAG_SKIP_PRECOMPUTE_TABLE)));
++        faiss::initialize_IVFPQ_precomputed_table(
++                shared_use_precomputed_table,
++                index_read_pq_table_disabled->quantizer,
++                index_read_pq_table_disabled->pq,
++                *sharedAlignedTable,
++                index_read_pq_table_disabled->by_residual,
++                index_read_pq_table_disabled->verbose);
++        index_read_pq_table_disabled->set_precomputed_table(
++                sharedAlignedTable.get(), shared_use_precomputed_table);
++
++        ASSERT_TRUE(index_read_pq_table_enabled->owns_precomputed_table);
++        ASSERT_FALSE(index_read_pq_table_disabled->owns_precomputed_table);
++        index_read_pq_table_enabled->search(
++                n,
++                query_vectors.data(),
++                k,
++                distances_baseline.data(),
++                labels_baseline.data());
++        index_read_pq_table_disabled->search(
++                n,
++                query_vectors.data(),
++                k,
++                distances_test_a.data(),
++                labels_test_a.data());
++
++        assert_float_vectors_almost_equal(distances_baseline, distances_test_a);
++        ASSERT_EQ(labels_baseline, labels_test_a);
++    }
++
++    // The precomputed table should only be set for L2 metric type
++    if (metric == faiss::METRIC_L2) {
++        ASSERT_EQ(shared_use_precomputed_table, 1);
++    } else {
++        ASSERT_EQ(shared_use_precomputed_table, 0);
++    }
++
++    // At this point, the original has gone out of scope, the destructor has
++    // been called. Confirm that initializing a new index from the table
++    // preserves the functionality.
++    {
++        std::vector<float> distances_test_b(k * n);
++        std::vector<faiss::idx_t> labels_test_b(k * n);
++
++        std::unique_ptr<T> index_read_pq_table_disabled(
++                dynamic_cast<T*>(faiss::read_index(
++                        index_filename.c_str(),
++                        faiss::IO_FLAG_READ_ONLY |
++                                faiss::IO_FLAG_SKIP_PRECOMPUTE_TABLE)));
++        index_read_pq_table_disabled->set_precomputed_table(
++                sharedAlignedTable.get(), shared_use_precomputed_table);
++        ASSERT_FALSE(index_read_pq_table_disabled->owns_precomputed_table);
++        index_read_pq_table_disabled->search(
++                n,
++                query_vectors.data(),
++                k,
++                distances_test_b.data(),
++                labels_test_b.data());
++        assert_float_vectors_almost_equal(distances_test_a, distances_test_b);
++        ASSERT_EQ(labels_test_a, labels_test_b);
++    }
++}
++
++TEST(TestIVFPQTableSharing, L2) {
++    test_ivfpq_table_sharing<faiss::IndexIVFPQ>(
++            "IVF16,PQ8x4", "/tmp/ivfpql2", faiss::METRIC_L2);
++}
++
++TEST(TestIVFPQTableSharing, IP) {
++    test_ivfpq_table_sharing<faiss::IndexIVFPQ>(
++            "IVF16,PQ8x4", "/tmp/ivfpqip", faiss::METRIC_INNER_PRODUCT);
++}
++
++TEST(TestIVFPQTableSharing, FastScanL2) {
++    test_ivfpq_table_sharing<faiss::IndexIVFPQFastScan>(
++            "IVF16,PQ8x4fsr", "/tmp/ivfpqfsl2", faiss::METRIC_L2);
++}
++
++TEST(TestIVFPQTableSharing, FastScanIP) {
++    test_ivfpq_table_sharing<faiss::IndexIVFPQFastScan>(
++            "IVF16,PQ8x4fsr", "/tmp/ivfpqfsip", faiss::METRIC_INNER_PRODUCT);
++}
+-- 
+2.39.3 (Apple Git-145)
+

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -21,6 +21,7 @@
 #include "faiss/MetaIndexes.h"
 #include "faiss/Index.h"
 #include "faiss/impl/IDSelector.h"
+#include "faiss/IndexIVFPQ.h"
 
 #include <algorithm>
 #include <jni.h>
@@ -72,6 +73,13 @@ void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, fa
 void buildFilterIdsBitMap(const int* filterIds, int filterIdsLength, uint8_t* bitsetVector);
 
 std::unique_ptr<faiss::IDGrouperBitmap> buildIDGrouperBitmap(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env, jintArray parentIdsJ, std::vector<uint64_t>* bitmap);
+
+// Check if a loaded index is an IVFPQ index with l2 space type
+bool isIndexIVFPQL2(faiss::Index * index);
+
+// Gets IVFPQ index from a faiss index. For faiss, we wrap the index in the type
+// IndexIDMap which has member that will point to underlying index that stores the data
+faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index);
 
 void knn_jni::faiss_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
                                          jobjectArray vectorsJ, jstring indexPathJ, jobject parametersJ) {
@@ -214,8 +222,58 @@ jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
 
     std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
     // Skipping IO_FLAG_PQ_SKIP_SDC_TABLE because the index is read only and the sdc table is only used during ingestion
-    faiss::Index* indexReader = faiss::read_index(indexPathCpp.c_str(), faiss::IO_FLAG_READ_ONLY | faiss::IO_FLAG_PQ_SKIP_SDC_TABLE);
+    // Skipping IO_PRECOMPUTE_TABLE because it is only needed for IVFPQ-l2 and it leads to high memory consumption if
+    // done for each segment. Instead, we will set it later on with `setSharedIndexState`
+    faiss::Index* indexReader = faiss::read_index(indexPathCpp.c_str(), faiss::IO_FLAG_READ_ONLY | faiss::IO_FLAG_PQ_SKIP_SDC_TABLE | faiss::IO_FLAG_SKIP_PRECOMPUTE_TABLE);
     return (jlong) indexReader;
+}
+
+bool knn_jni::faiss_wrapper::IsSharedIndexStateRequired(jlong indexPointerJ) {
+    auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    return isIndexIVFPQL2(index);
+}
+
+jlong knn_jni::faiss_wrapper::InitSharedIndexState(jlong indexPointerJ) {
+    auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    if (!isIndexIVFPQL2(index)) {
+        throw std::runtime_error("Unable to init shared index state from index. index is not of type IVFPQ-l2");
+    }
+
+    auto * indexIVFPQ = extractIVFPQIndex(index);
+    int use_precomputed_table = 0;
+    auto * sharedMemoryAddress = new faiss::AlignedTable<float>();
+    faiss::initialize_IVFPQ_precomputed_table(
+            use_precomputed_table,
+            indexIVFPQ->quantizer,
+            indexIVFPQ->pq,
+            *sharedMemoryAddress,
+            indexIVFPQ->by_residual,
+            indexIVFPQ->verbose);
+    return (jlong) sharedMemoryAddress;
+}
+
+void knn_jni::faiss_wrapper::SetSharedIndexState(jlong indexPointerJ, jlong shareIndexStatePointerJ) {
+    auto * index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    if (!isIndexIVFPQL2(index)) {
+        throw std::runtime_error("Unable to set shared index state from index. index is not of type IVFPQ-l2");
+    }
+    auto * indexIVFPQ = extractIVFPQIndex(index);
+
+    //TODO: Currently, the only shared state is that of the AlignedTable associated with
+    // IVFPQ-l2 index type (see https://github.com/opensearch-project/k-NN/issues/1507). In the future,
+    // this will be generalized and more information will be needed to determine the shared type. But, until then,
+    // this is fine.
+    auto *alignTable = reinterpret_cast<faiss::AlignedTable<float>*>(shareIndexStatePointerJ);
+    // In faiss, usePrecomputedTable can have a couple different values:
+    //  -1  -> dont use the table
+    //   0  -> tell initialize_IVFPQ_precomputed_table to select the best value and change the value
+    //   1  -> default behavior
+    //   2  -> Index is of type "MultiIndexQuantizer"
+    // This index will be of type IndexIVFPQ always. We never create "MultiIndexQuantizer". So, the value we
+    // want is 1.
+    // (ref: https://github.com/facebookresearch/faiss/blob/v1.8.0/faiss/IndexIVFPQ.cpp#L383-L410)
+    int usePrecomputedTable = 1;
+    indexIVFPQ->set_precomputed_table(alignTable, usePrecomputedTable);
 }
 
 jobjectArray knn_jni::faiss_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
@@ -335,6 +393,15 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
 void knn_jni::faiss_wrapper::Free(jlong indexPointer) {
     auto *indexWrapper = reinterpret_cast<faiss::Index*>(indexPointer);
     delete indexWrapper;
+}
+
+void knn_jni::faiss_wrapper::FreeSharedIndexState(jlong shareIndexStatePointerJ) {
+    //TODO: Currently, the only shared state is that of the AlignedTable associated with
+    // IVFPQ-l2 index type (see https://github.com/opensearch-project/k-NN/issues/1507). In the future,
+    // this will be generalized and more information will be needed to determine the shared type. But, until then,
+    // this is fine.
+    auto *alignTable = reinterpret_cast<faiss::AlignedTable<float>*>(shareIndexStatePointerJ);
+    delete alignTable;
 }
 
 void knn_jni::faiss_wrapper::InitLibrary() {
@@ -468,4 +535,36 @@ std::unique_ptr<faiss::IDGrouperBitmap> buildIDGrouperBitmap(knn_jni::JNIUtilInt
     std::unique_ptr<faiss::IDGrouperBitmap> idGrouper = faiss_util::buildIDGrouperBitmap(parentIdsArray, parentIdsLength, bitmap);
     jniUtil->ReleaseIntArrayElements(env, parentIdsJ, parentIdsArray, JNI_ABORT);
     return idGrouper;
+}
+
+bool isIndexIVFPQL2(faiss::Index * index) {
+    faiss::Index * candidateIndex = index;
+    // Unwrap the index if it is wrapped in IndexIDMap. Dynamic cast will "Safely converts pointers and references to
+    // classes up, down, and sideways along the inheritance hierarchy." It will return a nullptr if the
+    // cast fails. (ref: https://en.cppreference.com/w/cpp/language/dynamic_cast)
+    if (auto indexIDMap = dynamic_cast<faiss::IndexIDMap *>(index)) {
+        candidateIndex = indexIDMap->index;
+    }
+
+    // Check if the index is of type IndexIVFPQ. If so, confirm its metric type is
+    // l2.
+    if (auto indexIVFPQ = dynamic_cast<faiss::IndexIVFPQ *>(candidateIndex)) {
+        return faiss::METRIC_L2 == indexIVFPQ->metric_type;
+    }
+
+    return false;
+}
+
+faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index) {
+    faiss::Index * candidateIndex = index;
+    if (auto indexIDMap = dynamic_cast<faiss::IndexIDMap *>(index)) {
+        candidateIndex = indexIDMap->index;
+    }
+
+    faiss::IndexIVFPQ * indexIVFPQ;
+    if ((indexIVFPQ = dynamic_cast<faiss::IndexIVFPQ *>(candidateIndex))) {
+        return indexIVFPQ;
+    }
+
+    throw std::runtime_error("Unable to extract IVFPQ index. IVFPQ index not present.");
 }

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -75,6 +75,38 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex(JNIEn
     return NULL;
 }
 
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isSharedIndexStateRequired
+        (JNIEnv * env, jclass cls, jlong indexPointerJ)
+{
+    try {
+        return knn_jni::faiss_wrapper::IsSharedIndexStateRequired(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return NULL;
+}
+
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initSharedIndexState
+        (JNIEnv * env, jclass cls, jlong indexPointerJ)
+{
+    try {
+        return knn_jni::faiss_wrapper::InitSharedIndexState(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return NULL;
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setSharedIndexState
+        (JNIEnv * env, jclass cls, jlong indexPointerJ, jlong shareIndexStatePointerJ)
+{
+    try {
+        knn_jni::faiss_wrapper::SetSharedIndexState(indexPointerJ, shareIndexStatePointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryIndex(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ, jint kJ, jintArray parentIdsJ)
@@ -104,6 +136,16 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_free(JNIEnv * en
 {
     try {
         return knn_jni::faiss_wrapper::Free(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_freeSharedIndexState
+        (JNIEnv * env, jclass cls, jlong shareIndexStatePointerJ)
+{
+    try {
+        knn_jni::faiss_wrapper::FreeSharedIndexState(shareIndexStatePointerJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -18,6 +18,7 @@
 #include "jni_util.h"
 #include "test_util.h"
 #include "faiss/IndexHNSW.h"
+#include "faiss/IndexIVFPQ.h"
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -202,6 +203,37 @@ TEST(FaissLoadIndexTest, HNSWPQDisableSdcTable) {
     auto pqIndex = dynamic_cast<faiss::IndexPQ*>(hnswPQIndex->storage);
     ASSERT_NE(pqIndex, nullptr);
     ASSERT_EQ(0, pqIndex->pq.sdc_table.size());
+}
+
+TEST(FaissLoadIndexTest, IVFPQDisablePrecomputeTable) {
+    faiss::idx_t numIds = 256;
+    int dim = 2;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    std::vector<float> vectors = test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax);
+
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::MetricType metricType = faiss::METRIC_L2;
+    std::string indexDescription = "IVF4,PQ1x4";
+
+    std::unique_ptr<faiss::Index> faissIndex(test_util::FaissCreateIndex(dim, indexDescription, metricType));
+    test_util::FaissTrainIndex(faissIndex.get(), numIds, vectors.data());
+    auto faissIndexWithIDMap = test_util::FaissAddData(faissIndex.get(), ids, vectors);
+    test_util::FaissWriteIndex(&faissIndexWithIDMap, indexPath);
+
+    // Setup jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    std::unique_ptr<faiss::Index> loadedIndexPointer(
+            reinterpret_cast<faiss::Index *>(knn_jni::faiss_wrapper::LoadIndex(
+                    &mockJNIUtil, jniEnv, (jstring)&indexPath)));
+
+    // Cast down until we get to the ivfpq-l2 state
+    auto idMapIndex = dynamic_cast<faiss::IndexIDMap *>(loadedIndexPointer.get());
+    ASSERT_NE(idMapIndex, nullptr);
+    auto ivfpqIndex = dynamic_cast<faiss::IndexIVFPQ *>(idMapIndex->index);
+    ASSERT_NE(ivfpqIndex, nullptr);
+    ASSERT_EQ(0, ivfpqIndex->precomputed_table->size());
 }
 
 TEST(FaissQueryIndexTest, BasicAssertions) {
@@ -500,4 +532,95 @@ TEST(FaissCreateHnswSQfp16IndexTest, BasicAssertions) {
     
     // Clean up
     std::remove(indexPath.c_str());
+}
+
+TEST(FaissIsSharedIndexStateRequired, BasicAssertions) {
+    int d = 128;
+    int hnswM = 16;
+    int ivfNlist = 4;
+    int pqM = 1;
+    int pqCodeSize = 8;
+    std::unique_ptr<faiss::IndexHNSW> indexHNSWL2(new faiss::IndexHNSW(d, hnswM, faiss::METRIC_L2));
+    std::unique_ptr<faiss::IndexIVFPQ> indexIVFPQIP(new faiss::IndexIVFPQ(
+                new faiss::IndexFlat(d, faiss::METRIC_INNER_PRODUCT),
+                d,
+                ivfNlist,
+                pqM,
+                pqCodeSize,
+                faiss::METRIC_INNER_PRODUCT
+            ));
+    std::unique_ptr<faiss::IndexIVFPQ> indexIVFPQL2(new faiss::IndexIVFPQ(
+                new faiss::IndexFlat(d, faiss::METRIC_L2),
+                d,
+                ivfNlist,
+                pqM,
+                pqCodeSize,
+                faiss::METRIC_L2
+            ));
+    std::unique_ptr<faiss::IndexIDMap> indexIDMapIVFPQL2(new faiss::IndexIDMap(
+                new faiss::IndexIVFPQ(
+                        new faiss::IndexFlat(d, faiss::METRIC_L2),
+                        d,
+                        ivfNlist,
+                        pqM,
+                        pqCodeSize,
+                        faiss::METRIC_L2
+                )
+            ));
+    std::unique_ptr<faiss::IndexIDMap> indexIDMapIVFPQIP(new faiss::IndexIDMap(
+                new faiss::IndexIVFPQ(
+                        new faiss::IndexFlat(d, faiss::METRIC_INNER_PRODUCT),
+                        d,
+                        ivfNlist,
+                        pqM,
+                        pqCodeSize,
+                        faiss::METRIC_INNER_PRODUCT
+                )
+            ));
+    jlong nullAddress = 0;
+
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexHNSWL2.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIVFPQIP.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIDMapIVFPQIP.get()));
+    ASSERT_FALSE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) nullAddress));
+
+    ASSERT_TRUE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIVFPQL2.get()));
+    ASSERT_TRUE(knn_jni::faiss_wrapper::IsSharedIndexStateRequired((jlong) indexIDMapIVFPQL2.get()));
+}
+
+TEST(FaissInitAndSetSharedIndexState, BasicAssertions) {
+    faiss::idx_t numIds = 256;
+    int dim = 2;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    std::vector<float> vectors = test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax);
+
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::MetricType metricType = faiss::METRIC_L2;
+    std::string indexDescription = "IVF4,PQ1x4";
+
+    std::unique_ptr<faiss::Index> faissIndex(test_util::FaissCreateIndex(dim, indexDescription, metricType));
+    test_util::FaissTrainIndex(faissIndex.get(), numIds, vectors.data());
+    auto faissIndexWithIDMap = test_util::FaissAddData(faissIndex.get(), ids, vectors);
+    test_util::FaissWriteIndex(&faissIndexWithIDMap, indexPath);
+
+    // Setup jni
+    JNIEnv *jniEnv = nullptr;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    std::unique_ptr<faiss::Index> loadedIndexPointer(
+            reinterpret_cast<faiss::Index *>(knn_jni::faiss_wrapper::LoadIndex(
+                    &mockJNIUtil, jniEnv, (jstring)&indexPath)));
+
+    auto idMapIndex = dynamic_cast<faiss::IndexIDMap *>(loadedIndexPointer.get());
+    ASSERT_NE(idMapIndex, nullptr);
+    auto ivfpqIndex = dynamic_cast<faiss::IndexIVFPQ *>(idMapIndex->index);
+    ASSERT_NE(ivfpqIndex, nullptr);
+    ASSERT_EQ(0, ivfpqIndex->precomputed_table->size());
+    jlong sharedModelAddress = knn_jni::faiss_wrapper::InitSharedIndexState((jlong) loadedIndexPointer.get());
+    ASSERT_EQ(0, ivfpqIndex->precomputed_table->size());
+    knn_jni::faiss_wrapper::SetSharedIndexState((jlong) loadedIndexPointer.get(), sharedModelAddress);
+    ASSERT_EQ(sharedModelAddress, (jlong) ivfpqIndex->precomputed_table);
+    ASSERT_NE(0, ivfpqIndex->precomputed_table->size());
+    ASSERT_EQ(1, ivfpqIndex->use_precomputed_table);
+    knn_jni::faiss_wrapper::FreeSharedIndexState(sharedModelAddress);
 }

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.jni.JNIService;
 
 import java.io.File;
 import java.util.Collections;
@@ -267,5 +268,20 @@ public class IndexUtil {
             return false;
         }
         return version.onOrAfter(minimalRequiredVersion);
+    }
+
+    /**
+     * Checks if index requires shared state
+     *
+     * @param knnEngine The knnEngine associated with the index
+     * @param modelId The modelId associated with the index
+     * @param indexAddr Address to check if loaded index requires shared state
+     * @return true if state can be shared; false otherwise
+     */
+    public static boolean isSharedIndexStateRequired(KNNEngine knnEngine, String modelId, long indexAddr) {
+        if (StringUtils.isEmpty(modelId)) {
+            return false;
+        }
+        return JNIService.isSharedIndexStateRequired(indexAddr, knnEngine);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.knn.index;
 
+import com.google.common.annotations.VisibleForTesting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,12 +27,13 @@ import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.buildEngineFilePrefix;
@@ -82,14 +86,19 @@ public class KNNIndexShard {
     public void warmup() throws IOException {
         logger.info("[KNN] Warming up index: " + getIndexName());
         try (Engine.Searcher searcher = indexShard.acquireSearcher("knn-warmup")) {
-            getAllEnginePaths(searcher.getIndexReader()).forEach((key, value) -> {
+            getAllEngineFileContexts(searcher.getIndexReader()).forEach((engineFileContext) -> {
                 try {
                     nativeMemoryCacheManager.get(
                         new NativeMemoryEntryContext.IndexEntryContext(
-                            key,
+                            engineFileContext.getIndexPath(),
                             NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
-                            getParametersAtLoading(value, KNNEngine.getEngineNameFromPath(key), getIndexName()),
-                            getIndexName()
+                            getParametersAtLoading(
+                                engineFileContext.getSpaceType(),
+                                KNNEngine.getEngineNameFromPath(engineFileContext.getIndexPath()),
+                                getIndexName()
+                            ),
+                            getIndexName(),
+                            engineFileContext.getModelId()
                         ),
                         true
                     );
@@ -103,20 +112,21 @@ public class KNNIndexShard {
     /**
      * For the given shard, get all of its engine paths
      *
-     * @param indexReader IndexReader to read the file paths for the shard
-     * @return List of engine file Paths
+     * @param indexReader IndexReader to read the information for each segment in the shard
+     * @return List of engine contexts
      * @throws IOException Thrown when the SegmentReader is attempting to read the segments files
      */
-    public Map<String, SpaceType> getAllEnginePaths(IndexReader indexReader) throws IOException {
-        Map<String, SpaceType> engineFiles = new HashMap<>();
+    @VisibleForTesting
+    List<EngineFileContext> getAllEngineFileContexts(IndexReader indexReader) throws IOException {
+        List<EngineFileContext> engineFiles = new ArrayList<>();
         for (KNNEngine knnEngine : KNNEngine.getEnginesThatCreateCustomSegmentFiles()) {
-            engineFiles.putAll(getEnginePaths(indexReader, knnEngine));
+            engineFiles.addAll(getEngineFileContexts(indexReader, knnEngine));
         }
         return engineFiles;
     }
 
-    private Map<String, SpaceType> getEnginePaths(IndexReader indexReader, KNNEngine knnEngine) throws IOException {
-        Map<String, SpaceType> engineFiles = new HashMap<>();
+    List<EngineFileContext> getEngineFileContexts(IndexReader indexReader, KNNEngine knnEngine) throws IOException {
+        List<EngineFileContext> engineFiles = new ArrayList<>();
 
         for (LeafReaderContext leafReaderContext : indexReader.leaves()) {
             SegmentReader reader = (SegmentReader) FilterLeafReader.unwrap(leafReaderContext.reader());
@@ -131,15 +141,17 @@ public class KNNIndexShard {
                     // was L2. So, if Space Type is not present, just fall back to L2
                     String spaceTypeName = fieldInfo.attributes().getOrDefault(SPACE_TYPE, SpaceType.L2.getValue());
                     SpaceType spaceType = SpaceType.getSpace(spaceTypeName);
+                    String modelId = fieldInfo.attributes().getOrDefault(MODEL_ID, null);
 
-                    engineFiles.putAll(
-                        getEnginePaths(
+                    engineFiles.addAll(
+                        getEngineFileContexts(
                             reader.getSegmentInfo().files(),
                             reader.getSegmentInfo().info.name,
                             fieldInfo.name,
                             fileExtension,
                             shardPath,
-                            spaceType
+                            spaceType,
+                            modelId
                         )
                     );
                 }
@@ -148,13 +160,15 @@ public class KNNIndexShard {
         return engineFiles;
     }
 
-    protected Map<String, SpaceType> getEnginePaths(
+    @VisibleForTesting
+    List<EngineFileContext> getEngineFileContexts(
         Collection<String> files,
         String segmentName,
         String fieldName,
         String fileExtension,
         Path shardPath,
-        SpaceType spaceType
+        SpaceType spaceType,
+        String modelId
     ) {
         String prefix = buildEngineFilePrefix(segmentName);
         String suffix = buildEngineFileSuffix(fieldName, fileExtension);
@@ -162,6 +176,16 @@ public class KNNIndexShard {
             .filter(fileName -> fileName.startsWith(prefix))
             .filter(fileName -> fileName.endsWith(suffix))
             .map(fileName -> shardPath.resolve(fileName).toString())
-            .collect(Collectors.toMap(fileName -> fileName, fileName -> spaceType));
+            .map(fileName -> new EngineFileContext(spaceType, modelId, fileName))
+            .collect(Collectors.toList());
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @VisibleForTesting
+    static class EngineFileContext {
+        private final SpaceType spaceType;
+        private final String modelId;
+        private final String indexPath;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -184,7 +184,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             KNNSettings.state().getSettingValue(KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY)
         );
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, parameters, knnEngine.getName());
+            JNIService.createIndexFromTemplate(pair.docs, pair.vectors, indexPath, model, parameters, knnEngine);
             return null;
         });
     }
@@ -223,7 +223,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
 
         // Pass the path for the nms library to save the file
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            JNIService.createIndex(pair.docs, pair.vectors, indexPath, parameters, knnEngine.getName());
+            JNIService.createIndex(pair.docs, pair.vectors, indexPath, parameters, knnEngine);
             return null;
         });
     }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryAllocation.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryAllocation.java
@@ -143,7 +143,7 @@ public interface NativeMemoryAllocation {
 
             // memoryAddress is sometimes initialized to 0. If this is ever the case, freeing will surely fail.
             if (memoryAddress != 0) {
-                JNIService.free(memoryAddress, knnEngine.getName());
+                JNIService.free(memoryAddress, knnEngine);
             }
         }
 

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index.memory;
 
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.IndexUtil;
 
 import java.io.IOException;
@@ -63,6 +64,8 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         private final NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy;
         private final String openSearchIndexName;
         private final Map<String, Object> parameters;
+        @Nullable
+        private final String modelId;
 
         /**
          * Constructor
@@ -78,10 +81,30 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             Map<String, Object> parameters,
             String openSearchIndexName
         ) {
+            this(indexPath, indexLoadStrategy, parameters, openSearchIndexName, null);
+        }
+
+        /**
+         * Constructor
+         *
+         * @param indexPath path to index file. Also used as key in cache.
+         * @param indexLoadStrategy strategy to load index into memory
+         * @param parameters load time parameters
+         * @param openSearchIndexName opensearch index associated with index
+         * @param modelId model to be loaded. If none available, pass null
+         */
+        public IndexEntryContext(
+            String indexPath,
+            NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy,
+            Map<String, Object> parameters,
+            String openSearchIndexName,
+            String modelId
+        ) {
             super(indexPath);
             this.indexLoadStrategy = indexLoadStrategy;
             this.openSearchIndexName = openSearchIndexName;
             this.parameters = parameters;
+            this.modelId = modelId;
         }
 
         @Override
@@ -110,6 +133,15 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
          */
         public Map<String, Object> getParameters() {
             return parameters;
+        }
+
+        /**
+         * Getter
+         *
+         * @return return model ID for the index. null if no model is in use
+         */
+        public String getModelId() {
+            return modelId;
         }
 
         private static class IndexSizeCalculator implements Function<IndexEntryContext, Integer> {

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategy.java
@@ -92,7 +92,7 @@ public interface NativeMemoryLoadStrategy<T extends NativeMemoryAllocation, U ex
             fileWatcher.init();
 
             KNNEngine knnEngine = KNNEngine.getEngineNameFromPath(indexPath.toString());
-            long memoryAddress = JNIService.loadIndex(indexPath.toString(), indexEntryContext.getParameters(), knnEngine.getName());
+            long memoryAddress = JNIService.loadIndex(indexPath.toString(), indexEntryContext.getParameters(), knnEngine);
             final WatcherHandle<FileWatcher> watcherHandle = resourceWatcherService.add(fileWatcher);
 
             return new NativeMemoryAllocation.IndexAllocation(

--- a/src/main/java/org/opensearch/knn/index/memory/SharedIndexState.java
+++ b/src/main/java/org/opensearch/knn/index/memory/SharedIndexState.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.memory;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.knn.index.util.KNNEngine;
+
+/**
+ * Class stores information about the shared memory allocations between loaded native indices.
+ */
+@RequiredArgsConstructor
+@Getter
+public class SharedIndexState {
+    private final long sharedIndexStateAddress;
+    private final String modelId;
+    private final KNNEngine knnEngine;
+}

--- a/src/main/java/org/opensearch/knn/index/memory/SharedIndexStateManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/SharedIndexStateManager.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.memory;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.jni.JNIService;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Class manages allocations that can be shared between native indices. No locking is required.
+ * Once a caller obtain an instance of a {@link org.opensearch.knn.index.memory.SharedIndexState}, it is guaranteed to
+ * be valid until it is returned. {@link org.opensearch.knn.index.memory.SharedIndexState} are reference counted
+ * internally. Once the reference count goes to 0, it will be freed.
+ */
+@Log4j2
+class SharedIndexStateManager {
+    // Map storing the shared index state with key being the modelId.
+    private final ConcurrentHashMap<String, SharedIndexStateEntry> sharedIndexStateCache;
+    private final ReadWriteLock readWriteLock;
+
+    private static SharedIndexStateManager INSTANCE;
+
+    // TODO: Going to refactor away from doing this in the future. For now, keeping for simplicity.
+    public static synchronized SharedIndexStateManager getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SharedIndexStateManager();
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * Constructor
+     */
+    @VisibleForTesting
+    SharedIndexStateManager() {
+        this.sharedIndexStateCache = new ConcurrentHashMap<>();
+        this.readWriteLock = new ReentrantReadWriteLock();
+    }
+
+    /**
+     * Return a {@link SharedIndexState} associated with the key. If no value exists, it will attempt to create it.
+     * Once returned, the {@link SharedIndexState} will be valid until
+     * {@link SharedIndexStateManager#release(SharedIndexState)} is called. Caller must ensure that this is
+     * called after it is done using it.
+     *
+     * In order to create the shared state, it will use the indexAddress passed in to create the shared state from
+     * using {@link org.opensearch.knn.jni.JNIService#initSharedIndexState(long, KNNEngine)}.
+     *
+     * @param indexAddress Address of index to initialize the shared state from
+     * @param knnEngine engine index belongs to
+     * @return ShareModelContext
+     */
+    public SharedIndexState get(long indexAddress, String modelId, KNNEngine knnEngine) {
+        this.readWriteLock.readLock().lock();
+        try {
+            // This can be done safely with readLock because the ConcurrentHasMap.computeIfAbsent guarantees:
+            //
+            // "If the specified key is not already associated with a value, attempts to compute its value using the given
+            // mapping function and enters it into this map unless null. The entire method invocation is performed
+            // atomically, so the function is applied at most once per key. Some attempted update operations on this map
+            // by other threads may be blocked while computation is in progress, so the computation should be short and
+            // simple, and must not attempt to update any other mappings of this map."
+            //
+            // Ref:
+            // https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#computeIfAbsent-K-java.util.function.Function-
+            SharedIndexStateEntry entry = sharedIndexStateCache.computeIfAbsent(modelId, m -> {
+                log.info("Loading entry to shared index state cache for model {}", modelId);
+                long sharedIndexStateAddress = JNIService.initSharedIndexState(indexAddress, knnEngine);
+                return new SharedIndexStateEntry(new SharedIndexState(sharedIndexStateAddress, modelId, knnEngine));
+            });
+            entry.incRef();
+            return entry.getSharedIndexState();
+        } finally {
+            this.readWriteLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Indicate that the {@link SharedIndexState} is no longer being used. If nothing else is using it, it will be
+     * removed from the cache and evicted.
+     *
+     * After calling this method, {@link SharedIndexState} should no longer be used by calling thread.
+     *
+     * @param sharedIndexState to return to the system.
+     */
+    public void release(SharedIndexState sharedIndexState) {
+        this.readWriteLock.writeLock().lock();
+
+        try {
+            SharedIndexStateEntry sharedIndexStateEntry;
+            if ((sharedIndexStateEntry = sharedIndexStateCache.get(sharedIndexState.getModelId())) == null) {
+                // This should not happen. Will log the error and return to prevent crash
+                log.error("Attempting to evict model from cache but it is not present: {}", sharedIndexState.getModelId());
+                return;
+            }
+
+            if (sharedIndexStateEntry.decRef() <= 0) {
+                log.info("Evicting entry from shared index state cache for key {}", sharedIndexState.getModelId());
+                sharedIndexStateCache.remove(sharedIndexState.getModelId());
+                JNIService.freeSharedIndexState(sharedIndexState.getSharedIndexStateAddress(), sharedIndexState.getKnnEngine());
+            }
+        } finally {
+            this.readWriteLock.writeLock().unlock();
+        }
+    }
+
+    private static final class SharedIndexStateEntry {
+        @Getter
+        private final SharedIndexState sharedIndexState;
+        private final AtomicLong referenceCount;
+
+        /**
+         * Constructor
+         *
+         * @param sharedIndexState sharedIndexStateContext being wrapped
+         */
+        private SharedIndexStateEntry(SharedIndexState sharedIndexState) {
+            this.sharedIndexState = sharedIndexState;
+            this.referenceCount = new AtomicLong(0);
+        }
+
+        /**
+         * Increases reference count by 1
+         *
+         * @return ++referenceCount
+         */
+        private long incRef() {
+            return referenceCount.incrementAndGet();
+        }
+
+        /**
+         * Decrease reference count by 1
+         *
+         * @return --referenceCount
+         */
+        private long decRef() {
+            return referenceCount.decrementAndGet();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -280,7 +280,7 @@ public class KNNWeight extends Weight {
                 indexAllocation.getMemoryAddress(),
                 knnQuery.getQueryVector(),
                 knnQuery.getK(),
-                knnEngine.getName(),
+                knnEngine,
                 filterIds,
                 filterType.getValue(),
                 parentIds

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -256,7 +256,8 @@ public class KNNWeight extends Weight {
                     indexPath.toString(),
                     NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
                     getParametersAtLoading(spaceType, knnEngine, knnQuery.getIndexName()),
-                    knnQuery.getIndexName()
+                    knnQuery.getIndexName(),
+                    modelId
                 ),
                 true
             );

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -85,6 +85,30 @@ class FaissService {
     public static native long loadIndex(String indexPath);
 
     /**
+     * Determine if index contains shared state.
+     *
+     * @param indexAddr address of index to be checked.
+     * @return true if index requires shared index state; false otherwise
+     */
+    public static native boolean isSharedIndexStateRequired(long indexAddr);
+
+    /**
+     * Initialize the shared state for an index
+     *
+     * @param indexAddr address of the index to initialize from
+     * @return Address of shared index state address
+     */
+    public static native long initSharedIndexState(long indexAddr);
+
+    /**
+     * Set the index state for an index
+     *
+     * @param indexAddr address of index to set state for
+     * @param shareIndexStateAddr address of shared state to be set
+     */
+    public static native void setSharedIndexState(long indexAddr, long shareIndexStateAddr);
+
+    /**
      * Query an index without filter
      *
      * If the "knn" field is a nested field, each vector value within that nested field will be assigned its
@@ -124,6 +148,13 @@ class FaissService {
      * Free native memory pointer
      */
     public static native void free(long indexPointer);
+
+    /**
+     * Deallocate memory of the shared index state
+     *
+     * @param shareIndexStateAddr address of shared state
+     */
+    public static native void freeSharedIndexState(long shareIndexStateAddr);
 
     /**
      * Initialize library

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -25,35 +25,35 @@ public class JNIService {
     /**
      * Create an index for the native library
      *
-     * @param ids array of ids mapping to the data passed in
-     * @param data array of float arrays to be indexed
-     * @param indexPath path to save index file to
+     * @param ids        array of ids mapping to the data passed in
+     * @param data       array of float arrays to be indexed
+     * @param indexPath  path to save index file to
      * @param parameters parameters to build index
-     * @param engineName name of engine to build index for
+     * @param knnEngine  engine to build index for
      */
-    public static void createIndex(int[] ids, float[][] data, String indexPath, Map<String, Object> parameters, String engineName) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+    public static void createIndex(int[] ids, float[][] data, String indexPath, Map<String, Object> parameters, KNNEngine knnEngine) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             NmslibService.createIndex(ids, data, indexPath, parameters);
             return;
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.createIndex(ids, data, indexPath, parameters);
             return;
         }
 
-        throw new IllegalArgumentException("CreateIndex not supported for provided engine");
+        throw new IllegalArgumentException(String.format("CreateIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**
      * Create an index for the native library with a provided template index
      *
-     * @param ids array of ids mapping to the data passed in
-     * @param data array of float arrays to be indexed
-     * @param indexPath path to save index file to
+     * @param ids           array of ids mapping to the data passed in
+     * @param data          array of float arrays to be indexed
+     * @param indexPath     path to save index file to
      * @param templateIndex empty template index
-     * @param parameters parameters to build index
-     * @param engineName name of engine to build index for
+     * @param parameters    parameters to build index
+     * @param knnEngine     engine to build index for
      */
     public static void createIndexFromTemplate(
         int[] ids,
@@ -61,44 +61,97 @@ public class JNIService {
         String indexPath,
         byte[] templateIndex,
         Map<String, Object> parameters,
-        String engineName
+        KNNEngine knnEngine
     ) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.createIndexFromTemplate(ids, data, indexPath, templateIndex, parameters);
             return;
         }
 
-        throw new IllegalArgumentException("CreateIndexFromTemplate not supported for provided engine");
+        throw new IllegalArgumentException(
+            String.format("CreateIndexFromTemplate not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Load an index into memory
      *
-     * @param indexPath path to index file
+     * @param indexPath  path to index file
      * @param parameters parameters to be used when loading index
-     * @param engineName name of engine to load index
+     * @param knnEngine  engine to load index
      * @return pointer to location in memory the index resides in
      */
-    public static long loadIndex(String indexPath, Map<String, Object> parameters, String engineName) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+    public static long loadIndex(String indexPath, Map<String, Object> parameters, KNNEngine knnEngine) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             return NmslibService.loadIndex(indexPath, parameters);
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             return FaissService.loadIndex(indexPath);
         }
 
-        throw new IllegalArgumentException("LoadIndex not supported for provided engine");
+        throw new IllegalArgumentException(String.format("LoadIndex not supported for provided engine : %s", knnEngine.getName()));
+    }
+
+    /**
+     * Determine if index contains shared state. Currently, we cannot do this in the plugin because we do not store the
+     * model definition anywhere. Only faiss supports indices that have shared state. So for all other engines it will
+     * return false.
+     *
+     * @param indexAddr address of index to be checked.
+     * @param knnEngine engine
+     * @return true if index requires shared index state; false otherwise
+     */
+    public static boolean isSharedIndexStateRequired(long indexAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
+            return FaissService.isSharedIndexStateRequired(indexAddr);
+        }
+
+        return false;
+    }
+
+    /**
+     * Initialize the shared state for an index
+     *
+     * @param indexAddr address of the index to initialize from
+     * @param knnEngine engine
+     * @return Address of shared index state address
+     */
+    public static long initSharedIndexState(long indexAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
+            return FaissService.initSharedIndexState(indexAddr);
+        }
+        throw new IllegalArgumentException(
+            String.format("InitSharedIndexState not supported for provided engine : %s", knnEngine.getName())
+        );
+    }
+
+    /**
+     * Set the index state for an index
+     *
+     * @param indexAddr           address of index to set state for
+     * @param shareIndexStateAddr address of shared state to be set
+     * @param knnEngine           engine
+     */
+    public static void setSharedIndexState(long indexAddr, long shareIndexStateAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
+            FaissService.setSharedIndexState(indexAddr, shareIndexStateAddr);
+            return;
+        }
+
+        throw new IllegalArgumentException(
+            String.format("SetSharedIndexState not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Query an index
      *
-     * @param indexPointer pointer to index in memory
-     * @param queryVector  vector to be used for query
-     * @param k            neighbors to be returned
-     * @param engineName   name of engine to query index
-     * @param filteredIds  array of ints on which should be used for search.
+     * @param indexPointer  pointer to index in memory
+     * @param queryVector   vector to be used for query
+     * @param k             neighbors to be returned
+     * @param knnEngine     engine to query index
+     * @param filteredIds   array of ints on which should be used for search.
      * @param filterIdsType how to filter ids: Batch or BitMap
      * @return KNNQueryResult array of k neighbors
      */
@@ -106,16 +159,16 @@ public class JNIService {
         long indexPointer,
         float[] queryVector,
         int k,
-        String engineName,
+        KNNEngine knnEngine,
         long[] filteredIds,
         int filterIdsType,
         int[] parentIds
     ) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             return NmslibService.queryIndex(indexPointer, queryVector, k);
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             // This code assumes that if filteredIds == null / filteredIds.length == 0 if filter is specified then empty
             // k-NN results are already returned. Otherwise, it's a filter case and we need to run search with
             // filterIds. FilterIds is coming as empty then its the case where we need to do search with Faiss engine
@@ -125,44 +178,60 @@ public class JNIService {
             }
             return FaissService.queryIndex(indexPointer, queryVector, k, parentIds);
         }
-        throw new IllegalArgumentException("QueryIndex not supported for provided engine");
+        throw new IllegalArgumentException(String.format("QueryIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**
      * Free native memory pointer
      *
      * @param indexPointer location to be freed
-     * @param engineName engine to perform free
+     * @param knnEngine    engine to perform free
      */
-    public static void free(long indexPointer, String engineName) {
-        if (KNNEngine.NMSLIB.getName().equals(engineName)) {
+    public static void free(long indexPointer, KNNEngine knnEngine) {
+        if (KNNEngine.NMSLIB == knnEngine) {
             NmslibService.free(indexPointer);
             return;
         }
 
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+        if (KNNEngine.FAISS == knnEngine) {
             FaissService.free(indexPointer);
             return;
         }
 
-        throw new IllegalArgumentException("Free not supported for provided engine");
+        throw new IllegalArgumentException(String.format("Free not supported for provided engine : %s", knnEngine.getName()));
+    }
+
+    /**
+     * Deallocate memory of the shared index state
+     *
+     * @param shareIndexStateAddr address of shared state
+     * @param knnEngine           engine
+     */
+    public static void freeSharedIndexState(long shareIndexStateAddr, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
+            FaissService.freeSharedIndexState(shareIndexStateAddr);
+            return;
+        }
+        throw new IllegalArgumentException(
+            String.format("FreeSharedIndexState not supported for provided engine : %s", knnEngine.getName())
+        );
     }
 
     /**
      * Train an empty index
      *
-     * @param indexParameters parameters used to build index
-     * @param dimension dimension for the index
+     * @param indexParameters     parameters used to build index
+     * @param dimension           dimension for the index
      * @param trainVectorsPointer pointer to where training vectors are stored in native memory
-     * @param engineName engine to perform the training
+     * @param knnEngine           engine to perform the training
      * @return bytes array of trained template index
      */
-    public static byte[] trainIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer, String engineName) {
-        if (KNNEngine.FAISS.getName().equals(engineName)) {
+    public static byte[] trainIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer, KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
             return FaissService.trainIndex(indexParameters, dimension, trainVectorsPointer);
         }
 
-        throw new IllegalArgumentException("TrainIndex not supported for provided engine");
+        throw new IllegalArgumentException(String.format("TrainIndex not supported for provided engine : %s", knnEngine.getName()));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -186,7 +186,7 @@ public class TrainingJob implements Runnable {
                 trainParameters,
                 model.getModelMetadata().getDimension(),
                 trainingDataAllocation.getMemoryAddress(),
-                model.getModelMetadata().getKnnEngine().getName()
+                model.getModelMetadata().getKnnEngine()
             );
 
             // Once training finishes, update model

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -12,6 +12,8 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.BeforeClass;
+import org.mockito.MockedStatic;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -24,12 +26,16 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.jni.JNIService;
 
 import java.util.Map;
 import java.util.Objects;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.HNSW_ALGO_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
@@ -37,6 +43,15 @@ import static org.opensearch.knn.index.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
 
 public class IndexUtilTests extends KNNTestCase {
+
+    private static MockedStatic<JNIService> jniServiceMockedStatic;
+    private static final long TEST_INDEX_ADDRESS = 0;
+
+    @BeforeClass
+    public static void setUpClass() {
+        jniServiceMockedStatic = mockStatic(JNIService.class);
+    }
+
     public void testGetLoadParameters() {
         // Test faiss to ensure that space type gets set properly
         SpaceType spaceType1 = SpaceType.COSINESIMIL;
@@ -205,5 +220,25 @@ public class IndexUtilTests extends KNNTestCase {
         ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
 
         assert (Objects.requireNonNull(e).getMessage().matches("Validation Failed: 1: Invalid index. Index does not contain a mapping;"));
+    }
+
+    public void testIsShareableStateContainedInIndex_whenIndexNotModelBased_thenReturnFalse() {
+        String modelId = null;
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        assertFalse(IndexUtil.isSharedIndexStateRequired(knnEngine, modelId, TEST_INDEX_ADDRESS));
+    }
+
+    public void testIsShareableStateContainedInIndex_whenFaissHNSWIsUsed_thenReturnFalse() {
+        jniServiceMockedStatic.when(() -> JNIService.isSharedIndexStateRequired(anyLong(), any())).thenReturn(false);
+        String modelId = "test-model";
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        assertFalse(IndexUtil.isSharedIndexStateRequired(knnEngine, modelId, TEST_INDEX_ADDRESS));
+    }
+
+    public void testIsShareableStateContainedInIndex_whenJNIIsSharedIndexStateRequiredIsTrue_thenReturnTrue() {
+        jniServiceMockedStatic.when(() -> JNIService.isSharedIndexStateRequired(anyLong(), any())).thenReturn(true);
+        String modelId = "test-model";
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        assertTrue(IndexUtil.isSharedIndexStateRequired(knnEngine, modelId, TEST_INDEX_ADDRESS));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -50,7 +50,7 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,
             vectorsPointer,
-            KNNEngine.FAISS.getName()
+            KNNEngine.FAISS
         );
 
         // Setup model

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -341,7 +341,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
             SpaceType.L2.getValue()
         );
 
-        byte[] modelBytes = JNIService.trainIndex(parameters, dimension, trainingPtr, knnEngine.getName());
+        byte[] modelBytes = JNIService.trainIndex(parameters, dimension, trainingPtr, knnEngine);
         Model model = new Model(
             new ModelMetadata(
                 knnEngine,

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -197,7 +197,7 @@ public class KNNCodecTestCase extends KNNTestCase {
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,
             vectorsPointer,
-            KNNEngine.FAISS.getName()
+            KNNEngine.FAISS
         );
 
         // Setup model cache

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -334,16 +334,12 @@ public class KNNCodecTestUtil {
     ) {
         String filePath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(state.directory))).getDirectory().toString(), fileName)
             .toString();
-        long indexPtr = JNIService.loadIndex(
-            filePath,
-            Maps.newHashMap(ImmutableMap.of(SPACE_TYPE, spaceType.getValue())),
-            knnEngine.getName()
-        );
+        long indexPtr = JNIService.loadIndex(filePath, Maps.newHashMap(ImmutableMap.of(SPACE_TYPE, spaceType.getValue())), knnEngine);
         int k = 2;
         float[] queryVector = new float[dimension];
-        KNNQueryResult[] results = JNIService.queryIndex(indexPtr, queryVector, k, knnEngine.getName(), null, 0, null);
+        KNNQueryResult[] results = JNIService.queryIndex(indexPtr, queryVector, k, knnEngine, null, 0, null);
         assertTrue(results.length > 0);
-        JNIService.free(indexPtr, knnEngine.getName());
+        JNIService.free(indexPtr, knnEngine);
     }
 
     public static float[][] getRandomVectors(int count, int dimension) {

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
@@ -52,10 +52,10 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
             Arrays.fill(vectors[i], 1f);
         }
         Map<String, Object> parameters = ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.DEFAULT.getValue());
-        JNIService.createIndex(ids, vectors, path, parameters, knnEngine.getName());
+        JNIService.createIndex(ids, vectors, path, parameters, knnEngine);
 
         // Load index into memory
-        long memoryAddress = JNIService.loadIndex(path, parameters, knnEngine.getName());
+        long memoryAddress = JNIService.loadIndex(path, parameters, knnEngine);
 
         @SuppressWarnings("unchecked")
         WatcherHandle<FileWatcher> watcherHandle = (WatcherHandle<FileWatcher>) mock(WatcherHandle.class);

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
@@ -53,7 +53,7 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
             Arrays.fill(vectors[i], 1f);
         }
         Map<String, Object> parameters = ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.DEFAULT.getValue());
-        JNIService.createIndex(ids, vectors, path, parameters, knnEngine.getName());
+        JNIService.createIndex(ids, vectors, path, parameters, knnEngine);
 
         // Setup mock resource manager
         ResourceWatcherService resourceWatcherService = mock(ResourceWatcherService.class);
@@ -74,7 +74,7 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
         // Confirm that the file was loaded by querying
         float[] query = new float[dimension];
         Arrays.fill(query, numVectors + 1);
-        KNNQueryResult[] results = JNIService.queryIndex(indexAllocation.getMemoryAddress(), query, 2, knnEngine.getName(), null, 0, null);
+        KNNQueryResult[] results = JNIService.queryIndex(indexAllocation.getMemoryAddress(), query, 2, knnEngine, null, 0, null);
         assertTrue(results.length > 0);
     }
 

--- a/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateManagerTests.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.memory;
+
+import org.junit.BeforeClass;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.jni.JNIService;
+
+import static org.mockito.Mockito.mockStatic;
+
+public class SharedIndexStateManagerTests extends KNNTestCase {
+    private static MockedStatic<JNIService> jniServiceMockedStatic;
+    private final static long TEST_SHARED_TABLE_ADDRESS = 123;
+    private final static long TEST_INDEX_ADDRESS = 1234;
+    private final static String TEST_MODEL_ID = "test-model-id";
+    private final static KNNEngine TEST_KNN_ENGINE = KNNEngine.DEFAULT;
+
+    @BeforeClass
+    public static void setUpClass() {
+        jniServiceMockedStatic = mockStatic(JNIService.class);
+        jniServiceMockedStatic.when(() -> JNIService.freeSharedIndexState(TEST_SHARED_TABLE_ADDRESS, TEST_KNN_ENGINE))
+            .then(invocation -> null);
+        jniServiceMockedStatic.when(() -> JNIService.initSharedIndexState(TEST_INDEX_ADDRESS, TEST_KNN_ENGINE))
+            .thenReturn(TEST_SHARED_TABLE_ADDRESS);
+    }
+
+    public void testGet_whenNormalWorkfloatApplied_thenSucceed() {
+        SharedIndexStateManager sharedIndexStateManager = new SharedIndexStateManager();
+        SharedIndexState firstSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        assertEquals(TEST_SHARED_TABLE_ADDRESS, firstSharedIndexStateRetrieved.getSharedIndexStateAddress());
+        assertEquals(TEST_MODEL_ID, firstSharedIndexStateRetrieved.getModelId());
+        assertEquals(TEST_KNN_ENGINE, firstSharedIndexStateRetrieved.getKnnEngine());
+
+        SharedIndexState secondSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        assertEquals(TEST_SHARED_TABLE_ADDRESS, secondSharedIndexStateRetrieved.getSharedIndexStateAddress());
+        assertEquals(TEST_MODEL_ID, secondSharedIndexStateRetrieved.getModelId());
+        assertEquals(TEST_KNN_ENGINE, secondSharedIndexStateRetrieved.getKnnEngine());
+    }
+
+    public void testRelease_whenNormalWorkflowApplied_thenSucceed() {
+        SharedIndexStateManager sharedIndexStateManager = new SharedIndexStateManager();
+        SharedIndexState firstSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        SharedIndexState secondSharedIndexStateRetrieved = sharedIndexStateManager.get(TEST_INDEX_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+
+        sharedIndexStateManager.release(firstSharedIndexStateRetrieved);
+        jniServiceMockedStatic.verify(() -> JNIService.freeSharedIndexState(TEST_SHARED_TABLE_ADDRESS, TEST_KNN_ENGINE), Mockito.times(0));
+        sharedIndexStateManager.release(secondSharedIndexStateRetrieved);
+        jniServiceMockedStatic.verify(() -> JNIService.freeSharedIndexState(TEST_SHARED_TABLE_ADDRESS, TEST_KNN_ENGINE), Mockito.times(1));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/SharedIndexStateTests.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.memory;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNEngine;
+
+public class SharedIndexStateTests extends KNNTestCase {
+
+    private static final String TEST_MODEL_ID = "test-model";
+    private static final long TEST_SHARED_INDEX_STATE_ADDRESS = 22L;
+    private static final KNNEngine TEST_KNN_ENGINE = KNNEngine.DEFAULT;
+
+    public void testSharedIndexState() {
+        SharedIndexState sharedIndexState = new SharedIndexState(TEST_SHARED_INDEX_STATE_ADDRESS, TEST_MODEL_ID, TEST_KNN_ENGINE);
+        assertEquals(TEST_MODEL_ID, sharedIndexState.getModelId());
+        assertEquals(TEST_SHARED_INDEX_STATE_ADDRESS, sharedIndexState.getSharedIndexStateAddress());
+        assertEquals(TEST_KNN_ENGINE, sharedIndexState.getKnnEngine());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -157,7 +157,7 @@ public class KNNWeightTests extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         final Function<Float, Float> scoreTranslator = spaceType::scoreTranslation;
         final String modelId = "modelId";
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), any()))
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), any()))
             .thenReturn(getKNNQueryResults());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);
@@ -300,7 +300,7 @@ public class KNNWeightTests extends KNNTestCase {
     @SneakyThrows
     public void testEmptyQueryResults() {
         final KNNQueryResult[] knnQueryResults = new KNNQueryResult[] {};
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), any()))
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), any()))
             .thenReturn(knnQueryResults);
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);
@@ -350,7 +350,7 @@ public class KNNWeightTests extends KNNTestCase {
             filterBitSet.set(docId);
         }
         jniServiceMockedStatic.when(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), eq(filterBitSet.getBits()), anyInt(), any())
+            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), eq(filterBitSet.getBits()), anyInt(), any())
         ).thenReturn(getFilteredKNNQueryResults());
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -411,7 +411,7 @@ public class KNNWeightTests extends KNNTestCase {
         assertEquals(FILTERED_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
 
         jniServiceMockedStatic.verify(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), eq(filterBitSet.getBits()), anyInt(), any())
+            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), eq(filterBitSet.getBits()), anyInt(), any())
         );
 
         final List<Integer> actualDocIds = new ArrayList<>();
@@ -677,17 +677,14 @@ public class KNNWeightTests extends KNNTestCase {
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, 1, INDEX_NAME, null, bitSetProducer);
         final KNNWeight knnWeight = new KNNWeight(query, 0.0f, null);
 
-        jniServiceMockedStatic.when(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), eq(parentsFilter))
-        ).thenReturn(getKNNQueryResults());
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), eq(parentsFilter)))
+            .thenReturn(getKNNQueryResults());
 
         // Execute
         Scorer knnScorer = knnWeight.scorer(leafReaderContext);
 
         // Verify
-        jniServiceMockedStatic.verify(
-            () -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), eq(parentsFilter))
-        );
+        jniServiceMockedStatic.verify(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), eq(parentsFilter)));
         assertNotNull(knnScorer);
         final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
         assertNotNull(docIdSetIterator);
@@ -746,7 +743,7 @@ public class KNNWeightTests extends KNNTestCase {
         final Set<String> segmentFiles,
         final Map<String, String> fileAttributes
     ) throws IOException {
-        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), anyString(), any(), anyInt(), any()))
+        jniServiceMockedStatic.when(() -> JNIService.queryIndex(anyLong(), any(), anyInt(), any(), any(), anyInt(), any()))
             .thenReturn(getKNNQueryResults());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -86,7 +86,7 @@ public class JNIServiceTests extends KNNTestCase {
                 new float[][] {},
                 "test",
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                "invalid-engine"
+                KNNEngine.LUCENE
             )
         );
     }
@@ -113,7 +113,7 @@ public class JNIServiceTests extends KNNTestCase {
                 testData.indexData.vectors,
                 "something",
                 Collections.emptyMap(),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -131,7 +131,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors1,
                 tmpFile1.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
@@ -145,7 +145,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors2,
                 tmpFile2.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -163,7 +163,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
@@ -174,7 +174,7 @@ public class JNIServiceTests extends KNNTestCase {
                 null,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
@@ -185,13 +185,13 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 null,
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
 
         expectThrows(
             Exception.class,
-            () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, KNNEngine.NMSLIB.getName())
+            () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, KNNEngine.NMSLIB)
         );
 
         expectThrows(
@@ -219,7 +219,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, "invalid"),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -237,7 +237,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -261,7 +261,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue(), KNNConstants.PARAMETERS, parametersMap),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -276,7 +276,7 @@ public class JNIServiceTests extends KNNTestCase {
                 testData.indexData.vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertTrue(tmpFile.toFile().length() > 0);
 
@@ -294,7 +294,7 @@ public class JNIServiceTests extends KNNTestCase {
                     KNNConstants.METHOD_PARAMETER_M,
                     12
                 ),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertTrue(tmpFile.toFile().length() > 0);
         }
@@ -312,7 +312,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 "something",
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -330,7 +330,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors1,
                 tmpFile1.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -344,7 +344,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors2,
                 tmpFile2.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -362,7 +362,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -373,7 +373,7 @@ public class JNIServiceTests extends KNNTestCase {
                 null,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -384,11 +384,14 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 null,
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
-        expectThrows(Exception.class, () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, FAISS_NAME));
+        expectThrows(
+            Exception.class,
+            () -> JNIService.createIndex(docIds, vectors, tmpFile.toAbsolutePath().toString(), null, KNNEngine.FAISS)
+        );
 
         expectThrows(
             Exception.class,
@@ -415,7 +418,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, "invalid"),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -433,7 +436,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -451,7 +454,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -469,7 +472,7 @@ public class JNIServiceTests extends KNNTestCase {
                 vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "invalid", KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -494,7 +497,7 @@ public class JNIServiceTests extends KNNTestCase {
                     KNNConstants.SPACE_TYPE,
                     SpaceType.L2.getValue()
                 ),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
     }
@@ -512,11 +515,11 @@ public class JNIServiceTests extends KNNTestCase {
             vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, sqfp16IndexDescription, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
     }
 
@@ -532,21 +535,21 @@ public class JNIServiceTests extends KNNTestCase {
             truncateToFp16Range(testData.indexData.vectors),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, sqfp16IndexDescription, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
 
         for (float[] query : testData.queries) {
-            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null, 0, null);
+            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, null, 0, null);
             assertEquals(k, results.length);
         }
 
         // Filter will result in no ids
         for (float[] query : testData.queries) {
-            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, new long[] { 0 }, 0, null);
+            KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, new long[] { 0 }, 0, null);
             assertEquals(0, results.length);
         }
     }
@@ -590,7 +593,7 @@ public class JNIServiceTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -616,7 +619,7 @@ public class JNIServiceTests extends KNNTestCase {
                     KNNConstants.PARAMETERS,
                     ImmutableMap.of(KNNConstants.METHOD_PARAMETER_NPROBES, "14")
                 ),
-                FAISS_NAME
+                KNNEngine.FAISS
             )
         );
 
@@ -634,7 +637,7 @@ public class JNIServiceTests extends KNNTestCase {
                     testData.indexData.vectors,
                     tmpFile1.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertTrue(tmpFile1.toFile().length() > 0);
             }
@@ -642,28 +645,24 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     public void testLoadIndex_invalidEngine() {
-        expectThrows(IllegalArgumentException.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), "invalid-engine"));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), KNNEngine.LUCENE));
     }
 
     public void testLoadIndex_nmslib_invalid_badSpaceType() {
         expectThrows(
             Exception.class,
-            () -> JNIService.loadIndex("test", ImmutableMap.of(KNNConstants.SPACE_TYPE, "invalid"), KNNEngine.NMSLIB.getName())
+            () -> JNIService.loadIndex("test", ImmutableMap.of(KNNConstants.SPACE_TYPE, "invalid"), KNNEngine.NMSLIB)
         );
     }
 
     public void testLoadIndex_nmslib_invalid_noSpaceType() {
-        expectThrows(Exception.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), KNNEngine.NMSLIB.getName()));
+        expectThrows(Exception.class, () -> JNIService.loadIndex("test", Collections.emptyMap(), KNNEngine.NMSLIB));
     }
 
     public void testLoadIndex_nmslib_invalid_fileDoesNotExist() {
         expectThrows(
             Exception.class,
-            () -> JNIService.loadIndex(
-                "invalid",
-                ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
-            )
+            () -> JNIService.loadIndex("invalid", ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()), KNNEngine.NMSLIB)
         );
     }
 
@@ -674,7 +673,7 @@ public class JNIServiceTests extends KNNTestCase {
             () -> JNIService.loadIndex(
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             )
         );
     }
@@ -688,27 +687,30 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertNotEquals(0, pointer);
     }
 
     public void testLoadIndex_faiss_invalid_fileDoesNotExist() {
-        expectThrows(Exception.class, () -> JNIService.loadIndex("invalid", Collections.emptyMap(), FAISS_NAME));
+        expectThrows(Exception.class, () -> JNIService.loadIndex("invalid", Collections.emptyMap(), KNNEngine.FAISS));
     }
 
     public void testLoadIndex_faiss_invalid_badFile() throws IOException {
 
         Path tmpFile = createTempFile();
 
-        expectThrows(Exception.class, () -> JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME));
+        expectThrows(
+            Exception.class,
+            () -> JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS)
+        );
     }
 
     public void testLoadIndex_faiss_valid() throws IOException {
@@ -720,24 +722,21 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
     }
 
     public void testQueryIndex_invalidEngine() {
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> JNIService.queryIndex(0L, new float[] {}, 0, "invalid" + "-engine", null, 0, null)
-        );
+        expectThrows(IllegalArgumentException.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.LUCENE, null, 0, null));
     }
 
     public void testQueryIndex_nmslib_invalid_badPointer() {
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.NMSLIB.getName(), null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.NMSLIB, null, 0, null));
     }
 
     public void testQueryIndex_nmslib_invalid_nullQueryVector() throws IOException {
@@ -749,18 +748,18 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertNotEquals(0, pointer);
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.NMSLIB.getName(), null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.NMSLIB, null, 0, null));
     }
 
     public void testQueryIndex_nmslib_valid() throws IOException {
@@ -774,19 +773,19 @@ public class JNIServiceTests extends KNNTestCase {
                 testData.indexData.vectors,
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertTrue(tmpFile.toFile().length() > 0);
 
             long pointer = JNIService.loadIndex(
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                KNNEngine.NMSLIB.getName()
+                KNNEngine.NMSLIB
             );
             assertNotEquals(0, pointer);
 
             for (float[] query : testData.queries) {
-                KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.NMSLIB.getName(), null, 0, null);
+                KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.NMSLIB, null, 0, null);
                 assertEquals(k, results.length);
             }
         }
@@ -794,7 +793,7 @@ public class JNIServiceTests extends KNNTestCase {
 
     public void testQueryIndex_faiss_invalid_badPointer() {
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, FAISS_NAME, null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(0L, new float[] {}, 0, KNNEngine.FAISS, null, 0, null));
     }
 
     public void testQueryIndex_faiss_invalid_nullQueryVector() throws IOException {
@@ -806,14 +805,14 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
 
-        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, FAISS_NAME, null, 0, null));
+        expectThrows(Exception.class, () -> JNIService.queryIndex(pointer, null, 10, KNNEngine.FAISS, null, 0, null));
     }
 
     public void testQueryIndex_faiss_valid() throws IOException {
@@ -830,25 +829,25 @@ public class JNIServiceTests extends KNNTestCase {
                     testData.indexData.vectors,
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertTrue(tmpFile.toFile().length() > 0);
 
                 long pointer = JNIService.loadIndex(
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertNotEquals(0, pointer);
 
                 for (float[] query : testData.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null, 0, null);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, null, 0, null);
                     assertEquals(k, results.length);
                 }
 
                 // Filter will result in no ids
                 for (float[] query : testData.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, new long[] { 0 }, 0, null);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, new long[] { 0 }, 0, null);
                     assertEquals(0, results.length);
                 }
             }
@@ -871,19 +870,19 @@ public class JNIServiceTests extends KNNTestCase {
                     testDataNested.indexData.vectors,
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertTrue(tmpFile.toFile().length() > 0);
 
                 long pointer = JNIService.loadIndex(
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
-                    FAISS_NAME
+                    KNNEngine.FAISS
                 );
                 assertNotEquals(0, pointer);
 
                 for (float[] query : testDataNested.queries) {
-                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, FAISS_NAME, null, 0, parentIds);
+                    KNNQueryResult[] results = JNIService.queryIndex(pointer, query, k, KNNEngine.FAISS, null, 0, parentIds);
                     // Verify there is no more than one result from same parent
                     Set<Integer> parentIdSet = toParentIdSet(results, idToParentIdMap);
                     assertEquals(results.length, parentIdSet.size());
@@ -933,7 +932,7 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     public void testFree_invalidEngine() {
-        expectThrows(IllegalArgumentException.class, () -> JNIService.free(0L, "invalid-engine"));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.free(0L, KNNEngine.LUCENE));
     }
 
     public void testFree_nmslib_valid() throws IOException {
@@ -945,18 +944,18 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
         long pointer = JNIService.loadIndex(
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            KNNEngine.NMSLIB.getName()
+            KNNEngine.NMSLIB
         );
         assertNotEquals(0, pointer);
 
-        JNIService.free(pointer, KNNEngine.NMSLIB.getName());
+        JNIService.free(pointer, KNNEngine.NMSLIB);
     }
 
     public void testFree_faiss_valid() throws IOException {
@@ -968,14 +967,14 @@ public class JNIServiceTests extends KNNTestCase {
             testData.indexData.vectors,
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
 
-        JNIService.free(pointer, FAISS_NAME);
+        JNIService.free(pointer, KNNEngine.FAISS);
     }
 
     public void testTransferVectors() {
@@ -1006,7 +1005,7 @@ public class JNIServiceTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1036,7 +1035,7 @@ public class JNIServiceTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1063,7 +1062,7 @@ public class JNIServiceTests extends KNNTestCase {
         knnMethodContext.getMethodComponentContext().setIndexVersion(Version.CURRENT);
         Map<String, Object> parameters = KNNEngine.FAISS.getMethodAsMap(knnMethodContext);
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer);
@@ -1118,7 +1117,7 @@ public class JNIServiceTests extends KNNTestCase {
             spaceType.getValue()
         );
 
-        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer1, FAISS_NAME);
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer1, KNNEngine.FAISS);
 
         assertNotEquals(0, faissIndex.length);
         JNIService.freeVectors(trainPointer1);
@@ -1130,11 +1129,157 @@ public class JNIServiceTests extends KNNTestCase {
             tmpFile1.toAbsolutePath().toString(),
             faissIndex,
             ImmutableMap.of(INDEX_THREAD_QTY, 1),
-            FAISS_NAME
+            KNNEngine.FAISS
         );
         assertTrue(tmpFile1.toFile().length() > 0);
 
-        long pointer = JNIService.loadIndex(tmpFile1.toAbsolutePath().toString(), Collections.emptyMap(), FAISS_NAME);
+        long pointer = JNIService.loadIndex(tmpFile1.toAbsolutePath().toString(), Collections.emptyMap(), KNNEngine.FAISS);
         assertNotEquals(0, pointer);
+    }
+
+    @SneakyThrows
+    public void testIndexLoad_whenStateIsShared_thenSucceed() {
+        // Creates a single IVFPQ-l2 index. Then, we will configure a set of indices in memory in different ways to
+        // ensure that everything is loaded properly and the results are consistent.
+        int k = 10;
+        int ivfNlist = 16;
+        int pqM = 16;
+        int pqCodeSize = 4;
+
+        String indexIVFPQPath = createFaissIVFPQIndex(ivfNlist, pqM, pqCodeSize, SpaceType.L2);
+
+        long indexIVFPQIndexTest1 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), KNNEngine.FAISS);
+        assertNotEquals(0, indexIVFPQIndexTest1);
+        long indexIVFPQIndexTest2 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), KNNEngine.FAISS);
+        assertNotEquals(0, indexIVFPQIndexTest2);
+
+        long sharedStateAddress = JNIService.initSharedIndexState(indexIVFPQIndexTest1, KNNEngine.FAISS);
+        JNIService.setSharedIndexState(indexIVFPQIndexTest1, sharedStateAddress, KNNEngine.FAISS);
+        JNIService.setSharedIndexState(indexIVFPQIndexTest2, sharedStateAddress, KNNEngine.FAISS);
+
+        assertQueryResultsMatch(testData.queries, k, List.of(indexIVFPQIndexTest1, indexIVFPQIndexTest2));
+
+        // Free the first test index 1. This will ensure that the shared state persists after index that initialized
+        // shared state is gone.
+        JNIService.free(indexIVFPQIndexTest1, KNNEngine.FAISS);
+
+        long indexIVFPQIndexTest3 = JNIService.loadIndex(indexIVFPQPath, Collections.emptyMap(), KNNEngine.FAISS);
+        assertNotEquals(0, indexIVFPQIndexTest3);
+
+        JNIService.setSharedIndexState(indexIVFPQIndexTest3, sharedStateAddress, KNNEngine.FAISS);
+
+        assertQueryResultsMatch(testData.queries, k, List.of(indexIVFPQIndexTest2, indexIVFPQIndexTest3));
+
+        // Ensure everything gets freed
+        JNIService.free(indexIVFPQIndexTest2, KNNEngine.FAISS);
+        JNIService.free(indexIVFPQIndexTest3, KNNEngine.FAISS);
+        JNIService.freeSharedIndexState(sharedStateAddress, KNNEngine.FAISS);
+    }
+
+    @SneakyThrows
+    public void testIsIndexIVFPQL2() {
+        long dummyAddress = 0;
+        assertFalse(JNIService.isSharedIndexStateRequired(dummyAddress, KNNEngine.NMSLIB));
+
+        String faissIVFPQL2Index = createFaissIVFPQIndex(16, 16, 4, SpaceType.L2);
+        long faissIVFPQL2Address = JNIService.loadIndex(faissIVFPQL2Index, Collections.emptyMap(), KNNEngine.FAISS);
+        assertTrue(JNIService.isSharedIndexStateRequired(faissIVFPQL2Address, KNNEngine.FAISS));
+        JNIService.free(faissIVFPQL2Address, KNNEngine.FAISS);
+
+        String faissIVFPQIPIndex = createFaissIVFPQIndex(16, 16, 4, SpaceType.INNER_PRODUCT);
+        long faissIVFPQIPAddress = JNIService.loadIndex(faissIVFPQIPIndex, Collections.emptyMap(), KNNEngine.FAISS);
+        assertFalse(JNIService.isSharedIndexStateRequired(faissIVFPQIPAddress, KNNEngine.FAISS));
+        JNIService.free(faissIVFPQIPAddress, KNNEngine.FAISS);
+
+        String faissHNSWIndex = createFaissHNSWIndex(SpaceType.L2);
+        long faissHNSWAddress = JNIService.loadIndex(faissHNSWIndex, Collections.emptyMap(), KNNEngine.FAISS);
+        assertFalse(JNIService.isSharedIndexStateRequired(faissHNSWAddress, KNNEngine.FAISS));
+        JNIService.free(faissHNSWAddress, KNNEngine.FAISS);
+    }
+
+    @SneakyThrows
+    public void testFunctionsUnsupportedForEngine_whenEngineUnsupported_thenThrowIllegalArgumentException() {
+        int dummyAddress = 0;
+        expectThrows(IllegalArgumentException.class, () -> JNIService.initSharedIndexState(dummyAddress, KNNEngine.NMSLIB));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.setSharedIndexState(dummyAddress, dummyAddress, KNNEngine.NMSLIB));
+        expectThrows(IllegalArgumentException.class, () -> JNIService.freeSharedIndexState(dummyAddress, KNNEngine.NMSLIB));
+    }
+
+    private void assertQueryResultsMatch(float[][] testQueries, int k, List<Long> indexAddresses) {
+        // Checks that the set of queries is consistent amongst all indices in the list
+        for (float[] query : testQueries) {
+            KNNQueryResult[][] allResults = new KNNQueryResult[indexAddresses.size()][];
+            for (int i = 0; i < indexAddresses.size(); i++) {
+                allResults[i] = JNIService.queryIndex(indexAddresses.get(i), query, k, KNNEngine.FAISS, null, 0, null);
+                assertEquals(k, allResults[i].length);
+            }
+
+            for (int i = 1; i < indexAddresses.size(); i++) {
+                for (int j = 0; j < k; j++) {
+                    assertEquals(allResults[0][j].getId(), allResults[i][j].getId());
+                    assertEquals(allResults[0][j].getScore(), allResults[i][j].getScore(), 0.00001);
+                }
+            }
+        }
+    }
+
+    private String createFaissIVFPQIndex(int ivfNlist, int pqM, int pqCodeSize, SpaceType spaceType) throws IOException {
+        long trainPointer = JNIService.transferVectors(0, testData.indexData.vectors);
+        assertNotEquals(0, trainPointer);
+
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            spaceType,
+            new MethodComponentContext(
+                METHOD_IVF,
+                ImmutableMap.of(
+                    METHOD_PARAMETER_NLIST,
+                    ivfNlist,
+                    METHOD_ENCODER_PARAMETER,
+                    new MethodComponentContext(
+                        ENCODER_PQ,
+                        ImmutableMap.of(ENCODER_PARAMETER_PQ_M, pqM, ENCODER_PARAMETER_PQ_CODE_SIZE, pqCodeSize)
+                    )
+                )
+            )
+        );
+
+        String description = knnMethodContext.getKnnEngine().getMethodAsMap(knnMethodContext).get(INDEX_DESCRIPTION_PARAMETER).toString();
+        Map<String, Object> parameters = ImmutableMap.of(
+            INDEX_DESCRIPTION_PARAMETER,
+            description,
+            KNNConstants.SPACE_TYPE,
+            spaceType.getValue()
+        );
+
+        byte[] faissIndex = JNIService.trainIndex(parameters, 128, trainPointer, KNNEngine.FAISS);
+
+        assertNotEquals(0, faissIndex.length);
+        JNIService.freeVectors(trainPointer);
+        Path tmpFile = createTempFile();
+        JNIService.createIndexFromTemplate(
+            testData.indexData.docs,
+            testData.indexData.vectors,
+            tmpFile.toAbsolutePath().toString(),
+            faissIndex,
+            ImmutableMap.of(INDEX_THREAD_QTY, 1),
+            KNNEngine.FAISS
+        );
+        assertTrue(tmpFile.toFile().length() > 0);
+
+        return tmpFile.toAbsolutePath().toString();
+    }
+
+    private String createFaissHNSWIndex(SpaceType spaceType) throws IOException {
+        Path tmpFile = createTempFile();
+        JNIService.createIndex(
+            testData.indexData.docs,
+            testData.indexData.vectors,
+            tmpFile.toAbsolutePath().toString(),
+            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, spaceType.getValue()),
+            KNNEngine.FAISS
+        );
+        assertTrue(tmpFile.toFile().length() > 0);
+        return tmpFile.toAbsolutePath().toString();
     }
 }

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -11,54 +11,520 @@
 
 package org.opensearch.knn.recall;
 
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.util.KNNEngine;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY;
 import static org.opensearch.knn.index.KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED;
 
+/**
+ * Tests confirm that for the different supported configurations, recall is sound. The recall thresholds are
+ * conservatively and empirically determined to prevent flakiness.
+ *
+ * This test suite can take a long time to run. The primary reason is that training can take a long time for PQ.
+ * The parameters for PQ have been reduced significantly, but it still takes time.
+ */
 public class RecallTestsIT extends KNNRestTestCase {
 
-    private final String testFieldName = "test-field";
-    private final int dimensions = 50;
-    private final int docCount = 10000;
-    private final int queryCount = 100;
-    private final int k = 5;
-    private final double expRecallValue = 1.0;
+    private static final String PROPERTIES_FIELD = "properties";
+    private final static String TEST_INDEX_PREFIX_NAME = "test_index";
+    private final static String TEST_FIELD_NAME = "test_field";
+    private final static String TRAIN_INDEX_NAME = "train_index";
+    private final static String TRAIN_FIELD_NAME = "train_field";
+    private final static String TEST_MODEL_ID = "test_model_id";
+    private final static int TEST_DIMENSION = 32;
+    private final static int DOC_COUNT = 500;
+    private final static int QUERY_COUNT = 100;
+    private final static int TEST_K = 100;
+    private final static double PERFECT_RECALL = 1.0;
+    private final static int SHARD_COUNT = 1;
+    private final static int REPLICA_COUNT = 0;
+    private final static int MAX_SEGMENT_COUNT = 10;
 
-    public void testRecallL2StandardData() throws Exception {
-        String testIndexStandard = "test-index-standard";
+    // Standard algorithm parameters
+    private final static int HNSW_M = 16;
+    private final static int HNSW_EF_CONSTRUCTION = 100;
+    private final static int HNSW_EF_SEARCH = TEST_K; // For consistency with lucene
+    private final static int IVF_NLIST = 4;
+    private final static int IVF_NPROBES = IVF_NLIST; // This equates to essentially a brute force search
+    private final static int PQ_CODE_SIZE = 8; // This is low and going to produce bad recall, but reduces build time
+    private final static int PQ_M = TEST_DIMENSION / 8; // Will give low recall, but required for test time
 
-        addDocs(testIndexStandard, testFieldName, dimensions, docCount, true);
-        float[][] indexVectors = getIndexVectorsFromIndex(testIndexStandard, testFieldName, docCount, dimensions);
-        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, docCount, true);
-        List<Set<String>> groundTruthValues = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, k);
-        List<List<String>> searchResults = bulkSearch(testIndexStandard, testFieldName, queryVectors, k);
-        double recallValue = TestUtils.calculateRecallValue(searchResults, groundTruthValues, k);
-        assertEquals(expRecallValue, recallValue, 0.2);
-    }
+    // Setup ground truth for all tests once
+    private final static float[][] INDEX_VECTORS = TestUtils.getIndexVectors(DOC_COUNT, TEST_DIMENSION, true);
+    private final static float[][] QUERY_VECTORS = TestUtils.getQueryVectors(QUERY_COUNT, TEST_DIMENSION, DOC_COUNT, true);
+    private final static Map<SpaceType, List<Set<String>>> GROUND_TRUTH = Map.of(
+        SpaceType.L2,
+        TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.L2, TEST_K),
+        SpaceType.COSINESIMIL,
+        TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.COSINESIMIL, TEST_K),
+        SpaceType.INNER_PRODUCT,
+        TestUtils.computeGroundTruthValues(INDEX_VECTORS, QUERY_VECTORS, SpaceType.INNER_PRODUCT, TEST_K)
+    );
 
-    public void testRecallL2RandomData() throws Exception {
-        String testIndexRandom = "test-index-random";
-
-        addDocs(testIndexRandom, testFieldName, dimensions, docCount, false);
-        float[][] indexVectors = getIndexVectorsFromIndex(testIndexRandom, testFieldName, docCount, dimensions);
-        float[][] queryVectors = TestUtils.getQueryVectors(queryCount, dimensions, docCount, false);
-        List<Set<String>> groundTruthValues = TestUtils.computeGroundTruthValues(indexVectors, queryVectors, SpaceType.L2, k);
-        List<List<String>> searchResults = bulkSearch(testIndexRandom, testFieldName, queryVectors, k);
-        double recallValue = TestUtils.calculateRecallValue(searchResults, groundTruthValues, k);
-        assertEquals(expRecallValue, recallValue, 0.2);
-    }
-
-    private void addDocs(String testIndex, String testField, int dimensions, int docCount, boolean isStandard) throws Exception {
-        createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(testField, dimensions));
-
+    @SneakyThrows
+    @Before
+    public void setupClusterSettings() {
         updateClusterSettings(KNN_ALGO_PARAM_INDEX_THREAD_QTY, 2);
         updateClusterSettings(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, true);
-
-        bulkAddKnnDocs(testIndex, testField, TestUtils.getIndexVectors(docCount, dimensions, isStandard), docCount);
     }
 
+    /**
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"nmslib",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH}
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenNmslibHnswFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.COSINESIMIL, SpaceType.INNER_PRODUCT);
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.NMSLIB, spaceType);
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(TEST_FIELD_NAME)
+                .field(TYPE, TYPE_KNN_VECTOR)
+                .field(DIMENSION, TEST_DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .field(KNN_ENGINE, KNNEngine.NMSLIB.getName())
+                .field(NAME, METHOD_HNSW)
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createIndexAndIngestDocs(
+                indexName,
+                TEST_FIELD_NAME,
+                Settings.builder()
+                    .put("number_of_shards", SHARD_COUNT)
+                    .put("number_of_replicas", REPLICA_COUNT)
+                    .put("index.knn", true)
+                    .put(KNN_ALGO_PARAM_EF_SEARCH, HNSW_EF_SEARCH)
+                    .build(),
+                builder.toString()
+            );
+            assertRecall(indexName, spaceType, 0.25f);
+        }
+    }
+
+    /**
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"lucene",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION}
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenLuceneHnswFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.COSINESIMIL);
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.LUCENE, spaceType);
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(TEST_FIELD_NAME)
+                .field(TYPE, TYPE_KNN_VECTOR)
+                .field(DIMENSION, TEST_DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+                .field(NAME, METHOD_HNSW)
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), builder.toString());
+            assertRecall(indexName, spaceType, 0.25f);
+        }
+    }
+
+    /**
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {TEST_DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"faiss",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH},
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissHnswFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES_FIELD)
+                .startObject(TEST_FIELD_NAME)
+                .field(TYPE, TYPE_KNN_VECTOR)
+                .field(DIMENSION, TEST_DIMENSION)
+                .startObject(KNN_METHOD)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+                .field(NAME, METHOD_HNSW)
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .field(METHOD_PARAMETER_EF_SEARCH, HNSW_EF_SEARCH)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), builder.toString());
+            assertRecall(indexName, spaceType, 0.25f);
+        }
+    }
+
+    /**
+     * Train context:
+     * {
+     *  "method": {
+     *      "name":"ivf",
+     *      "engine":"faiss",
+     *      "space_type": "{SPACE_TYPE}",
+     *      "parameters":{
+     *          "nlist":{IVF_NLIST},
+     *          "nprobes": {IVF_NPROBES}
+     *      }
+     *   }
+     * }
+     *
+     * Index Mapping:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "model_id": {MODEL_ID}
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissIVFFP32_thenRecallAbove75percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        setupTrainingIndex();
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+
+            // Train the model
+            XContentBuilder trainingBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, METHOD_IVF)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, IVF_NLIST)
+                .field(METHOD_PARAMETER_NPROBES, IVF_NPROBES)
+                .endObject()
+                .endObject();
+            trainModel(
+                TEST_MODEL_ID,
+                TRAIN_INDEX_NAME,
+                TRAIN_FIELD_NAME,
+                TEST_DIMENSION,
+                xContentBuilderToMap(trainingBuilder),
+                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+            );
+            assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
+
+            // Build the index
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), getModelMapping());
+            assertRecall(indexName, spaceType, 0.25f);
+
+            // Delete the model
+            deleteModel(TEST_MODEL_ID);
+        }
+    }
+
+    /**
+     * Train context:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {TEST_DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"faiss",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH},
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     *
+     * Index Mapping:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "model_id": {MODEL_ID}
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissIVFPQFP32_thenRecallAbove50percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        setupTrainingIndex();
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+
+            // Train the model
+            XContentBuilder trainingBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, METHOD_IVF)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, IVF_NLIST)
+                .field(METHOD_PARAMETER_NPROBES, IVF_NPROBES)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_PQ)
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, PQ_CODE_SIZE)
+                .field(ENCODER_PARAMETER_PQ_M, PQ_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            trainModel(
+                TEST_MODEL_ID,
+                TRAIN_INDEX_NAME,
+                TRAIN_FIELD_NAME,
+                TEST_DIMENSION,
+                xContentBuilderToMap(trainingBuilder),
+                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+            );
+            assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
+
+            // Build the index
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), getModelMapping());
+            assertRecall(indexName, spaceType, 0.5f);
+
+            // Delete the model
+            deleteModel(TEST_MODEL_ID);
+        }
+    }
+
+    /**
+     * Train context:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "dimension": {TEST_DIMENSION},
+     *      "method": {
+     *          "name":"hnsw",
+     *          "engine":"faiss",
+     *          "space_type": "{SPACE_TYPE}",
+     *          "parameters":{
+     *              "m":{HNSW_M},
+     *              "ef_construction": {HNSW_EF_CONSTRUCTION},
+     *              "ef_search": {HNSW_EF_SEARCH},
+     *          }
+     *       }
+     *     }
+     *   }
+     * }
+     *
+     * Index Mapping:
+     * {
+     * 	"properties": {
+     *     {
+     *      "type": "knn_vector",
+     *      "model_id": {MODEL_ID}
+     *     }
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testRecall_whenFaissHNSWPQFP32_thenRecallAbove50percent() {
+        List<SpaceType> spaceTypes = List.of(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        setupTrainingIndex();
+        for (SpaceType spaceType : spaceTypes) {
+            String indexName = createIndexName(KNNEngine.FAISS, spaceType);
+
+            // Train the model
+            XContentBuilder trainingBuilder = XContentFactory.jsonBuilder()
+                .startObject()
+                .field(NAME, METHOD_HNSW)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_M, HNSW_M)
+                .field(METHOD_PARAMETER_EF_SEARCH, HNSW_EF_SEARCH)
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, HNSW_EF_CONSTRUCTION)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_PQ)
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, PQ_CODE_SIZE)
+                .field(ENCODER_PARAMETER_PQ_M, PQ_M)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+            trainModel(
+                TEST_MODEL_ID,
+                TRAIN_INDEX_NAME,
+                TRAIN_FIELD_NAME,
+                TEST_DIMENSION,
+                xContentBuilderToMap(trainingBuilder),
+                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+            );
+            assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
+
+            // Build the index
+            createIndexAndIngestDocs(indexName, TEST_FIELD_NAME, getSettings(), getModelMapping());
+            assertRecall(indexName, spaceType, 0.5f);
+
+            // Delete the model
+            deleteModel(TEST_MODEL_ID);
+        }
+    }
+
+    @SneakyThrows
+    private void assertRecall(String testIndexName, SpaceType spaceType, float acceptableRecallFromPerfect) {
+        List<List<String>> searchResults = bulkSearch(testIndexName, TEST_FIELD_NAME, QUERY_VECTORS, TEST_K);
+        double recallValue = TestUtils.calculateRecallValue(searchResults, GROUND_TRUTH.get(spaceType), TEST_K);
+        logger.info("Recall value = {}", recallValue);
+        assertEquals(PERFECT_RECALL, recallValue, acceptableRecallFromPerfect);
+    }
+
+    private String createIndexName(KNNEngine knnEngine, SpaceType spaceType) {
+        return String.format("%s_%s_%s", TEST_INDEX_PREFIX_NAME, knnEngine.getName(), spaceType.getValue());
+    }
+
+    @SneakyThrows
+    private void createIndexAndIngestDocs(String indexName, String fieldName, Settings settings, String mapping) {
+        createKnnIndex(indexName, settings, mapping);
+        bulkAddKnnDocs(indexName, fieldName, INDEX_VECTORS, DOC_COUNT);
+        forceMergeKnnIndex(indexName, MAX_SEGMENT_COUNT);
+    }
+
+    @SneakyThrows
+    private void setupTrainingIndex() {
+        XContentBuilder trainingIndexBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(TRAIN_FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, TEST_DIMENSION)
+            .endObject()
+            .endObject()
+            .endObject();
+        createIndexAndIngestDocs(
+            TRAIN_INDEX_NAME,
+            TRAIN_FIELD_NAME,
+            Settings.builder().put("number_of_shards", SHARD_COUNT).put("number_of_replicas", REPLICA_COUNT).build(),
+            trainingIndexBuilder.toString()
+        );
+    }
+
+    @SneakyThrows
+    private String getModelMapping() {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(TEST_FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(MODEL_ID, TEST_MODEL_ID)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    private Settings getSettings() {
+        return Settings.builder()
+            .put("number_of_shards", SHARD_COUNT)
+            .put("number_of_replicas", REPLICA_COUNT)
+            .put("index.knn", true)
+            .build();
+    }
 }

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -205,7 +205,7 @@ public class TrainingJobTests extends KNNTestCase {
             indexPath.toString(),
             model.getModelBlob(),
             ImmutableMap.of(INDEX_THREAD_QTY, 1),
-            knnEngine.getName()
+            knnEngine
         );
         assertNotEquals(0, new File(indexPath.toString()).length());
     }

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn;
 
 import com.google.common.primitives.Floats;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
@@ -449,6 +450,13 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Force merge KNN index segments
      */
     protected void forceMergeKnnIndex(String index) throws Exception {
+        forceMergeKnnIndex(index, 1);
+    }
+
+    /**
+     * Force merge KNN index segments
+     */
+    protected void forceMergeKnnIndex(String index, int maxSegments) throws Exception {
         Request request = new Request("POST", "/" + index + "/_refresh");
 
         Response response = client().performRequest(request);
@@ -456,7 +464,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         request = new Request("POST", "/" + index + "/_forcemerge");
 
-        request.addParameter("max_num_segments", "1");
+        request.addParameter("max_num_segments", String.valueOf(maxSegments));
         request.addParameter("flush", "true");
         response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
@@ -655,6 +663,12 @@ public class KNNRestTestCase extends ODFERestTestCase {
         Response response = client().performRequest(request);
         assertEquals(RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
         return response;
+    }
+
+    @SneakyThrows
+    protected void doKnnWarmup(List<String> indices) {
+        Response response = knnWarmup(indices);
+        assertEquals(response.getStatusLine().getStatusCode(), 200);
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -141,6 +141,12 @@ public class TestUtils {
             pq = new PriorityQueue<>(k, new DistComparator());
             for (int j = 0; j < indexVectors.length; j++) {
                 float dist = computeDistFromSpaceType(spaceType, indexVectors[j], queryVectors[i]);
+
+                // Need to invert distance for IP or COSINE because higher is better in these cases
+                if (spaceType == SpaceType.INNER_PRODUCT || spaceType == SpaceType.COSINESIMIL) {
+                    dist *= -1;
+                }
+
                 pq = insertWithOverflow(pq, k, dist, j);
             }
 
@@ -201,6 +207,11 @@ public class TestUtils {
         for (int id = 0; id < numDocs; id++) {
             float[] indexVector = idVectorProducer.getVector(id);
             float dist = computeDistFromSpaceType(spaceType, indexVector, queryVector);
+            // Need to invert distance for IP or COSINE because higher is better in these cases
+            if (spaceType == SpaceType.INNER_PRODUCT || spaceType == SpaceType.COSINESIMIL) {
+                dist *= -1;
+            }
+
             pq = insertWithOverflow(pq, k, dist, id);
         }
         return pq;


### PR DESCRIPTION
### Description
Backport #1558 to 2.x.

Removed clear cache related components
 
### Issues Resolved
#1507 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
