### PR TITLE
Fix script to pick up correct zip

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -129,7 +129,7 @@ fi
 ./gradlew publishPluginZipPublicationToMavenLocal -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Dopensearch.version=$VERSION
 
 # Add lib to zip
-zipPath=$(find "$(pwd)" -path \*build/distributions/*.zip)
+zipPath=$(find "$(pwd)/build/distributions" -path \*.zip)
 distributions="$(dirname "${zipPath}")"
 mkdir $distributions/lib
 libPrefix="libopensearchknn"


### PR DESCRIPTION
### Description
Fix find command to look in correct place. This broke because micro-benchmarks ends up producing a zip in the build/distributions folder.

Locally:

Without fix:
```
$ find "$(pwd)" -path \*build/distributions/*.zip
<PATH>/k-NN-1/micro-benchmarks/build/distributions/micro-benchmarks-2.14.0.0-SNAPSHOT.zip
<PATH>/k-NN-1/build/distributions/opensearch-knn-3.0.0.0-SNAPSHOT.zip
```

With fix
```
$ find "$(pwd)/build/distributions" -path \*.zip
<PATH>/k-NN-1/build/distributions/opensearch-knn-3.0.0.0-SNAPSHOT.zip
```

 
### Issues Resolved
#1591  #1585
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
