### PR TITLE
Support ef_search parameter in radial search Faiss engine

### DIFF
--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -90,6 +90,7 @@ namespace knn_jni {
          * @param indexPointerJ - pointer to the index
          * @param queryVectorJ - the query vector
          * @param radiusJ - the radius for the range search
+         * @param methodParamsJ - the method parameters
          * @param maxResultsWindowJ - the maximum number of results to return
          * @param filterIdsJ - the filter ids
          * @param filterIdsTypeJ - the filter ids type
@@ -98,7 +99,7 @@ namespace knn_jni {
          * @return an array of RangeQueryResults
          */
         jobjectArray RangeSearchWithFilter(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
-                                           jfloat radiusJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ);
+                                           jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ);
 
         /*
          * Perform a range search against the index located in memory at indexPointerJ.
@@ -106,13 +107,14 @@ namespace knn_jni {
          * @param indexPointerJ - pointer to the index
          * @param queryVectorJ - the query vector
          * @param radiusJ - the radius for the range search
+         * @param methodParamsJ - the method parameters
          * @param maxResultsWindowJ - the maximum number of results to return
          * @param parentIdsJ - the parent ids
          *
          * @return an array of RangeQueryResults
          */
         jobjectArray RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
-                    jfloat radiusJ, jint maxResultWindowJ, jintArray parentIdsJ);
+                    jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jintArray parentIdsJ);
     }
 }
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -125,18 +125,18 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 /*
 * Class:     org_opensearch_knn_jni_FaissService
 * Method:    rangeSearchIndexWithFilter
-* Signature: (J[FJ[I)[Lorg/opensearch/knn/index/query/RangeQueryResult;
+* Signature: (J[FJLjava/util/MapI[JII)[Lorg/opensearch/knn/index/query/RangeQueryResult;
 */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter
-  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint, jlongArray, jint, jintArray);
+  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jobject, jint, jlongArray, jint, jintArray);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    rangeSearchIndex
- * Signature: (J[FJ[I)[Lorg/opensearch/knn/index/query/RangeQueryResult;
+ * Signature: (J[FJLjava/util/MapII)[Lorg/opensearch/knn/index/query/RangeQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex
-  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint, jintArray);
+  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jobject, jint, jintArray);
 
 #ifdef __cplusplus
 }

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -595,12 +595,12 @@ faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index) {
 }
 
 jobjectArray knn_jni::faiss_wrapper::RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ,
-                                                 jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ, jintArray parentIdsJ) {
-    return knn_jni::faiss_wrapper::RangeSearchWithFilter(jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ, nullptr, 0, parentIdsJ);
+                                                 jfloatArray queryVectorJ, jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jintArray parentIdsJ) {
+    return knn_jni::faiss_wrapper::RangeSearchWithFilter(jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, nullptr, 0, parentIdsJ);
 }
 
 jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ,
-                                                           jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ) {
+                                                           jfloatArray queryVectorJ, jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ) {
     if (queryVectorJ == nullptr) {
         throw std::runtime_error("Query Vector cannot be null");
     }
@@ -612,6 +612,13 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
     }
 
     float *rawQueryVector = jniUtil->GetFloatArrayElements(env, queryVectorJ, nullptr);
+
+    std::unordered_map<std::string, jobject> methodParams;
+    if (methodParamsJ != nullptr) {
+        methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
+    }
+
+    int ef_search = getQueryEfSearch(env, jniUtil, methodParams, 16);
 
     // The res will be freed by ~RangeSearchResult() in FAISS
     // The second parameter is always true, as lims is allocated by FAISS
