### PR TITLE
Switch from byte stream to byte ref for serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Adds dynamic query parameter ef_search in radial search faiss engine [#1790](https://github.com/opensearch-project/k-NN/pull/1790)
 * Add binary format support with HNSW method in Faiss Engine [#1781](https://github.com/opensearch-project/k-NN/pull/1781)
 ### Enhancements
+* Switch from byte stream to byte ref for serde [#1825](https://github.com/opensearch-project/k-NN/pull/1825)
 ### Bug Fixes
 * Fixing the arithmetic to find the number of vectors to stream from java to jni layer.[#1804](https://github.com/opensearch-project/k-NN/pull/1804)
 * Release memory properly for an array type [#1820](https://github.com/opensearch-project/k-NN/pull/1820)

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -15,7 +15,6 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
@@ -71,9 +70,8 @@ public enum VectorDataType {
 
         @Override
         public float[] getVectorFromBytesRef(BytesRef binaryValue) {
-            ByteArrayInputStream byteStream = new ByteArrayInputStream(binaryValue.bytes, binaryValue.offset, binaryValue.length);
-            final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
-            return vectorSerializer.byteToFloatArray(byteStream);
+            final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByBytesRef(binaryValue);
+            return vectorSerializer.byteToFloatArray(binaryValue);
         }
 
     };

--- a/src/main/java/org/opensearch/knn/index/codec/transfer/VectorTransfer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/transfer/VectorTransfer.java
@@ -6,9 +6,8 @@
 package org.opensearch.knn.index.codec.transfer;
 
 import lombok.Data;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.util.SerializationMode;
-
-import java.io.ByteArrayInputStream;
 
 /**
  * Abstract class to transfer vector value from Java to native memory
@@ -36,9 +35,9 @@ public abstract class VectorTransfer {
     /**
      * Transfer a single vector
      *
-     * @param byteStream a vector in byte stream format
+     * @param bytesRef a vector in bytes format
      */
-    abstract public void transfer(final ByteArrayInputStream byteStream);
+    abstract public void transfer(final BytesRef bytesRef);
 
     /**
      * Close the transfer
@@ -48,8 +47,8 @@ public abstract class VectorTransfer {
     /**
      * Get serialization mode of given byte stream
      *
-     * @param byteStream byte stream of a vector
+     * @param bytesRef bytes of a vector
      * @return serialization mode
      */
-    abstract public SerializationMode getSerializationMode(final ByteArrayInputStream byteStream);
+    abstract public SerializationMode getSerializationMode(final BytesRef bytesRef);
 }

--- a/src/main/java/org/opensearch/knn/index/codec/transfer/VectorTransferFloat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/transfer/VectorTransferFloat.java
@@ -5,12 +5,12 @@
 
 package org.opensearch.knn.index.codec.transfer;
 
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 import org.opensearch.knn.index.codec.util.SerializationMode;
 import org.opensearch.knn.jni.JNICommons;
 
-import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,9 +32,9 @@ public class VectorTransferFloat extends VectorTransfer {
     }
 
     @Override
-    public void transfer(final ByteArrayInputStream byteStream) {
-        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
-        final float[] vector = vectorSerializer.byteToFloatArray(byteStream);
+    public void transfer(final BytesRef bytesRef) {
+        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByBytesRef(bytesRef);
+        final float[] vector = vectorSerializer.byteToFloatArray(bytesRef);
         dimension = vector.length;
 
         if (vectorsPerTransfer == Integer.MIN_VALUE) {
@@ -58,8 +58,8 @@ public class VectorTransferFloat extends VectorTransfer {
     }
 
     @Override
-    public SerializationMode getSerializationMode(final ByteArrayInputStream byteStream) {
-        return KNNVectorSerializerFactory.getSerializerModeFromStream(byteStream);
+    public SerializationMode getSerializationMode(final BytesRef bytesRef) {
+        return KNNVectorSerializerFactory.getSerializerModeFromBytesRef(bytesRef);
     }
 
     private void transfer() {

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorAsArraySerializer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorAsArraySerializer.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.index.codec.util;
 
+import org.apache.lucene.util.BytesRef;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -31,8 +33,8 @@ public class KNNVectorAsArraySerializer implements KNNVectorSerializer {
     }
 
     @Override
-    public float[] byteToFloatArray(ByteArrayInputStream byteStream) {
-        try {
+    public float[] byteToFloatArray(BytesRef bytesRef) {
+        try (ByteArrayInputStream byteStream = new ByteArrayInputStream(bytesRef.bytes, bytesRef.offset, bytesRef.length)) {
             final ObjectInputStream objectStream = new ObjectInputStream(byteStream);
             final float[] vector = (float[]) objectStream.readObject();
             return vector;

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorAsCollectionOfFloatsSerializer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorAsCollectionOfFloatsSerializer.java
@@ -5,7 +5,8 @@
 
 package org.opensearch.knn.index.codec.util;
 
-import java.io.ByteArrayInputStream;
+import org.apache.lucene.util.BytesRef;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.stream.IntStream;
@@ -26,15 +27,13 @@ public class KNNVectorAsCollectionOfFloatsSerializer implements KNNVectorSeriali
     }
 
     @Override
-    public float[] byteToFloatArray(ByteArrayInputStream byteStream) {
-        if (byteStream == null || byteStream.available() % BYTES_IN_FLOAT != 0) {
+    public float[] byteToFloatArray(BytesRef bytesRef) {
+        if (bytesRef == null || bytesRef.length % BYTES_IN_FLOAT != 0) {
             throw new IllegalArgumentException("Byte stream cannot be deserialized to array of floats");
         }
-        final byte[] vectorAsByteArray = new byte[byteStream.available()];
-        byteStream.read(vectorAsByteArray, 0, byteStream.available());
-        final int sizeOfFloatArray = vectorAsByteArray.length / BYTES_IN_FLOAT;
+        final int sizeOfFloatArray = bytesRef.length / BYTES_IN_FLOAT;
         final float[] vector = new float[sizeOfFloatArray];
-        ByteBuffer.wrap(vectorAsByteArray).asFloatBuffer().get(vector);
+        ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length).asFloatBuffer().get(vector);
         return vector;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializer.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.index.codec.util;
 
-import java.io.ByteArrayInputStream;
+import org.apache.lucene.util.BytesRef;
 
 /**
  * Interface abstracts the vector serializer object that is responsible for serialization and de-serialization of k-NN vector
@@ -20,8 +20,9 @@ public interface KNNVectorSerializer {
 
     /**
      * Deserializes all bytes from the stream to array of floats
-     * @param byteStream stream of bytes that will be used for deserialization to array of floats
+     *
+     * @param bytesRef bytes that will be used for deserialization to array of floats
      * @return array of floats deserialized from the stream
      */
-    float[] byteToFloatArray(ByteArrayInputStream byteStream);
+    float[] byteToFloatArray(BytesRef bytesRef);
 }

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerFactory.java
@@ -6,10 +6,9 @@
 package org.opensearch.knn.index.codec.util;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.lucene.util.BytesRef;
 
-import java.io.ByteArrayInputStream;
 import java.io.ObjectStreamConstants;
-import java.util.Arrays;
 import java.util.Map;
 
 import static org.opensearch.knn.index.codec.util.SerializationMode.ARRAY;
@@ -51,25 +50,24 @@ public class KNNVectorSerializerFactory {
         return getSerializerBySerializationMode(COLLECTION_OF_FLOATS);
     }
 
-    public static KNNVectorSerializer getSerializerByStreamContent(final ByteArrayInputStream byteStream) {
-        final SerializationMode serializationMode = getSerializerModeFromStream(byteStream);
+    public static KNNVectorSerializer getSerializerByBytesRef(final BytesRef bytesRef) {
+        final SerializationMode serializationMode = getSerializerModeFromBytesRef(bytesRef);
         return getSerializerBySerializationMode(serializationMode);
     }
 
-    public static SerializationMode getSerializerModeFromStream(ByteArrayInputStream byteStream) {
-        int numberOfAvailableBytesInStream = byteStream.available();
-        if (numberOfAvailableBytesInStream < ARRAY_HEADER_OFFSET) {
-            return getSerializerOrThrowError(numberOfAvailableBytesInStream, COLLECTION_OF_FLOATS);
+    public static SerializationMode getSerializerModeFromBytesRef(BytesRef bytesRef) {
+        int numberOfAvailableBytes = bytesRef.length;
+        if (numberOfAvailableBytes < ARRAY_HEADER_OFFSET) {
+            return getSerializerOrThrowError(numberOfAvailableBytes, COLLECTION_OF_FLOATS);
         }
-        final byte[] byteArray = new byte[SERIALIZATION_PROTOCOL_HEADER_PREFIX.length];
-        byteStream.read(byteArray, 0, SERIALIZATION_PROTOCOL_HEADER_PREFIX.length);
-        byteStream.reset();
-        // checking if stream protocol grammar in header is valid for serialized array
-        if (Arrays.equals(SERIALIZATION_PROTOCOL_HEADER_PREFIX, byteArray)) {
-            int numberOfAvailableBytesAfterHeader = numberOfAvailableBytesInStream - ARRAY_HEADER_OFFSET;
-            return getSerializerOrThrowError(numberOfAvailableBytesAfterHeader, ARRAY);
+
+        for (int i = 0; i < SERIALIZATION_PROTOCOL_HEADER_PREFIX.length; i++) {
+            if (bytesRef.bytes[i + bytesRef.offset] != SERIALIZATION_PROTOCOL_HEADER_PREFIX[i]) {
+                return getSerializerOrThrowError(numberOfAvailableBytes, COLLECTION_OF_FLOATS);
+            }
         }
-        return getSerializerOrThrowError(numberOfAvailableBytesInStream, COLLECTION_OF_FLOATS);
+        int numberOfAvailableBytesAfterHeader = numberOfAvailableBytes - ARRAY_HEADER_OFFSET;
+        return getSerializerOrThrowError(numberOfAvailableBytesAfterHeader, ARRAY);
     }
 
     private static SerializationMode getSerializerOrThrowError(int numberOfRemainingBytes, final SerializationMode serializationMode) {

--- a/src/main/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIterator.java
@@ -14,7 +14,6 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializer;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 /**
@@ -72,9 +71,8 @@ public class FilteredIdsKNNIterator implements KNNIterator {
 
     protected float computeScore() throws IOException {
         final BytesRef value = binaryDocValues.binaryValue();
-        final ByteArrayInputStream byteStream = new ByteArrayInputStream(value.bytes, value.offset, value.length);
-        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(byteStream);
-        final float[] vector = vectorSerializer.byteToFloatArray(byteStream);
+        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByBytesRef(value);
+        final float[] vector = vectorSerializer.byteToFloatArray(value);
         // Calculates a similarity score between the two vectors with a specified function. Higher similarity
         // scores correspond to closer vectors.
         return spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector);

--- a/src/test/java/org/opensearch/knn/index/codec/transfer/VectorTransferByteTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/transfer/VectorTransferByteTests.java
@@ -7,10 +7,10 @@ package org.opensearch.knn.index.codec.transfer;
 
 import junit.framework.TestCase;
 import lombok.SneakyThrows;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.util.SerializationMode;
 import org.opensearch.knn.jni.JNICommons;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Random;
 
@@ -19,17 +19,17 @@ import static org.junit.Assert.assertNotEquals;
 public class VectorTransferByteTests extends TestCase {
     @SneakyThrows
     public void testTransfer_whenCalled_thenAdded() {
-        final ByteArrayInputStream bais1 = getByteArrayOfVectors(20);
-        final ByteArrayInputStream bais2 = getByteArrayOfVectors(20);
+        final BytesRef bytesRef1 = getByteArrayOfVectors(20);
+        final BytesRef bytesRef2 = getByteArrayOfVectors(20);
         VectorTransferByte vectorTransfer = new VectorTransferByte(1000);
         try {
             vectorTransfer.init(2);
 
-            vectorTransfer.transfer(bais1);
+            vectorTransfer.transfer(bytesRef1);
             // flush is not called
             assertEquals(0, vectorTransfer.getVectorAddress());
 
-            vectorTransfer.transfer(bais2);
+            vectorTransfer.transfer(bytesRef2);
             // flush should be called
             assertNotEquals(0, vectorTransfer.getVectorAddress());
         } finally {
@@ -41,16 +41,16 @@ public class VectorTransferByteTests extends TestCase {
 
     @SneakyThrows
     public void testSerializationMode_whenCalled_thenReturn() {
-        final ByteArrayInputStream bais = getByteArrayOfVectors(20);
+        final BytesRef bytesRef = getByteArrayOfVectors(20);
         VectorTransferByte vectorTransfer = new VectorTransferByte(1000);
 
         // Verify
-        assertEquals(SerializationMode.COLLECTIONS_OF_BYTES, vectorTransfer.getSerializationMode(bais));
+        assertEquals(SerializationMode.COLLECTIONS_OF_BYTES, vectorTransfer.getSerializationMode(bytesRef));
     }
 
-    private ByteArrayInputStream getByteArrayOfVectors(int vectorLength) throws IOException {
+    private BytesRef getByteArrayOfVectors(int vectorLength) throws IOException {
         byte[] vector = new byte[vectorLength];
         new Random().nextBytes(vector);
-        return new ByteArrayInputStream(vector);
+        return new BytesRef(vector);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/transfer/VectorTransferFloatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/transfer/VectorTransferFloatTests.java
@@ -7,10 +7,10 @@ package org.opensearch.knn.index.codec.transfer;
 
 import junit.framework.TestCase;
 import lombok.SneakyThrows;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 import org.opensearch.knn.jni.JNICommons;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -22,17 +22,17 @@ import static org.junit.Assert.assertNotEquals;
 public class VectorTransferFloatTests extends TestCase {
     @SneakyThrows
     public void testTransfer_whenCalled_thenAdded() {
-        final ByteArrayInputStream bais1 = getByteArrayOfVectors(20);
-        final ByteArrayInputStream bais2 = getByteArrayOfVectors(20);
+        final BytesRef bytesRef1 = getByteArrayOfVectors(20);
+        final BytesRef bytesRef2 = getByteArrayOfVectors(20);
         VectorTransferFloat vectorTransfer = new VectorTransferFloat(1000);
         try {
             vectorTransfer.init(2);
 
-            vectorTransfer.transfer(bais1);
+            vectorTransfer.transfer(bytesRef1);
             // flush is not called
             assertEquals(0, vectorTransfer.getVectorAddress());
 
-            vectorTransfer.transfer(bais2);
+            vectorTransfer.transfer(bytesRef2);
             // flush should be called
             assertNotEquals(0, vectorTransfer.getVectorAddress());
         } finally {
@@ -44,14 +44,14 @@ public class VectorTransferFloatTests extends TestCase {
 
     @SneakyThrows
     public void testSerializationMode_whenCalled_thenReturn() {
-        final ByteArrayInputStream bais = getByteArrayOfVectors(20);
+        final BytesRef bytesRef = getByteArrayOfVectors(20);
         VectorTransferFloat vectorTransfer = new VectorTransferFloat(1000);
 
         // Verify
-        assertEquals(KNNVectorSerializerFactory.getSerializerModeFromStream(bais), vectorTransfer.getSerializationMode(bais));
+        assertEquals(KNNVectorSerializerFactory.getSerializerModeFromBytesRef(bytesRef), vectorTransfer.getSerializationMode(bytesRef));
     }
 
-    private ByteArrayInputStream getByteArrayOfVectors(int vectorLength) throws IOException {
+    private BytesRef getByteArrayOfVectors(int vectorLength) throws IOException {
         float[] vector = new float[vectorLength];
         IntStream.range(0, vectorLength).forEach(index -> vector[index] = new Random().nextFloat());
 
@@ -61,6 +61,6 @@ public class VectorTransferFloatTests extends TestCase {
             ds.writeFloat(f);
         }
         final byte[] vectorAsCollectionOfFloats = bas.toByteArray();
-        return new ByteArrayInputStream(vectorAsCollectionOfFloats);
+        return new BytesRef(vectorAsCollectionOfFloats);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/util/KNNCodecUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/util/KNNCodecUtilTests.java
@@ -11,7 +11,6 @@ import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.index.codec.transfer.VectorTransfer;
 
-import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
@@ -35,7 +34,7 @@ public class KNNCodecUtilTests extends TestCase {
         when(binaryDocValues.binaryValue()).thenReturn(bytesRef);
 
         VectorTransfer vectorTransfer = mock(VectorTransfer.class);
-        when(vectorTransfer.getSerializationMode(any(ByteArrayInputStream.class))).thenReturn(SerializationMode.COLLECTIONS_OF_BYTES);
+        when(vectorTransfer.getSerializationMode(any(BytesRef.class))).thenReturn(SerializationMode.COLLECTIONS_OF_BYTES);
         when(vectorTransfer.getVectorAddress()).thenReturn(vectorAddress);
         when(vectorTransfer.getDimension()).thenReturn(dimension);
 
@@ -44,8 +43,8 @@ public class KNNCodecUtilTests extends TestCase {
 
         // Verify
         verify(vectorTransfer).init(liveDocCount);
-        verify(vectorTransfer).getSerializationMode(any(ByteArrayInputStream.class));
-        verify(vectorTransfer).transfer(any(ByteArrayInputStream.class));
+        verify(vectorTransfer).getSerializationMode(any(BytesRef.class));
+        verify(vectorTransfer).transfer(any(BytesRef.class));
         verify(vectorTransfer).close();
 
         assertTrue(Arrays.equals(docId, pair.docs));

--- a/src/test/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/util/KNNVectorSerializerTests.java
@@ -5,9 +5,9 @@
 
 package org.opensearch.knn.index.codec.util;
 
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.KNNTestCase;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.ObjectOutputStream;
@@ -26,14 +26,11 @@ public class KNNVectorSerializerTests extends KNNTestCase {
         final DataOutputStream ds = new DataOutputStream(bas);
         for (float f : vector)
             ds.writeFloat(f);
-        final byte[] vectorAsCollectionOfFloats = bas.toByteArray();
-        final ByteArrayInputStream bais = new ByteArrayInputStream(vectorAsCollectionOfFloats);
-        bais.reset();
-
+        final BytesRef vectorAsCollectionOfFloats = new BytesRef(bas.toByteArray());
         final KNNVectorSerializer defaultSerializer = KNNVectorSerializerFactory.getDefaultSerializer();
         assertNotNull(defaultSerializer);
 
-        final float[] actualDeserializedVector = defaultSerializer.byteToFloatArray(bais);
+        final float[] actualDeserializedVector = defaultSerializer.byteToFloatArray(vectorAsCollectionOfFloats);
         assertNotNull(actualDeserializedVector);
         assertArrayEquals(vector, actualDeserializedVector, 0.1f);
 
@@ -46,18 +43,16 @@ public class KNNVectorSerializerTests extends KNNTestCase {
         assertNotNull(collectionOfFloatsSerializer);
     }
 
-    public void testVectorSerializerFactory_throwExceptionForStreamWithUnsupportedDataType() throws Exception {
+    public void testVectorSerializerFactory_throwExceptionForBytesWithUnsupportedDataType() throws Exception {
         // prepare array of chars that is not supported by serializer factory. expected behavior is to fail
         final char[] arrayOfChars = new char[] { 'a', 'b', 'c' };
         final ByteArrayOutputStream bas = new ByteArrayOutputStream();
         final DataOutputStream ds = new DataOutputStream(bas);
         for (char ch : arrayOfChars)
             ds.writeChar(ch);
-        final byte[] vectorAsCollectionOfChars = bas.toByteArray();
-        final ByteArrayInputStream bais = new ByteArrayInputStream(vectorAsCollectionOfChars);
-        bais.reset();
+        final BytesRef vectorAsCollectionOfChars = new BytesRef(bas.toByteArray());
 
-        expectThrows(RuntimeException.class, () -> KNNVectorSerializerFactory.getSerializerByStreamContent(bais));
+        expectThrows(RuntimeException.class, () -> KNNVectorSerializerFactory.getSerializerByBytesRef(vectorAsCollectionOfChars));
     }
 
     public void testVectorAsArraySerializer() throws Exception {
@@ -66,21 +61,17 @@ public class KNNVectorSerializerTests extends KNNTestCase {
         final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
         final ObjectOutputStream objectStream = new ObjectOutputStream(byteStream);
         objectStream.writeObject(vector);
-        final byte[] serializedVector = byteStream.toByteArray();
-        final ByteArrayInputStream bais = new ByteArrayInputStream(serializedVector);
-
-        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(bais);
+        final BytesRef serializedVector = new BytesRef(byteStream.toByteArray());
+        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByBytesRef(serializedVector);
 
         // testing serialization
-        bais.reset();
         final byte[] actualSerializedVector = vectorSerializer.floatToByteArray(vector);
 
         assertNotNull(actualSerializedVector);
-        assertArrayEquals(serializedVector, actualSerializedVector);
+        assertArrayEquals(serializedVector.bytes, actualSerializedVector);
 
         // testing deserialization
-        bais.reset();
-        final float[] actualDeserializedVector = vectorSerializer.byteToFloatArray(bais);
+        final float[] actualDeserializedVector = vectorSerializer.byteToFloatArray(serializedVector);
 
         assertNotNull(actualDeserializedVector);
         assertArrayEquals(vector, actualDeserializedVector, 0.1f);
@@ -94,24 +85,35 @@ public class KNNVectorSerializerTests extends KNNTestCase {
         final DataOutputStream ds = new DataOutputStream(bas);
         for (float f : vector)
             ds.writeFloat(f);
-        final byte[] vectorAsCollectionOfFloats = bas.toByteArray();
-        final ByteArrayInputStream bais = new ByteArrayInputStream(vectorAsCollectionOfFloats);
-
-        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByStreamContent(bais);
+        final BytesRef vectorAsCollectionOfFloats = new BytesRef(bas.toByteArray());
+        final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerByBytesRef(vectorAsCollectionOfFloats);
 
         // testing serialization
-        bais.reset();
         final byte[] actualSerializedVector = vectorSerializer.floatToByteArray(vector);
 
         assertNotNull(actualSerializedVector);
-        assertArrayEquals(vectorAsCollectionOfFloats, actualSerializedVector);
+        assertArrayEquals(vectorAsCollectionOfFloats.bytes, actualSerializedVector);
 
         // testing deserialization
-        bais.reset();
-        final float[] actualDeserializedVector = vectorSerializer.byteToFloatArray(bais);
+        final float[] actualDeserializedVector = vectorSerializer.byteToFloatArray(vectorAsCollectionOfFloats);
 
         assertNotNull(actualDeserializedVector);
         assertArrayEquals(vector, actualDeserializedVector, 0.1f);
+    }
+
+    public void testVectorSerializer_whenVectorBytesOffset_thenSuccess() {
+        final float[] vector = getArrayOfRandomFloats(20);
+        int offset = randomInt(4);
+        for (SerializationMode serializationMode : SerializationMode.values()) {
+            final KNNVectorSerializer vectorSerializer = KNNVectorSerializerFactory.getSerializerBySerializationMode(serializationMode);
+            assertNotNull(vectorSerializer);
+            byte[] bytes = vectorSerializer.floatToByteArray(vector);
+            byte[] bytesWithOffset = new byte[bytes.length + 2 * offset];
+            System.arraycopy(bytes, 0, bytesWithOffset, offset, bytes.length);
+            BytesRef serializedVector = new BytesRef(bytesWithOffset, offset, bytes.length);
+            float[] deserializedVector = vectorSerializer.byteToFloatArray(serializedVector);
+            assertArrayEquals(vector, deserializedVector, 0.1f);
+        }
     }
 
     private float[] getArrayOfRandomFloats(int arrayLength) {

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.util.BytesRef;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNMethodContext;
@@ -24,7 +25,6 @@ import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 
-import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -51,13 +51,8 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
     public void testStoredFields_whenVectorIsFloatType_thenSucceed() {
         StoredField storedField = KNNVectorFieldMapperUtil.createStoredFieldForFloatVector(TEST_FIELD_NAME, TEST_FLOAT_VECTOR);
         assertEquals(TEST_FIELD_NAME, storedField.name());
-        byte[] bytes = storedField.binaryValue().bytes;
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes, 0, bytes.length);
-        assertArrayEquals(
-            TEST_FLOAT_VECTOR,
-            KNNVectorSerializerFactory.getDefaultSerializer().byteToFloatArray(byteArrayInputStream),
-            0.001f
-        );
+        BytesRef bytes = new BytesRef(storedField.binaryValue().bytes);
+        assertArrayEquals(TEST_FLOAT_VECTOR, KNNVectorSerializerFactory.getDefaultSerializer().byteToFloatArray(bytes), 0.001f);
 
         Object vector = KNNVectorFieldMapperUtil.deserializeStoredVector(storedField.binaryValue(), VectorDataType.FLOAT);
         assertTrue(vector instanceof float[]);


### PR DESCRIPTION
### Description
Avoids copy during serialization and deserialization by switching from requiring byte streams to only requiring byte refs. From [KNNCodecUtil](https://github.com/opensearch-project/k-NN/blob/2.15.0.0/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java#L57-L62), we can see that we convert byte ref to byte stream just to convert it back in the [KNNVectorSerializer](https://github.com/opensearch-project/k-NN/blob/2.15.0.0/src/main/java/org/opensearch/knn/index/codec/util/KNNVectorAsCollectionOfFloatsSerializer.java#L29-L39) logic - in other words, it is not necessary. This can speed up operations by 15-20% for exact search (see #1736).

This will not have impact on KnnVectorsFormat structures. Those will use lucenes vector serde which is already optimized. This change is meant to add a boost in performance until that is used completely.

New functionality is not added - existing tests provide coverage.

### Issues Resolved
#1736 
 
### Check List
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
