### PR TITLE
Fix Windows CI on 1.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Checkout k-NN
         uses: actions/checkout@v1
 
+      - name: Apply Git Patch
+        # Deleting file at the end to skip `git apply` inside CMAKE file
+        run: |
+          git submodule update --init -- jni/external/faiss
+          cd jni/external/faiss
+          git apply --ignore-space-change --ignore-whitespace --3way ../../patches/faiss/0001-Add-missing-headers-for-gcc.patch
+          rm ../../patches/faiss/0001-Add-missing-headers-for-gcc.patch
+        working-directory: ${{ github.workspace }}
+
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
@@ -75,6 +84,15 @@ jobs:
           echo "C:/Users/runneradmin/scoop/apps/mingw/current/bin" >> $env:GITHUB_PATH
           Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
           refreshenv
+
+      - name: Install Zlib Using Scoop
+        run: |
+          echo "C:/Users/runneradmin/scoop/shims" >> $env:GITHUB_PATH
+          Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+          refreshenv
+          scoop bucket add extras
+          scoop install zlib
+          regedit /s "C:\\Users\\runneradmin\\scoop\\apps\\zlib\\current\\register.reg"
 
       - name: Download OpenBLAS
         run: |

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <cstdint>
 
 namespace knn_jni {
 

--- a/jni/patches/faiss/0001-Add-missing-headers-for-gcc.patch
+++ b/jni/patches/faiss/0001-Add-missing-headers-for-gcc.patch
@@ -1,0 +1,26 @@
+diff --git a/faiss/Clustering.h b/faiss/Clustering.h
+index ef1f00ad..ae341115 100644
+--- a/faiss/Clustering.h
++++ b/faiss/Clustering.h
+@@ -10,7 +10,7 @@
+ #ifndef FAISS_CLUSTERING_H
+ #define FAISS_CLUSTERING_H
+ #include <faiss/Index.h>
+-
++#include <cstdint>
+ #include <vector>
+ 
+ namespace faiss {
+diff --git a/faiss/Index.h b/faiss/Index.h
+index 3d1bdb99..eaed1b14 100644
+--- a/faiss/Index.h
++++ b/faiss/Index.h
+@@ -16,6 +16,8 @@
+ #include <string>
+ #include <typeinfo>
+ 
++#include <cstdint>
++
+ #define FAISS_VERSION_MAJOR 1
+ #define FAISS_VERSION_MINOR 8
+ #define FAISS_VERSION_PATCH 0


### PR DESCRIPTION
### Description
This PR will fix the failing Windows CI on 1.3 by including the following changes:

- Manually installing ZLIB (cherry picked from commit https://github.com/opensearch-project/k-NN/commit/231ad934e6b0f4e62ee0ca68bcb160534262d401)
- Added a git patch for the CI to fix the [header dependency issues due to GCC 13](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
