### PR TITLE
Limit tests run based on changed path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,10 +6,30 @@ on:
     branches:
       - "*"
       - "feature/**"
+    paths:
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'src/**'
+      - 'build-tools/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'jni/**'
+      - 'micro-benchmarks/**'
+      - '.github/workflows/CI.yml'
   pull_request:
     branches:
       - "*"
       - "feature/**"
+    paths:
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'src/**'
+      - 'build-tools/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'jni/**'
+      - 'micro-benchmarks/**'
+      - '.github/workflows/CI.yml'
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -4,10 +4,30 @@ on:
     branches:
       - "*"
       - "feature/**"
+    paths:
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'src/**'
+      - 'build-tools/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'jni/**'
+      - 'qa/**'
+      - '.github/workflows/backwards_compatibility_tests_workflow.yml'
   pull_request:
     branches:
       - "*"
       - "feature/**"
+    paths:
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'src/**'
+      - 'build-tools/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'jni/**'
+      - 'qa/**'
+      - '.github/workflows/backwards_compatibility_tests_workflow.yml'
 
 jobs:
   Restart-Upgrade-BWCTests-k-NN:

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -6,10 +6,28 @@ on:
     branches:
       - "*"
       - "feature/**"
+    paths:
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'src/**'
+      - 'build-tools/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'jni/**'
+      - '.github/workflows/test_security.yml'
   pull_request:
     branches:
       - "*"
       - "feature/**"
+    paths:
+      - 'build.gradle'
+      - 'settings.gradle'
+      - 'src/**'
+      - 'build-tools/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'jni/**'
+      - '.github/workflows/test_security.yml'
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 


### PR DESCRIPTION
### Description
Minor change that will make it so CI is not run if we are not touching a file that is involved in CI. This should make it easier to create and merge PRs not involving source code. 

Docs on GHA paths: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore.

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
