### PR TITLE
Support script score when doc value is disabled and fix misusing DISI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Add KnnCircuitBreakerException and modify exception message [#1688](https://github.com/opensearch-project/k-NN/pull/1688)
 * Add stats for radial search [#1684](https://github.com/opensearch-project/k-NN/pull/1684)
+* Support script score when doc value is disabled and fix misusing DISI [#1696](https://github.com/opensearch-project/k-NN/pull/1696)
 ### Bug Fixes
 * Block commas in model description [#1692](https://github.com/opensearch-project/k-NN/pull/1692)
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
@@ -5,9 +5,10 @@
 
 package org.opensearch.knn.index;
 
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.index.fielddata.LeafFieldData;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
@@ -39,10 +40,29 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
     @Override
     public ScriptDocValues<float[]> getScriptValues() {
         try {
-            BinaryDocValues values = DocValues.getBinary(reader, fieldName);
-            return new KNNVectorScriptDocValues(values, fieldName, vectorDataType);
+            FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(fieldName);
+            if (fieldInfo == null) {
+                return KNNVectorScriptDocValues.emptyValues(fieldName, vectorDataType);
+            }
+
+            DocIdSetIterator values;
+            if (fieldInfo.hasVectorValues()) {
+                switch (fieldInfo.getVectorEncoding()) {
+                    case FLOAT32:
+                        values = reader.getFloatVectorValues(fieldName);
+                        break;
+                    case BYTE:
+                        values = reader.getByteVectorValues(fieldName);
+                        break;
+                    default:
+                        throw new IllegalStateException("Unsupported Lucene vector encoding: " + fieldInfo.getVectorEncoding());
+                }
+            } else {
+                values = DocValues.getBinary(reader, fieldName);
+            }
+            return KNNVectorScriptDocValues.create(values, fieldName, vectorDataType);
         } catch (IOException e) {
-            throw new IllegalStateException("Cannot load doc values for knn vector field: " + fieldName, e);
+            throw new IllegalStateException("Cannot load values for knn vector field: " + fieldName, e);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -6,18 +6,21 @@
 package org.opensearch.knn.index;
 
 import java.io.IOException;
+import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.index.fielddata.ScriptDocValues;
 
-import java.io.IOException;
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
 
-@RequiredArgsConstructor
-public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
-
-    private final BinaryDocValues binaryDocValues;
+    private final DocIdSetIterator vectorValues;
     private final String fieldName;
     @Getter
     private final VectorDataType vectorDataType;
@@ -25,11 +28,7 @@ public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
 
     @Override
     public void setNextDocId(int docId) throws IOException {
-        if (binaryDocValues.advanceExact(docId)) {
-            docExists = true;
-            return;
-        }
-        docExists = false;
+        docExists = vectorValues.docID() == docId || vectorValues.advance(docId) == docId;
     }
 
     public float[] getValue() {
@@ -44,11 +43,13 @@ public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
             throw new IllegalStateException(errorMessage);
         }
         try {
-            return vectorDataType.getVectorFromBytesRef(binaryDocValues.binaryValue());
+            return doGetValue();
         } catch (IOException e) {
             throw ExceptionsHelper.convertToOpenSearchException(e);
         }
     }
+
+    protected abstract float[] doGetValue() throws IOException;
 
     @Override
     public int size() {
@@ -58,5 +59,90 @@ public final class KNNVectorScriptDocValues extends ScriptDocValues<float[]> {
     @Override
     public float[] get(int i) {
         throw new UnsupportedOperationException("knn vector does not support this operation");
+    }
+
+    /**
+     * Creates a KNNVectorScriptDocValues object based on the provided parameters.
+     *
+     * @param values          The DocIdSetIterator representing the vector values.
+     * @param fieldName       The name of the field.
+     * @param vectorDataType  The data type of the vector.
+     * @return A KNNVectorScriptDocValues object based on the type of the values.
+     * @throws IllegalArgumentException If the type of values is unsupported.
+     */
+    public static KNNVectorScriptDocValues create(DocIdSetIterator values, String fieldName, VectorDataType vectorDataType) {
+        Objects.requireNonNull(values, "values must not be null");
+        if (values instanceof ByteVectorValues) {
+            return new KNNByteVectorScriptDocValues((ByteVectorValues) values, fieldName, vectorDataType);
+        } else if (values instanceof FloatVectorValues) {
+            return new KNNFloatVectorScriptDocValues((FloatVectorValues) values, fieldName, vectorDataType);
+        } else if (values instanceof BinaryDocValues) {
+            return new KNNNativeVectorScriptDocValues((BinaryDocValues) values, fieldName, vectorDataType);
+        } else {
+            throw new IllegalArgumentException("Unsupported values type: " + values.getClass());
+        }
+    }
+
+    private static final class KNNByteVectorScriptDocValues extends KNNVectorScriptDocValues {
+        private final ByteVectorValues values;
+
+        KNNByteVectorScriptDocValues(ByteVectorValues values, String field, VectorDataType type) {
+            super(values, field, type);
+            this.values = values;
+        }
+
+        @Override
+        protected float[] doGetValue() throws IOException {
+            byte[] bytes = values.vectorValue();
+            float[] value = new float[bytes.length];
+            for (int i = 0; i < bytes.length; i++) {
+                value[i] = (float) bytes[i];
+            }
+            return value;
+        }
+    }
+
+    private static final class KNNFloatVectorScriptDocValues extends KNNVectorScriptDocValues {
+        private final FloatVectorValues values;
+
+        KNNFloatVectorScriptDocValues(FloatVectorValues values, String field, VectorDataType type) {
+            super(values, field, type);
+            this.values = values;
+        }
+
+        @Override
+        protected float[] doGetValue() throws IOException {
+            return values.vectorValue();
+        }
+    }
+
+    private static final class KNNNativeVectorScriptDocValues extends KNNVectorScriptDocValues {
+        private final BinaryDocValues values;
+
+        KNNNativeVectorScriptDocValues(BinaryDocValues values, String field, VectorDataType type) {
+            super(values, field, type);
+            this.values = values;
+        }
+
+        @Override
+        protected float[] doGetValue() throws IOException {
+            return getVectorDataType().getVectorFromBytesRef(values.binaryValue());
+        }
+    }
+
+    /**
+     * Creates an empty KNNVectorScriptDocValues object based on the provided field name and vector data type.
+     *
+     * @param fieldName The name of the field.
+     * @param type      The data type of the vector.
+     * @return An empty KNNVectorScriptDocValues object.
+     */
+    public static KNNVectorScriptDocValues emptyValues(String fieldName, VectorDataType type) {
+        return new KNNVectorScriptDocValues(DocIdSetIterator.empty(), fieldName, type) {
+            @Override
+            protected float[] doGetValue() throws IOException {
+                throw new UnsupportedOperationException("empty values");
+            }
+        };
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -25,10 +25,21 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
     @Getter
     private final VectorDataType vectorDataType;
     private boolean docExists = false;
+    private int lastDocID = -1;
 
     @Override
     public void setNextDocId(int docId) throws IOException {
-        docExists = vectorValues.docID() == docId || vectorValues.advance(docId) == docId;
+        if (docId < lastDocID) {
+            throw new IllegalArgumentException("docs were sent out-of-order: lastDocID=" + lastDocID + " vs docID=" + docId);
+        }
+
+        lastDocID = docId;
+
+        int curDocID = vectorValues.docID();
+        if (lastDocID > curDocID) {
+            curDocID = vectorValues.advance(docId);
+        }
+        docExists = lastDocID == curDocID;
     }
 
     public float[] getValue() {

--- a/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorScriptDocValuesTests.java
@@ -5,7 +5,15 @@
 
 package org.opensearch.knn.index;
 
-import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.knn.KNNTestCase;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -33,26 +41,39 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
     public void setUp() throws Exception {
         super.setUp();
         directory = newDirectory();
-        createKNNVectorDocument(directory);
+        Class<? extends DocIdSetIterator> valuesClass = randomFrom(BinaryDocValues.class, ByteVectorValues.class, FloatVectorValues.class);
+        createKNNVectorDocument(directory, valuesClass);
         reader = DirectoryReader.open(directory);
-        LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        scriptDocValues = new KNNVectorScriptDocValues(
-            leafReaderContext.reader().getBinaryDocValues(MOCK_INDEX_FIELD_NAME),
-            MOCK_INDEX_FIELD_NAME,
-            VectorDataType.FLOAT
-        );
+        LeafReader leafReader = reader.getContext().leaves().get(0).reader();
+        DocIdSetIterator vectorValues;
+        if (BinaryDocValues.class.equals(valuesClass)) {
+            vectorValues = DocValues.getBinary(leafReader, MOCK_INDEX_FIELD_NAME);
+        } else if (ByteVectorValues.class.equals(valuesClass)) {
+            vectorValues = leafReader.getByteVectorValues(MOCK_INDEX_FIELD_NAME);
+        } else {
+            vectorValues = leafReader.getFloatVectorValues(MOCK_INDEX_FIELD_NAME);
+        }
+
+        scriptDocValues = KNNVectorScriptDocValues.create(vectorValues, MOCK_INDEX_FIELD_NAME, VectorDataType.FLOAT);
     }
 
-    private void createKNNVectorDocument(Directory directory) throws IOException {
+    private void createKNNVectorDocument(Directory directory, Class<? extends DocIdSetIterator> valuesClass) throws IOException {
         IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
         IndexWriter writer = new IndexWriter(directory, conf);
         Document knnDocument = new Document();
-        knnDocument.add(
-            new BinaryDocValuesField(
+        Field field;
+        if (BinaryDocValues.class.equals(valuesClass)) {
+            field = new BinaryDocValuesField(
                 MOCK_INDEX_FIELD_NAME,
                 new VectorField(MOCK_INDEX_FIELD_NAME, SAMPLE_VECTOR_DATA, new FieldType()).binaryValue()
-            )
-        );
+            );
+        } else if (ByteVectorValues.class.equals(valuesClass)) {
+            field = new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, SAMPLE_BYTE_VECTOR_DATA);
+        } else {
+            field = new KnnFloatVectorField(MOCK_INDEX_FIELD_NAME, SAMPLE_VECTOR_DATA);
+        }
+
+        knnDocument.add(field);
         writer.addDocument(knnDocument);
         writer.commit();
         writer.close();
@@ -83,5 +104,19 @@ public class KNNVectorScriptDocValuesTests extends KNNTestCase {
 
     public void testGet() throws IOException {
         expectThrows(UnsupportedOperationException.class, () -> scriptDocValues.get(0));
+    }
+
+    public void testUnsupportedValues() throws IOException {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNVectorScriptDocValues.create(DocValues.emptyNumeric(), MOCK_INDEX_FIELD_NAME, VectorDataType.FLOAT)
+        );
+    }
+
+    public void testEmptyValues() throws IOException {
+        KNNVectorScriptDocValues values = KNNVectorScriptDocValues.emptyValues(MOCK_INDEX_FIELD_NAME, VectorDataType.FLOAT);
+        assertEquals(0, values.size());
+        scriptDocValues.setNextDocId(0);
+        assertEquals(0, values.size());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
@@ -57,7 +57,7 @@ public class VectorDataTypeTests extends KNNTestCase {
         createKNNFloatVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        return new KNNVectorScriptDocValues(
+        return KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME),
             VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME,
             VectorDataType.FLOAT
@@ -70,7 +70,7 @@ public class VectorDataTypeTests extends KNNTestCase {
         createKNNByteVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        return new KNNVectorScriptDocValues(
+        return KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME),
             VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME,
             VectorDataType.BYTE

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
@@ -280,7 +280,7 @@ public class KNNScoringUtilTests extends KNNTestCase {
             if (scriptDocValues == null) {
                 reader = DirectoryReader.open(directory);
                 LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-                scriptDocValues = new KNNVectorScriptDocValues(
+                scriptDocValues = KNNVectorScriptDocValues.create(
                     leafReaderContext.reader().getBinaryDocValues(fieldName),
                     fieldName,
                     VectorDataType.FLOAT

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -644,7 +644,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         final Map<String, KNNResult> dataset = new HashMap<>(dense ? numDocsWithField : numDocsWithField * 3);
         int id = 0;
         for (int i = 0; i < numDocsWithField; i++) {
-            final int dummyDocs = dense ? 0 : randomIntBetween(1, 5);
+            final int dummyDocs = dense ? 0 : randomIntBetween(2, 5);
             for (int j = 0; j < dummyDocs; j++) {
                 dataset.put(Integer.toString(id++), null);
             }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -612,7 +612,16 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
                 dimensions,
                 KNNConstants.METHOD_HNSW,
                 KNNEngine.LUCENE.getName(),
-                SpaceType.DEFAULT.getValue()
+                SpaceType.DEFAULT.getValue(),
+                true
+            ),
+            createKnnIndexMapping(
+                FIELD_NAME,
+                dimensions,
+                KNNConstants.METHOD_HNSW,
+                KNNEngine.LUCENE.getName(),
+                SpaceType.DEFAULT.getValue(),
+                false
             )
         );
     }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.plugin.script;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
@@ -193,7 +194,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testKNNScoreforNonVectorDocument() throws Exception {
+    public void testKNNScoreForNonVectorDocument() throws Exception {
         /*
          * Create knn index and populate data
          */
@@ -599,7 +600,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             if (spaceType != SpaceType.HAMMING_BIT) {
                 final float[] queryVector = randomVector(dimensions);
                 final BiFunction<float[], float[], Float> scoreFunction = getScoreFunction(spaceType, queryVector);
-                createIndexAndAssertScriptScore(testMapping, spaceType, scoreFunction, dimensions, queryVector);
+                createIndexAndAssertScriptScore(testMapping, spaceType, scoreFunction, dimensions, queryVector, true);
             }
         }
     }
@@ -634,12 +635,22 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         return vector;
     }
 
-    private Map<String, KNNResult> createDataset(Function<float[], Float> scoreFunction, int dimensions, int numDocs) {
-        final Map<String, KNNResult> dataset = new HashMap<>(numDocs);
-        for (int i = 0; i < numDocs; i++) {
+    private Map<String, KNNResult> createDataset(
+        Function<float[], Float> scoreFunction,
+        int dimensions,
+        int numDocsWithField,
+        boolean dense
+    ) {
+        final Map<String, KNNResult> dataset = new HashMap<>(dense ? numDocsWithField : numDocsWithField * 3);
+        int id = 0;
+        for (int i = 0; i < numDocsWithField; i++) {
+            final int dummyDocs = dense ? 0 : randomIntBetween(1, 5);
+            for (int j = 0; j < dummyDocs; j++) {
+                dataset.put(Integer.toString(id++), null);
+            }
             final float[] vector = randomVector(dimensions);
             final float score = scoreFunction.apply(vector);
-            dataset.put(Integer.toString(i), new KNNResult(Integer.toString(i), vector, score));
+            dataset.put(Integer.toString(id), new KNNResult(Integer.toString(id++), vector, score));
         }
         return dataset;
     }
@@ -678,7 +689,8 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         final float[] queryVector = randomVector(dims);
         final BiFunction<float[], float[], Float> scoreFunction = getScoreFunction(spaceType, queryVector);
         for (String mapper : createMappers(dims)) {
-            createIndexAndAssertScriptScore(mapper, spaceType, scoreFunction, dims, queryVector);
+            createIndexAndAssertScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, true);
+            createIndexAndAssertScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, false);
         }
     }
 
@@ -687,16 +699,20 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         SpaceType spaceType,
         BiFunction<float[], float[], Float> scoreFunction,
         int dimensions,
-        float[] queryVector
+        float[] queryVector,
+        boolean dense
     ) throws Exception {
         /*
          * Create knn index and populate data
          */
         createKnnIndex(INDEX_NAME, mapper);
-        Map<String, KNNResult> dataset = createDataset(v -> scoreFunction.apply(queryVector, v), dimensions, randomIntBetween(4, 10));
-        for (Map.Entry<String, KNNResult> entry : dataset.entrySet()) {
-            addKnnDoc(INDEX_NAME, entry.getKey(), FIELD_NAME, entry.getValue().getVector());
-        }
+        final int numDocsWithField = randomIntBetween(4, 10);
+        Map<String, KNNResult> dataset = createDataset(v -> scoreFunction.apply(queryVector, v), dimensions, numDocsWithField, dense);
+        final float[] dummyVector = new float[1];
+        dataset.forEach((k, v) -> {
+            final float[] vector = (v != null) ? v.getVector() : dummyVector;
+            ExceptionsHelper.catchAsRuntimeException(() -> addKnnDoc(INDEX_NAME, k, (v != null) ? FIELD_NAME : "dummy", vector));
+        });
 
         /**
          * Construct Search Request
@@ -712,7 +728,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         params.put("field", FIELD_NAME);
         params.put("query_value", queryVector);
         params.put("space_type", spaceType.getValue());
-        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params);
+        Request request = constructKNNScriptQueryRequest(INDEX_NAME, qb, params, numDocsWithField);
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
 

--- a/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/PainlessScriptIT.java
@@ -563,7 +563,9 @@ public class PainlessScriptIT extends KNNRestTestCase {
             new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
         );
         properties.add(
-            new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2").knnMethodContext(knnMethodContext)
+            new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2")
+                .knnMethodContext(knnMethodContext)
+                .docValues(randomBoolean())
         );
 
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -39,6 +39,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.script.Script;
+import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.metrics.ScriptedMetricAggregationBuilder;
 
 import javax.management.MBeanServerInvocationHandler;
@@ -954,9 +955,16 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     protected Request constructKNNScriptQueryRequest(String indexName, QueryBuilder qb, Map<String, Object> params) throws Exception {
+        return constructKNNScriptQueryRequest(indexName, qb, params, SearchService.DEFAULT_SIZE);
+    }
+
+    protected Request constructKNNScriptQueryRequest(String indexName, QueryBuilder qb, Map<String, Object> params, int size)
+        throws Exception {
         Script script = new Script(Script.DEFAULT_SCRIPT_TYPE, KNNScoringScriptEngine.NAME, KNNScoringScriptEngine.SCRIPT_SOURCE, params);
         ScriptScoreQueryBuilder sc = new ScriptScoreQueryBuilder(qb, script);
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.field("size", size);
+        builder.startObject("query");
         builder.startObject("script_score");
         builder.field("query");
         sc.query().toXContent(builder, ToXContent.EMPTY_PARAMS);


### PR DESCRIPTION
### Description
The function was initially introduced in #1573, but was later reverted due to #1647. The root cause of the issue can be found in [this comment](https://github.com/opensearch-project/k-NN/issues/1647#issuecomment-2084495122). This PR reintroduces the function and fixes misusing DISI.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
