### PR TITLE
Add painless script support for hamming with binary vector data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Adds dynamic query parameter nprobes [#1792](https://github.com/opensearch-project/k-NN/pull/1792)
 * Add binary format support with HNSW method in Faiss Engine [#1781](https://github.com/opensearch-project/k-NN/pull/1781)
 * Add script scoring support for knn field with binary data type [#1826](https://github.com/opensearch-project/k-NN/pull/1826)
+* Add painless script support for hamming with binary vector data type [#1839](https://github.com/opensearch-project/k-NN/pull/1839)
 ### Enhancements
 * Switch from byte stream to byte ref for serde [#1825](https://github.com/opensearch-project/k-NN/pull/1825)
 ### Bug Fixes

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.plugin.script;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +42,52 @@ public class KNNScoringUtil {
     }
 
     /**
+     * checks both query vector and input vector has equal dimension
+     *
+     * @param queryVector query vector
+     * @param inputVector input vector
+     * @throws IllegalArgumentException if query vector and input vector has different dimensions
+     */
+    private static void requireEqualDimension(final byte[] queryVector, final byte[] inputVector) {
+        Objects.requireNonNull(queryVector);
+        Objects.requireNonNull(inputVector);
+        if (queryVector.length != inputVector.length) {
+            String errorMessage = String.format(
+                "query vector dimension mismatch. Expected: %d, Given: %d",
+                inputVector.length,
+                queryVector.length
+            );
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    private static void requireNonBinaryType(final String spaceName, final VectorDataType vectorDataType) {
+        if (VectorDataType.BINARY == vectorDataType) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Incompatible field_type for %s space. The data type should be either float or byte but got %s",
+                    spaceName,
+                    vectorDataType.getValue()
+                )
+            );
+        }
+    }
+
+    private static void requireBinaryType(final String spaceName, final VectorDataType vectorDataType) {
+        if (VectorDataType.BINARY != vectorDataType) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Incompatible field_type for %s space. The data type should be binary but got %s",
+                    spaceName,
+                    vectorDataType.getValue()
+                )
+            );
+        }
+    }
+
+    /**
      * This method calculates L2 squared distance between query vector
      * and input vector
      *
@@ -52,13 +99,13 @@ public class KNNScoringUtil {
         return VectorUtil.squareDistance(queryVector, inputVector);
     }
 
-    private static float[] toFloat(List<Number> inputVector, VectorDataType vectorDataType) {
+    private static float[] toFloat(final List<Number> inputVector, final VectorDataType vectorDataType) {
         Objects.requireNonNull(inputVector);
         float[] value = new float[inputVector.size()];
         int index = 0;
         for (final Number val : inputVector) {
             float floatValue = val.floatValue();
-            if (VectorDataType.BYTE == vectorDataType) {
+            if (VectorDataType.BYTE == vectorDataType || VectorDataType.BINARY == vectorDataType) {
                 validateByteVectorValue(floatValue, vectorDataType);
             }
             value[index++] = floatValue;
@@ -66,24 +113,35 @@ public class KNNScoringUtil {
         return value;
     }
 
+    private static byte[] toByte(final List<Number> inputVector, final VectorDataType vectorDataType) {
+        Objects.requireNonNull(inputVector);
+        byte[] value = new byte[inputVector.size()];
+        int index = 0;
+        for (final Number val : inputVector) {
+            float floatValue = val.floatValue();
+            if (VectorDataType.BYTE == vectorDataType || VectorDataType.BINARY == vectorDataType) {
+                validateByteVectorValue(floatValue, vectorDataType);
+            }
+            value[index++] = val.byteValue();
+        }
+        return value;
+    }
+
     /**
-     * Allowlisted l2Squared method for users to calculate L2 squared distance between query vector
-     * and document vectors
-     * Example
-     *  "script": {
-     *         "source": "1/(1 + l2Squared(params.query_vector, doc[params.field]))",
-     *         "params": {
-     *           "query_vector": [1, 2, 3.4],
-     *           "field": "my_dense_vector"
-     *         }
-     *       }
+     * This method calculates cosine similarity
      *
      * @param queryVector query vector
-     * @param docValues   script doc values
-     * @return L2 score
+     * @param inputVector input vector
+     * @return cosine score
      */
-    public static float l2Squared(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return l2Squared(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
+    public static float cosinesimil(float[] queryVector, float[] inputVector) {
+        requireEqualDimension(queryVector, inputVector);
+        try {
+            return VectorUtil.cosine(queryVector, inputVector);
+        } catch (IllegalArgumentException | AssertionError e) {
+            logger.debug("Invalid vectors for cosine. Returning minimum score to put this result to end");
+            return 0.0f;
+        }
     }
 
     /**
@@ -109,68 +167,6 @@ public class KNNScoringUtil {
             return 0.0f;
         }
         return (float) (dotProduct / (Math.sqrt(normalizedProduct)));
-    }
-
-    /**
-     * Allowlisted cosineSimilarity method that can be used in a script to avoid repeated
-     * calculation of normalization for the query vector.
-     * Example:
-     *  "script": {
-     *         "source": "cosineSimilarity(params.query_vector, docs[field], 1.0) ",
-     *         "params": {
-     *           "query_vector": [1, 2, 3.4],
-     *           "field": "my_dense_vector"
-     *         }
-     *       }
-     *
-     * @param queryVector          query vector
-     * @param docValues            script doc values
-     * @param queryVectorMagnitude the magnitude of the query vector.
-     * @return cosine score
-     */
-    public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues, Number queryVectorMagnitude) {
-        float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
-        SpaceType.COSINESIMIL.validateVector(inputVector);
-        return cosinesimilOptimized(inputVector, docValues.getValue(), queryVectorMagnitude.floatValue());
-    }
-
-    /**
-     * This method calculates cosine similarity
-     *
-     * @param queryVector query vector
-     * @param inputVector input vector
-     * @return cosine score
-     */
-    public static float cosinesimil(float[] queryVector, float[] inputVector) {
-        requireEqualDimension(queryVector, inputVector);
-        try {
-            return VectorUtil.cosine(queryVector, inputVector);
-        } catch (IllegalArgumentException | AssertionError e) {
-            logger.debug("Invalid vectors for cosine. Returning minimum score to put this result to end");
-            return 0.0f;
-        }
-    }
-
-    /**
-     * Allowlisted cosineSimilarity method for users to calculate cosine similarity between query vectors and
-     * document vectors
-     * Example:
-     *  "script": {
-     *         "source": "cosineSimilarity(params.query_vector, docs[field]) ",
-     *         "params": {
-     *           "query_vector": [1, 2, 3.4],
-     *           "field": "my_dense_vector"
-     *         }
-     *       }
-     *
-     * @param queryVector query vector
-     * @param docValues   script doc values
-     * @return cosine score
-     */
-    public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
-        SpaceType.COSINESIMIL.validateVector(inputVector);
-        return cosinesimil(inputVector, docValues.getValue());
     }
 
     /**
@@ -204,6 +200,7 @@ public class KNNScoringUtil {
      * @return hamming distance
      */
     public static float calculateHammingBit(byte[] queryVector, byte[] inputVector) {
+        requireEqualDimension(queryVector, inputVector);
         return VectorUtil.xorBitCount(queryVector, inputVector);
     }
 
@@ -216,32 +213,13 @@ public class KNNScoringUtil {
      * @return L1 score
      */
     public static float l1Norm(float[] queryVector, float[] inputVector) {
+        requireEqualDimension(queryVector, inputVector);
         float distance = 0;
         for (int i = 0; i < inputVector.length; i++) {
             float diff = queryVector[i] - inputVector[i];
             distance += Math.abs(diff);
         }
         return distance;
-    }
-
-    /**
-     * Allowlisted l1distance method for users to calculate L1 distance between query vector
-     * and document vectors
-     * Example
-     *  "script": {
-     *         "source": "1/(1 + l1Norm(params.query_vector, doc[params.field]))",
-     *         "params": {
-     *           "query_vector": [1, 2, 3.4],
-     *           "field": "my_dense_vector"
-     *         }
-     *       }
-     *
-     * @param queryVector query vector
-     * @param docValues   script doc values
-     * @return L1 score
-     */
-    public static float l1Norm(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
-        return l1Norm(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -253,12 +231,53 @@ public class KNNScoringUtil {
      * @return L-inf score
      */
     public static float lInfNorm(float[] queryVector, float[] inputVector) {
+        requireEqualDimension(queryVector, inputVector);
         float distance = 0;
         for (int i = 0; i < inputVector.length; i++) {
             float diff = queryVector[i] - inputVector[i];
             distance = Math.max(Math.abs(diff), distance);
         }
         return distance;
+    }
+
+    /**
+     * This method calculates dot product distance between query vector
+     * and input vector
+     *
+     * @param queryVector query vector
+     * @param inputVector input vector
+     * @return dot product score
+     */
+    public static float innerProduct(float[] queryVector, float[] inputVector) {
+        requireEqualDimension(queryVector, inputVector);
+        return VectorUtil.dotProduct(queryVector, inputVector);
+    }
+
+    /**
+     *********************************************************************************************
+     * Functions to be used in painless script which is defined in knn_allowlist.txt
+     *********************************************************************************************
+     */
+
+    /**
+     * Allowlisted l2Squared method for users to calculate L2 squared distance between query vector
+     * and document vectors
+     * Example
+     *  "script": {
+     *         "source": "1/(1 + l2Squared(params.query_vector, doc[params.field]))",
+     *         "params": {
+     *           "query_vector": [1, 2, 3.4],
+     *           "field": "my_dense_vector"
+     *         }
+     *       }
+     *
+     * @param queryVector query vector
+     * @param docValues   script doc values
+     * @return L2 score
+     */
+    public static float l2Squared(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        requireNonBinaryType("l2Squared", docValues.getVectorDataType());
+        return l2Squared(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -278,19 +297,29 @@ public class KNNScoringUtil {
      * @return L-inf score
      */
     public static float lInfNorm(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        requireNonBinaryType("lInfNorm", docValues.getVectorDataType());
         return lInfNorm(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
-     * This method calculates dot product distance between query vector
-     * and input vector
+     * Allowlisted l1distance method for users to calculate L1 distance between query vector
+     * and document vectors
+     * Example
+     *  "script": {
+     *         "source": "1/(1 + l1Norm(params.query_vector, doc[params.field]))",
+     *         "params": {
+     *           "query_vector": [1, 2, 3.4],
+     *           "field": "my_dense_vector"
+     *         }
+     *       }
      *
      * @param queryVector query vector
-     * @param inputVector input vector
-     * @return dot product score
+     * @param docValues   script doc values
+     * @return L1 score
      */
-    public static float innerProduct(float[] queryVector, float[] inputVector) {
-        return VectorUtil.dotProduct(queryVector, inputVector);
+    public static float l1Norm(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        requireNonBinaryType("l1Norm", docValues.getVectorDataType());
+        return l1Norm(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
     }
 
     /**
@@ -310,6 +339,84 @@ public class KNNScoringUtil {
      * @return inner product score
      */
     public static float innerProduct(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        requireNonBinaryType("innerProduct", docValues.getVectorDataType());
         return innerProduct(toFloat(queryVector, docValues.getVectorDataType()), docValues.getValue());
+    }
+
+    /**
+     * Allowlisted cosineSimilarity method for users to calculate cosine similarity between query vectors and
+     * document vectors
+     * Example:
+     *  "script": {
+     *         "source": "cosineSimilarity(params.query_vector, docs[field]) ",
+     *         "params": {
+     *           "query_vector": [1, 2, 3.4],
+     *           "field": "my_dense_vector"
+     *         }
+     *       }
+     *
+     * @param queryVector query vector
+     * @param docValues   script doc values
+     * @return cosine score
+     */
+    public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        requireNonBinaryType("cosineSimilarity", docValues.getVectorDataType());
+        float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
+        SpaceType.COSINESIMIL.validateVector(inputVector);
+        return cosinesimil(inputVector, docValues.getValue());
+    }
+
+    /**
+     * Allowlisted cosineSimilarity method that can be used in a script to avoid repeated
+     * calculation of normalization for the query vector.
+     * Example:
+     *  "script": {
+     *         "source": "cosineSimilarity(params.query_vector, docs[field], 1.0) ",
+     *         "params": {
+     *           "query_vector": [1, 2, 3.4],
+     *           "field": "my_dense_vector"
+     *         }
+     *       }
+     *
+     * @param queryVector          query vector
+     * @param docValues            script doc values
+     * @param queryVectorMagnitude the magnitude of the query vector.
+     * @return cosine score
+     */
+    public static float cosineSimilarity(List<Number> queryVector, KNNVectorScriptDocValues docValues, Number queryVectorMagnitude) {
+        requireNonBinaryType("cosineSimilarity", docValues.getVectorDataType());
+        float[] inputVector = toFloat(queryVector, docValues.getVectorDataType());
+        SpaceType.COSINESIMIL.validateVector(inputVector);
+        return cosinesimilOptimized(inputVector, docValues.getValue(), queryVectorMagnitude.floatValue());
+    }
+
+    /**
+     * Allowlisted hamming method that can be used in a script to avoid repeated
+     * calculation of normalization for the query vector.
+     * Example:
+     *  "script": {
+     *         "source": "hamming(params.query_vector, docs[field]) ",
+     *         "params": {
+     *           "query_vector": [1, 2],
+     *           "field": "my_dense_vector"
+     *         }
+     *       }
+     *
+     * @param queryVector          query vector
+     * @param docValues            script doc values
+     * @return hamming score
+     */
+    public static float hamming(List<Number> queryVector, KNNVectorScriptDocValues docValues) {
+        requireBinaryType("hamming", docValues.getVectorDataType());
+        byte[] queryVectorInByte = toByte(queryVector, docValues.getVectorDataType());
+
+        // TODO Optimization need be done for doc value to return byte[] instead of float[]
+        float[] docVectorInFloat = docValues.getValue();
+        byte[] docVectorInByte = new byte[docVectorInFloat.length];
+        for (int i = 0; i < docVectorInByte.length; i++) {
+            docVectorInByte[i] = (byte) docVectorInFloat[i];
+        }
+
+        return calculateHammingBit(queryVectorInByte, docVectorInByte);
     }
 }

--- a/src/main/resources/org/opensearch/knn/plugin/script/knn_allowlist.txt
+++ b/src/main/resources/org/opensearch/knn/plugin/script/knn_allowlist.txt
@@ -13,4 +13,5 @@ static_import {
   float innerProduct(List, org.opensearch.knn.index.KNNVectorScriptDocValues) from_class org.opensearch.knn.plugin.script.KNNScoringUtil
   float cosineSimilarity(List, org.opensearch.knn.index.KNNVectorScriptDocValues) from_class org.opensearch.knn.plugin.script.KNNScoringUtil
   float cosineSimilarity(List, org.opensearch.knn.index.KNNVectorScriptDocValues, Number) from_class org.opensearch.knn.plugin.script.KNNScoringUtil
+  float hamming(List, org.opensearch.knn.index.KNNVectorScriptDocValues) from_class org.opensearch.knn.plugin.script.KNNScoringUtil
 }

--- a/src/test/java/org/opensearch/knn/common/KNNValidationUtilTests.java
+++ b/src/test/java/org/opensearch/knn/common/KNNValidationUtilTests.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.containsString;
 
 public class KNNValidationUtilTests extends KNNTestCase {
     public void testValidateVectorDimension_whenBinary_thenVectorSizeShouldBeEightTimesLarger() {
-        int vectorLength = randomInt(100);
+        int vectorLength = randomInt(100) + 1;
         Exception ex = expectThrows(
             IllegalArgumentException.class,
             () -> KNNValidationUtil.validateVectorDimension(vectorLength, vectorLength, VectorDataType.BINARY)


### PR DESCRIPTION
### Description
Add painless script support for hamming with binary vector data type

Changes are
1. Moved all painless script method to the bottom of the class for better readability.
2. Added a validation on all existing painless method to block binary vector
3. Added a painless method for hamming with binary vector
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
