### PR TITLE
Adds ef_search support for Lucene kNN queries

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.index.util.KNNEngine;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
@@ -101,12 +102,17 @@ public class KNNQueryFactory extends BaseQueryFactory {
                 .build();
         }
 
+        Integer requestEfSearch = null;
+        if (methodParameters != null && methodParameters.containsKey(METHOD_PARAMETER_EF_SEARCH)) {
+            requestEfSearch = (Integer) methodParameters.get(METHOD_PARAMETER_EF_SEARCH);
+        }
+        int luceneK = requestEfSearch == null ? k : Math.max(k, requestEfSearch);
         log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
         switch (vectorDataType) {
             case BYTE:
-                return getKnnByteVectorQuery(fieldName, byteVector, k, filterQuery, parentFilter);
+                return getKnnByteVectorQuery(fieldName, byteVector, luceneK, filterQuery, parentFilter);
             case FLOAT:
-                return getKnnFloatVectorQuery(fieldName, vector, k, filterQuery, parentFilter);
+                return getKnnFloatVectorQuery(fieldName, vector, luceneK, filterQuery, parentFilter);
             default:
                 throw new IllegalArgumentException(
                     String.format(

--- a/src/main/java/org/opensearch/knn/index/query/parser/MethodParametersParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/MethodParametersParser.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.opensearch.knn.index.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.METHOD_PARAMS_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.NAME;
 

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -67,7 +67,7 @@ public class Lucene extends JVMLibrary {
      * @param distanceTransform Map of space type to distance transformation function
      */
     Lucene(Map<String, KNNMethod> methods, String version, Map<SpaceType, Function<Float, Float>> distanceTransform) {
-        super(methods, Map.of(METHOD_HNSW, EngineSpecificMethodContext.EMPTY), version);
+        super(methods, Map.of(METHOD_HNSW, new DefaultHnswContext()), version);
         this.distanceTransform = distanceTransform;
     }
 

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -499,13 +499,18 @@ public class LuceneEngineIT extends KNNRestTestCase {
         }
 
         validateQueries(spaceType, FIELD_NAME);
+        validateQueries(spaceType, FIELD_NAME, Map.of("ef_search", 100));
     }
 
     private void validateQueries(SpaceType spaceType, String fieldName) throws Exception {
+        validateQueries(spaceType, fieldName, null);
+    }
+
+    private void validateQueries(SpaceType spaceType, String fieldName, Map<String, ?> methodParameters) throws Exception {
 
         int k = LuceneEngineIT.TEST_INDEX_VECTORS.length;
         for (float[] queryVector : TEST_QUERY_VECTORS) {
-            Response response = searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(fieldName, queryVector, k), k);
+            Response response = searchKNNIndex(INDEX_NAME, buildLuceneKSearchQuery(fieldName, k, queryVector, methodParameters), k);
             String responseBody = EntityUtils.toString(response.getEntity());
             List<KNNResult> knnResults = parseSearchResponse(responseBody, fieldName);
             assertEquals(k, knnResults.size());
@@ -518,6 +523,27 @@ public class LuceneEngineIT extends KNNRestTestCase {
                 assertEquals(KNNEngine.LUCENE.score(rawScore, spaceType), actualScores.get(j), 0.0001);
             }
         }
+    }
+
+    @SneakyThrows
+    private XContentBuilder buildLuceneKSearchQuery(String fieldName, int k, float[] vector, Map<String, ?> methodParams) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(fieldName)
+            .field("vector", vector)
+            .field("k", k);
+        if (methodParams != null) {
+            builder.startObject("method_parameters");
+            for (Map.Entry<String, ?> entry : methodParams.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
+        }
+
+        builder.endObject().endObject().endObject().endObject();
+        return builder;
     }
 
     private List<float[]> queryResults(final float[] searchVector, final int k) throws Exception {

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -825,6 +825,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(HNSW_METHOD_PARAMS, ((KNNQuery) query).getMethodParameters());
     }
 
+    /** This test should be uncommented once we have nprobs. Considering engine instance is static its not possible to test this right now
     public void testDoToQuery_ThrowsIllegalArgumentExceptionForUnknownMethodParameter() {
 
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
@@ -832,7 +833,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getDimension()).thenReturn(4);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(
-            new KNNMethodContext(KNNEngine.NMSLIB, SpaceType.COSINESIMIL, new MethodComponentContext("hnsw", Map.of()))
+            new KNNMethodContext(KNNEngine.LUCENE, SpaceType.COSINESIMIL, new MethodComponentContext("hnsw", Map.of()))
         );
 
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
@@ -844,7 +845,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
 
         expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
-    }
+    }**/
 
     public void testDoToQuery_whenknnQueryWithFilterAndNmsLibEngine_thenException() {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -83,6 +84,98 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             );
             assertEquals(KnnFloatVectorQuery.class, query.getClass());
         }
+    }
+
+    public void testLuceneFloatVectorQuery() {
+        Query actualQuery1 = KNNQueryFactory.create(
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .vector(testQueryVector)
+                .k(testK)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .methodParameters(methodParameters)
+                .vectorDataType(VectorDataType.FLOAT)
+                .build()
+        );
+
+        // efsearch > k
+        Query expectedQuery1 = new KnnFloatVectorQuery(testFieldName, testQueryVector, 100, null);
+        assertEquals(expectedQuery1, actualQuery1);
+
+        // efsearch < k
+        actualQuery1 = KNNQueryFactory.create(
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .vector(testQueryVector)
+                .k(testK)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .methodParameters(Map.of("ef_search", 1))
+                .vectorDataType(VectorDataType.FLOAT)
+                .build()
+        );
+        expectedQuery1 = new KnnFloatVectorQuery(testFieldName, testQueryVector, testK, null);
+        assertEquals(expectedQuery1, actualQuery1);
+
+        actualQuery1 = KNNQueryFactory.create(
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .vector(testQueryVector)
+                .k(testK)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .vectorDataType(VectorDataType.FLOAT)
+                .build()
+        );
+        expectedQuery1 = new KnnFloatVectorQuery(testFieldName, testQueryVector, testK, null);
+        assertEquals(expectedQuery1, actualQuery1);
+    }
+
+    public void testLuceneByteVectorQuery() {
+        Query actualQuery1 = KNNQueryFactory.create(
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .byteVector(testByteQueryVector)
+                .k(testK)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .methodParameters(methodParameters)
+                .vectorDataType(VectorDataType.BYTE)
+                .build()
+        );
+
+        // efsearch > k
+        Query expectedQuery1 = new KnnByteVectorQuery(testFieldName, testByteQueryVector, 100, null);
+        assertEquals(expectedQuery1, actualQuery1);
+
+        // efsearch < k
+        actualQuery1 = KNNQueryFactory.create(
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .byteVector(testByteQueryVector)
+                .k(testK)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .methodParameters(Map.of("ef_search", 1))
+                .vectorDataType(VectorDataType.BYTE)
+                .build()
+        );
+        expectedQuery1 = new KnnByteVectorQuery(testFieldName, testByteQueryVector, testK, null);
+        assertEquals(expectedQuery1, actualQuery1);
+
+        actualQuery1 = KNNQueryFactory.create(
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .byteVector(testByteQueryVector)
+                .k(testK)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .vectorDataType(VectorDataType.BYTE)
+                .build()
+        );
+        expectedQuery1 = new KnnByteVectorQuery(testFieldName, testByteQueryVector, testK, null);
+        assertEquals(expectedQuery1, actualQuery1);
     }
 
     public void testCreateLuceneQueryWithFilter() {

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -193,18 +193,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
         knnQueryBuilder.doXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject().endObject();
-
-        Request request = new Request("POST", "/" + index + "/_search");
-
-        request.addParameter("size", Integer.toString(resultSize));
-        request.addParameter("explain", Boolean.toString(true));
-        request.addParameter("search_type", "query_then_fetch");
-        request.setJsonEntity(builder.toString());
-
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        return response;
+        return searchKNNIndex(index, builder, resultSize);
     }
 
     /**


### PR DESCRIPTION
### Description
Lucene queries use `k` as `efsearch`. So we take the max of two to pass is the right `k` value to Lucene. The `size` parameter will dictate the number of the hits

```
curl -XGET "http://localhost:9200/lucene-hnsw-index/_search" -H 'Content-Type: application/json' -d'
{
"size": 1,
  "query": {
    "knn": {
      "lucene_vector": {
        "vector": [2.5, 3.5, 2.2],
        "k": 3,
        "method_parameters": {
          "ef_search": 5
        }
        }
      }
    }
  }'
```
```
{
  "took": 4,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 4,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "lucene-hnsw-index",
        "_id": "2",
        "_score": 1,
        "_source": {
          "lucene_vector": [
            2.5,
            3.5,
            2.2
          ],
          "price": 7.1
        }
      }
    ]
  }
}
```

 
### Issues Resolved
[#1537](https://github.com/opensearch-project/k-NN/issues/1537)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
