### PR TITLE
Upgrade byte-buddy version to 1.14.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,9 +283,9 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     api group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.7'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.9'
     testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.2'
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.7'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.9'
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     implementation 'com.github.oshi:oshi-core:6.4.13'
     api "net.java.dev.jna:jna:5.13.0"


### PR DESCRIPTION
### Description
Upgrade byte-buddy version to 1.14.9
Reference: https://github.com/opensearch-project/OpenSearch/blob/d4e1ab135dfcb058b476fce09a669f4be5854702/buildSrc/version.properties#L60
 
### Issues Resolved
[https://github.com/opensearch-project/k-NN/issues/1566](https://github.com/opensearch-project/k-NN/issues/1566)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
