### PR TITLE
Fix idea xml file

### DIFF
--- a/.idea/copyright/SPDX_ALv2.xml
+++ b/.idea/copyright/SPDX_ALv2.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright OpenSearch Contributors&#10;SPDX-License-Identifier: Apache-2.0&#10;" />
+    <option name="notice" value="Copyright OpenSearch Contributors&#10;SPDX-License-Identifier: Apache-2.0" />
     <option name="myName" value="SPDX-ALv2" />
   </copyright>
 </component>

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -1,7 +1,6 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
  */
 
 package org.opensearch.knn.index.query.parser;

--- a/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
@@ -1,7 +1,6 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
  */
 
 package org.opensearch.knn.index.query.parser;
@@ -33,7 +32,7 @@ import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.NAME;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.EF_SEARCH_FIELD;
 
-public class KNNQueryParserTests extends KNNTestCase {
+public class KNNQueryBuilderParserTests extends KNNTestCase {
 
     private static final String FIELD_NAME = "myvector";
     private static final int K = 1;


### PR DESCRIPTION
### Description
Fixes file so it gives 
```
/*
 * Copyright OpenSearch Contributors
 * SPDX-License-Identifier: Apache-2.0
 */
```

instead of 
```
/*
 * Copyright OpenSearch Contributors
 * SPDX-License-Identifier: Apache-2.0
 * 
 */

Related #1824 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
