### PR TITLE
Ensure gcc is newer >= 11.2.1 < 12.0.0 when building knn lib

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,14 +103,14 @@ if [ "$JAVA_HOME" = "" ]; then
     echo "SET JAVA_HOME=$JAVA_HOME"
 fi
 
-# Ensure gcc version is > 10.3.1 and < 12.0.0 for faiss 1.7.4+ / SIMD Neon support on ARM64 compilation
+# Ensure gcc version is > 11.2.1 and < 12.0.0 for faiss 1.7.4+ / SIMD Neon support on ARM64 compilation
 # https://github.com/opensearch-project/k-NN/issues/975
 # https://github.com/opensearch-project/k-NN/issues/1138
 # https://github.com/opensearch-project/opensearch-build/issues/4386
 # https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2067191682
 # https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2083623882
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
-GCC_REQUIRED_VERSION=10.3.1
+GCC_REQUIRED_VERSION=11.2.1
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ]; then
     echo "gcc version on this env is older than $GCC_REQUIRED_VERSION, exit 1"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,16 +103,23 @@ if [ "$JAVA_HOME" = "" ]; then
     echo "SET JAVA_HOME=$JAVA_HOME"
 fi
 
-# Ensure gcc version is at least 12.0.0 for faiss 1.7.4+ / SIMD Neon support on ARM64 compilation
+# Ensure gcc version is > 10.3.1 and < 12.0.0 for faiss 1.7.4+ / SIMD Neon support on ARM64 compilation
 # https://github.com/opensearch-project/k-NN/issues/975
 # https://github.com/opensearch-project/k-NN/issues/1138
 # https://github.com/opensearch-project/opensearch-build/issues/4386
 # https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2067191682
+# https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2083623882
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
-GCC_REQUIRED_VERSION=12.0.0
+GCC_REQUIRED_VERSION=10.3.1
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ]; then
     echo "gcc version on this env is older than $GCC_REQUIRED_VERSION, exit 1"
+    exit 1
+fi
+GCC_REQUIRED_VERSION_CEILING=12.0.0
+COMPARE_VERSION_CEILING=`echo $GCC_REQUIRED_VERSION_CEILING $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | tail -n 1`
+if [ "$COMPARE_VERSION_CEILING" != "$GCC_REQUIRED_VERSION_CEILING" ] && (echo "$OSTYPE" | grep -i linux); then
+    echo "gcc version on this env is newer than $GCC_REQUIRED_VERSION_CEILING, exit 1"
     exit 1
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -109,6 +109,7 @@ fi
 # https://github.com/opensearch-project/opensearch-build/issues/4386
 # https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2067191682
 # https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2083623882
+# https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2084133839
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
 GCC_REQUIRED_VERSION=11.2.1
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`


### PR DESCRIPTION
### Description
Ensure gcc is newer >= 11.2.1 < 12.0.0 when building knn lib
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2083623882
https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2084133839
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
