### PR TITLE
[Backport 2.x] Add stored fields for knn_vector type (#1630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Implemented the Streaming Feature to stream vectors from Java to JNI layer to enable creation of larger segments for vector indices [#1604](https://github.com/opensearch-project/k-NN/pull/1604)
 * Remove unnecessary toString conversion of vector field and added some minor optimization in KNNCodec [1613](https://github.com/opensearch-project/k-NN/pull/1613)
 ### Bug Fixes
+* Add stored fields for knn_vector type [#1630](https://github.com/opensearch-project/k-NN/pull/1630)
 ### Infrastructure
 * Add micro-benchmark module in k-NN plugin for benchmark streaming vectors to JNI layer functionality. [#1583](https://github.com/opensearch-project/k-NN/pull/1583)
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -126,7 +126,7 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
 
         @Override
         protected float[] doGetValue() throws IOException {
-            return getVectorDataType().getVectorFromDocValues(values.binaryValue());
+            return getVectorDataType().getVectorFromBytesRef(values.binaryValue());
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -37,7 +37,7 @@ public enum VectorDataType {
         }
 
         @Override
-        public float[] getVectorFromDocValues(BytesRef binaryValue) {
+        public float[] getVectorFromBytesRef(BytesRef binaryValue) {
             float[] vector = new float[binaryValue.length];
             int i = 0;
             int j = binaryValue.offset;
@@ -56,7 +56,7 @@ public enum VectorDataType {
         }
 
         @Override
-        public float[] getVectorFromDocValues(BytesRef binaryValue) {
+        public float[] getVectorFromBytesRef(BytesRef binaryValue) {
             ByteArrayInputStream byteStream = new ByteArrayInputStream(binaryValue.bytes, binaryValue.offset, binaryValue.length);
             final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
             return vectorSerializer.byteToFloatArray(byteStream);
@@ -81,12 +81,12 @@ public enum VectorDataType {
     public abstract FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction);
 
     /**
-     * Deserializes float vector from doc values binary value.
+     * Deserializes float vector from BytesRef.
      *
-     * @param binaryValue Binary Value of DocValues
+     * @param binaryValue Binary Value
      * @return float vector deserialized from binary value
      */
-    public abstract float[] getVectorFromDocValues(BytesRef binaryValue);
+    public abstract float[] getVectorFromBytesRef(BytesRef binaryValue);
 
     /**
      * Validates if given VectorDataType is in the list of supported data types.

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -13,15 +13,16 @@ package org.opensearch.knn.index.mapper;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.index.mapper.ParametrizedFieldMapper;
-import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 import org.opensearch.knn.index.util.KNNEngine;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
@@ -44,7 +45,6 @@ public class KNNVectorFieldMapperUtil {
      */
     public static void validateFP16VectorValue(float value) {
         validateFloatVectorValue(value);
-
         if (value < FP16_MIN_VALUE || value > FP16_MAX_VALUE) {
             throw new IllegalArgumentException(
                 String.format(
@@ -136,9 +136,39 @@ public class KNNVectorFieldMapperUtil {
         return field;
     }
 
-    public static void addStoredFieldForVectorField(ParseContext context, FieldType fieldType, String mapperName, Field vectorField) {
-        if (fieldType.stored()) {
-            context.doc().add(new StoredField(mapperName, vectorField.toString()));
+    /**
+     * Creates a stored field for a byte vector
+     *
+     * @param name field name
+     * @param vector vector to be added to stored field
+     */
+    public static StoredField createStoredFieldForByteVector(String name, byte[] vector) {
+        return new StoredField(name, vector);
+    }
+
+    /**
+     * Creates a stored field for a float vector
+     *
+     * @param name field name
+     * @param vector vector to be added to stored field
+     */
+    public static StoredField createStoredFieldForFloatVector(String name, float[] vector) {
+        return new StoredField(name, KNNVectorSerializerFactory.getDefaultSerializer().floatToByteArray(vector));
+    }
+
+    /**
+     * @param storedVector Vector representation in bytes
+     * @param vectorDataType type of vector
+     * @return either int[] or float[] of corresponding vector
+     */
+    public static Object deserializeStoredVector(BytesRef storedVector, VectorDataType vectorDataType) {
+        if (VectorDataType.BYTE == vectorDataType) {
+            byte[] bytes = storedVector.bytes;
+            int[] byteAsIntArray = new int[bytes.length];
+            Arrays.setAll(byteAsIntArray, i -> bytes[i]);
+            return byteAsIntArray;
         }
+
+        return vectorDataType.getVectorFromBytesRef(storedVector);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -25,7 +25,8 @@ import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.addStoredFieldForVectorField;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForByteVector;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForFloatVector;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
 
 /**
@@ -92,7 +93,9 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
             KnnByteVectorField point = new KnnByteVectorField(name(), array, fieldType);
 
             context.doc().add(point);
-            addStoredFieldForVectorField(context, fieldType, name(), point);
+            if (this.stored) {
+                context.doc().add(createStoredFieldForByteVector(name(), array));
+            }
 
             if (hasDocValues && vectorFieldType != null) {
                 context.doc().add(new VectorField(name(), array, vectorFieldType));
@@ -108,7 +111,9 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
             KnnVectorField point = new KnnVectorField(name(), array, fieldType);
 
             context.doc().add(point);
-            addStoredFieldForVectorField(context, fieldType, name(), point);
+            if (this.stored) {
+                context.doc().add(createStoredFieldForFloatVector(name(), array));
+            }
 
             if (hasDocValues && vectorFieldType != null) {
                 context.doc().add(new VectorField(name(), array, vectorFieldType));

--- a/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
+++ b/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
@@ -53,8 +53,6 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
 
     private static final String FIELD_NAME_VECTOR = "test_vector";
 
-    private static final String PROPERTIES_FIELD = "properties";
-
     private static final String FILTER_FIELD = "filter";
 
     private static final String TERM_FIELD = "term";

--- a/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
@@ -5,20 +5,34 @@
 
 package org.opensearch.knn.index;
 
+import lombok.SneakyThrows;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.apache.http.util.EntityUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Response;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.util.KNNEngine;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.QUERY;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
 public class KNNMapperSearcherIT extends KNNRestTestCase {
-    private static final Logger logger = LogManager.getLogger(KNNMapperSearcherIT.class);
+
+    private static final String INDEX_NAME = "test_index";
+    private static final String FIELD_NAME = "test_vector";
 
     /**
      * Test Data set
@@ -239,4 +253,166 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
         List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
         assertEquals(results.size(), 4);
     }
+
+    /**
+     * Request:
+     * {
+     *   "stored_fields": ["test_vector"],
+     *   "query": {
+     *     "match_all": {}
+     *   }
+     * }
+     *
+     * Example Response:
+     * {
+     *   "took":248,
+     *   "timed_out":false,
+     *   "_shards":{
+     *     "total":1,
+     *     "successful":1,
+     *     "skipped":0,
+     *     "failed":0
+     *   },
+     *   "hits":{
+     *     "total":{
+     *       "value":1,
+     *       "relation":"eq"
+     *     },
+     *     "max_score":1.0,
+     *     "hits":[
+     *       {
+     *         "_index":"test_index",
+     *         "_id":"1",
+     *         "_score":1.0,
+     *         "fields":{"test_vector":[[-128,0,1,127]]}
+     *       }
+     *     ]
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testStoredFields_whenByteDataType_thenSucceed() {
+        // Create index with stored field and confirm that we can properly retrieve it
+        int[] testVector = new int[] { -128, 0, 1, 127 };
+        String expectedResponse = String.format("\"fields\":{\"%s\":[[-128,0,1,127]]}}", FIELD_NAME);
+        createKnnIndex(
+            INDEX_NAME,
+            createVectorMapping(testVector.length, KNNEngine.LUCENE.getName(), VectorDataType.BYTE.getValue(), true)
+        );
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, testVector);
+
+        final XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field(STORED_QUERY_FIELD, List.of(FIELD_NAME));
+        builder.startObject(QUERY);
+        builder.startObject(MATCH_ALL_QUERY_FIELD);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        String response = EntityUtils.toString(performSearch(INDEX_NAME, builder.toString()).getEntity());
+        assertTrue(response.contains(expectedResponse));
+
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    /**
+     * Request:
+     * {
+     *   "stored_fields": ["test_vector"],
+     *   "query": {
+     *     "match_all": {}
+     *   }
+     * }
+     *
+     * Example Response:
+     * {
+     *   "took":248,
+     *   "timed_out":false,
+     *   "_shards":{
+     *     "total":1,
+     *     "successful":1,
+     *     "skipped":0,
+     *     "failed":0
+     *   },
+     *   "hits":{
+     *     "total":{
+     *       "value":1,
+     *       "relation":"eq"
+     *     },
+     *     "max_score":1.0,
+     *     "hits":[
+     *       {
+     *         "_index":"test_index",
+     *         "_id":"1",
+     *         "_score":1.0,
+     *         "fields":{"test_vector":[[-100.0,100.0,0.0,1.0]]}
+     *       }
+     *     ]
+     *   }
+     * }
+     */
+    @SneakyThrows
+    public void testStoredFields_whenFloatDataType_thenSucceed() {
+        List<KNNEngine> enginesToTest = List.of(KNNEngine.NMSLIB, KNNEngine.FAISS, KNNEngine.LUCENE);
+        float[] testVector = new float[] { -100.0f, 100.0f, 0f, 1f };
+        String expectedResponse = String.format("\"fields\":{\"%s\":[[-100.0,100.0,0.0,1.0]]}}", FIELD_NAME);
+        for (KNNEngine knnEngine : enginesToTest) {
+            createKnnIndex(INDEX_NAME, createVectorMapping(testVector.length, knnEngine.getName(), VectorDataType.FLOAT.getValue(), true));
+            addKnnDoc(INDEX_NAME, "1", FIELD_NAME, testVector);
+
+            final XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.startObject();
+            builder.field(STORED_QUERY_FIELD, List.of(FIELD_NAME));
+            builder.startObject(QUERY);
+            builder.startObject(MATCH_ALL_QUERY_FIELD);
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+
+            String response = EntityUtils.toString(performSearch(INDEX_NAME, builder.toString()).getEntity());
+            assertTrue(response.contains(expectedResponse));
+
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+
+    /**
+     * Mapping
+     * {
+     *     "properties": {
+     *         "test_vector": {
+     *             "type": "knn_vector",
+     *             "dimension": {dimension},
+     *             "data_type": "{type}",
+     *             "stored": true
+     *             "method": {
+     *                 "name": "hnsw",
+     *                 "engine": "{engine}"
+     *             }
+     *         }
+     *     }
+     * }
+     */
+    @SneakyThrows
+    private String createVectorMapping(final int dimension, final String engine, final String dataType, final boolean isStored) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .field(VECTOR_DATA_TYPE_FIELD, dataType)
+            .field(STORE_FIELD, isStored)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, engine)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        return builder.toString();
+    }
+
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.StoredField;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+
+public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
+
+    private static final String TEST_FIELD_NAME = "test_field_name";
+    private static final byte[] TEST_BYTE_VECTOR = new byte[] { -128, 0, 1, 127 };
+    private static final float[] TEST_FLOAT_VECTOR = new float[] { -100.0f, 100.0f, 0f, 1f };
+
+    public void testStoredFields_whenVectorIsByteType_thenSucceed() {
+        StoredField storedField = KNNVectorFieldMapperUtil.createStoredFieldForByteVector(TEST_FIELD_NAME, TEST_BYTE_VECTOR);
+        assertEquals(TEST_FIELD_NAME, storedField.name());
+        assertEquals(TEST_BYTE_VECTOR, storedField.binaryValue().bytes);
+        Object vector = KNNVectorFieldMapperUtil.deserializeStoredVector(storedField.binaryValue(), VectorDataType.BYTE);
+        assertTrue(vector instanceof int[]);
+        int[] byteAsIntArray = new int[TEST_BYTE_VECTOR.length];
+        Arrays.setAll(byteAsIntArray, i -> TEST_BYTE_VECTOR[i]);
+        assertArrayEquals(byteAsIntArray, (int[]) vector);
+    }
+
+    public void testStoredFields_whenVectorIsFloatType_thenSucceed() {
+        StoredField storedField = KNNVectorFieldMapperUtil.createStoredFieldForFloatVector(TEST_FIELD_NAME, TEST_FLOAT_VECTOR);
+        assertEquals(TEST_FIELD_NAME, storedField.name());
+        byte[] bytes = storedField.binaryValue().bytes;
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes, 0, bytes.length);
+        assertArrayEquals(
+            TEST_FLOAT_VECTOR,
+            KNNVectorSerializerFactory.getDefaultSerializer().byteToFloatArray(byteArrayInputStream),
+            0.001f
+        );
+
+        Object vector = KNNVectorFieldMapperUtil.deserializeStoredVector(storedField.binaryValue(), VectorDataType.FLOAT);
+        assertTrue(vector instanceof float[]);
+        assertArrayEquals(TEST_FLOAT_VECTOR, (float[]) vector, 0.001f);
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -108,6 +108,10 @@ import static org.opensearch.knn.plugin.stats.StatNames.INDICES_IN_CACHE;
 public class KNNRestTestCase extends ODFERestTestCase {
     public static final String INDEX_NAME = "test_index";
     public static final String FIELD_NAME = "test_field";
+    public static final String PROPERTIES_FIELD = "properties";
+    public static final String STORE_FIELD = "store";
+    public static final String STORED_QUERY_FIELD = "stored_fields";
+    public static final String MATCH_ALL_QUERY_FIELD = "match_all";
     private static final String DOCUMENT_FIELD_SOURCE = "_source";
     private static final String DOCUMENT_FIELD_FOUND = "found";
     protected static final int DELAY_MILLI_SEC = 1000;


### PR DESCRIPTION
### Description
(Backport #1630 to 2.x)
Fixes bug where we were not creating stored field type for knn_vector even when the mapping parameter is passed. Along with this, clean up the field mapper implementations.

Add relevant uTs and iTs to ensure functionality is working as expected.


(cherry picked from commit 699510d61dd8c583653118be172fb60a00463760)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
