### PR TITLE
Avoid conflict of mock class name to fix test failure

### DIFF
--- a/jni/tests/faiss_wrapper_unit_test.cpp
+++ b/jni/tests/faiss_wrapper_unit_test.cpp
@@ -25,12 +25,12 @@ using ::testing::NiceMock;
 
 using idx_t = faiss::idx_t;
 
-struct MockIndex : faiss::IndexHNSW {
-    explicit MockIndex(idx_t d) : faiss::IndexHNSW(d, 32) {
+struct FaissMockIndex : faiss::IndexHNSW {
+    explicit FaissMockIndex(idx_t d) : faiss::IndexHNSW(d, 32) {
     }
 };
 
-struct MockIdMap : faiss::IndexIDMap {
+struct FaissMockIdMap : faiss::IndexIDMap {
     mutable idx_t nCalled{};
     mutable const float *xCalled{};
     mutable int kCalled{};
@@ -40,7 +40,7 @@ struct MockIdMap : faiss::IndexIDMap {
     mutable const faiss::SearchParametersHNSW *paramsCalled{};
     mutable faiss::RangeSearchResult *resCalled{};
 
-    explicit MockIdMap(MockIndex *index) : faiss::IndexIDMapTemplate<faiss::Index>(index) {
+    explicit FaissMockIdMap(FaissMockIndex *index) : faiss::IndexIDMapTemplate<faiss::Index>(index) {
     }
 
     void search(
@@ -108,8 +108,8 @@ public:
     }
 
 protected:
-    MockIndex index_;
-    MockIdMap id_map_;
+    FaissMockIndex index_;
+    FaissMockIdMap id_map_;
 };
 
 class FaissWrapperParametrizedRangeSearchTestFixture : public testing::TestWithParam<RangeSearchTestInput> {
@@ -119,8 +119,8 @@ public:
     }
 
 protected:
-    MockIndex index_;
-    MockIdMap id_map_;
+    FaissMockIndex index_;
+    FaissMockIdMap id_map_;
 };
 
 namespace query_index_test {
@@ -369,4 +369,3 @@ namespace range_search_test {
         )
     );
 }
-


### PR DESCRIPTION
### Attention! No need to backport to 2.x as it is already fixed there.

### Description
Rename MockIndex to FaissMockIndex in faiss_wrapper_unit_test.cpp to avoid interference during unit tests. Also, rename MockIDMap to FaissMockIdMap for consistency. The MockIndex class is defined in tests/mocks/faiss_index_mock.h
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
