### PR TITLE
Refactor parsing logic of the Query Builder

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.query;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.experimental.Accessors;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -60,6 +61,7 @@ import static org.opensearch.knn.validation.ParameterValidator.validateParameter
  * Helper class to build the KNN query
  */
 // The builder validates the member variables so access to the constructor is prohibited to not accidentally bypass validations
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Log4j2
 public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
@@ -81,19 +83,15 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     /**
      * The default mode terms are combined in a match query
      */
+    @Accessors(fluent = true)
     private final String fieldName;
+    @Accessors(fluent = true)
     private final float[] vector;
-    @Getter
     private int k;
-    @Getter
     private Float maxDistance;
-    @Getter
     private Float minScore;
-    @Getter
     private Map<String, ?> methodParameters;
-    @Getter
     private QueryBuilder filter;
-    @Getter
     private boolean ignoreUnmapped;
 
     /**
@@ -437,20 +435,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (isClusterOnOrAfterMinRequiredVersion(METHOD_PARAMETER)) {
             MethodParametersParser.streamOutput(out, methodParameters, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
         }
-    }
-
-    /**
-     * @return The field name used in this query
-     */
-    public String fieldName() {
-        return this.fieldName;
-    }
-
-    /**
-     * @return Returns the vector used in this query.
-     */
-    public Object vector() {
-        return this.vector;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -191,7 +191,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             .queryName(queryName)
             .boost(boost)
             .fieldName(fieldName)
-            .vector(ObjectsToFloats(vector))
+            .vector(objectsToFloats(vector))
             .k(k)
             .maxDistance(maxDistance)
             .minScore(minScore)
@@ -228,28 +228,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         } catch (IOException ex) {
             throw new RuntimeException("[KNN] Unable to create KNNQueryBuilder", ex);
         }
-    }
-
-    /**
-     * Constructs a new query with the given field name and vector
-     *
-     * @param fieldName Name of the field
-     * @param vector    Array of floating points
-     * @deprecated Use {@code {@link KNNQueryBuilder.Builder}} instead
-     */
-    @Deprecated
-    public KNNQueryBuilder(String fieldName, float[] vector) {
-        if (Strings.isNullOrEmpty(fieldName)) {
-            throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
-        }
-        if (vector == null) {
-            throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
-        }
-        if (vector.length == 0) {
-            throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
-        }
-        this.fieldName = fieldName;
-        this.vector = vector;
     }
 
     /**
@@ -627,7 +605,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         return NAME;
     }
 
-    private static float[] ObjectsToFloats(List<Object> objs) {
+    private static float[] objectsToFloats(List<Object> objs) {
         if (Objects.isNull(objs) || objs.isEmpty()) {
             throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be non-null and non-empty", NAME));
         }


### PR DESCRIPTION
### Description
I was working on some code for #1779 where I had to add a parameter to KNNQueryBuilder and noticed it has gotten pretty complex. I know @shatejas recently did some refactoring and wanted to build upon that to see if I could simplify the parsing logic. 

What I found was that we can use [ObjectParser](https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/core/xcontent/ObjectParser.java) on the inner structure of the query to better define the parsing structure so we do not have to deal with tokens. I have noticed a couple other queries also use this, but many still do it the old way (one example using parser: https://github.com/opensearch-project/OpenSearch/blob/main/modules/mapper-extras/src/main/java/org/opensearch/index/query/RankFeatureQueryBuilder.java)

Anyway, this is in early phases. Just wanted to get some preliminary feedback.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
