### PR TITLE
Index Initialization Alloc Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add functionality to iteratively insert vectors into a faiss index to improve the memory footprint during indexing. [#1840](https://github.com/opensearch-project/k-NN/pull/1840)
 ### Bug Fixes
 * Corrected search logic for scenario with non-existent fields in filter [#1874](https://github.com/opensearch-project/k-NN/pull/1874)
+* Fixed and abstracted functionality for allocating index memory [#1933](https://github.com/opensearch-project/k-NN/pull/1933)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/jni/include/faiss_index_service.h
+++ b/jni/include/faiss_index_service.h
@@ -65,6 +65,7 @@ public:
     virtual void writeIndex(std::string indexPath, jlong idMapAddress);
     virtual ~IndexService() = default;
 protected:
+    virtual void allocIndex(faiss::Index * index, size_t dim, size_t numVectors);
     std::unique_ptr<FaissMethods> faissMethods;
 };
 
@@ -120,6 +121,8 @@ public:
      */
     virtual void writeIndex(std::string indexPath, jlong idMapAddress) override;
     virtual ~BinaryIndexService() = default;
+protected:
+    virtual void allocIndex(faiss::Index * index, size_t dim, size_t numVectors) override;
 };
 
 }

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 #include <memory>
 #include <type_traits>
-#include <iostream>
 
 namespace knn_jni {
 namespace faiss_wrapper {

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 #include <memory>
 #include <type_traits>
-#include <iostream>
 
 namespace knn_jni {
 namespace faiss_wrapper {
@@ -60,8 +59,8 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
-        if(auto * indexFlat = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
-            indexFlat->codes.reserve(dim * numVectors * 2);
+        if(auto * indexScalarQuantizer = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
+            indexScalarQuantizer->codes.reserve(dim * numVectors * 2);
         }
         return;
     }

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <memory>
 #include <type_traits>
+#include <iostream>
 
 namespace knn_jni {
 namespace faiss_wrapper {
@@ -59,15 +60,14 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
-        auto * indexFlatCodes = dynamic_cast<faiss::IndexFlat *>(indexHNSWSQ->storage);
-        indexFlatCodes->codes.reserve(dim * numVectors * 2);
+        if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSW->storage)) {
+            indexFlat->codes.reserve(dim * numVectors * 2);
+        }
         return;
     }
     if(auto * indexHNSW = dynamic_cast<faiss::IndexHNSW *>(index)) {
-        if(auto * indexFlatCodes = dynamic_cast<faiss::IndexFlatL2 *>(indexHNSW->storage)) {
-            indexFlatCodes->codes.reserve(dim * numVectors * 4);
-        } else if(auto * indexFlatCodes = dynamic_cast<faiss::IndexFlatIP *>(indexHNSW->storage)) {
-            indexFlatCodes->codes.reserve(dim * numVectors * 4);
+        if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSW->storage)) {
+            indexFlat->codes.reserve(dim * numVectors * 4);
         }
         return;
     }

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -57,6 +57,23 @@ void SetExtraParameters(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env,
 
 IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMethods(std::move(faissMethods)) {}
 
+void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
+    if(auto * indexHNSWFlat = dynamic_cast<faiss::IndexHNSWFlat *>(index)) {
+        auto * indexFlatCodes = dynamic_cast<faiss::IndexFlatCodes *>(indexHNSWFlat->storage);
+        indexFlatCodes->codes.reserve(dim * numVectors * 4);
+        return;
+    }
+    if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
+        auto * indexFlatCodes = dynamic_cast<faiss::IndexFlatCodes *>(indexHNSWSQ->storage);
+        indexFlatCodes->codes.reserve(dim * numVectors * 2);
+        return;
+    }
+    if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(index)) {
+        indexFlat->codes.reserve(dim * numVectors * 4);
+        return;
+    }
+}
+
 jlong IndexService::initIndex(
         knn_jni::JNIUtilInterface * jniUtil,
         JNIEnv * env,
@@ -83,36 +100,9 @@ jlong IndexService::initIndex(
         throw std::runtime_error("Index is not trained");
     }
 
-    // Add vectors
     std::unique_ptr<faiss::IndexIDMap> idMap (faissMethods->indexIdMap(indexWriter.get()));
 
-    /*
-     * NOTE: The process of memory allocation is currently only implemented for HNSW.
-     * This technique of checking the types of the index and subindices should be generalized into
-     * another function.
-     */
-
-    // Check to see if the current index is HNSW
-    faiss::IndexHNSWFlat * hnsw = dynamic_cast<faiss::IndexHNSWFlat *>(idMap->index);
-    if(hnsw != NULL) {
-        // Check to see if the HNSW storage is IndexFlat
-        faiss::IndexFlat * storage = dynamic_cast<faiss::IndexFlat *>(hnsw->storage);
-        if(storage != NULL) {
-            // Allocate enough memory for all of the vectors we plan on inserting
-            // We do this to avoid unnecessary memory allocations during insert
-            storage->codes.reserve(dim * numVectors * 4);
-        }
-    }
-    faiss::IndexHNSWSQ * hnswSq = dynamic_cast<faiss::IndexHNSWSQ *>(idMap->index);
-    if(hnswSq != NULL) {
-        // Check to see if the HNSW storage is IndexFlat
-        faiss::IndexFlat * storage = dynamic_cast<faiss::IndexFlat *>(hnswSq->storage);
-        if(storage != NULL) {
-            // Allocate enough memory for all of the vectors we plan on inserting
-            // We do this to avoid unnecessary memory allocations during insert
-            storage->codes.reserve(dim * numVectors * 2);
-        }
-    }
+    allocIndex(dynamic_cast<faiss::Index *>(idMap.get()), dim, numVectors);
     indexWriter.release();
     return reinterpret_cast<jlong>(idMap.release());
 }
