### PR TITLE
Fix flaky faiss integration tests

### DIFF
--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -232,7 +232,7 @@ public class FaissIT extends KNNRestTestCase {
 
         final Set<Integer> docIdsToBeDeleted = new HashSet<>();
         while (docIdsToBeDeleted.size() < 10) {
-            docIdsToBeDeleted.add(randomInt(testData.indexData.docs.length));
+            docIdsToBeDeleted.add(randomInt(testData.indexData.docs.length - 1));
         }
 
         for (Integer id : docIdsToBeDeleted) {
@@ -741,6 +741,7 @@ public class FaissIT extends KNNRestTestCase {
             .field(KNN_ENGINE, FAISS_NAME)
             .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
             .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NPROBES, 4)
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_SQ)
             .startObject(PARAMETERS)


### PR DESCRIPTION
### Description

- Increase `nprobes` to 4 for improving the ivf search accuracy which will fix the failing sqfp16 ivf integ test.
```
                                       ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
13 warnings
Apr 19, 2024 2:55:22 AM sun.util.locale.provider.LocaleProviderAdapter <clinit>
WARNING: COMPAT locale provider will be removed in a future release

REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.knn.index.FaissIT.testIVFSQFP16_whenIndexedAndQueried_thenSucceed" -Dtests.seed=704AA6389C8616FD -Dtests.security.manager=false -Dtests.locale=ca -Dtests.timezone=Africa/Harare -Druntime.java=21


Suite: Test class org.opensearch.knn.index.FaissIT
  2> REPRODUCE WITH: ./gradlew ':integTest' --tests "org.opensearch.knn.index.FaissIT.testIVFSQFP16_whenIndexedAndQueried_thenSucceed" -Dtests.seed=704AA6389C8616FD -Dtests.security.manager=false -Dtests.locale=ca -Dtests.timezone=Africa/Harare -Druntime.java=21
  2> java.lang.AssertionError: expected:<98> but was:<97>
        at __randomizedtesting.SeedInfo.seed([704AA6389C8616FD:7A51537778CBC789]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at org.opensearch.knn.index.FaissIT.queryTestData(FaissIT.java:1380)
        at org.opensearch.knn.index.FaissIT.testIVFSQFP16_whenIndexedAndQueried_thenSucceed(FaissIT.java:498)
  2> NOTE: leaving temporary files on disk at: /tmp/tmpaevuj86w/k-NN/build/testrun/integTest/temp/org.opensearch.knn.index.FaissIT_704AA6389C8616FD-001
  2> NOTE: test params are: codec=Asserting(Lucene99): {}, docValues:{}, maxPointsInLeafNode=1862, maxMBSortInHeap=7.382107889035421, sim=Asserting(RandomSimilarity(queryNorm=false): {}), locale=ca, timezone=Africa/Harare
  2> NOTE: Linux 6.1.49-70.116.amzn2023.aarch64 aarch64/Eclipse Adoptium 21.0.1 (64-bit)/cpus=4,threads=1,free=505653232,total=536870912
  2> NOTE: All tests run in this JVM: [AdvancedFilteringUseCasesIT, FaissIT]

199 tests completed, 1 failed
```
- Fix the HNSW test running into ArrayIndexOutOfBoundsException
```
org.opensearch.knn.index.FaissIT > testEndToEnd_whenMethodIsHNSWFlatAndHasDeletedDocs_thenSucceed FAILED
    java.lang.ArrayIndexOutOfBoundsException: Index 1000 out of bounds for length 1000
        at __randomizedtesting.SeedInfo.seed([E57DF8FEF413D7E2:39AA74F34D34702B]:0)
        at org.opensearch.knn.index.FaissIT.testEndToEnd_whenMethodIsHNSWFlatAndHasDeletedDocs_thenSucceed(FaissIT.java:239)
```

 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1631
 
### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
