### PR TITLE
[backport 2.x] Support ef_search parameter in radial search faiss engine (#1790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.15...2.x)
 ### Features
 * Adds dynamic query parameter ef_search [#1783](https://github.com/opensearch-project/k-NN/pull/1783)
+* Adds dynamic query parameter ef_search in radial search faiss engine [#1790](https://github.com/opensearch-project/k-NN/pull/1790)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -90,6 +90,7 @@ namespace knn_jni {
          * @param indexPointerJ - pointer to the index
          * @param queryVectorJ - the query vector
          * @param radiusJ - the radius for the range search
+         * @param methodParamsJ - the method parameters
          * @param maxResultsWindowJ - the maximum number of results to return
          * @param filterIdsJ - the filter ids
          * @param filterIdsTypeJ - the filter ids type
@@ -98,7 +99,7 @@ namespace knn_jni {
          * @return an array of RangeQueryResults
          */
         jobjectArray RangeSearchWithFilter(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
-                                           jfloat radiusJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ);
+                                           jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ);
 
         /*
          * Perform a range search against the index located in memory at indexPointerJ.
@@ -106,13 +107,14 @@ namespace knn_jni {
          * @param indexPointerJ - pointer to the index
          * @param queryVectorJ - the query vector
          * @param radiusJ - the radius for the range search
+         * @param methodParamsJ - the method parameters
          * @param maxResultsWindowJ - the maximum number of results to return
          * @param parentIdsJ - the parent ids
          *
          * @return an array of RangeQueryResults
          */
         jobjectArray RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
-                    jfloat radiusJ, jint maxResultWindowJ, jintArray parentIdsJ);
+                    jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jintArray parentIdsJ);
     }
 }
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -125,18 +125,18 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 /*
 * Class:     org_opensearch_knn_jni_FaissService
 * Method:    rangeSearchIndexWithFilter
-* Signature: (J[FJ[I)[Lorg/opensearch/knn/index/query/RangeQueryResult;
+* Signature: (J[FJLjava/util/MapI[JII)[Lorg/opensearch/knn/index/query/RangeQueryResult;
 */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter
-  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint, jlongArray, jint, jintArray);
+  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jobject, jint, jlongArray, jint, jintArray);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    rangeSearchIndex
- * Signature: (J[FJ[I)[Lorg/opensearch/knn/index/query/RangeQueryResult;
+ * Signature: (J[FJLjava/util/MapII)[Lorg/opensearch/knn/index/query/RangeQueryResult;
  */
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex
-  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jint, jintArray);
+  (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jobject, jint, jintArray);
 
 #ifdef __cplusplus
 }

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -595,12 +595,12 @@ faiss::IndexIVFPQ * extractIVFPQIndex(faiss::Index * index) {
 }
 
 jobjectArray knn_jni::faiss_wrapper::RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ,
-                                                 jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ, jintArray parentIdsJ) {
-    return knn_jni::faiss_wrapper::RangeSearchWithFilter(jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ, nullptr, 0, parentIdsJ);
+                                                 jfloatArray queryVectorJ, jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jintArray parentIdsJ) {
+    return knn_jni::faiss_wrapper::RangeSearchWithFilter(jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, nullptr, 0, parentIdsJ);
 }
 
 jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ,
-                                                           jfloatArray queryVectorJ, jfloat radiusJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ) {
+                                                           jfloatArray queryVectorJ, jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ) {
     if (queryVectorJ == nullptr) {
         throw std::runtime_error("Query Vector cannot be null");
     }
@@ -612,6 +612,11 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
     }
 
     float *rawQueryVector = jniUtil->GetFloatArrayElements(env, queryVectorJ, nullptr);
+
+    std::unordered_map<std::string, jobject> methodParams;
+    if (methodParamsJ != nullptr) {
+        methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
+    }
 
     // The res will be freed by ~RangeSearchResult() in FAISS
     // The second parameter is always true, as lims is allocated by FAISS
@@ -634,9 +639,8 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         std::vector<uint64_t> idGrouperBitmap;
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
         if(hnswReader) {
-            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
-            // value of ef_search = 16 which will then be used.
-            hnswParams.efSearch = hnswReader->hnsw.efSearch;
+            // Query param ef_search supersedes ef_search provided during index setting.
+            hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
             hnswParams.sel = idSelector.get();
             if (parentIdsJ != nullptr) {
                 idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
@@ -664,12 +668,13 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         std::unique_ptr<faiss::IDGrouperBitmap> idGrouper;
         std::vector<uint64_t> idGrouperBitmap;
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
-        if(hnswReader!= nullptr && parentIdsJ != nullptr) {
-            // Setting the ef_search value equal to what was provided during index creation. SearchParametersHNSW has a default
-            // value of ef_search = 16 which will then be used.
-            hnswParams.efSearch = hnswReader->hnsw.efSearch;
-            idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
-            hnswParams.grp = idGrouper.get();
+        if(hnswReader!= nullptr) {
+            // Query param ef_search supersedes ef_search provided during index setting.
+            hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
+            if (parentIdsJ != nullptr) {
+                idGrouper = buildIDGrouperBitmap(jniUtil, env, parentIdsJ, &idGrouperBitmap);
+                hnswParams.grp = idGrouper.get();
+            }
             searchParameters = &hnswParams;
         }
         try {

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -194,11 +194,11 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jint maxResultWindowJ,
-                                                                                   jintArray parentIdsJ)
+                                                                                   jfloat radiusJ, jobject methodParamsJ,
+                                                                                   jint maxResultWindowJ, jintArray parentIdsJ)
 {
     try {
-        return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, maxResultWindowJ, parentIdsJ);
+        return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, parentIdsJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -208,12 +208,11 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter(JNIEnv * env, jclass cls,
                                                                                    jlong indexPointerJ,
                                                                                    jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jint maxResultWindowJ,
+                                                                                   jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ,
                                                                                    jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ)
 {
     try {
-        return knn_jni::faiss_wrapper::RangeSearchWithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ,
-                                                             maxResultWindowJ, filterIdsJ, filterIdsTypeJ, parentIdsJ);
+        return knn_jni::faiss_wrapper::RangeSearchWithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, filterIdsJ, filterIdsTypeJ, parentIdsJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -634,6 +634,11 @@ TEST(FaissRangeSearchQueryIndexTest, BasicAssertions) {
     faiss::MetricType metricType = faiss::METRIC_L2;
     std::string method = "HNSW32,Flat";
 
+    int efSearch = 20;
+    std::unordered_map<std::string, jobject> methodParams;
+    methodParams[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
+    auto methodParamsJ = reinterpret_cast<jobject>(&methodParams);
+
     // Define query data
     int numQueries = 100;
     std::vector<std::vector<float>> queries;
@@ -666,7 +671,7 @@ TEST(FaissRangeSearchQueryIndexTest, BasicAssertions) {
                         knn_jni::faiss_wrapper::RangeSearch(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow, nullptr)));
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, methodParamsJ, maxResultWindow, nullptr)));
 
         // assert result size is not 0
         ASSERT_NE(0, results->size());
@@ -721,7 +726,7 @@ TEST(FaissRangeSearchQueryIndexTest_WhenHitMaxWindowResult, BasicAssertions){
                         knn_jni::faiss_wrapper::RangeSearch(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow, nullptr)));
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, nullptr, maxResultWindow, nullptr)));
 
         // assert result size is not 0
         ASSERT_NE(0, results->size());
