### PR TITLE
Ensure blas is statically linked

### DIFF
--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -41,13 +41,15 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
 endif()
 
 find_package(ZLIB REQUIRED)
+
+# Statically link BLAS - ensure this is before we find the blas package so we dont dynamically link
+set(BLA_STATIC ON)
 find_package(BLAS REQUIRED)
 enable_language(Fortran)
 find_package(LAPACK REQUIRED)
 
 # Set relevant properties
 set(BUILD_TESTING OFF)          # Avoid building faiss tests
-set(BLA_STATIC ON)              # Statically link BLAS
 set(FAISS_ENABLE_GPU OFF)
 set(FAISS_ENABLE_PYTHON OFF)
 


### PR DESCRIPTION
### Description
This fixes a bug where we set BLA_STATIC after we find the package, leading OpenBlas to be dynamically linked instead of statically linked. In 2.13 it was the other way around: https://github.com/opensearch-project/k-NN/blob/2.13/jni/CMakeLists.txt#L126-L157

Bug was introduced in https://github.com/opensearch-project/k-NN/pull/1636
 
### Issues Resolved
Related https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2083623882. This may resolve the issue with binutils because we are statically linking.
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
