### PR TITLE
Support score type threshold in radial search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Support distance type radius search for Lucene engine [#1498](https://github.com/opensearch-project/k-NN/pull/1498)
 * Support distance type radius search for Faiss engine [#1546](https://github.com/opensearch-project/k-NN/pull/1546)
+* Support score type threshold in radial search [#1589](https://github.com/opensearch-project/k-NN/pull/1589)
 ### Enhancements
 * Make the HitQueue size more appropriate for exact search [#1549](https://github.com/opensearch-project/k-NN/pull/1549)
 * Support script score when doc value is disabled [#1573](https://github.com/opensearch-project/k-NN/pull/1573)

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -39,6 +39,9 @@ public enum SpaceType {
 
         @Override
         public float scoreToDistanceTranslation(float score) {
+            if (score == 0) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "score cannot be 0 when space type is [%s]", getValue()));
+            }
             return 1 / score - 1;
         }
     },

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -36,6 +36,11 @@ public enum SpaceType {
         public VectorSimilarityFunction getVectorSimilarityFunction() {
             return VectorSimilarityFunction.EUCLIDEAN;
         }
+
+        @Override
+        public float scoreToDistanceTranslation(float score) {
+            return 1 / score - 1;
+        }
     },
     COSINESIMIL("cosinesimil") {
         @Override
@@ -169,5 +174,15 @@ public enum SpaceType {
             }
         }
         throw new IllegalArgumentException("Unable to find space: " + spaceTypeName);
+    }
+
+    /**
+     * Translate a score to a distance for this space type
+     *
+     * @param score score to translate
+     * @return translated distance
+     */
+    public float scoreToDistanceTranslation(float score) {
+        throw new UnsupportedOperationException(String.format("Space [%s] does not have a score to distance translation", getValue()));
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -52,6 +52,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     public static final ParseField FILTER_FIELD = new ParseField("filter");
     public static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
     public static final ParseField DISTANCE_FIELD = new ParseField("distance");
+    public static final ParseField SCORE_FIELD = new ParseField("score");
     public static final int K_MAX = 10000;
     /**
      * The name for the knn query
@@ -64,6 +65,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     private final float[] vector;
     private int k = 0;
     private Float distance = null;
+    private Float score = null;
     private QueryBuilder filter;
     private boolean ignoreUnmapped = false;
 
@@ -92,12 +94,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
      *
      * @param k K nearest neighbours for the given vector
      */
-    public KNNQueryBuilder k(int k) {
+    public KNNQueryBuilder k(Integer k) {
+        if (k == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires k to be set");
+        }
+        validSingleQueryType(k, distance, score);
         if (k <= 0 || k > K_MAX) {
             throw new IllegalArgumentException("[" + NAME + "] requires 0 < k <= " + K_MAX);
-        }
-        if (distance != null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires either k or distance must be set");
         }
         this.k = k;
         return this;
@@ -112,10 +115,25 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (distance == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires distance to be set");
         }
-        if (k != 0) {
-            throw new IllegalArgumentException("[" + NAME + "] requires either k or distance must be set");
-        }
+        validSingleQueryType(k, distance, score);
         this.distance = distance;
+        return this;
+    }
+
+    /**
+     * Builder method for score
+     *
+     * @param score the score threshold for the nearest neighbours
+     */
+    public KNNQueryBuilder score(Float score) {
+        if (score == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires score to be set");
+        }
+        validSingleQueryType(k, distance, score);
+        if (score <= 0) {
+            throw new IllegalArgumentException("[" + NAME + "] requires score greater than 0");
+        }
+        this.score = score;
         return this;
     }
 
@@ -163,6 +181,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         this.filter = filter;
         this.ignoreUnmapped = false;
         this.distance = null;
+        this.score = null;
     }
 
     public static void initialize(ModelDao modelDao) {
@@ -200,6 +219,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
                 distance = in.readOptionalFloat();
             }
+            if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
+                score = in.readOptionalFloat();
+            }
         } catch (IOException ex) {
             throw new RuntimeException("[KNN] Unable to create KNNQueryBuilder", ex);
         }
@@ -211,6 +233,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         Integer k = null;
         Float distance = null;
+        Float score = null;
         QueryBuilder filter = null;
         String queryName = null;
         String currentFieldName = null;
@@ -241,6 +264,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                             queryName = parser.text();
                         } else if (DISTANCE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                             distance = (Float) NumberFieldMapper.NumberType.FLOAT.parse(parser.objectBytes(), false);
+                        } else if (SCORE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            score = (Float) NumberFieldMapper.NumberType.FLOAT.parse(parser.objectBytes(), false);
                         } else {
                             throw new ParsingException(
                                 parser.getTokenLocation(),
@@ -270,9 +295,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             }
         }
 
