### PR TITLE
Move free vectorAddress from Java to JNI layer to reduce the memory footprint for Nmslib.

### DIFF
--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -161,6 +161,10 @@ void knn_jni::faiss_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JN
     // Write the index to disk
     std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
     faiss::write_index(&idMap, indexPathCpp.c_str());
+    // Releasing the vectorsAddressJ memory as that is not required once we have created the index.
+    // This is not the ideal approach, please refer this gh issue for long term solution:
+    // https://github.com/opensearch-project/k-NN/issues/1600
+    delete inputVectors;
 }
 
 void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
@@ -221,7 +225,10 @@ void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface *
     auto idVector = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexIDMap idMap =  faiss::IndexIDMap(indexWriter.get());
     idMap.add_with_ids(numVectors, inputVectors->data(), idVector.data());
-
+    // Releasing the vectorsAddressJ memory as that is not required once we have created the index.
+    // This is not the ideal approach, please refer this gh issue for long term solution:
+    // https://github.com/opensearch-project/k-NN/issues/1600
+    delete inputVectors;
     // Write the index to disk
     std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
     faiss::write_index(&idMap, indexPathCpp.c_str());

--- a/jni/src/nmslib_wrapper.cpp
+++ b/jni/src/nmslib_wrapper.cpp
@@ -153,6 +153,12 @@ void knn_jni::nmslib_wrapper::CreateIndex(knn_jni::JNIUtilInterface * jniUtil, J
         }
         jniUtil->ReleaseIntArrayElements(env, idsJ, idsCpp, JNI_ABORT);
 
