### PR TITLE
Support script score when doc value is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 * Make the HitQueue size more appropriate for exact search [#1549](https://github.com/opensearch-project/k-NN/pull/1549)
+* Support script score when doc value is disabled [#1573](https://github.com/opensearch-project/k-NN/pull/1573)
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
@@ -41,17 +41,18 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
     @Override
     public ScriptDocValues<float[]> getScriptValues() {
         try {
-            DocIdSetIterator values = null;
             FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(fieldName);
-            System.out.println(fieldInfo);
+            if (fieldInfo == null) {
+                return KNNVectorScriptDocValues.emptyValues(fieldName, vectorDataType);
+            }
+
+            DocIdSetIterator values = null;
             if (fieldInfo.hasVectorValues()) {
                 values = fieldInfo.getVectorEncoding() == VectorEncoding.FLOAT32
                     ? reader.getFloatVectorValues(fieldName)
                     : reader.getByteVectorValues(fieldName);
-                System.out.println("use vector values");
             } else {
                 values = DocValues.getBinary(reader, fieldName);
-                System.out.println("use binary values");
             }
             return KNNVectorScriptDocValues.create(values, fieldName, vectorDataType);
         } catch (IOException e) {

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index;
 
 import java.io.IOException;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -60,7 +61,17 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
         throw new UnsupportedOperationException("knn vector does not support this operation");
     }
 
+    /**
+     * Creates a KNNVectorScriptDocValues object based on the provided parameters.
+     *
+     * @param values          The DocIdSetIterator representing the vector values.
+     * @param fieldName       The name of the field.
+     * @param vectorDataType  The data type of the vector.
+     * @return A KNNVectorScriptDocValues object based on the type of the values.
+     * @throws IllegalArgumentException If the type of values is unsupported.
+     */
     public static KNNVectorScriptDocValues create(DocIdSetIterator values, String fieldName, VectorDataType vectorDataType) {
+        Objects.requireNonNull(values, "values must not be null");
         if (values instanceof ByteVectorValues) {
             return new KNNByteVectorScriptDocValues((ByteVectorValues) values, fieldName, vectorDataType);
         } else if (values instanceof FloatVectorValues) {
@@ -117,5 +128,21 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
         protected float[] doGetValue() throws IOException {
             return getVectorDataType().getVectorFromDocValues(values.binaryValue());
         }
+    }
+
+    /**
+     * Creates an empty KNNVectorScriptDocValues object based on the provided field name and vector data type.
+     *
+     * @param fieldName The name of the field.
+     * @param type      The data type of the vector.
+     * @return An empty KNNVectorScriptDocValues object.
+     */
+    public static KNNVectorScriptDocValues emptyValues(String fieldName, VectorDataType type) {
+        return new KNNVectorScriptDocValues(DocIdSetIterator.empty(), fieldName, type) {
+            @Override
+            protected float[] doGetValue() throws IOException {
+                throw new UnsupportedOperationException("empty values");
+            }
+        };
     }
 }

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -148,7 +148,7 @@ public class FaissIT extends KNNRestTestCase {
 
             List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 assertEquals(
                     KNNEngine.FAISS.score(KNNScoringUtil.l2Squared(testData.queries[i], primitiveArray), spaceType),
                     actualScores.get(j),
@@ -258,7 +258,7 @@ public class FaissIT extends KNNRestTestCase {
 
             List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 assertEquals(
                     KNNEngine.FAISS.score(KNNScoringUtil.l2Squared(testData.queries[i], primitiveArray), spaceType),
                     actualScores.get(j),
@@ -828,7 +828,7 @@ public class FaissIT extends KNNRestTestCase {
 
             List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 assertEquals(
                     KNNEngine.FAISS.score(KNNScoringUtil.l2Squared(testData.queries[i], primitiveArray), spaceType),
                     actualScores.get(j),

--- a/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
@@ -5,6 +5,15 @@
 
 package org.opensearch.knn.index;
 
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.knn.KNNTestCase;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -13,7 +22,6 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.store.Directory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,6 +32,7 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
 
     private static final String MOCK_INDEX_FIELD_NAME = "test-index-field-name";
     private static final float[] SAMPLE_VECTOR_DATA = new float[] { 1.0f, 2.0f };
+    private static final byte[] SAMPLE_BYTE_VECTOR_DATA = new byte[] { 1, 2 };
     private KNNVectorScriptDocValues scriptDocValues;
     private Directory directory;
     private DirectoryReader reader;
@@ -32,26 +41,39 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
     public void setUp() throws Exception {
         super.setUp();
         directory = newDirectory();
-        createKNNVectorDocument(directory);
+        Class<? extends DocIdSetIterator> valuesClass = randomFrom(BinaryDocValues.class, ByteVectorValues.class, FloatVectorValues.class);
+        createKNNVectorDocument(directory, valuesClass);
         reader = DirectoryReader.open(directory);
-        LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        scriptDocValues = KNNVectorScriptDocValues.create(
-            leafReaderContext.reader().getBinaryDocValues(MOCK_INDEX_FIELD_NAME),
-            MOCK_INDEX_FIELD_NAME,
-            VectorDataType.FLOAT
-        );
+        LeafReader leafReader = reader.getContext().leaves().get(0).reader();
+        DocIdSetIterator vectorValues;
+        if (BinaryDocValues.class.equals(valuesClass)) {
+            vectorValues = DocValues.getBinary(leafReader, MOCK_INDEX_FIELD_NAME);
+        } else if (ByteVectorValues.class.equals(valuesClass)) {
+            vectorValues = leafReader.getByteVectorValues(MOCK_INDEX_FIELD_NAME);
+        } else {
+            vectorValues = leafReader.getFloatVectorValues(MOCK_INDEX_FIELD_NAME);
+        }
+
+        scriptDocValues = KNNVectorScriptDocValues.create(vectorValues, MOCK_INDEX_FIELD_NAME, VectorDataType.FLOAT);
     }
 
-    private void createKNNVectorDocument(Directory directory) throws IOException {
+    private void createKNNVectorDocument(Directory directory, Class<? extends DocIdSetIterator> valuesClass) throws IOException {
         IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
         IndexWriter writer = new IndexWriter(directory, conf);
         Document knnDocument = new Document();
-        knnDocument.add(
-            new BinaryDocValuesField(
+        Field field;
+        if (BinaryDocValues.class.equals(valuesClass)) {
+            field = new BinaryDocValuesField(
                 MOCK_INDEX_FIELD_NAME,
                 new VectorField(MOCK_INDEX_FIELD_NAME, SAMPLE_VECTOR_DATA, new FieldType()).binaryValue()
-            )
-        );
+            );
+        } else if (ByteVectorValues.class.equals(valuesClass)) {
+            field = new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, SAMPLE_BYTE_VECTOR_DATA);
+        } else {
+            field = new KnnFloatVectorField(MOCK_INDEX_FIELD_NAME, SAMPLE_VECTOR_DATA);
+        }
+
+        knnDocument.add(field);
         writer.addDocument(knnDocument);
         writer.commit();
         writer.close();
@@ -82,5 +104,19 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
 
     public void testGet() throws IOException {
         expectThrows(UnsupportedOperationException.class, () -> scriptDocValues.get(0));
+    }
+
+    public void testUnsupportedValues() throws IOException {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNVectorScriptDocValues.create(DocValues.emptyNumeric(), MOCK_INDEX_FIELD_NAME, VectorDataType.FLOAT)
+        );
+    }
+
+    public void testEmptyValues() throws IOException {
+        KNNVectorScriptDocValues values = KNNVectorScriptDocValues.emptyValues(MOCK_INDEX_FIELD_NAME, VectorDataType.FLOAT);
+        assertEquals(0, values.size());
+        scriptDocValues.setNextDocId(0);
+        assertEquals(0, values.size());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
@@ -35,7 +35,7 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
         createKNNVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        scriptDocValues = new KNNVectorScriptDocValues(
+        scriptDocValues = KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(MOCK_INDEX_FIELD_NAME),
             MOCK_INDEX_FIELD_NAME,
             VectorDataType.FLOAT

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -307,14 +306,14 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float[] searchVector = TEST_QUERY_VECTORS[0];
         final int k = 1 + RandomUtils.nextInt(TEST_INDEX_VECTORS.length);
 
-        final List<Float[]> knnResultsBeforeIndexClosure = queryResults(searchVector, k);
+        final List<float[]> knnResultsBeforeIndexClosure = queryResults(searchVector, k);
 
         closeIndex(INDEX_NAME);
         openIndex(INDEX_NAME);
 
         ensureGreen(INDEX_NAME);
 
-        final List<Float[]> knnResultsAfterIndexClosure = queryResults(searchVector, k);
+        final List<float[]> knnResultsAfterIndexClosure = queryResults(searchVector, k);
 
         assertArrayEquals(knnResultsBeforeIndexClosure.toArray(), knnResultsAfterIndexClosure.toArray());
     }
@@ -365,7 +364,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
 
             List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 float distance = TestUtils.computeDistFromSpaceType(spaceType, primitiveArray, queryVector);
                 float rawScore = VECTOR_SIMILARITY_TO_SCORE.get(spaceType.getVectorSimilarityFunction()).apply(distance);
                 assertEquals(KNNEngine.LUCENE.score(rawScore, spaceType), actualScores.get(j), 0.0001);
@@ -373,7 +372,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         }
     }
 
-    private List<Float[]> queryResults(final float[] searchVector, final int k) throws Exception {
+    private List<float[]> queryResults(final float[] searchVector, final int k) throws Exception {
         final String responseBody = EntityUtils.toString(
             searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, searchVector, k), k).getEntity()
         );

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -30,11 +30,9 @@ import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -115,7 +113,7 @@ public class NmslibIT extends KNNRestTestCase {
 
             List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 assertEquals(
                     KNNEngine.NMSLIB.score(KNNScoringUtil.l1Norm(testData.queries[i], primitiveArray), spaceType),
                     actualScores.get(j),

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -39,7 +39,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -143,7 +142,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
             List<Float> actualScores = parseSearchResponseScore(responseBody, fieldName1);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 assertEquals(
                     knnEngine1.score(1 - KNNScoringUtil.cosinesimil(testData.queries[i], primitiveArray), spaceType1),
                     actualScores.get(j),
@@ -159,7 +158,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
             actualScores = parseSearchResponseScore(responseBody, fieldName2);
             for (int j = 0; j < k; j++) {
-                float[] primitiveArray = Floats.toArray(Arrays.stream(knnResults.get(j).getVector()).collect(Collectors.toList()));
+                float[] primitiveArray = knnResults.get(j).getVector();
                 assertEquals(
                     knnEngine2.score(KNNScoringUtil.l2Squared(testData.queries[i], primitiveArray), spaceType2),
                     actualScores.get(j),

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
@@ -57,7 +57,7 @@ public class VectorDataTypeTests extends KNNTestCase {
         createKNNFloatVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        return new KNNVectorScriptDocValues(
+        return KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME),
             VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME,
             VectorDataType.FLOAT
@@ -70,7 +70,7 @@ public class VectorDataTypeTests extends KNNTestCase {
         createKNNByteVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        return new KNNVectorScriptDocValues(
+        return KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME),
             VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME,
             VectorDataType.BYTE

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
@@ -280,7 +280,7 @@ public class KNNScoringUtilTests extends KNNTestCase {
             if (scriptDocValues == null) {
                 reader = DirectoryReader.open(directory);
                 LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-                scriptDocValues = new KNNVectorScriptDocValues(
+                scriptDocValues = KNNVectorScriptDocValues.create(
                     leafReaderContext.reader().getBinaryDocValues(fieldName),
                     fieldName,
                     VectorDataType.FLOAT

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -5,8 +5,10 @@
 
 package org.opensearch.knn.plugin.script;
 
+import java.io.IOException;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
@@ -21,6 +23,7 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.script.Script;
 
 import java.util.ArrayList;
@@ -35,12 +38,29 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.containsString;
 
 public class KNNScriptScoringIT extends KNNRestTestCase {
+    private void randomCreateKNNIndex() throws IOException {
+        if (randomBoolean()) {
+            createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        } else {
+            createKnnIndex(
+                INDEX_NAME,
+                createKnnIndexMapping(
+                    FIELD_NAME,
+                    2,
+                    KNNConstants.METHOD_HNSW,
+                    KNNEngine.LUCENE.getName(),
+                    SpaceType.DEFAULT.getValue(),
+                    randomBoolean()
+                )
+            );
+        }
+    }
 
     public void testKNNL2ScriptScore() throws Exception {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
 
@@ -93,7 +113,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
 
@@ -146,7 +166,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
 
@@ -199,7 +219,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 1.0f, -1.0f };
         addKnnDoc(INDEX_NAME, "0", FIELD_NAME, f1);
 
@@ -251,7 +271,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
 
         /**
          * Construct Search Request
@@ -293,7 +313,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
 
         /**
          * Construct Search Request
@@ -316,7 +336,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
 
         /**
          * Construct Search Request
@@ -349,7 +369,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 1.0f, -1.0f };
         addKnnDoc(INDEX_NAME, "0", FIELD_NAME, f1);
 
@@ -372,7 +392,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 1.0f, 1.0f };
         addDocWithNumericField(INDEX_NAME, "0", "price", 10);
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
@@ -636,7 +656,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { -2.0f, -2.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
 
@@ -690,7 +710,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        randomCreateKNNIndex();
         Float[] f1 = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
 

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -5,7 +5,8 @@
 
 package org.opensearch.knn.plugin.script;
 
-import java.io.IOException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
@@ -23,6 +24,8 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.script.Script;
 
@@ -40,221 +43,26 @@ import static org.hamcrest.Matchers.containsString;
 public class KNNScriptScoringIT extends KNNRestTestCase {
 
     public void testKNNL2ScriptScore() throws Exception {
-        /*
-         * Create knn index and populate data
-         */
-        randomCreateKNNIndex();
-        Float[] f1 = { 6.0f, 6.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
-
-        Float[] f2 = { 2.0f, 2.0f };
-        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f2);
-
-        Float[] f3 = { 4.0f, 4.0f };
-        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, f3);
-
-        Float[] f4 = { 3.0f, 3.0f };
-        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, f4);
-
-        /**
-         * Construct Search Request
-         */
-        QueryBuilder qb = new MatchAllQueryBuilder();
-        Map<String, Object> params = new HashMap<>();
-        /*
-         *   params": {
-         *       "field": "my_dense_vector",
-         *       "vector": [2.0, 2.0]
-         *      }
-         */
-        float[] queryVector = { 1.0f, 1.0f };
-        params.put("field", FIELD_NAME);
-        params.put("query_value", queryVector);
-        params.put("space_type", SpaceType.L2.getValue());
-        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
-        List<String> expectedDocids = Arrays.asList("2", "4", "3", "1");
-
-        List<String> actualDocids = new ArrayList<>();
-        for (KNNResult result : results) {
-            actualDocids.add(result.getDocId());
-        }
-
-        assertEquals(4, results.size());
-
-        // assert document order
-        assertEquals("2", results.get(0).getDocId());
-        assertEquals("4", results.get(1).getDocId());
-        assertEquals("3", results.get(2).getDocId());
-        assertEquals("1", results.get(3).getDocId());
+        testKNNScriptScore(SpaceType.L2);
     }
 
     public void testKNNL1ScriptScore() throws Exception {
-        /*
-         * Create knn index and populate data
-         */
-        randomCreateKNNIndex();
-        Float[] f1 = { 6.0f, 6.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
-
-        Float[] f2 = { 4.0f, 1.0f };
-        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f2);
-
-        Float[] f3 = { 3.0f, 3.0f };
-        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, f3);
-
-        Float[] f4 = { 5.0f, 5.0f };
-        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, f4);
-
-        /**
-         * Construct Search Request
-         */
-        QueryBuilder qb = new MatchAllQueryBuilder();
-        Map<String, Object> params = new HashMap<>();
-        /*
-         *   params": {
-         *       "field": "my_dense_vector",
-         *       "vector": [1.0, 1.0]
-         *      }
-         */
-        float[] queryVector = { 1.0f, 1.0f };
-        params.put("field", FIELD_NAME);
-        params.put("query_value", queryVector);
-        params.put("space_type", SpaceType.L1);
-        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
-        List<String> expectedDocids = Arrays.asList("2", "4", "3", "1");
-
-        List<String> actualDocids = new ArrayList<>();
-        for (KNNResult result : results) {
-            actualDocids.add(result.getDocId());
-        }
-
-        assertEquals(4, results.size());
-
-        // assert document order
-        assertEquals("2", results.get(0).getDocId());
-        assertEquals("3", results.get(1).getDocId());
-        assertEquals("4", results.get(2).getDocId());
-        assertEquals("1", results.get(3).getDocId());
+        testKNNScriptScore(SpaceType.L1);
     }
 
     public void testKNNLInfScriptScore() throws Exception {
-        /*
-         * Create knn index and populate data
-         */
-        randomCreateKNNIndex();
-        Float[] f1 = { 6.0f, 6.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
-
-        Float[] f2 = { 4.0f, 1.0f };
-        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f2);
-
-        Float[] f3 = { 3.0f, 3.0f };
-        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, f3);
-
-        Float[] f4 = { 5.0f, 5.0f };
-        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, f4);
-
-        /**
-         * Construct Search Request
-         */
-        QueryBuilder qb = new MatchAllQueryBuilder();
-        Map<String, Object> params = new HashMap<>();
-        /*
-         *   params": {
-         *       "field": "my_dense_vector",
-         *       "vector": [1.0, 1.0]
-         *      }
-         */
-        float[] queryVector = { 1.0f, 1.0f };
-        params.put("field", FIELD_NAME);
-        params.put("query_value", queryVector);
-        params.put("space_type", SpaceType.LINF.getValue());
-        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
-        List<String> expectedDocids = Arrays.asList("3", "2", "4", "1");
-
-        List<String> actualDocids = new ArrayList<>();
-        for (KNNResult result : results) {
-            actualDocids.add(result.getDocId());
-        }
-
-        assertEquals(4, results.size());
-
-        // assert document order
-        assertEquals("3", results.get(0).getDocId());
-        assertEquals("2", results.get(1).getDocId());
-        assertEquals("4", results.get(2).getDocId());
-        assertEquals("1", results.get(3).getDocId());
+        testKNNScriptScore(SpaceType.LINF);
     }
 
     public void testKNNCosineScriptScore() throws Exception {
-        /*
-         * Create knn index and populate data
-         */
-        randomCreateKNNIndex();
-        Float[] f1 = { 1.0f, -1.0f };
-        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, f1);
-
-        Float[] f2 = { 1.0f, 0.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f2);
-
-        Float[] f3 = { 1.0f, 1.0f };
-        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f3);
-
-        /**
-         * Construct Search Request
-         */
-        QueryBuilder qb = new MatchAllQueryBuilder();
-        Map<String, Object> params = new HashMap<>();
-        /*
-         *   params": {
-         *       "field": "my_dense_vector",
-         *       "query_value": [2.0, 2.0],
-         *       "space_type": "L2"
-         *      }
-         *
-         *
-         */
-        float[] queryVector = { 2.0f, -2.0f };
-        params.put("field", FIELD_NAME);
-        params.put("query_value", queryVector);
-        params.put("space_type", SpaceType.COSINESIMIL.getValue());
-        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
-        List<String> expectedDocids = Arrays.asList("0", "1", "2");
-
-        List<String> actualDocids = new ArrayList<>();
-        for (KNNResult result : results) {
-            actualDocids.add(result.getDocId());
-        }
-
-        assertEquals(3, results.size());
-
-        // assert document order
-        assertEquals("0", results.get(0).getDocId());
-        assertEquals("1", results.get(1).getDocId());
-        assertEquals("2", results.get(2).getDocId());
+        testKNNScriptScore(SpaceType.COSINESIMIL);
     }
 
     public void testKNNInvalidSourceScript() throws Exception {
         /*
          * Create knn index and populate data
          */
-        randomCreateKNNIndex();
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
 
         /**
          * Construct Search Request
@@ -296,7 +104,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        randomCreateKNNIndex();
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
 
         /**
          * Construct Search Request
@@ -319,7 +127,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        randomCreateKNNIndex();
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
 
         /**
          * Construct Search Request
@@ -352,7 +160,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        randomCreateKNNIndex();
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         Float[] f1 = { 1.0f, -1.0f };
         addKnnDoc(INDEX_NAME, "0", FIELD_NAME, f1);
 
@@ -375,7 +183,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        randomCreateKNNIndex();
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         Float[] f1 = { 1.0f, 1.0f };
         addDocWithNumericField(INDEX_NAME, "0", "price", 10);
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
@@ -399,10 +207,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             responseBody
         ).map().get("hits")).get("hits");
 
-        List<String> docIds = hits.stream().map(hit -> {
-            String id = ((String) ((Map<String, Object>) hit).get("_id"));
-            return id;
-        }).collect(Collectors.toList());
+        List<String> docIds = hits.stream().map(hit -> ((String) ((Map<String, Object>) hit).get("_id"))).collect(Collectors.toList());
         // assert document order
         assertEquals("1", docIds.get(0));
         assertEquals("0", docIds.get(1));
@@ -636,64 +441,14 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     }
 
     public void testKNNInnerProdScriptScore() throws Exception {
-        /*
-         * Create knn index and populate data
-         */
-        randomCreateKNNIndex();
-        Float[] f1 = { -2.0f, -2.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
-
-        Float[] f2 = { 1.0f, 1.0f };
-        addKnnDoc(INDEX_NAME, "2", FIELD_NAME, f2);
-
-        Float[] f3 = { 2.0f, 2.0f };
-        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, f3);
-
-        Float[] f4 = { 2.0f, -2.0f };
-        addKnnDoc(INDEX_NAME, "4", FIELD_NAME, f4);
-
-        /**
-         * Construct Search Request
-         */
-        QueryBuilder qb = new MatchAllQueryBuilder();
-        Map<String, Object> params = new HashMap<>();
-        /*
-         *   params": {
-         *       "field": "my_dense_vector",
-         *       "query_value": [1.0, 1.0],
-         *       "space_type": "innerproduct",
-         *      }
-         */
-        float[] queryVector = { 1.0f, 1.0f };
-        params.put("field", FIELD_NAME);
-        params.put("query_value", queryVector);
-        params.put("space_type", SpaceType.INNER_PRODUCT.getValue());
-        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
-        List<String> expectedDocids = Arrays.asList("3", "2", "4", "1");
-
-        List<String> actualDocids = new ArrayList<>();
-        for (KNNResult result : results) {
-            actualDocids.add(result.getDocId());
-        }
-
-        assertEquals(4, results.size());
-
-        // assert document order
-        assertEquals("3", results.get(0).getDocId());
-        assertEquals("2", results.get(1).getDocId());
-        assertEquals("4", results.get(2).getDocId());
-        assertEquals("1", results.get(3).getDocId());
+        testKNNScriptScore(SpaceType.INNER_PRODUCT);
     }
 
     public void testKNNScriptScoreWithRequestCacheEnabled() throws Exception {
         /*
          * Create knn index and populate data
          */
-        randomCreateKNNIndex();
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         Float[] f1 = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, f1);
 
@@ -795,25 +550,120 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(1, secondQueryCacheMap.get("hit_count"));
     }
 
-    /**
-     * Create native knn index or Lucene knn index with/without doc values randomly
-     * @throws IOException
-     */
-    private void randomCreateKNNIndex() throws IOException {
-        if (randomBoolean()) {
-            createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
-        } else {
-            createKnnIndex(
-                INDEX_NAME,
-                createKnnIndexMapping(
-                    FIELD_NAME,
-                    2,
-                    KNNConstants.METHOD_HNSW,
-                    KNNEngine.LUCENE.getName(),
-                    SpaceType.DEFAULT.getValue(),
-                    randomBoolean()
-                )
-            );
+    private List<String> createMappers(int dimensions) throws Exception {
+        return List.of(
+            createKnnIndexMapping(FIELD_NAME, dimensions),
+            createKnnIndexMapping(
+                FIELD_NAME,
+                dimensions,
+                KNNConstants.METHOD_HNSW,
+                KNNEngine.LUCENE.getName(),
+                SpaceType.DEFAULT.getValue(),
+                true
+            ),
+            createKnnIndexMapping(
+                FIELD_NAME,
+                dimensions,
+                KNNConstants.METHOD_HNSW,
+                KNNEngine.LUCENE.getName(),
+                SpaceType.DEFAULT.getValue(),
+                false
+            )
+        );
+    }
+
+    private float[] randomVector(int dimensions) {
+        final float[] vector = new float[dimensions];
+        for (int i = 0; i < dimensions; i++) {
+            vector[i] = randomFloat();
         }
+        return vector;
+    }
+
+    private Map<String, KNNResult> createDataset(Function<float[], Float> scoreFunction, int dimensions, int numDocs) {
+        final Map<String, KNNResult> dataset = new HashMap<>(numDocs);
+        for (int i = 0; i < numDocs; i++) {
+            final float[] vector = randomVector(dimensions);
+            final float score = scoreFunction.apply(vector);
+            dataset.put(Integer.toString(i), new KNNResult(Integer.toString(i), vector, score));
+        }
+        return dataset;
+    }
+
+    private BiFunction<float[], float[], Float> getScoreFunction(SpaceType spaceType, float[] queryVector) {
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = new KNNVectorFieldMapper.KNNVectorFieldType(
+            FIELD_NAME,
+            Collections.emptyMap(),
+            queryVector.length,
+            VectorDataType.FLOAT,
+            null
+        );
+        List<Float> target = new ArrayList<>(queryVector.length);
+        for (float f : queryVector) {
+            target.add(f);
+        }
+        KNNScoringSpace knnScoringSpace = KNNScoringSpaceFactory.create(spaceType.getValue(), target, knnVectorFieldType);
+        switch (spaceType) {
+            case L1:
+                return ((KNNScoringSpace.L1) knnScoringSpace).scoringMethod;
+            case L2:
+                return ((KNNScoringSpace.L2) knnScoringSpace).scoringMethod;
+            case LINF:
+                return ((KNNScoringSpace.LInf) knnScoringSpace).scoringMethod;
+            case COSINESIMIL:
+                return ((KNNScoringSpace.CosineSimilarity) knnScoringSpace).scoringMethod;
+            case INNER_PRODUCT:
+                return ((KNNScoringSpace.InnerProd) knnScoringSpace).scoringMethod;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private void testKNNScriptScore(SpaceType spaceType) throws Exception {
+        final int dims = randomIntBetween(2, 10);
+        final float[] queryVector = randomVector(dims);
+        final BiFunction<float[], float[], Float> scoreFunction = getScoreFunction(spaceType, queryVector);
+        for (String mapper : createMappers(dims)) {
+            createIndexAndAssertScriptScore(mapper, spaceType, scoreFunction, dims, queryVector);
+        }
+    }
+
+    private void createIndexAndAssertScriptScore(
+        String mapper,
+        SpaceType spaceType,
+        BiFunction<float[], float[], Float> scoreFunction,
+        int dimensions,
+        float[] queryVector
+    ) throws Exception {
+        /*
+         * Create knn index and populate data
+         */
+        createKnnIndex(INDEX_NAME, mapper);
+        Map<String, KNNResult> dataset = createDataset(v -> scoreFunction.apply(queryVector, v), dimensions, randomIntBetween(4, 10));
+        for (Map.Entry<String, KNNResult> entry : dataset.entrySet()) {
+            addKnnDoc(INDEX_NAME, entry.getKey(), FIELD_NAME, entry.getValue().getVector());
+        }
+
+        /**
+         * Construct Search Request
+         */
+        QueryBuilder qb = new MatchAllQueryBuilder();
+        Map<String, Object> params = new HashMap<>();
+        /*
+         *   params": {
+         *       "field": FIELD_NAME,
+         *       "vector": queryVector
+         *      }
+         */
+        params.put("field", FIELD_NAME);
+        params.put("query_value", queryVector);
+        params.put("space_type", spaceType.getValue());
+        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+        assertTrue(results.stream().allMatch(r -> dataset.get(r.getDocId()).equals(r)));
+        deleteKNNIndex(INDEX_NAME);
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -38,23 +38,6 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.containsString;
 
 public class KNNScriptScoringIT extends KNNRestTestCase {
-    private void randomCreateKNNIndex() throws IOException {
-        if (randomBoolean()) {
-            createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
-        } else {
-            createKnnIndex(
-                INDEX_NAME,
-                createKnnIndexMapping(
-                    FIELD_NAME,
-                    2,
-                    KNNConstants.METHOD_HNSW,
-                    KNNEngine.LUCENE.getName(),
-                    SpaceType.DEFAULT.getValue(),
-                    randomBoolean()
-                )
-            );
-        }
-    }
 
     public void testKNNL2ScriptScore() throws Exception {
         /*
@@ -810,5 +793,27 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(1, secondQueryCacheMap.get("miss_count"));
         // assert that the request cache was hit at second request
         assertEquals(1, secondQueryCacheMap.get("hit_count"));
+    }
+
+    /**
+     * Create native knn index or Lucene knn index with/without doc values randomly
+     * @throws IOException
+     */
+    private void randomCreateKNNIndex() throws IOException {
+        if (randomBoolean()) {
+            createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        } else {
+            createKnnIndex(
+                INDEX_NAME,
+                createKnnIndexMapping(
+                    FIELD_NAME,
+                    2,
+                    KNNConstants.METHOD_HNSW,
+                    KNNEngine.LUCENE.getName(),
+                    SpaceType.DEFAULT.getValue(),
+                    randomBoolean()
+                )
+            );
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
@@ -53,6 +53,10 @@ public class PainlessScriptIT extends KNNRestTestCase {
                 builder.field("dimension", property.getDimension());
             }
 
+            if (property.getDocValues() != null) {
+                builder.field("doc_values", property.getDocValues());
+            }
+
             if (property.getKnnMethodContext() != null) {
                 builder.startObject(KNNConstants.KNN_METHOD);
                 property.getKnnMethodContext().toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -554,12 +558,14 @@ public class PainlessScriptIT extends KNNRestTestCase {
     public void testL2ScriptingWithLuceneBackedIndex() throws Exception {
         List<MappingProperty> properties = new ArrayList<>();
         KNNMethodContext knnMethodContext = new KNNMethodContext(
-            KNNEngine.NMSLIB,
+            KNNEngine.LUCENE,
             SpaceType.DEFAULT,
             new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
         );
         properties.add(
-            new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2").knnMethodContext(knnMethodContext)
+            new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2")
+                .knnMethodContext(knnMethodContext)
+                .docValues(randomBoolean())
         );
 
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
@@ -585,6 +591,7 @@ public class PainlessScriptIT extends KNNRestTestCase {
         private String dimension;
 
         private KNNMethodContext knnMethodContext;
+        private Boolean docValues;
 
         MappingProperty(String name, String type) {
             this.name = name;
@@ -598,6 +605,11 @@ public class PainlessScriptIT extends KNNRestTestCase {
 
         MappingProperty knnMethodContext(KNNMethodContext knnMethodContext) {
             this.knnMethodContext = knnMethodContext;
+            return this;
+        }
+
+        MappingProperty docValues(boolean docValues) {
+            this.docValues = docValues;
             return this;
         }
 
@@ -615,6 +627,10 @@ public class PainlessScriptIT extends KNNRestTestCase {
 
         String getType() {
             return type;
+        }
+
+        Boolean getDocValues() {
+            return docValues;
         }
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -329,20 +329,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Utility to create a Knn Index Mapping with specific algorithm and engine
      */
     protected String createKnnIndexMapping(String fieldName, Integer dimensions, String algoName, String knnEngine) throws IOException {
-        return XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(fieldName)
-            .field("type", "knn_vector")
-            .field("dimension", dimensions.toString())
-            .startObject("method")
-            .field("name", algoName)
-            .field("engine", knnEngine)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+        return this.createKnnIndexMapping(fieldName, dimensions, algoName, knnEngine, SpaceType.DEFAULT.getValue());
     }
 
     /**
@@ -350,12 +337,27 @@ public class KNNRestTestCase extends ODFERestTestCase {
      */
     protected String createKnnIndexMapping(String fieldName, Integer dimensions, String algoName, String knnEngine, String spaceType)
         throws IOException {
+        return this.createKnnIndexMapping(fieldName, dimensions, algoName, knnEngine, spaceType, true);
+    }
+
+    /**
+     * Utility to create a Knn Index Mapping with specific algorithm, engine, spaceType and docValues
+     */
+    protected String createKnnIndexMapping(
+        String fieldName,
+        Integer dimensions,
+        String algoName,
+        String knnEngine,
+        String spaceType,
+        boolean docValues
+    ) throws IOException {
         return XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
             .field(KNNConstants.DIMENSION, dimensions.toString())
+            .field("doc_values", docValues)
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, algoName)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType)

--- a/src/testFixtures/java/org/opensearch/knn/KNNResult.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNResult.java
@@ -5,20 +5,41 @@
 
 package org.opensearch.knn;
 
-public class KNNResult {
-    private String docId;
-    private Float[] vector;
+import java.util.Arrays;
+import java.util.Objects;
 
-    public KNNResult(String docId, Float[] vector) {
+public class KNNResult {
+    private final static float delta = 1e-3f;
+
+    private String docId;
+    private float[] vector;
+    private Float score;
+
+    public KNNResult(String docId, float[] vector, Float score) {
         this.docId = docId;
         this.vector = vector;
+        this.score = score;
     }
 
     public String getDocId() {
         return docId;
     }
 
-    public Float[] getVector() {
+    public float[] getVector() {
         return vector;
+    }
+
+    public Float getScore() {
+        return score;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KNNResult knnResult = (KNNResult) o;
+        return Objects.equals(docId, knnResult.docId)
+            && Arrays.equals(vector, knnResult.vector)
+            && (Float.compare(score, knnResult.score) == 0 || Math.abs(score - knnResult.score) <= delta);
     }
 }


### PR DESCRIPTION
### Description
Today, script score is not supported if using lucene engine and doc value is disabled, because k-NN plugin uses doc value to execute exact query with script score. But actually, we can use `ByteVectorValues/FloatVectorValues` to execute this type of query.

In addition to , I think that we can totally disable doc value when using lucene engine, vector values can replace the function of doc value. Further, we can use `FlatVectorsFormat` to store vector values and implement our own native index functionality, so that we can avoid extra de/serialization and unify the script doc value interface. Any thoughts?

Btw, This PR has not added relevant tests yet. 
 
### Issues Resolved


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