-        if ((k != null && distance != null) || (k == null && distance == null)) {
-            throw new IllegalArgumentException("[" + NAME + "] requires either k or distance must be set");
-        }
+        validSingleQueryType(k, distance, score);
 
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(fieldName, ObjectsToFloats(vector)).filter(filter)
             .ignoreUnmapped(ignoreUnmapped)
@@ -281,8 +304,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
         if (k != null) {
             knnQueryBuilder.k(k);
-        } else {
+        } else if (distance != null) {
             knnQueryBuilder.distance(distance);
+        } else if (score != null) {
+            knnQueryBuilder.score(score);
         }
 
         return knnQueryBuilder;
@@ -299,6 +324,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
         if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
             out.writeOptionalFloat(distance);
+        }
+        if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
+            out.writeOptionalFloat(score);
         }
     }
 
@@ -322,6 +350,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     public float getDistance() {
         return this.distance;
+    }
+
+    public float getScore() {
+        return this.score;
     }
 
     public QueryBuilder getFilter() {
@@ -357,6 +389,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
         if (ignoreUnmapped) {
             builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
+        }
+        if (score != null) {
+            builder.field(SCORE_FIELD.getPreferredName(), score);
         }
         printBoostAndQueryName(builder);
         builder.endObject();
@@ -397,14 +432,21 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             spaceType = knnMethodContext.getSpaceType();
         }
 
-        // Currently, k-NN supports distance type radius search.
-        // We need transform distance radius to right type of engine required radius.
+        // Currently, k-NN supports distance and score types radial search
+        // We need transform distance/score to right type of engine required radius.
         Float radius = null;
         if (this.distance != null) {
             if (this.distance < 0 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException("[" + NAME + "] requires distance to be non-negative for space type: " + spaceType);
             }
             radius = knnEngine.distanceToRadialThreshold(this.distance, spaceType);
+        }
+
+        if (this.score != null) {
+            if (this.score > 1 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
+                throw new IllegalArgumentException("[" + NAME + "] requires score to be in the range (0, 1] for space type: " + spaceType);
+            }
+            radius = knnEngine.scoreToRadialThreshold(this.score, spaceType);
         }
 
         if (fieldDimension != vector.length) {
@@ -464,7 +506,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 .build();
             return RNNQueryFactory.create(createQueryRequest);
         }
-        throw new IllegalArgumentException("[" + NAME + "] requires either k or distance must be set");
+        throw new IllegalArgumentException("[" + NAME + "] requires either k or distance or score to be set");
     }
 
     private ModelMetadata getModelMetadataForField(KNNVectorFieldMapper.KNNVectorFieldType knnVectorField) {
@@ -498,5 +540,25 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     @Override
     public String getWriteableName() {
         return NAME;
+    }
+
+    private static void validSingleQueryType(Integer k, Float distance, Float score) {
+        int countSetFields = 0;
+
+        if (k != null && k != 0) {
+            countSetFields++;
+        }
+        if (distance != null) {
+            countSetFields++;
+        }
+        if (score != null) {
+            countSetFields++;
+        }
+
+        if (countSetFields != 1) {
+            throw new IllegalArgumentException(
+                "[" + NAME + "] requires only one query type to be set, it can be either k, distance, or score"
+            );
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -98,7 +98,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (k == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires k to be set");
         }
-        validSingleQueryType(k, distance, score);
+        validateSingleQueryType(k, distance, score);
         if (k <= 0 || k > K_MAX) {
             throw new IllegalArgumentException("[" + NAME + "] requires 0 < k <= " + K_MAX);
         }
@@ -115,7 +115,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (distance == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires distance to be set");
         }
-        validSingleQueryType(k, distance, score);
+        validateSingleQueryType(k, distance, score);
         this.distance = distance;
         return this;
     }
@@ -129,7 +129,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (score == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires score to be set");
         }
-        validSingleQueryType(k, distance, score);
+        validateSingleQueryType(k, distance, score);
         if (score <= 0) {
             throw new IllegalArgumentException("[" + NAME + "] requires score greater than 0");
         }
@@ -295,7 +295,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             }
         }
 
-        validSingleQueryType(k, distance, score);
+        validateSingleQueryType(k, distance, score);
 
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(fieldName, ObjectsToFloats(vector)).filter(filter)
             .ignoreUnmapped(ignoreUnmapped)
