### PR TITLE
Support filter and nested field in faiss engine radial search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.13...2.x)
 ### Features
-* Support radial search in k-NN plugin [#1617](https://github.com/opensearch-project/k-NN/pull/1617)
+* Support radial search in k-NN plugin [#814](https://github.com/opensearch-project/k-NN/issues/814)
 ### Enhancements
 * Make the HitQueue size more appropriate for exact search [#1549](https://github.com/opensearch-project/k-NN/pull/1549)
 * Support script score when doc value is disabled [#1573](https://github.com/opensearch-project/k-NN/pull/1573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.13...2.x)
 ### Features
-* Support radial search in k-NN plugin [#814](https://github.com/opensearch-project/k-NN/issues/814)
+* Support radial search in k-NN plugin [#1617](https://github.com/opensearch-project/k-NN/pull/1617)
+* Support filter and nested field in faiss engine radial search [#1652](https://github.com/opensearch-project/k-NN/pull/1652)
 ### Enhancements
 * Make the HitQueue size more appropriate for exact search [#1549](https://github.com/opensearch-project/k-NN/pull/1549)
 * Support script score when doc value is disabled [#1573](https://github.com/opensearch-project/k-NN/pull/1573)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -36,7 +36,7 @@ endif ()
 # build workflow once, it can cause issues because git commits require that the user and the user's email be set.
 # See https://github.com/opensearch-project/k-NN/issues/1651. So, we provide a flag that allows users to select between
 # the two
-if(NOT DEFINED COMMIT_LIB_PATCHES OR ${COMMIT_LIB_PATCHES} STREQUAL true)
+if(NOT DEFINED COMMIT_LIB_PATCHES OR "${COMMIT_LIB_PATCHES}" STREQUAL true)
     set(GIT_PATCH_COMMAND am)
 else()
     set(GIT_PATCH_COMMAND apply)

--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -13,13 +13,14 @@ if (NOT EXISTS ${FAISS_REPO_DIR})
 endif ()
 
 # Check if patch exist, this is to skip git apply during CI build. See CI.yml with ubuntu.
-find_path(PATCH_FILE NAMES 0001-Custom-patch-to-support-multi-vector.patch 0002-Enable-precomp-table-to-be-shared-ivfpq.patch PATHS ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss NO_DEFAULT_PATH)
+find_path(PATCH_FILE NAMES 0001-Custom-patch-to-support-multi-vector.patch 0002-Enable-precomp-table-to-be-shared-ivfpq.patch 0003-Custom-patch-to-support-range-search-params.patch PATHS ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss NO_DEFAULT_PATH)
 
 # If it exists, apply patches
 if (EXISTS ${PATCH_FILE})
     message(STATUS "Applying custom patches.")
     execute_process(COMMAND git ${GIT_PATCH_COMMAND} --3way --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
     execute_process(COMMAND git ${GIT_PATCH_COMMAND} --3way --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0002-Enable-precomp-table-to-be-shared-ivfpq.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
+    execute_process(COMMAND git ${GIT_PATCH_COMMAND} --3way --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0003-Custom-patch-to-support-range-search-params.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
     if(RESULT_CODE)
         message(FATAL_ERROR "Failed to apply patch:\n${ERROR_MSG}")
     endif()

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -75,16 +75,34 @@ namespace knn_jni {
                               jlong trainVectorsPointerJ);
 
         /*
+         * Perform a range search with filter against the index located in memory at indexPointerJ.
+         *
+         * @param indexPointerJ - pointer to the index
+         * @param queryVectorJ - the query vector
+         * @param radiusJ - the radius for the range search
+         * @param maxResultsWindowJ - the maximum number of results to return
+         * @param filterIdsJ - the filter ids
+         * @param filterIdsTypeJ - the filter ids type
+         * @param parentIdsJ - the parent ids
+         *
+         * @return an array of RangeQueryResults
+         */
+        jobjectArray RangeSearchWithFilter(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
+                                           jfloat radiusJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ);
+
+        /*
          * Perform a range search against the index located in memory at indexPointerJ.
          *
          * @param indexPointerJ - pointer to the index
          * @param queryVectorJ - the query vector
          * @param radiusJ - the radius for the range search
          * @param maxResultsWindowJ - the maximum number of results to return
+         * @param parentIdsJ - the parent ids
+         *
          * @return an array of RangeQueryResults
          */
         jobjectArray RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
-                    jfloat radiusJ, jint maxResultsWindowJ);
+                    jfloat radiusJ, jint maxResultWindowJ, jintArray parentIdsJ);
     }
 }
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -124,11 +124,19 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 
 /*
 * Class:     org_opensearch_knn_jni_FaissService
-* Method:    rangeSearchIndex
-* Signature: (J[F[F)J
+* Method:    rangeSearchIndexWithFilter
+* Signature: (J[FJ[I)[Lorg/opensearch/knn/index/query/RangeQueryResult;
 */
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter
+  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint, jlongArray, jint, jintArray);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    rangeSearchIndex
+ * Signature: (J[FJ[I)[Lorg/opensearch/knn/index/query/RangeQueryResult;
+ */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex
-  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint);
+  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint, jintArray);
 
 #ifdef __cplusplus
 }

--- a/jni/patches/faiss/0003-Custom-patch-to-support-range-search-params.patch
+++ b/jni/patches/faiss/0003-Custom-patch-to-support-range-search-params.patch
@@ -1,0 +1,53 @@
+From af6770b505a32b2c4eab2036d2509dec4b137f28 Mon Sep 17 00:00:00 2001
+From: Junqiu Lei <junqiu@amazon.com>
+Date: Tue, 23 Apr 2024 17:18:56 -0700
+Subject: [PATCH] Custom patch to support range search params
+
+Signed-off-by: Junqiu Lei <junqiu@amazon.com>
+---
+ faiss/IndexIDMap.cpp | 28 ++++++++++++++++++++++++----
+ 1 file changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/faiss/IndexIDMap.cpp b/faiss/IndexIDMap.cpp
+index 3f375e7b..11f3a847 100644
+--- a/faiss/IndexIDMap.cpp
++++ b/faiss/IndexIDMap.cpp
+@@ -176,11 +176,31 @@ void IndexIDMapTemplate<IndexT>::range_search(
+         RangeSearchResult* result,
+         const SearchParameters* params) const {
+     if (params) {
+-        SearchParameters internal_search_parameters;
+-        IDSelectorTranslated id_selector_translated(id_map, params->sel);
+-        internal_search_parameters.sel = &id_selector_translated;
++        IDSelectorTranslated this_idtrans(this->id_map, nullptr);
++        ScopedSelChange sel_change;
++        IDGrouperTranslated this_idgrptrans(this->id_map, nullptr);
++        ScopedGrpChange grp_change;
++
++        if (params->sel) {
++            auto idtrans = dynamic_cast<const IDSelectorTranslated*>(params->sel);
++
++            if (!idtrans) {
++                auto params_non_const = const_cast<SearchParameters*>(params);
++                this_idtrans.sel = params->sel;
++                sel_change.set(params_non_const, &this_idtrans);
++            }
++        }
++
++        if (params->grp) {
++            auto idtrans = dynamic_cast<const IDGrouperTranslated*>(params->grp);
+ 
+-        index->range_search(n, x, radius, result, &internal_search_parameters);
++            if (!idtrans) {
++                auto params_non_const = const_cast<SearchParameters*>(params);
++                this_idgrptrans.grp = params->grp;
++                grp_change.set(params_non_const, &this_idgrptrans);
++            }
++        }
++        index->range_search(n, x, radius, result, params);
+     } else {
+         index->range_search(n, x, radius, result);
+     }
+-- 
+2.39.0
+

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -27,6 +27,7 @@
 #include <jni.h>
 #include <string>
 #include <vector>
+#include <iostream>
 
 // Defines type of IDSelector
 enum FilterIdsSelectorType{
@@ -589,7 +590,12 @@ faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index) {
 }
 
 jobjectArray knn_jni::faiss_wrapper::RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ,
-                                                 jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ) {
+                                                 jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ, jintArray parentIdsJ) {
+    return knn_jni::faiss_wrapper::RangeSearchWithFilter(jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ, nullptr, 0, parentIdsJ);
+}
+
+jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ,
+                                                           jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ) {
     if (queryVectorJ == nullptr) {
         throw std::runtime_error("Query Vector cannot be null");
     }
@@ -605,7 +611,69 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearch(knn_jni::JNIUtilInterface *jniU
     // The res will be freed by ~RangeSearchResult() in FAISS
     // The second parameter is always true, as lims is allocated by FAISS
     faiss::RangeSearchResult res(1, true);
-    indexReader->range_search(1, rawQueryVector, radiusJ, &res);
+
+    if(filterIdsJ != nullptr) {
+        jlong *filteredIdsArray = jniUtil->GetLongArrayElements(env, filterIdsJ, nullptr);
+        int filterIdsLength = jniUtil->GetJavaLongArrayLength(env, filterIdsJ);
+        std::unique_ptr<faiss::IDSelector> idSelector;
+        if(filterIdsTypeJ == BITMAP) {
+            idSelector.reset(new faiss::IDSelectorJlongBitmap(filterIdsLength, filteredIdsArray));
+        } else {
+            faiss::idx_t* batchIndices = reinterpret_cast<faiss::idx_t*>(filteredIdsArray);
+            idSelector.reset(new faiss::IDSelectorBatch(filterIdsLength, batchIndices));
+        }
+        faiss::SearchParameters *searchParameters;
+        faiss::SearchParametersHNSW hnswParams;
+        faiss::SearchParametersIVF ivfParams;
+        std::unique_ptr<faiss::IDGrouperBitmap> idGrouper;
+        std::vector<uint64_t> idGrouperBitmap;
+        auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
+        if(hnswReader) {
+            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
+            // value of ef_search = 16 which will then be used.
+            hnswParams.efSearch = hnswReader->hnsw.efSearch;
+            hnswParams.sel = idSelector.get();
+            if (parentIdsJ != nullptr) {
+                idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
+                hnswParams.grp = idGrouper.get();
+            }
+            searchParameters = &hnswParams;
+        } else {
+            auto ivfReader = dynamic_cast<const faiss::IndexIVF*>(indexReader->index);
+            auto ivfFlatReader = dynamic_cast<const faiss::IndexIVFFlat*>(indexReader->index);
+            if(ivfReader || ivfFlatReader) {
+                ivfParams.sel = idSelector.get();
+                searchParameters = &ivfParams;
+            }
+        }
+        try {
+            indexReader->range_search(1, rawQueryVector, radiusJ, &res, searchParameters);
+        } catch (...) {
+            jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryVector, JNI_ABORT);
+            jniUtil->ReleaseLongArrayElements(env, filterIdsJ, filteredIdsArray, JNI_ABORT);
+            throw;
+        }
+    } else {
+        faiss::SearchParameters *searchParameters = nullptr;
+        faiss::SearchParametersHNSW hnswParams;
+        std::unique_ptr<faiss::IDGrouperBitmap> idGrouper;
+        std::vector<uint64_t> idGrouperBitmap;
+        auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
+        if(hnswReader!= nullptr && parentIdsJ != nullptr) {
+            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
+            // value of ef_search = 16 which will then be used.
+            hnswParams.efSearch = hnswReader->hnsw.efSearch;
+            idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
+            hnswParams.grp = idGrouper.get();
+            searchParameters = &hnswParams;
+        }
+        try {
+            indexReader->range_search(1, rawQueryVector, radiusJ, &res, searchParameters);
+        } catch (...) {
+            jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryVector, JNI_ABORT);
+            throw;
+        }
+    }
 
     // lims is structured to support batched queries, it has a length of nq + 1 (where nq is the number of queries),
     // lims[i] - lims[i-1] gives the number of results for the i-th query. With a single query we used in k-NN,

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -27,7 +27,6 @@
 #include <jni.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 // Defines type of IDSelector
 enum FilterIdsSelectorType{

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -194,11 +194,26 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jint maxResultWindowJ)
+                                                                                   jfloat radiusJ, jint maxResultWindowJ,
+                                                                                   jintArray parentIdsJ)
 {
     try {
-        return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ);
+        return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ, parentIdsJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return nullptr;
+}
 
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter(JNIEnv * env, jclass cls,
+                                                                                   jlong indexPointerJ,
+                                                                                   jfloatArray queryVectorJ,
+                                                                                   jfloat radiusJ, jint maxResultWindowJ,
+                                                                                   jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ)
+{
+    try {
+        return knn_jni::faiss_wrapper::RangeSearchWithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ,
+                                                             maxResultWindowJ, filterIdsJ, filterIdsTypeJ, parentIdsJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -135,4 +135,5 @@ public class KNNConstants {
     public static int MAX_DISTANCE_COMPUTATIONS = 2048000;
 
     public static final Float DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
+    public static final String MIN_SCORE = "min_score";
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -136,4 +136,5 @@ public class KNNConstants {
 
     public static final Float DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
     public static final String MIN_SCORE = "min_score";
+    public static final String MAX_DISTANCE = "max_distance";
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -65,8 +65,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     private final String fieldName;
     private final float[] vector;
     private int k = 0;
-    private Float max_distance = null;
-    private Float min_score = null;
+    private Float maxDistance = null;
+    private Float minScore = null;
     private QueryBuilder filter;
     private boolean ignoreUnmapped = false;
 
@@ -99,7 +99,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (k == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires k to be set");
         }
-        validateSingleQueryType(k, max_distance, min_score);
+        validateSingleQueryType(k, maxDistance, minScore);
         if (k <= 0 || k > K_MAX) {
             throw new IllegalArgumentException("[" + NAME + "] requires 0 < k <= " + K_MAX);
         }
@@ -108,33 +108,33 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     }
 
     /**
-     * Builder method for max_distance
+     * Builder method for maxDistance
      *
-     * @param max_distance the max_distance threshold for the nearest neighbours
+     * @param maxDistance the maxDistance threshold for the nearest neighbours
      */
-    public KNNQueryBuilder maxDistance(Float max_distance) {
-        if (max_distance == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires max_distance to be set");
+    public KNNQueryBuilder maxDistance(Float maxDistance) {
+        if (maxDistance == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires maxDistance to be set");
         }
-        validateSingleQueryType(k, max_distance, min_score);
-        this.max_distance = max_distance;
+        validateSingleQueryType(k, maxDistance, minScore);
+        this.maxDistance = maxDistance;
         return this;
     }
 
     /**
-     * Builder method for min_score
+     * Builder method for minScore
      *
-     * @param min_score the min_score threshold for the nearest neighbours
+     * @param minScore the minScore threshold for the nearest neighbours
      */
-    public KNNQueryBuilder minScore(Float min_score) {
-        if (min_score == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires min_score to be set");
+    public KNNQueryBuilder minScore(Float minScore) {
+        if (minScore == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires minScore to be set");
         }
-        validateSingleQueryType(k, max_distance, min_score);
-        if (min_score <= 0) {
-            throw new IllegalArgumentException("[" + NAME + "] requires min_score greater than 0");
+        validateSingleQueryType(k, maxDistance, minScore);
+        if (minScore <= 0) {
+            throw new IllegalArgumentException("[" + NAME + "] requires minScore greater than 0");
         }
-        this.min_score = min_score;
+        this.minScore = minScore;
         return this;
     }
 
@@ -181,8 +181,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         this.k = k;
         this.filter = filter;
         this.ignoreUnmapped = false;
-        this.max_distance = null;
-        this.min_score = null;
+        this.maxDistance = null;
+        this.minScore = null;
     }
 
     public static void initialize(ModelDao modelDao) {
@@ -218,10 +218,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 ignoreUnmapped = in.readOptionalBoolean();
             }
             if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
-                max_distance = in.readOptionalFloat();
+                maxDistance = in.readOptionalFloat();
             }
             if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
-                min_score = in.readOptionalFloat();
+                minScore = in.readOptionalFloat();
             }
         } catch (IOException ex) {
             throw new RuntimeException("[KNN] Unable to create KNNQueryBuilder", ex);
@@ -233,8 +233,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         List<Object> vector = null;
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         Integer k = null;
-        Float max_distance = null;
-        Float min_score = null;
+        Float maxDistance = null;
+        Float minScore = null;
         QueryBuilder filter = null;
         String queryName = null;
         String currentFieldName = null;
@@ -264,9 +264,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                         } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                             queryName = parser.text();
                         } else if (MAX_DISTANCE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                            max_distance = (Float) NumberFieldMapper.NumberType.FLOAT.parse(parser.objectBytes(), false);
+                            maxDistance = (Float) NumberFieldMapper.NumberType.FLOAT.parse(parser.objectBytes(), false);
                         } else if (MIN_SCORE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                            min_score = (Float) NumberFieldMapper.NumberType.FLOAT.parse(parser.objectBytes(), false);
+                            minScore = (Float) NumberFieldMapper.NumberType.FLOAT.parse(parser.objectBytes(), false);
                         } else {
                             throw new ParsingException(
                                 parser.getTokenLocation(),
@@ -296,7 +296,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             }
         }
 
-        validateSingleQueryType(k, max_distance, min_score);
+        validateSingleQueryType(k, maxDistance, minScore);
 
         KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(fieldName, ObjectsToFloats(vector)).filter(filter)
             .ignoreUnmapped(ignoreUnmapped)
@@ -305,10 +305,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
         if (k != null) {
             knnQueryBuilder.k(k);
-        } else if (max_distance != null) {
-            knnQueryBuilder.maxDistance(max_distance);
-        } else if (min_score != null) {
-            knnQueryBuilder.minScore(min_score);
+        } else if (maxDistance != null) {
+            knnQueryBuilder.maxDistance(maxDistance);
+        } else if (minScore != null) {
+            knnQueryBuilder.minScore(minScore);
         }
 
         return knnQueryBuilder;
@@ -324,10 +324,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             out.writeOptionalBoolean(ignoreUnmapped);
         }
         if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
-            out.writeOptionalFloat(max_distance);
+            out.writeOptionalFloat(maxDistance);
         }
         if (isClusterOnOrAfterMinRequiredVersion(KNNConstants.RADIAL_SEARCH_KEY)) {
-            out.writeOptionalFloat(min_score);
+            out.writeOptionalFloat(minScore);
         }
     }
 
@@ -350,11 +350,11 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     }
 
     public float getMaxDistance() {
-        return this.max_distance;
+        return this.maxDistance;
     }
 
     public float getMinScore() {
-        return this.min_score;
+        return this.minScore;
     }
 
     public QueryBuilder getFilter() {
@@ -385,14 +385,14 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (filter != null) {
             builder.field(FILTER_FIELD.getPreferredName(), filter);
         }
-        if (max_distance != null) {
-            builder.field(MAX_DISTANCE_FIELD.getPreferredName(), max_distance);
+        if (maxDistance != null) {
+            builder.field(MAX_DISTANCE_FIELD.getPreferredName(), maxDistance);
         }
         if (ignoreUnmapped) {
             builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), ignoreUnmapped);
         }
-        if (min_score != null) {
-            builder.field(MIN_SCORE_FIELD.getPreferredName(), min_score);
+        if (minScore != null) {
+            builder.field(MIN_SCORE_FIELD.getPreferredName(), minScore);
         }
         printBoostAndQueryName(builder);
         builder.endObject();
@@ -436,18 +436,18 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         // Currently, k-NN supports distance and score types radial search
         // We need transform distance/score to right type of engine required radius.
         Float radius = null;
-        if (this.max_distance != null) {
-            if (this.max_distance < 0 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
+        if (this.maxDistance != null) {
+            if (this.maxDistance < 0 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException("[" + NAME + "] requires distance to be non-negative for space type: " + spaceType);
             }
-            radius = knnEngine.distanceToRadialThreshold(this.max_distance, spaceType);
+            radius = knnEngine.distanceToRadialThreshold(this.maxDistance, spaceType);
         }
 
-        if (this.min_score != null) {
-            if (this.min_score > 1 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
+        if (this.minScore != null) {
+            if (this.minScore > 1 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException("[" + NAME + "] requires score to be in the range (0, 1] for space type: " + spaceType);
             }
-            radius = knnEngine.scoreToRadialThreshold(this.min_score, spaceType);
+            radius = knnEngine.scoreToRadialThreshold(this.minScore, spaceType);
         }
 
         if (fieldDimension != vector.length) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -80,13 +80,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
      */
     public KNNQueryBuilder(String fieldName, float[] vector) {
         if (Strings.isNullOrEmpty(fieldName)) {
-            throw new IllegalArgumentException("[" + NAME + "] requires fieldName");
+            throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
         }
         if (vector == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires query vector");
+            throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
         }
         if (vector.length == 0) {
-            throw new IllegalArgumentException("[" + NAME + "] query vector is empty");
+            throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
         }
         this.fieldName = fieldName;
         this.vector = vector;
@@ -99,11 +99,11 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
      */
     public KNNQueryBuilder k(Integer k) {
         if (k == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires k to be set");
+            throw new IllegalArgumentException(String.format("[%s] requires k to be set", NAME));
         }
         validateSingleQueryType(k, maxDistance, minScore);
         if (k <= 0 || k > K_MAX) {
-            throw new IllegalArgumentException("[" + NAME + "] requires 0 < k <= " + K_MAX);
+            throw new IllegalArgumentException(String.format("[%s] requires k to be in the range (0, %d]", NAME, K_MAX));
         }
         this.k = k;
         return this;
@@ -116,7 +116,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
      */
     public KNNQueryBuilder maxDistance(Float maxDistance) {
         if (maxDistance == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires maxDistance to be set");
+            throw new IllegalArgumentException(String.format("[%s] requires maxDistance to be set", NAME));
         }
         validateSingleQueryType(k, maxDistance, minScore);
         this.maxDistance = maxDistance;
@@ -130,11 +130,11 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
      */
     public KNNQueryBuilder minScore(Float minScore) {
         if (minScore == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires minScore to be set");
+            throw new IllegalArgumentException(String.format("[%s] requires minScore to be set", NAME));
         }
         validateSingleQueryType(k, maxDistance, minScore);
         if (minScore <= 0) {
-            throw new IllegalArgumentException("[" + NAME + "] requires minScore greater than 0");
+            throw new IllegalArgumentException(String.format("[%s] requires minScore to be greater than 0", NAME));
         }
         this.minScore = minScore;
         return this;
@@ -163,19 +163,19 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     public KNNQueryBuilder(String fieldName, float[] vector, int k, QueryBuilder filter) {
         if (Strings.isNullOrEmpty(fieldName)) {
-            throw new IllegalArgumentException("[" + NAME + "] requires fieldName");
+            throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
         }
         if (vector == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires query vector");
+            throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
         }
         if (vector.length == 0) {
-            throw new IllegalArgumentException("[" + NAME + "] query vector is empty");
+            throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
         }
         if (k <= 0) {
-            throw new IllegalArgumentException("[" + NAME + "] requires k > 0");
+            throw new IllegalArgumentException(String.format("[%s] requires k > 0", NAME));
         }
         if (k > K_MAX) {
-            throw new IllegalArgumentException("[" + NAME + "] requires k <= " + K_MAX);
+            throw new IllegalArgumentException(String.format("[%s] requires k <= %d", NAME, K_MAX));
         }
 
         this.fieldName = fieldName;
@@ -440,14 +440,18 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         Float radius = null;
         if (this.maxDistance != null) {
             if (this.maxDistance < 0 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
-                throw new IllegalArgumentException("[" + NAME + "] requires distance to be non-negative for space type: " + spaceType);
+                throw new IllegalArgumentException(
+                    String.format("[" + NAME + "] requires distance to be non-negative for space type: %s", spaceType)
+                );
             }
             radius = knnEngine.distanceToRadialThreshold(this.maxDistance, spaceType);
         }
 
         if (this.minScore != null) {
             if (this.minScore > 1 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
-                throw new IllegalArgumentException("[" + NAME + "] requires score to be in the range (0, 1] for space type: " + spaceType);
+                throw new IllegalArgumentException(
+                    String.format("[" + NAME + "] requires score to be in the range [0, 1] for space type: %s", spaceType)
+                );
             }
             radius = knnEngine.scoreToRadialThreshold(this.minScore, spaceType);
         }
@@ -509,7 +513,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 .build();
             return RNNQueryFactory.create(createQueryRequest);
         }
-        throw new IllegalArgumentException("[" + NAME + "] requires either k or distance or score to be set");
+        throw new IllegalArgumentException(String.format("[%s] requires k or distance or score to be set", NAME));
     }
 
     private ModelMetadata getModelMetadataForField(KNNVectorFieldMapper.KNNVectorFieldType knnVectorField) {
@@ -559,9 +563,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
 
         if (countSetFields != 1) {
-            throw new IllegalArgumentException(
-                "[" + NAME + "] requires only one query type to be set, it can be either k, distance, or score"
-            );
+            throw new IllegalArgumentException(String.format("[%s] requires exactly one of k, distance or score to be set", NAME));
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -37,6 +37,8 @@ import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryShardContext;
 
+import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
+import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
 import static org.opensearch.knn.index.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
 import static org.opensearch.knn.index.util.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
@@ -52,8 +54,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     public static final ParseField K_FIELD = new ParseField("k");
     public static final ParseField FILTER_FIELD = new ParseField("filter");
     public static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
-    public static final ParseField MAX_DISTANCE_FIELD = new ParseField("max_distance");
-    public static final ParseField MIN_SCORE_FIELD = new ParseField("min_score");
+    public static final ParseField MAX_DISTANCE_FIELD = new ParseField(MAX_DISTANCE);
+    public static final ParseField MIN_SCORE_FIELD = new ParseField(MIN_SCORE);
     public static final int K_MAX = 10000;
     /**
      * The name for the knn query

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -294,7 +294,10 @@ public class KNNWeight extends Weight {
                     knnQuery.getQueryVector(),
                     knnQuery.getRadius(),
                     knnEngine,
-                    knnQuery.getContext().getMaxResultWindow()
+                    knnQuery.getContext().getMaxResultWindow(),
+                    filterIds,
+                    filterType.getValue(),
+                    parentIds
                 );
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -192,13 +192,42 @@ class FaissService {
     public static native long transferVectors(long vectorsPointer, float[][] trainingData);
 
     /**
+     * Range search index with filter
+     *
+     * @param indexPointer pointer to index in memory
+     * @param queryVector vector to be used for query
+     * @param radius search within radius threshold
+     * @param indexMaxResultWindow maximum number of results to return
+     * @param filteredIds list of doc ids to include in the query result
+     * @param filterIdsType type of filter ids
+     * @param parentIds list of parent doc ids when the knn field is a nested field
+     * @return KNNQueryResult array of neighbors within radius
+     */
+    public static native KNNQueryResult[] rangeSearchIndexWithFilter(
+        long indexPointer,
+        float[] queryVector,
+        float radius,
+        int indexMaxResultWindow,
+        long[] filteredIds,
+        int filterIdsType,
+        int[] parentIds
+    );
+
+    /**
      * Range search index
      *
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
      * @param indexMaxResultWindow maximum number of results to return
+     * @param parentIds list of parent doc ids when the knn field is a nested field
      * @return KNNQueryResult array of neighbors within radius
      */
-    public static native KNNQueryResult[] rangeSearchIndex(long indexPointer, float[] queryVector, float radius, int indexMaxResultWindow);
+    public static native KNNQueryResult[] rangeSearchIndex(
+        long indexPointer,
+        float[] queryVector,
+        float radius,
+        int indexMaxResultWindow,
+        int[] parentIds
+    );
 }

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -271,6 +271,9 @@ public class JNIService {
      * @param radius search within radius threshold
      * @param knnEngine engine to query index
      * @param indexMaxResultWindow maximum number of results to return
+     * @param filteredIds list of doc ids to include in the query result
+     * @param filterIdsType how to filter ids: Batch or BitMap
+     * @param parentIds parent ids of the vectors
      * @return KNNQueryResult array of neighbors within radius
      */
     public static KNNQueryResult[] radiusQueryIndex(
@@ -278,10 +281,24 @@ public class JNIService {
         float[] queryVector,
         float radius,
         KNNEngine knnEngine,
-        int indexMaxResultWindow
+        int indexMaxResultWindow,
+        long[] filteredIds,
+        int filterIdsType,
+        int[] parentIds
     ) {
         if (KNNEngine.FAISS == knnEngine) {
-            return FaissService.rangeSearchIndex(indexPointer, queryVector, radius, indexMaxResultWindow);
+            if (ArrayUtils.isNotEmpty(filteredIds)) {
+                return FaissService.rangeSearchIndexWithFilter(
+                    indexPointer,
+                    queryVector,
+                    radius,
+                    indexMaxResultWindow,
+                    filteredIds,
+                    filterIdsType,
+                    parentIds
+                );
+            }
+            return FaissService.rangeSearchIndex(indexPointer, queryVector, radius, indexMaxResultWindow, parentIds);
         }
         throw new IllegalArgumentException("RadiusQueryIndex not supported for provided engine");
     }

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -23,6 +23,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.client.ResponseException;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNResult;
@@ -34,6 +35,7 @@ import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -91,7 +93,7 @@ public class FaissIT extends KNNRestTestCase {
         String indexName = "test-index-1";
         String fieldName = "test-field-1";
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
@@ -108,10 +110,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -180,7 +182,7 @@ public class FaissIT extends KNNRestTestCase {
         String indexName = "test-index-1";
         String fieldName = "test-field-1";
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
@@ -197,10 +199,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -279,7 +281,7 @@ public class FaissIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testEndToEnd_whenDoRadiusSearch_whenDistanceThreshold_whenMethodIsHNSWFlat_thenSucceed() {
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
@@ -296,10 +298,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -330,7 +332,7 @@ public class FaissIT extends KNNRestTestCase {
         assertEquals(testData.indexData.docs.length, getDocCount(INDEX_NAME));
 
         float distance = 300000000000f;
-        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, distance, null, spaceType);
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, distance, null, spaceType, null);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
@@ -338,7 +340,7 @@ public class FaissIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testEndToEnd_whenDoRadiusSearch_whenScoreThreshold_whenMethodIsHNSWFlat_thenSucceed() {
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
@@ -355,10 +357,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -390,7 +392,7 @@ public class FaissIT extends KNNRestTestCase {
 
         float score = 0.00001f;
 
-        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType);
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType, null);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
@@ -398,7 +400,7 @@ public class FaissIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testEndToEnd_whenDoRadiusSearch_whenMoreThanOneScoreThreshold_whenMethodIsHNSWFlat_thenSucceed() {
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.INNER_PRODUCT;
 
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
@@ -415,10 +417,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -450,14 +452,14 @@ public class FaissIT extends KNNRestTestCase {
 
         float score = 5f;
 
-        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType);
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType, null);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
     }
 
     @SneakyThrows
-    public void testEndToEnd_whenDoRadiusSearch__whenDistanceThreshold_whenMethodIsHNSWPQ_thenSucceed() {
+    public void testEndToEnd_whenDoRadiusSearch_whenDistanceThreshold_whenMethodIsHNSWPQ_thenSucceed() {
         String indexName = "test-index";
         String fieldName = "test-field";
         String trainingIndexName = "training-index";
@@ -535,7 +537,7 @@ public class FaissIT extends KNNRestTestCase {
 
         float distance = 300000000000f;
 
-        validateRadiusSearchResults(indexName, fieldName, testData.queries, distance, null, spaceType);
+        validateRadiusSearchResults(indexName, fieldName, testData.queries, distance, null, spaceType, null);
 
         // Delete index
         deleteKNNIndex(indexName);
@@ -552,6 +554,32 @@ public class FaissIT extends KNNRestTestCase {
         }
 
         fail("Graphs are not getting evicted");
+    }
+
+    @SneakyThrows
+    public void testRadialQuery_withFilter_thenSuccess() {
+        setupKNNIndexForFilterQuery();
+
+        final float[][] searchVector = new float[][] { { 3.3f, 3.0f, 5.0f } };
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery("color", "red");
+        List<String> expectedDocIds = Arrays.asList(DOC_ID_3);
+
+        float distance = 15f;
+        List<List<KNNResult>> queryResult = validateRadiusSearchResults(
+            INDEX_NAME,
+            FIELD_NAME,
+            searchVector,
+            distance,
+            null,
+            SpaceType.L2,
+            termQueryBuilder
+        );
+
+        assertEquals(1, queryResult.get(0).size());
+        assertEquals(expectedDocIds.get(0), queryResult.get(0).get(0).getDocId());
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
     }
 
     @SneakyThrows
@@ -670,7 +698,7 @@ public class FaissIT extends KNNRestTestCase {
         String indexName = "test-index-hnsw-sqfp16";
         String fieldName = "test-field-hnsw-sqfp16";
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType[] spaceTypes = { SpaceType.L2, SpaceType.INNER_PRODUCT };
         Random random = new Random();
         SpaceType spaceType = spaceTypes[random.nextInt(spaceTypes.length)];
@@ -690,10 +718,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -784,7 +812,7 @@ public class FaissIT extends KNNRestTestCase {
         String indexName = "test-index-sqfp16";
         String fieldName = "test-field-sqfp16";
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType[] spaceTypes = { SpaceType.L2, SpaceType.INNER_PRODUCT };
         Random random = new Random();
         SpaceType spaceType = spaceTypes[random.nextInt(spaceTypes.length)];
@@ -803,10 +831,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -886,7 +914,7 @@ public class FaissIT extends KNNRestTestCase {
         String indexName = "test-index-sqfp16-clip-fp16";
         String fieldName = "test-field-sqfp16";
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         Random random = new Random();
 
         List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
@@ -903,10 +931,10 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .startObject(KNNConstants.PARAMETERS)
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
             .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
@@ -1351,7 +1379,7 @@ public class FaissIT extends KNNRestTestCase {
         String fieldName = "test-field-1";
         Integer dimension = 2;
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
         // Create an index
@@ -1362,9 +1390,9 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -1387,7 +1415,7 @@ public class FaissIT extends KNNRestTestCase {
         String fieldName = "test-field-1";
         Integer dimension = 2;
 
-        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW);
+        KNNMethod hnswMethod = KNNEngine.FAISS.getMethod(METHOD_HNSW);
         SpaceType spaceType = SpaceType.L2;
 
         // Create an index
@@ -1398,9 +1426,9 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", dimension)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, hnswMethod.getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .field(NAME, hnswMethod.getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -1576,9 +1604,9 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", 2)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW).getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .field(NAME, KNNEngine.FAISS.getMethod(METHOD_HNSW).getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -1627,9 +1655,9 @@ public class FaissIT extends KNNRestTestCase {
             .field("type", "knn_vector")
             .field("dimension", 3)
             .startObject(KNNConstants.KNN_METHOD)
-            .field(KNNConstants.NAME, KNNEngine.FAISS.getMethod(KNNConstants.METHOD_HNSW).getMethodComponent().getName())
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .field(NAME, KNNEngine.FAISS.getMethod(METHOD_HNSW).getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .endObject()
             .endObject()
             .endObject()
@@ -1689,14 +1717,16 @@ public class FaissIT extends KNNRestTestCase {
         fail("Graphs are not getting evicted");
     }
 
-    private void validateRadiusSearchResults(
+    private List<List<KNNResult>> validateRadiusSearchResults(
         String indexName,
         String fieldName,
         float[][] queryVectors,
         Float distanceThreshold,
         Float scoreThreshold,
-        final SpaceType spaceType
+        final SpaceType spaceType,
+        TermQueryBuilder filterQuery
     ) throws IOException, ParseException {
+        List<List<KNNResult>> queryResults = new ArrayList<>();
         for (float[] queryVector : queryVectors) {
             XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject("query");
             queryBuilder.startObject("knn");
@@ -1708,6 +1738,9 @@ public class FaissIT extends KNNRestTestCase {
                 queryBuilder.field("min_score", scoreThreshold);
             } else {
                 throw new IllegalArgumentException("Invalid threshold");
+            }
+            if (filterQuery != null) {
+                queryBuilder.field("filter", filterQuery);
             }
             queryBuilder.endObject();
             queryBuilder.endObject();
@@ -1727,6 +1760,8 @@ public class FaissIT extends KNNRestTestCase {
                     throw new IllegalArgumentException("Invalid space type");
                 }
             }
+            queryResults.add(knnResults);
         }
+        return queryResults;
     }
 }

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -57,12 +57,14 @@ import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MAX_VALUE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MIN_VALUE;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
@@ -1733,9 +1735,9 @@ public class FaissIT extends KNNRestTestCase {
             queryBuilder.startObject(fieldName);
             queryBuilder.field("vector", queryVector);
             if (distanceThreshold != null) {
-                queryBuilder.field("max_distance", distanceThreshold);
+                queryBuilder.field(MAX_DISTANCE, distanceThreshold);
             } else if (scoreThreshold != null) {
-                queryBuilder.field("min_score", scoreThreshold);
+                queryBuilder.field(MIN_SCORE, scoreThreshold);
             } else {
                 throw new IllegalArgumentException("Invalid threshold");
             }

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -34,7 +34,9 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
@@ -629,9 +631,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             builder.startObject(FIELD_NAME);
             builder.field("vector", searchVectors[i]);
             if (distanceThreshold != null) {
-                builder.field("max_distance", distanceThreshold);
+                builder.field(MAX_DISTANCE, distanceThreshold);
             } else if (scoreThreshold != null) {
-                builder.field("min_score", scoreThreshold);
+                builder.field(MIN_SCORE, scoreThreshold);
             } else {
                 throw new IllegalArgumentException("Either distance or score must be provided");
             }

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -699,8 +699,9 @@ public class KNNWeightTests extends KNNTestCase {
         final float[] queryVector = new float[] { 0.1f, 0.3f };
         final float radius = 0.5f;
         final int maxResults = 1000;
-        jniServiceMockedStatic.when(() -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt()))
-            .thenReturn(getKNNQueryResults());
+        jniServiceMockedStatic.when(
+            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt(), any(), anyInt(), any())
+        ).thenReturn(getKNNQueryResults());
         KNNQuery.Context context = mock(KNNQuery.Context.class);
         when(context.getMaxResultWindow()).thenReturn(maxResults);
 
@@ -742,7 +743,9 @@ public class KNNWeightTests extends KNNTestCase {
 
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
-        jniServiceMockedStatic.verify(() -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt()));
+        jniServiceMockedStatic.verify(
+            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt(), any(), anyInt(), any())
+        );
 
         final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
 


### PR DESCRIPTION
### Description
This PR will allow user to use filter and nested field in faiss engine radial search by reusing existing logics from top-k search. 
* The custom patch for range_search is reused from [faiss search patch](https://github.com/opensearch-project/k-NN/blame/main/jni/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch#L136-L158). Please check [this](https://github.com/junqiu-lei/faiss/commit/b36a28778a493df46a7f40b03cc5b426e94a4ba1) commit for the patch updated code in faiss.
* In jni faiss_wrapper.cpp, the params set up process is reused from existing search function.
* IT tests added for both nested field and filter queries.


### Issues Resolved
Part of #814  
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
