### PR TITLE
Add binary format support with IVF method in Faiss Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Adds dynamic query parameter ef_search [#1783](https://github.com/opensearch-project/k-NN/pull/1783)
 * Adds dynamic query parameter ef_search in radial search faiss engine [#1790](https://github.com/opensearch-project/k-NN/pull/1790)
 * Add binary format support with HNSW method in Faiss Engine [#1781](https://github.com/opensearch-project/k-NN/pull/1781)
+* Add binary format support with IVF method in Faiss Engine [#1784](https://github.com/opensearch-project/k-NN/pull/1784)
 ### Enhancements
 ### Bug Fixes
 * Fixing the arithmetic to find the number of vectors to stream from java to jni layer.[#1804](https://github.com/opensearch-project/k-NN/pull/1804)

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -29,6 +29,12 @@ namespace knn_jni {
                                      jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
                                      jobject parametersJ);
 
+        // Create an index with ids and vectors. Instead of creating a new index, this function creates the index
+        // based off of the template index passed in. The index is serialized to indexPathJ.
+        void CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
+                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
+                                     jobject parametersJ);
+
         // Load an index from indexPathJ into memory.
         //
         // Return a pointer to the loaded index
@@ -95,6 +101,13 @@ namespace knn_jni {
         // Return the serialized representation
         jbyteArray TrainIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ, jint dimension,
                               jlong trainVectorsPointerJ);
+
+        // Create an empty binary index defined by the values in the Java map, parametersJ. Train the index with
+        // the vector of floats located at trainVectorsPointerJ.
+        //
+        // Return the serialized representation
+        jbyteArray TrainBinaryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ, jint dimension,
+                         jlong trainVectorsPointerJ);
 
         /*
          * Perform a range search with filter against the index located in memory at indexPointerJ.

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -45,6 +45,14 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromT
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    createBinaryIndexFromTemplate
+ * Signature: ([IJILjava/lang/String;[BLjava/util/Map;)V
+ */
+    JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryIndexFromTemplate
+      (JNIEnv *, jclass, jintArray, jlong, jint, jstring, jbyteArray, jobject);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
  * Method:    loadIndex
  * Signature: (Ljava/lang/String;)J
  */
@@ -137,6 +145,14 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_initLibrary
  * Signature: (Ljava/util/Map;IJ)[B
  */
 JNIEXPORT jbyteArray JNICALL Java_org_opensearch_knn_jni_FaissService_trainIndex
+  (JNIEnv *, jclass, jobject, jint, jlong);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    trainBinaryIndex
+ * Signature: (Ljava/util/Map;IJ)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_org_opensearch_knn_jni_FaissService_trainBinaryIndex
   (JNIEnv *, jclass, jobject, jint, jlong);
 
 /*

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -70,6 +70,9 @@ void SetExtraParameters(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env,
 // Train an index with data provided
 void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x);
 
+// Train a binary index with data provided
+void InternalTrainBinaryIndex(faiss::IndexBinary * index, faiss::idx_t n, const float* x);
+
 // Converts the int FilterIds to Faiss ids type array.
 void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, faiss::idx_t* convertedFilterIds);
 
@@ -221,6 +224,76 @@ void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface *
     // Write the index to disk
     std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
     faiss::write_index(&idMap, indexPathCpp.c_str());
+}
+
+void knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
+                                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ,
+                                                     jbyteArray templateIndexJ, jobject parametersJ) {
+    if (idsJ == nullptr) {
+        throw std::runtime_error("IDs cannot be null");
+    }
+
+    if (vectorsAddressJ <= 0) {
+        throw std::runtime_error("VectorsAddress cannot be less than 0");
+    }
+
+    if(dimJ <= 0) {
+        throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
+    }
+
+    if (indexPathJ == nullptr) {
+        throw std::runtime_error("Index path cannot be null");
+    }
+
+    if (templateIndexJ == nullptr) {
+        throw std::runtime_error("Template index cannot be null");
+    }
+
+    // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
+    auto parametersCpp = jniUtil->ConvertJavaMapToCppMap(env, parametersJ);
+    if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
+        auto threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
+        omp_set_num_threads(threadCount);
+    }
+    jniUtil->DeleteLocalRef(env, parametersJ);
+
+    // Read data set
+    // Read vectors from memory address
+    auto *inputVectors = reinterpret_cast<std::vector<uint8_t>*>(vectorsAddressJ);
+    int dim = (int)dimJ;
+    if (dim % 8 != 0) {
+        throw std::runtime_error("Dimensions should be multiply of 8");
+    }
+    int numVectors = (int) (inputVectors->size() / (uint64_t) (dim / 8));
+    int numIds = jniUtil->GetJavaIntArrayLength(env, idsJ);
+    if (numIds != numVectors) {
+        throw std::runtime_error("Number of IDs does not match number of vectors");
+    }
+
+    // Get vector of bytes from jbytearray
+    int indexBytesCount = jniUtil->GetJavaBytesArrayLength(env, templateIndexJ);
+    jbyte * indexBytesJ = jniUtil->GetByteArrayElements(env, templateIndexJ, nullptr);
+
+    faiss::VectorIOReader vectorIoReader;
+    for (int i = 0; i < indexBytesCount; i++) {
+        vectorIoReader.data.push_back((uint8_t) indexBytesJ[i]);
+    }
+    jniUtil->ReleaseByteArrayElements(env, templateIndexJ, indexBytesJ, JNI_ABORT);
+
+    // Create faiss index
+    std::unique_ptr<faiss::IndexBinary> indexWriter;
+    indexWriter.reset(faiss::read_index_binary(&vectorIoReader, 0));
+
+    auto idVector = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
+    faiss::IndexBinaryIDMap idMap =  faiss::IndexBinaryIDMap(indexWriter.get());
+    idMap.add_with_ids(numVectors, reinterpret_cast<const uint8_t*>(inputVectors->data()), idVector.data());
+    // Releasing the vectorsAddressJ memory as that is not required once we have created the index.
+    // This is not the ideal approach, please refer this gh issue for long term solution:
+    // https://github.com/opensearch-project/k-NN/issues/1600
+    delete inputVectors;
+    // Write the index to disk
+    std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
+    faiss::write_index_binary(&idMap, indexPathCpp.c_str());
 }
 
 jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jstring indexPathJ) {
@@ -624,6 +697,57 @@ jbyteArray knn_jni::faiss_wrapper::TrainIndex(knn_jni::JNIUtilInterface * jniUti
     return ret;
 }
 
+jbyteArray knn_jni::faiss_wrapper::TrainBinaryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ,
+                                              jint dimensionJ, jlong trainVectorsPointerJ) {
+    // First, we need to build the index
+    if (parametersJ == nullptr) {
+        throw std::runtime_error("Parameters cannot be null");
+    }
+
+    auto parametersCpp = jniUtil->ConvertJavaMapToCppMap(env, parametersJ);
+
+    jobject spaceTypeJ = knn_jni::GetJObjectFromMapOrThrow(parametersCpp, knn_jni::SPACE_TYPE);
+    std::string spaceTypeCpp(jniUtil->ConvertJavaObjectToCppString(env, spaceTypeJ));
+    faiss::MetricType metric = TranslateSpaceToMetric(spaceTypeCpp);
+
+    // Create faiss index
+    jobject indexDescriptionJ = knn_jni::GetJObjectFromMapOrThrow(parametersCpp, knn_jni::INDEX_DESCRIPTION);
+    std::string indexDescriptionCpp(jniUtil->ConvertJavaObjectToCppString(env, indexDescriptionJ));
+
+    std::unique_ptr<faiss::IndexBinary> indexWriter;
+    indexWriter.reset(faiss::index_binary_factory((int) dimensionJ, indexDescriptionCpp.c_str()));
+
+    // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
+    if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
+        auto threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
+        omp_set_num_threads(threadCount);
+    }
+
+    // Train index if needed
+    auto *trainingVectorsPointerCpp = reinterpret_cast<std::vector<float>*>(trainVectorsPointerJ);
+    int numVectors = trainingVectorsPointerCpp->size()/(int) dimensionJ;
+    if(!indexWriter->is_trained) {
+        InternalTrainBinaryIndex(indexWriter.get(), numVectors, trainingVectorsPointerCpp->data());
+    }
+    jniUtil->DeleteLocalRef(env, parametersJ);
+
+    // Now that indexWriter is trained, we just load the bytes into an array and return
+    faiss::VectorIOWriter vectorIoWriter;
+    faiss::write_index_binary(indexWriter.get(), &vectorIoWriter);
+
+    // Wrap in smart pointer
+    std::unique_ptr<jbyte[]> jbytesBuffer;
+    jbytesBuffer.reset(new jbyte[vectorIoWriter.data.size()]);
+    int c = 0;
+    for (auto b : vectorIoWriter.data) {
+        jbytesBuffer[c++] = (jbyte) b;
+    }
+
+    jbyteArray ret = jniUtil->NewByteArray(env, vectorIoWriter.data.size());
+    jniUtil->SetByteArrayRegion(env, ret, 0, vectorIoWriter.data.size(), jbytesBuffer.get());
+    return ret;
+}
+
 faiss::MetricType TranslateSpaceToMetric(const std::string& spaceType) {
     if (spaceType == knn_jni::L2) {
         return faiss::METRIC_L2;
@@ -679,6 +803,15 @@ void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x) {
 
     if (!index->is_trained) {
         index->train(n, x);
+    }
+}
+
+void InternalTrainBinaryIndex(faiss::IndexBinary * index, faiss::idx_t n, const float* x) {
+    if (auto * indexIvf = dynamic_cast<faiss::IndexBinaryIVF*>(index)) {
+        indexIvf->make_direct_map();
+    }
+    if (!index->is_trained) {
+        index->train(n, reinterpret_cast<const uint8_t*>(x));
     }
 }
 

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -90,6 +90,21 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromT
     }
 }
 
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryIndexFromTemplate(JNIEnv * env, jclass cls,
+                                                                                        jintArray idsJ,
+                                                                                        jlong vectorsAddressJ,
+                                                                                        jint dimJ,
+                                                                                        jstring indexPathJ,
+                                                                                        jbyteArray templateIndexJ,
+                                                                                        jobject parametersJ)
+{
+    try {
+        knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex(JNIEnv * env, jclass cls, jstring indexPathJ)
 {
     try {
@@ -214,6 +229,19 @@ JNIEXPORT jbyteArray JNICALL Java_org_opensearch_knn_jni_FaissService_trainIndex
 {
     try {
         return knn_jni::faiss_wrapper::TrainIndex(&jniUtil, env, parametersJ, dimensionJ, trainVectorsPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return nullptr;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_org_opensearch_knn_jni_FaissService_trainBinaryIndex(JNIEnv * env, jclass cls,
+                                                                                 jobject parametersJ,
+                                                                                 jint dimensionJ,
+                                                                                 jlong trainVectorsPointerJ)
+{
+    try {
+        return knn_jni::faiss_wrapper::TrainBinaryIndex(&jniUtil, env, parametersJ, dimensionJ, trainVectorsPointerJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -67,6 +67,7 @@ public class KNNConstants {
     public static final String SEARCH_SIZE_PARAMETER = "search_size";
 
     public static final String VECTOR_DATA_TYPE_FIELD = "data_type";
+    public static final String MODEL_VECTOR_DATA_TYPE_KEY = VECTOR_DATA_TYPE_FIELD;
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";

--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -48,27 +48,9 @@ public class IndexUtil {
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_METHOD_COMPONENT_CONTEXT = Version.V_2_13_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_RADIAL_SEARCH = Version.V_2_14_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_METHOD_PARAMETERS = Version.V_2_16_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VECTOR_DATA_TYPE = Version.V_2_16_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
-
-    private static Map<String, Version> initializeMinimalRequiredVersionMap() {
-        final Map<String, Version> versionMap = new HashMap<>() {
-            {
-                put("ignore_unmapped", MINIMAL_SUPPORTED_VERSION_FOR_IGNORE_UNMAPPED);
-                put(MODEL_NODE_ASSIGNMENT_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_NODE_ASSIGNMENT);
-                put(MODEL_METHOD_COMPONENT_CONTEXT_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_METHOD_COMPONENT_CONTEXT);
-                put(KNNConstants.RADIAL_SEARCH_KEY, MINIMAL_SUPPORTED_VERSION_FOR_RADIAL_SEARCH);
-                put(KNNConstants.METHOD_PARAMETER, MINIMAL_SUPPORTED_VERSION_FOR_METHOD_PARAMETERS);
-            }
-        };
-
-        for (final MethodParameter methodParameter : MethodParameter.values()) {
-            if (methodParameter.getVersion() != null) {
-                versionMap.put(methodParameter.getName(), methodParameter.getVersion());
-            }
-        }
-        return Collections.unmodifiableMap(versionMap);
-    }
 
     /**
      * Determines the size of a file on disk in kilobytes
@@ -89,37 +71,6 @@ public class IndexUtil {
     }
 
     /**
-     * This method retrieves the field mapping by a given field path from the index metadata.
-     *
-     * @param properties Index metadata mapping properties.
-     * @param fieldPath The field path string that make up the path to the field mapping. e.g. "a.b.field" or "field".
-     *                  The field path is applied and checked in OpenSearch, so it is guaranteed to be valid.
-     *
-     * @return           The field mapping object if found, or null if the field is not found in the index metadata.
-     */
-    private static Object getFieldMapping(final Map<String, Object> properties, final String fieldPath) {
-        String[] fieldPaths = fieldPath.split("\\.");
-        Object currentFieldMapping = properties;
-
-        // Iterate through the field path list to retrieve the field mapping.
-        for (String path : fieldPaths) {
-            currentFieldMapping = ((Map<String, Object>) currentFieldMapping).get(path);
-            if (currentFieldMapping == null) {
-                return null;
-            }
-
-            if (currentFieldMapping instanceof Map<?, ?>) {
-                Object possibleProperties = ((Map<String, Object>) currentFieldMapping).get("properties");
-                if (possibleProperties instanceof Map<?, ?>) {
-                    currentFieldMapping = possibleProperties;
-                }
-            }
-        }
-
-        return currentFieldMapping;
-    }
-
-    /**
      * Validate that a field is a k-NN vector field and has the expected dimension
      *
      * @param indexMetadata metadata for index to validate
@@ -135,7 +86,8 @@ public class IndexUtil {
         IndexMetadata indexMetadata,
         String field,
         int expectedDimension,
-        ModelDao modelDao
+        ModelDao modelDao,
+        VectorDataType expectedVectorDataType
     ) {
         // Index metadata should not be null
         if (indexMetadata == null) {
@@ -188,6 +140,29 @@ public class IndexUtil {
         if (!(type instanceof String) || !KNNVectorFieldMapper.CONTENT_TYPE.equals(type)) {
             exception.addValidationError(String.format("Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE));
             return exception;
+        }
+
+        if (expectedVectorDataType != null) {
+            if (VectorDataType.BYTE == expectedVectorDataType) {
+                exception.addValidationError(
+                    String.format(Locale.ROOT, "vector data type \"%s\" is not supported for training.", expectedVectorDataType.getValue())
+                );
+                return exception;
+            }
+            VectorDataType trainIndexDataType = getVectorDataTypeFromFieldMapping(fieldMap);
+
+            if (trainIndexDataType != expectedVectorDataType) {
+                exception.addValidationError(
+                    String.format(
+                        Locale.ROOT,
+                        "Field \"%s\" has data type %s, which is different from data type used in the training request: %s",
+                        field,
+                        trainIndexDataType.getValue(),
+                        expectedVectorDataType.getValue()
+                    )
+                );
+                return exception;
+            }
         }
 
         // Return if dimension does not need to be checked
@@ -320,5 +295,95 @@ public class IndexUtil {
         return KNNEngine.FAISS == knnEngine
             && parameters.get(VECTOR_DATA_TYPE_FIELD) != null
             && parameters.get(VECTOR_DATA_TYPE_FIELD).toString().equals(VectorDataType.BINARY.getValue());
+    }
+
+    /**
+     * Tell if it is binary index or not
+     *
+     * @param vectorDataType vector data type
+     * @return true if it is binary index
+     */
+    public static boolean isBinaryIndex(VectorDataType vectorDataType) {
+        return VectorDataType.BINARY == vectorDataType;
+    }
+
+    /**
+     * Update vector data type into parameters
+     *
+     * @param parameters parameters associated with an index
+     * @param vectorDataType vector data type
+     */
+    public static void updateVectorDataTypeToParameters(Map<String, Object> parameters, VectorDataType vectorDataType) {
+        if (VectorDataType.BINARY == vectorDataType) {
+            parameters.put(VECTOR_DATA_TYPE_FIELD, VectorDataType.BINARY.getValue());
+        }
+    }
+
+    /**
+     * This method retrieves the field mapping by a given field path from the index metadata.
+     *
+     * @param properties Index metadata mapping properties.
+     * @param fieldPath The field path string that make up the path to the field mapping. e.g. "a.b.field" or "field".
+     *                  The field path is applied and checked in OpenSearch, so it is guaranteed to be valid.
+     *
+     * @return           The field mapping object if found, or null if the field is not found in the index metadata.
+     */
+    private static Object getFieldMapping(final Map<String, Object> properties, final String fieldPath) {
+        String[] fieldPaths = fieldPath.split("\\.");
+        Object currentFieldMapping = properties;
+
+        // Iterate through the field path list to retrieve the field mapping.
+        for (String path : fieldPaths) {
+            currentFieldMapping = ((Map<String, Object>) currentFieldMapping).get(path);
+            if (currentFieldMapping == null) {
+                return null;
+            }
+
+            if (currentFieldMapping instanceof Map<?, ?>) {
+                Object possibleProperties = ((Map<String, Object>) currentFieldMapping).get("properties");
+                if (possibleProperties instanceof Map<?, ?>) {
+                    currentFieldMapping = possibleProperties;
+                }
+            }
+        }
+
+        return currentFieldMapping;
+    }
+
+    /**
+     *  This method is used to get the vector data type from field mapping
+     * @param fieldMap field mapping
+     * @return vector data type
+     */
+    private static VectorDataType getVectorDataTypeFromFieldMapping(Map<String, Object> fieldMap) {
+        if (fieldMap.containsKey(VECTOR_DATA_TYPE_FIELD)) {
+            return VectorDataType.get((String) fieldMap.get(VECTOR_DATA_TYPE_FIELD));
+        }
+        return VectorDataType.DEFAULT;
+    }
+
+    /**
+     * Initialize the minimal required version map
+     *
+     * @return minimal required version map
+     */
+    private static Map<String, Version> initializeMinimalRequiredVersionMap() {
+        final Map<String, Version> versionMap = new HashMap<>() {
+            {
+                put("ignore_unmapped", MINIMAL_SUPPORTED_VERSION_FOR_IGNORE_UNMAPPED);
+                put(MODEL_NODE_ASSIGNMENT_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_NODE_ASSIGNMENT);
+                put(MODEL_METHOD_COMPONENT_CONTEXT_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_METHOD_COMPONENT_CONTEXT);
+                put(KNNConstants.RADIAL_SEARCH_KEY, MINIMAL_SUPPORTED_VERSION_FOR_RADIAL_SEARCH);
+                put(KNNConstants.METHOD_PARAMETER, MINIMAL_SUPPORTED_VERSION_FOR_METHOD_PARAMETERS);
+                put(KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VECTOR_DATA_TYPE);
+            }
+        };
+
+        for (final MethodParameter methodParameter : MethodParameter.values()) {
+            if (methodParameter.getVersion() != null) {
+                versionMap.put(methodParameter.getName(), methodParameter.getVersion());
+            }
+        }
+        return Collections.unmodifiableMap(versionMap);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -131,4 +131,6 @@ public enum VectorDataType {
             );
         }
     }
+
+    public static VectorDataType DEFAULT = FLOAT;
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -603,7 +603,8 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             context,
             fieldType().getDimension(),
             fieldType().getSpaceType(),
-            getMethodComponentContext(fieldType().getKnnMethodContext())
+            getMethodComponentContext(fieldType().getKnnMethodContext()),
+            fieldType().getVectorDataType()
         );
     }
 
@@ -646,8 +647,13 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         return fields;
     }
 
