### PR TITLE
Add rolling version upgrade support for ignore_unmapped

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -331,7 +331,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
      */
     public KNNQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        KNNQueryBuilder.Builder builder = KNNQueryBuilderParser.streamInput(in, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+        KNNQueryBuilder.Builder builder = KNNQueryBuilderParser.streamInput(in, IndexUtil::isStreamOnOrAfterMinRequiredVersion);
         fieldName = builder.fieldName;
         vector = builder.vector;
         k = builder.k;
@@ -345,7 +345,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        KNNQueryBuilderParser.streamOutput(out, this, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+        KNNQueryBuilderParser.streamOutput(out, this, IndexUtil::isStreamOnOrAfterMinRequiredVersion);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
@@ -106,7 +105,8 @@ public final class KNNQueryBuilderParser {
      * @return KNNQueryBuilder.Builder class
      * @throws IOException on stream failure
      */
-    public static KNNQueryBuilder.Builder streamInput(StreamInput in, BiFunction<Version, String, Boolean> minClusterVersionCheck) throws IOException {
+    public static KNNQueryBuilder.Builder streamInput(StreamInput in, BiFunction<Version, String, Boolean> minClusterVersionCheck)
+        throws IOException {
         KNNQueryBuilder.Builder builder = new KNNQueryBuilder.Builder();
         builder.fieldName(in.readString());
         builder.vector(in.readFloatArray());
@@ -126,7 +126,7 @@ public final class KNNQueryBuilderParser {
             builder.methodParameters(MethodParametersParser.streamInput(in, IndexUtil::isClusterOnOrAfterMinRequiredVersion));
         }
 
-        if (minClusterVersionCheck.apply(RESCORE_PARAMETER)) {
+        if (minClusterVersionCheck.apply(in.getVersion(), RESCORE_PARAMETER)) {
             builder.rescoreContext(RescoreParser.streamInput(in));
         }
 
@@ -159,7 +159,7 @@ public final class KNNQueryBuilderParser {
         if (minClusterVersionCheck.apply(out.getVersion(), METHOD_PARAMETER)) {
             MethodParametersParser.streamOutput(out, builder.getMethodParameters(), IndexUtil::isClusterOnOrAfterMinRequiredVersion);
         }
-        if (minClusterVersionCheck.apply(RESCORE_PARAMETER)) {
+        if (minClusterVersionCheck.apply(out.getVersion(), RESCORE_PARAMETER)) {
             RescoreParser.streamOutput(out, builder.getRescoreContext());
         }
     }

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -295,7 +295,7 @@ public class IndexUtil {
 
     /**
      * Returns the min version required for feature support
-     * 
+     *
      * @param feature The name of the feature
      * @return Min OpenSearch version required for the feature support
      */

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -294,6 +294,16 @@ public class IndexUtil {
     }
 
     /**
+     * Returns the min version required for feature support
+     * 
+     * @param feature The name of the feature
+     * @return Min OpenSearch version required for the feature support
+     */
+    public static boolean isStreamOnOrAfterMinRequiredVersion(Version streamVersion, String feature) {
+        return streamVersion.onOrAfter(minimalRequiredVersionMap.get(feature));
+    }
+
+    /**
      * Checks if index requires shared state
      *
      * @param knnEngine The knnEngine associated with the index


### PR DESCRIPTION
### Description
- Adds in rolling version upgrade support for `ignore_unmapped`

### Issues Resolved
- N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
