### PR TITLE
Fix KNN module to avoid invalid characters to be included as a part of file name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Corrected search logic for scenario with non-existent fields in filter [#1874](https://github.com/opensearch-project/k-NN/pull/1874)
 * Add script_fields context to KNNAllowlist [#1917] (https://github.com/opensearch-project/k-NN/pull/1917)
+* Fix KNN module to avoid invalid characters to be included as a part of file name. [#1934] (https://github.com/opensearch-project/k-NN/pull/1934)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormat.java
@@ -6,12 +6,12 @@
 package org.opensearch.knn.index.codec.KNN80Codec;
 
 import org.apache.lucene.backward_codecs.lucene50.Lucene50CompoundFormat;
-import org.opensearch.knn.common.KNNConstants;
 import org.apache.lucene.codecs.CompoundDirectory;
 import org.apache.lucene.codecs.CompoundFormat;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
+import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
@@ -63,7 +63,7 @@ public class KNN80CompoundFormat extends CompoundFormat {
 
         if (!engineFiles.isEmpty()) {
             for (String engineFile : engineFiles) {
-                String engineCompoundFile = engineFile + KNNConstants.COMPOUND_EXTENSION;
+                String engineCompoundFile = KNNCodecUtil.buildCompoundFile(engineFile, true);
                 dir.copyFrom(dir, engineFile, engineCompoundFile, context);
             }
             segmentFiles.removeAll(engineFiles);

--- a/src/main/java/org/opensearch/knn/index/engine/NativeLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/engine/NativeLibrary.java
@@ -6,8 +6,8 @@
 package org.opensearch.knn.index.engine;
 
 import lombok.Getter;
-import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +46,7 @@ public abstract class NativeLibrary extends AbstractKNNLibrary {
 
     @Override
     public String getCompoundExtension() {
-        return getExtension() + KNNConstants.COMPOUND_EXTENSION;
+        return KNNCodecUtil.buildCompoundFile(getExtension(), true);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -33,6 +33,7 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
@@ -339,14 +340,9 @@ public class KNNWeight extends Weight {
 
     @VisibleForTesting
     List<String> getEngineFiles(SegmentReader reader, String extension) throws IOException {
-        /*
-         * In case of compound file, extension would be <engine-extension> + c otherwise <engine-extension>
-         */
-        String engineExtension = reader.getSegmentInfo().info.getUseCompoundFile()
-            ? extension + KNNConstants.COMPOUND_EXTENSION
-            : extension;
-        String engineSuffix = knnQuery.getField() + engineExtension;
-        String underLineEngineSuffix = "_" + engineSuffix;
+        final String engineExtension = KNNCodecUtil.buildCompoundFile(extension, reader.getSegmentInfo().info.getUseCompoundFile());
+        final String underLineEngineSuffix = KNNCodecUtil.buildEngineFileSuffix(knnQuery.getField(), engineExtension);
+
         List<String> engineFiles = reader.getSegmentInfo()
             .files()
             .stream()

--- a/src/test/java/org/opensearch/knn/index/codec/util/KNNCodecUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/util/KNNCodecUtilTests.java
@@ -52,4 +52,27 @@ public class KNNCodecUtilTests extends TestCase {
         assertEquals(dimension, pair.getDimension());
         assertEquals(SerializationMode.COLLECTIONS_OF_BYTES, pair.serializationMode);
     }
+
+    public void testBuildEngineFileSuffix() {
+        // With a normal field name.
+        assertEquals("_field_name_foo.ext", KNNCodecUtil.buildEngineFileSuffix("field_name_foo", ".ext"));
+
+        // When invalid characters for a filename are included in field name,
+        // we should make them escape with '.'.
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field\\name\\foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field/name/foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field*name*foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field?name?foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field\"name\"foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field<name<foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field>name>foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field|name|foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field name foo", ".ext"));
+        assertEquals("_field.name.foo.ext", KNNCodecUtil.buildEngineFileSuffix("field,name,foo", ".ext"));
+    }
+
+    public void testCompoundEngileFile() {
+        assertEquals("filename.extc", KNNCodecUtil.buildCompoundFile("filename.ext", true));
+        assertEquals("filename.ext", KNNCodecUtil.buildCompoundFile("filename.ext", false));
+    }
 }

--- a/src/test/java/org/opensearch/knn/integ/KNNIndexSnapshotWithFieldNameHavingBlankIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNIndexSnapshotWithFieldNameHavingBlankIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.junit.After;
+import org.junit.Assert;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.knn.KNNRestTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+@Log4j2
+@AllArgsConstructor
+public class KNNIndexSnapshotWithFieldNameHavingBlankIT extends KNNRestTestCase {
+    private static final String FIELD_NAME_HAVING_BLANK = "my vector";
+    private static final String REPO_NAME = "fieldWithBlankTestRepo-" + System.nanoTime();
+    private static final List<String> SNAPSHOTS = List.of("first", "second");
+    private static final String INDEX_NAME = "field-with-blank-test-index-" + System.nanoTime();
+    private static final int DIMENSION = 16;
+
+    @After
+    public void cleanUp() {
+        try {
+            deleteSnapshots();
+        } catch (Exception e) {
+            log.error(e);
+        }
+
+        try {
+            deleteRepo();
+        } catch (Exception e) {
+            log.error(e);
+        }
+
+        try {
+            deleteKNNIndex(INDEX_NAME);
+        } catch (Exception e) {
+            log.error(e);
+        }
+    }
+
+    @SneakyThrows
+    public void testSnapshotTwice() {
+        // Create a KNN index
+        final String indexMapping = createKnnIndexMapping(FIELD_NAME_HAVING_BLANK, DIMENSION);
+        createKnnIndex(INDEX_NAME, indexMapping);
+
+        // Add vectors
+        bulkIngestRandomVectors(INDEX_NAME, FIELD_NAME_HAVING_BLANK, 100, DIMENSION);
+
+        // Create repo
+        createRepo();
+
+        // Take the first snapshot
+        takeSnapshot(SNAPSHOTS.get(0));
+
+        // Take the second snapshot
+        takeSnapshot(SNAPSHOTS.get(1));
+    }
+
+    private static void createRepo() throws IOException {
+        final Request request = new Request("PUT", "_snapshot/" + REPO_NAME);
+        final String jsonBody = "{\n"
+            + "  \"type\": \"fs\",\n"
+            + "  \"settings\": {\n"
+            + "    \"compress\": true,\n"
+            + "    \"location\": \"testrepo-"
+            + System.nanoTime()
+            + "\"\n"
+            + "  }\n"
+            + "}\n";
+        request.setJsonEntity(jsonBody);
+        final Response response = client().performRequest(request);
+        Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    }
+
+    private static void takeSnapshot(final String snapshotName) throws IOException {
+        final Request request = new Request("PUT", "_snapshot/" + REPO_NAME + "/" + snapshotName);
+        final Response response = client().performRequest(request);
+        Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
+    }
+
+    private void deleteSnapshots() {
+        for (String snapshot : SNAPSHOTS) {
+            try {
+                final Request request = new Request("DELETE", "_snapshot/" + REPO_NAME + "/" + snapshot);
+                final Response response = client().performRequest(request);
+                assertEquals(
+                    request.getEndpoint() + ": failed",
+                    RestStatus.OK,
+                    RestStatus.fromCode(response.getStatusLine().getStatusCode())
+                );
+            } catch (Exception e) {
+                log.error(e);
+            }
+        }
+    }
+
+    private void deleteRepo() throws IOException {
+        final Request request = new Request("DELETE", "_snapshot/" + REPO_NAME);
+        final Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+}


### PR DESCRIPTION
### Description
Issue : https://github.com/opensearch-project/k-NN/issues/1859.

#### Issue
While OpenSearch does allow for a field name to have an empty space within it and it disallows an empty space to be contained in a physical file name, [KNNCodecUtil::buildEngineFileName](https://github.com/opensearch-project/k-NN/blob/a16b8aa965f66268799c001756c78174c7baba19/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java#L106C26-L106C45) uses the field name as a part of a vector file name directly without any proper adjustment to be made. As a result, if the field name does not meet the valid criteria, it can fail due to failing the validation in [BlobStoreIndexShardSnapshot](https://github.com/opensearch-project/OpenSearch/blob/7cbff4f9fd8ae53b1672aa8e2582e23bb2c16def/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java). For example, _0_2011_my vector.hnswc ('my vector' is the field name). As a result, [BlobStoreIndexShardSnapshot](https://github.com/opensearch-project/OpenSearch/blob/7cbff4f9fd8ae53b1672aa8e2582e23bb2c16def/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java#L343) throws an exception complaining file name is not valid.

#### Solution
In KNNCodecUtil, we need to add a method to escape invalid characters in the field name when creating file name.
In this solution proposal, I'm suggesting to escape it to '.'. For example, `_0_2011_my vector.hnswc` → `_0_2011_my.vector.hnswc`.

Field name does not have "." inside, as it indicates more than one field name if the dot presents. 
For example, `a.b.c` indicates three fields with `a`, `b` and `c`.


AS-IS:
```
public static String buildEngineFileSuffix(String fieldName, String extension) {
    return String.format("_%s%s", fieldName, extension);
}
```

TO-BE:

```
public static String buildEngineFileSuffix(String fieldName, String extension) {
    return String.format("_%s%s", escapeSpaceInFieldName(fieldName), extension);
}

private static String escapeSpaceInFieldName(String fieldName) {
    char[] characters = fieldName.toCharArray();
    for (int i = 0 ; i < characters.length ; ++i) {
        if (Strings.INVALID_FILENAME_CHARS.contains(characters[i])) {
            characters[i] = '.';  // Overwrite with an escaping character.
        }
    }
    return new String(characters);
}
```

### Related Issues
Issue : https://github.com/opensearch-project/k-NN/issues/1859.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