@@ -634,9 +641,8 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         std::vector<uint64_t> idGrouperBitmap;
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader) {
-            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
-            // value of ef_search = 16 which will then be used.
-            hnswParams.efSearch = hnswReader->hnsw.efSearch;
+            // Query param ef_search supersedes ef_search provided during index setting.
+            hnswParams.efSearch = getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
             hnswParams.sel = idSelector.get();
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
@@ -664,12 +670,13 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         std::unique_ptr<faiss::IDGrouperBitmap> idGrouper;
         std::vector<uint64_t> idGrouperBitmap;
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
-        if(hnswReader!= nullptr && parentIdsJ != nullptr) {
-            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
-            // value of ef_search = 16 which will then be used.
-            hnswParams.efSearch = hnswReader->hnsw.efSearch;
-            idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
-            hnswParams.grp = idGrouper.get();
+        if(hnswReader!= nullptr) {
+            // Query param ef_search supersedes ef_search provided during index setting.
+            hnswParams.efSearch = getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            if (parentIdsJ != nullptr) {
+                idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
+                hnswParams.grp = idGrouper.get();
+            }
             searchParameters = &hnswParams;
         }
         try {

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -618,8 +618,6 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
     }
 
-    int ef_search = getQueryEfSearch(env, jniUtil, methodParams, 16);
-
     // The res will be freed by ~RangeSearchResult() in FAISS
     // The second parameter is always true, as lims is allocated by FAISS
     faiss::RangeSearchResult res(1, true);

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -640,7 +640,7 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader) {
             // Query param ef_search supersedes ef_search provided during index setting.
-            hnswParams.efSearch = getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
             hnswParams.sel = idSelector.get();
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
@@ -670,7 +670,7 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader!= nullptr) {
             // Query param ef_search supersedes ef_search provided during index setting.
-            hnswParams.efSearch = getQueryEfSearch(env, jniUtil, methodParams, hnswReader->hnsw.efSearch);
+            hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
                 hnswParams.grp = idGrouper.get();

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -194,11 +194,11 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jint maxResultWindowJ,
-                                                                                   jintArray parentIdsJ)
+                                                                                   jfloat radiusJ, jobject methodParamsJ,
+                                                                                   jint maxResultWindowJ, jintArray parentIdsJ)
 {
     try {
-        return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ, parentIdsJ);
+        return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, parentIdsJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -208,12 +208,11 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jint maxResultWindowJ,
+                                                                                   jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ,
                                                                                    jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ)
 {
     try {
-        return knn_jni::faiss_wrapper::RangeSearchWithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ,
-                                                             maxResultWindowJ, filterIdsJ, filterIdsTypeJ, parentIdsJ);
+        return knn_jni::faiss_wrapper::RangeSearchWithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, filterIdsJ, filterIdsTypeJ, parentIdsJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -635,6 +635,11 @@ TEST(FaissRangeSearchQueryIndexTest, BasicAssertions) {
     faiss::MetricType metricType = faiss::METRIC_L2;
     std::string method = "HNSW32,Flat";
 
+    int efSearch = 20;
+    std::unordered_map<std::string, jobject> methodParams;
+    methodParams[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
+    auto methodParamsJ = reinterpret_cast<jobject>(&methodParams);
+
     // Define query data
     int numQueries = 100;
     std::vector<std::vector<float>> queries;
@@ -667,7 +672,7 @@ TEST(FaissRangeSearchQueryIndexTest, BasicAssertions) {
                         knn_jni::faiss_wrapper::RangeSearch(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow, nullptr)));
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, methodParamsJ, maxResultWindow, nullptr)));
 
         // assert result size is not 0
         ASSERT_NE(0, results->size());
@@ -722,7 +727,7 @@ TEST(FaissRangeSearchQueryIndexTest_WhenHitMaxWindowResult, BasicAssertions){
                         knn_jni::faiss_wrapper::RangeSearch(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow, nullptr)));
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, nullptr, maxResultWindow, nullptr)));
 
         // assert result size is not 0
         ASSERT_NE(0, results->size());
@@ -788,7 +793,7 @@ TEST(FaissRangeSearchQueryIndexTestWithFilterTest, BasicAssertions) {
                         knn_jni::faiss_wrapper::RangeSearchWithFilter(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow,
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, nullptr, maxResultWindow,
                                 reinterpret_cast<jlongArray>(&bitmap), 0, nullptr)));
 
         // assert result size is not 0
