### PR TITLE
Use 0.95 as default ratio for lucene radial search traversal similarity

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -134,5 +134,5 @@ public class KNNConstants {
     // https://github.com/opensearch-project/k-NN/issues/1049#issuecomment-1694741092
     public static int MAX_DISTANCE_COMPUTATIONS = 2048000;
 
-    public static float DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
+    public static final Float DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -133,4 +133,6 @@ public class KNNConstants {
     // Please refer this github issue for more details for choosing this value:
     // https://github.com/opensearch-project/k-NN/issues/1049#issuecomment-1694741092
     public static int MAX_DISTANCE_COMPUTATIONS = 2048000;
+
+    public static float LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -134,5 +134,5 @@ public class KNNConstants {
     // https://github.com/opensearch-project/k-NN/issues/1049#issuecomment-1694741092
     public static int MAX_DISTANCE_COMPUTATIONS = 2048000;
 
-    public static float LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
+    public static float DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
 }

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -120,11 +120,11 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery
     ) {
         return new FloatVectorSimilarityQuery(
-                fieldName,
-                floatVector,
-                DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
-                resultSimilarity,
-                filterQuery
+            fieldName,
+            floatVector,
+            DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
+            resultSimilarity,
+            filterQuery
         );
     }
 
@@ -139,11 +139,11 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery
     ) {
         return new ByteVectorSimilarityQuery(
-                fieldName,
-                byteVector,
-                DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
-                resultSimilarity,
-                filterQuery
+            fieldName,
+            byteVector,
+            DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
+            resultSimilarity,
+            filterQuery
         );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import static org.opensearch.knn.common.KNNConstants.LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
@@ -118,7 +119,13 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float resultSimilarity,
         final Query filterQuery
     ) {
-        return new FloatVectorSimilarityQuery(fieldName, floatVector, resultSimilarity, filterQuery);
+        return new FloatVectorSimilarityQuery(
+            fieldName,
+            floatVector,
+            LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
+            resultSimilarity,
+            filterQuery
+        );
     }
 
     /**
@@ -131,6 +138,12 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float resultSimilarity,
         final Query filterQuery
     ) {
-        return new ByteVectorSimilarityQuery(fieldName, byteVector, resultSimilarity, filterQuery);
+        return new ByteVectorSimilarityQuery(
+            fieldName,
+            byteVector,
+            LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
+            resultSimilarity,
+            filterQuery
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
-import static org.opensearch.knn.common.KNNConstants.LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
@@ -120,11 +120,11 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery
     ) {
         return new FloatVectorSimilarityQuery(
-            fieldName,
-            floatVector,
-            LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
-            resultSimilarity,
-            filterQuery
+                fieldName,
+                floatVector,
+                DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
+                resultSimilarity,
+                filterQuery
         );
     }
 
@@ -139,11 +139,11 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery
     ) {
         return new ByteVectorSimilarityQuery(
-            fieldName,
-            byteVector,
-            LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
-            resultSimilarity,
-            filterQuery
+                fieldName,
+                byteVector,
+                DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
+                resultSimilarity,
+                filterQuery
         );
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.knn.common.KNNConstants.LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
 import static org.opensearch.knn.index.util.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
@@ -398,7 +398,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         float resultSimilarity = KNNEngine.LUCENE.distanceToRadialThreshold(MAX_DISTANCE, SpaceType.L2);
 
         assertTrue(query.toString().contains("resultSimilarity=" + resultSimilarity));
-        assertTrue(query.toString().contains("traversalSimilarity=" + LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity));
+        assertTrue(query.toString().contains("traversalSimilarity=" + DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity));
     }
 
     public void testDoToQuery_whenNormal_whenDoRadiusSearch_whenScoreThreshold_thenSucceed() {

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -398,7 +398,9 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         float resultSimilarity = KNNEngine.LUCENE.distanceToRadialThreshold(MAX_DISTANCE, SpaceType.L2);
 
         assertTrue(query.toString().contains("resultSimilarity=" + resultSimilarity));
-        assertTrue(query.toString().contains("traversalSimilarity=" + DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity));
+        assertTrue(
+            query.toString().contains("traversalSimilarity=" + DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity)
+        );
     }
 
     public void testDoToQuery_whenNormal_whenDoRadiusSearch_whenScoreThreshold_thenSucceed() {

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
 import static org.opensearch.knn.index.util.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
@@ -394,7 +395,10 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
         FloatVectorSimilarityQuery query = (FloatVectorSimilarityQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
-        assertTrue(query.toString().contains("resultSimilarity=" + KNNEngine.LUCENE.distanceToRadialThreshold(MAX_DISTANCE, SpaceType.L2)));
+        float resultSimilarity = KNNEngine.LUCENE.distanceToRadialThreshold(MAX_DISTANCE, SpaceType.L2);
+
+        assertTrue(query.toString().contains("resultSimilarity=" + resultSimilarity));
+        assertTrue(query.toString().contains("traversalSimilarity=" + LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity));
     }
 
     public void testDoToQuery_whenNormal_whenDoRadiusSearch_whenScoreThreshold_thenSucceed() {


### PR DESCRIPTION
### Description
This PR set up Lucene engine traversalSimilarity value to 0.95 * resultSimilarity(min_score) based on benchmark result https://github.com/opensearch-project/k-NN/issues/814#issuecomment-2060195145 
 
### Issues Resolved
Part of https://github.com/opensearch-project/k-NN/issues/814
 
### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
