### PR TITLE
Fix few bugs on binary index with Faiss HNSW

### DIFF
--- a/src/main/java/org/opensearch/knn/index/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/IndexUtil.java
@@ -190,6 +190,19 @@ public class IndexUtil {
             return exception;
         }
 
+        String vectorDataType = (String) fieldMap.get(VECTOR_DATA_TYPE_FIELD);
+        if (VectorDataType.BINARY.toString().equalsIgnoreCase(vectorDataType)) {
+            exception.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "Field \"%s\" is of data type %s. Only FLOAT or BYTE is supported.",
+                    field,
+                    VectorDataType.BINARY
+                )
+            );
+            return exception;
+        }
+
         // Return if dimension does not need to be checked
         if (expectedDimension < 0) {
             return null;

--- a/src/main/java/org/opensearch/knn/index/KNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/KNNMethod.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,8 +58,10 @@ public class KNNMethod {
         if (!isSpaceTypeSupported(knnMethodContext.getSpaceType())) {
             errorMessages.add(
                 String.format(
-                    "\"%s\" configuration does not support space type: " + "\"%s\".",
+                    Locale.ROOT,
+                    "\"%s\" with \"%s\" configuration does not support space type: " + "\"%s\".",
                     this.methodComponent.getName(),
+                    knnMethodContext.getKnnEngine().getName().toLowerCase(Locale.ROOT),
                     knnMethodContext.getSpaceType().getValue()
                 )
             );
@@ -90,8 +93,10 @@ public class KNNMethod {
         if (!isSpaceTypeSupported(knnMethodContext.getSpaceType())) {
             errorMessages.add(
                 String.format(
-                    "\"%s\" configuration does not support space type: " + "\"%s\".",
+                    Locale.ROOT,
+                    "\"%s\" with \"%s\" configuration does not support space type: " + "\"%s\".",
                     this.methodComponent.getName(),
+                    knnMethodContext.getKnnEngine().getName().toLowerCase(Locale.ROOT),
                     knnMethodContext.getSpaceType().getValue()
                 )
             );

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -86,6 +86,7 @@ public class KNNSettings {
      */
     public static final boolean KNN_DEFAULT_FAISS_AVX2_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
+    public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hammingbit";
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_M = 16;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH = 100;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION = 100;

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -307,7 +307,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
             // Build legacy
             if (this.spaceType == null) {
-                this.spaceType = LegacyFieldMapper.getSpaceType(context.indexSettings());
+                this.spaceType = LegacyFieldMapper.getSpaceType(context.indexSettings(), vectorDataType.getValue());
             }
 
             if (this.m == null) {

--- a/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LegacyFieldMapper.java
@@ -12,6 +12,7 @@ import org.opensearch.common.Explicit;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.mapper.ParametrizedFieldMapper;
 import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.util.IndexHyperParametersUtil;
 import org.opensearch.knn.index.util.KNNEngine;
 
@@ -78,17 +79,19 @@ public class LegacyFieldMapper extends KNNVectorFieldMapper {
         );
     }
 
-    static String getSpaceType(Settings indexSettings) {
+    static String getSpaceType(final Settings indexSettings, final VectorDataType vectorDataType) {
         String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
         if (spaceType == null) {
+            spaceType = VectorDataType.BINARY == vectorDataType
+                ? KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY
+                : KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
             log.info(
                 String.format(
                     "[KNN] The setting \"%s\" was not set for the index. Likely caused by recent version upgrade. Setting the setting to the default value=%s",
                     METHOD_PARAMETER_SPACE_TYPE,
-                    KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE
+                    spaceType
                 )
             );
-            return KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE;
         }
         return spaceType;
     }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -622,6 +622,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                     String.format(Locale.ROOT, "Engine [%s] does not support radial search", knnEngine)
                 );
             }
+            if (vectorDataType == VectorDataType.BINARY) {
+                throw new UnsupportedOperationException(String.format(Locale.ROOT, "Binary data type does not support radial search"));
+            }
             RNNQueryFactory.CreateQueryRequest createQueryRequest = RNNQueryFactory.CreateQueryRequest.builder()
                 .knnEngine(knnEngine)
                 .indexName(indexName)

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -476,8 +476,15 @@ public class KNNWeight extends Weight {
         if (isExactSearchThresholdSettingSet(filterThresholdValue)) {
             return filterThresholdValue >= filterIdsCount;
         }
+
         // if no setting is set, then use the default max distance computation value to see if we can do exact search.
-        return KNNConstants.MAX_DISTANCE_COMPUTATIONS >= filterIdsCount * knnQuery.getQueryVector().length;
+        /**
+         * TODO we can have a different MAX_DISTANCE_COMPUTATIONS for binary index as computation cost for binary index
+         * is cheaper than computation cost for non binary vector
+         */
+        return KNNConstants.MAX_DISTANCE_COMPUTATIONS >= filterIdsCount * (knnQuery.getVectorDataType() == VectorDataType.FLOAT
+            ? knnQuery.getQueryVector().length
+            : knnQuery.getByteQueryVector().length);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/IndexUtilTests.java
@@ -228,6 +228,27 @@ public class IndexUtilTests extends KNNTestCase {
         assert (Objects.requireNonNull(e).getMessage().matches("Validation Failed: 1: Invalid index. Index does not contain a mapping;"));
     }
 
+    public void testValidateKnnField_whenBinaryDataType_thenThrowException() {
+        Map<String, Object> fieldValues = Map.of("type", "knn_vector", "dimension", 8, "data_type", "BINARY");
+        Map<String, Object> top_level_field = Map.of("top_level_field", fieldValues);
+        Map<String, Object> properties = Map.of("properties", top_level_field);
+        String field = "top_level_field";
+        int dimension = 8;
+
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(properties);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        ModelDao modelDao = mock(ModelDao.class);
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+        when(modelDao.getMetadata(anyString())).thenReturn(trainingFieldModelMetadata);
+
+        ValidationException e = IndexUtil.validateKnnField(indexMetadata, field, dimension, modelDao);
+
+        assert (Objects.requireNonNull(e).getMessage().contains("is of data type BINARY. Only FLOAT or BYTE is supported"));
+    }
+
     public void testIsShareableStateContainedInIndex_whenIndexNotModelBased_thenReturnFalse() {
         String modelId = null;
         KNNEngine knnEngine = KNNEngine.FAISS;

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -718,6 +718,30 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
     }
 
+    public void testDoToQuery_whenRadialSearchOnBinaryIndex_thenException() {
+        float[] queryVector = { 1.0f };
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .maxDistance(MAX_DISTANCE)
+            .build();
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldMapper.KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getDimension()).thenReturn(8);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.BINARY);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        MethodComponentContext methodComponentContext = new MethodComponentContext(
+            org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
+            ImmutableMap.of()
+        );
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.HAMMING_BIT, methodComponentContext);
+        when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
+        assertTrue(e.getMessage().contains("Binary data type does not support radial search"));
+    }
+
     public void testDoToQuery_KnnQueryWithFilter_Lucene() throws Exception {
         // Given
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };


### PR DESCRIPTION
### Description
Did a manual test on following items. Will raise a new PR implementing this as integ test.

#### Test case
1. Can create binary index using Faiss HNSW
2. Can create binary index with knn index as false
3. Cannot create binary index using Lucene
4. Cannot create binary index using Nmslib
5. Cannot run training API on binary index
6. Cannot create binary index using encoding(sq)
7. Cannot run range query on binary index
8. Can run knn query on binary index
9. Can run knn query with nested field on binary index
10. Can run knn query with filtering on binary index
11. Can run knn query with filtering on nested field with binary index
12. Can run script scoring with hamming on binary index
13. Cannot run script scoring with hamming on non binary index
14. Cannot run script scoring with non hamming on binary index
15. Can run painless script with hamming on binary index
16. Cannot run painless script with hamming on non binary index
17. Cannot run painless script with non hamming on binary index
18. Can run script scoring with hamming on binary index with knn set as false
19. Can run painless script with hamming on binary index with knn set as false

#### Bug1 (2. Can create binary index with knn index as false)
* Actual: Following index creation succeeded but got an error while ingesting as default space was set as l2.
* Expected: It should set hamming as default space type and ingesting should succeed.
```
{
  "settings": {
    "index": {
      "knn": false
    }
  },
  "mappings": {
    "properties": {
      "my_vector": {
        "type": "knn_vector",
        "dimension": 8,
        "data_type": "binary"
      }
    }
  }
}
```

#### Bug2 (3. Cannot create binary index using Lucene)
* Actual: I got error  `\"hnsw\" configuration does not support space type: \"hammingbit\"` which is not appropriate without mentioning what engine it uses.
* Expected: The error message should have engine name as well because hnsw with faiss support hammingbit.
```
Create index with knn as false
{
  "settings": {
    "index": {
      "knn": false
    }
  },
  "mappings": {
    "properties": {
      "my_vector": {
        "type": "knn_vector",
        "dimension": 8,
        "data_type": "binary",
        "method": {
          "name": "hnsw",
          "engine": "lucene",
          "space_type": "hammingbit"
        }
      }
    }
  }
}
```

#### Bug 3. (7. Cannot run range query on binary index)
* Actual: Runtime error
* Expected: It should be Unsupported operation error with a message like "radial search is not supported with binary index"
```
"root_cause": [
    {
    "type": "runtime_exception",
    "reason": "java.lang.Exception: Query Vector cannot be null"
    }
],
```

#### Bug 4 (11. Can run knn query with filtering on nested field with binary index)
* Actual: Failed to run filtered query with binary Index. Error was happening while validating if exact search is required or not based on calculation cost
* Expected: Filtered query with binary index should work.
```
    "root_cause": [
      {
        "type": "null_pointer_exception",
        "reason": "Cannot read the array length because the return value of \"org.opensearch.knn.index.query.KNNQuery.getQueryVector()\" is null"
      }
    ],
```

### Related Issues
N/A

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