-    protected void parseCreateField(ParseContext context, int dimension, SpaceType spaceType, MethodComponentContext methodComponentContext)
-        throws IOException {
+    protected void parseCreateField(
+        ParseContext context,
+        int dimension,
+        SpaceType spaceType,
+        MethodComponentContext methodComponentContext,
+        VectorDataType vectorDataType
+    ) throws IOException {
 
         validateIfKNNPluginEnabled();
         validateIfCircuitBreakerIsNotTriggered();

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -62,6 +62,12 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
             );
         }
 
-        parseCreateField(context, modelMetadata.getDimension(), modelMetadata.getSpaceType(), modelMetadata.getMethodComponentContext());
+        parseCreateField(
+            context,
+            modelMetadata.getDimension(),
+            modelMetadata.getSpaceType(),
+            modelMetadata.getMethodComponentContext(),
+            modelMetadata.getVectorDataType()
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -14,6 +14,7 @@ package org.opensearch.knn.index.memory;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.IndexUtil;
+import org.opensearch.knn.index.VectorDataType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -169,6 +170,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         private final String trainFieldName;
         private final int maxVectorCount;
         private final int searchSize;
+        private final VectorDataType vectorDataType;
 
         /**
          * Constructor
@@ -188,7 +190,8 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             NativeMemoryLoadStrategy.TrainingLoadStrategy trainingLoadStrategy,
             ClusterService clusterService,
             int maxVectorCount,
-            int searchSize
+            int searchSize,
+            VectorDataType vectorDataType
         ) {
             super(generateKey(trainIndexName, trainFieldName));
             this.size = size;
@@ -198,6 +201,7 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
             this.clusterService = clusterService;
             this.maxVectorCount = maxVectorCount;
             this.searchSize = searchSize;
+            this.vectorDataType = vectorDataType;
         }
 
         @Override
@@ -253,6 +257,15 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
          */
         public ClusterService getClusterService() {
             return clusterService;
+        }
+
+        /**
+         * Getter for vector data type.
+         *
+         * @return vector data type
+         */
+        public VectorDataType getVectorDataType() {
+            return vectorDataType;
         }
 
         private static String generateKey(String trainIndexName, String trainFieldName) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -515,6 +515,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             knnEngine = modelMetadata.getKnnEngine();
             spaceType = modelMetadata.getSpaceType();
             methodComponentContext = modelMetadata.getMethodComponentContext();
+            vectorDataType = modelMetadata.getVectorDataType();
 
         } else if (knnMethodContext != null) {
             // If the dimension is set but the knnMethodContext is not then the field is using the legacy mapping

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -213,6 +213,7 @@ public class KNNWeight extends Weight {
 
         KNNEngine knnEngine;
         SpaceType spaceType;
+        VectorDataType vectorDataType;
 
         // Check if a modelId exists. If so, the space type and engine will need to be picked up from the model's
         // metadata.
@@ -225,11 +226,15 @@ public class KNNWeight extends Weight {
 
             knnEngine = modelMetadata.getKnnEngine();
             spaceType = modelMetadata.getSpaceType();
+            vectorDataType = modelMetadata.getVectorDataType();
         } else {
             String engineName = fieldInfo.attributes().getOrDefault(KNN_ENGINE, KNNEngine.NMSLIB.getName());
             knnEngine = KNNEngine.getEngine(engineName);
             String spaceTypeName = fieldInfo.attributes().getOrDefault(SPACE_TYPE, SpaceType.L2.getValue());
             spaceType = SpaceType.getSpace(spaceTypeName);
+            vectorDataType = VectorDataType.get(
+                fieldInfo.attributes().getOrDefault(VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue())
+            );
         }
 
         /*
@@ -261,12 +266,7 @@ public class KNNWeight extends Weight {
                 new NativeMemoryEntryContext.IndexEntryContext(
                     indexPath.toString(),
                     NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance(),
-                    getParametersAtLoading(
-                        spaceType,
-                        knnEngine,
-                        knnQuery.getIndexName(),
-                        VectorDataType.get(fieldInfo.attributes().getOrDefault(VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue()))
-                    ),
+                    getParametersAtLoading(spaceType, knnEngine, knnQuery.getIndexName(), vectorDataType),
                     knnQuery.getIndexName(),
                     modelId
                 ),

--- a/src/main/java/org/opensearch/knn/index/util/Faiss.java
+++ b/src/main/java/org/opensearch/knn/index/util/Faiss.java
@@ -305,7 +305,7 @@ public class Faiss extends NativeLibrary {
                     return ((4L * centroids * dimension) / BYTES_PER_KILOBYTES) + 1;
                 })
                 .build()
-        ).addSpaces(SpaceType.UNDEFINED, SpaceType.L2, SpaceType.INNER_PRODUCT).build()
+        ).addSpaces(SpaceType.UNDEFINED, SpaceType.L2, SpaceType.INNER_PRODUCT, SpaceType.HAMMING_BIT).build()
     );
 
     final static Faiss INSTANCE = new Faiss(

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -292,6 +292,7 @@ public interface ModelDao {
                     put(KNNConstants.MODEL_DESCRIPTION, modelMetadata.getDescription());
                     put(KNNConstants.MODEL_ERROR, modelMetadata.getError());
                     put(KNNConstants.MODEL_NODE_ASSIGNMENT, modelMetadata.getNodeAssignment());
+                    put(KNNConstants.VECTOR_DATA_TYPE_FIELD, modelMetadata.getVectorDataType());
 
                     MethodComponentContext methodComponentContext = modelMetadata.getMethodComponentContext();
                     if (!methodComponentContext.getName().isEmpty()) {

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -26,6 +26,7 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.IndexUtil;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.IOException;
@@ -48,6 +49,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
     final private String timestamp;
     final private String description;
     final private String trainingNodeAssignment;
+    final private VectorDataType vectorDataType;
     private MethodComponentContext methodComponentContext;
     private String error;
 
@@ -81,6 +83,12 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         } else {
             this.methodComponentContext = MethodComponentContext.EMPTY;
         }
+
+        if (IndexUtil.isVersionOnOrAfterMinRequiredVersion(in.getVersion(), KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY)) {
+            this.vectorDataType = VectorDataType.get(in.readString());
+        } else {
+            this.vectorDataType = VectorDataType.DEFAULT;
+        }
     }
 
     /**
@@ -95,6 +103,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
      * @param error error message associated with model
      * @param trainingNodeAssignment node assignment for the model
      * @param methodComponentContext method component context associated with model
+     * @param vectorDataType vector data type of the model
      */
     public ModelMetadata(
         KNNEngine knnEngine,
@@ -105,7 +114,8 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         String description,
         String error,
         String trainingNodeAssignment,
-        MethodComponentContext methodComponentContext
+        MethodComponentContext methodComponentContext,
+        VectorDataType vectorDataType
     ) {
         this.knnEngine = Objects.requireNonNull(knnEngine, "knnEngine must not be null");
         this.spaceType = Objects.requireNonNull(spaceType, "spaceType must not be null");
@@ -128,6 +138,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         this.error = Objects.requireNonNull(error, "error must not be null");
         this.trainingNodeAssignment = Objects.requireNonNull(trainingNodeAssignment, "node assignment must not be null");
         this.methodComponentContext = Objects.requireNonNull(methodComponentContext, "method context must not be null");
+        this.vectorDataType = Objects.requireNonNull(vectorDataType, "vector data type must not be null");
     }
 
     /**
@@ -211,6 +222,10 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         return methodComponentContext;
     }
 
+    public VectorDataType getVectorDataType() {
+        return vectorDataType;
+    }
+
     /**
      * setter for model's state
      *
@@ -241,7 +256,8 @@ public class ModelMetadata implements Writeable, ToXContentObject {
             description,
             error,
             trainingNodeAssignment,
-            methodComponentContext.toClusterStateString()
+            methodComponentContext.toClusterStateString(),
+            vectorDataType.getValue()
         );
     }
 
@@ -259,6 +275,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         equalsBuilder.append(getTimestamp(), other.getTimestamp());
         equalsBuilder.append(getDescription(), other.getDescription());
         equalsBuilder.append(getError(), other.getError());
+        equalsBuilder.append(getVectorDataType(), other.getVectorDataType());
 
         return equalsBuilder.isEquals();
     }
@@ -273,6 +290,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
             .append(getDescription())
             .append(getError())
             .append(getMethodComponentContext())
+            .append(getVectorDataType())
             .toHashCode();
     }
 
@@ -284,80 +302,59 @@ public class ModelMetadata implements Writeable, ToXContentObject {
      */
     public static ModelMetadata fromString(String modelMetadataString) {
         String[] modelMetadataArray = modelMetadataString.split(DELIMITER, -1);
+        int length = modelMetadataArray.length;
 
-        // Training node assignment was added as a field in Version 2.12.0
-        // Because models can be created on older versions and the cluster can be upgraded after,
-        // we need to accept model metadata arrays both with and without the training node assignment.
-        if (modelMetadataArray.length == 7) {
-            log.debug(
-                "Model metadata array does not contain training node assignment or method component context. Assuming empty string node assignment and empty method component context."
-            );
-            KNNEngine knnEngine = KNNEngine.getEngine(modelMetadataArray[0]);
-            SpaceType spaceType = SpaceType.getSpace(modelMetadataArray[1]);
-            int dimension = Integer.parseInt(modelMetadataArray[2]);
-            ModelState modelState = ModelState.getModelState(modelMetadataArray[3]);
-            String timestamp = modelMetadataArray[4];
-            String description = modelMetadataArray[5];
-            String error = modelMetadataArray[6];
-            return new ModelMetadata(
-                knnEngine,
-                spaceType,
-                dimension,
-                modelState,
-                timestamp,
-                description,
-                error,
-                "",
-                MethodComponentContext.EMPTY
-            );
-        } else if (modelMetadataArray.length == 8) {
-            log.debug("Model metadata contains training node assignment.  Assuming empty method component context.");
-            KNNEngine knnEngine = KNNEngine.getEngine(modelMetadataArray[0]);
-            SpaceType spaceType = SpaceType.getSpace(modelMetadataArray[1]);
-            int dimension = Integer.parseInt(modelMetadataArray[2]);
-            ModelState modelState = ModelState.getModelState(modelMetadataArray[3]);
-            String timestamp = modelMetadataArray[4];
-            String description = modelMetadataArray[5];
-            String error = modelMetadataArray[6];
-            String trainingNodeAssignment = modelMetadataArray[7];
-            return new ModelMetadata(
-                knnEngine,
-                spaceType,
-                dimension,
-                modelState,
-                timestamp,
-                description,
-                error,
-                trainingNodeAssignment,
-                MethodComponentContext.EMPTY
-            );
-        } else if (modelMetadataArray.length == 9) {
-            log.debug("Model metadata contains training node assignment and method context");
-            KNNEngine knnEngine = KNNEngine.getEngine(modelMetadataArray[0]);
-            SpaceType spaceType = SpaceType.getSpace(modelMetadataArray[1]);
-            int dimension = Integer.parseInt(modelMetadataArray[2]);
-            ModelState modelState = ModelState.getModelState(modelMetadataArray[3]);
-            String timestamp = modelMetadataArray[4];
-            String description = modelMetadataArray[5];
-            String error = modelMetadataArray[6];
-            String trainingNodeAssignment = modelMetadataArray[7];
-            MethodComponentContext methodComponentContext = MethodComponentContext.fromClusterStateString(modelMetadataArray[8]);
-            return new ModelMetadata(
-                knnEngine,
-                spaceType,
-                dimension,
-                modelState,
-                timestamp,
-                description,
-                error,
-                trainingNodeAssignment,
-                methodComponentContext
-            );
-        } else {
+        if (length < 7 || length > 10) {
             throw new IllegalArgumentException(
                 "Illegal format for model metadata. Must be of the form "
-                    + "\"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>\" or \"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>,<NodeAssignment>\" or \"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>,<NodeAssignment>,<MethodContext>\"."
+                    + "\"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>\" or "
+                    + "\"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>,<NodeAssignment>\" or "
+                    + "\"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>,<NodeAssignment>,<MethodContext>\" or "
+                    + "\"<KNNEngine>,<SpaceType>,<Dimension>,<ModelState>,<Timestamp>,<Description>,<Error>,<NodeAssignment>,<MethodContext>,<VectorDataType>\"."
             );
+        }
+
+        KNNEngine knnEngine = KNNEngine.getEngine(modelMetadataArray[0]);
+        SpaceType spaceType = SpaceType.getSpace(modelMetadataArray[1]);
+        int dimension = Integer.parseInt(modelMetadataArray[2]);
+        ModelState modelState = ModelState.getModelState(modelMetadataArray[3]);
+        String timestamp = modelMetadataArray[4];
+        String description = modelMetadataArray[5];
+        String error = modelMetadataArray[6];
+        String trainingNodeAssignment = length > 7 ? modelMetadataArray[7] : "";
+        MethodComponentContext methodComponentContext = length > 8
+            ? MethodComponentContext.fromClusterStateString(modelMetadataArray[8])
+            : MethodComponentContext.EMPTY;
+        VectorDataType vectorDataType = length > 9 ? VectorDataType.get(modelMetadataArray[9]) : VectorDataType.DEFAULT;
+
+        log.debug(getLogMessage(length));
+
+        return new ModelMetadata(
+            knnEngine,
+            spaceType,
+            dimension,
+            modelState,
+            timestamp,
+            description,
+            error,
+            trainingNodeAssignment,
+            methodComponentContext,
+            vectorDataType
+        );
+    }
+
+    private static String getLogMessage(int length) {
+        switch (length) {
+            case 7:
+                return "Model metadata array does not contain training node assignment or method component context. Assuming empty string node assignment and empty method component context.";
+            case 8:
+                return "Model metadata contains training node assignment. Assuming empty method component context.";
+            case 9:
+                return "Model metadata contains training node assignment and method context.";
+            case 10:
+                return "Model metadata contains training node assignment, method context and vector data type.";
+            default:
+                throw new IllegalArgumentException("Unexpected metadata array length: " + length);
         }
     }
 
@@ -387,6 +384,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         Object error = modelSourceMap.get(KNNConstants.MODEL_ERROR);
         Object trainingNodeAssignment = modelSourceMap.get(KNNConstants.MODEL_NODE_ASSIGNMENT);
         Object methodComponentContext = modelSourceMap.get(KNNConstants.MODEL_METHOD_COMPONENT_CONTEXT);
+        Object vectorDataType = modelSourceMap.get(KNNConstants.VECTOR_DATA_TYPE_FIELD);
 
         if (trainingNodeAssignment == null) {
             trainingNodeAssignment = "";
@@ -407,6 +405,10 @@ public class ModelMetadata implements Writeable, ToXContentObject {
             methodComponentContext = MethodComponentContext.EMPTY;
         }
 
+        if (vectorDataType == null) {
+            vectorDataType = VectorDataType.DEFAULT.getValue();
+        }
+
         ModelMetadata modelMetadata = new ModelMetadata(
             KNNEngine.getEngine(objectToString(engine)),
             SpaceType.getSpace(objectToString(space)),
@@ -416,7 +418,8 @@ public class ModelMetadata implements Writeable, ToXContentObject {
             objectToString(description),
             objectToString(error),
             objectToString(trainingNodeAssignment),
-            (MethodComponentContext) methodComponentContext
+            (MethodComponentContext) methodComponentContext,
+            VectorDataType.get(objectToString(vectorDataType))
         );
         return modelMetadata;
     }
@@ -435,6 +438,9 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         }
         if (IndexUtil.isVersionOnOrAfterMinRequiredVersion(out.getVersion(), IndexUtil.MODEL_METHOD_COMPONENT_CONTEXT_KEY)) {
             getMethodComponentContext().writeTo(out);
+        }
+        if (IndexUtil.isVersionOnOrAfterMinRequiredVersion(out.getVersion(), KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY)) {
+            out.writeString(vectorDataType.getValue());
         }
     }
 
@@ -455,6 +461,9 @@ public class ModelMetadata implements Writeable, ToXContentObject {
             builder.field(KNNConstants.MODEL_METHOD_COMPONENT_CONTEXT).startObject();
             getMethodComponentContext().toXContent(builder, params);
             builder.endObject();
+        }
+        if (IndexUtil.isClusterOnOrAfterMinRequiredVersion(KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY)) {
+            builder.field(KNNConstants.VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
         }
         return builder;
     }

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -97,6 +97,25 @@ class FaissService {
     );
 
     /**
+     * Create a binary index for the native library with a provided template index
+     *
+     * @param ids array of ids mapping to the data passed in
+     * @param vectorsAddress address of native memory where vectors are stored
+     * @param dim dimension of the vector to be indexed
+     * @param indexPath path to save index file to
+     * @param templateIndex empty template index
+     * @param parameters additional build time parameters
+     */
+    public static native void createBinaryIndexFromTemplate(
+        int[] ids,
+        long vectorsAddress,
+        int dim,
+        String indexPath,
+        byte[] templateIndex,
+        Map<String, Object> parameters
+    );
+
+    /**
      * Load an index into memory
      *
      * @param indexPath path to index file
@@ -248,6 +267,16 @@ class FaissService {
      * @return bytes array of trained template index
      */
     public static native byte[] trainIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer);
+
+    /**
+     * Train an empty binary index
+     *
+     * @param indexParameters parameters used to build index
+     * @param dimension dimension for the index
+     * @param trainVectorsPointer pointer to where training vectors are stored in native memory
+     * @return bytes array of trained template index
+     */
+    public static native byte[] trainBinaryIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer);
 
     /**
      * <p>

--- a/src/main/java/org/opensearch/knn/jni/JNICommons.java
+++ b/src/main/java/org/opensearch/knn/jni/JNICommons.java
@@ -78,4 +78,17 @@ public class JNICommons {
      * @param memoryAddress address to be freed.
      */
     public static native void freeVectorData(long memoryAddress);