@@ -168,6 +158,18 @@ void IndexService::writeIndex(
 
 BinaryIndexService::BinaryIndexService(std::unique_ptr<FaissMethods> faissMethods) : IndexService(std::move(faissMethods)) {}
 
+void BinaryIndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
+    if(auto * indexBinaryHNSW = dynamic_cast<faiss::IndexBinaryHNSW *>(index)) {
+        auto * indexBinaryFlat = dynamic_cast<faiss::IndexBinaryFlat *>(indexBinaryHNSW->storage);
+        indexBinaryFlat->xb.reserve(dim * numVectors / 8);
+        return;
+    }
+    if(auto * indexBinaryFlat = dynamic_cast<faiss::IndexBinaryFlat *>(index)) {
+        indexBinaryFlat->xb.reserve(dim * numVectors / 8);
+        return;
+    }
+}
+
 jlong BinaryIndexService::initIndex(
         knn_jni::JNIUtilInterface * jniUtil,
         JNIEnv * env,
@@ -194,27 +196,9 @@ jlong BinaryIndexService::initIndex(
         throw std::runtime_error("Index is not trained");
     }
 
-    // Add vectors
     std::unique_ptr<faiss::IndexBinaryIDMap> idMap(faissMethods->indexBinaryIdMap(indexWriter.get()));
 
-    /*
-     * NOTE: The process of memory allocation is currently only implemented for HNSW.
-     * This technique of checking the types of the index and subindices should be generalized into
-     * another function.
-     */
-
-    // Check to see if the current index is BinaryHNSW
-    faiss::IndexBinaryHNSW * hnsw = dynamic_cast<faiss::IndexBinaryHNSW *>(idMap->index);
-
-    if(hnsw != NULL) {
-        // Check to see if the HNSW storage is IndexBinaryFlat
-        faiss::IndexBinaryFlat * storage = dynamic_cast<faiss::IndexBinaryFlat *>(hnsw->storage);
-        if(storage != NULL) {
-            // Allocate enough memory for all of the vectors we plan on inserting
-            // We do this to avoid unnecessary memory allocations during insert
-            storage->xb.reserve(dim / 8 * numVectors);
-        }
-    }
+    allocIndex(dynamic_cast<faiss::Index *>(idMap.get()), dim, numVectors);
     indexWriter.release();
     return reinterpret_cast<jlong>(idMap.release());
 }

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -60,13 +60,13 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
         if(auto * indexScalarQuantizer = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
-            indexScalarQuantizer->codes.reserve(dim * numVectors * 2);
+            indexScalarQuantizer->codes.reserve(indexScalarQuantizer->code_size * numVectors);
         }
         return;
     }
     if(auto * indexHNSW = dynamic_cast<faiss::IndexHNSW *>(index)) {
         if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSW->storage)) {
-            indexFlat->codes.reserve(dim * numVectors * 4);
+            indexFlat->codes.reserve(indexFlat->code_size * numVectors);
         }
         return;
     }

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -60,7 +60,7 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
-        if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSW->storage)) {
+        if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSWSQ->storage)) {
             indexFlat->codes.reserve(dim * numVectors * 2);
         }
         return;

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -60,13 +60,11 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
-        std::cout << "HNSWSQ" << std::endl;
         auto * indexFlatCodes = dynamic_cast<faiss::IndexFlat *>(indexHNSWSQ->storage);
         indexFlatCodes->codes.reserve(dim * numVectors * 2);
         return;
     }
     if(auto * indexHNSW = dynamic_cast<faiss::IndexHNSW *>(index)) {
-        std::cout << "HNSWFlat" << std::endl;
         if(auto * indexFlatCodes = dynamic_cast<faiss::IndexFlatL2 *>(indexHNSW->storage)) {
             indexFlatCodes->codes.reserve(dim * numVectors * 4);
         } else if(auto * indexFlatCodes = dynamic_cast<faiss::IndexFlatIP *>(indexHNSW->storage)) {
@@ -74,7 +72,6 @@ void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVector
         }
         return;
     }
