### PR TITLE
Introduce NativeEngineKNNVectorsFormat as a KNNVectorsFormat for Native engines

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngineFieldVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngineFieldVectorsWriter.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import lombok.Getter;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * NativeEngineVectorFieldsWriter is a class that will be used to accumulate all the vectors during ingestion before
+ * lucene does a flush. This class ensures that KNNVectorWriter is free from generics and this class can encapsulate
+ * all the details related to vectors types and docIds.
+ *
+ * @param <T> float[] or byte[]
+ */
+class NativeEngineFieldVectorsWriter<T> extends KnnFieldVectorsWriter<T> {
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(NativeEngineFieldVectorsWriter.class);
+    private final FieldInfo fieldInfo;
+    /**
+     * We are using a map here instead of list, because for sampler interface for quantization we have to advance the iterator
+     * to a specific docId, there a list cannot be useful because a docId != index of the vector in the list. Similar
+     * thing is true when we have vector field in child document. There doc Ids will not be consistent. Hence, we need to
+     * use the map here.
+     */
+    @Getter
+    private final Map<Integer, T> vectors;
+    private int lastDocID = -1;
+    @Getter
+    private final DocsWithFieldSet docsWithField;
+    private final InfoStream infoStream;
+
+    static NativeEngineFieldVectorsWriter<?> create(final FieldInfo fieldInfo, final InfoStream infoStream) {
+        switch (fieldInfo.getVectorEncoding()) {
+            case FLOAT32:
+                return new NativeEngineFieldVectorsWriter<float[]>(fieldInfo, infoStream);
+            case BYTE:
+                return new NativeEngineFieldVectorsWriter<byte[]>(fieldInfo, infoStream);
+        }
+        throw new IllegalStateException("Unsupported Vector encoding : " + fieldInfo.getVectorEncoding());
+    }
+
+    NativeEngineFieldVectorsWriter(final FieldInfo fieldInfo, final InfoStream infoStream) {
+        this.fieldInfo = fieldInfo;
+        this.infoStream = infoStream;
+        vectors = new HashMap<>();
+        this.docsWithField = new DocsWithFieldSet();
+    }
+
+    /**
+     * Add new docID with its vector value to the given field for indexing. Doc IDs must be added in
+     * increasing order.
+     *
+     * @param docID int
+     * @param vectorValue T
+     */
+    @Override
+    public void addValue(int docID, T vectorValue) {
+        if (docID == lastDocID) {
+            throw new IllegalArgumentException(
+                "[NativeEngineKNNVectorWriter]VectorValuesField \""
+                    + fieldInfo.name
+                    + "\" appears more than once in this document (only one value is allowed per field)"
+            );
+        }
+        assert docID > lastDocID;
+        vectors.put(docID, vectorValue);
+        docsWithField.add(docID);
+        lastDocID = docID;
+    }
+
+    /**
+     * Used to copy values being indexed to internal storage.
+     *
+     * @param vectorValue an array containing the vector value to add
+     * @return a copy of the value; a new array
+     */
+    @Override
+    public T copyValue(T vectorValue) {
+        throw new UnsupportedOperationException("NativeEngineVectorFieldsWriter doesn't support copyValue operation");
+    }
+
+    /**
+     * Return the memory usage of this object in bytes. Negative values are illegal.
+     */
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + docsWithField.ramBytesUsed() + (long) this.vectors.size() * (long) (RamUsageEstimator.NUM_BYTES_OBJECT_REF
+            + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER) + (long) this.vectors.size() * RamUsageEstimator.shallowSizeOfInstance(
+                Integer.class
+            ) + (long) vectors.size() * fieldInfo.getVectorDimension() * fieldInfo.getVectorEncoding().byteSize;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+import java.io.IOException;
+
+/**
+ * This is a Vector format that will be used for Native engines like Faiss and Nmslib for reading and writing vector
+ * related data structures.
+ */
+public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
+    /** The format for storing, reading, merging vectors on disk */
+    private static FlatVectorsFormat flatVectorsFormat;
+    private static final String FORMAT_NAME = "NativeEngines99KnnVectorsFormat";
+
+    public NativeEngines990KnnVectorsFormat() {
+        super(FORMAT_NAME);
+        flatVectorsFormat = new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer());
+    }
+
+    public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat lucene99FlatVectorsFormat) {
+        super(FORMAT_NAME);
+        flatVectorsFormat = lucene99FlatVectorsFormat;
+    }
+
+    /**
+     * Returns a {@link KnnVectorsWriter} to write the vectors to the index.
+     *
+     * @param state {@link SegmentWriteState}
+     */
+    @Override
+    public KnnVectorsWriter fieldsWriter(final SegmentWriteState state) throws IOException {
+        return new NativeEngines990KnnVectorsWriter(state, flatVectorsFormat.fieldsWriter(state));
+    }
+
+    /**
+     * Returns a {@link KnnVectorsReader} to read the vectors from the index.
+     *
+     * @param state {@link SegmentReadState}
+     */
+    @Override
+    public KnnVectorsReader fieldsReader(final SegmentReadState state) throws IOException {
+        return new NativeEngines990KnnVectorsReader(state, flatVectorsFormat.fieldsReader(state));
+    }
+
+    @Override
+    public String toString() {
+        return "NativeEngines99KnnVectorsFormat(name=" + this.getClass().getSimpleName() + ", flatVectorsFormat=" + flatVectorsFormat + ")";
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
+
+/**
+ * Vectors reader class for reading the flat vectors for native engines. The class provides methods for iterating
+ * over the vectors and retrieving their values.
+ */
+public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
+
+    private final FlatVectorsReader flatVectorsReader;
+
+    public NativeEngines990KnnVectorsReader(final SegmentReadState state, final FlatVectorsReader flatVectorsReader) {
+        this.flatVectorsReader = flatVectorsReader;
+    }
+
+    /**
+     * Checks consistency of this reader.
+     *
+     * <p>Note that this may be costly in terms of I/O, e.g. may involve computing a checksum value
+     * against large data files.
+     *
+     */
+    @Override
+    public void checkIntegrity() throws IOException {
+        flatVectorsReader.checkIntegrity();
+    }
+
+    /**
+     * Returns the {@link FloatVectorValues} for the given {@code field}. The behavior is undefined if
+     * the given field doesn't have KNN vectors enabled on its {@link FieldInfo}. The return value is
+     * never {@code null}.
+     *
+     * @param field {@link String}
+     */
+    @Override
+    public FloatVectorValues getFloatVectorValues(final String field) throws IOException {
+        return flatVectorsReader.getFloatVectorValues(field);
+    }
+
+    /**
+     * Returns the {@link ByteVectorValues} for the given {@code field}. The behavior is undefined if
+     * the given field doesn't have KNN vectors enabled on its {@link FieldInfo}. The return value is
+     * never {@code null}.
+     *
+     * @param field {@link String}
+     */
+    @Override
+    public ByteVectorValues getByteVectorValues(final String field) throws IOException {
+        return flatVectorsReader.getByteVectorValues(field);
+    }
+
+    /**
+     * Return the k nearest neighbor documents as determined by comparison of their vector values for
+     * this field, to the given vector, by the field's similarity function. The score of each document
+     * is derived from the vector similarity in a way that ensures scores are positive and that a
+     * larger score corresponds to a higher ranking.
+     *
+     * <p>The search is allowed to be approximate, meaning the results are not guaranteed to be the
+     * true k closest neighbors. For large values of k (for example when k is close to the total
+     * number of documents), the search may also retrieve fewer than k documents.
+     *
+     * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor, in
+     * order of their similarity to the query vector (decreasing scores). The {@link TotalHits}
+     * contains the number of documents visited during the search. If the search stopped early because
+     * it hit {@code visitedLimit}, it is indicated through the relation {@code
+     * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
+     *
+     * <p>The behavior is undefined if the given field doesn't have KNN vectors enabled on its {@link
+     * FieldInfo}. The return value is never {@code null}.
+     *
+     * @param field        the vector field to search
+     * @param target       the vector-valued query
+     * @param knnCollector a KnnResults collector and relevant settings for gathering vector results
+     * @param acceptDocs   {@link Bits} that represents the allowed documents to match, or {@code null}
+     *                     if they are all allowed to match.
+     */
+    @Override
+    public void search(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+        throw new UnsupportedOperationException("Search functionality using codec is not supported with Native Engine Reader");
+    }
+
+    /**
+     * Return the k nearest neighbor documents as determined by comparison of their vector values for
+     * this field, to the given vector, by the field's similarity function. The score of each document
+     * is derived from the vector similarity in a way that ensures scores are positive and that a
+     * larger score corresponds to a higher ranking.
+     *
+     * <p>The search is allowed to be approximate, meaning the results are not guaranteed to be the
+     * true k closest neighbors. For large values of k (for example when k is close to the total
+     * number of documents), the search may also retrieve fewer than k documents.
+     *
+     * <p>The returned {@link TopDocs} will contain a {@link ScoreDoc} for each nearest neighbor, in
+     * order of their similarity to the query vector (decreasing scores). The {@link TotalHits}
+     * contains the number of documents visited during the search. If the search stopped early because
+     * it hit {@code visitedLimit}, it is indicated through the relation {@code
+     * TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO}.
+     *
+     * <p>The behavior is undefined if the given field doesn't have KNN vectors enabled on its {@link
+     * FieldInfo}. The return value is never {@code null}.
+     *
+     * @param field        the vector field to search
+     * @param target       the vector-valued query
+     * @param knnCollector a KnnResults collector and relevant settings for gathering vector results
+     * @param acceptDocs   {@link Bits} that represents the allowed documents to match, or {@code null}
+     *                     if they are all allowed to match.
+     */
+    @Override
+    public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+        throw new UnsupportedOperationException("Search functionality using codec is not supported with Native Engine Reader");
+    }
+
+    /**
+     * Closes this stream and releases any system resources associated
+     * with it. If the stream is already closed then invoking this
+     * method has no effect.
+     *
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(flatVectorsReader);
+    }
+
+    /**
+     * Return the memory usage of this object in bytes. Negative values are illegal.
+     */
+    @Override
+    public long ramBytesUsed() {
+        return flatVectorsReader.ramBytesUsed();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A KNNVectorsWriter class for writing the vector data strcutures and flat vectors for Native Engines.
+ */
+@RequiredArgsConstructor
+public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(NativeEngines990KnnVectorsWriter.class);
+    private final SegmentWriteState segmentWriteState;
+    private final FlatVectorsWriter flatVectorsWriter;
+    private final List<NativeEngineFieldVectorsWriter<?>> fields = new ArrayList<>();
+    private boolean finished;
+
+    /**
+     * Add new field for indexing.
+     * In Lucene, we use single file for all the vector fields so here we need to see how we are going to make things
+     * work.
+     * @param fieldInfo {@link FieldInfo}
+     */
+    @Override
+    public KnnFieldVectorsWriter<?> addField(final FieldInfo fieldInfo) throws IOException {
+        final NativeEngineFieldVectorsWriter<?> newField = NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream);
+        // TODO: we can build the graph here too iteratively. but right now I am skipping that as we need iterative
+        // graph build support on the JNI layer.
+        fields.add(newField);
+        return flatVectorsWriter.addField(fieldInfo, newField);
+    }
+
+    /**
+     * Flush all buffered data on disk. This is not fsync. This is lucene flush.
+     *
+     * @param maxDoc int
+     * @param sortMap {@link Sorter.DocMap}
+     */
+    @Override
+    public void flush(int maxDoc, final Sorter.DocMap sortMap) throws IOException {
+        // simply write data in the flat file
+        flatVectorsWriter.flush(maxDoc, sortMap);
+        // TODO: add code for creating Vector datastructures during lucene flush operation
+    }
+
+    @Override
+    public void mergeOneField(final FieldInfo fieldInfo, final MergeState mergeState) throws IOException {
+        // This will ensure that we are merging the FlatIndex during force merge.
+        flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+        // TODO: add code for creating Vector datastructures during merge operation
+    }
+
+    /**
+     * Called once at the end before close
+     */
+    @Override
+    public void finish() throws IOException {
+        if (finished) {
+            throw new IllegalStateException("NativeEnginesKNNVectorsWriter is already finished");
+        }
+        finished = true;
+        flatVectorsWriter.finish();
+    }
+
+    /**
+     * Closes this stream and releases any system resources associated
+     * with it. If the stream is already closed then invoking this
+     * method has no effect.
+     *
+     * <p> As noted in {@link AutoCloseable#close()}, cases where the
+     * close may fail require careful attention. It is strongly advised
+     * to relinquish the underlying resources and to internally
+     * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+     * the {@code IOException}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(flatVectorsWriter);
+    }
+
+    /**
+     * Return the memory usage of this object in bytes. Negative values are illegal.
+     */
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + flatVectorsWriter.ramBytesUsed() + fields.stream()
+            .mapToLong(NativeEngineFieldVectorsWriter::ramBytesUsed)
+            .sum();
+    }
+
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/UnitTestCodec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/UnitTestCodec.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNNCodecVersion;
+
+/**
+ * This codec is for testing. The reason for putting this codec here is SPI is only scanning the src folder and not
+ * able to pick this class if its in test folder. Don't use this codec outside of testing
+ */
+public class UnitTestCodec extends FilterCodec {
+    public UnitTestCodec() {
+        super("UnitTestCodec", KNNCodecVersion.current().getDefaultKnnCodecSupplier().get());
+    }
+
+    @Override
+    public KnnVectorsFormat knnVectorsFormat() {
+        return new PerFieldKnnVectorsFormat() {
+            @Override
+            public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+                return new NativeEngines990KnnVectorsFormat();
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -7,3 +7,4 @@ org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec
 org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec
 org.opensearch.knn.index.codec.KNN950Codec.KNN950Codec
 org.opensearch.knn.index.codec.KNN990Codec.KNN990Codec
+org.opensearch.knn.index.codec.KNN990Codec.UnitTestCodec

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -1,0 +1,12 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+
+org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngineFieldVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngineFieldVectorsWriterTests.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.util.InfoStream;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.opensearch.knn.index.codec.KNNCodecTestCase;
+
+public class NativeEngineFieldVectorsWriterTests extends KNNCodecTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testCreate_ForDifferentInputs_thenSuccess() {
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
+        NativeEngineFieldVectorsWriter<float[]> floatWriter = (NativeEngineFieldVectorsWriter<float[]>) NativeEngineFieldVectorsWriter
+            .create(fieldInfo, InfoStream.getDefault());
+        floatWriter.addValue(1, new float[] { 1.0f, 2.0f });
+
+        Mockito.verify(fieldInfo).getVectorEncoding();
+
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
+        NativeEngineFieldVectorsWriter<byte[]> byteWriter = (NativeEngineFieldVectorsWriter<byte[]>) NativeEngineFieldVectorsWriter.create(
+            fieldInfo,
+            InfoStream.getDefault()
+        );
+        Assert.assertNotNull(byteWriter);
+        Mockito.verify(fieldInfo, Mockito.times(2)).getVectorEncoding();
+        byteWriter.addValue(1, new byte[] { 1, 2 });
+    }
+
+    public void testAddValue_ForDifferentInputs_thenSuccess() {
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        final NativeEngineFieldVectorsWriter<float[]> floatWriter = new NativeEngineFieldVectorsWriter<>(
+            fieldInfo,
+            InfoStream.getDefault()
+        );
+        final float[] vec1 = new float[] { 1.0f, 2.0f };
+        final float[] vec2 = new float[] { 2.0f, 2.0f };
+        floatWriter.addValue(1, vec1);
+        floatWriter.addValue(2, vec2);
+
+        Assert.assertEquals(vec1, floatWriter.getVectors().get(1));
+        Assert.assertEquals(vec2, floatWriter.getVectors().get(2));
+        Mockito.verify(fieldInfo, Mockito.never()).getVectorEncoding();
+
+        final NativeEngineFieldVectorsWriter<byte[]> byteWriter = new NativeEngineFieldVectorsWriter<>(fieldInfo, InfoStream.getDefault());
+        final byte[] bvec1 = new byte[] { 1, 2 };
+        final byte[] bvec2 = new byte[] { 2, 2 };
+        byteWriter.addValue(1, bvec1);
+        byteWriter.addValue(2, bvec2);
+
+        Assert.assertEquals(bvec1, byteWriter.getVectors().get(1));
+        Assert.assertEquals(bvec2, byteWriter.getVectors().get(2));
+        Mockito.verify(fieldInfo, Mockito.never()).getVectorEncoding();
+    }
+
+    public void testCopyValue_whenValidInput_thenException() {
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        final NativeEngineFieldVectorsWriter<float[]> floatWriter = new NativeEngineFieldVectorsWriter<>(
+            fieldInfo,
+            InfoStream.getDefault()
+        );
+        expectThrows(UnsupportedOperationException.class, () -> floatWriter.copyValue(new float[3]));
+
+        final NativeEngineFieldVectorsWriter<byte[]> byteWriter = new NativeEngineFieldVectorsWriter<>(fieldInfo, InfoStream.getDefault());
+        expectThrows(UnsupportedOperationException.class, () -> byteWriter.copyValue(new byte[3]));
+    }
+
+    public void testRamByteUsed_whenValidInput_thenSuccess() {
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
+        Mockito.when(fieldInfo.getVectorDimension()).thenReturn(2);
+        final NativeEngineFieldVectorsWriter<float[]> floatWriter = new NativeEngineFieldVectorsWriter<>(
+            fieldInfo,
+            InfoStream.getDefault()
+        );
+        // testing for value > 0 as we don't have a concrete way to find out expected bytes. This can OS dependent too.
+        Assert.assertTrue(floatWriter.ramBytesUsed() > 0);
+
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
+        final NativeEngineFieldVectorsWriter<byte[]> byteWriter = new NativeEngineFieldVectorsWriter<>(fieldInfo, InfoStream.getDefault());
+        // testing for value > 0 as we don't have a concrete way to find out expected bytes. This can OS dependent too.
+        Assert.assertTrue(byteWriter.ramBytesUsed() > 0);
+
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormatTests.java
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.store.BaseDirectoryWrapper;
+import org.apache.lucene.util.Bits;
+import org.junit.After;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.knn.index.util.KNNEngine;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Log4j2
+public class NativeEngines990KnnVectorsFormatTests extends KNNTestCase {
+    private static final Codec TESTING_CODEC = new UnitTestCodec();
+    private static final String FLAT_VECTOR_FILE_EXT = ".vec";
+    private static final String HNSW_FILE_EXT = ".hnsw";
+    private static final String FLOAT_VECTOR_FIELD = "float_field";
+    private static final String BYTE_VECTOR_FIELD = "byte_field";
+    private Directory dir;
+    private RandomIndexWriter indexWriter;
+
+    @After
+    public void tearDown() throws Exception {
+        if (dir != null) {
+            dir.close();
+        }
+        super.tearDown();
+    }
+
+    @SneakyThrows
+    public void testReaderAndWriter_whenValidInput_thenSuccess() {
+        final Lucene99FlatVectorsFormat mockedFlatVectorsFormat = Mockito.mock(Lucene99FlatVectorsFormat.class);
+        final SegmentWriteState mockedSegmentWriteState = Mockito.mock(SegmentWriteState.class);
+        final SegmentReadState mockedSegmentReadState = Mockito.mock(SegmentReadState.class);
+
+        Mockito.when(mockedFlatVectorsFormat.fieldsReader(mockedSegmentReadState)).thenReturn(Mockito.mock(FlatVectorsReader.class));
+        Mockito.when(mockedFlatVectorsFormat.fieldsWriter(mockedSegmentWriteState)).thenReturn(Mockito.mock(FlatVectorsWriter.class));
+
+        final NativeEngines990KnnVectorsFormat nativeEngines990KnnVectorsFormat = new NativeEngines990KnnVectorsFormat(
+            mockedFlatVectorsFormat
+        );
+        Assert.assertTrue(
+            nativeEngines990KnnVectorsFormat.fieldsReader(mockedSegmentReadState) instanceof NativeEngines990KnnVectorsReader
+        );
+        Assert.assertTrue(
+            nativeEngines990KnnVectorsFormat.fieldsWriter(mockedSegmentWriteState) instanceof NativeEngines990KnnVectorsWriter
+        );
+    }
+
+    @SneakyThrows
+    public void testNativeEngineVectorFormat_whenMultipleVectorFieldIndexed_thenSuccess() {
+        setup();
+        float[] floatVector = { 1.0f, 3.0f, 4.0f };
+        byte[] byteVector = { 6, 14 };
+
+        addFieldToIndex(
+            new KnnFloatVectorField(FLOAT_VECTOR_FIELD, floatVector, createVectorField(3, VectorEncoding.FLOAT32)),
+            indexWriter
+        );
+        addFieldToIndex(new KnnByteVectorField(BYTE_VECTOR_FIELD, byteVector, createVectorField(2, VectorEncoding.BYTE)), indexWriter);
+        final IndexReader indexReader = indexWriter.getReader();
+        // ensuring segments are created
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Validate to see if correct values are returned, assumption here is only 1 segment is getting created
+        IndexSearcher searcher = new IndexSearcher(indexReader);
+        final LeafReader leafReader = searcher.getLeafContexts().get(0).reader();
+        SegmentReader segmentReader = Lucene.segmentReader(leafReader);
+        final List<String> hnswfiles = getFilesFromSegment(dir, HNSW_FILE_EXT);
+        // 0 hnsw files for now as we have not integrated graph creation here.
+        assertEquals(0, hnswfiles.size());
+        assertEquals(hnswfiles.stream().filter(x -> x.contains(FLOAT_VECTOR_FIELD)).count(), 0);
+        assertEquals(hnswfiles.stream().filter(x -> x.contains(BYTE_VECTOR_FIELD)).count(), 0);
+
+        // Even setting IWC to not use compound file it still uses compound file, hence ensuring we don't check .vec
+        // file in case segment uses compound format. use this seed once we fix this to validate everything is
+        // working or not. -Dtests.seed=CAAE1B8D573EEB7E
+        if (segmentReader.getSegmentInfo().info.getUseCompoundFile() == false) {
+            final List<String> vecfiles = getFilesFromSegment(dir, FLAT_VECTOR_FILE_EXT);
+            // 2 .vec files will be created as we are using per field vectors format.
+            assertEquals(2, vecfiles.size());
+        }
+
+        final FloatVectorValues floatVectorValues = leafReader.getFloatVectorValues(FLOAT_VECTOR_FIELD);
+        floatVectorValues.nextDoc();
+        assertArrayEquals(floatVector, floatVectorValues.vectorValue(), 0.0f);
+        assertEquals(1, floatVectorValues.size());
+        assertEquals(3, floatVectorValues.dimension());
+
+        final ByteVectorValues byteVectorValues = leafReader.getByteVectorValues(BYTE_VECTOR_FIELD);
+        byteVectorValues.nextDoc();
+        assertArrayEquals(byteVector, byteVectorValues.vectorValue());
+        assertEquals(1, byteVectorValues.size());
+        assertEquals(2, byteVectorValues.dimension());
+
+        Assert.assertThrows(
+            UnsupportedOperationException.class,
+            () -> leafReader.searchNearestVectors(FLOAT_VECTOR_FIELD, floatVector, 10, new Bits.MatchAllBits(1), 10)
+        );
+
+        Assert.assertThrows(
+            UnsupportedOperationException.class,
+            () -> leafReader.searchNearestVectors(BYTE_VECTOR_FIELD, byteVector, 10, new Bits.MatchAllBits(1), 10)
+        );
+        // do it at the end so that all search is completed
+        indexReader.close();
+    }
+
+    private List<String> getFilesFromSegment(Directory dir, String fileFormat) throws IOException {
+        return Arrays.stream(dir.listAll()).filter(x -> x.contains(fileFormat)).collect(Collectors.toList());
+    }
+
+    /**
+     * This should have been annotated with @Before, but somehow when I annotate with @Before apart from running
+     * before tests, it is also running independently and failing. Need to figure this out.
+     * @throws IOException
+     */
+    private void setup() throws IOException {
+        dir = newFSDirectory(createTempDir());
+        // on the mock directory Lucene goes ahead and does a search on different fields. We want to avoid that as of
+        // now. Given we have not implemented search for the native engine format using codec, the dir.close fails
+        // with exception. Hence, marking this as false.
+        ((BaseDirectoryWrapper) dir).setCheckIndexOnClose(false);
+        indexWriter = createIndexWriter(dir);
+    }
+
+    private RandomIndexWriter createIndexWriter(final Directory dir) throws IOException {
+        final IndexWriterConfig iwc = newIndexWriterConfig();
+        iwc.setMergeScheduler(new SerialMergeScheduler());
+        iwc.setCodec(TESTING_CODEC);
+        iwc.setUseCompoundFile(false);
+        // Set merge policy to no merges so that we create a predictable number of segments.
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        return new RandomIndexWriter(random(), dir, iwc);
+    }
+
+    private void addFieldToIndex(final Field vectorField, final RandomIndexWriter indexWriter) throws IOException {
+        final Document doc1 = new Document();
+        doc1.add(vectorField);
+        indexWriter.addDocument(doc1);
+    }
+
+    private FieldType createVectorField(int dimension, VectorEncoding vectorEncoding) {
+        FieldType nativeVectorField = new FieldType();
+        // TODO: Replace this with the default field which will be created in mapper for Native Engines with KNNVectorsFormat
+        nativeVectorField.setTokenized(false);
+        nativeVectorField.setIndexOptions(IndexOptions.NONE);
+        nativeVectorField.putAttribute(KNNVectorFieldMapper.KNN_FIELD, "true");
+        nativeVectorField.putAttribute(KNNConstants.KNN_METHOD, KNNConstants.METHOD_HNSW);
+        nativeVectorField.putAttribute(KNNConstants.KNN_ENGINE, KNNEngine.NMSLIB.getName());
+        nativeVectorField.putAttribute(KNNConstants.SPACE_TYPE, SpaceType.L2.getValue());
+        nativeVectorField.putAttribute(KNNConstants.HNSW_ALGO_M, "32");
+        nativeVectorField.putAttribute(KNNConstants.HNSW_ALGO_EF_CONSTRUCTION, "512");
+        nativeVectorField.setVectorAttributes(
+            dimension,
+            vectorEncoding,
+            SpaceType.L2.getKnnVectorSimilarityFunction().getVectorSimilarityFunction()
+        );
+        nativeVectorField.freeze();
+        return nativeVectorField;
+    }
+}


### PR DESCRIPTION
### Description
Introduced NativeEngineKNNVectorsFormat as a KNNVectorsFormat for Native engines(faiss and nmslib). This PR doesn't change any code path or do the integration of the new format in the actual flow. This is more of a base work I am adding for next step of changes which are coming. 

**Changes include:**
1. Introduce the NativeEngineKNNVectorsFormat, readers and writers.
2. Added the unit test for this new format.
3. Currently the format is only writing the FlatVectors and not building the hnsw vector files. I will add this change in next few PRs.
4. Not adding the backport label on this PR. I will add the backport label once 2.16 is released, as this change is not intended for 2.16 version of Opensearch.

### Related Issues
https://github.com/opensearch-project/k-NN/issues/1853
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
