### PR TITLE
Update KNN80BinaryDocValues reader count live docs and use live docs as initial capacity to initialize vector address

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80BinaryDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80BinaryDocValues.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.KNN80Codec;
 
+import lombok.Getter;
 import org.opensearch.knn.index.codec.util.BinaryDocValuesSub;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocIDMerger;
@@ -15,9 +16,12 @@ import java.io.IOException;
 /**
  * A per-document kNN numeric value.
  */
-class KNN80BinaryDocValues extends BinaryDocValues {
+public class KNN80BinaryDocValues extends BinaryDocValues {
 
     private DocIDMerger<BinaryDocValuesSub> docIDMerger;
+
+    @Getter
+    private long totalLiveDocs;
 
     KNN80BinaryDocValues(DocIDMerger<BinaryDocValuesSub> docIdMerger) {
         this.docIDMerger = docIdMerger;
@@ -61,4 +65,14 @@ class KNN80BinaryDocValues extends BinaryDocValues {
     public BytesRef binaryValue() throws IOException {
         return current.getValues().binaryValue();
     }
-};
+
+    /**
+     * Builder pattern like setter for setting totalLiveDocs. We can use setter also. But this way the code is clean.
+     * @param totalLiveDocs int
+     * @return {@link KNN80BinaryDocValues}
+     */
+    public KNN80BinaryDocValues setTotalLiveDocs(long totalLiveDocs) {
+        this.totalLiveDocs = totalLiveDocs;
+        return this;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesReader.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.knn.index.codec.KNN80Codec;
 
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.opensearch.common.StopWatch;
 import org.opensearch.knn.index.codec.util.BinaryDocValuesSub;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.index.BinaryDocValues;
@@ -14,12 +18,14 @@ import org.apache.lucene.index.EmptyDocValuesProducer;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Reader for KNNDocValues from the segments
  */
+@Log4j2
 class KNN80DocValuesReader extends EmptyDocValuesProducer {
 
     private final MergeState mergeState;
@@ -30,6 +36,7 @@ class KNN80DocValuesReader extends EmptyDocValuesProducer {
 
     @Override
     public BinaryDocValues getBinary(FieldInfo field) {
+        long totalLiveDocs = 0;
         try {
             List<BinaryDocValuesSub> subs = new ArrayList<>(this.mergeState.docValuesProducers.length);
             for (int i = 0; i < this.mergeState.docValuesProducers.length; i++) {
@@ -41,13 +48,49 @@ class KNN80DocValuesReader extends EmptyDocValuesProducer {
                         values = docValuesProducer.getBinary(readerFieldInfo);
                     }
                     if (values != null) {
+                        totalLiveDocs = totalLiveDocs + getLiveDocsCount(values, this.mergeState.liveDocs[i]);
+                        // docValues will be consumed when liveDocs are not null, hence resetting the docsValues
+                        // pointer.
+                        values = this.mergeState.liveDocs[i] != null ? docValuesProducer.getBinary(readerFieldInfo) : values;
+
                         subs.add(new BinaryDocValuesSub(mergeState.docMaps[i], values));
                     }
                 }
             }
-            return new KNN80BinaryDocValues(DocIDMerger.of(subs, mergeState.needsIndexSort));
+            return new KNN80BinaryDocValues(DocIDMerger.of(subs, mergeState.needsIndexSort)).setTotalLiveDocs(totalLiveDocs);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * This function return the liveDocs count present in the BinaryDocValues. If the liveDocsBits is null, then we
+     * can use {@link BinaryDocValues#cost()} function to get max docIds. But if LiveDocsBits is not null, then we
+     * iterate over the BinaryDocValues and validate if the docId is present in the live docs bits or not.
+     *
+     * @param binaryDocValues {@link BinaryDocValues}
+     * @param liveDocsBits {@link Bits}
+     * @return total number of liveDocs.
+     * @throws IOException
+     */
+    private long getLiveDocsCount(final BinaryDocValues binaryDocValues, final Bits liveDocsBits) throws IOException {
+        long liveDocs = 0;
+        if (liveDocsBits != null) {
+            int docId;
+            // This is not the right way to log the time. I create a github issue for adding an annotation to track
+            // the time. https://github.com/opensearch-project/k-NN/issues/1594
+            StopWatch stopWatch = new StopWatch();
+            stopWatch.start();
+            for (docId = binaryDocValues.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = binaryDocValues.nextDoc()) {
+                if (liveDocsBits.get(docId)) {
+                    liveDocs++;
+                }
+            }
+            stopWatch.stop();
+            log.debug("Time taken to iterate over binary doc values: {} ms", stopWatch.totalTime().millis());
+        } else {
+            liveDocs = binaryDocValues.cost();
+        }
+        return liveDocs;
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecServiceTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecServiceTests.java
@@ -36,6 +36,7 @@ public class KNNCodecServiceTests extends KNNTestCase {
         super.setUp();
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
         when(indexMetadata.getIndex()).thenReturn(new Index(TEST_INDEX, INDEX_UUID.toString()));
+        when(indexMetadata.getCustomData(IndexMetadata.REMOTE_STORE_CUSTOM_KEY)).thenReturn(null);
         when(indexMetadata.getSettings()).thenReturn(Settings.EMPTY);
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, Integer.toString(NUM_OF_SHARDS)).build();
         indexSettings = new IndexSettings(indexMetadata, settings);


### PR DESCRIPTION
### Description
Update KNN80BinaryDocValues reader count live docs and use live docs as initial capacity to initialize vector address.

I have also added a fix for UTs which were failing. https://github.com/opensearch-project/k-NN/issues/1593


**Older Prs:**
https://github.com/opensearch-project/k-NN/pull/1588
https://github.com/opensearch-project/k-NN/pull/1583
https://github.com/opensearch-project/k-NN/pull/1586
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1506
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