@@ -863,7 +868,7 @@ TEST(FaissRangeSearchQueryIndexTestWithParentFilterTest, BasicAssertions) {
                         knn_jni::faiss_wrapper::RangeSearchWithFilter(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow, nullptr, 0,
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, nullptr, maxResultWindow, nullptr, 0,
                                 reinterpret_cast<jintArray>(&parentIds))));
 
         // assert result size is not 0

--- a/jni/tests/faiss_wrapper_unit_test.cpp
+++ b/jni/tests/faiss_wrapper_unit_test.cpp
@@ -20,8 +20,6 @@
 #include "test_util.h"
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexIDMap.h"
-#include "faiss/index_factory.h"
-#include "faiss/IndexIVFPQ.h"
 
 using ::testing::NiceMock;
 
@@ -135,7 +133,6 @@ namespace query_index_test {
         NiceMock<test_util::MockJNIUtil> mockJNIUtil;
 
         QueryIndexHNSWTestInput const &input = GetParam();
-        std::cout << "Running test: " << input.description << std::endl;
         float query[] = {1.2, 2.3, 3.4};
 
         int efSearch = input.efSearch;

--- a/jni/tests/faiss_wrapper_unit_test.cpp
+++ b/jni/tests/faiss_wrapper_unit_test.cpp
@@ -20,6 +20,8 @@
 #include "test_util.h"
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexIDMap.h"
+#include "faiss/index_factory.h"
+#include "faiss/IndexIVFPQ.h"
 
 using ::testing::NiceMock;
 
@@ -30,14 +32,15 @@ struct MockIndex : faiss::IndexHNSW {
     }
 };
 
