### PR TITLE
Removed JDK 11 and 17 version from CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
   Build-k-NN-Linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Build and Test k-NN Plugin on Linux
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
   Build-k-NN-MacOS:
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 21 ]
 
     name: Build and Test k-NN Plugin on MacOS
     needs: Get-CI-Image-Tag
@@ -131,7 +131,7 @@ jobs:
   Build-k-NN-Windows:
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 21 ]
 
     name: Build and Test k-NN Plugin on Windows
     needs: Get-CI-Image-Tag

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -33,7 +33,7 @@ jobs:
   Restart-Upgrade-BWCTests-k-NN:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 21 ]
         os: [ubuntu-latest]
         bwc_version : [ "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0", "2.12.0", "2.13.0", "2.14.0", "2.15.0", "2.16.0-SNAPSHOT"]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
@@ -112,7 +112,7 @@ jobs:
   Rolling-Upgrade-BWCTests-k-NN:
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 21 ]
         os: [ubuntu-latest]
         bwc_version: [ "2.16.0-SNAPSHOT" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes 
 ### Infrastructure
+* Removed JDK 11 and 17 version from CI runs [#1921](https://github.com/opensearch-project/k-NN/pull/1921)
 ### Documentation
 ### Maintenance
 ### Refactoring


### PR DESCRIPTION
### Description
Removed JDK 11 and 17 version from CI runs as main branch is moved to higher versions of JDK. I didn't make changes in the target and source compatibility because there is some other issues I am seeing for micro-benchmarks module. Will try to resolve it and then raise another PR for the same.

### Related Issues
Ref: https://github.com/opensearch-project/k-NN/issues/1729

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
