### PR TITLE
Fix linux build CI error due to action runner env upgrade node 20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - "*"
       - "feature/**"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - "*"
       - "feature/**"
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:
@@ -20,7 +22,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Run Integration Tests on Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Build CI recently occurred one error, this is due to github action runner env upgrade node 20 https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
``` 

### Issues Resolved
Example: https://github.com/opensearch-project/k-NN/actions/runs/9811145501/job/27093445183

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