-
 struct MockIdMap : faiss::IndexIDMap {
-    mutable idx_t nCalled;
-    mutable const float *xCalled;
-    mutable idx_t kCalled;
-    mutable float *distancesCalled;
-    mutable idx_t *labelsCalled;
-    mutable const faiss::SearchParametersHNSW *paramsCalled;
+    mutable idx_t nCalled{};
+    mutable const float *xCalled{};
+    mutable int kCalled{};
+    mutable float radiusCalled{};
+    mutable float *distancesCalled{};
+    mutable idx_t *labelsCalled{};
+    mutable const faiss::SearchParametersHNSW *paramsCalled{};
+    mutable faiss::RangeSearchResult *resCalled{};
 
     explicit MockIdMap(MockIndex *index) : faiss::IndexIDMapTemplate<faiss::Index>(index) {
     }
@@ -57,18 +60,33 @@ struct MockIdMap : faiss::IndexIDMap {
         paramsCalled = dynamic_cast<const faiss::SearchParametersHNSW *>(params);
     }
 
+    void range_search(
+        idx_t n,
+        const float *x,
+        float radius,
+        faiss::RangeSearchResult *res,
+        const faiss::SearchParameters *params) const override {
+        nCalled = n;
+        xCalled = x;
+        radiusCalled = radius;
+        resCalled = res;
+        paramsCalled = dynamic_cast<const faiss::SearchParametersHNSW *>(params);
+    }
+
     void resetMock() const {
         nCalled = 0;
         xCalled = nullptr;
         kCalled = 0;
+        radiusCalled = 0.0;
         distancesCalled = nullptr;
         labelsCalled = nullptr;
+        resCalled = nullptr;
         paramsCalled = nullptr;
     }
 };
 
 struct QueryIndexHNSWTestInput {
-    string description;
+    std::string description;
     int k;
     int efSearch;
     int filterIdType;
@@ -76,13 +94,31 @@ struct QueryIndexHNSWTestInput {
     bool parentIdsPresent;
 };
 
-
+struct RangeSearchTestInput {
+    std::string description;
+    float radius;
+    int efSearch;
+    int filterIdType;
+    bool filterIdsPresent;
+    bool parentIdsPresent;
+};
 
 class FaissWrappeterParametrizedTestFixture : public testing::TestWithParam<QueryIndexHNSWTestInput> {
 public:
     FaissWrappeterParametrizedTestFixture() : index_(3), id_map_(&index_) {
         index_.hnsw.efSearch = 100; // assigning 100 to make sure default of 16 is not used anywhere
-    };
+    }
+
+protected:
+    MockIndex index_;
+    MockIdMap id_map_;
+};
+
+class FaissWrapperParametrizedRangeSearchTestFixture : public testing::TestWithParam<RangeSearchTestInput> {
+public:
+    FaissWrapperParametrizedRangeSearchTestFixture() : index_(3), id_map_(&index_) {
+        index_.hnsw.efSearch = 100; // assigning 100 to make sure default of 16 is not used anywhere
+    }
 
 protected:
     MockIndex index_;
@@ -93,14 +129,13 @@ namespace query_index_test {
 
     std::unordered_map<std::string, jobject> methodParams;
 
-
     TEST_P(FaissWrappeterParametrizedTestFixture, QueryIndexHNSWTests) {
-        //Given
+        // Given
         JNIEnv *jniEnv = nullptr;
         NiceMock<test_util::MockJNIUtil> mockJNIUtil;
 
-
         QueryIndexHNSWTestInput const &input = GetParam();
+        std::cout << "Running test: " << input.description << std::endl;
         float query[] = {1.2, 2.3, 3.4};
 
         int efSearch = input.efSearch;
@@ -137,7 +172,7 @@ namespace query_index_test {
             reinterpret_cast<jfloatArray>(&query), input.k, reinterpret_cast<jobject>(&methodParams),
             reinterpret_cast<jintArray>(parentIdPtr));
 
-        //Then
+        // Then
         int actualEfSearch = id_map_.paramsCalled->efSearch;
         // Asserting the captured argument
         EXPECT_EQ(input.k, id_map_.kCalled);
@@ -165,10 +200,9 @@ namespace query_index_test {
 namespace query_index_with_filter_test {
 
     TEST_P(FaissWrappeterParametrizedTestFixture, QueryIndexWithFilterHNSWTests) {
-        //Given
+        // Given
         JNIEnv *jniEnv = nullptr;
         NiceMock<test_util::MockJNIUtil> mockJNIUtil;
-
 
         QueryIndexHNSWTestInput const &input = GetParam();
         float query[] = {1.2, 2.3, 3.4};
@@ -218,7 +252,7 @@ namespace query_index_with_filter_test {
             input.filterIdType,
             reinterpret_cast<jintArray>(parentIdPtr));
 
-        //Then
+        // Then
         int actualEfSearch = id_map_.paramsCalled->efSearch;
         // Asserting the captured argument
         EXPECT_EQ(input.k, id_map_.kCalled);
@@ -249,3 +283,93 @@ namespace query_index_with_filter_test {
         )
     );
 }
+
+namespace range_search_test {
+
+    TEST_P(FaissWrapperParametrizedRangeSearchTestFixture, RangeSearchHNSWTests) {
+        // Given
+        JNIEnv *jniEnv = nullptr;
+        NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+        RangeSearchTestInput const &input = GetParam();
+        float query[] = {1.2, 2.3, 3.4};
+        float radius = input.radius;
+        int maxResultWindow = 100; // Set your max result window
+
+        std::unordered_map<std::string, jobject> methodParams;
+        int efSearch = input.efSearch;
+        int expectedEfSearch = 100; // default set in mock
+        if (efSearch != -1) {
+            expectedEfSearch = input.efSearch;
+            methodParams[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
+        }
+
+        std::vector<int> *parentIdPtr = nullptr;
+        if (input.parentIdsPresent) {
+            std::vector<int> parentId;
+            parentId.reserve(2);
+            parentId.push_back(1);
+            parentId.push_back(2);
+            parentIdPtr = &parentId;
+
+            EXPECT_CALL(mockJNIUtil,
+                        GetJavaIntArrayLength(
+                            jniEnv, reinterpret_cast<jintArray>(parentIdPtr)))
+                    .WillOnce(testing::Return(parentId.size()));
+
+            EXPECT_CALL(mockJNIUtil,
+                        GetIntArrayElements(
+                            jniEnv, reinterpret_cast<jintArray>(parentIdPtr), nullptr))
+                    .WillOnce(testing::Return(new int[2]{1, 2}));
+        }
+
+        std::vector<long> filter;
+        std::vector<long> *filterptr = nullptr;
+        if (input.filterIdsPresent) {
+            filter.reserve(2);
+            filter.push_back(1);
+            filter.push_back(2);
+            filterptr = &filter;
+        }
+
+        // When
+        knn_jni::faiss_wrapper::RangeSearchWithFilter(
+            &mockJNIUtil, jniEnv,
+            reinterpret_cast<jlong>(&id_map_),
+            reinterpret_cast<jfloatArray>(&query), radius, reinterpret_cast<jobject>(&methodParams),
+            maxResultWindow,
+            reinterpret_cast<jlongArray>(filterptr),
+            input.filterIdType,
+            reinterpret_cast<jintArray>(parentIdPtr));
+
+        // Then
+        int actualEfSearch = id_map_.paramsCalled->efSearch;
+        // Asserting the captured argument
+        EXPECT_EQ(expectedEfSearch, actualEfSearch);
+        if (input.parentIdsPresent) {
+            faiss::IDGrouper *grouper = id_map_.paramsCalled->grp;
+            EXPECT_TRUE(grouper != nullptr);
+        }
+        if (input.filterIdsPresent) {
+            faiss::IDSelector *sel = id_map_.paramsCalled->sel;
+            EXPECT_TRUE(sel != nullptr);
+        }
+        id_map_.resetMock();
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        RangeSearchHNSWTests,
+        FaissWrapperParametrizedRangeSearchTestFixture,
+        ::testing::Values(
+            RangeSearchTestInput{"algoParams present, parent absent, filter absent", 10.0f, 200, 0, false, false},
+            RangeSearchTestInput{"algoParams present, parent absent, filter absent, filter type 1", 10.0f, 200, 1, false, false},
+            RangeSearchTestInput{"algoParams absent, parent absent, filter present", 10.0f, -1, 0, true, false},
+            RangeSearchTestInput{"algoParams absent, parent absent, filter present, filter type 1", 10.0f, -1, 1, true, false},
+            RangeSearchTestInput{"algoParams present, parent present, filter absent", 10.0f, 200, 0, false, true},
+            RangeSearchTestInput{"algoParams present, parent present, filter absent, filter type 1", 10.0f, 150, 1, false, true},
+            RangeSearchTestInput{"algoParams absent, parent present, filter present", 10.0f, -1, 0, true, true},
+            RangeSearchTestInput{"algoParams absent, parent present, filter present, filter type 1", 10.0f, -1, 1, true, true}
+        )
+    );
+}
+

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.query;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.lucene.search.BooleanClause;
@@ -205,6 +206,7 @@ public class KNNQuery extends Query {
     @Setter
     @Getter
     @AllArgsConstructor
+    @EqualsAndHashCode
     public static class Context {
         int maxResultWindow;
     }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -611,6 +611,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 .byteVector(VectorDataType.BYTE == vectorDataType ? byteVector : null)
                 .vectorDataType(vectorDataType)
                 .radius(radius)
+                .methodParameters(this.methodParameters)
                 .filter(this.filter)
                 .context(context)
                 .build();

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -294,6 +294,7 @@ public class KNNWeight extends Weight {
                     indexAllocation.getMemoryAddress(),
                     knnQuery.getQueryVector(),
                     knnQuery.getRadius(),
+                    knnQuery.getMethodParameters(),
                     knnEngine,
                     knnQuery.getContext().getMaxResultWindow(),
                     filterIds,

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -10,6 +10,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
 import java.util.Locale;
+import java.util.Map;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.ByteVectorSimilarityQuery;
@@ -69,6 +70,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final byte[] byteVector = createQueryRequest.getByteVector();
         final VectorDataType vectorDataType = createQueryRequest.getVectorDataType();
         final Query filterQuery = getFilterQuery(createQueryRequest);
+        final Map<String, ?> methodParameters = createQueryRequest.getMethodParameters();
 
         if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
             BitSetProducer parentFilter = null;
@@ -79,15 +81,17 @@ public class RNNQueryFactory extends BaseQueryFactory {
             }
             IndexSettings indexSettings = context.getIndexSettings();
             KNNQuery.Context knnQueryContext = new KNNQuery.Context(indexSettings.getMaxResultWindow());
-            KNNQuery rnnQuery = new KNNQuery(fieldName, vector, indexName, parentFilter).radius(radius).kNNQueryContext(knnQueryContext);
-            if (filterQuery != null && KNNEngine.getEnginesThatSupportsFilters().contains(createQueryRequest.getKnnEngine())) {
-                log.debug("Creating custom radius search with filters for index: {}, field: {} , r: {}", indexName, fieldName, radius);
-                rnnQuery.filterQuery(filterQuery);
-            }
-            log.debug(
-                String.format("Creating custom radius search for index: %s \"\", field: %s \"\", r: %f", indexName, fieldName, radius)
-            );
-            return rnnQuery;
+
+            return KNNQuery.builder()
+                .field(fieldName)
+                .queryVector(vector)
+                .indexName(indexName)
+                .parentsFilter(parentFilter)
+                .radius(radius)
+                .methodParameters(methodParameters)
+                .context(knnQueryContext)
+                .filterQuery(filterQuery)
+                .build();
         }
 
         log.debug(String.format("Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", indexName, fieldName, radius));

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -204,6 +204,7 @@ class FaissService {
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
+     * @param methodParameters parameters to be used for the query
      * @param indexMaxResultWindow maximum number of results to return
      * @param filteredIds list of doc ids to include in the query result
      * @param filterIdsType type of filter ids
@@ -214,6 +215,7 @@ class FaissService {
         long indexPointer,
         float[] queryVector,
         float radius,
+        Map<String, ?> methodParameters,
         int indexMaxResultWindow,
         long[] filteredIds,
         int filterIdsType,
@@ -226,6 +228,7 @@ class FaissService {
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
+     * @param methodParameters parameters to be used for the query
      * @param indexMaxResultWindow maximum number of results to return
      * @param parentIds list of parent doc ids when the knn field is a nested field
      * @return KNNQueryResult array of neighbors within radius
@@ -234,6 +237,7 @@ class FaissService {
         long indexPointer,
         float[] queryVector,
         float radius,
+        Map<String, ?> methodParameters,
         int indexMaxResultWindow,
         int[] parentIds
     );

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -279,6 +279,7 @@ public class JNIService {
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
+     * @param methodParameters parameters to be used when loading index
      * @param knnEngine engine to query index
      * @param indexMaxResultWindow maximum number of results to return
      * @param filteredIds list of doc ids to include in the query result
@@ -290,6 +291,7 @@ public class JNIService {
         long indexPointer,
         float[] queryVector,
         float radius,
+        @Nullable Map<String, ?> methodParameters,
         KNNEngine knnEngine,
         int indexMaxResultWindow,
         long[] filteredIds,
@@ -302,13 +304,14 @@ public class JNIService {
                     indexPointer,
                     queryVector,
                     radius,
+                    methodParameters,
                     indexMaxResultWindow,
                     filteredIds,
                     filterIdsType,
                     parentIds
                 );
             }
-            return FaissService.rangeSearchIndex(indexPointer, queryVector, radius, indexMaxResultWindow, parentIds);
+            return FaissService.rangeSearchIndex(indexPointer, queryVector, radius, methodParameters, indexMaxResultWindow, parentIds);
         }
         throw new IllegalArgumentException("RadiusQueryIndex not supported for provided engine");
     }

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -59,6 +59,7 @@ import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
@@ -141,7 +142,7 @@ public class FaissIT extends KNNRestTestCase {
         assertEquals(testData.indexData.docs.length, getDocCount(INDEX_NAME));
 
         float distance = 300000000000f;
-        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, distance, null, spaceType, null);
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, distance, null, spaceType, null, null);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
@@ -201,7 +202,7 @@ public class FaissIT extends KNNRestTestCase {
 
         float score = 0.00001f;
 
-        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType, null);
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType, null, null);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
@@ -261,7 +262,7 @@ public class FaissIT extends KNNRestTestCase {
 
         float score = 5f;
 
-        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType, null);
+        validateRadiusSearchResults(INDEX_NAME, FIELD_NAME, testData.queries, null, score, spaceType, null, null);
 
         // Delete index
         deleteKNNIndex(INDEX_NAME);
@@ -345,8 +346,11 @@ public class FaissIT extends KNNRestTestCase {
         assertEquals(testData.indexData.docs.length, getDocCount(indexName));
 
         float distance = 300000000000f;
+        // create method parameter wih ef_search
+        Map<String, Object> methodParameters = new ImmutableMap.Builder<String, Object>().put(KNNConstants.METHOD_PARAMETER_EF_SEARCH, 150)
+            .build();
 
-        validateRadiusSearchResults(indexName, fieldName, testData.queries, distance, null, spaceType, null);
+        validateRadiusSearchResults(indexName, fieldName, testData.queries, distance, null, spaceType, null, methodParameters);
 
         // Delete index
         deleteKNNIndex(indexName);
@@ -381,7 +385,8 @@ public class FaissIT extends KNNRestTestCase {
             distance,
             null,
             SpaceType.L2,
-            termQueryBuilder
+            termQueryBuilder,
+            null
         );
 
         assertEquals(1, queryResult.get(0).size());
@@ -1665,7 +1670,8 @@ public class FaissIT extends KNNRestTestCase {
         Float distanceThreshold,
         Float scoreThreshold,
         final SpaceType spaceType,
-        TermQueryBuilder filterQuery
+        TermQueryBuilder filterQuery,
+        Map<String, ?> methodParameters
     ) throws IOException, ParseException {
         List<List<KNNResult>> queryResults = new ArrayList<>();
         for (float[] queryVector : queryVectors) {
@@ -1682,6 +1688,13 @@ public class FaissIT extends KNNRestTestCase {
             }
             if (filterQuery != null) {
                 queryBuilder.field("filter", filterQuery);
+            }
+            if (methodParameters != null) {
+                queryBuilder.startObject(METHOD_PARAMETER);
+                for (Map.Entry<String, ?> entry : methodParameters.entrySet()) {
+                    queryBuilder.field(entry.getKey(), entry.getValue());
+                }
+                queryBuilder.endObject();
             }
             queryBuilder.endObject();
             queryBuilder.endObject();

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -199,18 +199,22 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(knnQueryBuilder, actualBuilder);
     }
 
-    public void testFromXContent_whenDoRadiusSearch_whenDistanceThreshold_thenSucceed() throws Exception {
+    public void testFromXContent_whenDoRadiusSearch_whenDistanceThreshold_whenMethodParameter_thenSucceed() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
             .maxDistance(MAX_DISTANCE)
+            .methodParameters(HNSW_METHOD_PARAMS)
             .build();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject(knnQueryBuilder.fieldName());
         builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
         builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), knnQueryBuilder.getMaxDistance());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
         builder.endObject();
         builder.endObject();
         XContentParser contentParser = createParser(builder);
@@ -219,18 +223,22 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(knnQueryBuilder, actualBuilder);
     }
 
-    public void testFromXContent_whenDoRadiusSearch_whenScoreThreshold_thenSucceed() throws Exception {
+    public void testFromXContent_whenDoRadiusSearch_whenScoreThreshold_whenMethodParameter_thenSucceed() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
             .minScore(MAX_DISTANCE)
+            .methodParameters(HNSW_METHOD_PARAMS)
             .build();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject(knnQueryBuilder.fieldName());
         builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
         builder.field(KNNQueryBuilder.MIN_SCORE_FIELD.getPreferredName(), knnQueryBuilder.getMinScore());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
         builder.endObject();
         builder.endObject();
         XContentParser contentParser = createParser(builder);

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -763,7 +763,7 @@ public class KNNWeightTests extends KNNTestCase {
         final float radius = 0.5f;
         final int maxResults = 1000;
         jniServiceMockedStatic.when(
-            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt(), any(), anyInt(), any())
+            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), any(), anyInt(), any(), anyInt(), any())
         ).thenReturn(getKNNQueryResults());
         KNNQuery.Context context = mock(KNNQuery.Context.class);
         when(context.getMaxResultWindow()).thenReturn(maxResults);
@@ -807,7 +807,7 @@ public class KNNWeightTests extends KNNTestCase {
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
         jniServiceMockedStatic.verify(
-            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt(), any(), anyInt(), any())
+            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), any(), anyInt(), any(), anyInt(), any())
         );
 
         final DocIdSetIterator docIdSetIterator = knnScorer.iterator();

--- a/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
@@ -109,12 +109,24 @@ public class RNNQueryFactoryTests extends KNNTestCase {
     }
 
     public void testCreate_whenFaiss_thenSucceed() {
+        // Given
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         MappedFieldType testMapper = mock(MappedFieldType.class);
         IndexSettings indexSettings = mock(IndexSettings.class);
         when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
         when(mockQueryShardContext.fieldMapper(any())).thenReturn(testMapper);
         when(mockQueryShardContext.getIndexSettings().getMaxResultWindow()).thenReturn(maxResultWindow);
+
+        final KNNQuery expectedQuery = KNNQuery.builder()
+            .field(testFieldName)
+            .queryVector(testQueryVector)
+            .indexName(testIndexName)
+            .radius(testRadius)
+            .methodParameters(methodParameters)
+            .context(new KNNQuery.Context(maxResultWindow))
+            .build();
+
+        // When
         final RNNQueryFactory.CreateQueryRequest createQueryRequest = RNNQueryFactory.CreateQueryRequest.builder()
             .knnEngine(KNNEngine.FAISS)
             .indexName(testIndexName)
@@ -128,12 +140,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
 
         Query query = RNNQueryFactory.create(createQueryRequest);
 
-        assertTrue(query instanceof KNNQuery);
-        assertEquals(testIndexName, ((KNNQuery) query).getIndexName());
-        assertEquals(testFieldName, ((KNNQuery) query).getField());
-        assertEquals(testQueryVector, ((KNNQuery) query).getQueryVector());
-        assertEquals(testRadius, ((KNNQuery) query).getRadius(), 0);
-        assertEquals(maxResultWindow, ((KNNQuery) query).getContext().getMaxResultWindow());
-        assertEquals(methodParameters, ((KNNQuery) query).getMethodParameters());
+        // Then
+        assertEquals(expectedQuery, query);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
@@ -9,9 +9,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.search.ByteVectorSimilarityQuery;
@@ -38,6 +40,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
     private final String testFieldName = "test-field";
     private final Float testRadius = 0.5f;
     private final int maxResultWindow = 20000;
+    private final Map<String, ?> methodParameters = Map.of(METHOD_PARAMETER_EF_SEARCH, 100);
 
     public void testCreate_whenLucene_withRadiusQuery_withFloatVector() {
         List<KNNEngine> luceneDefaultQueryEngineList = Arrays.stream(KNNEngine.values())
@@ -120,6 +123,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
             .radius(testRadius)
             .vectorDataType(DEFAULT_VECTOR_DATA_TYPE_FIELD)
             .context(mockQueryShardContext)
+            .methodParameters(methodParameters)
             .build();
 
         Query query = RNNQueryFactory.create(createQueryRequest);
@@ -130,5 +134,6 @@ public class RNNQueryFactoryTests extends KNNTestCase {
         assertEquals(testQueryVector, ((KNNQuery) query).getQueryVector());
         assertEquals(testRadius, ((KNNQuery) query).getRadius(), 0);
         assertEquals(maxResultWindow, ((KNNQuery) query).getContext().getMaxResultWindow());
+        assertEquals(methodParameters, ((KNNQuery) query).getMethodParameters());
     }
 }


### PR DESCRIPTION
### Description
This PR is adding the ability for Faiss engine to support radial search with `ef_search` parameter in query request.


### Query example
```
GET /target-index-faiss/_search HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 198

{
  "query": {
    "knn": {
      "my_vector1": {
        "vector": [5.5, 8.5],
        "min_score": 0.3,
        "method_parameters": {
            "ef_search" : 10000
        }
      }
    }
  }
}
```
 
### Issues Resolved
Part of https://github.com/opensearch-project/k-NN/issues/1537 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
