### PR TITLE
Refactor train index and create index from template APIs in JNI layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Clean up parsing for query [#1824](https://github.com/opensearch-project/k-NN/pull/1824)
 * Refactor engine package structure [#1913](https://github.com/opensearch-project/k-NN/pull/1913)
 * Refactor method structure and definitions [#1920](https://github.com/opensearch-project/k-NN/pull/1920)
+* Refactor train index and create index from template APIs in JNI layer [#1918](https://github.com/opensearch-project/k-NN/pull/1918)

--- a/jni/include/faiss_index_service.h
+++ b/jni/include/faiss_index_service.h
@@ -88,6 +88,29 @@ public:
         std::unordered_map<std::string, jobject> parameters,
         std::vector<uint8_t> templateIndexData);
 
+    /**
+     * Train index
+     *
+     * @param index faiss index
+     * @param n number of vectors
+     * @param x memory address which is holding vector data
+     */
+    virtual void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x);
+
+    /**
+     *
+     * @param jniUtil  jni util
+     * @param env jni environment
+     * @param metric space type for distance calculation
+     * @param indexDescription index description to be used by faiss index factory
+     * @param dimension dimension of vectors
+     * @param numVectors number of vectors
+     * @param trainingVectors memory address which is holding vector data
+     * @param parameters parameters to be applied to faiss index
+     * @return vector containing the trained index data
+     */
+    virtual std::vector<uint8_t> trainIndex(JNIUtilInterface* jniUtil, JNIEnv* env, faiss::MetricType metric, std::string& indexDescription, int dimension, int numVectors, float* trainingVectors, std::unordered_map<std::string, jobject>& parameters);
+
     virtual ~IndexService() = default;
 protected:
     std::unique_ptr<FaissMethods> faissMethods;
@@ -101,7 +124,7 @@ class BinaryIndexService : public IndexService {
 public:
     //TODO Remove dependency on JNIUtilInterface and JNIEnv
     //TODO Reduce the number of parameters
-    BinaryIndexService(std::unique_ptr<FaissMethods> faissMethods);
+    explicit BinaryIndexService(std::unique_ptr<FaissMethods> faissMethods);
 
     /**
      * Create binary index
@@ -118,7 +141,7 @@ public:
      * @param indexPath path to write index
      * @param parameters parameters to be applied to faiss index
      */
-    virtual void createIndex(
+    void createIndex(
         knn_jni::JNIUtilInterface * jniUtil,
         JNIEnv * env,
         faiss::MetricType metric,
@@ -145,7 +168,7 @@ public:
      * @param parameters parameters to be applied to faiss index
      * @param templateIndexData vector containing the template index data
      */
-    virtual void createIndexFromTemplate(
+    void createIndexFromTemplate(
         knn_jni::JNIUtilInterface * jniUtil,
         JNIEnv * env,
         int dim,
@@ -154,9 +177,34 @@ public:
         std::vector<int64_t> ids,
         std::string indexPath,
         std::unordered_map<std::string, jobject> parameters,
-        std::vector<uint8_t> templateIndexData);
+        std::vector<uint8_t> templateIndexData) override;
 
-    virtual ~BinaryIndexService() = default;
+    /**
+     * Train binary index
+     *
+     * @param index faiss index
+     * @param n number of vectors
+     * @param x memory address which is holding vector data
+     */
+    void InternalTrainIndex(faiss::IndexBinary * index, faiss::idx_t n, const float* x);
+
+ /**
+  * Train binary index
+  *
+  * @param jniUtil  jni util
+  * @param env jni environment
+  * @param metric space type for distance calculation
+  * @param indexDescription index description to be used by faiss index factory
+  * @param dimension dimension of vectors
+  * @param numVectors number of vectors
+  * @param trainingVectors memory address which is holding vector data
+  * @param parameters parameters to be applied to faiss index
+  * @return vector containing the trained index data
+  */
+    std::vector<uint8_t> trainIndex(JNIUtilInterface* jniUtil, JNIEnv* env, faiss::MetricType metric, std::string& indexDescription, int dimension, int numVectors, float* trainingVectors, std::unordered_map<std::string, jobject>& parameters) override;
+
+
+    ~BinaryIndexService() override = default;
 };
 
 }

--- a/jni/include/faiss_index_service.h
+++ b/jni/include/faiss_index_service.h
@@ -19,10 +19,12 @@
 #include "jni_util.h"
 #include "faiss_methods.h"
 #include <memory>
+#include <vector>
+#include <unordered_map>
+#include <string>
 
 namespace knn_jni {
 namespace faiss_wrapper {
-
 
 /**
  * A class to provide operations on index
@@ -61,13 +63,38 @@ public:
         std::vector<int64_t> ids,
         std::string indexPath,
         std::unordered_map<std::string, jobject> parameters);
+
+    /**
+     * Create index from template
+     *
+     * @param jniUtil jni util
+     * @param env jni environment
+     * @param dim dimension of vectors
+     * @param numIds number of vectors
+     * @param vectorsAddress memory address which is holding vector data
+     * @param ids a list of document ids for corresponding vectors
+     * @param indexPath path to write index
+     * @param parameters parameters to be applied to faiss index
+     * @param templateIndexData vector containing the template index data
+     */
+    virtual void createIndexFromTemplate(
+        knn_jni::JNIUtilInterface * jniUtil,
+        JNIEnv * env,
+        int dim,
+        int numIds,
+        int64_t vectorsAddress,
+        std::vector<int64_t> ids,
+        std::string indexPath,
+        std::unordered_map<std::string, jobject> parameters,
+        std::vector<uint8_t> templateIndexData);
+
     virtual ~IndexService() = default;
 protected:
     std::unique_ptr<FaissMethods> faissMethods;
 };
 
 /**
- * A class to provide operations on index
+ * A class to provide operations on binary index
  * This class should evolve to have only cpp object but not jni object
  */
 class BinaryIndexService : public IndexService {
@@ -75,6 +102,7 @@ public:
     //TODO Remove dependency on JNIUtilInterface and JNIEnv
     //TODO Reduce the number of parameters
     BinaryIndexService(std::unique_ptr<FaissMethods> faissMethods);
+
     /**
      * Create binary index
      *
@@ -103,11 +131,35 @@ public:
         std::string indexPath,
         std::unordered_map<std::string, jobject> parameters
     ) override;
+
+    /**
+     * Create binary index from template
+     *
+     * @param jniUtil jni util
+     * @param env jni environment
+     * @param dim dimension of vectors
+     * @param numIds number of vectors
+     * @param vectorsAddress memory address which is holding vector data
+     * @param ids a list of document ids for corresponding vectors
+     * @param indexPath path to write index
+     * @param parameters parameters to be applied to faiss index
+     * @param templateIndexData vector containing the template index data
+     */
+    virtual void createIndexFromTemplate(
+        knn_jni::JNIUtilInterface * jniUtil,
+        JNIEnv * env,
+        int dim,
+        int numIds,
+        int64_t vectorsAddress,
+        std::vector<int64_t> ids,
+        std::string indexPath,
+        std::unordered_map<std::string, jobject> parameters,
+        std::vector<uint8_t> templateIndexData);
+
     virtual ~BinaryIndexService() = default;
 };
 
 }
 }
-
 
 #endif //OPENSEARCH_KNN_FAISS_INDEX_SERVICE_H

--- a/jni/include/faiss_methods.h
+++ b/jni/include/faiss_methods.h
@@ -32,6 +32,8 @@ public:
     virtual faiss::IndexIDMapTemplate<faiss::IndexBinary>* indexBinaryIdMap(faiss::IndexBinary* index);
     virtual void writeIndex(const faiss::Index* idx, const char* fname);
     virtual void writeIndexBinary(const faiss::IndexBinary* idx, const char* fname);
+    virtual faiss::Index* readIndex(faiss::IOReader* f, int io_flags);
+    virtual faiss::IndexBinary* readIndexBinary(faiss::IOReader* f, int io_flags);
     virtual ~FaissMethods() = default;
 };
 

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -94,14 +94,7 @@ namespace knn_jni {
         //
         // Return the serialized representation
         jbyteArray TrainIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ, jint dimension,
-                              jlong trainVectorsPointerJ);
-
-        // Create an empty binary index defined by the values in the Java map, parametersJ. Train the index with
-        // the vector of floats located at trainVectorsPointerJ.
-        //
-        // Return the serialized representation
-        jbyteArray TrainBinaryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ, jint dimension,
-                         jlong trainVectorsPointerJ);
+                      jlong trainVectorsPointerJ, IndexService* indexService);
 
         /*
          * Perform a range search with filter against the index located in memory at indexPointerJ.

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -27,13 +27,7 @@ namespace knn_jni {
         // based off of the template index passed in. The index is serialized to indexPathJ.
         void CreateIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
                                      jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
-                                     jobject parametersJ);
-
-        // Create an index with ids and vectors. Instead of creating a new index, this function creates the index
-        // based off of the template index passed in. The index is serialized to indexPathJ.
-        void CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
-                                     jobject parametersJ);
+                                     jobject parametersJ, IndexService* indexService);
 
         // Load an index from indexPathJ into memory.
         //

--- a/jni/src/faiss_methods.cpp
+++ b/jni/src/faiss_methods.cpp
@@ -32,12 +32,15 @@ faiss::IndexIDMapTemplate<faiss::IndexBinary>* FaissMethods::indexBinaryIdMap(fa
 void FaissMethods::writeIndex(const faiss::Index* idx, const char* fname) {
     faiss::write_index(idx, fname);
 }
+
 void FaissMethods::writeIndexBinary(const faiss::IndexBinary* idx, const char* fname) {
     faiss::write_index_binary(idx, fname);
 }
+
 faiss::Index* FaissMethods::readIndex(faiss::IOReader* f, int io_flags) {
     return faiss::read_index(f, io_flags);
 }
+
 faiss::IndexBinary* FaissMethods::readIndexBinary(faiss::IOReader* f, int io_flags) {
     return faiss::read_index_binary(f, io_flags);
 }

--- a/jni/src/faiss_methods.cpp
+++ b/jni/src/faiss_methods.cpp
@@ -35,6 +35,11 @@ void FaissMethods::writeIndex(const faiss::Index* idx, const char* fname) {
 void FaissMethods::writeIndexBinary(const faiss::IndexBinary* idx, const char* fname) {
     faiss::write_index_binary(idx, fname);
 }
-
+faiss::Index* FaissMethods::readIndex(faiss::IOReader* f, int io_flags) {
+    return faiss::read_index(f, io_flags);
+}
+faiss::IndexBinary* FaissMethods::readIndexBinary(faiss::IOReader* f, int io_flags) {
+    return faiss::read_index_binary(f, io_flags);
+}
 } // namespace faiss_wrapper
 } // namesapce knn_jni

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -84,7 +84,9 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromT
                                                                                         jobject parametersJ)
 {
     try {
-        knn_jni::faiss_wrapper::CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ);
+        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+        knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
+        CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ, &indexService);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -99,7 +101,9 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryInde
                                                                                         jobject parametersJ)
 {
     try {
-        knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ);
+        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+        knn_jni::faiss_wrapper::BinaryIndexService binaryIndexService(std::move(faissMethods));
+        CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ, &binaryIndexService);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -86,7 +86,7 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromT
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
         knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
-        CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ, &indexService);
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ, &indexService);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -232,7 +232,9 @@ JNIEXPORT jbyteArray JNICALL Java_org_opensearch_knn_jni_FaissService_trainIndex
                                                                                  jlong trainVectorsPointerJ)
 {
     try {
-        return knn_jni::faiss_wrapper::TrainIndex(&jniUtil, env, parametersJ, dimensionJ, trainVectorsPointerJ);
+        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+        knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
+        return knn_jni::faiss_wrapper::TrainIndex(&jniUtil, env, parametersJ, dimensionJ, trainVectorsPointerJ, &indexService);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -245,7 +247,9 @@ JNIEXPORT jbyteArray JNICALL Java_org_opensearch_knn_jni_FaissService_trainBinar
                                                                                  jlong trainVectorsPointerJ)
 {
     try {
-        return knn_jni::faiss_wrapper::TrainBinaryIndex(&jniUtil, env, parametersJ, dimensionJ, trainVectorsPointerJ);
+        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+        knn_jni::faiss_wrapper::BinaryIndexService indexService(std::move(faissMethods));
+        return knn_jni::faiss_wrapper::TrainIndex(&jniUtil, env, parametersJ, dimensionJ, trainVectorsPointerJ, &indexService);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -703,12 +703,16 @@ TEST(FaissTrainIndexTest, BasicAssertions) {
     JNIEnv *jniEnv = nullptr;
     NiceMock<test_util::MockJNIUtil> mockJNIUtil;
 
+    // Create the index service
+    std::unique_ptr<FaissMethods> faissMethods(new FaissMethods());
+    IndexService indexService(std::move(faissMethods));
+
     // Perform training
     std::unique_ptr<std::vector<uint8_t>> trainedIndexSerialization(
             reinterpret_cast<std::vector<uint8_t> *>(
                     knn_jni::faiss_wrapper::TrainIndex(
                             &mockJNIUtil, jniEnv, (jobject) &parametersMap, dim,
-                            reinterpret_cast<jlong>(&trainingVectors))));
+                            reinterpret_cast<jlong>(&trainingVectors), &indexService)));
 
     std::unique_ptr<faiss::Index> trainedIndex(
             test_util::FaissLoadFromSerializedIndex(trainedIndexSerialization.get()));

--- a/jni/tests/mocks/faiss_index_service_mock.h
+++ b/jni/tests/mocks/faiss_index_service_mock.h
@@ -39,6 +39,22 @@ public:
             StringToJObjectMap parameters
         ),
         (override));
+
+    MOCK_METHOD(
+        void,
+        createIndexFromTemplate,
+        (
+            knn_jni::JNIUtilInterface * jniUtil,
+            JNIEnv * env,
+            int dim,
+            int numIds,
+            int64_t vectorsAddress,
+            std::vector<int64_t> ids,
+            std::string indexPath,
+            StringToJObjectMap parameters,
+            std::vector<uint8_t> templateIndexData
+        ),
+        (override));
 };
 
 #endif  // OPENSEARCH_KNN_FAISS_INDEX_SERVICE_MOCK_H

--- a/jni/tests/mocks/faiss_methods_mock.h
+++ b/jni/tests/mocks/faiss_methods_mock.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
+* SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
@@ -9,8 +9,8 @@
  * GitHub history for details.
  */
 
