### PR TITLE
Release memory properly for an array type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 * Fixing the arithmetic to find the number of vectors to stream from java to jni layer.[#1804](https://github.com/opensearch-project/k-NN/pull/1804)
+* Release memory properly for an array type [#1820](https://github.com/opensearch-project/k-NN/pull/1820)
 ### Infrastructure
 ### Documentation
 * Update dev guide to fix clang linking issue on arm [#1746](https://github.com/opensearch-project/k-NN/pull/1746)

--- a/jni/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch
+++ b/jni/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch
@@ -450,7 +450,7 @@ index 713fe8e4..d307fd70 100644
 +        /// series of results for query i is done
 +        void end() {
 +            heap_reorder<C>(k, heap_dis, heap_ids);
-+            delete heap_group_ids;
++            delete[] heap_group_ids;
 +        }
 +    };
 +
@@ -527,8 +527,8 @@ index 713fe8e4..d307fd70 100644
 +        for (size_t i = i0; i < i1; i++) {
 +            heap_reorder<C>(k, heap_dis_tab + i * k, heap_ids_tab + i * k);
 +        }
-+        delete group_id_to_index_in_heap_tab;
-+        delete heap_group_ids_tab;
++        delete[] group_id_to_index_in_heap_tab;
++        delete[] heap_group_ids_tab;
 +    }
 +};
 +


### PR DESCRIPTION
### Description
Release memory properly for an array type.

There is no immediate impact on user.
k-nn plugin is only making single query at a time and hitting the line 453(single query at at time), but not 530 and 531(multi query at a time). Because the heap_group_ids is array of primitive type(int64_t), there is no difference between `delete` and `delete[]` as I believe no one replaced the behavior of `operator delete[](void*)` for int64_t. However, it is recommended to call `delete[]` for a memory allocation of array type because `delete[]` method of an object can be replaced by user to behave differently.

https://isocpp.org/wiki/faq/freestore-mgmt#delete-array-built-ins
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
