### PR TITLE
Fixed LeafReaders casting errors to SegmentReaders when segment repli…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 * Fixing the arithmetic to find the number of vectors to stream from java to jni layer.[#1804](https://github.com/opensearch-project/k-NN/pull/1804)
+* Fixed LeafReaders casting errors to SegmentReaders when segment replication is enabled during search.[#1808](https://github.com/opensearch-project/k-NN/pull/1808)
 * Release memory properly for an array type [#1820](https://github.com/opensearch-project/k-NN/pull/1820)
 * FIX Same Suffix Cause Recall Drop to zero [#1802](https://github.com/opensearch-project/k-NN/pull/1802)
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -10,12 +10,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FilterDirectory;
+import org.opensearch.common.lucene.Lucene;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
@@ -160,7 +160,7 @@ public class KNNIndexShard {
         List<EngineFileContext> engineFiles = new ArrayList<>();
 
         for (LeafReaderContext leafReaderContext : indexReader.leaves()) {
-            SegmentReader reader = (SegmentReader) FilterLeafReader.unwrap(leafReaderContext.reader());
+            SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
             Path shardPath = ((FSDirectory) FilterDirectory.unwrap(reader.directory())).getDirectory();
             String fileExtension = reader.getSegmentInfo().info.getUseCompoundFile()
                 ? knnEngine.getCompoundExtension()

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -29,6 +28,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.common.io.PathUtils;
+import org.opensearch.common.lucene.Lucene;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
@@ -203,7 +203,7 @@ public class KNNWeight extends Weight {
 
     private Map<Integer, Float> doANNSearch(final LeafReaderContext context, final BitSet filterIdsBitSet, final int cardinality)
         throws IOException {
-        SegmentReader reader = (SegmentReader) FilterLeafReader.unwrap(context.reader());
+        final SegmentReader reader = Lucene.segmentReader(context.reader());
         String directory = ((FSDirectory) FilterDirectory.unwrap(reader.directory())).getDirectory().toString();
 
         FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
@@ -394,7 +394,7 @@ public class KNNWeight extends Weight {
     }
 
     private KNNIterator getFilteredKNNIterator(final LeafReaderContext leafReaderContext, final BitSet filterIdsBitSet) throws IOException {
-        final SegmentReader reader = (SegmentReader) FilterLeafReader.unwrap(leafReaderContext.reader());
+        final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
         final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
         final BinaryDocValues values = DocValues.getBinary(leafReaderContext.reader(), fieldInfo.getName());
         final SpaceType spaceType = getSpaceType(fieldInfo);

--- a/src/test/java/org/opensearch/knn/index/SegmentReplicationIT.java
+++ b/src/test/java/org/opensearch/knn/index/SegmentReplicationIT.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index;
+
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.Assert;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+
+import java.util.List;
+
+/**
+ * This IT class contains will contain special cases of IT for segment replication behavior.
+ * All the index created in this test will have replication type SEGMENT, number of replicas: 1 and should be run on
+ * at-least 2 node configuration.
+ */
+@Log4j2
+public class SegmentReplicationIT extends KNNRestTestCase {
+    private static final String INDEX_NAME = "segment-replicated-knn-index";
+
+    @SneakyThrows
+    public void testSearchOnReplicas_whenIndexHasDeletedDocs_thenSuccess() {
+        createKnnIndex(INDEX_NAME, getKNNSegmentReplicatedIndexSettings(), createKNNIndexMethodFieldMapping(FIELD_NAME, 2));
+
+        Float[] vector = { 1.3f, 2.2f };
+        int docsInIndex = 10;
+
+        for (int i = 0; i < docsInIndex; i++) {
+            addKnnDoc(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector);
+        }
+        refreshIndex(INDEX_NAME);
+        int deleteDocs = 5;
+        for (int i = 0; i < deleteDocs; i++) {
+            deleteKnnDoc(INDEX_NAME, Integer.toString(i));
+        }
+        refreshIndex(INDEX_NAME);
+        // sleep for 5sec to ensure data is replicated. I don't have a better way here to know if segments has been
+        // replicated.
+        Thread.sleep(5000);
+        // validate warmup is successful or not.
+        doKnnWarmup(List.of(INDEX_NAME));
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        queryBuilder.startObject("knn");
+        queryBuilder.startObject(FIELD_NAME);
+        queryBuilder.field("vector", vector);
+        queryBuilder.field("k", docsInIndex);
+        queryBuilder.endObject().endObject().endObject().endObject();
+
+        // validate primaries are working
+        Response searchResponse = performSearch(INDEX_NAME, queryBuilder.toString(), "preference=_primary");
+        String responseBody = EntityUtils.toString(searchResponse.getEntity());
+        List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
+        assertEquals(docsInIndex - deleteDocs, knnResults.size());
+
+        if (ensureMinDataNodesCountForTestingQueriesOnReplica()) {
+            // validate replicas are working
+            searchResponse = performSearch(INDEX_NAME, queryBuilder.toString(), "preference=_replica");
+            responseBody = EntityUtils.toString(searchResponse.getEntity());
+            knnResults = parseSearchResponse(responseBody, FIELD_NAME);
+            assertEquals(docsInIndex - deleteDocs, knnResults.size());
+        }
+    }
+
+    private boolean ensureMinDataNodesCountForTestingQueriesOnReplica() {
+        int dataNodeCount = getDataNodeCount();
+        if (dataNodeCount <= 1) {
+            log.warn(
+                "Not running segment replication tests named: "
+                    + "testSearchOnReplicas_whenIndexHasDeletedDocs_thenSuccess, as data nodes count is not atleast 2. "
+                    + "Actual datanode count : {}",
+                dataNodeCount
+            );
+            Assert.assertTrue(true);
+            // making the test successful because we don't want to break already running tests.
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
### Description
Fixed LeafReaders casting errors to SegmentReaders when segment replication is enabled during search

#### Root Cause

When Segment replication is enabled, then for replicas [IndexReaders are opened via passing directory path](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java#L531-L534), rather than using [IndexWriters to Open the IndexReaders](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/InternalEngine.java#L565-L568). This happens because replicas don't take write for Segment Replication. To ensure that soft deletes are applied on replicas too, seg-rep engine uses SoftDeletesDirectoryReaderWrapper(which extends the FilterDirectoryReader) to open the directory with soft deletes field. During search when the LeafReader for this directory is provided the SegmentReader gets wrapped into different readers like SoftDeletesFilterCodecReader or SoftDeletesFilterLeafReader. So in order to get SegmentReader we need unwrap the reader properly. Here, the idea is first we unwrap the Reader via FilterLeafReader and if the instance is of FilterCodecReader(base class for SoftDeletesFilterCodecReader), we need another round of unwrapping via FilterCodecReader to get SegmentReader. If we don't do this kind of unwrapping then during query we get cast exceptions on query on replicas with deletes in segment replication cases. We are using a helper function from OpenSearch Core to do the same.
 

### Future Improvement:
1. May be we can create 1 more GH action which is special for multi node testing and just have some annotations on IT to say whether this test should run under multi node cluster or not. Will see what options are available for that. Currently I have tested locally using 

```
./gradlew integTest --tests "org.opensearch.knn.index.SegmentReplicationIT.testSearchOnReplicas_whenIndexHasDeletedDocs_thenSuccess" -PnumNodes=2
```

### Issues Resolved
#1807 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
