### PR TITLE
Fix a flaky unit test:testMultiFieldsKnnIndex, which was failing due to inconsistent merge behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Fix a flaky unit test:testMultiFieldsKnnIndex, which was failing due to inconsistent merge behaviors [#1924](https://github.com/opensearch-project/k-NN/pull/1924)
 ### Refactoring
 * Introduce KNNVectorValues interface to iterate on different types of Vector values during indexing and search [#1897](https://github.com/opensearch-project/k-NN/pull/1897)
 * Clean up parsing for query [#1824](https://github.com/opensearch-project/k-NN/pull/1824)

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -137,20 +137,19 @@ public class KNNCodecTestCase extends KNNTestCase {
         Document doc = new Document();
         doc.add(vectorField);
         writer.addDocument(doc);
-        writer.close();
+        // ensuring the refresh happens, to create the segment and hnsw file
+        writer.flush();
 
         /**
          * Add doc with field "my_vector"
          */
-        IndexWriterConfig iwc1 = newIndexWriterConfig();
-        iwc1.setMergeScheduler(new SerialMergeScheduler());
-        iwc1.setCodec(ACTUAL_CODEC);
-        writer = new RandomIndexWriter(random(), dir, iwc1);
         float[] array1 = { 6.0f, 14.0f };
         VectorField vectorField1 = new VectorField("my_vector", array1, sampleFieldType);
         Document doc1 = new Document();
         doc1.add(vectorField1);
         writer.addDocument(doc1);
+        // ensuring the refresh happens, to create the segment and hnsw file
+        writer.flush();
         IndexReader reader = writer.getReader();
         writer.close();
         ResourceWatcherService resourceWatcherService = createDisabledResourceWatcherService();
@@ -158,7 +157,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
 
         // there should be 2 hnsw index files created. one for test_vector and one for my_vector
-        assertEquals(hnswfiles.size(), 2);
+        assertEquals(2, hnswfiles.size());
         assertEquals(hnswfiles.stream().filter(x -> x.contains("test_vector")).collect(Collectors.toList()).size(), 1);
         assertEquals(hnswfiles.stream().filter(x -> x.contains("my_vector")).collect(Collectors.toList()).size(), 1);
 


### PR DESCRIPTION
### Description
Fix a flaky unit test:testMultiFieldsKnnIndex, which was failing due to inconsistent merge behaviors

#### Validated by running a failing seed:
```
./gradlew ':test' --tests "org.opensearch.knn.index.codec.KNN990Codec.KNN990CodecTests.testMultiFieldsKnnIndex" -Dtests.seed=F72B6D8EB481B0BB
```

#### Old Logs:
The log shows that refresh and merges happening multiple times, resulting in 4 files, 2 from old segments and 2 files from new merged segment.

```
2> INFO: Using MemorySegmentIndexInput and native madvise support with Java 21 or later; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
  1> [2024-08-02T03:53:40,805][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Refresh operation complete in 60 ms
  1> [2024-08-02T03:53:40,926][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Refresh operation complete in 2 ms
  1> [2024-08-02T03:53:41,029][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Merge operation complete in 4 ms
  1> [2024-08-02T03:53:41,072][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Merge operation complete in 3 ms
  1> [2024-08-02T03:53:41,075][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Merge operation complete in 3 ms
  1> [_0.fdm, _0.fdt, _0.fdx, _0.fnm, _0.si, _0_2011_test_vector.hnsw, _0_Lucene90_0.dvd, _0_Lucene90_0.dvm, _2.fdm, _2.fdt, _2.fdx, _2.fnm, _2.si, _2_2011_my_vector.hnsw, _2_Lucene90_0.dvd, _2_Lucene90_0.dvm, _3.fdm, _3.fdt, _3.fdx, _3.fnm, _3.si, _3_2011_my_vector.hnsw, _3_2011_test_vector.hnsw, _3_Lucene90_0.dvd, _3_Lucene90_0.dvm, segments_3, write.lock]
```

#### Logs after fix
```
org.apache.lucene.store.MemorySegmentIndexInputProvider <init>
  2> INFO: Using MemorySegmentIndexInput and native madvise support with Java 21 or later; to disable start with -Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false
  1> [2024-08-02T03:59:26,262][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Refresh operation complete in 78 ms
  1> [2024-08-02T03:59:26,304][WARN ][o.o.k.i.c.K.KNN80DocValuesConsumer] [testMultiFieldsKnnIndex] Refresh operation complete in 2 ms
  1> [2024-08-02T03:59:26,788][INFO ][o.o.k.i.c.K.KNN990CodecTests] [testMultiFieldsKnnIndex] after test
  2> SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".

```


### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/1828

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
