### PR TITLE
Enable script score to work with model based indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Serialize all models into cluster metadata [#1499](https://github.com/opensearch-project/k-NN/pull/1499)
 ### Bug Fixes
 * Add stored fields for knn_vector type [#1630](https://github.com/opensearch-project/k-NN/pull/1630)
+* Enable script score to work with model based indices [#1649](https://github.com/opensearch-project/k-NN/pull/1649)
 ### Infrastructure
 * Add micro-benchmark module in k-NN plugin for benchmark streaming vectors to JNI layer functionality. [#1583](https://github.com/opensearch-project/k-NN/pull/1583)
 * Add arm64 check when SIMD is disabled [#1618](https://github.com/opensearch-project/k-NN/pull/1618)

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -195,7 +195,7 @@ public class KNNVectorFieldMapperUtil {
      * @param knnVectorFieldType knn vector field type
      * @return expected dimensions
      */
-    public static int getExpectedDimensions(KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType) {
+    public static int getExpectedDimensions(final KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType) {
         int expectedDimensions = knnVectorFieldType.getDimension();
         if (isModelBasedIndex(expectedDimensions)) {
             ModelMetadata modelMetadata = getModelMetadataForField(knnVectorFieldType);
@@ -214,7 +214,7 @@ public class KNNVectorFieldMapperUtil {
      * @param knnVectorField knn vector field
      * @return the model metadata from knnVectorField
      */
-    private static ModelMetadata getModelMetadataForField(KNNVectorFieldMapper.KNNVectorFieldType knnVectorField) {
+    private static ModelMetadata getModelMetadataForField(final KNNVectorFieldMapper.KNNVectorFieldType knnVectorField) {
         String modelId = knnVectorField.getModelId();
 
         if (modelId == null) {

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -33,6 +33,7 @@ import org.opensearch.knn.plugin.rest.RestSearchModelHandler;
 import org.opensearch.knn.plugin.rest.RestTrainModelHandler;
 import org.opensearch.knn.plugin.rest.RestClearCacheHandler;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
+import org.opensearch.knn.plugin.script.KNNScoringSpaceUtil;
 import org.opensearch.knn.plugin.stats.KNNStats;
 import org.opensearch.knn.plugin.transport.DeleteModelAction;
 import org.opensearch.knn.plugin.transport.DeleteModelTransportAction;
@@ -204,6 +205,7 @@ public class KNNPlugin extends Plugin
         TrainingJobClusterStateListener.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
         KNNQueryBuilder.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
+        KNNScoringSpaceUtil.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         TrainingModelRequest.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
 

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -14,6 +14,7 @@ import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.knn.index.KNNCircuitBreaker;
 import org.opensearch.knn.index.KNNClusterUtil;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
@@ -33,7 +34,6 @@ import org.opensearch.knn.plugin.rest.RestSearchModelHandler;
 import org.opensearch.knn.plugin.rest.RestTrainModelHandler;
 import org.opensearch.knn.plugin.rest.RestClearCacheHandler;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
-import org.opensearch.knn.plugin.script.KNNScoringSpaceUtil;
 import org.opensearch.knn.plugin.stats.KNNStats;
 import org.opensearch.knn.plugin.transport.DeleteModelAction;
 import org.opensearch.knn.plugin.transport.DeleteModelTransportAction;
@@ -205,7 +205,7 @@ public class KNNPlugin extends Plugin
         TrainingJobClusterStateListener.initialize(threadPool, ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
         KNNQueryBuilder.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
-        KNNScoringSpaceUtil.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
+        KNNVectorFieldMapperUtil.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         TrainingModelRequest.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
 

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.plugin.script;
 import org.apache.lucene.search.IndexSearcher;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.apache.lucene.index.LeafReaderContext;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -61,7 +62,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
+                KNNVectorFieldMapperUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
@@ -97,7 +98,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
+                KNNVectorFieldMapperUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             SpaceType.COSINESIMIL.validateVector(processedQuery);
@@ -192,7 +193,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
+                KNNVectorFieldMapperUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
@@ -227,7 +228,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
+                KNNVectorFieldMapperUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
@@ -264,7 +265,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
+                KNNVectorFieldMapperUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -28,6 +28,7 @@ import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToFloatA
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToLong;
 
 public interface KNNScoringSpace {
+
     /**
      * Return the correct scoring script for a given query. The scoring script
      *
@@ -60,7 +61,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
@@ -96,7 +97,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             SpaceType.COSINESIMIL.validateVector(processedQuery);
@@ -191,7 +192,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
@@ -226,7 +227,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
@@ -263,7 +264,7 @@ public interface KNNScoringSpace {
 
             this.processedQuery = parseToFloatArray(
                 query,
-                ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getDimension(),
+                KNNScoringSpaceUtil.getExpectedDimensions((KNNVectorFieldMapper.KNNVectorFieldType) fieldType),
                 ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
             );
             this.scoringMethod = (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -8,9 +8,6 @@ package org.opensearch.knn.plugin.script;
 import java.util.List;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
-import org.opensearch.knn.indices.ModelDao;
-import org.opensearch.knn.indices.ModelMetadata;
-import org.opensearch.knn.indices.ModelUtil;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.MappedFieldType;
@@ -22,13 +19,10 @@ import java.util.Base64;
 import static org.opensearch.index.mapper.NumberFieldMapper.NumberType.LONG;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
 
+/**
+ * Utility class for KNNScoringSpace
+ */
 public class KNNScoringSpaceUtil {
-
-    private static ModelDao modelDao;
-
-    public static void initialize(ModelDao modelDao) {
-        KNNScoringSpaceUtil.modelDao = modelDao;
-    }
 
     /**
      * Check if the passed in fieldType is of type NumberFieldType with numericType being Long
@@ -145,44 +139,5 @@ public class KNNScoringSpaceUtil {
             normInputVector += inputVector[i] * inputVector[i];
         }
         return normInputVector;
-    }
-
-    /**
-     * Get the expected dimensions from a specified knn vector field type.
-     *
-     * If the field is model-based, get dimensions from model metadata.
-     * @param knnVectorFieldType knn vector field type
-     * @return expected dimensions
-     */
-    public static int getExpectedDimensions(KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType) {
-        int expectedDimensions = knnVectorFieldType.getDimension();
-        // Value will be -1 when a model-based index is used. In this case, retrieve expected dimensions from model metadata.
-        if (expectedDimensions == -1) {
-            ModelMetadata modelMetadata = getModelMetadataForField(knnVectorFieldType);
-            expectedDimensions = modelMetadata.getDimension();
-        }
-        return expectedDimensions;
-    }
-
-    /**
-     * Returns the model metadata for a specified knn vector field
-     *
-     * @param knnVectorField knn vector field
-     * @return the model metadata from knnVectorField
-     */
-    private static ModelMetadata getModelMetadataForField(KNNVectorFieldMapper.KNNVectorFieldType knnVectorField) {
-        String modelId = knnVectorField.getModelId();
-
-        if (modelId == null) {
-            throw new IllegalArgumentException(
-                String.format("Field '%s' does not have model.", knnVectorField.getKnnMethodContext().getMethodComponentContext().getName())
-            );
-        }
-
-        ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
-        if (!ModelUtil.isModelCreated(modelMetadata)) {
-            throw new IllegalArgumentException(String.format("Model ID '%s' is not created.", modelId));
-        }
-        return modelMetadata;
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -13,11 +13,19 @@ package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.StoredField;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelState;
 
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
 
@@ -50,5 +58,60 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
         Object vector = KNNVectorFieldMapperUtil.deserializeStoredVector(storedField.binaryValue(), VectorDataType.FLOAT);
         assertTrue(vector instanceof float[]);
         assertArrayEquals(TEST_FLOAT_VECTOR, (float[]) vector, 0.001f);
+    }
+
+    public void testGetExpectedDimensionsSuccess() {
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldType.getDimension()).thenReturn(3);
+
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldTypeModelBased = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldTypeModelBased.getDimension()).thenReturn(-1);
+        String modelId = "test-model";
+        when(knnVectorFieldTypeModelBased.getModelId()).thenReturn(modelId);
+
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata modelMetadata = mock(ModelMetadata.class);
+        when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
+        when(modelMetadata.getDimension()).thenReturn(4);
+        when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
+
+        KNNVectorFieldMapperUtil.initialize(modelDao);
+
+        assertEquals(3, KNNVectorFieldMapperUtil.getExpectedDimensions(knnVectorFieldType));
+        assertEquals(4, KNNVectorFieldMapperUtil.getExpectedDimensions(knnVectorFieldTypeModelBased));
+    }
+
+    public void testGetExpectedDimensionsFailure() {
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldTypeModelBased = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldTypeModelBased.getDimension()).thenReturn(-1);
+        String modelId = "test-model";
+        when(knnVectorFieldTypeModelBased.getModelId()).thenReturn(modelId);
+
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata modelMetadata = mock(ModelMetadata.class);
+        when(modelMetadata.getState()).thenReturn(ModelState.TRAINING);
+        when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
+
+        KNNVectorFieldMapperUtil.initialize(modelDao);
+
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNVectorFieldMapperUtil.getExpectedDimensions(knnVectorFieldTypeModelBased)
+        );
+        assertEquals(String.format("Model ID '%s' is not created.", modelId), e.getMessage());
+
+        when(knnVectorFieldTypeModelBased.getModelId()).thenReturn(null);
+        KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
+        MethodComponentContext methodComponentContext = mock(MethodComponentContext.class);
+        String fieldName = "test-field";
+        when(methodComponentContext.getName()).thenReturn(fieldName);
+        when(knnMethodContext.getMethodComponentContext()).thenReturn(methodComponentContext);
+        when(knnVectorFieldTypeModelBased.getKnnMethodContext()).thenReturn(knnMethodContext);
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNVectorFieldMapperUtil.getExpectedDimensions(knnVectorFieldTypeModelBased)
+        );
+        assertEquals(String.format("Field '%s' does not have model.", fieldName), e.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
@@ -6,15 +6,10 @@
 package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.index.mapper.BinaryFieldMapper;
 import org.opensearch.index.mapper.NumberFieldMapper;
-import org.opensearch.knn.indices.ModelDao;
-import org.opensearch.knn.indices.ModelMetadata;
-import org.opensearch.knn.indices.ModelState;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -79,45 +74,5 @@ public class KNNScoringSpaceUtilTests extends KNNTestCase {
 
         String invalidObject = "invalidObject";
         expectThrows(ClassCastException.class, () -> KNNScoringSpaceUtil.parseToFloatArray(invalidObject, 3, VectorDataType.FLOAT));
-    }
-
-    public void testGetExpectedDimensions() {
-        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
-        when(knnVectorFieldType.getDimension()).thenReturn(3);
-
-        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldTypeModelBased = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
-        when(knnVectorFieldTypeModelBased.getDimension()).thenReturn(-1);
-        String modelId = "test-model";
-        when(knnVectorFieldTypeModelBased.getModelId()).thenReturn(modelId);
-
-        ModelDao modelDao = mock(ModelDao.class);
-        ModelMetadata modelMetadata = mock(ModelMetadata.class);
-        when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
-        when(modelMetadata.getDimension()).thenReturn(4);
-        when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
-
-        KNNScoringSpaceUtil.initialize(modelDao);
-
-        assertEquals(3, KNNScoringSpaceUtil.getExpectedDimensions(knnVectorFieldType));
-        assertEquals(4, KNNScoringSpaceUtil.getExpectedDimensions(knnVectorFieldTypeModelBased));
-
-        when(modelMetadata.getState()).thenReturn(ModelState.TRAINING);
-
-        IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> KNNScoringSpaceUtil.getExpectedDimensions(knnVectorFieldTypeModelBased)
-        );
-        assertEquals(String.format("Model ID '%s' is not created.", modelId), e.getMessage());
-
-        when(knnVectorFieldTypeModelBased.getModelId()).thenReturn(null);
-        KNNMethodContext knnMethodContext = mock(KNNMethodContext.class);
-        MethodComponentContext methodComponentContext = mock(MethodComponentContext.class);
-        String fieldName = "test-field";
-        when(methodComponentContext.getName()).thenReturn(fieldName);
-        when(knnMethodContext.getMethodComponentContext()).thenReturn(methodComponentContext);
-        when(knnVectorFieldTypeModelBased.getKnnMethodContext()).thenReturn(knnMethodContext);
-
-        e = expectThrows(IllegalArgumentException.class, () -> KNNScoringSpaceUtil.getExpectedDimensions(knnVectorFieldTypeModelBased));
-        assertEquals(String.format("Field '%s' does not have model.", fieldName), e.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -555,7 +555,6 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
     public void testKNNScriptScoreOnModelBasedIndex() throws Exception {
         int dimensions = randomIntBetween(2, 10);
-        String modelName = TEST_MODEL;
         String trainMapping = createKnnIndexMapping(TRAIN_FIELD_PARAMETER, dimensions);
         createKnnIndex(TRAIN_INDEX_PARAMETER, trainMapping);
         bulkIngestRandomVectors(TRAIN_INDEX_PARAMETER, TRAIN_FIELD_PARAMETER, dimensions * 3, dimensions);
@@ -571,15 +570,15 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             .endObject();
         Map<String, Object> method = xContentBuilderToMap(methodBuilder);
 
-        trainModel(modelName, TRAIN_INDEX_PARAMETER, TRAIN_FIELD_PARAMETER, dimensions, method, "test model for script score");
-        assertTrainingSucceeds(modelName, 30, 1000);
+        trainModel(TEST_MODEL, TRAIN_INDEX_PARAMETER, TRAIN_FIELD_PARAMETER, dimensions, method, "test model for script score");
+        assertTrainingSucceeds(TEST_MODEL, 30, 1000);
 
         String testMapping = XContentFactory.jsonBuilder()
             .startObject()
             .startObject(PROPERTIES_FIELD)
             .startObject(FIELD_NAME)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(MODEL_ID, modelName)
+            .field(MODEL_ID, TEST_MODEL)
             .endObject()
             .endObject()
             .endObject()

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -39,7 +39,18 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 
 public class KNNScriptScoringIT extends KNNRestTestCase {
 


### PR DESCRIPTION
### Description
Previously, an exception would be thrown when attempting to use script score with a model-based index.  Since the expected dimensions for a model-based index field are set to -1, there would be a mismatch between the actual dimension of the float array and the expected dimension.  This PR retrieves the expected dimensions from the model metadata for model-based indices, thus enabling script score to work as intended.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1554
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