+        // Releasing the vectorsAddressJ memory as that is not required once we have created the index.
+        // This is not the ideal approach, please refer this gh issue for long term solution:
+        // https://github.com/opensearch-project/k-NN/issues/1600
+        //commons::freeVectorData(vectorsAddressJ);
+        delete inputVectors;
+
         std::unique_ptr<similarity::Index<float>> index;
         index.reset(similarity::MethodFactoryRegistry<float>::Instance().CreateMethod(false, "hnsw", spaceTypeCpp, *(space), dataset));
         index->CreateIndex(similarity::AnyParams(indexParameters));

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -30,13 +30,13 @@ TEST(FaissCreateIndexTest, BasicAssertions) {
     // Define the data
     faiss::idx_t numIds = 200;
     std::vector<faiss::idx_t> ids;
-    std::vector<float> vectors;
+    auto *vectors = new std::vector<float>();
     int dim = 2;
-    vectors.reserve(dim * numIds);
+    vectors->reserve(dim * numIds);
     for (int64_t i = 0; i < numIds; ++i) {
         ids.push_back(i);
         for (int j = 0; j < dim; ++j) {
-            vectors.push_back(test_util::RandomFloat(-500.0, 500.0));
+            vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
         }
     }
 
@@ -55,12 +55,12 @@ TEST(FaissCreateIndexTest, BasicAssertions) {
     EXPECT_CALL(mockJNIUtil,
                 GetJavaObjectArrayLength(
                         jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
-            .WillRepeatedly(Return(vectors.size()));
+            .WillRepeatedly(Return(vectors->size()));
 
     // Create the index
     knn_jni::faiss_wrapper::CreateIndex(
             &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
-            (jlong) &vectors, dim , (jstring)&indexPath,
+            (jlong) vectors, dim , (jstring)&indexPath,
             (jobject)&parametersMap);
 
     // Make sure index can be loaded
@@ -74,13 +74,13 @@ TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
     // Define the data
     faiss::idx_t numIds = 100;
     std::vector<faiss::idx_t> ids;
-    std::vector<float> vectors;
+    auto *vectors = new std::vector<float>();
     int dim = 2;
-    vectors.reserve(dim * numIds);
+    vectors->reserve(dim * numIds);
     for (int64_t i = 0; i < numIds; ++i) {
         ids.push_back(i);
         for (int j = 0; j < dim; ++j) {
-            vectors.push_back(test_util::RandomFloat(-500.0, 500.0));
+            vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
         }
     }
 
@@ -99,7 +99,7 @@ TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
     EXPECT_CALL(mockJNIUtil,
                 GetJavaObjectArrayLength(
                         jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
-            .WillRepeatedly(Return(vectors.size()));
+            .WillRepeatedly(Return(vectors->size()));
 
     std::string spaceType = knn_jni::L2;
     std::unordered_map<std::string, jobject> parametersMap;
@@ -107,7 +107,7 @@ TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
 
     knn_jni::faiss_wrapper::CreateIndexFromTemplate(
             &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
-            (jlong)&vectors, dim, (jstring)&indexPath,
+            (jlong)vectors, dim, (jstring)&indexPath,
             reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
             (jobject) &parametersMap
             );
@@ -480,13 +480,13 @@ TEST(FaissCreateHnswSQfp16IndexTest, BasicAssertions) {
     // Define the data
     faiss::idx_t numIds = 200;
     std::vector<faiss::idx_t> ids;
-    std::vector<float> vectors;
+    auto *vectors = new std::vector<float>();
     int dim = 2;
-    vectors.reserve(dim * numIds);
+    vectors->reserve(dim * numIds);
     for (int64_t i = 0; i < numIds; ++i) {
         ids.push_back(i);
         for (int j = 0; j < dim; ++j) {
-            vectors.push_back(test_util::RandomFloat(-500.0, 500.0));
+            vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
         }
     }
 
@@ -505,12 +505,12 @@ TEST(FaissCreateHnswSQfp16IndexTest, BasicAssertions) {
     EXPECT_CALL(mockJNIUtil,
                 GetJavaObjectArrayLength(
                         jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
-            .WillRepeatedly(Return(vectors.size()));
+            .WillRepeatedly(Return(vectors->size()));
 
     // Create the index
     knn_jni::faiss_wrapper::CreateIndex(
             &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
-            (jlong)&vectors, dim, (jstring)&indexPath,
+            (jlong)vectors, dim, (jstring)&indexPath,
             (jobject)&parametersMap);
 
     // Make sure index can be loaded

--- a/jni/tests/nmslib_wrapper_test.cpp
+++ b/jni/tests/nmslib_wrapper_test.cpp
@@ -39,13 +39,13 @@ TEST(NmslibCreateIndexTest, BasicAssertions) {
     // Define index data
     int numIds = 100;
     std::vector<int> ids;
-    std::vector<float> vectors;
+    auto *vectors = new std::vector<float>();
     int dim = 2;
-    vectors.reserve(dim * numIds);
+    vectors->reserve(dim * numIds);
     for (int64_t i = 0; i < numIds; ++i) {
         ids.push_back(i);
         for (int j = 0; j < dim; ++j) {
-            vectors.push_back(test_util::RandomFloat(-500.0, 500.0));
+            vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
         }
     }
 
@@ -67,7 +67,7 @@ TEST(NmslibCreateIndexTest, BasicAssertions) {
     EXPECT_CALL(mockJNIUtil,
                 GetJavaObjectArrayLength(
                         jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
-            .WillRepeatedly(Return(vectors.size()));
+            .WillRepeatedly(Return(vectors->size()));
 
     EXPECT_CALL(mockJNIUtil,
                 GetJavaIntArrayLength(jniEnv, reinterpret_cast<jintArray>(&ids)))
@@ -76,7 +76,7 @@ TEST(NmslibCreateIndexTest, BasicAssertions) {
     // Create the index
     knn_jni::nmslib_wrapper::CreateIndex(
             &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
-            (jlong) &vectors, dim, (jstring)&indexPath,
+            (jlong) vectors, dim, (jstring)&indexPath,
             (jobject)&parametersMap);
 
     // Make sure index can be loaded

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -50,7 +50,10 @@ class FaissService {
     }
 
     /**
-     * Create an index for the native library
+     * Create an index for the native library The memory occupied by the vectorsAddress will be freed up during the
+     * function call. So Java layer doesn't need to free up the memory. This is not an ideal behavior because Java layer
+     * created the memory address and that should only free up the memory. We are tracking the proper fix for this on this
+     * <a href="https://github.com/opensearch-project/k-NN/issues/1600">issue</a>
      *
      * @param ids array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -23,7 +23,10 @@ import java.util.Map;
 public class JNIService {
 
     /**
-     * Create an index for the native library
+     * Create an index for the native library. The memory occupied by the vectorsAddress will be freed up during the
+     * function call. So Java layer doesn't need to free up the memory. This is not an ideal behavior because Java layer
+     * created the memory address and that should only free up the memory. We are tracking the proper fix for this on this
+     * <a href="https://github.com/opensearch-project/k-NN/issues/1600">issue</a>
      *
      * @param ids        array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored

--- a/src/main/java/org/opensearch/knn/jni/NmslibService.java
+++ b/src/main/java/org/opensearch/knn/jni/NmslibService.java
@@ -39,7 +39,10 @@ class NmslibService {
     }
 
     /**
-     * Create an index for the native library
+     * Create an index for the native library.  The memory occupied by the vectorsAddress will be freed up during the
+     * function call. So Java layer doesn't need to free up the memory. This is not an ideal behavior because Java layer
+     * created the memory address and that should only free up the memory. We are tracking the proper fix for this on this
+     * <a href="https://github.com/opensearch-project/k-NN/issues/1600">issue</a>
      *
      * @param ids array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -111,7 +111,7 @@ public class JNIServiceTests extends KNNTestCase {
             Exception.class,
             () -> JNIService.createIndex(
                 testData.indexData.docs,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 "something",
                 Collections.emptyMap(),
@@ -267,7 +267,7 @@ public class JNIServiceTests extends KNNTestCase {
 
             JNIService.createIndex(
                 testData.indexData.docs,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
@@ -279,7 +279,7 @@ public class JNIServiceTests extends KNNTestCase {
 
             JNIService.createIndex(
                 testData.indexData.docs,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(
@@ -303,7 +303,7 @@ public class JNIServiceTests extends KNNTestCase {
             Exception.class,
             () -> JNIService.createIndex(
                 docIds,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 "something",
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod),
@@ -381,7 +381,7 @@ public class JNIServiceTests extends KNNTestCase {
             Exception.class,
             () -> JNIService.createIndex(
                 docIds,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 null,
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -393,7 +393,7 @@ public class JNIServiceTests extends KNNTestCase {
             Exception.class,
             () -> JNIService.createIndex(
                 docIds,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 tmpFile.toAbsolutePath().toString(),
                 null,
@@ -405,7 +405,7 @@ public class JNIServiceTests extends KNNTestCase {
             Exception.class,
             () -> JNIService.createIndex(
                 docIds,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -610,7 +610,7 @@ public class JNIServiceTests extends KNNTestCase {
             Exception.class,
             () -> JNIService.createIndex(
                 docIds,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(
@@ -636,7 +636,7 @@ public class JNIServiceTests extends KNNTestCase {
                 Path tmpFile1 = createTempFile();
                 JNIService.createIndex(
                     testData.indexData.docs,
-                    testData.indexData.getVectorAddress(),
+                    testData.loadDataToMemoryAddress(),
                     testData.indexData.getDimension(),
                     tmpFile1.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
@@ -687,7 +687,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -723,7 +723,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -750,7 +750,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -776,7 +776,7 @@ public class JNIServiceTests extends KNNTestCase {
 
             JNIService.createIndex(
                 testData.indexData.docs,
-                testData.indexData.getVectorAddress(),
+                testData.loadDataToMemoryAddress(),
                 testData.indexData.getDimension(),
                 tmpFile.toAbsolutePath().toString(),
                 ImmutableMap.of(KNNConstants.SPACE_TYPE, spaceType.getValue()),
@@ -809,7 +809,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -834,7 +834,7 @@ public class JNIServiceTests extends KNNTestCase {
                 Path tmpFile = createTempFile();
                 JNIService.createIndex(
                     testData.indexData.docs,
-                    testData.indexData.getVectorAddress(),
+                    testData.loadDataToMemoryAddress(),
                     testData.indexData.getDimension(),
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
@@ -876,7 +876,7 @@ public class JNIServiceTests extends KNNTestCase {
                 Path tmpFile = createTempFile();
                 JNIService.createIndex(
                     testDataNested.indexData.docs,
-                    testDataNested.indexData.getVectorAddress(),
+                    testData.loadDataToMemoryAddress(),
                     testDataNested.indexData.getDimension(),
                     tmpFile.toAbsolutePath().toString(),
                     ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, method, KNNConstants.SPACE_TYPE, spaceType.getValue()),
@@ -951,7 +951,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -975,7 +975,7 @@ public class JNIServiceTests extends KNNTestCase {
 
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue()),
@@ -1137,7 +1137,7 @@ public class JNIServiceTests extends KNNTestCase {
         Path tmpFile1 = createTempFile();
         JNIService.createIndexFromTemplate(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile1.toAbsolutePath().toString(),
             faissIndex,
@@ -1272,7 +1272,7 @@ public class JNIServiceTests extends KNNTestCase {
         Path tmpFile = createTempFile();
         JNIService.createIndexFromTemplate(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             faissIndex,
@@ -1288,7 +1288,7 @@ public class JNIServiceTests extends KNNTestCase {
         Path tmpFile = createTempFile();
         JNIService.createIndex(
             testData.indexData.docs,
-            testData.indexData.getVectorAddress(),
+            testData.loadDataToMemoryAddress(),
             testData.indexData.getDimension(),
             tmpFile.toAbsolutePath().toString(),
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, spaceType.getValue()),

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -295,9 +295,7 @@ public class TestUtils {
                     vectorsArray[i][j] = vectorsList.get(i)[j];
                 }
             }
-            long memoryAddress = JNICommons.storeVectorData(0, vectorsArray, (long) vectorsArray.length * vectorsArray[0].length);
-
-            return new Pair(idsArray, memoryAddress, vectorsArray[0].length, SerializationMode.COLLECTION_OF_FLOATS, vectorsArray);
+            return new Pair(idsArray, vectorsArray[0].length, SerializationMode.COLLECTION_OF_FLOATS, vectorsArray);
         }
 
         private float[][] readQueries(String path) throws IOException {
@@ -329,12 +327,13 @@ public class TestUtils {
             return queryArray;
         }
 
+        public long loadDataToMemoryAddress() {
+            return JNICommons.storeVectorData(0, indexData.vectors, (long) indexData.vectors.length * indexData.vectors[0].length);
+        }
+
         @AllArgsConstructor
         public static class Pair {
             public int[] docs;
-            @Getter
-            @Setter
-            private long vectorAddress;
             @Getter
             @Setter
             private int dimension;


### PR DESCRIPTION
### Description
Move free vectorAddress from Java to JNI layer to reduce the memory footprint for Nmslib.

Earlier we were freeing up memory in the Java layer where the thought process was as Java layer has init the memory location it should free up the space. 

But due to limitations provided here: https://github.com/opensearch-project/k-NN/issues/1600 for nmslib doing that can triple the memory footprint for index creation. Hence, we are freeing up the memory in the JNI layer.

This code will be removed once we do the long term fix via #1600 

## JNI Test output

```
(base) 13:22 ~/workplace/k-NN/jni (stream-vectors-v2)$ ./bin/jni_test 
Running main() from /Users/navneev/workplace/k-NN/jni/googletest-src/googletest/src/gtest_main.cc
[==========] Running 22 tests from 20 test suites.
[----------] Global test environment set-up.
[----------] 1 test from FaissCreateIndexTest
[ RUN      ] FaissCreateIndexTest.BasicAssertions
[       OK ] FaissCreateIndexTest.BasicAssertions (11 ms)
[----------] 1 test from FaissCreateIndexTest (11 ms total)

[----------] 1 test from FaissCreateIndexFromTemplateTest
[ RUN      ] FaissCreateIndexFromTemplateTest.BasicAssertions
[       OK ] FaissCreateIndexFromTemplateTest.BasicAssertions (4 ms)
[----------] 1 test from FaissCreateIndexFromTemplateTest (4 ms total)

[----------] 3 tests from FaissLoadIndexTest
[ RUN      ] FaissLoadIndexTest.BasicAssertions
[       OK ] FaissLoadIndexTest.BasicAssertions (5 ms)
[ RUN      ] FaissLoadIndexTest.HNSWPQDisableSdcTable
WARNING clustering 256 points to 16 centroids: please provide at least 624 training points
[       OK ] FaissLoadIndexTest.HNSWPQDisableSdcTable (420 ms)
[ RUN      ] FaissLoadIndexTest.IVFPQDisablePrecomputeTable
WARNING clustering 256 points to 16 centroids: please provide at least 624 training points
[       OK ] FaissLoadIndexTest.IVFPQDisablePrecomputeTable (414 ms)
[----------] 3 tests from FaissLoadIndexTest (840 ms total)

[----------] 1 test from FaissQueryIndexTest
[ RUN      ] FaissQueryIndexTest.BasicAssertions
[       OK ] FaissQueryIndexTest.BasicAssertions (6 ms)
[----------] 1 test from FaissQueryIndexTest (6 ms total)

[----------] 1 test from FaissQueryIndexWithFilterTest1435
[ RUN      ] FaissQueryIndexWithFilterTest1435.BasicAssertions
[       OK ] FaissQueryIndexWithFilterTest1435.BasicAssertions (11 ms)
[----------] 1 test from FaissQueryIndexWithFilterTest1435 (11 ms total)

[----------] 1 test from FaissQueryIndexWithParentFilterTest
[ RUN      ] FaissQueryIndexWithParentFilterTest.BasicAssertions
[       OK ] FaissQueryIndexWithParentFilterTest.BasicAssertions (5 ms)
[----------] 1 test from FaissQueryIndexWithParentFilterTest (5 ms total)

[----------] 1 test from FaissFreeTest
[ RUN      ] FaissFreeTest.BasicAssertions
[       OK ] FaissFreeTest.BasicAssertions (0 ms)
[----------] 1 test from FaissFreeTest (0 ms total)

[----------] 1 test from FaissInitLibraryTest
[ RUN      ] FaissInitLibraryTest.BasicAssertions
[       OK ] FaissInitLibraryTest.BasicAssertions (0 ms)
[----------] 1 test from FaissInitLibraryTest (0 ms total)

[----------] 1 test from FaissTrainIndexTest
[ RUN      ] FaissTrainIndexTest.BasicAssertions
[       OK ] FaissTrainIndexTest.BasicAssertions (0 ms)
[----------] 1 test from FaissTrainIndexTest (0 ms total)

[----------] 1 test from FaissCreateHnswSQfp16IndexTest
[ RUN      ] FaissCreateHnswSQfp16IndexTest.BasicAssertions
[       OK ] FaissCreateHnswSQfp16IndexTest.BasicAssertions (5 ms)
[----------] 1 test from FaissCreateHnswSQfp16IndexTest (5 ms total)

[----------] 1 test from FaissIsSharedIndexStateRequired
[ RUN      ] FaissIsSharedIndexStateRequired.BasicAssertions
[       OK ] FaissIsSharedIndexStateRequired.BasicAssertions (0 ms)
[----------] 1 test from FaissIsSharedIndexStateRequired (0 ms total)

[----------] 1 test from FaissInitAndSetSharedIndexState
[ RUN      ] FaissInitAndSetSharedIndexState.BasicAssertions
WARNING clustering 256 points to 16 centroids: please provide at least 624 training points
[       OK ] FaissInitAndSetSharedIndexState.BasicAssertions (368 ms)
[----------] 1 test from FaissInitAndSetSharedIndexState (368 ms total)

[----------] 1 test from IDGrouperBitMapTest
[ RUN      ] IDGrouperBitMapTest.BasicAssertions
[       OK ] IDGrouperBitMapTest.BasicAssertions (0 ms)
[----------] 1 test from IDGrouperBitMapTest (0 ms total)

[----------] 1 test from NmslibIndexWrapperSearchTest
[ RUN      ] NmslibIndexWrapperSearchTest.BasicAssertions
[       OK ] NmslibIndexWrapperSearchTest.BasicAssertions (0 ms)
[----------] 1 test from NmslibIndexWrapperSearchTest (0 ms total)

[----------] 1 test from NmslibCreateIndexTest
[ RUN      ] NmslibCreateIndexTest.BasicAssertions
[       OK ] NmslibCreateIndexTest.BasicAssertions (3 ms)
[----------] 1 test from NmslibCreateIndexTest (3 ms total)

[----------] 1 test from NmslibLoadIndexTest
[ RUN      ] NmslibLoadIndexTest.BasicAssertions
[       OK ] NmslibLoadIndexTest.BasicAssertions (1 ms)
[----------] 1 test from NmslibLoadIndexTest (2 ms total)

[----------] 1 test from NmslibQueryIndexTest
[ RUN      ] NmslibQueryIndexTest.BasicAssertions
[       OK ] NmslibQueryIndexTest.BasicAssertions (2 ms)
[----------] 1 test from NmslibQueryIndexTest (2 ms total)

[----------] 1 test from NmslibFreeTest
[ RUN      ] NmslibFreeTest.BasicAssertions
[       OK ] NmslibFreeTest.BasicAssertions (0 ms)
[----------] 1 test from NmslibFreeTest (0 ms total)

[----------] 1 test from NmslibInitLibraryTest
[ RUN      ] NmslibInitLibraryTest.BasicAssertions
[       OK ] NmslibInitLibraryTest.BasicAssertions (0 ms)
[----------] 1 test from NmslibInitLibraryTest (0 ms total)

[----------] 1 test from CommonsTests
[ RUN      ] CommonsTests.BasicAssertions
[       OK ] CommonsTests.BasicAssertions (0 ms)
[----------] 1 test from CommonsTests (0 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 20 test suites ran. (1265 ms total)
[  PASSED  ] 22 tests.

```

 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1506
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
