### PR TITLE
Add script_fields context  to KNNAllowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes
 * Corrected search logic for scenario with non-existent fields in filter [#1874](https://github.com/opensearch-project/k-NN/pull/1874)
+* Add script_fields context to KNNAllowlist [#1917] (https://github.com/opensearch-project/k-NN/pull/1917)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNAllowlistExtension.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNAllowlistExtension.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import org.opensearch.painless.spi.PainlessExtension;
 import org.opensearch.painless.spi.Allowlist;
 import org.opensearch.painless.spi.AllowlistLoader;
+import org.opensearch.script.FieldScript;
 import org.opensearch.script.ScoreScript;
 import org.opensearch.script.ScriptContext;
 import org.opensearch.script.ScriptedMetricAggContexts;
@@ -33,6 +34,8 @@ public class KNNAllowlistExtension implements PainlessExtension {
             ScriptedMetricAggContexts.CombineScript.CONTEXT,
             allowLists,
             ScriptedMetricAggContexts.ReduceScript.CONTEXT,
+            allowLists,
+            FieldScript.CONTEXT,
             allowLists
         );
     }

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.knn.integ.PainlessScriptHelper.MappingProperty;
+import org.opensearch.script.Script;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
+
+// PainlesScriptScoreIT already tests every similarity methods with different field type. Hence,
+// we don't have to recreate all tests for script_fields. From implementation point of view,
+// it is clear if similarity method is supported by script_score, then same is applicable for script_fields
+// provided script_fields context is supported. Hence, we test for one similarity method to verify that script_fields
+// context is supported by this plugin.
+public class PainlessScriptFieldsIT extends KNNRestTestCase {
+
+    private static final String NUMERIC_INDEX_FIELD_NAME = "price";
+
+    private void buildTestIndex(Map<String, Float[]> knnDocuments) throws Exception {
+        List<MappingProperty> properties = buildMappingProperties();
+        buildTestIndex(knnDocuments, properties);
+    }
+
+    private void buildTestIndex(Map<String, Float[]> knnDocuments, List<MappingProperty> properties) throws Exception {
+        createKnnIndex(INDEX_NAME, createMapping(properties));
+        for (Map.Entry<String, Float[]> data : knnDocuments.entrySet()) {
+            addKnnDoc(INDEX_NAME, data.getKey(), FIELD_NAME, data.getValue());
+        }
+    }
+
+    private Map<String, Float[]> getKnnVectorTestData() {
+        Map<String, Float[]> data = new HashMap<>();
+        data.put("1", new Float[] { 100.0f, 1.0f });
+        data.put("2", new Float[] { 99.0f, 2.0f });
+        data.put("3", new Float[] { 97.0f, 3.0f });
+        data.put("4", new Float[] { 98.0f, 4.0f });
+        return data;
+    }
+
+    private Map<String, Float[]> getCosineTestData() {
+        Map<String, Float[]> data = new HashMap<>();
+        data.put("0", new Float[] { 1.0f, -1.0f });
+        data.put("2", new Float[] { 1.0f, 1.0f });
+        data.put("1", new Float[] { 1.0f, 0.0f });
+        return data;
+    }
+
+    /*
+     The doc['field'] will throw an error if field is missing from the mappings.
+     */
+    private List<MappingProperty> buildMappingProperties() {
+        List<MappingProperty> properties = new ArrayList<>();
+        properties.add(new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2"));
+        properties.add(new MappingProperty(NUMERIC_INDEX_FIELD_NAME, "integer"));
+        return properties;
+    }
+
+    @SneakyThrows
+    public void testCosineSimilarity_whenUsedInScriptFields_thenExecutesScript() {
+        String source = String.format(Locale.ROOT, "1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
+        String scriptFieldName = "similarity";
+        Request request = buildPainlessScriptFieldsRequest(source, 3, getCosineTestData(), scriptFieldName);
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponseScriptFields(EntityUtils.toString(response.getEntity()), scriptFieldName);
+        assertEquals(3, results.size());
+
+        String[] expectedDocIDs = { "0", "1", "2" };
+        for (int i = 0; i < results.size(); i++) {
+            assertEquals(expectedDocIDs[i], results.get(i).getDocId());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testGetValue_whenUsedInScriptFields_thenReturnsDocValues() {
+        String source = String.format(Locale.ROOT, "doc['%s'].value[0]", FIELD_NAME);
+        String scriptFieldName = "doc_value_field";
+        Map<String, Float[]> testData = getKnnVectorTestData();
+        Request request = buildPainlessScriptFieldsRequest(source, testData.size(), testData, scriptFieldName);
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponseScriptFields(EntityUtils.toString(response.getEntity()), scriptFieldName);
+        assertEquals(testData.size(), results.size());
+
+        String[] expectedDocIDs = { "1", "2", "3", "4" };
+        for (int i = 0; i < results.size(); i++) {
+            assertEquals(expectedDocIDs[i], results.get(i).getDocId());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    private Request buildPainlessScriptFieldsRequest(
+        final String source,
+        final int size,
+        final Map<String, Float[]> documents,
+        final String scriptFieldName
+    ) throws Exception {
+        buildTestIndex(documents);
+        return constructScriptFieldsContextSearchRequest(
+            INDEX_NAME,
+            scriptFieldName,
+            Collections.emptyMap(),
+            Script.DEFAULT_SCRIPT_LANG,
+            source,
+            size,
+            Collections.emptyMap()
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
@@ -34,12 +34,12 @@ public final class PainlessScriptFieldsIT extends KNNRestTestCase {
 
     private static final String NUMERIC_INDEX_FIELD_NAME = "price";
 
-    private void buildTestIndex(Map<String, Float[]> knnDocuments) throws Exception {
+    private void buildTestIndex(final Map<String, Float[]> knnDocuments) throws Exception {
         List<MappingProperty> properties = buildMappingProperties();
         buildTestIndex(knnDocuments, properties);
     }
 
-    private void buildTestIndex(Map<String, Float[]> knnDocuments, List<MappingProperty> properties) throws Exception {
+    private void buildTestIndex(final Map<String, Float[]> knnDocuments, final List<MappingProperty> properties) throws Exception {
         createKnnIndex(INDEX_NAME, createMapping(properties));
         for (Map.Entry<String, Float[]> data : knnDocuments.entrySet()) {
             addKnnDoc(INDEX_NAME, data.getKey(), FIELD_NAME, data.getValue());
@@ -68,8 +68,8 @@ public final class PainlessScriptFieldsIT extends KNNRestTestCase {
      */
     private List<MappingProperty> buildMappingProperties() {
         List<MappingProperty> properties = new ArrayList<>();
-        properties.add(new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2"));
-        properties.add(new MappingProperty(NUMERIC_INDEX_FIELD_NAME, "integer"));
+        properties.add(MappingProperty.builder().name(FIELD_NAME).type(KNNVectorFieldMapper.CONTENT_TYPE).dimension("2").build());
+        properties.add(MappingProperty.builder().name(NUMERIC_INDEX_FIELD_NAME).type("integer").build());
         return properties;
     }
 

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
@@ -30,7 +30,7 @@ import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
 // it is clear if similarity method is supported by script_score, then same is applicable for script_fields
 // provided script_fields context is supported. Hence, we test for one similarity method to verify that script_fields
 // context is supported by this plugin.
-public class PainlessScriptFieldsIT extends KNNRestTestCase {
+public final class PainlessScriptFieldsIT extends KNNRestTestCase {
 
     private static final String NUMERIC_INDEX_FIELD_NAME = "price";
 

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptHelper.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptHelper.java
@@ -15,8 +15,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class PainlessScriptHelper {
-
+public final class PainlessScriptHelper {
     /**
      * Utility to create a Index Mapping with multiple fields
      */
@@ -45,7 +44,7 @@ public class PainlessScriptHelper {
         return xContentBuilder.toString();
     }
 
-    static class MappingProperty {
+    final static class MappingProperty {
 
         private final String name;
         private final String type;

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptHelper.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptHelper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class PainlessScriptHelper {
+
+    /**
+     * Utility to create a Index Mapping with multiple fields
+     */
+    public static String createMapping(List<MappingProperty> properties) throws IOException {
+        Objects.requireNonNull(properties);
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        for (MappingProperty property : properties) {
+            XContentBuilder builder = xContentBuilder.startObject(property.getName()).field("type", property.getType());
+            if (property.getDimension() != null) {
+                builder.field("dimension", property.getDimension());
+            }
+
+            if (property.getDocValues() != null) {
+                builder.field("doc_values", property.getDocValues());
+            }
+
+            if (property.getKnnMethodContext() != null) {
+                builder.startObject(KNNConstants.KNN_METHOD);
+                property.getKnnMethodContext().toXContent(builder, ToXContent.EMPTY_PARAMS);
+                builder.endObject();
+            }
+
+            builder.endObject();
+        }
+        xContentBuilder.endObject().endObject();
+        return xContentBuilder.toString();
+    }
+
+    static class MappingProperty {
+
+        private final String name;
+        private final String type;
+        private String dimension;
+
+        private KNNMethodContext knnMethodContext;
+        private Boolean docValues;
+
+        MappingProperty(String name, String type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        MappingProperty dimension(String dimension) {
+            this.dimension = dimension;
+            return this;
+        }
+
+        MappingProperty knnMethodContext(KNNMethodContext knnMethodContext) {
+            this.knnMethodContext = knnMethodContext;
+            return this;
+        }
+
+        MappingProperty docValues(boolean docValues) {
+            this.docValues = docValues;
+            return this;
+        }
+
+        KNNMethodContext getKnnMethodContext() {
+            return knnMethodContext;
+        }
+
+        String getDimension() {
+            return dimension;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        String getType() {
+            return type;
+        }
+
+        Boolean getDocValues() {
+            return docValues;
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptHelper.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptHelper.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.integ;
 
+import lombok.Builder;
+import lombok.Getter;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -19,7 +21,7 @@ public final class PainlessScriptHelper {
     /**
      * Utility to create a Index Mapping with multiple fields
      */
-    public static String createMapping(List<MappingProperty> properties) throws IOException {
+    public static String createMapping(final List<MappingProperty> properties) throws IOException {
         Objects.requireNonNull(properties);
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("properties");
         for (MappingProperty property : properties) {
@@ -44,53 +46,13 @@ public final class PainlessScriptHelper {
         return xContentBuilder.toString();
     }
 
+    @Getter
+    @Builder
     final static class MappingProperty {
-
         private final String name;
         private final String type;
         private String dimension;
-
         private KNNMethodContext knnMethodContext;
         private Boolean docValues;
-
-        MappingProperty(String name, String type) {
-            this.name = name;
-            this.type = type;
-        }
-
-        MappingProperty dimension(String dimension) {
-            this.dimension = dimension;
-            return this;
-        }
-
-        MappingProperty knnMethodContext(KNNMethodContext knnMethodContext) {
-            this.knnMethodContext = knnMethodContext;
-            return this;
-        }
-
-        MappingProperty docValues(boolean docValues) {
-            this.docValues = docValues;
-            return this;
-        }
-
-        KNNMethodContext getKnnMethodContext() {
-            return knnMethodContext;
-        }
-
-        String getDimension() {
-            return dimension;
-        }
-
-        String getName() {
-            return name;
-        }
-
-        String getType() {
-            return type;
-        }
-
-        Boolean getDocValues() {
-            return docValues;
-        }
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -116,8 +116,8 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
      */
     private List<MappingProperty> buildMappingProperties() {
         List<MappingProperty> properties = new ArrayList<>();
-        properties.add(new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2"));
-        properties.add(new MappingProperty(NUMERIC_INDEX_FIELD_NAME, "integer"));
+        properties.add(MappingProperty.builder().name(FIELD_NAME).type(KNNVectorFieldMapper.CONTENT_TYPE).dimension("2").build());
+        properties.add(MappingProperty.builder().name(NUMERIC_INDEX_FIELD_NAME).type("integer").build());
         return properties;
     }
 
@@ -536,9 +536,13 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
             new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
         );
         properties.add(
-            new MappingProperty(FIELD_NAME, KNNVectorFieldMapper.CONTENT_TYPE).dimension("2")
+            MappingProperty.builder()
+                .name(FIELD_NAME)
+                .type(KNNVectorFieldMapper.CONTENT_TYPE)
+                .dimension("2")
                 .knnMethodContext(knnMethodContext)
                 .docValues(randomBoolean())
+                .build()
         );
 
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -6,29 +6,25 @@
 package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
-import org.opensearch.client.ResponseException;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.ToXContent;
-import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.index.query.MatchAllQueryBuilder;
-import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
-import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.knn.integ.PainlessScriptHelper.MappingProperty;
 import org.opensearch.script.Script;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,43 +32,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
 
-public class PainlessScriptIT extends KNNRestTestCase {
+public class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public static final int AGGREGATION_FIELD_NAME_MIN_LENGTH = 2;
     public static final int AGGREGATION_FIELD_NAME_MAX_LENGTH = 5;
     private static final String NUMERIC_INDEX_FIELD_NAME = "price";
-
-    /**
-     * Utility to create a Index Mapping with multiple fields
-     */
-    protected String createMapping(List<MappingProperty> properties) throws IOException {
-        Objects.requireNonNull(properties);
-        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("properties");
-        for (MappingProperty property : properties) {
-            XContentBuilder builder = xContentBuilder.startObject(property.getName()).field("type", property.getType());
-            if (property.getDimension() != null) {
-                builder.field("dimension", property.getDimension());
-            }
-
-            if (property.getDocValues() != null) {
-                builder.field("doc_values", property.getDocValues());
-            }
-
-            if (property.getKnnMethodContext() != null) {
-                builder.startObject(KNNConstants.KNN_METHOD);
-                property.getKnnMethodContext().toXContent(builder, ToXContent.EMPTY_PARAMS);
-                builder.endObject();
-            }
-
-            builder.endObject();
-        }
-        xContentBuilder.endObject().endObject();
-        return xContentBuilder.toString();
-    }
 
     /*
      creates KnnIndex based on properties, we add single non-knn vector documents to verify whether actions
@@ -161,62 +129,12 @@ public class PainlessScriptIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
-    public void testCosineSimilarityScriptFields() throws Exception {
-        String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
-        String scriptFieldName = "similarity";
-        Request request = buildPainlessScriptFieldsRequest(source, 3, getCosineTestData(), scriptFieldName);
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponseScriptFields(EntityUtils.toString(response.getEntity()), scriptFieldName);
-        assertEquals(3, results.size());
-
-        String[] expectedDocIDs = { "0", "1", "2" };
-        for (int i = 0; i < results.size(); i++) {
-            assertEquals(expectedDocIDs[i], results.get(i).getDocId());
-        }
-        deleteKNNIndex(INDEX_NAME);
-    }
-
-    public void testScriptFieldsGetValueReturnsDocValues() throws Exception {
-        String source = String.format("doc['%s'].value[0]", FIELD_NAME);
-        String scriptFieldName = "doc_value_field";
-        Map<String, Float[]> testData = getKnnVectorTestData();
-        Request request = buildPainlessScriptFieldsRequest(source, testData.size(), testData, scriptFieldName);
-
-        Response response = client().performRequest(request);
-        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        List<KNNResult> results = parseSearchResponseScriptFields(EntityUtils.toString(response.getEntity()), scriptFieldName);
-        assertEquals(testData.size(), results.size());
-
-        String[] expectedDocIDs = { "1", "2", "3", "4" };
-        for (int i = 0; i < results.size(); i++) {
-            assertEquals(expectedDocIDs[i], results.get(i).getDocId());
-        }
-        deleteKNNIndex(INDEX_NAME);
-    }
-
     private Request buildPainlessScoreScriptRequest(String source, int size, Map<String, Float[]> documents) throws Exception {
         buildTestIndex(documents);
         QueryBuilder qb = new MatchAllQueryBuilder();
         return constructScriptScoreContextSearchRequest(
             INDEX_NAME,
             qb,
-            Collections.emptyMap(),
-            Script.DEFAULT_SCRIPT_LANG,
-            source,
-            size,
-            Collections.emptyMap()
-        );
-    }
-
-    private Request buildPainlessScriptFieldsRequest(String source, int size, Map<String, Float[]> documents, String scriptFieldName)
-        throws Exception {
-        buildTestIndex(documents);
-        return constructScriptFieldsContextSearchRequest(
-            INDEX_NAME,
-            scriptFieldName,
             Collections.emptyMap(),
             Script.DEFAULT_SCRIPT_LANG,
             source,
@@ -719,56 +637,6 @@ public class PainlessScriptIT extends KNNRestTestCase {
             return client().performRequest(request);
         } finally {
             deleteKNNIndex(INDEX_NAME);
-        }
-    }
-
-    static class MappingProperty {
-
-        private final String name;
-        private final String type;
-        private String dimension;
-
-        private KNNMethodContext knnMethodContext;
-        private Boolean docValues;
-
-        MappingProperty(String name, String type) {
-            this.name = name;
-            this.type = type;
-        }
-
-        MappingProperty dimension(String dimension) {
-            this.dimension = dimension;
-            return this;
-        }
-
-        MappingProperty knnMethodContext(KNNMethodContext knnMethodContext) {
-            this.knnMethodContext = knnMethodContext;
-            return this;
-        }
-
-        MappingProperty docValues(boolean docValues) {
-            this.docValues = docValues;
-            return this;
-        }
-
-        KNNMethodContext getKnnMethodContext() {
-            return knnMethodContext;
-        }
-
-        String getDimension() {
-            return dimension;
-        }
-
-        String getName() {
-            return name;
-        }
-
-        String getType() {
-            return type;
-        }
-
-        Boolean getDocValues() {
-            return docValues;
         }
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
 
-public class PainlessScriptScoreIT extends KNNRestTestCase {
+public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public static final int AGGREGATION_FIELD_NAME_MIN_LENGTH = 2;
     public static final int AGGREGATION_FIELD_NAME_MAX_LENGTH = 5;

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -303,7 +303,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return knnSearchResponses;
     }
 
-    protected List<KNNResult> parseSearchResponseScriptFields(String responseBody, String scriptFieldName) throws IOException {
+    protected List<KNNResult> parseSearchResponseScriptFields(final String responseBody, final String scriptFieldName) throws IOException {
         @SuppressWarnings("unchecked")
         List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
             MediaTypeRegistry.getDefaultMediaType().xContent(),
@@ -1028,13 +1028,13 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     protected Request constructScriptFieldsContextSearchRequest(
-        String indexName,
-        String fieldName,
-        Map<String, Object> scriptParams,
-        String language,
-        String source,
-        int size,
-        Map<String, Object> searchParams
+        final String indexName,
+        final String fieldName,
+        final Map<String, Object> scriptParams,
+        final String language,
+        final String source,
+        final int size,
+        final Map<String, Object> searchParams
     ) throws Exception {
         Script script = buildScript(source, language, scriptParams);
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field("size", size).startObject("query");

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -303,6 +303,31 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return knnSearchResponses;
     }
 
+    protected List<KNNResult> parseSearchResponseScriptFields(String responseBody, String scriptFieldName) throws IOException {
+        @SuppressWarnings("unchecked")
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("hits")).get("hits");
+
+        @SuppressWarnings("unchecked")
+        List<KNNResult> knnSearchResponses = hits.stream().map(hit -> {
+            @SuppressWarnings("unchecked")
+            final float[] vector = Floats.toArray(
+                Arrays.stream(
+                    ((ArrayList<Float>) ((Map<String, Object>) ((Map<String, Object>) hit).get("fields")).get(scriptFieldName)).toArray()
+                ).map(Object::toString).map(Float::valueOf).collect(Collectors.toList())
+            );
+            return new KNNResult(
+                (String) ((Map<String, Object>) hit).get("_id"),
+                vector,
+                ((Double) ((Map<String, Object>) hit).get("_score")).floatValue()
+            );
+        }).collect(Collectors.toList());
+
+        return knnSearchResponses;
+    }
+
     /**
      * Parse the response of Aggregation to extract the value
      */
@@ -998,6 +1023,37 @@ public class KNNRestTestCase extends ODFERestTestCase {
         builder.endObject();
         String endpoint = String.format(Locale.getDefault(), "/%s/_search?size=0&filter_path=aggregations", INDEX_NAME);
         Request request = new Request("POST", endpoint);
+        request.setJsonEntity(builder.toString());
+        return request;
+    }
+
+    protected Request constructScriptFieldsContextSearchRequest(
+        String indexName,
+        String fieldName,
+        Map<String, Object> scriptParams,
+        String language,
+        String source,
+        int size,
+        Map<String, Object> searchParams
+    ) throws Exception {
+        Script script = buildScript(source, language, scriptParams);
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().field("size", size).startObject("query");
+        builder.startObject("match_all");
+        builder.endObject();
+        builder.endObject();
+        builder.startObject("script_fields");
+        builder.startObject(fieldName);
+        builder.field("script", script);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        URIBuilder uriBuilder = new URIBuilder("/" + indexName + "/_search");
+        if (Objects.nonNull(searchParams)) {
+            for (Map.Entry<String, Object> entry : searchParams.entrySet()) {
+                uriBuilder.addParameter(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        Request request = new Request("POST", uriBuilder.toString());
         request.setJsonEntity(builder.toString());
         return request;
     }


### PR DESCRIPTION
### Description
Include script_fields context to existing supported context for knn methods like script_score. script_fields can be used to retrieve painless scripting evaluation.

### Related Issues
#1878 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
