### PR TITLE
Switch space type name from hammingbit to hamming for binary index

### DIFF
--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -199,7 +199,7 @@ namespace knn_jni {
     extern const std::string COSINESIMIL;
     extern const std::string INNER_PRODUCT;
     extern const std::string NEG_DOT_PRODUCT;
-    extern const std::string HAMMING_BIT;
+    extern const std::string HAMMING;
 
     extern const std::string NPROBES;
     extern const std::string COARSE_QUANTIZER;

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -644,7 +644,7 @@ faiss::MetricType TranslateSpaceToMetric(const std::string& spaceType) {
     }
 
     // Space type is not used for binary index. Use L2 just to avoid an error.
-    if (spaceType == knn_jni::HAMMING_BIT) {
+    if (spaceType == knn_jni::HAMMING) {
         return faiss::METRIC_L2;
     }
 

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -540,7 +540,7 @@ const std::string knn_jni::LINF = "linf";
 const std::string knn_jni::COSINESIMIL = "cosinesimil";
 const std::string knn_jni::INNER_PRODUCT = "innerproduct";
 const std::string knn_jni::NEG_DOT_PRODUCT = "negdotprod";
-const std::string knn_jni::HAMMING_BIT = "hammingbit";
+const std::string knn_jni::HAMMING = "hamming";
 
 const std::string knn_jni::NPROBES = "nprobes";
 const std::string knn_jni::COARSE_QUANTIZER = "coarse_quantizer";

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -87,7 +87,7 @@ TEST(FaissCreateBinaryIndexTest, BasicAssertions) {
     }
 
     std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
-    std::string spaceType = knn_jni::HAMMING_BIT;
+    std::string spaceType = knn_jni::HAMMING;
     std::string indexDescription = "BHNSW32";
 
     std::unordered_map<std::string, jobject> parametersMap;
@@ -222,7 +222,7 @@ TEST(FaissLoadBinaryIndexTest, BasicAssertions) {
     }
 
     std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
-    std::string spaceType = knn_jni::HAMMING_BIT;
+    std::string spaceType = knn_jni::HAMMING;
     std::string method = "BHNSW32";
 
     // Create the index

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -86,7 +86,7 @@ public class KNNSettings {
      */
     public static final boolean KNN_DEFAULT_FAISS_AVX2_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
-    public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hammingbit";
+    public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hamming";
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_M = 16;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH = 100;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION = 100;

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -120,7 +120,7 @@ public enum SpaceType {
             return KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
         }
     },
-    HAMMING_BIT("hammingbit") {
+    HAMMING("hamming") {
         @Override
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
@@ -147,7 +147,7 @@ public enum SpaceType {
     };
 
     public static SpaceType DEFAULT = L2;
-    public static SpaceType DEFAULT_BINARY = HAMMING_BIT;
+    public static SpaceType DEFAULT_BINARY = HAMMING;
 
     private final String value;
 

--- a/src/main/java/org/opensearch/knn/index/util/Faiss.java
+++ b/src/main/java/org/opensearch/knn/index/util/Faiss.java
@@ -247,7 +247,7 @@ public class Faiss extends NativeLibrary {
                     ).addParameter(METHOD_PARAMETER_M, "", "").addParameter(METHOD_ENCODER_PARAMETER, ",", "").build())
                 )
                 .build()
-        ).addSpaces(SpaceType.UNDEFINED, SpaceType.HAMMING_BIT, SpaceType.L2, SpaceType.INNER_PRODUCT).build(),
+        ).addSpaces(SpaceType.UNDEFINED, SpaceType.HAMMING, SpaceType.L2, SpaceType.INNER_PRODUCT).build(),
         METHOD_IVF,
         KNNMethod.Builder.builder(
             MethodComponent.Builder.builder(METHOD_IVF)

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -5,13 +5,14 @@
 
 package org.opensearch.knn.plugin.script;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
+import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
 import org.opensearch.knn.index.query.KNNWeight;
-import org.apache.lucene.index.LeafReaderContext;
-import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.script.ScoreScript;
 import org.opensearch.search.lookup.SearchLookup;
 
@@ -19,11 +20,11 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.getVectorMagnitudeSquared;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryFieldType;
-import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryVectorDataType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isKNNVectorFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isLongFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToBigInteger;
@@ -31,7 +32,6 @@ import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToFloatA
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToLong;
 
 public interface KNNScoringSpace {
-
     /**
      * Return the correct scoring script for a given query. The scoring script
      *
@@ -47,17 +47,29 @@ public interface KNNScoringSpace {
         throws IOException;
 
     /**
-     * Base class to represent linear space
-     *
-     * As of now, all supporting spaces are linear space except hamming.
-     * LinearSpace does not support binary vector.
+     * Base class to represent vector space for knn field
      */
-    abstract class LinearSpace implements KNNScoringSpace {
+    abstract class KNNFieldSpace implements KNNScoringSpace {
+        public static final Set<VectorDataType> DATA_TYPES_DEFAULT = Set.of(VectorDataType.FLOAT, VectorDataType.BYTE);
+
         float[] processedQuery;
         BiFunction<float[], float[], Float> scoringMethod;
 
-        public LinearSpace(final Object query, final MappedFieldType fieldType, final String spaceName) {
-            KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = toKNNVectorFieldType(fieldType, spaceName);
+        public KNNFieldSpace(final Object query, final MappedFieldType fieldType, final String spaceName) {
+            this(query, fieldType, spaceName, DATA_TYPES_DEFAULT);
+        }
+
+        public KNNFieldSpace(
+            final Object query,
+            final MappedFieldType fieldType,
+            final String spaceName,
+            final Set<VectorDataType> supportingVectorDataTypes
+        ) {
+            KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = toKNNVectorFieldType(
+                fieldType,
+                spaceName,
+                supportingVectorDataTypes
+            );
             this.processedQuery = getProcessedQuery(query, knnVectorFieldType);
             this.scoringMethod = getScoringMethod(this.processedQuery);
         }
@@ -72,7 +84,11 @@ public interface KNNScoringSpace {
             return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
         }
 
-        private KNNVectorFieldMapper.KNNVectorFieldType toKNNVectorFieldType(final MappedFieldType fieldType, final String spaceName) {
+        private KNNVectorFieldMapper.KNNVectorFieldType toKNNVectorFieldType(
+            final MappedFieldType fieldType,
+            final String spaceName,
+            final Set<VectorDataType> supportingVectorDataTypes
+        ) {
             if (isKNNVectorFieldType(fieldType) == false) {
                 throw new IllegalArgumentException(
                     String.format(Locale.ROOT, "Incompatible field_type for %s space. The field type must be knn_vector.", spaceName)
@@ -80,13 +96,17 @@ public interface KNNScoringSpace {
             }
 
             KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldMapper.KNNVectorFieldType) fieldType;
-            if (isBinaryVectorDataType(knnVectorFieldType)) {
+            VectorDataType vectorDataType = knnVectorFieldType.getVectorDataType() == null
+                ? VectorDataType.FLOAT
+                : knnVectorFieldType.getVectorDataType();
+            if (supportingVectorDataTypes.contains(vectorDataType) == false) {
                 throw new IllegalArgumentException(
                     String.format(
                         Locale.ROOT,
-                        "Incompatible field_type for %s space. The data type should be either float or byte but got %s",
+                        "Incompatible field_type for %s space. The data type should be %s but got %s",
                         spaceName,
-                        knnVectorFieldType.getVectorDataType().getValue()
+                        supportingVectorDataTypes,
+                        vectorDataType
                     )
                 );
             }
@@ -106,7 +126,7 @@ public interface KNNScoringSpace {
 
     }
 
-    class L2 extends LinearSpace {
+    class L2 extends KNNFieldSpace {
         public L2(final Object query, final MappedFieldType fieldType) {
             super(query, fieldType, "l2");
         }
@@ -117,7 +137,7 @@ public interface KNNScoringSpace {
         }
     }
 
-    class CosineSimilarity extends LinearSpace {
+    class CosineSimilarity extends KNNFieldSpace {
         public CosineSimilarity(Object query, MappedFieldType fieldType) {
             super(query, fieldType, "cosine");
         }
@@ -130,7 +150,7 @@ public interface KNNScoringSpace {
         }
     }
 
-    class L1 extends LinearSpace {
+    class L1 extends KNNFieldSpace {
         public L1(Object query, MappedFieldType fieldType) {
             super(query, fieldType, "l1");
         }
@@ -141,7 +161,7 @@ public interface KNNScoringSpace {
         }
     }
 
-    class LInf extends LinearSpace {
+    class LInf extends KNNFieldSpace {
         public LInf(Object query, MappedFieldType fieldType) {
             super(query, fieldType, "l-inf");
         }
@@ -152,7 +172,7 @@ public interface KNNScoringSpace {
         }
     }
 
-    class InnerProd extends LinearSpace {
+    class InnerProd extends KNNFieldSpace {
         public InnerProd(Object query, MappedFieldType fieldType) {
             super(query, fieldType, "innerproduct");
         }
@@ -163,6 +183,28 @@ public interface KNNScoringSpace {
         }
     }
 
+    class Hamming extends KNNFieldSpace {
+        private static final Set<VectorDataType> DATA_TYPES_HAMMING = Set.of(VectorDataType.BINARY);
+
+        public Hamming(Object query, MappedFieldType fieldType) {
+            super(query, fieldType, "hamming", DATA_TYPES_HAMMING);
+        }
+
+        @Override
+        protected BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery) {
+            // TODO we want to avoid converting back and forth between byte and float
+            return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.calculateHammingBit(toByte(q), toByte(v)));
+        }
+
+        private byte[] toByte(final float[] vector) {
+            byte[] bytes = new byte[vector.length];
+            for (int i = 0; i < vector.length; i++) {
+                bytes[i] = (byte) vector[i];
+            }
+            return bytes;
+        }
+    }
+
     class HammingBit implements KNNScoringSpace {
 
         Object processedQuery;
@@ -170,7 +212,7 @@ public interface KNNScoringSpace {
 
         /**
          * Constructor for HammingBit scoring space. HammingBit scoring space expects values to either be of type
-         * Long or Base64 encoded strings, or KNN type with binary data type.
+         * Long or Base64 encoded strings.
          *
          * @param query Query object that, along with the doc values, will be used to compute HammingBit score
          * @param fieldType FieldType for the doc values that will be used
@@ -182,37 +224,11 @@ public interface KNNScoringSpace {
             } else if (isBinaryFieldType(fieldType)) {
                 this.processedQuery = parseToBigInteger(query);
                 this.scoringMethod = (BigInteger q, BigInteger v) -> 1.0f / (1 + KNNScoringUtil.calculateHammingBit(q, v));
-            } else if (isKNNVectorFieldType(fieldType)) {
-                KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldMapper.KNNVectorFieldType) fieldType;
-                if (isBinaryVectorDataType(knnVectorFieldType) == false) {
-                    throw new IllegalArgumentException(
-                        String.format(
-                            Locale.ROOT,
-                            "Incompatible field_type for hamming space. The data type should be binary but got %s",
-                            knnVectorFieldType.getVectorDataType().getValue()
-                        )
-                    );
-                }
-                this.processedQuery = parseToFloatArray(
-                    query,
-                    KNNVectorFieldMapperUtil.getExpectedVectorLength(knnVectorFieldType),
-                    ((KNNVectorFieldMapper.KNNVectorFieldType) fieldType).getVectorDataType()
-                );
-                // TODO we want to avoid converting back and forth between byte and float
-                this.scoringMethod = (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.calculateHammingBit(toByte(q), toByte(v)));
             } else {
                 throw new IllegalArgumentException(
-                    "Incompatible field_type for hamming space. The field type must of type long, binary, or knn_vector."
+                    "Incompatible field_type for hammingbit space. The field type must of type long or binary."
                 );
             }
-        }
-
-        private byte[] toByte(final float[] vector) {
-            byte[] bytes = new byte[vector.length];
-            for (int i = 0; i < vector.length; i++) {
-                bytes[i] = (byte) vector[i];
-            }
-            return bytes;
         }
 
         @SuppressWarnings("unchecked")
@@ -233,27 +249,17 @@ public interface KNNScoringSpace {
                     ctx,
                     searcher
                 );
-            } else if (this.processedQuery instanceof BigInteger) {
-                return new KNNScoreScript.BigIntegerType(
-                    params,
-                    (BigInteger) this.processedQuery,
-                    field,
-                    (BiFunction<BigInteger, BigInteger, Float>) this.scoringMethod,
-                    lookup,
-                    ctx,
-                    searcher
-                );
-            } else {
-                return new KNNScoreScript.KNNVectorType(
-                    params,
-                    (float[]) this.processedQuery,
-                    field,
-                    (BiFunction<float[], float[], Float>) this.scoringMethod,
-                    lookup,
-                    ctx,
-                    searcher
-                );
             }
+
+            return new KNNScoreScript.BigIntegerType(
+                params,
+                (BigInteger) this.processedQuery,
+                field,
+                (BiFunction<BigInteger, BigInteger, Float>) this.scoringMethod,
+                lookup,
+                ctx,
+                searcher
+            );
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactory.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactory.java
@@ -13,9 +13,11 @@ import org.opensearch.index.mapper.MappedFieldType;
  * Factory to create correct KNNScoringSpace based on the spaceType passed in.
  */
 public class KNNScoringSpaceFactory {
+    public static final String HAMMING_BIT = "hammingbit";
+
     public static KNNScoringSpace create(String spaceType, Object query, MappedFieldType mappedFieldType) {
-        if (SpaceType.HAMMING_BIT.getValue().equalsIgnoreCase(spaceType)) {
-            return new KNNScoringSpace.HammingBit(query, mappedFieldType);
+        if (SpaceType.HAMMING.getValue().equalsIgnoreCase(spaceType)) {
+            return new KNNScoringSpace.Hamming(query, mappedFieldType);
         }
 
         if (SpaceType.L2.getValue().equalsIgnoreCase(spaceType)) {
@@ -34,6 +36,10 @@ public class KNNScoringSpaceFactory {
 
         if (SpaceType.COSINESIMIL.getValue().equalsIgnoreCase(spaceType)) {
             return new KNNScoringSpace.CosineSimilarity(query, mappedFieldType);
+        }
+
+        if (HAMMING_BIT.equalsIgnoreCase(spaceType)) {
+            return new KNNScoringSpace.HammingBit(query, mappedFieldType);
         }
 
         KNNCounter.SCRIPT_QUERY_ERRORS.increment();

--- a/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/SpaceTypeTests.java
@@ -79,7 +79,7 @@ public class SpaceTypeTests extends KNNTestCase {
             Set.of(VectorDataType.FLOAT, VectorDataType.BYTE),
             SpaceType.INNER_PRODUCT,
             Set.of(VectorDataType.FLOAT, VectorDataType.BYTE),
-            SpaceType.HAMMING_BIT,
+            SpaceType.HAMMING,
             Set.of(VectorDataType.BINARY)
         );
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -339,7 +339,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
 
         KNNEngine knnEngine = KNNEngine.FAISS;
-        SpaceType spaceType = SpaceType.HAMMING_BIT;
+        SpaceType spaceType = SpaceType.HAMMING;
         VectorDataType dataType = VectorDataType.BINARY;
         int dimension = 16;
 

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -223,7 +223,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
         KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
         assertTrue(knnVectorFieldMapper instanceof LegacyFieldMapper);
-        assertEquals(SpaceType.HAMMING_BIT.getValue(), ((LegacyFieldMapper) knnVectorFieldMapper).spaceType);
+        assertEquals(SpaceType.HAMMING.getValue(), ((LegacyFieldMapper) knnVectorFieldMapper).spaceType);
     }
 
     public void testBuilder_parse_fromKnnMethodContext_luceneEngine() throws IOException {
@@ -944,7 +944,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
     public void testBuilder_whenBinaryFaissHNSWWithInvalidSpaceType_thenException() {
         for (SpaceType spaceType : SpaceType.values()) {
-            if (SpaceType.UNDEFINED == spaceType || SpaceType.HAMMING_BIT == spaceType) {
+            if (SpaceType.UNDEFINED == spaceType || SpaceType.HAMMING == spaceType) {
                 continue;
             }
             testBuilderWithBinaryDataType(KNNEngine.FAISS, spaceType, METHOD_HNSW, 8, "is not supported");
@@ -980,7 +980,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
             assertTrue(knnVectorFieldMapper instanceof MethodFieldMapper);
             if (SpaceType.UNDEFINED == spaceType) {
-                assertEquals(SpaceType.HAMMING_BIT, knnVectorFieldMapper.fieldType().spaceType);
+                assertEquals(SpaceType.HAMMING, knnVectorFieldMapper.fieldType().spaceType);
             }
         } else {
             Exception ex = expectThrows(Exception.class, () -> builder.build(builderContext));
@@ -998,7 +998,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         builder.knnMethodContext.setValue(
             new KNNMethodContext(
                 KNNEngine.FAISS,
-                SpaceType.HAMMING_BIT,
+                SpaceType.HAMMING,
                 new MethodComponentContext(
                     METHOD_HNSW,
                     Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Collections.emptyMap()))

--- a/src/test/java/org/opensearch/knn/index/mapper/MethodFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/MethodFieldMapperTests.java
@@ -20,7 +20,7 @@ public class MethodFieldMapperTests extends TestCase {
             Collections.emptyMap(),
             1,
             VectorDataType.BINARY,
-            SpaceType.HAMMING_BIT
+            SpaceType.HAMMING
         );
         MethodFieldMapper mappers = new MethodFieldMapper(
             "simpleName",

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
@@ -110,7 +110,7 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         }
         Map<String, Object> parameters = ImmutableMap.of(
             KNNConstants.SPACE_TYPE,
-            SpaceType.HAMMING_BIT.getValue(),
+            SpaceType.HAMMING.getValue(),
             KNNConstants.INDEX_DESCRIPTION_PARAMETER,
             "BHNSW32",
             KNNConstants.VECTOR_DATA_TYPE_FIELD,

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
@@ -97,7 +97,7 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
         }
         Map<String, Object> parameters = ImmutableMap.of(
             KNNConstants.SPACE_TYPE,
-            SpaceType.HAMMING_BIT.getValue(),
+            SpaceType.HAMMING.getValue(),
             KNNConstants.INDEX_DESCRIPTION_PARAMETER,
             "BHNSW32",
             KNNConstants.VECTOR_DATA_TYPE_FIELD,

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -736,7 +736,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
             ImmutableMap.of()
         );
-        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.HAMMING_BIT, methodComponentContext);
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.HAMMING, methodComponentContext);
         when(mockKNNVectorField.getKnnMethodContext()).thenReturn(knnMethodContext);
         Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
         assertTrue(e.getMessage().contains("Binary data type does not support radial search"));
@@ -1269,7 +1269,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(32);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.BINARY);
-        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.HAMMING_BIT);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.HAMMING);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         KNNQuery query = (KNNQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
         assertArrayEquals(expectedQueryVector, query.getByteQueryVector());
@@ -1285,7 +1285,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getDimension()).thenReturn(8);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.BINARY);
-        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.HAMMING_BIT);
+        when(mockKNNVectorField.getSpaceType()).thenReturn(SpaceType.HAMMING);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         Exception ex = expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
         assertTrue(ex.getMessage(), ex.getMessage().contains("invalid dimension"));

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -581,7 +581,7 @@ public class KNNWeightTests extends KNNTestCase {
             KNN_ENGINE,
             KNNEngine.FAISS.getName(),
             SPACE_TYPE,
-            isBinary ? SpaceType.HAMMING_BIT.getValue() : SpaceType.L2.getValue()
+            isBinary ? SpaceType.HAMMING.getValue() : SpaceType.L2.getValue()
         );
 
         when(reader.getFieldInfos()).thenReturn(fieldInfos);
@@ -694,7 +694,7 @@ public class KNNWeightTests extends KNNTestCase {
             KNN_ENGINE,
             KNNEngine.FAISS.getName(),
             SPACE_TYPE,
-            isBinary ? SpaceType.HAMMING_BIT.getValue() : SpaceType.L2.getValue()
+            isBinary ? SpaceType.HAMMING.getValue() : SpaceType.L2.getValue()
         );
         final FieldInfos fieldInfos = mock(FieldInfos.class);
         final FieldInfo fieldInfo = mock(FieldInfo.class);
@@ -703,7 +703,7 @@ public class KNNWeightTests extends KNNTestCase {
         when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
         when(fieldInfo.attributes()).thenReturn(attributesMap);
         if (isBinary) {
-            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.HAMMING_BIT.getValue());
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.HAMMING.getValue());
         } else {
             when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
         }
@@ -899,7 +899,7 @@ public class KNNWeightTests extends KNNTestCase {
             KNN_ENGINE,
             KNNEngine.FAISS.getName(),
             SPACE_TYPE,
-            SpaceType.HAMMING_BIT.name(),
+            SpaceType.HAMMING.name(),
             PARAMETERS,
             String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "BHNSW32")
         );
@@ -909,7 +909,7 @@ public class KNNWeightTests extends KNNTestCase {
         when(reader.getFieldInfos()).thenReturn(fieldInfos);
         when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
         when(fieldInfo.attributes()).thenReturn(attributesMap);
-        when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.HAMMING_BIT.getValue());
+        when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.HAMMING.getValue());
         when(fieldInfo.getName()).thenReturn(FIELD_NAME);
         when(reader.getBinaryDocValues(FIELD_NAME)).thenReturn(binaryDocValues);
         when(binaryDocValues.advance(0)).thenReturn(0);

--- a/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNByteIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNByteIteratorTests.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 public class FilteredIdsKNNByteIteratorTests extends TestCase {
     @SneakyThrows
     public void testNextDoc_whenCalled_IterateAllDocs() {
-        final SpaceType spaceType = SpaceType.HAMMING_BIT;
+        final SpaceType spaceType = SpaceType.HAMMING;
         final byte[] queryVector = { 1, 2, 3 };
         final int[] filterIds = { 1, 2, 3 };
         final List<byte[]> dataVectors = Arrays.asList(new byte[] { 11, 12, 13 }, new byte[] { 14, 15, 16 }, new byte[] { 17, 18, 19 });

--- a/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNByteIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNByteIteratorTests.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 public class NestedFilteredIdsKNNByteIteratorTests extends TestCase {
     @SneakyThrows
     public void testNextDoc_whenIterate_ReturnBestChildDocsPerParent() {
-        final SpaceType spaceType = SpaceType.HAMMING_BIT;
+        final SpaceType spaceType = SpaceType.HAMMING;
         final byte[] queryVector = { 1, 2, 3 };
         final int[] filterIds = { 0, 2, 3 };
         // Parent id for 0 -> 1

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -678,7 +678,7 @@ public class JNIServiceTests extends KNNTestCase {
                 INDEX_DESCRIPTION_PARAMETER,
                 faissBinaryMethod,
                 KNNConstants.SPACE_TYPE,
-                SpaceType.HAMMING_BIT.getValue(),
+                SpaceType.HAMMING.getValue(),
                 KNNConstants.VECTOR_DATA_TYPE_FIELD,
                 VectorDataType.BINARY.getValue()
             ),
@@ -993,7 +993,7 @@ public class JNIServiceTests extends KNNTestCase {
                     INDEX_DESCRIPTION_PARAMETER,
                     method,
                     KNNConstants.SPACE_TYPE,
-                    SpaceType.HAMMING_BIT.getValue(),
+                    SpaceType.HAMMING.getValue(),
                     KNNConstants.VECTOR_DATA_TYPE_FIELD,
                     VectorDataType.BINARY.getValue()
                 ),

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceFactoryTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.plugin.script;
 
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.index.mapper.NumberFieldMapper;
@@ -17,9 +18,11 @@ import static org.mockito.Mockito.when;
 
 public class KNNScoringSpaceFactoryTests extends KNNTestCase {
     public void testValidSpaces() {
-
         KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
         when(knnVectorFieldType.getDimension()).thenReturn(3);
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldTypeBinary = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldTypeBinary.getDimension()).thenReturn(24);
+        when(knnVectorFieldTypeBinary.getVectorDataType()).thenReturn(VectorDataType.BINARY);
         NumberFieldMapper.NumberFieldType numberFieldType = new NumberFieldMapper.NumberFieldType(
             "field",
             NumberFieldMapper.NumberType.LONG
@@ -46,7 +49,14 @@ public class KNNScoringSpaceFactoryTests extends KNNTestCase {
         );
         assertTrue(
             KNNScoringSpaceFactory.create(
-                SpaceType.HAMMING_BIT.getValue(),
+                SpaceType.HAMMING.getValue(),
+                floatQueryObject,
+                knnVectorFieldTypeBinary
+            ) instanceof KNNScoringSpace.Hamming
+        );
+        assertTrue(
+            KNNScoringSpaceFactory.create(
+                KNNScoringSpaceFactory.HAMMING_BIT,
                 longQueryObject,
                 numberFieldType
             ) instanceof KNNScoringSpace.HammingBit
@@ -54,6 +64,22 @@ public class KNNScoringSpaceFactoryTests extends KNNTestCase {
     }
 
     public void testInvalidSpace() {
+        List<Float> floatQueryObject = List.of(1.0f, 1.0f, 1.0f);
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldType.getDimension()).thenReturn(3);
+        KNNVectorFieldMapper.KNNVectorFieldType knnVectorFieldTypeBinary = mock(KNNVectorFieldMapper.KNNVectorFieldType.class);
+        when(knnVectorFieldTypeBinary.getDimension()).thenReturn(24);
+        when(knnVectorFieldTypeBinary.getVectorDataType()).thenReturn(VectorDataType.BINARY);
+
+        // Verify
         expectThrows(IllegalArgumentException.class, () -> KNNScoringSpaceFactory.create(SpaceType.L2.getValue(), null, null));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNScoringSpaceFactory.create(SpaceType.L2.getValue(), floatQueryObject, knnVectorFieldTypeBinary)
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNScoringSpaceFactory.create(SpaceType.HAMMING.getValue(), floatQueryObject, knnVectorFieldType)
+        );
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScriptScoringIT.java
@@ -275,7 +275,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         Long queryValue1 = -9223372036818526181L;
         params1.put("field", FIELD_NAME);
         params1.put("query_value", queryValue1);
-        params1.put("space_type", SpaceType.HAMMING_BIT.getValue());
+        params1.put("space_type", KNNScoringSpaceFactory.HAMMING_BIT);
         Request request1 = constructKNNScriptQueryRequest(INDEX_NAME, qb1, params1, 4, Collections.emptyMap());
         Response response1 = client().performRequest(request1);
         assertEquals(request1.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response1.getStatusLine().getStatusCode()));
@@ -315,7 +315,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         Long queryValue2 = 10L;
         params2.put("field", FIELD_NAME);
         params2.put("query_value", queryValue2);
-        params2.put("space_type", SpaceType.HAMMING_BIT.getValue());
+        params2.put("space_type", KNNScoringSpaceFactory.HAMMING_BIT);
         Request request2 = constructKNNScriptQueryRequest(INDEX_NAME, qb2, params2, 4, Collections.emptyMap());
         Response response2 = client().performRequest(request2);
         assertEquals(request2.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response2.getStatusLine().getStatusCode()));
@@ -385,7 +385,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         String queryValue1 = "gAAAAAIpIBs=";
         params1.put("field", FIELD_NAME);
         params1.put("query_value", queryValue1);
-        params1.put("space_type", SpaceType.HAMMING_BIT.getValue());
+        params1.put("space_type", KNNScoringSpaceFactory.HAMMING_BIT);
         Request request1 = constructKNNScriptQueryRequest(INDEX_NAME, qb1, params1, 4, Collections.emptyMap());
         Response response1 = client().performRequest(request1);
         assertEquals(request1.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response1.getStatusLine().getStatusCode()));
@@ -425,7 +425,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         String queryValue2 = "AAAAAAIpIBs=";
         params2.put("field", FIELD_NAME);
         params2.put("query_value", queryValue2);
-        params2.put("space_type", SpaceType.HAMMING_BIT.getValue());
+        params2.put("space_type", KNNScoringSpaceFactory.HAMMING_BIT);
         Request request2 = constructKNNScriptQueryRequest(INDEX_NAME, qb2, params2, 4, Collections.emptyMap());
         Response response2 = client().performRequest(request2);
         assertEquals(request2.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response2.getStatusLine().getStatusCode()));
@@ -597,7 +597,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             .toString();
 
         for (SpaceType spaceType : SpaceType.values()) {
-            if (SpaceType.UNDEFINED == spaceType || SpaceType.HAMMING_BIT == spaceType) {
+            if (SpaceType.UNDEFINED == spaceType || SpaceType.HAMMING == spaceType) {
                 continue;
             }
             final float[] queryVector = randomVector(dimensions);


### PR DESCRIPTION
### Description
Switch space type name from hammingbit to hamming for binary index
Note that hammingbit in script scoring for long and base64 exist before 2.16.

Before this PR the hamming space type name looks like
```
ANN: hammingbit
Script Scoring: hammingbit(long, base64, knn binary field)
Painless: hamming
```

After this PR the hamming space type will look like
```
ANN: hamming
Script Scoring: hammingbit(long, base64), hamming(knn binary field)
Painless: hamming
```
### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
