### PR TITLE
Introduces query parameter ef_search for NMSLIB

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -150,6 +150,7 @@ if ("${WIN32}" STREQUAL "")
                 tests/faiss_wrapper_unit_test.cpp
                 tests/faiss_util_test.cpp
                 tests/nmslib_wrapper_test.cpp
+                tests/nmslib_wrapper_unit_test.cpp
                 tests/test_util.cpp
                 tests/commons_test.cpp
                 )

--- a/jni/cmake/init-nmslib.cmake
+++ b/jni/cmake/init-nmslib.cmake
@@ -13,12 +13,13 @@ if (NOT EXISTS ${NMS_REPO_DIR})
 endif ()
 
 # Check if patch exist, this is to skip git apply during CI build. See CI.yml with ubuntu.
-find_path(PATCH_FILE NAMES 0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch PATHS ${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib NO_DEFAULT_PATH)
+find_path(PATCH_FILE NAMES 0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch 0002-Adds-ability-to-pass-ef-parameter-in-the-query-for-h.patch PATHS ${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib NO_DEFAULT_PATH)
 
 # If it exists, apply patches
 if (EXISTS ${PATCH_FILE})
     message(STATUS "Applying custom patches.")
     execute_process(COMMAND git ${GIT_PATCH_COMMAND} --3way --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
+    execute_process(COMMAND git ${GIT_PATCH_COMMAND} --3way --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0002-Adds-ability-to-pass-ef-parameter-in-the-query-for-h.patch WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib ERROR_VARIABLE ERROR_MSG RESULT_VARIABLE RESULT_CODE)
 
     if(RESULT_CODE)
         message(FATAL_ERROR "Failed to apply patch:\n${ERROR_MSG}")

--- a/jni/include/commons.h
+++ b/jni/include/commons.h
@@ -33,5 +33,10 @@ namespace knn_jni {
          * @param memoryAddress address to be freed.
          */
         void freeVectorData(jlong);
+
+        /**
+         * Extracts query time efSearch from method parameters
+         **/
+        int getQueryEfSearch(JNIEnv *, knn_jni::JNIUtilInterface *, std::unordered_map<std::string, jobject>, int);
     }
 }

--- a/jni/include/commons.h
+++ b/jni/include/commons.h
@@ -37,6 +37,6 @@ namespace knn_jni {
         /**
          * Extracts query time efSearch from method parameters
          **/
-        int getQueryEfSearch(JNIEnv *, knn_jni::JNIUtilInterface *, std::unordered_map<std::string, jobject>, int);
+        int getIntegerMethodParameter(JNIEnv *, knn_jni::JNIUtilInterface *, std::unordered_map<std::string, jobject>, std::string, int);
     }
 }

--- a/jni/include/nmslib_wrapper.h
+++ b/jni/include/nmslib_wrapper.h
@@ -37,7 +37,7 @@ namespace knn_jni {
         //
         // Return an array of KNNQueryResults
         jobjectArray QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
-                                jfloatArray queryVectorJ, jint kJ);
+                                jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ);
 
         // Free the index located in memory at indexPointerJ
         void Free(jlong indexPointer);