@@ -787,7 +792,7 @@ TEST(FaissRangeSearchQueryIndexTestWithFilterTest, BasicAssertions) {
                         knn_jni::faiss_wrapper::RangeSearchWithFilter(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow,
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, nullptr, maxResultWindow,
                                 reinterpret_cast<jlongArray>(&bitmap), 0, nullptr)));
 
         // assert result size is not 0
@@ -862,7 +867,7 @@ TEST(FaissRangeSearchQueryIndexTestWithParentFilterTest, BasicAssertions) {
                         knn_jni::faiss_wrapper::RangeSearchWithFilter(
                                 &mockJNIUtil, jniEnv,
                                 reinterpret_cast<jlong>(&createdIndexWithData),
-                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, maxResultWindow, nullptr, 0,
+                                reinterpret_cast<jfloatArray>(&query), rangeSearchRadius, nullptr, maxResultWindow, nullptr, 0,
                                 reinterpret_cast<jintArray>(&parentIds))));
 
         // assert result size is not 0

--- a/jni/tests/faiss_wrapper_unit_test.cpp
+++ b/jni/tests/faiss_wrapper_unit_test.cpp
@@ -30,14 +30,15 @@ struct MockIndex : faiss::IndexHNSW {
     }
 };
 
-
 struct MockIdMap : faiss::IndexIDMap {
-    mutable idx_t nCalled;
-    mutable const float *xCalled;
-    mutable idx_t kCalled;
-    mutable float *distancesCalled;
-    mutable idx_t *labelsCalled;
-    mutable const faiss::SearchParametersHNSW *paramsCalled;
+    mutable idx_t nCalled{};
+    mutable const float *xCalled{};
+    mutable int kCalled{};
+    mutable float radiusCalled{};
+    mutable float *distancesCalled{};
+    mutable idx_t *labelsCalled{};
+    mutable const faiss::SearchParametersHNSW *paramsCalled{};
+    mutable faiss::RangeSearchResult *resCalled{};
 
     explicit MockIdMap(MockIndex *index) : faiss::IndexIDMapTemplate<faiss::Index>(index) {
     }
@@ -57,18 +58,33 @@ struct MockIdMap : faiss::IndexIDMap {
         paramsCalled = dynamic_cast<const faiss::SearchParametersHNSW *>(params);
     }
 
+    void range_search(
+        idx_t n,
+        const float *x,
+        float radius,
+        faiss::RangeSearchResult *res,
+        const faiss::SearchParameters *params) const override {
+        nCalled = n;
+        xCalled = x;
+        radiusCalled = radius;
+        resCalled = res;
+        paramsCalled = dynamic_cast<const faiss::SearchParametersHNSW *>(params);
+    }
+
     void resetMock() const {
         nCalled = 0;
         xCalled = nullptr;
         kCalled = 0;
+        radiusCalled = 0.0;
         distancesCalled = nullptr;
         labelsCalled = nullptr;
+        resCalled = nullptr;
         paramsCalled = nullptr;
     }
 };
 
 struct QueryIndexHNSWTestInput {
-    string description;
+    std::string description;
     int k;
     int efSearch;
     int filterIdType;
@@ -76,13 +92,31 @@ struct QueryIndexHNSWTestInput {
     bool parentIdsPresent;
 };
 
-
+struct RangeSearchTestInput {
+    std::string description;
+    float radius;
+    int efSearch;
+    int filterIdType;
+    bool filterIdsPresent;
+    bool parentIdsPresent;
+};
 
 class FaissWrappeterParametrizedTestFixture : public testing::TestWithParam<QueryIndexHNSWTestInput> {
 public:
     FaissWrappeterParametrizedTestFixture() : index_(3), id_map_(&index_) {
         index_.hnsw.efSearch = 100; // assigning 100 to make sure default of 16 is not used anywhere
-    };
+    }
+
+protected:
+    MockIndex index_;
+    MockIdMap id_map_;
+};
+
+class FaissWrapperParametrizedRangeSearchTestFixture : public testing::TestWithParam<RangeSearchTestInput> {
+public:
+    FaissWrapperParametrizedRangeSearchTestFixture() : index_(3), id_map_(&index_) {
+        index_.hnsw.efSearch = 100; // assigning 100 to make sure default of 16 is not used anywhere
+    }
 
 protected:
     MockIndex index_;
@@ -93,12 +127,10 @@ namespace query_index_test {
 
     std::unordered_map<std::string, jobject> methodParams;
 
-
     TEST_P(FaissWrappeterParametrizedTestFixture, QueryIndexHNSWTests) {
-        //Given
+        // Given
         JNIEnv *jniEnv = nullptr;
         NiceMock<test_util::MockJNIUtil> mockJNIUtil;
-
 
         QueryIndexHNSWTestInput const &input = GetParam();
         float query[] = {1.2, 2.3, 3.4};
@@ -137,7 +169,7 @@ namespace query_index_test {
             reinterpret_cast<jfloatArray>(&query), input.k, reinterpret_cast<jobject>(&methodParams),
             reinterpret_cast<jintArray>(parentIdPtr));
 
-        //Then
+        // Then
         int actualEfSearch = id_map_.paramsCalled->efSearch;
         // Asserting the captured argument
         EXPECT_EQ(input.k, id_map_.kCalled);
@@ -165,10 +197,9 @@ namespace query_index_test {
 namespace query_index_with_filter_test {
 
     TEST_P(FaissWrappeterParametrizedTestFixture, QueryIndexWithFilterHNSWTests) {
-        //Given
+        // Given
         JNIEnv *jniEnv = nullptr;
         NiceMock<test_util::MockJNIUtil> mockJNIUtil;
-
 
         QueryIndexHNSWTestInput const &input = GetParam();
         float query[] = {1.2, 2.3, 3.4};
@@ -218,7 +249,7 @@ namespace query_index_with_filter_test {
             input.filterIdType,
             reinterpret_cast<jintArray>(parentIdPtr));
 
-        //Then
+        // Then
         int actualEfSearch = id_map_.paramsCalled->efSearch;
         // Asserting the captured argument
         EXPECT_EQ(input.k, id_map_.kCalled);
@@ -249,3 +280,93 @@ namespace query_index_with_filter_test {
         )
     );
 }
+
+namespace range_search_test {
+
+    TEST_P(FaissWrapperParametrizedRangeSearchTestFixture, RangeSearchHNSWTests) {
+        // Given
+        JNIEnv *jniEnv = nullptr;
+        NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+
+        RangeSearchTestInput const &input = GetParam();
+        float query[] = {1.2, 2.3, 3.4};
+        float radius = input.radius;
+        int maxResultWindow = 100; // Set your max result window
+
+        std::unordered_map<std::string, jobject> methodParams;
+        int efSearch = input.efSearch;
+        int expectedEfSearch = 100; // default set in mock
+        if (efSearch != -1) {
+            expectedEfSearch = input.efSearch;
+            methodParams[knn_jni::EF_SEARCH] = reinterpret_cast<jobject>(&efSearch);
+        }
+
+        std::vector<int> *parentIdPtr = nullptr;
+        if (input.parentIdsPresent) {
+            std::vector<int> parentId;
+            parentId.reserve(2);
+            parentId.push_back(1);
+            parentId.push_back(2);
+            parentIdPtr = &parentId;
+
+            EXPECT_CALL(mockJNIUtil,
+                        GetJavaIntArrayLength(
+                            jniEnv, reinterpret_cast<jintArray>(parentIdPtr)))
+                    .WillOnce(testing::Return(parentId.size()));
+
+            EXPECT_CALL(mockJNIUtil,
+                        GetIntArrayElements(
+                            jniEnv, reinterpret_cast<jintArray>(parentIdPtr), nullptr))
+                    .WillOnce(testing::Return(new int[2]{1, 2}));
+        }
+
+        std::vector<long> filter;
+        std::vector<long> *filterptr = nullptr;
+        if (input.filterIdsPresent) {
+            filter.reserve(2);
+            filter.push_back(1);
+            filter.push_back(2);
+            filterptr = &filter;
+        }
+
+        // When
+        knn_jni::faiss_wrapper::RangeSearchWithFilter(
+            &mockJNIUtil, jniEnv,
+            reinterpret_cast<jlong>(&id_map_),
+            reinterpret_cast<jfloatArray>(&query), radius, reinterpret_cast<jobject>(&methodParams),
+            maxResultWindow,
+            reinterpret_cast<jlongArray>(filterptr),
+            input.filterIdType,
+            reinterpret_cast<jintArray>(parentIdPtr));
+
+        // Then
+        int actualEfSearch = id_map_.paramsCalled->efSearch;
+        // Asserting the captured argument
+        EXPECT_EQ(expectedEfSearch, actualEfSearch);
+        if (input.parentIdsPresent) {
+            faiss::IDGrouper *grouper = id_map_.paramsCalled->grp;
+            EXPECT_TRUE(grouper != nullptr);
+        }
+        if (input.filterIdsPresent) {
+            faiss::IDSelector *sel = id_map_.paramsCalled->sel;
+            EXPECT_TRUE(sel != nullptr);
+        }
+        id_map_.resetMock();
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        RangeSearchHNSWTests,
+        FaissWrapperParametrizedRangeSearchTestFixture,
+        ::testing::Values(
+            RangeSearchTestInput{"algoParams present, parent absent, filter absent", 10.0f, 200, 0, false, false},
+            RangeSearchTestInput{"algoParams present, parent absent, filter absent, filter type 1", 10.0f, 200, 1, false, false},
+            RangeSearchTestInput{"algoParams absent, parent absent, filter present", 10.0f, -1, 0, true, false},
+            RangeSearchTestInput{"algoParams absent, parent absent, filter present, filter type 1", 10.0f, -1, 1, true, false},
+            RangeSearchTestInput{"algoParams present, parent present, filter absent", 10.0f, 200, 0, false, true},
+            RangeSearchTestInput{"algoParams present, parent present, filter absent, filter type 1", 10.0f, 150, 1, false, true},
+            RangeSearchTestInput{"algoParams absent, parent present, filter present", 10.0f, -1, 0, true, true},
+            RangeSearchTestInput{"algoParams absent, parent present, filter present, filter type 1", 10.0f, -1, 1, true, true}
+        )
+    );
+}
+

--- a/src/main/java/org/opensearch/knn/index/VectorQueryType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorQueryType.java
@@ -54,4 +54,8 @@ public enum VectorQueryType {
     public abstract KNNCounter getQueryStatCounter();
 
     public abstract KNNCounter getQueryWithFilterStatCounter();
+
+    public boolean isRadialSearch() {
+        return this == MAX_DISTANCE || this == MIN_SCORE;
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.query;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.lucene.search.BooleanClause;
@@ -205,6 +206,7 @@ public class KNNQuery extends Query {
     @Setter
     @Getter
     @AllArgsConstructor
+    @EqualsAndHashCode
     public static class Context {
         int maxResultWindow;
     }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -36,6 +36,7 @@ import org.opensearch.knn.index.VectorQueryType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.query.parser.MethodParametersParser;
 import org.opensearch.knn.index.util.KNNEngine;
+import org.opensearch.knn.index.util.QueryContext;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
@@ -215,9 +216,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 throw new IllegalArgumentException(String.format("[%s] requires exactly one of k, distance or score to be set", NAME));
             }
 
-            VectorQueryType vectorQueryType = VectorQueryType.MAX_DISTANCE;
             if (k != null) {
-                vectorQueryType = VectorQueryType.K;
                 if (k <= 0 || k > K_MAX) {
                     final String errorMessage = "[" + NAME + "] requires k to be in the range (0, " + K_MAX + "]";
                     throw new IllegalArgumentException(errorMessage);
@@ -225,7 +224,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             }
 
             if (minScore != null) {
-                vectorQueryType = VectorQueryType.MIN_SCORE;
                 if (minScore <= 0) {
                     throw new IllegalArgumentException(String.format("[%s] requires minScore to be greater than 0", NAME));
                 }
@@ -238,12 +236,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                         String.format("[%s] errors in method parameter [%s]", NAME, validationException.getMessage())
                     );
                 }
-            }
-
-            // Update stats
-            vectorQueryType.getQueryStatCounter().increment();
-            if (filter != null) {
-                vectorQueryType.getQueryWithFilterStatCounter().increment();
             }
         }
     }
@@ -529,6 +521,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         KNNEngine knnEngine = KNNEngine.DEFAULT;
         VectorDataType vectorDataType = knnVectorFieldType.getVectorDataType();
         SpaceType spaceType = knnVectorFieldType.getSpaceType();
+        VectorQueryType vectorQueryType = getVectorQueryType(k, maxDistance, minScore);
+        updateQueryStats(vectorQueryType);
 
         if (fieldDimension == -1) {
             if (spaceType != null) {
@@ -551,16 +545,18 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         final String method = methodComponentContext != null ? methodComponentContext.getName() : null;
         if (StringUtils.isNotBlank(method)) {
             final EngineSpecificMethodContext engineSpecificMethodContext = knnEngine.getMethodContext(method);
+            QueryContext queryContext = new QueryContext(vectorQueryType);
             ValidationException validationException = validateParameters(
-                engineSpecificMethodContext.supportedMethodParameters(),
+                engineSpecificMethodContext.supportedMethodParameters(queryContext),
                 (Map<String, Object>) methodParameters
             );
             if (validationException != null) {
                 throw new IllegalArgumentException(
                     String.format(
-                        "Parameters not valid for [%s]:[%s] combination: [%s]",
+                        "Parameters not valid for [%s]:[%s]:[%s] combination: [%s]",
                         knnEngine,
                         method,
+                        vectorQueryType.getQueryTypeName(),
                         validationException.getMessage()
                     )
                 );
@@ -641,6 +637,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 .byteVector(VectorDataType.BYTE == vectorDataType ? byteVector : null)
                 .vectorDataType(vectorDataType)
                 .radius(radius)
+                .methodParameters(this.methodParameters)
                 .filter(this.filter)
                 .context(context)
                 .build();
@@ -661,6 +658,38 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             throw new IllegalArgumentException(String.format("Model ID '%s' is not created.", modelId));
         }
         return modelMetadata;
+    }
+
+    /**
+     * Function to get the vector query type based on the valid query parameter.
+     *
+     * @param k K nearest neighbours for the given vector, if k is set, then the query type is K
+     * @param maxDistance Maximum distance for the given vector, if maxDistance is set, then the query type is MAX_DISTANCE
+     * @param minScore Minimum score for the given vector, if minScore is set, then the query type is MIN_SCORE
+     */
+    private VectorQueryType getVectorQueryType(int k, Float maxDistance, Float minScore) {
+        if (maxDistance != null) {
+            return VectorQueryType.MAX_DISTANCE;
+        }
+        if (minScore != null) {
+            return VectorQueryType.MIN_SCORE;
+        }
+        if (k != 0) {
+            return VectorQueryType.K;
+        }
+        throw new IllegalArgumentException(String.format("[%s] requires exactly one of k, distance or score to be set", NAME));
+    }
+
+    /**
+     * Function to update query stats.
+     *
+     * @param vectorQueryType The type of query to be executed
+     */
+    private void updateQueryStats(VectorQueryType vectorQueryType) {
+        vectorQueryType.getQueryStatCounter().increment();
+        if (filter != null) {
+            vectorQueryType.getQueryWithFilterStatCounter().increment();
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -294,6 +294,7 @@ public class KNNWeight extends Weight {
                     indexAllocation.getMemoryAddress(),
                     knnQuery.getQueryVector(),
                     knnQuery.getRadius(),
+                    knnQuery.getMethodParameters(),
                     knnEngine,
                     knnQuery.getContext().getMaxResultWindow(),
                     filterIds,

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -10,6 +10,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
 import java.util.Locale;
+import java.util.Map;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.ByteVectorSimilarityQuery;
@@ -69,6 +70,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final byte[] byteVector = createQueryRequest.getByteVector();
         final VectorDataType vectorDataType = createQueryRequest.getVectorDataType();
         final Query filterQuery = getFilterQuery(createQueryRequest);
+        final Map<String, ?> methodParameters = createQueryRequest.getMethodParameters();
 
         if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
             BitSetProducer parentFilter = null;
@@ -79,15 +81,17 @@ public class RNNQueryFactory extends BaseQueryFactory {
             }
             IndexSettings indexSettings = context.getIndexSettings();
             KNNQuery.Context knnQueryContext = new KNNQuery.Context(indexSettings.getMaxResultWindow());
-            KNNQuery rnnQuery = new KNNQuery(fieldName, vector, indexName, parentFilter).radius(radius).kNNQueryContext(knnQueryContext);
-            if (filterQuery != null && KNNEngine.getEnginesThatSupportsFilters().contains(createQueryRequest.getKnnEngine())) {
-                log.debug("Creating custom radius search with filters for index: {}, field: {} , r: {}", indexName, fieldName, radius);
-                rnnQuery.filterQuery(filterQuery);
-            }
-            log.debug(
-                String.format("Creating custom radius search for index: %s \"\", field: %s \"\", r: %f", indexName, fieldName, radius)
-            );
-            return rnnQuery;
+
+            return KNNQuery.builder()
+                .field(fieldName)
+                .queryVector(vector)
+                .indexName(indexName)
+                .parentsFilter(parentFilter)
+                .radius(radius)
+                .methodParameters(methodParameters)
+                .context(knnQueryContext)
+                .filterQuery(filterQuery)
+                .build();
         }
 
         log.debug(String.format("Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", indexName, fieldName, radius));

--- a/src/main/java/org/opensearch/knn/index/util/EngineSpecificMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/util/EngineSpecificMethodContext.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public interface EngineSpecificMethodContext {
 
-    Map<String, Parameter<?>> supportedMethodParameters();
+    Map<String, Parameter<?>> supportedMethodParameters(QueryContext ctx);
 
-    EngineSpecificMethodContext EMPTY = Collections::emptyMap;
+    EngineSpecificMethodContext EMPTY = ctx -> Collections.emptyMap();
 }

--- a/src/main/java/org/opensearch/knn/index/util/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/util/Lucene.java
@@ -67,7 +67,7 @@ public class Lucene extends JVMLibrary {
      * @param distanceTransform Map of space type to distance transformation function
      */
     Lucene(Map<String, KNNMethod> methods, String version, Map<SpaceType, Function<Float, Float>> distanceTransform) {
-        super(methods, Map.of(METHOD_HNSW, new DefaultHnswContext()), version);
+        super(methods, Map.of(METHOD_HNSW, new LuceneHNSWContext()), version);
         this.distanceTransform = distanceTransform;
     }
 

--- a/src/main/java/org/opensearch/knn/index/util/LuceneHNSWContext.java
+++ b/src/main/java/org/opensearch/knn/index/util/LuceneHNSWContext.java
@@ -15,12 +15,10 @@ import com.google.common.collect.ImmutableMap;
 import org.opensearch.knn.index.Parameter;
 import org.opensearch.knn.index.query.request.MethodParameter;
 
+import java.util.Collections;
 import java.util.Map;
 
-/**
- * Default HNSW context for all engines. Have a different implementation if engine context differs.
- */
-public final class DefaultHnswContext implements EngineSpecificMethodContext {
+public class LuceneHNSWContext implements EngineSpecificMethodContext {
 
     private final Map<String, Parameter<?>> supportedMethodParameters = ImmutableMap.<String, Parameter<?>>builder()
         .put(MethodParameter.EF_SEARCH.getName(), new Parameter.IntegerParameter(MethodParameter.EF_SEARCH.getName(), null, value -> true))
@@ -28,6 +26,11 @@ public final class DefaultHnswContext implements EngineSpecificMethodContext {
 
     @Override
     public Map<String, Parameter<?>> supportedMethodParameters(QueryContext ctx) {
+        if (ctx.queryType.isRadialSearch()) {
+            // return empty map if radial search is true
+            return Collections.emptyMap();
+        }
+        // Return the supported method parameters for non-radial cases
         return supportedMethodParameters;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/util/QueryContext.java
+++ b/src/main/java/org/opensearch/knn/index/util/QueryContext.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.util;
+
+import lombok.AllArgsConstructor;
+import org.opensearch.knn.index.VectorQueryType;
+
+/**
+ * Context class for query-specific information.
+ */
+@AllArgsConstructor
+public class QueryContext {
+    VectorQueryType queryType;
+}

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -204,6 +204,7 @@ class FaissService {
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
+     * @param methodParameters parameters to be used for the query
      * @param indexMaxResultWindow maximum number of results to return
      * @param filteredIds list of doc ids to include in the query result
      * @param filterIdsType type of filter ids
@@ -214,6 +215,7 @@ class FaissService {
         long indexPointer,
         float[] queryVector,
         float radius,
+        Map<String, ?> methodParameters,
         int indexMaxResultWindow,
         long[] filteredIds,
         int filterIdsType,
@@ -226,6 +228,7 @@ class FaissService {
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
+     * @param methodParameters parameters to be used for the query
      * @param indexMaxResultWindow maximum number of results to return
      * @param parentIds list of parent doc ids when the knn field is a nested field
      * @return KNNQueryResult array of neighbors within radius
@@ -234,6 +237,7 @@ class FaissService {
         long indexPointer,
         float[] queryVector,
         float radius,
+        Map<String, ?> methodParameters,
         int indexMaxResultWindow,
         int[] parentIds
     );

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -279,6 +279,7 @@ public class JNIService {
      * @param indexPointer pointer to index in memory
      * @param queryVector vector to be used for query
      * @param radius search within radius threshold
+     * @param methodParameters parameters to be used when loading index
      * @param knnEngine engine to query index
      * @param indexMaxResultWindow maximum number of results to return
      * @param filteredIds list of doc ids to include in the query result
@@ -290,6 +291,7 @@ public class JNIService {
         long indexPointer,
         float[] queryVector,
         float radius,
+        @Nullable Map<String, ?> methodParameters,
         KNNEngine knnEngine,
         int indexMaxResultWindow,
         long[] filteredIds,
@@ -302,13 +304,14 @@ public class JNIService {
                     indexPointer,
                     queryVector,
                     radius,
+                    methodParameters,
                     indexMaxResultWindow,
                     filteredIds,
                     filterIdsType,
                     parentIds
                 );
             }
-            return FaissService.rangeSearchIndex(indexPointer, queryVector, radius, indexMaxResultWindow, parentIds);
+            return FaissService.rangeSearchIndex(indexPointer, queryVector, radius, methodParameters, indexMaxResultWindow, parentIds);
         }
         throw new IllegalArgumentException("RadiusQueryIndex not supported for provided engine");
     }

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
@@ -339,7 +340,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float distance = 3.5f;
         final int[] expectedResults = { 2, 3, 2 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.L2, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.L2, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingScoreThreshold_usingL2Metrics_usingFloatType() throws Exception {
@@ -351,7 +352,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float score = 0.23f;
         final int[] expectedResults = { 2, 3, 2 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.L2, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.L2, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingDistanceThreshold_usingCosineMetrics_usingFloatType() throws Exception {
@@ -363,7 +364,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float distance = 0.03f;
         final int[] expectedResults = { 1, 1, 1 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.COSINESIMIL, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.COSINESIMIL, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingScoreThreshold_usingCosineMetrics_usingFloatType() throws Exception {
@@ -375,7 +376,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float score = 0.97f;
         final int[] expectedResults = { 1, 1, 1 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.COSINESIMIL, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.COSINESIMIL, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingScoreThreshold_usingInnerProductMetrics_usingFloatType() throws Exception {
@@ -387,7 +388,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float score = 2f;
         final int[] expectedResults = { 1, 1, 1 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.INNER_PRODUCT, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.INNER_PRODUCT, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingDistanceThreshold_usingL2Metrics_usingByteType() throws Exception {
@@ -399,7 +400,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float distance = 3.5f;
         final int[] expectedResults = { 2, 2, 2 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.L2, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.L2, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingScoreThreshold_usingL2Metrics_usingByteType() throws Exception {
@@ -411,7 +412,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float score = 0.23f;
         final int[] expectedResults = { 2, 2, 2 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.L2, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.L2, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingDistanceThreshold_usingCosineMetrics_usingByteType() throws Exception {
@@ -423,7 +424,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float distance = 0.05f;
         final int[] expectedResults = { 2, 2, 2 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.COSINESIMIL, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.COSINESIMIL, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingScoreThreshold_usingCosineMetrics_usingByteType() throws Exception {
@@ -435,7 +436,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float score = 0.97f;
         final int[] expectedResults = { 2, 2, 2 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.COSINESIMIL, expectedResults, null, null);
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.COSINESIMIL, expectedResults, null, null, null);
     }
 
     public void testRadiusSearch_usingDistanceThreshold_withFilter_usingL2Metrics_usingFloatType() throws Exception {
@@ -449,7 +450,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float distance = 45.0f;
         final int[] expectedResults = { 1, 1, 1 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.L2, expectedResults, COLOR_FIELD_NAME, "red");
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, distance, null, SpaceType.L2, expectedResults, COLOR_FIELD_NAME, "red", null);
     }
 
     public void testRadiusSearch_usingScoreThreshold_withFilter_usingCosineMetrics_usingFloatType() throws Exception {
@@ -463,7 +464,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final float score = 0.02f;
         final int[] expectedResults = { 1, 1, 1 };
 
-        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.COSINESIMIL, expectedResults, COLOR_FIELD_NAME, "red");
+        validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.COSINESIMIL, expectedResults, COLOR_FIELD_NAME, "red", null);
     }
 
     private void createKnnIndexMappingWithLuceneEngine(int dimension, SpaceType spaceType, VectorDataType vectorDataType) throws Exception {
@@ -642,6 +643,25 @@ public class LuceneEngineIT extends KNNRestTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testRadialSearch_whenEfSearchIsSet_thenThrowException() {
+        createKnnIndexMappingWithLuceneEngine(DIMENSION, SpaceType.L2, VectorDataType.FLOAT);
+        for (int j = 0; j < TEST_INDEX_VECTORS.length; j++) {
+            addKnnDoc(INDEX_NAME, Integer.toString(j + 1), FIELD_NAME, TEST_INDEX_VECTORS[j]);
+        }
+
+        final float score = 0.23f;
+        final int[] expectedResults = { 2, 3, 2 };
+
+        Map<String, Object> methodParameters = new ImmutableMap.Builder<String, Object>().put(KNNConstants.METHOD_PARAMETER_EF_SEARCH, 150)
+            .build();
+
+        expectThrows(
+            ResponseException.class,
+            () -> validateRadiusSearchResults(TEST_QUERY_VECTORS, null, score, SpaceType.L2, expectedResults, null, null, methodParameters)
+        );
+    }
+
     private void validateRadiusSearchResults(
         final float[][] searchVectors,
         final Float distanceThreshold,
@@ -649,7 +669,8 @@ public class LuceneEngineIT extends KNNRestTestCase {
         final SpaceType spaceType,
         final int[] expectedResults,
         @Nullable final String filterField,
-        @Nullable final String filterValue
+        @Nullable final String filterValue,
+        @Nullable final Map<String, ?> methodParameters
     ) throws Exception {
         for (int i = 0; i < searchVectors.length; i++) {
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
@@ -668,6 +689,13 @@ public class LuceneEngineIT extends KNNRestTestCase {
                 builder.startObject("term");
                 builder.field(filterField, filterValue);
                 builder.endObject();
+                builder.endObject();
+            }
+            if (methodParameters != null) {
+                builder.startObject(METHOD_PARAMETER);
+                for (Map.Entry<String, ?> entry : methodParameters.entrySet()) {
+                    builder.field(entry.getKey(), entry.getValue());
+                }
                 builder.endObject();
             }
             builder.endObject();

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -161,7 +161,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
     public void testFromXContent() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
-        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, K);
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(queryVector).k(K).build();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject(knnQueryBuilder.fieldName());
@@ -199,18 +199,22 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(knnQueryBuilder, actualBuilder);
     }
 
-    public void testFromXContent_whenDoRadiusSearch_whenDistanceThreshold_thenSucceed() throws Exception {
+    public void testFromXContent_whenDoRadiusSearch_whenDistanceThreshold_whenMethodParameter_thenSucceed() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
             .maxDistance(MAX_DISTANCE)
+            .methodParameters(HNSW_METHOD_PARAMS)
             .build();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject(knnQueryBuilder.fieldName());
         builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
         builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), knnQueryBuilder.getMaxDistance());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
         builder.endObject();
         builder.endObject();
         XContentParser contentParser = createParser(builder);
@@ -219,18 +223,22 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(knnQueryBuilder, actualBuilder);
     }
 
-    public void testFromXContent_whenDoRadiusSearch_whenScoreThreshold_thenSucceed() throws Exception {
+    public void testFromXContent_whenDoRadiusSearch_whenScoreThreshold_whenMethodParameter_thenSucceed() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
             .minScore(MAX_DISTANCE)
+            .methodParameters(HNSW_METHOD_PARAMS)
             .build();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject(knnQueryBuilder.fieldName());
         builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilder.vector());
         builder.field(KNNQueryBuilder.MIN_SCORE_FIELD.getPreferredName(), knnQueryBuilder.getMinScore());
+        builder.startObject(org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER);
+        builder.field(EF_SEARCH_FIELD.getPreferredName(), EF_SEARCH);
+        builder.endObject();
         builder.endObject();
         builder.endObject();
         XContentParser contentParser = createParser(builder);
@@ -246,7 +254,12 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         knnClusterUtil.initialize(clusterService);
 
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
-        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, K, TERM_QUERY);
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .filter(TERM_QUERY)
+            .build();
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject(knnQueryBuilder.fieldName());
@@ -1191,5 +1204,59 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
             expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
         }
+    }
+
+    public void testRadialSearch_whenEfSearchIsSet_whenLuceneEngine_thenThrowException() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(org.opensearch.knn.common.KNNConstants.METHOD_HNSW, ImmutableMap.of())
+        );
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .maxDistance(MAX_DISTANCE)
+            .methodParameters(Map.of("ef_search", EF_SEARCH))
+            .build();
+
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        Index dummyIndex = new Index("dummy", "dummy");
+        when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+
+        expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testRadialSearch_whenEfSearchIsSet_whenFaissEngine_thenSuccess() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(org.opensearch.knn.common.KNNConstants.METHOD_HNSW, ImmutableMap.of())
+        );
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .minScore(MIN_SCORE)
+            .methodParameters(Map.of("ef_search", EF_SEARCH))
+            .build();
+
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        Index dummyIndex = new Index("dummy", "dummy");
+        when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(4);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
+        when(indexSettings.getMaxResultWindow()).thenReturn(1000);
+
+        KNNQuery query = (KNNQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
+        assertEquals(1 / MIN_SCORE - 1, query.getRadius(), 0);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -62,7 +62,6 @@ import java.util.stream.Collectors;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -763,12 +762,29 @@ public class KNNWeightTests extends KNNTestCase {
         final float radius = 0.5f;
         final int maxResults = 1000;
         jniServiceMockedStatic.when(
-            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt(), any(), anyInt(), any())
+            () -> JNIService.radiusQueryIndex(
+                anyLong(),
+                eq(queryVector),
+                eq(radius),
+                eq(HNSW_METHOD_PARAMETERS),
+                any(),
+                eq(maxResults),
+                any(),
+                anyInt(),
+                any()
+            )
         ).thenReturn(getKNNQueryResults());
         KNNQuery.Context context = mock(KNNQuery.Context.class);
         when(context.getMaxResultWindow()).thenReturn(maxResults);
 
-        final KNNQuery query = new KNNQuery(FIELD_NAME, queryVector, INDEX_NAME, null).radius(radius).kNNQueryContext(context);
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .radius(radius)
+            .indexName(INDEX_NAME)
+            .context(context)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .build();
         final float boost = (float) randomDoubleBetween(0, 10, true);
         final KNNWeight knnWeight = new KNNWeight(query, boost);
 
@@ -807,7 +823,17 @@ public class KNNWeightTests extends KNNTestCase {
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
         jniServiceMockedStatic.verify(
-            () -> JNIService.radiusQueryIndex(anyLong(), any(), anyFloat(), any(), anyInt(), any(), anyInt(), any())
+            () -> JNIService.radiusQueryIndex(
+                anyLong(),
+                eq(queryVector),
+                eq(radius),
+                eq(HNSW_METHOD_PARAMETERS),
+                any(),
+                eq(maxResults),
+                any(),
+                anyInt(),
+                any()
+            )
         );
 
         final DocIdSetIterator docIdSetIterator = knnScorer.iterator();

--- a/src/test/java/org/opensearch/knn/index/util/AbstractKNNLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/AbstractKNNLibraryTests.java
@@ -11,12 +11,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.KNNMethod;
-import org.opensearch.knn.index.KNNMethodContext;
-import org.opensearch.knn.index.MethodComponent;
-import org.opensearch.knn.index.MethodComponentContext;
-import org.opensearch.knn.index.Parameter;
-import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.*;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -78,9 +73,13 @@ public class AbstractKNNLibraryTests extends KNNTestCase {
         assertNotNull(testAbstractKNNLibrary2.validateMethod(knnMethodContext2));
     }
 
-    public void testEngineSpecificMethods() throws IOException {
+    public void testEngineSpecificMethods() {
         String methodName1 = "test-method-1";
-        EngineSpecificMethodContext context = () -> Map.of("myparameter", new Parameter.BooleanParameter("myparameter", false, o -> o));
+        QueryContext engineSpecificMethodContext = new QueryContext(VectorQueryType.K);
+        EngineSpecificMethodContext context = ctx -> ImmutableMap.of(
+            "myparameter",
+            new Parameter.BooleanParameter("myparameter", null, value -> true)
+        );
 
         TestAbstractKNNLibrary testAbstractKNNLibrary1 = new TestAbstractKNNLibrary(
             Collections.emptyMap(),
@@ -89,7 +88,11 @@ public class AbstractKNNLibraryTests extends KNNTestCase {
         );
 
         assertNotNull(testAbstractKNNLibrary1.getMethodContext(methodName1));
-        assertTrue(testAbstractKNNLibrary1.getMethodContext(methodName1).supportedMethodParameters().containsKey("myparameter"));
+        assertTrue(
+            testAbstractKNNLibrary1.getMethodContext(methodName1)
+                .supportedMethodParameters(engineSpecificMethodContext)
+                .containsKey("myparameter")
+        );
     }
 
     public void testGetMethodAsMap() {


### PR DESCRIPTION

### Description
Manually backport https://github.com/opensearch-project/k-NN/pull/1790 to 2.x branch, cherry picked from commit e7d7ec81ec223ed4f54d5f9e8eeff1e776e8662e


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