+
+    /**
+     * Free up the memory allocated for the byte data stored in memory address. This function should be used with the memory
+     * address returned by {@link JNICommons#storeVectorData(long, float[][], long)}
+     *
+     * <p>
+     *  The function is not threadsafe. If multiple threads are trying to free up same memory location, then it can
+     *  lead to errors.
+     * </p>
+     *
+     * @param memoryAddress address to be freed.
+     */
+    public static native void freeByteVectorData(long memoryAddress);
 }

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -83,8 +83,13 @@ public class JNIService {
         KNNEngine knnEngine
     ) {
         if (KNNEngine.FAISS == knnEngine) {
-            FaissService.createIndexFromTemplate(ids, vectorsAddress, dim, indexPath, templateIndex, parameters);
-            return;
+            if (IndexUtil.isBinaryIndex(knnEngine, parameters)) {
+                FaissService.createBinaryIndexFromTemplate(ids, vectorsAddress, dim, indexPath, templateIndex, parameters);
+                return;
+            } else {
+                FaissService.createIndexFromTemplate(ids, vectorsAddress, dim, indexPath, templateIndex, parameters);
+                return;
+            }
         }
 
         throw new IllegalArgumentException(
@@ -308,6 +313,9 @@ public class JNIService {
      */
     public static byte[] trainIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer, KNNEngine knnEngine) {
         if (KNNEngine.FAISS == knnEngine) {
+            if (IndexUtil.isBinaryIndex(knnEngine, indexParameters)) {
+                return FaissService.trainBinaryIndex(indexParameters, dimension, trainVectorsPointer);
+            }
             return FaissService.trainIndex(indexParameters, dimension, trainVectorsPointer);
         }
 

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -21,6 +21,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.IndexUtil;
 import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.training.VectorSpaceInfo;
 
@@ -41,6 +42,7 @@ public class TrainingModelRequest extends ActionRequest {
     private final String trainingField;
     private final String preferredNodeId;
     private final String description;
+    private final VectorDataType vectorDataType;
 
     private int maximumVectorCount;
     private int searchSize;
@@ -65,7 +67,8 @@ public class TrainingModelRequest extends ActionRequest {
         String trainingIndex,
         String trainingField,
         String preferredNodeId,
-        String description
+        String description,
+        VectorDataType vectorDataType
     ) {
         super();
         this.modelId = modelId;
@@ -75,6 +78,7 @@ public class TrainingModelRequest extends ActionRequest {
         this.trainingField = trainingField;
         this.preferredNodeId = preferredNodeId;
         this.description = description;
+        this.vectorDataType = vectorDataType;
 
         // Set these as defaults initially. If call wants to override them, they can use the setters.
         this.maximumVectorCount = Integer.MAX_VALUE; // By default, get all vectors in the index
@@ -103,6 +107,11 @@ public class TrainingModelRequest extends ActionRequest {
         this.maximumVectorCount = in.readInt();
         this.searchSize = in.readInt();
         this.trainingDataSizeInKB = in.readInt();
+        if (IndexUtil.isVersionOnOrAfterMinRequiredVersion(in.getVersion(), KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY)) {
+            this.vectorDataType = VectorDataType.get(in.readString());
+        } else {
+            this.vectorDataType = VectorDataType.DEFAULT;
+        }
     }
 
     /**
@@ -213,6 +222,10 @@ public class TrainingModelRequest extends ActionRequest {
         return searchSize;
     }
 
+    public VectorDataType getVectorDataType() {
+        return vectorDataType;
+    }
+
     /**
      * Setter for search size.
      *
@@ -314,7 +327,13 @@ public class TrainingModelRequest extends ActionRequest {
         }
 
         // Validate the training field
-        ValidationException fieldValidation = IndexUtil.validateKnnField(indexMetadata, this.trainingField, this.dimension, modelDao);
+        ValidationException fieldValidation = IndexUtil.validateKnnField(
+            indexMetadata,
+            this.trainingField,
+            this.dimension,
+            modelDao,
+            this.vectorDataType
+        );
         if (fieldValidation != null) {
             exception = exception == null ? new ActionRequestValidationException() : exception;
             exception.addValidationErrors(fieldValidation.validationErrors());
@@ -336,5 +355,10 @@ public class TrainingModelRequest extends ActionRequest {
         out.writeInt(this.maximumVectorCount);
         out.writeInt(this.searchSize);
         out.writeInt(this.trainingDataSizeInKB);
+        if (IndexUtil.isVersionOnOrAfterMinRequiredVersion(out.getVersion(), KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY)) {
+            out.writeString(this.vectorDataType.getValue());
+        } else {
+            out.writeString(VectorDataType.DEFAULT.getValue());
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelTransportAction.java
@@ -51,7 +51,8 @@ public class TrainingModelTransportAction extends HandledTransportAction<Trainin
             NativeMemoryLoadStrategy.TrainingLoadStrategy.getInstance(),
             clusterService,
             request.getMaximumVectorCount(),
-            request.getSearchSize()
+            request.getSearchSize(),
+            request.getVectorDataType()
         );
 
         // Allocation representing size model will occupy in memory during training
@@ -68,7 +69,8 @@ public class TrainingModelTransportAction extends HandledTransportAction<Trainin
             modelAnonymousEntryContext,
             request.getDimension(),
             request.getDescription(),
-            clusterService.localNode().getEphemeralId()
+            clusterService.localNode().getEphemeralId(),
+            request.getVectorDataType()
         );
 
         KNNCounter.TRAINING_REQUESTS.increment();

--- a/src/main/java/org/opensearch/knn/training/ByteTrainingDataConsumer.java
+++ b/src/main/java/org/opensearch/knn/training/ByteTrainingDataConsumer.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.knn.jni.JNICommons;
+import org.opensearch.knn.index.memory.NativeMemoryAllocation;
+import org.opensearch.search.SearchHit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transfers byte vectors from JVM to native memory.
+ */
+public class ByteTrainingDataConsumer extends TrainingDataConsumer {
+    private static final Logger logger = LogManager.getLogger(TrainingDataConsumer.class);
+
+    /**
+     * Constructor
+     *
+     * @param trainingDataAllocation NativeMemoryAllocation that contains information about native memory allocation.
+     */
+    public ByteTrainingDataConsumer(NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation) {
+        super(trainingDataAllocation);
+    }
+
+    @Override
+    public void accept(List<?> byteVectors) {
+        long memoryAddress = trainingDataAllocation.getMemoryAddress();
+        memoryAddress = JNICommons.storeByteVectorData(memoryAddress, byteVectors.toArray(new byte[0][0]), byteVectors.size());
+        trainingDataAllocation.setMemoryAddress(memoryAddress);
+    }
+
+    @Override
+    public void processTrainingVectors(SearchResponse searchResponse, int vectorsToAdd, String fieldName) {
+        SearchHit[] hits = searchResponse.getHits().getHits();
+        List<byte[]> vectors = new ArrayList<>();
+        String[] fieldPath = fieldName.split("\\.");
+        int nullVectorCount = 0;
+
+        for (int vector = 0; vector < vectorsToAdd; vector++) {
+            Object fieldValue = extractFieldValue(hits[vector], fieldPath);
+            if (fieldValue == null) {
+                nullVectorCount++;
+                continue;
+            }
+
+            byte[] byteArray;
+            if (!(fieldValue instanceof List<?>)) {
+                continue;
+            }
+            List<Number> fieldList = (List<Number>) fieldValue;
+            byteArray = new byte[fieldList.size()];
+            for (int i = 0; i < fieldList.size(); i++) {
+                byteArray[i] = fieldList.get(i).byteValue();
+            }
+
+            vectors.add(byteArray);
+        }
+
+        if (nullVectorCount > 0) {
+            logger.warn("Found {} documents with null byte vectors in field {}", nullVectorCount, fieldName);
+        }
+
+        setTotalVectorsCountAdded(getTotalVectorsCountAdded() + vectors.size());
+
+        accept(vectors);
+    }
+}

--- a/src/main/java/org/opensearch/knn/training/FloatTrainingDataConsumer.java
+++ b/src/main/java/org/opensearch/knn/training/FloatTrainingDataConsumer.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.training;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.knn.jni.JNIService;
+import org.opensearch.knn.index.memory.NativeMemoryAllocation;
+import org.opensearch.search.SearchHit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Transfers float vectors from JVM to native memory.
+ */
+public class FloatTrainingDataConsumer extends TrainingDataConsumer {
+
+    /**
+     * Constructor
+     *
+     * @param trainingDataAllocation NativeMemoryAllocation that contains information about native memory allocation.
+     */
+    public FloatTrainingDataConsumer(NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation) {
+        super(trainingDataAllocation);
+    }
+
+    @Override
+    public void accept(List<?> floats) {
+        trainingDataAllocation.setMemoryAddress(
+            JNIService.transferVectors(
+                trainingDataAllocation.getMemoryAddress(),
+                floats.stream().map(v -> ArrayUtils.toPrimitive((Float[]) v)).toArray(float[][]::new)
+            )
+        );
+    }
+
+    @Override
+    public void processTrainingVectors(SearchResponse searchResponse, int vectorsToAdd, String fieldName) {
+        SearchHit[] hits = searchResponse.getHits().getHits();
+        List<Float[]> vectors = new ArrayList<>();
+        String[] fieldPath = fieldName.split("\\.");
+
+        for (int vector = 0; vector < vectorsToAdd; vector++) {
+            Object fieldValue = extractFieldValue(hits[vector], fieldPath);
+            if (!(fieldValue instanceof List<?>)) {
+                continue;
+            }
+
+            List<Number> fieldList = (List<Number>) fieldValue;
+            vectors.add(fieldList.stream().map(Number::floatValue).toArray(Float[]::new));
+        }
+
+        setTotalVectorsCountAdded(getTotalVectorsCountAdded() + vectors.size());
+
+        accept(vectors);
+    }
+}

--- a/src/main/java/org/opensearch/knn/training/VectorReader.java
+++ b/src/main/java/org/opensearch/knn/training/VectorReader.java
@@ -30,7 +30,6 @@ import org.opensearch.search.sort.SortOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 public class VectorReader {
 
@@ -59,13 +58,13 @@ public class VectorReader {
      * @param vectorConsumer consumer used to do something with the collected vectors after each search
      * @param listener ActionListener that should be called once all search operations complete
      */
-    public void read(
+    public <T> void read(
         ClusterService clusterService,
         String indexName,
         String fieldName,
         int maxVectorCount,
         int searchSize,
-        Consumer<List<Float[]>> vectorConsumer,
+        TrainingDataConsumer vectorConsumer,
         ActionListener<SearchResponse> listener
     ) {
 
@@ -89,7 +88,7 @@ public class VectorReader {
             throw validationException;
         }
 
-        ValidationException fieldValidationException = IndexUtil.validateKnnField(indexMetadata, fieldName, -1, null);
+        ValidationException fieldValidationException = IndexUtil.validateKnnField(indexMetadata, fieldName, -1, null, null);
         if (fieldValidationException != null) {
             validationException = validationException == null ? new ValidationException() : validationException;
             validationException.addValidationErrors(validationException.validationErrors());
@@ -136,14 +135,14 @@ public class VectorReader {
         return searchScrollRequestBuilder;
     }
 
-    private static class VectorReaderListener implements ActionListener<SearchResponse> {
+    private static class VectorReaderListener<T> implements ActionListener<SearchResponse> {
 
         final Client client;
         final String fieldName;
         final int maxVectorCount;
         int collectedVectorCount;
         final ActionListener<SearchResponse> listener;
-        final Consumer<List<Float[]>> vectorConsumer;
+        final TrainingDataConsumer vectorConsumer;
         SearchScrollRequestBuilder searchScrollRequestBuilder;
 
         /**
@@ -162,7 +161,7 @@ public class VectorReader {
             int maxVectorCount,
             int collectedVectorCount,
             ActionListener<SearchResponse> listener,
-            Consumer<List<Float[]>> vectorConsumer,
+            TrainingDataConsumer vectorConsumer,
             SearchScrollRequestBuilder searchScrollRequestBuilder
         ) {
             this.client = client;
@@ -181,12 +180,9 @@ public class VectorReader {
             // Either add the entire set of returned hits, or maxVectorCount - collectedVectorCount hits
             SearchHit[] hits = searchResponse.getHits().getHits();
             int vectorsToAdd = Integer.min(maxVectorCount - collectedVectorCount, hits.length);
-            List<Float[]> trainingData = extractVectorsFromHits(searchResponse, vectorsToAdd);
 
-            this.collectedVectorCount += trainingData.size();
-
-            // Do something with the vectors
-            vectorConsumer.accept(trainingData);
+            vectorConsumer.processTrainingVectors(searchResponse, vectorsToAdd, fieldName);
+            this.collectedVectorCount = vectorConsumer.getTotalVectorsCountAdded();
 
             if (vectorsToAdd <= 0 || this.collectedVectorCount >= maxVectorCount) {
                 // Clear scroll context

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -46,8 +46,17 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Mockito.when;
-import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_BLOB_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ERROR;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_TIMESTAMP;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
     @Override
@@ -201,7 +210,8 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
             .field(MODEL_STATE, modelMetadata.getState().getName())
             .field(MODEL_TIMESTAMP, modelMetadata.getTimestamp().toString())
             .field(MODEL_DESCRIPTION, modelMetadata.getDescription())
-            .field(MODEL_ERROR, modelMetadata.getError());
+            .field(MODEL_ERROR, modelMetadata.getError())
+            .field(VECTOR_DATA_TYPE_FIELD, modelMetadata.getVectorDataType().getValue());
 
         if (model.getModelBlob() != null) {
             builder.field(MODEL_BLOB_PARAMETER, Base64.getEncoder().encodeToString(model.getModelBlob()));

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -44,6 +44,7 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
@@ -55,18 +56,25 @@ import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MAX_VALUE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MIN_VALUE;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
 import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 public class FaissIT extends KNNRestTestCase {
     private static final String DOC_ID_1 = "doc1";
@@ -107,13 +115,13 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .endObject()
             .endObject()
@@ -166,13 +174,13 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .endObject()
             .endObject()
@@ -226,13 +234,13 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .endObject()
             .endObject()
@@ -296,8 +304,8 @@ public class FaissIT extends KNNRestTestCase {
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, FAISS_NAME)
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_PQ)
@@ -424,8 +432,8 @@ public class FaissIT extends KNNRestTestCase {
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, FAISS_NAME)
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_PQ)
@@ -531,13 +539,13 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_SQ)
@@ -644,13 +652,13 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_SQ)
@@ -744,13 +752,13 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
-            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
             .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_SQ)
@@ -997,7 +1005,7 @@ public class FaissIT extends KNNRestTestCase {
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, FAISS_NAME)
             .startObject(PARAMETERS)
-            .field(KNNConstants.METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_PQ)
             .startObject(PARAMETERS)
@@ -1204,7 +1212,7 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
@@ -1240,7 +1248,7 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, hnswMethod.getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
@@ -1418,7 +1426,7 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 2)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, KNNEngine.FAISS.getMethod(METHOD_HNSW).getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
@@ -1593,6 +1601,230 @@ public class FaissIT extends KNNRestTestCase {
         );
     }
 
+    @SneakyThrows
+    public void testIVF_whenBinaryFormat_whenIVF_thenSuccess() {
+        String modelId = "test-model-ivf-binary";
+        int dimension = 8;
+
+        String trainingIndexName = "train-index-ivf-binary";
+        String trainingFieldName = "train-field-ivf-binary";
+
+        String trainIndexMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(trainingFieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field("data_type", VectorDataType.BINARY.getValue())
+            .startObject(KNN_METHOD)
+            .field(NAME, KNNEngine.FAISS.getMethod(METHOD_HNSW).getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.HAMMING_BIT.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_M, 24)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, 128)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(trainingIndexName, trainIndexMapping);
+
+        int trainingDataCount = 40;
+        bulkIngestRandomBinaryVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
+
+        XContentBuilder trainModelXContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
+            .field(TRAIN_FIELD_PARAMETER, trainingFieldName)
+            .field(DIMENSION, dimension)
+            .field(MODEL_DESCRIPTION, "My model description")
+            .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.BINARY.getValue())
+            .field(
+                KNN_METHOD,
+                Map.of(
+                    NAME,
+                    METHOD_IVF,
+                    KNN_ENGINE,
+                    FAISS_NAME,
+                    METHOD_PARAMETER_SPACE_TYPE,
+                    SpaceType.HAMMING_BIT.getValue(),
+                    PARAMETERS,
+                    Map.of(METHOD_PARAMETER_NLIST, 1, METHOD_PARAMETER_NPROBES, 1)
+                )
+            )
+            .endObject();
+
+        trainModel(modelId, trainModelXContentBuilder);
+
+        // Make sure training succeeds after 30 seconds
+        assertTrainingSucceeds(modelId, 30, 1000);
+
+        // Create knn index from model
+        String fieldName = "test-field-name-ivf-binary";
+        String indexName = "test-index-name-ivf-binary";
+        String indexMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field(MODEL_ID, modelId)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), indexMapping);
+        Integer[] vector1 = { 11 };
+        Integer[] vector2 = { 22 };
+        Integer[] vector3 = { 33 };
+        Integer[] vector4 = { 44 };
+        addKnnDoc(indexName, "1", fieldName, vector1);
+        addKnnDoc(indexName, "2", fieldName, vector2);
+        addKnnDoc(indexName, "3", fieldName, vector3);
+        addKnnDoc(indexName, "4", fieldName, vector4);
+
+        Integer[] queryVector = { 15 };
+        int k = 2;
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(fieldName)
+            .field("vector", queryVector)
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response searchResponse = searchKNNIndex(indexName, queryBuilder, k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
+        assertEquals(k, results.size());
+
+        deleteKNNIndex(indexName);
+        Thread.sleep(45 * 1000);
+        deleteModel(modelId);
+        deleteKNNIndex(trainingIndexName);
+        validateGraphEviction();
+    }
+
+    @SneakyThrows
+    public void testIVF_whenBinaryFormat_whenIVFPQ_thenSuccess() {
+        String modelId = "test-model-ivfpq-binary";
+        int dimension = 8;
+
+        String trainingIndexName = "train-index-ivfpq-binary";
+        String trainingFieldName = "train-field-ivfpq-binary";
+
+        String trainIndexMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(trainingFieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field("data_type", VectorDataType.BINARY.getValue())
+            .startObject(KNN_METHOD)
+            .field(NAME, KNNEngine.FAISS.getMethod(METHOD_HNSW).getMethodComponent().getName())
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.HAMMING_BIT.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_M, 24)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, 128)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(trainingIndexName, trainIndexMapping);
+
+        int trainingDataCount = 50;
+        bulkIngestRandomBinaryVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
+
+        XContentBuilder trainModelXContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
+            .field(TRAIN_FIELD_PARAMETER, trainingFieldName)
+            .field(DIMENSION, dimension)
+            .field(MODEL_DESCRIPTION, "My model description")
+            .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.BINARY.getValue())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_IVF)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.HAMMING_BIT.getValue())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NPROBES, 1)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_PQ)
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 8)
+            .field(ENCODER_PARAMETER_PQ_M, 8)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        trainModel(modelId, trainModelXContentBuilder);
+
+        // Make sure training succeeds after 30 seconds
+        assertTrainingSucceeds(modelId, 30, 1000);
+
+        // Create knn index from model
+        String fieldName = "test-field-name-ivfpq-binary";
+        String indexName = "test-index-name-ivfpq-binary";
+
+        String indexMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field(MODEL_ID, modelId)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), indexMapping);
+        Integer[] vector1 = { 11 };
+        Integer[] vector2 = { 22 };
+        Integer[] vector3 = { 33 };
+        Integer[] vector4 = { 44 };
+        addKnnDoc(indexName, "1", fieldName, vector1);
+        addKnnDoc(indexName, "2", fieldName, vector2);
+        addKnnDoc(indexName, "3", fieldName, vector3);
+        addKnnDoc(indexName, "4", fieldName, vector4);
+
+        Integer[] queryVector = { 15 };
+        int k = 2;
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(fieldName)
+            .field("vector", queryVector)
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response searchResponse = searchKNNIndex(indexName, queryBuilder, k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
+        assertEquals(k, results.size());
+
+        deleteKNNIndex(indexName);
+        Thread.sleep(45 * 1000);
+        deleteModel(modelId);
+        deleteKNNIndex(trainingIndexName);
+        validateGraphEviction();
+    }
+
     protected void setupKNNIndexForFilterQuery() throws Exception {
         // Create Mappings
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -1601,7 +1833,7 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 3)
-            .startObject(KNNConstants.KNN_METHOD)
+            .startObject(KNN_METHOD)
             .field(NAME, KNNEngine.FAISS.getMethod(METHOD_HNSW).getMethodComponent().getName())
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -63,7 +63,8 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
             "",
             "",
             "test-node",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.FLOAT
         );
 
         Model model = new Model(modelMetadata, modelBlob, modelId);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -125,8 +125,21 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         DocValuesConsumer delegate = mock(DocValuesConsumer.class);
         doNothing().when(delegate).addBinaryField(fieldInfo, docValuesProducer);
 
+        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        int docsInSegment = 100;
+
+        SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
+            .directory(directory)
+            .segmentName(segmentName)
+            .docsInSegment(docsInSegment)
+            .codec(codec)
+            .build();
+
+        FieldInfos fieldInfos = mock(FieldInfos.class);
+        SegmentWriteState state = new SegmentWriteState(null, directory, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+
         final boolean[] called = { false };
-        KNN80DocValuesConsumer knn80DocValuesConsumer = new KNN80DocValuesConsumer(delegate, null) {
+        KNN80DocValuesConsumer knn80DocValuesConsumer = new KNN80DocValuesConsumer(delegate, state) {
 
             @Override
             public void addKNNBinaryField(FieldInfo field, DocValuesProducer valuesProducer, boolean isMerge, boolean isRefresh) {
@@ -148,7 +161,19 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         Long initialMergeOperations = KNNGraphValue.MERGE_TOTAL_OPERATIONS.getValue();
         Long initialMergeSize = KNNGraphValue.MERGE_TOTAL_SIZE_IN_BYTES.getValue();
         Long initialMergeDocs = KNNGraphValue.MERGE_TOTAL_DOCS.getValue();
-        KNN80DocValuesConsumer knn80DocValuesConsumer = new KNN80DocValuesConsumer(null, null);
+        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        int docsInSegment = 100;
+
+        SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
+            .directory(directory)
+            .segmentName(segmentName)
+            .docsInSegment(docsInSegment)
+            .codec(codec)
+            .build();
+
+        FieldInfos fieldInfos = mock(FieldInfos.class);
+        SegmentWriteState state = new SegmentWriteState(null, directory, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+        KNN80DocValuesConsumer knn80DocValuesConsumer = new KNN80DocValuesConsumer(null, state);
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test-field").build();
         knn80DocValuesConsumer.addKNNBinaryField(fieldInfo, randomVectorDocValuesProducer, true, true);
         assertEquals(initialGraphIndexRequests, KNNCounter.GRAPH_INDEX_REQUESTS.getCount());
@@ -424,7 +449,8 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
                 "Empty description",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.FLOAT
             ),
             modelBytes,
             modelId

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -20,15 +20,16 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethodContext;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.MethodComponentContext;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.query.KNNQueryFactory;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.query.KNNQuery;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.KNNWeight;
-import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.VectorField;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.FieldType;
@@ -213,7 +214,8 @@ public class KNNCodecTestCase extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.FLOAT
         );
 
         Model mockModel = new Model(modelMetadata1, modelBlob, modelId);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -175,7 +175,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.FLOAT
         );
         builder.modelId.setValue(modelId);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
@@ -676,7 +677,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.FLOAT
         );
         when(mockModelDao.getMetadata(modelId)).thenReturn(mockModelMetadata);
 
@@ -747,7 +749,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             parseContext,
             TEST_DIMENSION,
             luceneFieldMapper.fieldType().spaceType,
-            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext()
+            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext(),
+            VectorDataType.FLOAT
         );
 
         // Document should have 2 fields: one for VectorField (binary doc values) and one for KnnVectorField
@@ -791,7 +794,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             parseContext,
             TEST_DIMENSION,
             luceneFieldMapper.fieldType().spaceType,
-            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext()
+            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext(),
+            VectorDataType.FLOAT
         );
 
         // Document should have 1 field: one for KnnVectorField
@@ -826,7 +830,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             parseContext,
             TEST_DIMENSION,
             luceneFieldMapper.fieldType().spaceType,
-            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext()
+            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext(),
+            VectorDataType.BYTE
         );
 
         // Document should have 2 fields: one for VectorField (binary doc values) and one for KnnByteVectorField
@@ -869,7 +874,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             parseContext,
             TEST_DIMENSION,
             luceneFieldMapper.fieldType().spaceType,
-            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext()
+            luceneFieldMapper.fieldType().knnMethodContext.getMethodComponentContext(),
+            VectorDataType.BYTE
         );
 
         // Document should have 1 field: one for KnnByteVectorField

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
@@ -315,7 +315,8 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             executorService,
             memoryAddress,
-            0
+            0,
+            VectorDataType.FLOAT
         );
 
         trainingDataAllocation.close();
@@ -341,7 +342,8 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             memoryAddress,
-            0
+            0,
+            VectorDataType.FLOAT
         );
 
         assertEquals(memoryAddress, trainingDataAllocation.getMemoryAddress());
@@ -354,7 +356,8 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             0,
-            0
+            0,
+            VectorDataType.FLOAT
         );
 
         int initialValue = 10;
@@ -387,7 +390,8 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             0,
-            0
+            0,
+            VectorDataType.FLOAT
         );
 
         int initialValue = 10;
@@ -422,7 +426,8 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             0,
-            size
+            size,
+            VectorDataType.FLOAT
         );
 
         assertEquals(size, trainingDataAllocation.getSizeInKB());
@@ -434,7 +439,8 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             pointer,
-            0
+            0,
+            VectorDataType.FLOAT
         );
 
         assertEquals(pointer, trainingDataAllocation.getMemoryAddress());

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
@@ -16,6 +16,7 @@ import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.common.exception.OutOfNativeMemoryException;
 import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
@@ -186,7 +187,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             0,
-            allocationEntryWeight
+            allocationEntryWeight,
+            VectorDataType.FLOAT
         );
 
         NativeMemoryEntryContext.TrainingDataEntryContext trainingDataEntryContext = mock(

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryEntryContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryEntryContextTests.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableMap;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.IndexUtil;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.BufferedOutputStream;
@@ -122,13 +123,15 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
             trainingLoadStrategy,
             null,
             0,
-            0
+            0,
+            VectorDataType.DEFAULT
         );
 
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(
             null,
             0,
-            0
+            0,
+            VectorDataType.DEFAULT
         );
 
         when(trainingLoadStrategy.load(trainingDataEntryContext)).thenReturn(trainingDataAllocation);
@@ -145,7 +148,8 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
             null,
             null,
             0,
-            0
+            0,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(trainIndexName, trainingDataEntryContext.getTrainIndexName());
@@ -160,7 +164,8 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
             null,
             null,
             0,
-            0
+            0,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(trainFieldName, trainingDataEntryContext.getTrainFieldName());
@@ -175,7 +180,8 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
             null,
             null,
             maxVectorCount,
-            0
+            0,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(maxVectorCount, trainingDataEntryContext.getMaxVectorCount());
@@ -190,7 +196,8 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
             null,
             null,
             0,
-            searchSize
+            searchSize,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(searchSize, trainingDataEntryContext.getSearchSize());
@@ -205,7 +212,8 @@ public class NativeMemoryEntryContextTests extends KNNTestCase {
             null,
             clusterService,
             0,
-            0
+            0,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(clusterService, trainingDataEntryContext.getClusterService());

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
@@ -22,7 +22,7 @@ import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.query.KNNQueryResult;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
-import org.opensearch.knn.training.TrainingDataConsumer;
+import org.opensearch.knn.training.FloatTrainingDataConsumer;
 import org.opensearch.knn.training.VectorReader;
 import org.opensearch.watcher.ResourceWatcherService;
 
@@ -150,12 +150,12 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
         logger.info("J0");
         doAnswer(invocationOnMock -> {
             logger.info("J1");
-            TrainingDataConsumer trainingDataConsumer = (TrainingDataConsumer) invocationOnMock.getArguments()[5];
+            FloatTrainingDataConsumer floatTrainingDataConsumer = (FloatTrainingDataConsumer) invocationOnMock.getArguments()[5];
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[6];
             Thread thread = new Thread(() -> {
                 try {
                     Thread.sleep(2000);
-                    trainingDataConsumer.accept(vectors); // Transfer some floats
+                    floatTrainingDataConsumer.accept(vectors); // Transfer some floats
                     listener.onResponse(null);
                 } catch (InterruptedException e) {
                     listener.onFailure(null);
@@ -176,7 +176,8 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
             NativeMemoryLoadStrategy.TrainingLoadStrategy.getInstance(),
             null,
             0,
-            0
+            0,
+            VectorDataType.FLOAT
         );
 
         // Load the allocation. Initially, the memory address should be 0. However, after the readlock is obtained,

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -903,6 +903,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(modelMetadata.getSpaceType()).thenReturn(SpaceType.COSINESIMIL);
         when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
         when(modelMetadata.getMethodComponentContext()).thenReturn(new MethodComponentContext("ivf", emptyMap()));
+        when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.DEFAULT);
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
         KNNQueryBuilder.initialize(modelDao);
@@ -940,6 +941,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(modelMetadata.getSpaceType()).thenReturn(SpaceType.L2);
         when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
         when(modelMetadata.getMethodComponentContext()).thenReturn(new MethodComponentContext("ivf", emptyMap()));
+        when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.DEFAULT);
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
         KNNQueryBuilder.initialize(modelDao);
@@ -975,6 +977,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(modelMetadata.getKnnEngine()).thenReturn(KNNEngine.FAISS);
         when(modelMetadata.getSpaceType()).thenReturn(SpaceType.L2);
         when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
+        when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.DEFAULT);
         when(modelMetadata.getMethodComponentContext()).thenReturn(new MethodComponentContext("ivf", emptyMap()));
         ModelDao modelDao = mock(ModelDao.class);
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -38,6 +38,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
@@ -62,6 +63,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyMap;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -199,6 +201,8 @@ public class KNNWeightTests extends KNNTestCase {
         when(modelMetadata.getKnnEngine()).thenReturn(KNNEngine.FAISS);
         when(modelMetadata.getSpaceType()).thenReturn(spaceType);
         when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
+        when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.DEFAULT);
+        when(modelMetadata.getMethodComponentContext()).thenReturn(new MethodComponentContext("ivf", emptyMap()));
         when(modelDao.getMetadata(eq("modelId"))).thenReturn(modelMetadata);
 
         KNNWeight.initialize(modelDao);

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -19,6 +19,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.time.ZoneOffset;
@@ -45,7 +46,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             "hello".getBytes(),
             modelId
@@ -82,7 +84,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[BYTES_PER_KILOBYTES + 1],
             modelId
@@ -140,7 +143,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[size1],
             modelId1
@@ -156,7 +160,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[size2],
             modelId2
@@ -200,7 +205,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[size1],
             modelId1
@@ -216,8 +222,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
-
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[size2],
             modelId2
@@ -266,7 +272,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             "hello".getBytes(),
             modelId
@@ -312,7 +319,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[modelSize],
             modelId
@@ -381,7 +389,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[modelSize1],
             modelId1
@@ -423,7 +432,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[modelSize1],
             modelId1
@@ -441,7 +451,8 @@ public class ModelCacheTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[modelSize2],
             modelId2
@@ -487,7 +498,8 @@ public class ModelCacheTests extends KNNTestCase {
                     "",
                     "",
                     "",
-                    MethodComponentContext.EMPTY
+                    MethodComponentContext.EMPTY,
+                    VectorDataType.DEFAULT
                 ),
                 new byte[BYTES_PER_KILOBYTES * 2],
                 modelId

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -35,6 +35,7 @@ import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.common.exception.DeleteModelException;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.plugin.transport.DeleteModelResponse;
 import org.opensearch.knn.plugin.transport.GetModelResponse;
@@ -139,7 +140,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -159,7 +161,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -187,7 +190,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                new MethodComponentContext("test", Collections.emptyMap())
+                new MethodComponentContext("test", Collections.emptyMap()),
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -248,7 +252,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -310,7 +315,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             "any-id"
@@ -347,7 +353,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             null,
             modelId
@@ -386,7 +393,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -437,7 +445,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -456,7 +465,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             null,
             modelId
@@ -493,7 +503,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         Model model = new Model(modelMetadata, modelBlob, modelId);
@@ -570,7 +581,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -604,7 +616,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId1
@@ -672,7 +685,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId
@@ -714,7 +728,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId

--- a/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.io.IOException;
@@ -45,7 +46,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
@@ -67,7 +69,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(knnEngine, modelMetadata.getKnnEngine());
@@ -84,7 +87,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(spaceType, modelMetadata.getSpaceType());
@@ -101,7 +105,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(dimension, modelMetadata.getDimension());
@@ -118,7 +123,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(modelState, modelMetadata.getState());
@@ -135,7 +141,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(timeValue, modelMetadata.getTimestamp());
@@ -152,7 +159,8 @@ public class ModelMetadataTests extends KNNTestCase {
             description,
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(description, modelMetadata.getDescription());
@@ -169,10 +177,29 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             error,
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(error, modelMetadata.getError());
+    }
+
+    public void testGetVectorDataType() {
+        VectorDataType vectorDataType = VectorDataType.BINARY;
+        ModelMetadata modelMetadata = new ModelMetadata(
+            KNNEngine.DEFAULT,
+            SpaceType.L2,
+            12,
+            ModelState.CREATED,
+            ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
+            "",
+            "",
+            MethodComponentContext.EMPTY,
+            vectorDataType
+        );
+
+        assertEquals(vectorDataType, modelMetadata.getVectorDataType());
     }
 
     public void testSetState() {
@@ -186,7 +213,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(modelState, modelMetadata.getState());
@@ -207,7 +235,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             error,
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(error, modelMetadata.getError());
@@ -244,7 +273,9 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + nodeAssignment
             + ","
-            + methodComponentContext.toClusterStateString();
+            + methodComponentContext.toClusterStateString()
+            + ","
+            + VectorDataType.DEFAULT.getValue();
 
         ModelMetadata modelMetadata = new ModelMetadata(
             knnEngine,
@@ -255,7 +286,8 @@ public class ModelMetadataTests extends KNNTestCase {
             description,
             error,
             nodeAssignment,
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         assertEquals(expected, modelMetadata.toString());
@@ -275,7 +307,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata2 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -286,7 +319,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         ModelMetadata modelMetadata3 = new ModelMetadata(
@@ -298,7 +332,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata4 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -309,7 +344,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata5 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -320,7 +356,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata6 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -331,7 +368,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata7 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -342,7 +380,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata8 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -353,7 +392,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "diff descript",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata9 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -364,7 +404,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "diff error",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         ModelMetadata modelMetadata10 = new ModelMetadata(
@@ -376,7 +417,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            new MethodComponentContext("test", Collections.emptyMap())
+            new MethodComponentContext("test", Collections.emptyMap()),
+            VectorDataType.DEFAULT
         );
 
         assertEquals(modelMetadata1, modelMetadata1);
@@ -406,7 +448,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata2 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -417,7 +460,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         ModelMetadata modelMetadata3 = new ModelMetadata(
@@ -429,7 +473,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata4 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -440,7 +485,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata5 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -451,7 +497,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata6 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -462,7 +509,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata7 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -473,7 +521,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata8 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -484,7 +533,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "diff descript",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         ModelMetadata modelMetadata9 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -495,7 +545,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "diff error",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         ModelMetadata modelMetadata10 = new ModelMetadata(
@@ -507,7 +558,8 @@ public class ModelMetadataTests extends KNNTestCase {
             "",
             "",
             "",
-            new MethodComponentContext("test", Collections.emptyMap())
+            new MethodComponentContext("test", Collections.emptyMap()),
+            VectorDataType.DEFAULT
         );
 
         assertEquals(modelMetadata1.hashCode(), modelMetadata1.hashCode());
@@ -550,7 +602,9 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + nodeAssignment
             + ","
-            + methodComponentContext.toClusterStateString();
+            + methodComponentContext.toClusterStateString()
+            + ","
+            + VectorDataType.DEFAULT.getValue();
 
         String stringRep2 = knnEngine.getName()
             + ","
@@ -564,7 +618,9 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + description
             + ","
-            + error;
+            + error
+            + ","
+            + VectorDataType.DEFAULT.getValue();
 
         ModelMetadata expected1 = new ModelMetadata(
             knnEngine,
@@ -575,7 +631,8 @@ public class ModelMetadataTests extends KNNTestCase {
             description,
             error,
             nodeAssignment,
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         ModelMetadata expected2 = new ModelMetadata(
@@ -587,7 +644,8 @@ public class ModelMetadataTests extends KNNTestCase {
             description,
             error,
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         ModelMetadata fromString1 = ModelMetadata.fromString(stringRep1);
@@ -620,8 +678,8 @@ public class ModelMetadataTests extends KNNTestCase {
             description,
             error,
             nodeAssignment,
-            methodComponentContext
-
+            methodComponentContext,
+            VectorDataType.DEFAULT
         );
         ModelMetadata expected2 = new ModelMetadata(
             knnEngine,
@@ -632,7 +690,8 @@ public class ModelMetadataTests extends KNNTestCase {
             description,
             error,
             "",
-            emptyMethodComponentContext
+            emptyMethodComponentContext,
+            VectorDataType.DEFAULT
         );
         Map<String, Object> metadataAsMap = new HashMap<>();
         metadataAsMap.put(KNNConstants.KNN_ENGINE, knnEngine.getName());
@@ -643,6 +702,7 @@ public class ModelMetadataTests extends KNNTestCase {
         metadataAsMap.put(KNNConstants.MODEL_DESCRIPTION, description);
         metadataAsMap.put(KNNConstants.MODEL_ERROR, error);
         metadataAsMap.put(KNNConstants.MODEL_NODE_ASSIGNMENT, nodeAssignment);
+        metadataAsMap.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.DEFAULT.getValue());
 
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         builder = methodComponentContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
@@ -678,7 +738,8 @@ public class ModelMetadataTests extends KNNTestCase {
                 description,
                 error,
                 nodeAssignment,
-                methodComponentContext
+                methodComponentContext,
+                VectorDataType.DEFAULT
             )
         );
         assertEquals("Model description cannot contain any commas: ','", e.getMessage());

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -15,6 +15,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 
 import java.time.ZoneOffset;
@@ -41,7 +42,8 @@ public class ModelTests extends KNNTestCase {
                     "",
                     "",
                     "",
-                    MethodComponentContext.EMPTY
+                    MethodComponentContext.EMPTY,
+                    VectorDataType.DEFAULT
                 ),
                 null,
                 "test-model"
@@ -62,7 +64,8 @@ public class ModelTests extends KNNTestCase {
                     "",
                     "",
                     "",
-                    MethodComponentContext.EMPTY
+                    MethodComponentContext.EMPTY,
+                    VectorDataType.DEFAULT
                 ),
                 new byte[16],
                 "test-model"
@@ -80,7 +83,8 @@ public class ModelTests extends KNNTestCase {
                     "",
                     "",
                     "",
-                    MethodComponentContext.EMPTY
+                    MethodComponentContext.EMPTY,
+                    VectorDataType.DEFAULT
                 ),
                 new byte[16],
                 "test-model"
@@ -98,7 +102,8 @@ public class ModelTests extends KNNTestCase {
                     "",
                     "",
                     "",
-                    MethodComponentContext.EMPTY
+                    MethodComponentContext.EMPTY,
+                    VectorDataType.DEFAULT
                 ),
                 new byte[16],
                 "test-model"
@@ -117,7 +122,8 @@ public class ModelTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         Model model = new Model(modelMetadata, new byte[16], "test-model");
         assertEquals(modelMetadata, model.getModelMetadata());
@@ -135,7 +141,8 @@ public class ModelTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             "test-model"
@@ -155,7 +162,8 @@ public class ModelTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[size],
             "test-model"
@@ -172,7 +180,8 @@ public class ModelTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             null,
             "test-model"
@@ -192,7 +201,8 @@ public class ModelTests extends KNNTestCase {
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             blob1,
             "test-model"
@@ -209,17 +219,50 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", "", MethodComponentContext.EMPTY),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L1,
+                2,
+                ModelState.CREATED,
+                time,
+                "",
+                "",
+                "",
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
+            ),
             new byte[16],
             "test-model-1"
         );
         Model model2 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", "", MethodComponentContext.EMPTY),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L1,
+                2,
+                ModelState.CREATED,
+                time,
+                "",
+                "",
+                "",
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
+            ),
             new byte[16],
             "test-model-1"
         );
         Model model3 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L2, 2, ModelState.CREATED, time, "", "", "", MethodComponentContext.EMPTY),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L2,
+                2,
+                ModelState.CREATED,
+                time,
+                "",
+                "",
+                "",
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
+            ),
             new byte[16],
             "test-model-2"
         );
@@ -234,17 +277,50 @@ public class ModelTests extends KNNTestCase {
         String time = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
         Model model1 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", "", MethodComponentContext.EMPTY),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L1,
+                2,
+                ModelState.CREATED,
+                time,
+                "",
+                "",
+                "",
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
+            ),
             new byte[16],
             "test-model-1"
         );
         Model model2 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", "", MethodComponentContext.EMPTY),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L1,
+                2,
+                ModelState.CREATED,
+                time,
+                "",
+                "",
+                "",
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
+            ),
             new byte[16],
             "test-model-1"
         );
         Model model3 = new Model(
-            new ModelMetadata(KNNEngine.DEFAULT, SpaceType.L1, 2, ModelState.CREATED, time, "", "", "", MethodComponentContext.EMPTY),
+            new ModelMetadata(
+                KNNEngine.DEFAULT,
+                SpaceType.L1,
+                2,
+                ModelState.CREATED,
+                time,
+                "",
+                "",
+                "",
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
+            ),
             new byte[16],
             "test-model-2"
         );
@@ -274,7 +350,8 @@ public class ModelTests extends KNNTestCase {
             description,
             error,
             nodeAssignment,
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         Map<String, Object> modelAsMap = new HashMap<>();
         modelAsMap.put(KNNConstants.MODEL_ID, modelID);
@@ -287,6 +364,7 @@ public class ModelTests extends KNNTestCase {
         modelAsMap.put(KNNConstants.MODEL_ERROR, error);
         modelAsMap.put(KNNConstants.MODEL_NODE_ASSIGNMENT, nodeAssignment);
         modelAsMap.put(KNNConstants.MODEL_BLOB_PARAMETER, "aGVsbG8=");
+        modelAsMap.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.DEFAULT.getValue());
 
         byte[] blob1 = "hello".getBytes();
         Model expected = new Model(metadata, blob1, modelID);

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -36,7 +36,20 @@ import java.util.*;
 import static org.opensearch.knn.TestUtils.KNN_VECTOR;
 import static org.opensearch.knn.TestUtils.PROPERTIES;
 import static org.opensearch.knn.TestUtils.VECTOR_TYPE;
-import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
+import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.NAME;
 
 /**
  * Integration tests to check the correctness of RestKNNStatsHandler

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNClusterUtil;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelMetadata;
@@ -43,7 +44,8 @@ public class GetModelResponseTests extends KNNTestCase {
             "test model",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
     }
 
@@ -68,7 +70,7 @@ public class GetModelResponseTests extends KNNTestCase {
             Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
             String expectedResponseString =
-                "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}}}";
+                "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\"}";
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
             getModelResponse.toXContent(xContentBuilder, null);
             assertEquals(expectedResponseString, xContentBuilder.toString());
@@ -84,7 +86,7 @@ public class GetModelResponseTests extends KNNTestCase {
             Model model = new Model(getModelMetadata(ModelState.FAILED), null, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
             String expectedResponseString =
-                "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}}}";
+                "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\"}";
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
             getModelResponse.toXContent(xContentBuilder, null);
             assertEquals(expectedResponseString, xContentBuilder.toString());

--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -19,6 +19,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelCache;
@@ -78,7 +79,8 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
                 "description",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             new byte[128],
             modelId

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.MethodComponentContext;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.KNNEngine;
@@ -61,7 +62,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             preferredNode,
-            description
+            description,
+            VectorDataType.DEFAULT
         );
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
@@ -74,6 +76,7 @@ public class TrainingModelRequestTests extends KNNTestCase {
         assertEquals(original1.getTrainingIndex(), copy1.getTrainingIndex());
         assertEquals(original1.getTrainingField(), copy1.getTrainingField());
         assertEquals(original1.getPreferredNodeId(), copy1.getPreferredNodeId());
+        assertEquals(original1.getVectorDataType(), copy1.getVectorDataType());
 
         // Also, check when preferred node and model id and description are null
         TrainingModelRequest original2 = new TrainingModelRequest(
@@ -83,7 +86,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         streamOutput = new BytesStreamOutput();
@@ -96,6 +100,7 @@ public class TrainingModelRequestTests extends KNNTestCase {
         assertEquals(original2.getTrainingIndex(), copy2.getTrainingIndex());
         assertEquals(original2.getTrainingField(), copy2.getTrainingField());
         assertEquals(original2.getPreferredNodeId(), copy2.getPreferredNodeId());
+        assertEquals(original2.getVectorDataType(), copy2.getVectorDataType());
     }
 
     public void testGetters() {
@@ -117,7 +122,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             preferredNode,
-            description
+            description,
+            VectorDataType.DEFAULT
         );
 
         trainingModelRequest.setMaximumVectorCount(maxVectorCount);
@@ -156,7 +162,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return metadata for modelId to recognize it is a duplicate
@@ -170,7 +177,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
 
@@ -211,7 +219,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return true to recognize that the modelId is in graveyard
@@ -257,7 +266,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return null so that no exception is produced
@@ -300,7 +310,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return null so that no exception is produced
@@ -346,7 +357,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return null so that no exception is produced
@@ -397,7 +409,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return null so that no exception is produced
@@ -452,7 +465,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return null so that no exception is produced
@@ -509,7 +523,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             preferredNode,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return metadata for modelId to recognize it is a duplicate
@@ -574,7 +589,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            description
+            description,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return metadata for modelId to recognize it is a duplicate
@@ -618,7 +634,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return metadata for modelId to recognize it is a duplicate
@@ -655,7 +672,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             trainingIndex,
             trainingField,
             null,
-            null
+            null,
+            VectorDataType.DEFAULT
         );
 
         // Mock the model dao to return metadata for modelId to recognize it is a duplicate

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelTransportActionTests.java
@@ -17,6 +17,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 
@@ -72,9 +73,10 @@ public class TrainingModelTransportActionTests extends KNNSingleNodeTestCase {
             trainingIndexName,
             trainingFieldName,
             null,
-            "test-detector"
+            "test-detector",
+            VectorDataType.DEFAULT
         );
-        trainingModelRequest.setTrainingDataSizeInKB(estimateVectorSetSizeInKB(trainingDataCount, dimension));
+        trainingModelRequest.setTrainingDataSizeInKB(estimateVectorSetSizeInKB(trainingDataCount, dimension, VectorDataType.DEFAULT));
 
         // Create listener that ensures that the initial model put succeeds
         ActionListener<TrainingModelResponse> listener = ActionListener.wrap(

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.exception.DeleteModelException;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelGraveyard;
@@ -210,7 +211,8 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
                 "",
                 "",
                 "",
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             modelBlob,
             modelId

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
@@ -15,6 +15,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
@@ -42,7 +43,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest(modelId, isRemoveRequest, modelMetadata);
 
@@ -67,7 +69,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         UpdateModelMetadataRequest updateModelMetadataRequest1 = new UpdateModelMetadataRequest("test", true, null);
@@ -107,7 +110,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest("test", true, modelMetadata);
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -19,6 +19,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.KNNEngine;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
@@ -68,7 +69,8 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
             "",
             "",
             "",
-            MethodComponentContext.EMPTY
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT
         );
 
         // Get update transport action

--- a/src/test/java/org/opensearch/knn/training/FloatTrainingDataConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/training/FloatTrainingDataConsumerTests.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TrainingDataConsumerTests extends KNNTestCase {
+public class FloatTrainingDataConsumerTests extends KNNTestCase {
 
     public void testAccept() {
 
@@ -38,7 +38,7 @@ public class TrainingDataConsumerTests extends KNNTestCase {
         // Capture argument passed to set pointer
         ArgumentCaptor<Long> valueCapture = ArgumentCaptor.forClass(Long.class);
 
-        TrainingDataConsumer trainingDataConsumer = new TrainingDataConsumer(trainingDataAllocation);
+        FloatTrainingDataConsumer floatTrainingDataConsumer = new FloatTrainingDataConsumer(trainingDataAllocation);
 
         List<Float[]> vectorSet1 = new ArrayList<>(3);
         for (int i = 0; i < 3; i++) {
@@ -47,10 +47,8 @@ public class TrainingDataConsumerTests extends KNNTestCase {
             vectorSet1.add(vector);
         }
 
-        when(trainingDataAllocation.getMemoryAddress()).thenReturn(0L);
-
         // Transfer vectors
-        trainingDataConsumer.accept(vectorSet1);
+        floatTrainingDataConsumer.accept(vectorSet1);
 
         // Ensure that the pointer captured has been updated
         verify(trainingDataAllocation).setMemoryAddress(valueCapture.capture());

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNMethodContext;
 import org.opensearch.knn.index.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
@@ -67,7 +68,8 @@ public class TrainingJobTests extends KNNTestCase {
             mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
             10,
             "",
-            "test-node"
+            "test-node",
+            VectorDataType.DEFAULT
         );
 
         assertEquals(modelId, trainingJob.getModelId());
@@ -96,7 +98,8 @@ public class TrainingJobTests extends KNNTestCase {
             mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
             dimension,
             description,
-            nodeAssignment
+            nodeAssignment,
+            VectorDataType.DEFAULT
         );
 
         Model model = new Model(
@@ -109,7 +112,8 @@ public class TrainingJobTests extends KNNTestCase {
                 description,
                 error,
                 nodeAssignment,
-                MethodComponentContext.EMPTY
+                MethodComponentContext.EMPTY,
+                VectorDataType.DEFAULT
             ),
             null,
             modelID
@@ -183,8 +187,8 @@ public class TrainingJobTests extends KNNTestCase {
             modelContext,
             dimension,
             "",
-            "test-node"
-
+            "test-node",
+            VectorDataType.DEFAULT
         );
 
         trainingJob.run();
@@ -262,8 +266,8 @@ public class TrainingJobTests extends KNNTestCase {
             modelContext,
             dimension,
             "",
-
-            "test-node"
+            "test-node",
+            VectorDataType.DEFAULT
         );
 
         trainingJob.run();
@@ -330,8 +334,8 @@ public class TrainingJobTests extends KNNTestCase {
             modelContext,
             dimension,
             "",
-
-            "test-node"
+            "test-node",
+            VectorDataType.DEFAULT
         );
 
         trainingJob.run();
@@ -397,7 +401,8 @@ public class TrainingJobTests extends KNNTestCase {
             mock(NativeMemoryEntryContext.AnonymousEntryContext.class),
             dimension,
             "",
-            "test-node"
+            "test-node",
+            VectorDataType.DEFAULT
         );
 
         trainingJob.run();
@@ -470,7 +475,8 @@ public class TrainingJobTests extends KNNTestCase {
             modelContext,
             dimension,
             "",
-            "test-node"
+            "test-node",
+            VectorDataType.DEFAULT
         );
 
         trainingJob.run();


### PR DESCRIPTION
### Resolved comments in PR https://github.com/heemin32/k-NN/pull/2, which was friendly to check the file diffs when https://github.com/opensearch-project/k-NN/pull/1781 wasn't merged. Because https://github.com/opensearch-project/k-NN/pull/1781 now is merged, I rebased [junqiu-lei:binary-ivf](https://github.com/junqiu-lei/k-NN/tree/binary-ivf) against [opensearch-project:feature/binary-format](https://github.com/opensearch-project/k-NN/tree/feature/binary-format) 

### Description
This PR will support using binary format with Faiss IVF method, it mainly have changes:
* introduce `data_type` field when train model
* support train model with binary format index
* create binary format IVF target index with with binary format model
* query IVF index with binary format


JNI layer related refactor works will be complete in another PR tracked by https://github.com/opensearch-project/k-NN/issues/1846

### Example workflow
#### 1. Create binary format train index
```
PUT /train-index HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 481

{
  "settings": {
    "number_of_shards": 3,
    "number_of_replicas": 0,
    "index.knn": true
  },
  "mappings": {
    "properties": {
      "train-field": {
        "type": "knn_vector",
        "dimension": 8,
        "data_type": "binary",
        "method": {
          "name": "hnsw",
          "space_type": "hammingbit",
          "engine": "faiss",
          "parameters": {
            "ef_construction": 128,
            "m": 24
          }
        }
      }
    }
  }
}
```

#### 2. Ingest tran index
```
POST /_bulk HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 7067

{ "index": { "_index": "train-index", "_id": "1" } }
{ "train-field": [1]}
{ "index": { "_index": "train-index", "_id": "2" } }
{ "train-field": [2]}
{ "index": { "_index": "train-index", "_id": "3" } }
{ "train-field": [4]}
{ "index": { "_index": "train-index", "_id": "4" } }
........
```

#### 3. Create train model
```
POST /_plugins/_knn/models/my-model/_train HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 313

{
  "training_index": "train-index",
  "training_field": "train-field",
  "dimension": 8,
  "description": "My model description",
  "data_type": "binary",
  "method": {
    "name": "ivf",
    "engine": "faiss",
    "space_type": "hammingbit",
    "parameters": {
      "nlist": 4,
      "nprobes":2 
    }
  }
}

```

#### 4. Create IVF binary format target index
```
PUT /target-index HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 242

{
  "settings": {
    "number_of_shards": 1,
    "number_of_replicas": 1,
    "index.knn": true
  },
  "mappings": {
    "properties": {
      "target-field": {
        "type": "knn_vector",
        "model_id": "my-model"
      }
    }
  }
}
```



#### 5. Bulk target index
```
POST /_bulk HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 931

{ "index": { "_index": "target-index", "_id": "1" } }
{ "target-field": [2]}
{ "index": { "_index": "target-index", "_id": "2" } }
{ "target-field": [3]}
.......
```

#### 6. Query target index
```
GET /target-index/_search HTTP/1.1
Host: localhost:9200
Content-Type: application/json
Content-Length: 110

{
  "query": {
    "knn": {
      "target-field": {
        "vector": [10],
        "k": 5
      }
    }
  }
}
```

#### 7. Query result
```
{
    "took": 2898,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 5,
            "relation": "eq"
        },
        "max_score": 1.0,
        "hits": [
            {
                "_index": "target-index",
                "_id": "9",
                "_score": 1.0,
                "_source": {
                    "target-field": [
                        10
                    ]
                }
            },
            {
                "_index": "target-index",
                "_id": "1",
                "_score": 0.5,
                "_source": {
                    "target-field": [
                        2
                    ]
                }
            },
            {
                "_index": "target-index",
                "_id": "7",
                "_score": 0.5,
                "_source": {
                    "target-field": [
                        8
                    ]
                }
            },
            {
                "_index": "target-index",
                "_id": "10",
                "_score": 0.5,
                "_source": {
                    "target-field": [
                        11
                    ]
                }
            },
            {
                "_index": "target-index",
                "_id": "2",
                "_score": 0.33333334,
                "_source": {
                    "target-field": [
                        3
                    ]
                }
            }
        ]
    }
}
```

### Issues Resolved
part of https://github.com/opensearch-project/k-NN/issues/1767
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
