### PR TITLE
Add gfortran to target_link_libraries in cmake tests part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Block commas in model description [#1692](https://github.com/opensearch-project/k-NN/pull/1692)
 * Update threshold value after new result is added [#1715](https://github.com/opensearch-project/k-NN/pull/1715)
 ### Infrastructure
+* Add gfortran to target_link_libraries in cmake tests part [#1720](https://github.com/opensearch-project/k-NN/pull/1720)
 ### Documentation
 ### Maintenance
 ### Refactoring

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -160,6 +160,7 @@ if ("${WIN32}" STREQUAL "")
                 faiss
                 NonMetricSpaceLib
                 OpenMP::OpenMP_CXX
+                gfortran
                 ${TARGET_LIB_FAISS}
                 ${TARGET_LIB_NMSLIB}
                 ${TARGET_LIB_COMMON}


### PR DESCRIPTION
### Description
Add gfortran to target_link_libraries in CMakeLists tests part to avoid below error in AL2 build env:
```
[ 85%] Building CXX object CMakeFiles/jni_test.dir/tests/commons_test.cpp.o
[ 85%] Linking CXX executable bin/jni_test
release/libopensearchknn_faiss.so: error: undefined reference to '_gfortran_concat_string'
collect2: error: ld returned 1 exit status
make[2]: *** [bin/jni_test] Error 1
make[1]: *** [CMakeFiles/jni_test.dir/all] Error 2
make: *** [all] Error 2
``` 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
