### PR TITLE
Fixing the arithmetic to find the number of vectors to stream from java to jni layer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Adds dynamic query parameter ef_search in radial search faiss engine [#1790](https://github.com/opensearch-project/k-NN/pull/1790)
 ### Enhancements
 ### Bug Fixes
+* Fixing the arithmetic to find the number of vectors to stream from java to jni layer.[#1804](https://github.com/opensearch-project/k-NN/pull/1804)
 ### Infrastructure
 ### Documentation
 * Update dev guide to fix clang linking issue on arm [#1746](https://github.com/opensearch-project/k-NN/pull/1746)

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -63,11 +63,13 @@ public class KNNCodecUtil {
                 dimension = vector.length;
 
                 if (vectorsPerTransfer == Integer.MIN_VALUE) {
-                    vectorsPerTransfer = (dimension * Float.BYTES * totalLiveDocs) / vectorsStreamingMemoryLimit;
-                    // This condition comes if vectorsStreamingMemoryLimit is higher than total number floats to transfer
-                    // Doing this will reduce 1 extra trip to JNI layer.
+                    // if vectorsStreamingMemoryLimit is 100 bytes and we have 50 vectors with 5 dimension, then per
+                    // transfer we have to send 100/(5 * 4) => 20 vectors.
+                    vectorsPerTransfer = vectorsStreamingMemoryLimit / ((long) dimension * Float.BYTES);
+                    // If vectorsPerTransfer comes out to be 0, then we set number of vectors per transfer to 1, to ensure that
+                    // we are sending minimum number of vectors.
                     if (vectorsPerTransfer == 0) {
-                        vectorsPerTransfer = totalLiveDocs;
+                        vectorsPerTransfer = 1;
                     }
                 }
                 if (vectorList.size() == vectorsPerTransfer) {


### PR DESCRIPTION
### Description
Fixing the arithmetic to find the number of vectors to stream from java to jni layer.
 
### Issues Resolved
NA
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