@@ -542,7 +542,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         return NAME;
     }
 
-    private static void validSingleQueryType(Integer k, Float distance, Float score) {
+    private static void validateSingleQueryType(Integer k, Float distance, Float score) {
         int countSetFields = 0;
 
         if (k != null && k != 0) {

--- a/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNEngine.java
@@ -159,6 +159,11 @@ public enum KNNEngine implements KNNLibrary {
     }
 
     @Override
+    public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+        return knnLibrary.scoreToRadialThreshold(score, spaceType);
+    }
+
+    @Override
     public ValidationException validateMethod(KNNMethodContext knnMethodContext) {
         return knnLibrary.validateMethod(knnMethodContext);
     }

--- a/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNLibrary.java
@@ -79,6 +79,16 @@ public interface KNNLibrary {
     Float distanceToRadialThreshold(Float distance, SpaceType spaceType);
 
     /**
+     * Translate the score threshold input from end user to the engine's threshold.
+     *
+     * @param score score threshold input from end user
+     * @param spaceType spaceType used to compute the threshold
+     *
+     * @return transformed score for the library
+     */
+    Float scoreToRadialThreshold(Float score, SpaceType spaceType);
+
+    /**
      * Validate the knnMethodContext for the given library. A ValidationException should be thrown if the method is
      * deemed invalid.
      *

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -53,6 +53,7 @@ public class Lucene extends JVMLibrary {
         Function<Float, Float>>builder()
         .put(SpaceType.COSINESIMIL, distance -> (2 - distance) / 2)
         .put(SpaceType.L2, distance -> 1 / (1 + distance))
+        .put(SpaceType.INNER_PRODUCT, distance -> distance <= 0 ? 1 / (1 - distance) : distance + 1)
         .build();
 
     final static Lucene INSTANCE = new Lucene(METHODS, Version.LATEST.toString(), DISTANCE_TRANSLATIONS);
@@ -91,6 +92,12 @@ public class Lucene extends JVMLibrary {
     public Float distanceToRadialThreshold(Float distance, SpaceType spaceType) {
         // Lucene requires score threshold to be parameterized when calling the radius search.
         return this.distanceTransform.get(spaceType).apply(distance);
+    }
+
+    @Override
+    public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+        // Lucene engine uses distance as is and does not need transformation
+        return score;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/util/Nmslib.java
+++ b/src/main/java/org/opensearch/knn/index/util/Nmslib.java
@@ -73,4 +73,8 @@ class Nmslib extends NativeLibrary {
     public Float distanceToRadialThreshold(Float distance, SpaceType spaceType) {
         return distance;
     }
+
+    public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+        return score;
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -174,7 +174,7 @@ public class FaissIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testEndToEnd_whenDoRadiusSearch_whenMethodIsHNSWFlat_thenSucceed() {
+    public void testEndToEnd_whenDoRadiusSearch_whenDistanceThreshold_whenMethodIsHNSWFlat_thenSucceed() {
         KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
@@ -225,17 +225,135 @@ public class FaissIT extends KNNRestTestCase {
         refreshAllNonSystemIndices();
         assertEquals(testData.indexData.docs.length, getDocCount(INDEX_NAME));
 
-        float radius = 300000000000f;
-        for (float[] queryVector : testData.queries) {
-            validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, queryVector, radius, spaceType);
-        }
+        float distance = 300000000000f;
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, distance, null, spaceType);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
     }
 
     @SneakyThrows
-    public void testEndToEnd_whenDoRadiusSearch_whenMethodIsHNSWPQ_thenSucceed() {
+    public void testEndToEnd_whenDoRadiusSearch_whenScoreThreshold_whenMethodIsHNSWFlat_thenSucceed() {
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        SpaceType spaceType = SpaceType.L2;
+
+        List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
+        List<Integer> efConstructionValues = ImmutableList.of(16, 32, 64, 128);
+        List<Integer> efSearchValues = ImmutableList.of(16, 32, 64, 128);
+
+        Integer dimension = testData.indexData.vectors[0].length;
+
+        // Create an index
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Map<String, Object> mappingMap = xContentBuilderToMap(builder);
+        String mapping = builder.toString();
+
+        createKnnIndex(INDEX_NAME, mapping);
+        assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(INDEX_NAME)));
+
+        // Index the test data
+        for (int i = 0; i < testData.indexData.docs.length; i++) {
+            addKnnDoc(
+                INDEX_NAME,
+                Integer.toString(testData.indexData.docs[i]),
+                FIELD_NAME,
+                Floats.asList(testData.indexData.vectors[i]).toArray()
+            );
+        }
+
+        // Assert we have the right number of documents
+        refreshAllNonSystemIndices();
+        assertEquals(testData.indexData.docs.length, getDocCount(INDEX_NAME));
+
+        float score = 0.00001f;
+
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType);
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testEndToEnd_whenDoRadiusSearch_whenMoreThanOneScoreThreshold_whenMethodIsHNSWFlat_thenSucceed() {
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        SpaceType spaceType = SpaceType.INNER_PRODUCT;
+
+        List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
+        List<Integer> efConstructionValues = ImmutableList.of(16, 32, 64, 128);
+        List<Integer> efSearchValues = ImmutableList.of(16, 32, 64, 128);
+
+        Integer dimension = testData.indexData.vectors[0].length;
+
+        // Create an index
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Map<String, Object> mappingMap = xContentBuilderToMap(builder);
+        String mapping = builder.toString();
+
+        createKnnIndex(INDEX_NAME, mapping);
+        assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(INDEX_NAME)));
+
+        // Index the test data
+        for (int i = 0; i < testData.indexData.docs.length; i++) {
+            addKnnDoc(
+                INDEX_NAME,
+                Integer.toString(testData.indexData.docs[i]),
+                FIELD_NAME,
+                Floats.asList(testData.indexData.vectors[i]).toArray()
+            );
+        }
+
+        // Assert we have the right number of documents
+        refreshAllNonSystemIndices();
+        assertEquals(testData.indexData.docs.length, getDocCount(INDEX_NAME));
+
+        float score = 5f;
+
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType);
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testEndToEnd_whenDoRadiusSearch__whenDistanceThreshold_whenMethodIsHNSWPQ_thenSucceed() {
         String indexName = "test-index";
         String fieldName = "test-field";
         String trainingIndexName = "training-index";
@@ -311,11 +429,9 @@ public class FaissIT extends KNNRestTestCase {
         refreshAllNonSystemIndices();
         assertEquals(testData.indexData.docs.length, getDocCount(indexName));
 
-        float radius = 300000000000f;
+        float distance = 300000000000f;
 
-        for (float[] queryVector : testData.queries) {
-            validateRadiusSearchResults(indexName, fieldName, queryVector, radius, spaceType);
-        }
+        validateRadiusSearchResults(indexName, fieldName, testData.queries, distance, null, spaceType);
 
         // Delete index
         deleteKNNIndex(indexName);
@@ -1471,30 +1587,40 @@ public class FaissIT extends KNNRestTestCase {
     private void validateRadiusSearchResults(
         String indexName,
         String fieldName,
-        float[] queryVector,
-        float radius,
+        float[][] queryVectors,
+        Float distanceThreshold,
+        Float scoreThreshold,
         final SpaceType spaceType
     ) throws IOException, ParseException {
-        XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject("query");
-        queryBuilder.startObject("knn");
-        queryBuilder.startObject(fieldName);
-        queryBuilder.field("vector", queryVector);
-        queryBuilder.field("distance", radius);
-        queryBuilder.endObject();
-        queryBuilder.endObject();
-        queryBuilder.endObject().endObject();
-        final String responseBody = EntityUtils.toString(searchKNNIndex(indexName, queryBuilder, 10).getEntity());
-
-        List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
-
-        for (KNNResult knnResult : knnResults) {
-            float[] vector = Floats.toArray(Arrays.stream(knnResult.getVector()).collect(Collectors.toList()));
-            if (spaceType == SpaceType.L2) {
-                assertTrue(KNNScoringUtil.l2Squared(queryVector, vector) <= radius);
-            } else if (spaceType == SpaceType.INNER_PRODUCT) {
-                assertTrue(KNNScoringUtil.innerProduct(queryVector, vector) >= radius);
+        for (float[] queryVector : queryVectors) {
+            XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject("query");
+            queryBuilder.startObject("knn");
+            queryBuilder.startObject(fieldName);
+            queryBuilder.field("vector", queryVector);
+            if (distanceThreshold != null) {
+                queryBuilder.field("distance", distanceThreshold);
+            } else if (scoreThreshold != null) {
+                queryBuilder.field("score", scoreThreshold);
             } else {
-                throw new IllegalArgumentException("Invalid space type");
+                throw new IllegalArgumentException("Invalid threshold");
+            }
+            queryBuilder.endObject();
+            queryBuilder.endObject();
+            queryBuilder.endObject().endObject();
+            final String responseBody = EntityUtils.toString(searchKNNIndex(indexName, queryBuilder, 10).getEntity());
+
+            List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
+
+            for (KNNResult knnResult : knnResults) {
+                float[] vector = knnResult.getVector();
+                float distance = TestUtils.computeDistFromSpaceType(spaceType, vector, queryVector);
+                if (spaceType == SpaceType.L2) {
+                    assertTrue(KNNScoringUtil.l2Squared(queryVector, vector) <= distance);
+                } else if (spaceType == SpaceType.INNER_PRODUCT) {
+                    assertTrue(KNNScoringUtil.innerProduct(queryVector, vector) >= distance);
+                } else {
+                    throw new IllegalArgumentException("Invalid space type");
+                }
             }
         }
     }

--- a/src/test/java/org/opensearch/knn/index/util/AbstractKNNLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/AbstractKNNLibraryTests.java
@@ -132,6 +132,10 @@ public class AbstractKNNLibraryTests extends KNNTestCase {
             return 0f;
         }
 
+        public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+            return 0f;
+        }
+
         @Override
         public int estimateOverheadInKB(KNNMethodContext knnMethodContext, int dimension) {
             return 0;

--- a/src/test/java/org/opensearch/knn/index/util/NativeLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/NativeLibraryTests.java
@@ -69,5 +69,10 @@ public class NativeLibraryTests extends KNNTestCase {
         public Float distanceToRadialThreshold(Float distance, SpaceType spaceType) {
             return 0.0f;
         }
+
+        @Override
+        public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+            return 0.0f;
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/stats/suppliers/LibraryInitializedSupplierTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/stats/suppliers/LibraryInitializedSupplierTests.java
@@ -69,6 +69,11 @@ public class LibraryInitializedSupplierTests extends OpenSearchTestCase {
         }
 
         @Override
+        public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+            return 0.0f;
+        }
+
+        @Override
         public ValidationException validateMethod(KNNMethodContext knnMethodContext) {
             return null;
         }


### PR DESCRIPTION
### Description
This PR allows user to use `score` as threshold to search vectors, the search result contains all docs which score higher than the `score` for Lucene and Faiss engines ANN search.


### Usage
During index mapping and indexing stages no behavior change. Some query examples:

* Faiss engine with L2 space type
```
curl --location --request GET 'http://localhost:9200/target-index-faiss/_search' \
--header 'Content-Type: application/json' \
--data '{
  "size":12,  
  "query": {
    "knn": {
      "my_vector1": {
        "vector": [7.5, 8.5],
        "score": 0.5
      }
    }
  }
}'

// Query results
{
    "took": 4,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 0.7462686,
        "hits": [
            {
                "_index": "target-index-faiss",
                "_id": "1",
                "_score": 0.7462686,
                "_source": {
                    "my_vector1": [
                        7.0,
                        8.2
                    ],
                    "price": 4.4
                }
            }
        ]
    }
}
```



* Lucene engine with Inner product space type
```
curl --location --request GET 'http://localhost:9200/target-index-lucene/_search' \
--header 'Content-Type: application/json' \
--data '{
  "size":12,  
  "query": {
    "knn": {
      "my_vector1": {
        "vector": [7.0, 8.5],
        "score": 25
      }
    }
  }
}'
 
// Query results
{
    "took": 303,
    "timed_out": false,
    "_shards": {
        "total": 3,
        "successful": 3,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 4,
            "relation": "eq"
        },
        "max_score": 69.45,
        "hits": [
            {
                "_index": "target-index-lucene",
                "_id": "13",
                "_score": 69.45,
                "_source": {
                    "my_vector1": [
                        -2.0,
                        9.7
                    ],
                    "price": 18.0
                }
            },
            {
                "_index": "target-index-lucene",
                "_id": "17",
                "_score": 39.3,
                "_source": {
                    "my_vector1": [
                        -5.7,
                        9.2
                    ],
                    "price": 3.1
                }
            },
            {
                "_index": "target-index-lucene",
                "_id": "7",
                "_score": 34.45,
                "_source": {
                    "my_vector1": [
                        -1.9,
                        5.5
                    ],
                    "price": 11.0
                }
            },
            {
                "_index": "target-index-lucene",
                "_id": "3",
                "_score": 27.5,
                "_source": {
                    "my_vector1": [
                        -3.5,
                        6.0
                    ],
                    "price": 19.1
                }
            }
        ]
    }
}
```

### Issues Resolved
Part of https://github.com/opensearch-project/k-NN/issues/814
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
