### PR TITLE
Setting locale to Locale.ROOT while using String.format to ensure that UTs doesn't fail when validating the exception messages

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -44,6 +44,7 @@ import org.opensearch.knn.indices.ModelUtil;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -198,32 +199,38 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
         private void validate() {
             if (Strings.isNullOrEmpty(fieldName)) {
-                throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", NAME));
             }
 
             if (vector == null) {
-                throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", NAME));
             } else if (vector.length == 0) {
-                throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", NAME));
             }
 
             if (k == null && minScore == null && maxDistance == null) {
-                throw new IllegalArgumentException(String.format("[%s] requires exactly one of k, distance or score to be set", NAME));
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "[%s] requires exactly one of k, distance or score to be set", NAME)
+                );
             }
 
             if ((k != null && maxDistance != null) || (maxDistance != null && minScore != null) || (k != null && minScore != null)) {
-                throw new IllegalArgumentException(String.format("[%s] requires exactly one of k, distance or score to be set", NAME));
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "[%s] requires exactly one of k, distance or score to be set", NAME)
+                );
             }
 
             if (k != null) {
                 if (k <= 0 || k > K_MAX) {
-                    throw new IllegalArgumentException(String.format("[%s] requires k to be in the range (0, %d]", NAME, K_MAX));
+                    throw new IllegalArgumentException(
+                        String.format(Locale.ROOT, "[%s] requires k to be in the range (0, %d]", NAME, K_MAX)
+                    );
                 }
             }
 
             if (minScore != null) {
                 if (minScore <= 0) {
-                    throw new IllegalArgumentException(String.format("[%s] requires minScore to be greater than 0", NAME));
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires minScore to be greater than 0", NAME));
                 }
             }
 
@@ -231,7 +238,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 ValidationException validationException = validateMethodParameters(methodParameters);
                 if (validationException != null) {
                     throw new IllegalArgumentException(
-                        String.format("[%s] errors in method parameter [%s]", NAME, validationException.getMessage())
+                        String.format(Locale.ROOT, "[%s] errors in method parameter [%s]", NAME, validationException.getMessage())
                     );
                 }
             }
@@ -257,19 +264,19 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     @Deprecated
     public KNNQueryBuilder(String fieldName, float[] vector, int k, QueryBuilder filter) {
         if (Strings.isNullOrEmpty(fieldName)) {
-            throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", NAME));
         }
         if (vector == null) {
-            throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", NAME));
         }
         if (vector.length == 0) {
-            throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", NAME));
         }
         if (k <= 0) {
-            throw new IllegalArgumentException(String.format("[%s] requires k > 0", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires k > 0", NAME));
         }
         if (k > K_MAX) {
-            throw new IllegalArgumentException(String.format("[%s] requires k <= %d", NAME, K_MAX));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires k <= %d", NAME, K_MAX));
         }
 
         this.fieldName = fieldName;
@@ -287,12 +294,16 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
 
     private static float[] ObjectsToFloats(List<Object> objs) {
         if (Objects.isNull(objs) || objs.isEmpty()) {
-            throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be non-null and non-empty", NAME));
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "[%s] field 'vector' requires to be non-null and non-empty", NAME)
+            );
         }
         float[] vec = new float[objs.size()];
         for (int i = 0; i < objs.size(); i++) {
             if ((objs.get(i) instanceof Number) == false) {
-                throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be an array of numbers", NAME));
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "[%s] field 'vector' requires to be an array of numbers", NAME)
+                );
             }
             vec[i] = ((Number) objs.get(i)).floatValue();
         }
@@ -481,7 +492,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
 
         if (!(mappedFieldType instanceof KNNVectorFieldMapper.KNNVectorFieldType)) {
-            throw new IllegalArgumentException(String.format("Field '%s' is not knn_vector type.", this.fieldName));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not knn_vector type.", this.fieldName));
         }
 
         KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldMapper.KNNVectorFieldType) mappedFieldType;
@@ -523,6 +534,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             if (validationException != null) {
                 throw new IllegalArgumentException(
                     String.format(
+                        Locale.ROOT,
                         "Parameters not valid for [%s]:[%s]:[%s] combination: [%s]",
                         knnEngine,
                         method,
@@ -575,7 +587,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine)
             && filter != null
             && !KNNEngine.getEnginesThatSupportsFilters().contains(knnEngine)) {
-            throw new IllegalArgumentException(String.format("Engine [%s] does not support filters", knnEngine));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support filters", knnEngine));
         }
 
         String indexName = context.index().getName();
@@ -597,7 +609,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         }
         if (radius != null) {
             if (!ENGINES_SUPPORTING_RADIAL_SEARCH.contains(knnEngine)) {
-                throw new UnsupportedOperationException(String.format("Engine [%s] does not support radial search", knnEngine));
+                throw new UnsupportedOperationException(
+                    String.format(Locale.ROOT, "Engine [%s] does not support radial search", knnEngine)
+                );
             }
             RNNQueryFactory.CreateQueryRequest createQueryRequest = RNNQueryFactory.CreateQueryRequest.builder()
                 .knnEngine(knnEngine)
@@ -613,19 +627,19 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 .build();
             return RNNQueryFactory.create(createQueryRequest);
         }
-        throw new IllegalArgumentException(String.format("[%s] requires k or distance or score to be set", NAME));
+        throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires k or distance or score to be set", NAME));
     }
 
     private ModelMetadata getModelMetadataForField(KNNVectorFieldMapper.KNNVectorFieldType knnVectorField) {
         String modelId = knnVectorField.getModelId();
 
         if (modelId == null) {
-            throw new IllegalArgumentException(String.format("Field '%s' does not have model.", this.fieldName));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' does not have model.", this.fieldName));
         }
 
         ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
         if (!ModelUtil.isModelCreated(modelMetadata)) {
-            throw new IllegalArgumentException(String.format("Model ID '%s' is not created.", modelId));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Model ID '%s' is not created.", modelId));
         }
         return modelMetadata;
     }
@@ -647,7 +661,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (k != 0) {
             return VectorQueryType.K;
         }
-        throw new IllegalArgumentException(String.format("[%s] requires exactly one of k, distance or score to be set", NAME));
+        throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires exactly one of k, distance or score to be set", NAME));
     }
 
     /**


### PR DESCRIPTION
### Description
Setting locale to Locale.ROOT while using String.format to ensure that UTs doesn't fail when validating the exception messages.

So the idea here is whenever we use String.format we should ensure that we are using the Locale.ROOT to set the locale of the string, otherwise if you are validating the exception messages then the string comparison can fail and lead to flaky tests.

To reproduce the issue run the below command on the main branch of K-NN plugin.
```
./gradlew ':test' --tests "org.opensearch.knn.index.query.KNNQueryBuilderInvalidParamsTests" -Dtests.seed=EF1B1919EE6D650B  -Dtests.locale=ar-IQ -Dtests.timezone=America/Managua
```
 
### Issues Resolved
NA
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
