### PR TITLE
Integrate Lucene Vector field with native engines to use KNNVectorFormat during segment creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Corrected search logic for scenario with non-existent fields in filter [#1874](https://github.com/opensearch-project/k-NN/pull/1874)
 * Add script_fields context to KNNAllowlist [#1917] (https://github.com/opensearch-project/k-NN/pull/1917)
 * Fix graph merge stats size calculation [#1844](https://github.com/opensearch-project/k-NN/pull/1844)
+* Integrate Lucene Vector field with native engines to use KNNVectorFormat during segment creation [#1945](https://github.com/opensearch-project/k-NN/pull/1945)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -82,6 +82,12 @@ public class KNNSettings {
     public static final String MODEL_CACHE_SIZE_LIMIT = "knn.model.cache.size.limit";
     public static final String ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD = "index.knn.advanced.filtered_exact_search_threshold";
     public static final String KNN_FAISS_AVX2_DISABLED = "knn.faiss.avx2.disabled";
+    /**
+     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
+     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
+     * for native engines.
+     */
+    public static final String KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED = "knn.use.format.enabled";
 
     /**
      * Default setting values
@@ -256,6 +262,17 @@ public class KNNSettings {
     );
 
     /**
+     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
+     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
+     * for native engines.
+     */
+    public static final Setting<Boolean> KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING = Setting.boolSetting(
+        KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED,
+        false,
+        NodeScope
+    );
+
+    /**
      * Dynamic settings
      */
     public static Map<String, Setting<?>> dynamicCacheSettings = new HashMap<String, Setting<?>>() {
@@ -379,6 +396,10 @@ public class KNNSettings {
             return KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING;
         }
 
+        if (KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED.equals(key)) {
+            return KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING;
+        }
+
         throw new IllegalArgumentException("Cannot find setting by key [" + key + "]");
     }
 
@@ -397,7 +418,8 @@ public class KNNSettings {
             MODEL_CACHE_SIZE_LIMIT_SETTING,
             ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_SETTING,
             KNN_FAISS_AVX2_DISABLED_SETTING,
-            KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING
+            KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING,
+            KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING
         );
         return Stream.concat(settings.stream(), Stream.concat(getFeatureFlags().stream(), dynamicCacheSettings.values().stream()))
             .collect(Collectors.toList());
@@ -441,6 +463,15 @@ public class KNNSettings {
             .index(indexName)
             .getSettings()
             .getAsInt(ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_DEFAULT_VALUE);
+    }
+
+    /**
+     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
+     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
+     * for native engines.
+     */
+    public static boolean getIsLuceneVectorFormatEnabled() {
+        return KNNSettings.state().getSettingValue(KNNSettings.KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED);
     }
 
     public void initialize(Client client, ClusterService clusterService) {

--- a/src/main/java/org/opensearch/knn/index/mapper/FlatVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FlatVectorFieldMapper.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
 import org.opensearch.Version;
 import org.opensearch.common.Explicit;
 import org.opensearch.knn.index.VectorDataType;
@@ -57,8 +58,11 @@ public class FlatVectorFieldMapper extends KNNVectorFieldMapper {
         Version indexCreatedVersion
     ) {
         super(simpleName, mappedFieldType, multiFields, copyTo, ignoreMalformed, stored, hasDocValues, indexCreatedVersion, null);
+        // setting it explicitly false here to ensure that when flatmapper is used Lucene based Vector field is not created.
+        this.useLuceneBasedVectorField = false;
         this.perDimensionValidator = selectPerDimensionValidator(vectorDataType);
         this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
+        this.fieldType.setDocValuesType(DocValuesType.BINARY);
         this.fieldType.freeze();
     }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -238,6 +238,22 @@ public class KNNVectorFieldMapperUtil {
         }
     }
 
+    /**
+     * Prerequisite: Index should a knn index which is validated via index settings index.knn setting. This function
+     * assumes that caller has already validated that index is a KNN index.
+     * We will use LuceneKNNVectorsFormat when these below condition satisfy:
+     * <ol>
+     *  <li>Index is created with Version of opensearch >= 2.17</li>
+     *  <li>Cluster setting is enabled to use Lucene KNNVectors format. This condition is temporary condition and will be
+     * removed before release.</li>
+     * </ol>
+     * @param indexCreatedVersion {@link Version}
+     * @return true if vector field should use KNNVectorsFormat
+     */
+    static boolean useLuceneKNNVectorsFormat(final Version indexCreatedVersion) {
+        return indexCreatedVersion.onOrAfter(Version.V_2_17_0) && KNNSettings.getIsLuceneVectorFormatEnabled();
+    }
+
     private static SpaceType getSpaceType(final Settings indexSettings, final VectorDataType vectorDataType) {
         String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
         if (spaceType == null) {

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -17,7 +17,7 @@ import lombok.NonNull;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
-import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.Version;
 import org.opensearch.common.Explicit;
@@ -112,9 +112,9 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
     }
 
     @Override
-    protected List<Field> getFieldsForFloatVector(final float[] array, final FieldType fieldType) {
+    protected List<Field> getFieldsForFloatVector(final float[] array) {
         final List<Field> fieldsToBeAdded = new ArrayList<>();
-        fieldsToBeAdded.add(new KnnVectorField(name(), array, fieldType));
+        fieldsToBeAdded.add(new KnnFloatVectorField(name(), array, fieldType));
 
         if (hasDocValues && vectorFieldType != null) {
             fieldsToBeAdded.add(new VectorField(name(), array, vectorFieldType));
@@ -127,7 +127,7 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
     }
 
     @Override
-    protected List<Field> getFieldsForByteVector(final byte[] array, final FieldType fieldType) {
+    protected List<Field> getFieldsForByteVector(final byte[] array) {
         final List<Field> fieldsToBeAdded = new ArrayList<>();
         fieldsToBeAdded.add(new KnnByteVectorField(name(), array, fieldType));
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -8,7 +8,9 @@ package org.opensearch.knn.index.codec;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
@@ -89,8 +91,6 @@ import static org.opensearch.knn.index.KNNSettings.MODEL_CACHE_SIZE_LIMIT_SETTIN
  * Test used for testing Codecs
  */
 public class KNNCodecTestCase extends KNNTestCase {
-
-    private static final Codec ACTUAL_CODEC = KNNCodecVersion.current().getDefaultKnnCodecSupplier().get();
     private static final FieldType sampleFieldType;
     static {
         KNNMethodContext knnMethodContext = new KNNMethodContext(
@@ -109,6 +109,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         }
 
         sampleFieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
+        sampleFieldType.setDocValuesType(DocValuesType.BINARY);
         sampleFieldType.putAttribute(KNNVectorFieldMapper.KNN_FIELD, "true");
         sampleFieldType.putAttribute(KNNConstants.KNN_ENGINE, knnMethodContext.getKnnEngine().getName());
         sampleFieldType.putAttribute(KNNConstants.SPACE_TYPE, knnMethodContext.getSpaceType().getValue());
@@ -259,6 +260,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         iwc.setCodec(codec);
 
         FieldType fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
+        fieldType.setDocValuesType(DocValuesType.BINARY);
         fieldType.putAttribute(KNNConstants.MODEL_ID, modelId);
         fieldType.freeze();
 
@@ -356,9 +358,9 @@ public class KNNCodecTestCase extends KNNTestCase {
         /**
          * Add doc with field "test_vector_one"
          */
-        final FieldType luceneFieldType = KnnVectorField.createFieldType(3, VectorSimilarityFunction.EUCLIDEAN);
+        final FieldType luceneFieldType = KnnFloatVectorField.createFieldType(3, VectorSimilarityFunction.EUCLIDEAN);
         float[] array = { 1.0f, 3.0f, 4.0f };
-        KnnVectorField vectorField = new KnnVectorField(FIELD_NAME_ONE, array, luceneFieldType);
+        KnnFloatVectorField vectorField = new KnnFloatVectorField(FIELD_NAME_ONE, array, luceneFieldType);
         RandomIndexWriter writer = new RandomIndexWriter(random(), dir, iwc);
         Document doc = new Document();
         doc.add(vectorField);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -13,8 +13,13 @@ package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
+import org.junit.Assert;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
@@ -103,6 +108,23 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
         validateValidateVectorDataType(KNNEngine.FAISS, KNNConstants.METHOD_HNSW, VectorDataType.FLOAT, null);
         validateValidateVectorDataType(KNNEngine.LUCENE, KNNConstants.METHOD_HNSW, VectorDataType.FLOAT, null);
         validateValidateVectorDataType(KNNEngine.NMSLIB, KNNConstants.METHOD_HNSW, VectorDataType.FLOAT, null);
+    }
+
+    public void testUseLuceneKNNVectorsFormat_withDifferentInputs_thenSuccess() {
+        final KNNSettings knnSettings = mock(KNNSettings.class);
+        final MockedStatic<KNNSettings> mockedStatic = Mockito.mockStatic(KNNSettings.class);
+        mockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
+
+        mockedStatic.when(KNNSettings::getIsLuceneVectorFormatEnabled).thenReturn(false);
+        Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_16_0));
+        Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_3_0_0));
+
+        mockedStatic.when(KNNSettings::getIsLuceneVectorFormatEnabled).thenReturn(true);
+        Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_17_0));
+        Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_3_0_0));
+        // making sure to close the static mock to ensure that for tests running on this thread are not impacted by
+        // this mocking
+        mockedStatic.close();
     }
 
     private void validateValidateVectorDataType(


### PR DESCRIPTION
### Description
Integrate Lucene Vector field with native engines, to use KNNVectorFormat during segment creation

### What has changed and why:
1. With this change I added the capability to use Lucene based vector field to for native engines. This feature is currently added behind a cluster setting to ensure that 2.x and main branch builds don't break. Once the code for adding the vector data structures is added for new KNNVectorsFormat this setting will be removed and new ITs will also be added.
2. There is a loose attribute with name isIndexKNN added which will be refactored once this PR https://github.com/opensearch-project/k-NN/pull/1939 is merged with FlatVectorsMapper class.
3. If `index.knn` is false then we will use DocValuesBased Vector Field. Because if we use the Lucene based vector field then KNNCodec will not be triggered and default KNNFormat will be used which will create the HNSW graph as that is what default behavior of Lucene library. This is the reason why indexKNN check is added while deciding which VectorField to use.


### Related Issues
https://github.com/opensearch-project/k-NN/issues/1853

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