-    std::cout << "None" << std::endl;
 }
 
 jlong IndexService::initIndex(

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -60,8 +60,10 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
-        if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSWSQ->storage)) {
+        std::cout << "Allocating SQ index" << std::endl;
+        if(auto * indexFlat = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
             indexFlat->codes.reserve(dim * numVectors * 2);
+            std::cout << "Allocated SQ index" << std::endl;
         }
         return;
     }

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -163,10 +163,6 @@ void BinaryIndexService::allocIndex(faiss::Index * index, size_t dim, size_t num
         indexBinaryFlat->xb.reserve(dim * numVectors / 8);
         return;
     }
-    if(auto * indexBinaryFlat = dynamic_cast<faiss::IndexBinaryFlat *>(index)) {
-        indexBinaryFlat->xb.reserve(dim * numVectors / 8);
-        return;
-    }
 }
 
 jlong BinaryIndexService::initIndex(

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -60,10 +60,8 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> faissMethods) : faissMe
 
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if(auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
-        std::cout << "Allocating SQ index" << std::endl;
         if(auto * indexFlat = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
             indexFlat->codes.reserve(dim * numVectors * 2);
-            std::cout << "Allocated SQ index" << std::endl;
         }
         return;
     }


### PR DESCRIPTION
Previously, the iterative index insertion feature only allocated memory for HNSW indices. New functionality for other indices needs to be implemented.