- #ifndef OPENSEARCH_KNN_FAISS_METHODS_MOCK_H
- #define OPENSEARCH_KNN_FAISS_METHODS_MOCK_H
+#ifndef OPENSEARCH_KNN_FAISS_METHODS_MOCK_H
+#define OPENSEARCH_KNN_FAISS_METHODS_MOCK_H
 
 #include "faiss_methods.h"
 #include <gmock/gmock.h>
@@ -23,6 +23,8 @@ public:
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::IndexBinary>*, indexBinaryIdMap, (faiss::IndexBinary* index), (override));
     MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, const char* fname), (override));
     MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, const char* fname), (override));
+    MOCK_METHOD(faiss::Index*, readIndex, (faiss::IOReader* f, int io_flags), (override));
+    MOCK_METHOD(faiss::IndexBinary*, readIndexBinary, (faiss::IOReader* f, int io_flags), (override));
 };
 
 #endif  // OPENSEARCH_KNN_FAISS_METHODS_MOCK_H

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1621,6 +1621,9 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         Response trainResponse = trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, modelDescription);
 
+        // sleep to allow training to complete
+        Thread.sleep(5 * 1000);
+
         assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
     }
 


### PR DESCRIPTION
### Description
Follow up from https://github.com/opensearch-project/k-NN/pull/1784, this PR refactors `CreateIndexFromTemplate ` and `TrainIndex` APIs within JNI layer.

* Moved faiss lib train related function calls to their respective service classes.
* Cleaned up and removed redundant code in faiss wrapper.

### Related Issues
Closes https://github.com/opensearch-project/k-NN/issues/1846

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