--- a/jni/include/org_opensearch_knn_jni_NmslibService.h
+++ b/jni/include/org_opensearch_knn_jni_NmslibService.h
@@ -40,7 +40,7 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_NmslibService_loadIndex
  * Signature: (J[FI)[Lorg/opensearch/knn/index/query/KNNQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_NmslibService_queryIndex
-  (JNIEnv *, jclass, jlong, jfloatArray, jint);
+  (JNIEnv *, jclass, jlong, jfloatArray, jint, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_NmslibService

--- a/jni/patches/nmslib/0002-Adds-ability-to-pass-ef-parameter-in-the-query-for-h.patch
+++ b/jni/patches/nmslib/0002-Adds-ability-to-pass-ef-parameter-in-the-query-for-h.patch
@@ -1,0 +1,303 @@
+From 22c609af609e6f4214e67df0c405d2c86014c403 Mon Sep 17 00:00:00 2001
+From: Tejas Shah <shatejas@amazon.com>
+Date: Mon, 27 May 2024 22:02:12 -0700
+Subject: [PATCH] Adds ability to pass ef parameter in the query for hnsw
+
+It defaults to index ef_ value if its not type HNSWQuery
+---
+ similarity_search/include/hnswquery.h         | 37 +++++++++++++++++++
+ similarity_search/include/method/hnsw.h       |  1 +
+ similarity_search/include/space.h             |  4 ++
+ similarity_search/src/hnswquery.cc            | 32 ++++++++++++++++
+ similarity_search/src/method/hnsw.cc          | 28 +++++++++-----
+ .../src/method/hnsw_distfunc_opt.cc           | 12 +++---
+ 6 files changed, 100 insertions(+), 14 deletions(-)
+ create mode 100644 similarity_search/include/hnswquery.h
+ create mode 100644 similarity_search/src/hnswquery.cc
+
+diff --git a/similarity_search/include/hnswquery.h b/similarity_search/include/hnswquery.h
+new file mode 100644
+index 0000000..158bba3
+--- /dev/null
++++ b/similarity_search/include/hnswquery.h
+@@ -0,0 +1,37 @@
++/**
++ * Non-metric Space Library
++ *
++ * Main developers: Bilegsaikhan Naidan, Leonid Boytsov, Yury Malkov, Ben Frederickson, David Novak
++ *
++ * For the complete list of contributors and further details see:
++ * https://github.com/nmslib/nmslib
++ *
++ * Copyright (c) 2013-2018
++ *
++ * This code is released under the
++ * Apache License Version 2.0 http://www.apache.org/licenses/.
++ *
++ */
++
++#ifndef HNSWQUERY_H
++#define HNSWQUERY_H
++#include "global.h"
++#include "knnquery.h"
++
++namespace similarity {
++
++template<typename dist_t>
++class HNSWQuery : public KNNQuery<dist_t> {
++public:
++    ~HNSWQuery();
++    HNSWQuery(const Space<dist_t>& space, const Object *query_object, unsigned K, unsigned ef = 10, float eps = 0);
++
++    unsigned getEf() { return ef_; }
++
++protected:
++    unsigned ef_;
++};
++
++}
++
++#endif //HNSWQUERY_H
+diff --git a/similarity_search/include/method/hnsw.h b/similarity_search/include/method/hnsw.h
+index 57d99d0..e6dcea7 100644
+--- a/similarity_search/include/method/hnsw.h
++++ b/similarity_search/include/method/hnsw.h
+@@ -474,6 +474,7 @@ namespace similarity {
+         void baseSearchAlgorithmV1Merge(KNNQuery<dist_t> *query);
+         void SearchOld(KNNQuery<dist_t> *query, bool normalize);
+         void SearchV1Merge(KNNQuery<dist_t> *query, bool normalize);
++        size_t extractEf(KNNQuery<dist_t> *query, size_t defaultEf) const;
+ 
+         int getRandomLevel(double revSize)
+         {
+diff --git a/similarity_search/include/space.h b/similarity_search/include/space.h
+index fedad46..a0e9ea9 100644
+--- a/similarity_search/include/space.h
++++ b/similarity_search/include/space.h
+@@ -63,6 +63,9 @@ class Query;
+ template <typename dist_t>
+ class KNNQuery;
+ 
++    template <typename dist_t>
++class HNSWQuery;
++
+ template <typename dist_t>
+ class RangeQuery;
+ 
+@@ -263,6 +266,7 @@ class Space {
+   friend class Query<dist_t>;
+   friend class RangeQuery<dist_t>;
+   friend class KNNQuery<dist_t>;
++  friend class HNSWQuery<dist_t>;
+   friend class Experiments<dist_t>;
+   /* 
+    * This function is private, but it will be accessible by the friend class Query
+diff --git a/similarity_search/src/hnswquery.cc b/similarity_search/src/hnswquery.cc
+new file mode 100644
+index 0000000..4ee7b38
+--- /dev/null
++++ b/similarity_search/src/hnswquery.cc
+@@ -0,0 +1,32 @@
++/**
++* Non-metric Space Library
++ *
++ * Main developers: Bilegsaikhan Naidan, Leonid Boytsov, Yury Malkov, Ben Frederickson, David Novak
++ *
++ * For the complete list of contributors and further details see:
++ * https://github.com/nmslib/nmslib
++ *
++ * Copyright (c) 2013-2018
++ *
++ * This code is released under the
++ * Apache License Version 2.0 http://www.apache.org/licenses/.
++ *
++ */
++
++#include "hnswquery.h"
++
++namespace similarity {
++
++template<typename dist_t>
++HNSWQuery<dist_t>::HNSWQuery(const Space<dist_t> &space, const Object* query_object, const unsigned K, unsigned ef, float eps)
++    : KNNQuery<dist_t>(space, query_object, K, eps),
++      ef_(ef) {
++}
++
++template <typename dist_t>
++HNSWQuery<dist_t>::~HNSWQuery() = default;
++
++template class HNSWQuery<float>;
++template class HNSWQuery<int>;
++template class HNSWQuery<short int>;
++}
+diff --git a/similarity_search/src/method/hnsw.cc b/similarity_search/src/method/hnsw.cc
+index 35b372c..69ee9e4 100644
+--- a/similarity_search/src/method/hnsw.cc
++++ b/similarity_search/src/method/hnsw.cc
+@@ -46,6 +46,7 @@
+ #include <typeinfo>
+ #include <vector>
+ 
++#include "hnswquery.h"
+ #include "sort_arr_bi.h"
+ #define MERGE_BUFFER_ALGO_SWITCH_THRESHOLD 100
+ 
+@@ -101,9 +102,16 @@ namespace similarity {
+         return nullptr;
+     }
+ 
++    template <typename dist_t>
++    size_t Hnsw<dist_t>::extractEf(KNNQuery<dist_t>* searchQuery, size_t defaultEf) const {
++        auto* hnswQueryPtr = dynamic_cast<HNSWQuery<dist_t>*>(searchQuery);
++        if (hnswQueryPtr) {
++            return hnswQueryPtr->getEf();
++        }
++        return defaultEf;
++    }
+ 
+-
+-// This is the counter to keep the size of neighborhood information (for one node)
++    // This is the counter to keep the size of neighborhood information (for one node)
+     // TODO Can this one overflow? I really doubt
+     typedef uint32_t SIZEMASS_TYPE;
+ 
+@@ -718,10 +726,11 @@ namespace similarity {
+     void
+     Hnsw<dist_t>::Search(KNNQuery<dist_t> *query, IdType) const
+     {
++        size_t ef = this->extractEf(query, ef_);
+         if (this->data_.empty() && this->data_rearranged_.empty()) {
+           return;
+         }
+-        bool useOld = searchAlgoType_ == kOld || (searchAlgoType_ == kHybrid && ef_ >= 1000);
++        bool useOld = searchAlgoType_ == kOld || (searchAlgoType_ == kHybrid && ef >= 1000);
+         // cout << "Ef = " << ef_ << " use old = " << useOld << endl;
+         switch (searchMethod_) {
+         case 0:
+@@ -1148,6 +1157,7 @@ namespace similarity {
+                 PREFETCH((char *)(massVisited + (*iter)->getId()), _MM_HINT_T0);
+             }
+             // calculate distance to each neighbor
++            size_t ef = this->extractEf(query, ef_);
+             for (auto iter = neighbor.begin(); iter != neighbor.end(); ++iter) {
+                 curId = (*iter)->getId();
+ 
+@@ -1155,12 +1165,12 @@ namespace similarity {
+                     massVisited[curId] = currentV;
+                     currObj = (*iter)->getData();
+                     d = query->DistanceObjLeft(currObj);
+-                    if (closestDistQueue1.top().getDistance() > d || closestDistQueue1.size() < ef_) {
++                    if (closestDistQueue1.top().getDistance() > d || closestDistQueue1.size() < ef) {
+                         {
+                             query->CheckAndAddToResult(d, currObj);
+                             candidateQueue.emplace(d, *iter);
+                             closestDistQueue1.emplace(d, *iter);
+-                            if (closestDistQueue1.size() > ef_) {
++                            if (closestDistQueue1.size() > ef) {
+                                 closestDistQueue1.pop();
+                             }
+                         }
+@@ -1185,6 +1195,7 @@ namespace similarity {
+ 
+         const Object *currObj = provider->getData();
+ 
++            size_t ef = this->extractEf(query, ef_);
+         dist_t d = query->DistanceObjLeft(currObj);
+         dist_t curdist = d;
+         HnswNode *curNode = provider;
+@@ -1209,7 +1220,7 @@ namespace similarity {
+             }
+         }
+ 
+-        SortArrBI<dist_t, HnswNode *> sortedArr(max<size_t>(ef_, query->GetK()));
++        SortArrBI<dist_t, HnswNode *> sortedArr(max<size_t>(ef, query->GetK()));
+         sortedArr.push_unsorted_grow(curdist, curNode);
+ 
+         int_fast32_t currElem = 0;
+@@ -1225,8 +1236,7 @@ namespace similarity {
+         // PHASE TWO OF THE SEARCH
+         // Extraction of the neighborhood to find k nearest neighbors.
+         ////////////////////////////////////////////////////////////////////////////////
+-
+-        while (currElem < min(sortedArr.size(), ef_)) {
++        while (currElem < min(sortedArr.size(), ef)) {
+             auto &e = queueData[currElem];
+             CHECK(!e.used);
+             e.used = true;
+@@ -1255,7 +1265,7 @@ namespace similarity {
+                     currObj = (*iter)->getData();
+                     d = query->DistanceObjLeft(currObj);
+ 
+-                    if (d < topKey || sortedArr.size() < ef_) {
++                    if (d < topKey || sortedArr.size() < ef) {
+                         CHECK_MSG(itemBuff.size() > itemQty,
+                                   "Perhaps a bug: buffer size is not enough " + 
+                                   ConvertToString(itemQty) + " >= " + ConvertToString(itemBuff.size()));
+diff --git a/similarity_search/src/method/hnsw_distfunc_opt.cc b/similarity_search/src/method/hnsw_distfunc_opt.cc
+index 5c219cd..1913936 100644
+--- a/similarity_search/src/method/hnsw_distfunc_opt.cc
++++ b/similarity_search/src/method/hnsw_distfunc_opt.cc
+@@ -120,6 +120,7 @@ namespace similarity {
+             PREFETCH(data_level0_memory_ + (*(data + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+             PREFETCH((char *)(data + 2), _MM_HINT_T0);
+ 
++            size_t ef = this->extractEf(query, ef_);
+             for (int j = 1; j <= size; j++) {
+                 int tnum = *(data + j);
+                 PREFETCH((char *)(massVisited + *(data + j + 1)), _MM_HINT_T0);
+@@ -131,7 +132,7 @@ namespace similarity {
+                     massVisited[tnum] = currentV;
+                     char *currObj1 = (data_level0_memory_ + tnum * memoryPerObject_ + offsetData_);
+                     dist_t d = (fstdistfunc_(pVectq, (float *)(currObj1 + 16), qty, TmpRes));
+-                    if (closestDistQueuei.top().getDistance() > d || closestDistQueuei.size() < ef_) {
++                    if (closestDistQueuei.top().getDistance() > d || closestDistQueuei.size() < ef) {
+                         candidateQueuei.emplace(-d, tnum);
+                         PREFETCH(data_level0_memory_ + candidateQueuei.top().element * memoryPerObject_ + offsetLevel0_,
+                                      _MM_HINT_T0);
+@@ -139,7 +140,7 @@ namespace similarity {
+                         query->CheckAndAddToResult(d, data_rearranged_[tnum]);
+                         closestDistQueuei.emplace(d, tnum);
+ 
+-                        if (closestDistQueuei.size() > ef_) {
++                        if (closestDistQueuei.size() > ef) {
+                             closestDistQueuei.pop();
+                         }
+                     }
+@@ -153,6 +154,7 @@ namespace similarity {
+     void
+     Hnsw<dist_t>::SearchV1Merge(KNNQuery<dist_t> *query, bool normalize)
+     {
++        size_t ef = this->extractEf(query, ef_);
+         float *pVectq = (float *)((char *)query->QueryObject()->data());
+         TMP_RES_ARRAY(TmpRes);
+         size_t qty = query->QueryObject()->datalength() >> 2;
+@@ -197,7 +199,7 @@ namespace similarity {
+             }
+         }
+ 
+-        SortArrBI<dist_t, int> sortedArr(max<size_t>(ef_, query->GetK()));
++        SortArrBI<dist_t, int> sortedArr(max<size_t>(ef, query->GetK()));
+         sortedArr.push_unsorted_grow(curdist, curNodeNum);
+ 
+         int_fast32_t currElem = 0;
+@@ -208,7 +210,7 @@ namespace similarity {
+ 
+         massVisited[curNodeNum] = currentV;
+ 
+-        while (currElem < min(sortedArr.size(), ef_)) {
++        while (currElem < min(sortedArr.size(), ef)) {
+             auto &e = queueData[currElem];
+             CHECK(!e.used);
+             e.used = true;
+@@ -237,7 +239,7 @@ namespace similarity {
+                     char *currObj1 = (data_level0_memory_ + tnum * memoryPerObject_ + offsetData_);
+                     dist_t d = (fstdistfunc_(pVectq, (float *)(currObj1 + 16), qty, TmpRes));
+ 
+-                    if (d < topKey || sortedArr.size() < ef_) {
++                    if (d < topKey || sortedArr.size() < ef) {
+                         CHECK_MSG(itemBuff.size() > itemQty,
+                                   "Perhaps a bug: buffer size is not enough " + 
+                                   ConvertToString(itemQty) + " >= " + ConvertToString(itemBuff.size()));
+-- 
+2.44.0
+

--- a/jni/src/commons.cpp
+++ b/jni/src/commons.cpp
@@ -39,15 +39,15 @@ void knn_jni::commons::freeVectorData(jlong memoryAddressJ) {
     }
 }
 
-int knn_jni::commons::getQueryEfSearch(JNIEnv * env, knn_jni::JNIUtilInterface * jniUtil, std::unordered_map<std::string, jobject> methodParams, int defaultEfSearch) {
+int knn_jni::commons::getIntegerMethodParameter(JNIEnv * env, knn_jni::JNIUtilInterface * jniUtil, std::unordered_map<std::string, jobject> methodParams, std::string methodParam, int defaultValue) {
     if (methodParams.empty()) {
-        return defaultEfSearch;
+        return defaultValue;
     }
-    auto efSearchIt = methodParams.find(knn_jni::EF_SEARCH);
+    auto efSearchIt = methodParams.find(methodParam);
     if (efSearchIt != methodParams.end()) {
-        return jniUtil->ConvertJavaObjectToCppInteger(env, methodParams[knn_jni::EF_SEARCH]);
+        return jniUtil->ConvertJavaObjectToCppInteger(env, methodParams[methodParam]);
     }
 
-    return defaultEfSearch;
+    return defaultValue;
 }
 #endif //OPENSEARCH_KNN_COMMONS_H

--- a/jni/src/commons.cpp
+++ b/jni/src/commons.cpp
@@ -38,4 +38,16 @@ void knn_jni::commons::freeVectorData(jlong memoryAddressJ) {
         delete vect;
     }
 }
+
+int knn_jni::commons::getQueryEfSearch(JNIEnv * env, knn_jni::JNIUtilInterface * jniUtil, std::unordered_map<std::string, jobject> methodParams, int defaultEfSearch) {
+    if (methodParams.empty()) {
+        return defaultEfSearch;
+    }
+    auto efSearchIt = methodParams.find(knn_jni::EF_SEARCH);
+    if (efSearchIt != methodParams.end()) {
+        return jniUtil->ConvertJavaObjectToCppInteger(env, methodParams[knn_jni::EF_SEARCH]);
+    }
+
+    return defaultEfSearch;
+}
 #endif //OPENSEARCH_KNN_COMMONS_H

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -24,6 +24,7 @@
 #include "faiss/IndexIVFPQ.h"
 
 #include <algorithm>
+#include <commons.h>
 #include <jni.h>
 #include <string>
 #include <vector>
@@ -71,9 +72,6 @@ void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, fa
 
 // Concerts the FilterIds to BitMap
 void buildFilterIdsBitMap(const int* filterIds, int filterIdsLength, uint8_t* bitsetVector);
-
-// Gets efSearch from algo parameters
-int getQueryEfSearch(JNIEnv * env, knn_jni::JNIUtilInterface * jniUtil, std::unordered_map<std::string, jobject> methodParams, int defaultEfSearch);
 
 std::unique_ptr<faiss::IDGrouperBitmap> buildIDGrouperBitmap(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env, jintArray parentIdsJ, std::vector<uint64_t>* bitmap);
 
@@ -349,7 +347,7 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader) {
             // Query param efsearch supersedes ef_search provided during index setting.
-            hnswParams.efSearch = getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            hnswParams.efSearch = knn_jni::commons::getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
             hnswParams.sel = idSelector.get();
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
@@ -379,8 +377,8 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
         std::vector<uint64_t> idGrouperBitmap;
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader!= nullptr) {
-            // Query param efseatch supersedes ef_search provided during index setting.
-            hnswParams.efSearch = getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            // Query param efsearch supersedes ef_search provided during index setting.
+            hnswParams.efSearch = knn_jni::commons::getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
                 hnswParams.grp = idGrouper.get();
@@ -415,18 +413,6 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
         jniUtil->SetObjectArrayElement(env, results, i, result);
     }
     return results;
-}
-
-int getQueryEfSearch(JNIEnv * env, knn_jni::JNIUtilInterface * jniUtil, std::unordered_map<std::string, jobject> methodParams, int defaultEfSearch) {
-    if (methodParams.empty()) {
-        return defaultEfSearch;
-    }
-    auto efSearchIt = methodParams.find(knn_jni::EF_SEARCH);
-    if (efSearchIt != methodParams.end()) {
-        return jniUtil->ConvertJavaObjectToCppInteger(env, methodParams[knn_jni::EF_SEARCH]);
-    }
-
-    return defaultEfSearch;
 }
 
 void knn_jni::faiss_wrapper::Free(jlong indexPointer) {

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -347,7 +347,7 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader) {
             // Query param efsearch supersedes ef_search provided during index setting.
-            hnswParams.efSearch = knn_jni::commons::getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
             hnswParams.sel = idSelector.get();
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
@@ -378,7 +378,7 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader!= nullptr) {
             // Query param efsearch supersedes ef_search provided during index setting.
-            hnswParams.efSearch = knn_jni::commons::getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
                 hnswParams.grp = idGrouper.get();

--- a/jni/src/nmslib_wrapper.cpp
+++ b/jni/src/nmslib_wrapper.cpp
@@ -254,7 +254,7 @@ jobjectArray knn_jni::nmslib_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jni
         methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
     }
 
-    int queryEfSearch = knn_jni::commons::getQueryEfSearch(env, jniUtil, methodParams, -1);
+    int queryEfSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, -1);
     similarity::KNNQuery<float>* query;
     if (queryEfSearch == -1) {
         query = new similarity::KNNQuery<float>(*(indexWrapper->space), queryObject.get(), kJ);

--- a/jni/src/nmslib_wrapper.cpp
+++ b/jni/src/nmslib_wrapper.cpp
@@ -12,6 +12,8 @@
 #include "jni_util.h"
 #include "nmslib_wrapper.h"
 
+#include <commons.h>
+
 #include "init.h"
 #include "index.h"
 #include "params.h"
@@ -23,6 +25,8 @@
 
 #include <jni.h>
 #include <string>
+
+#include "hnswquery.h"
 
 
 std::string TranslateSpaceType(const std::string& spaceType);
@@ -220,7 +224,7 @@ jlong knn_jni::nmslib_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JN
 }
 
 jobjectArray knn_jni::nmslib_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
-                                                 jfloatArray queryVectorJ, jint kJ) {
+                                                 jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ) {
 
     if (queryVectorJ == nullptr) {
         throw std::runtime_error("Query Vector cannot be null");
@@ -243,14 +247,24 @@ jobjectArray knn_jni::nmslib_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jni
         jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
         throw;
     }
+
     jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryvector, JNI_ABORT);
+    std::unordered_map<std::string, jobject> methodParams;
+    if (methodParamsJ != nullptr) {
+        methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
+    }
 
-    similarity::KNNQuery<float> knnQuery(*(indexWrapper->space), queryObject.get(), kJ);
-    indexWrapper->index->Search(&knnQuery);
+    int queryEfSearch = knn_jni::commons::getQueryEfSearch(env, jniUtil, methodParams, -1);
+    similarity::KNNQuery<float>* query;
+    if (queryEfSearch == -1) {
+        query = new similarity::KNNQuery<float>(*(indexWrapper->space), queryObject.get(), kJ);
+    } else {
+        query = new similarity::HNSWQuery<float>(*(indexWrapper->space), queryObject.get(), kJ, queryEfSearch);
+    }
 
-    std::unique_ptr<similarity::KNNQueue<float>> neighbors(knnQuery.Result()->Clone());
+    indexWrapper->index->Search(query);
+    std::unique_ptr<similarity::KNNQueue<float>> neighbors(query->Result()->Clone());
     int resultSize = neighbors->Size();
-
     jclass resultClass = jniUtil->FindClass(env,"org/opensearch/knn/index/query/KNNQueryResult");
     jmethodID allArgs = jniUtil->FindMethod(env, "org/opensearch/knn/index/query/KNNQueryResult", "<init>");
 
@@ -265,6 +279,8 @@ jobjectArray knn_jni::nmslib_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jni
         result = jniUtil->NewObject(env, resultClass, allArgs, id, distance);
         jniUtil->SetObjectArrayElement(env, results, i, result);
     }
+
+    delete query;
     return results;
 }
 

--- a/jni/src/org_opensearch_knn_jni_NmslibService.cpp
+++ b/jni/src/org_opensearch_knn_jni_NmslibService.cpp
@@ -61,10 +61,10 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_NmslibService_loadIndex(JNIE
 
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_NmslibService_queryIndex(JNIEnv * env, jclass cls,
                                                                                     jlong indexPointerJ,
-                                                                                    jfloatArray queryVectorJ, jint kJ)
+                                                                                    jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ)
 {
     try {
-        return knn_jni::nmslib_wrapper::QueryIndex(&jniUtil, env, indexPointerJ, queryVectorJ, kJ);
+        return knn_jni::nmslib_wrapper::QueryIndex(&jniUtil, env, indexPointerJ, queryVectorJ, kJ, methodParamsJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/commons_test.cpp
+++ b/jni/tests/commons_test.cpp
@@ -71,3 +71,22 @@ TEST(CommonsTests, BasicAssertions) {
         }
     }
 }
+
+TEST(CommonTests, GetIntegerMethodParam) {
+    JNIEnv *jniEnv = nullptr;
+    testing::NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+    std::unordered_map<std::string, jobject> methodParams1;
+    int efSearch = 10;
+    methodParams1[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
+
+    int actualValue1 = knn_jni::commons::getIntegerMethodParameter(jniEnv, &mockJNIUtil, methodParams1, knn_jni::EF_SEARCH, 1);
+    EXPECT_EQ(efSearch, actualValue1);
+
+    int actualValue2 = knn_jni::commons::getIntegerMethodParameter(jniEnv, &mockJNIUtil, methodParams1, "param", 1);
+    EXPECT_EQ(1, actualValue2);
+
+    std::unordered_map<std::string, jobject> methodParams2;
+    int actualValue3 = knn_jni::commons::getIntegerMethodParameter(jniEnv, &mockJNIUtil, methodParams2, knn_jni::EF_SEARCH, 1);
+    EXPECT_EQ(1, actualValue3);
+}

--- a/jni/tests/nmslib_wrapper_test.cpp
+++ b/jni/tests/nmslib_wrapper_test.cpp
@@ -182,8 +182,11 @@ TEST(NmslibQueryIndexTest, BasicAssertions) {
 
     // Define query data
     int k = 10;
+    int efSearch = 20;
     int numQueries = 100;
     std::vector<std::vector<float>> queries;
+    std::unordered_map<std::string, jobject> methodParams;
+    methodParams[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
 
     for (int i = 0; i < numQueries; i++) {
         std::vector<float> query;
@@ -205,7 +208,7 @@ TEST(NmslibQueryIndexTest, BasicAssertions) {
                         knn_jni::nmslib_wrapper::QueryIndex(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(indexWrapper.get()),
-                                reinterpret_cast<jfloatArray>(&query), k)));
+                                reinterpret_cast<jfloatArray>(&query), k, nullptr)));
 
         ASSERT_EQ(k, results->size());
 

--- a/jni/tests/nmslib_wrapper_unit_test.cpp
+++ b/jni/tests/nmslib_wrapper_unit_test.cpp
@@ -1,0 +1,128 @@
+//
+// Created by Shah, Tejas on 5/30/24.
+//
+#include "hnswquery.h"
+#include "knnquery.h"
+#include "nmslib_wrapper.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "jni_util.h"
+#include "jni.h"
+#include "test_util.h"
+#include "method/hnsw.h"
+#include "space/space_dummy.h"
+
+namespace nmslib_query_index_test {
+
+    using ::testing::NiceMock;
+
+    struct QueryIndexHNSWTestInput {
+        string description;
+        int k;
+        int efSearch;
+        bool expectedHNSWQuery;
+    };
+
+    struct MockNMSIndex : similarity::Hnsw<float> {
+        mutable int kCalled;
+        mutable int efCalled = -1;
+
+        explicit MockNMSIndex(const similarity::Space<float> &space, const similarity::ObjectVector &data): Hnsw(false,
+                space, data) {
+            std::vector<string> input;
+            input.emplace_back("ef=10");
+            similarity::AnyParams ef(input);
+            this->Hnsw::SetQueryTimeParams(ef);
+        }
+
+        void Search(similarity::KNNQuery<float> *query, similarity::IdType id) const override {
+            auto hnsw = dynamic_cast<similarity::HNSWQuery<float> *>(query);
+            if (hnsw != nullptr) {
+                kCalled = hnsw->GetK();
+                efCalled = hnsw->getEf();
+            } else {
+                kCalled = query->GetK();
+            }
+            similarity::Object object(5, 0, 3*sizeof(float), new float[] { 2.2f, 2.5f, 2.6f });
+            similarity::Object* objectPtr = &object;
+            bool added = query->CheckAndAddToResult(0.0f, objectPtr);
+        };
+
+        void resetMocks() const {
+            kCalled = -1;
+            efCalled = -1;
+        }
+    };
+
+    class NmslibWrapperParametrizedTestFixture : public testing::TestWithParam<QueryIndexHNSWTestInput> {
+    public:
+        NmslibWrapperParametrizedTestFixture() : space_(nullptr), index_(nullptr) {
+            similarity::initLibrary();
+            std::string spaceType = knn_jni::L2;
+            space_ = similarity::SpaceFactoryRegistry<float>::Instance().CreateSpace(
+                    spaceType, similarity::AnyParams());
+            index_ = new MockNMSIndex(*space_, similarity::ObjectVector());
+        };
+
+    protected:
+        MockNMSIndex* index_;
+        similarity::Space<float>* space_; // Moved from local to member variable
+    };
+
+
+    TEST_P(NmslibWrapperParametrizedTestFixture, QueryIndexHNSWTests) {
+        //Given
+        JNIEnv *jniEnv = nullptr;
+        NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+
+        QueryIndexHNSWTestInput const &input = GetParam();
+        float query[] = { 1.2f, 2.3f, 3.4f };
+
+        std::string spaceType = knn_jni::L2;
+        std::unique_ptr<knn_jni::nmslib_wrapper::IndexWrapper> indexWrapper(
+            new knn_jni::nmslib_wrapper::IndexWrapper(spaceType));
+        indexWrapper->index.reset(index_);
+
+        int efSearch = input.efSearch;
+        std::unordered_map<std::string, jobject> methodParams;
+        if (efSearch != -1) {
+            methodParams[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
+        }
+        EXPECT_CALL(mockJNIUtil,
+                        GetJavaFloatArrayLength(
+                            jniEnv, reinterpret_cast<jfloatArray>(query)))
+                    .WillOnce(testing::Return(3));
+
+        EXPECT_CALL(mockJNIUtil,
+                    ReleaseFloatArrayElements(
+                        jniEnv, reinterpret_cast<jfloatArray>(query), query, JNI_ABORT));
+        EXPECT_CALL(mockJNIUtil,
+                    GetFloatArrayElements(
+                        jniEnv, reinterpret_cast<jfloatArray>(query), nullptr))
+                .WillOnce(testing::Return(query));
+
+        knn_jni::nmslib_wrapper::QueryIndex(
+            &mockJNIUtil, jniEnv,
+            reinterpret_cast<jlong>(indexWrapper.get()),
+            reinterpret_cast<jfloatArray>(&query), input.k, reinterpret_cast<jobject>(&methodParams));
+
+        if (input.expectedHNSWQuery) {
+            EXPECT_EQ(input.efSearch, index_->efCalled);
+            EXPECT_EQ(input.k, index_->kCalled);
+        } else {
+            EXPECT_EQ(input.k, index_->kCalled);
+        }
+        index_->resetMocks();
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        QueryIndexHNSWTests,
+        NmslibWrapperParametrizedTestFixture,
+        ::testing::Values(
+            QueryIndexHNSWTestInput{"methodParams present", 10, 200, true},
+            QueryIndexHNSWTestInput{"methodParams absent", 5, -1, false }
+        )
+    );
+}

--- a/jni/tests/nmslib_wrapper_unit_test.cpp
+++ b/jni/tests/nmslib_wrapper_unit_test.cpp
@@ -1,6 +1,13 @@
-//
-// Created by Shah, Tejas on 5/30/24.
-//
+/*
+* SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
 #include "hnswquery.h"
 #include "knnquery.h"
 #include "nmslib_wrapper.h"

--- a/src/main/java/org/opensearch/knn/index/util/Nmslib.java
+++ b/src/main/java/org/opensearch/knn/index/util/Nmslib.java
@@ -66,7 +66,7 @@ class Nmslib extends NativeLibrary {
         String currentVersion,
         String extension
     ) {
-        super(methods, Map.of(METHOD_HNSW, EngineSpecificMethodContext.EMPTY), scoreTranslation, currentVersion, extension);
+        super(methods, Map.of(METHOD_HNSW, new DefaultHnswContext()), scoreTranslation, currentVersion, extension);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -181,7 +181,7 @@ public class JNIService {
         int[] parentIds
     ) {
         if (KNNEngine.NMSLIB == knnEngine) {
-            return NmslibService.queryIndex(indexPointer, queryVector, k);
+            return NmslibService.queryIndex(indexPointer, queryVector, k, methodParameters);
         }
 
         if (KNNEngine.FAISS == knnEngine) {

--- a/src/main/java/org/opensearch/knn/jni/NmslibService.java
+++ b/src/main/java/org/opensearch/knn/jni/NmslibService.java
@@ -69,7 +69,7 @@ class NmslibService {
      * @param k neighbors to be returned
      * @return KNNQueryResult array of k neighbors
      */
-    public static native KNNQueryResult[] queryIndex(long indexPointer, float[] queryVector, int k);
+    public static native KNNQueryResult[] queryIndex(long indexPointer, float[] queryVector, int k, Map<String, ?> methodParameters);
 
     /**
      * Free native memory pointer

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -833,7 +833,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(
-            new KNNMethodContext(KNNEngine.NMSLIB, SpaceType.COSINESIMIL, new MethodComponentContext("hnsw", Map.of()))
+            new KNNMethodContext(KNNEngine.LUCENE, SpaceType.COSINESIMIL, new MethodComponentContext("hnsw", Map.of()))
         );
 
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };


### PR DESCRIPTION
### Description

Integrates NMSLIB with ef_search

```
curl -XGET "http://localhost:9200/nmslib-hnsw-index/_search" -H 'Content-Type: application/json' -d'
{
  "query": {
    "knn": {
      "nmslib_vector": {
        "vector": [2, 3, 5],
        "k": 2,
        "method_parameters" : {
            "ef_search" : 200
        }
        }
      }
    }
  }'
```
```
{
  "took": 6,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": 0.11918951,
    "hits": [
      {
        "_index": "nmslib-hnsw-index",
        "_id": "3",
        "_score": 0.11918951,
        "_source": {
          "nmslib_vector": [
            3.5,
            4.5,
            3.3
          ],
          "price": 12.9
        }
      },
      {
        "_index": "nmslib-hnsw-index",
        "_id": "2",
        "_score": 0.10706638,
        "_source": {
          "nmslib_vector": [
            2.5,
            3.5,
            2.2
          ],
          "price": 7.1
        }
      }
    ]
  }
}
```
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/1537
 
### Check List - Pending 
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