### Description
This branch adds a method to allocate an index and adds logic for HNSWSQ indices. The following benchmark was run on a 4gb docker container for COHERE with 1m vectors on HNSWSQ.
![graph_default_osb_sqtest-15](https://github.com/user-attachments/assets/6b048bd1-3244-4486-8dc1-1afb3a68cde1)
|                                                         Metric |                 Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                                                 Min Throughput |   custom-vector-bulk |      754.72 | docs/s |
|                                                Mean Throughput |   custom-vector-bulk |     1420.79 | docs/s |
|                                              Median Throughput |   custom-vector-bulk |     1194.48 | docs/s |
|                                                 Max Throughput |   custom-vector-bulk |     3388.12 | docs/s |
|                                        50th percentile latency |   custom-vector-bulk |     221.291 |     ms |
|                                        90th percentile latency |   custom-vector-bulk |     470.813 |     ms |
|                                        99th percentile latency |   custom-vector-bulk |     23489.8 |     ms |
|                                      99.9th percentile latency |   custom-vector-bulk |     69936.4 |     ms |
|                                     99.99th percentile latency |   custom-vector-bulk |     83420.9 |     ms |
|                                       100th percentile latency |   custom-vector-bulk |      112154 |     ms |
|                                   50th percentile service time |   custom-vector-bulk |     221.291 |     ms |
|                                   90th percentile service time |   custom-vector-bulk |     470.813 |     ms |
|                                   99th percentile service time |   custom-vector-bulk |     23489.8 |     ms |
|                                 99.9th percentile service time |   custom-vector-bulk |     69936.4 |     ms |
|                                99.99th percentile service time |   custom-vector-bulk |     83420.9 |     ms |
|                                  100th percentile service time |   custom-vector-bulk |      112154 |     ms |
|                                                     error rate |   custom-vector-bulk |           0 |      % |
|                                                 Min Throughput | force-merge-segments |           0 |  ops/s |
|                                                Mean Throughput | force-merge-segments |           0 |  ops/s |
|                                              Median Throughput | force-merge-segments |           0 |  ops/s |
|                                                 Max Throughput | force-merge-segments |           0 |  ops/s |
|                                       100th percentile latency | force-merge-segments | 4.24338e+06 |     ms |
|                                  100th percentile service time | force-merge-segments | 4.24338e+06 |     ms |
|                                                     error rate | force-merge-segments |           0 |      % |
|                                                 Min Throughput |       warmup-indices |        0.26 |  ops/s |
|                                                Mean Throughput |       warmup-indices |        0.26 |  ops/s |
|                                              Median Throughput |       warmup-indices |        0.26 |  ops/s |
|                                                 Max Throughput |       warmup-indices |        0.26 |  ops/s |
|                                       100th percentile latency |       warmup-indices |     3912.27 |     ms |
|                                  100th percentile service time |       warmup-indices |     3912.27 |     ms |
|                                                     error rate |       warmup-indices |           0 |      % |
|                                                 Min Throughput |         prod-queries |       15.96 |  ops/s |
|                                                Mean Throughput |         prod-queries |      131.02 |  ops/s |
|                                              Median Throughput |         prod-queries |      138.18 |  ops/s |
|                                                 Max Throughput |         prod-queries |      144.59 |  ops/s |
|                                        50th percentile latency |         prod-queries |     4.74785 |     ms |
|                                        90th percentile latency |         prod-queries |     5.54795 |     ms |
|                                        99th percentile latency |         prod-queries |     6.62209 |     ms |
|                                      99.9th percentile latency |         prod-queries |     10.8428 |     ms |
|                                     99.99th percentile latency |         prod-queries |     20.4215 |     ms |
|                                       100th percentile latency |         prod-queries |     417.638 |     ms |
|                                   50th percentile service time |         prod-queries |     4.74785 |     ms |
|                                   90th percentile service time |         prod-queries |     5.54795 |     ms |
|                                   99th percentile service time |         prod-queries |     6.62209 |     ms |
|                                 99.9th percentile service time |         prod-queries |     10.8428 |     ms |
|                                99.99th percentile service time |         prod-queries |     20.4215 |     ms |
|                                  100th percentile service time |         prod-queries |     417.638 |     ms |
|                                                     error rate |         prod-queries |           0 |      % |
|                                                  Mean recall@k |         prod-queries |        0.91 |        |
|                                                  Mean recall@1 |         prod-queries |        0.98 |        |

### Related Issues
https://github.com/opensearch-project/k-NN/issues/1600

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
