### PR TITLE
Integrate KNNVectorValues with vector ANN Search flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.16...2.x)
 ### Features
+* Integrate Lucene Vector field with native engines to use KNNVectorFormat during segment creation [#1945](https://github.com/opensearch-project/k-NN/pull/1945)
 ### Enhancements
 ### Bug Fixes
 * Corrected search logic for scenario with non-existent fields in filter [#1874](https://github.com/opensearch-project/k-NN/pull/1874)
 * Add script_fields context to KNNAllowlist [#1917] (https://github.com/opensearch-project/k-NN/pull/1917)
-* Fix graph merge stats size calculation [#1844](https://github.com/opensearch-project/k-NN/pull/1844)
-* Integrate Lucene Vector field with native engines to use KNNVectorFormat during segment creation [#1945](https://github.com/opensearch-project/k-NN/pull/1945)
-* Disallow a vector field to have an invalid character for a physical file name. [#1936] (https://github.com/opensearch-project/k-NN/pull/1936)
+* Fix graph merge stats size calculation [#1844](https://github.com/opensearch-project/k-NN/pull/1844) 
+* Disallow a vector field to have an invalid character for a physical file name. [#1936](https://github.com/opensearch-project/k-NN/pull/1936)
 ### Infrastructure
 ### Documentation
 ### Maintenance
 * Fix a flaky unit test:testMultiFieldsKnnIndex, which was failing due to inconsistent merge behaviors [#1924](https://github.com/opensearch-project/k-NN/pull/1924)
 ### Refactoring
 * Introduce KNNVectorValues interface to iterate on different types of Vector values during indexing and search [#1897](https://github.com/opensearch-project/k-NN/pull/1897)
+* Integrate KNNVectorValues with vector ANN Search flow [#1952](https://github.com/opensearch-project/k-NN/pull/1952)
 * Clean up parsing for query [#1824](https://github.com/opensearch-project/k-NN/pull/1824)
 * Refactor engine package structure [#1913](https://github.com/opensearch-project/k-NN/pull/1913)
 * Refactor method structure and definitions [#1920](https://github.com/opensearch-project/k-NN/pull/1920)

--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common;
+
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang.StringUtils;
+import org.apache.lucene.index.FieldInfo;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelUtil;
+
+/**
+ * A utility class to extract information from FieldInfo.
+ */
+@UtilityClass
+public class FieldInfoExtractor {
+
+    /**
+     * Extract vector data type from fieldInfo
+     * @param fieldInfo {@link FieldInfo}
+     * @return {@link VectorDataType}
+     */
+    public static VectorDataType extractVectorDataType(final FieldInfo fieldInfo) {
+        String vectorDataTypeString = fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD);
+        if (StringUtils.isEmpty(vectorDataTypeString)) {
+            final ModelMetadata modelMetadata = ModelUtil.getModelMetadata(fieldInfo.getAttribute(KNNConstants.MODEL_ID));
+            if (modelMetadata != null) {
+                VectorDataType vectorDataType = modelMetadata.getVectorDataType();
+                vectorDataTypeString = vectorDataType == null ? null : vectorDataType.getValue();
+            }
+        }
+        return StringUtils.isNotEmpty(vectorDataTypeString) ? VectorDataType.get(vectorDataTypeString) : VectorDataType.DEFAULT;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -8,8 +8,6 @@ package org.opensearch.knn.index.query;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
-import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
@@ -43,6 +41,10 @@ import org.opensearch.knn.index.query.filtered.KNNIterator;
 import org.opensearch.knn.index.query.filtered.NestedFilteredIdsKNNByteIterator;
 import org.opensearch.knn.index.query.filtered.NestedFilteredIdsKNNIterator;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
@@ -412,25 +414,31 @@ public class KNNWeight extends Weight {
     private KNNIterator getFilteredKNNIterator(final LeafReaderContext leafReaderContext, final BitSet filterIdsBitSet) throws IOException {
         final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
         final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
-        final BinaryDocValues values = DocValues.getBinary(leafReaderContext.reader(), fieldInfo.getName());
         final SpaceType spaceType = getSpaceType(fieldInfo);
         if (VectorDataType.BINARY == knnQuery.getVectorDataType()) {
+            final KNNVectorValues<byte[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, leafReaderContext.reader());
             return knnQuery.getParentsFilter() == null
-                ? new FilteredIdsKNNByteIterator(filterIdsBitSet, knnQuery.getByteQueryVector(), values, spaceType)
+                ? new FilteredIdsKNNByteIterator(
+                    filterIdsBitSet,
+                    knnQuery.getByteQueryVector(),
+                    (KNNBinaryVectorValues) vectorValues,
+                    spaceType
+                )
                 : new NestedFilteredIdsKNNByteIterator(
                     filterIdsBitSet,
                     knnQuery.getByteQueryVector(),
-                    values,
+                    (KNNBinaryVectorValues) vectorValues,
                     spaceType,
                     knnQuery.getParentsFilter().getBitSet(leafReaderContext)
                 );
         } else {
+            final KNNVectorValues<float[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, leafReaderContext.reader());
             return knnQuery.getParentsFilter() == null
-                ? new FilteredIdsKNNIterator(filterIdsBitSet, knnQuery.getQueryVector(), values, spaceType)
+                ? new FilteredIdsKNNIterator(filterIdsBitSet, knnQuery.getQueryVector(), (KNNFloatVectorValues) vectorValues, spaceType)
                 : new NestedFilteredIdsKNNIterator(
                     filterIdsBitSet,
                     knnQuery.getQueryVector(),
-                    values,
+                    (KNNFloatVectorValues) vectorValues,
                     spaceType,
                     knnQuery.getParentsFilter().getBitSet(leafReaderContext)
                 );

--- a/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNByteIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNByteIterator.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.knn.index.query.filtered;
 
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BitSet;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
 
 import java.io.IOException;
 
@@ -22,11 +22,11 @@ public class NestedFilteredIdsKNNByteIterator extends FilteredIdsKNNByteIterator
     public NestedFilteredIdsKNNByteIterator(
         final BitSet filterIdsArray,
         final byte[] queryVector,
-        final BinaryDocValues values,
+        final KNNBinaryVectorValues binaryVectorValues,
         final SpaceType spaceType,
         final BitSet parentBitSet
     ) {
-        super(filterIdsArray, queryVector, values, spaceType);
+        super(filterIdsArray, queryVector, binaryVectorValues, spaceType);
         this.parentBitSet = parentBitSet;
     }
 
@@ -47,7 +47,7 @@ public class NestedFilteredIdsKNNByteIterator extends FilteredIdsKNNByteIterator
         int bestChild = -1;
 
         while (docId != DocIdSetIterator.NO_MORE_DOCS && docId < currentParent) {
-            binaryDocValues.advance(docId);
+            binaryVectorValues.advance(docId);
             float score = computeScore();
             if (score > currentScore) {
                 bestChild = docId;

--- a/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIterator.java
@@ -5,10 +5,10 @@
 
 package org.opensearch.knn.index.query.filtered;
 
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BitSet;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
 
 import java.io.IOException;
 
@@ -22,11 +22,11 @@ public class NestedFilteredIdsKNNIterator extends FilteredIdsKNNIterator {
     public NestedFilteredIdsKNNIterator(
         final BitSet filterIdsArray,
         final float[] queryVector,
-        final BinaryDocValues values,
+        final KNNFloatVectorValues knnFloatVectorValues,
         final SpaceType spaceType,
         final BitSet parentBitSet
     ) {
-        super(filterIdsArray, queryVector, values, spaceType);
+        super(filterIdsArray, queryVector, knnFloatVectorValues, spaceType);
         this.parentBitSet = parentBitSet;
     }
 
@@ -47,7 +47,7 @@ public class NestedFilteredIdsKNNIterator extends FilteredIdsKNNIterator {
         int bestChild = -1;
 
         while (docId != DocIdSetIterator.NO_MORE_DOCS && docId < currentParent) {
-            binaryDocValues.advance(docId);
+            knnFloatVectorValues.advance(docId);
             float score = computeScore();
             if (score > currentScore) {
                 bestChild = docId;

--- a/src/main/java/org/opensearch/knn/indices/ModelUtil.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelUtil.java
@@ -11,6 +11,10 @@
 
 package org.opensearch.knn.indices;
 
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Locale;
+
 /**
  * A utility class for models.
  */
@@ -31,6 +35,23 @@ public class ModelUtil {
             return false;
         }
         return modelMetadata.getState().equals(ModelState.CREATED);
+    }
+
+    /**
+     * Gets Model Metadata from a given model id.
+     * @param modelId {@link String}
+     * @return {@link ModelMetadata}
+     */
+    public static ModelMetadata getModelMetadata(final String modelId) {
+        if (StringUtils.isEmpty(modelId)) {
+            return null;
+        }
+        final Model model = ModelCache.getInstance().get(modelId);
+        final ModelMetadata modelMetadata = model.getModelMetadata();
+        if (ModelUtil.isModelCreated(modelMetadata) == false) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Model ID '%s' is not created.", modelId));
+        }
+        return modelMetadata;
     }
 
 }

--- a/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
+++ b/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common;
+
+import org.apache.lucene.index.FieldInfo;
+import org.junit.Assert;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelUtil;
+
+public class FieldInfoExtractorTests extends KNNTestCase {
+
+    private static final String MODEL_ID = "model_id";
+
+    public void testExtractVectorDataType_whenDifferentConditions_thenSuccess() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        MockedStatic<ModelUtil> modelUtilMockedStatic = Mockito.mockStatic(ModelUtil.class);
+
+        // default case
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(null);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.MODEL_ID)).thenReturn(MODEL_ID);
+        modelUtilMockedStatic.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(null);
+        Assert.assertEquals(VectorDataType.DEFAULT, FieldInfoExtractor.extractVectorDataType(fieldInfo));
+
+        // VectorDataType present in fieldInfo
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
+        Assert.assertEquals(VectorDataType.BINARY, FieldInfoExtractor.extractVectorDataType(fieldInfo));
+
+        // VectorDataType present in ModelMetadata
+        ModelMetadata modelMetadata = Mockito.mock(ModelMetadata.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(null);
+        modelUtilMockedStatic.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(modelMetadata);
+        Mockito.when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.BYTE);
+        Assert.assertEquals(VectorDataType.BYTE, FieldInfoExtractor.extractVectorDataType(fieldInfo));
+
+        modelUtilMockedStatic.close();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNByteIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNByteIteratorTests.java
@@ -7,11 +7,10 @@ package org.opensearch.knn.index.query.filtered;
 
 import junit.framework.TestCase;
 import lombok.SneakyThrows;
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,9 +30,8 @@ public class FilteredIdsKNNByteIteratorTests extends TestCase {
             .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
             .collect(Collectors.toList());
 
-        BinaryDocValues values = mock(BinaryDocValues.class);
-        final List<BytesRef> byteRefs = dataVectors.stream().map(vector -> new BytesRef(vector)).collect(Collectors.toList());
-        when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
+        KNNBinaryVectorValues values = mock(KNNBinaryVectorValues.class);
+        when(values.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
 
         FixedBitSet filterBitSet = new FixedBitSet(4);
         for (int id : filterIds) {

--- a/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/FilteredIdsKNNIteratorTests.java
@@ -6,13 +6,11 @@
 package org.opensearch.knn.index.query.filtered;
 
 import lombok.SneakyThrows;
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.codec.util.KNNVectorAsArraySerializer;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,11 +34,8 @@ public class FilteredIdsKNNIteratorTests extends KNNTestCase {
             .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
             .collect(Collectors.toList());
 
-        BinaryDocValues values = mock(BinaryDocValues.class);
-        final List<BytesRef> byteRefs = dataVectors.stream()
-            .map(vector -> new BytesRef(new KNNVectorAsArraySerializer().floatToByteArray(vector)))
-            .collect(Collectors.toList());
-        when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
+        KNNFloatVectorValues values = mock(KNNFloatVectorValues.class);
+        when(values.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
 
         FixedBitSet filterBitSet = new FixedBitSet(4);
         for (int id : filterIds) {

--- a/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNByteIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNByteIteratorTests.java
@@ -7,12 +7,11 @@ package org.opensearch.knn.index.query.filtered;
 
 import junit.framework.TestCase;
 import lombok.SneakyThrows;
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BitSet;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,9 +35,8 @@ public class NestedFilteredIdsKNNByteIteratorTests extends TestCase {
             .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
             .collect(Collectors.toList());
 
-        BinaryDocValues values = mock(BinaryDocValues.class);
-        final List<BytesRef> byteRefs = dataVectors.stream().map(vector -> new BytesRef(vector)).collect(Collectors.toList());
-        when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
+        KNNBinaryVectorValues values = mock(KNNBinaryVectorValues.class);
+        when(values.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
 
         FixedBitSet filterBitSet = new FixedBitSet(4);
         for (int id : filterIds) {

--- a/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIteratorTests.java
@@ -7,13 +7,11 @@ package org.opensearch.knn.index.query.filtered;
 
 import junit.framework.TestCase;
 import lombok.SneakyThrows;
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BitSet;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.codec.util.KNNVectorAsArraySerializer;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,11 +39,12 @@ public class NestedFilteredIdsKNNIteratorTests extends TestCase {
             .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
             .collect(Collectors.toList());
 
-        BinaryDocValues values = mock(BinaryDocValues.class);
-        final List<BytesRef> byteRefs = dataVectors.stream()
-            .map(vector -> new BytesRef(new KNNVectorAsArraySerializer().floatToByteArray(vector)))
-            .collect(Collectors.toList());
-        when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
+        KNNFloatVectorValues values = mock(KNNFloatVectorValues.class);
+        when(values.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
+        // final List<BytesRef> byteRefs = dataVectors.stream()
+        // .map(vector -> new BytesRef(new KNNVectorAsArraySerializer().floatToByteArray(vector)))
+        // .collect(Collectors.toList());
+        // when(values.binaryValue()).thenReturn(byteRefs.get(0), byteRefs.get(1), byteRefs.get(2));
 
         FixedBitSet filterBitSet = new FixedBitSet(4);
         for (int id : filterIds) {

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesFactoryTests.java
@@ -5,12 +5,19 @@
 
 package org.opensearch.knn.index.vectorvalues;
 
+import lombok.SneakyThrows;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.VectorEncoding;
 import org.junit.Assert;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.VectorDataType;
 
+import java.util.List;
 import java.util.Map;
 
 public class KNNVectorValuesFactoryTests extends KNNTestCase {
@@ -56,6 +63,90 @@ public class KNNVectorValuesFactoryTests extends KNNTestCase {
             byteVectorMap
         );
         Assert.assertNotNull(binaryVectorValues);
+    }
+
+    @SneakyThrows
+    public void testGetVectorValuesFromFieldInfo_whenVectorDimIsNotZero_thenSuccess() {
+        final List<byte[]> byteArrayList = List.of(new byte[] { 1, 2, 3 });
+        final List<float[]> floatArrayList = List.of(new float[] { 1.3f, 2.2f, 3.2f });
+        final List<byte[]> binaryArrayList = List.of(new byte[] { 3, 2, 3 });
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        final SegmentReader reader = Mockito.mock(SegmentReader.class);
+        Mockito.when(fieldInfo.hasVectorValues()).thenReturn(true);
+        Mockito.when(fieldInfo.getName()).thenReturn("test_field");
+
+        // Checking for ByteVectorValues
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BYTE.getValue());
+        Mockito.when(reader.getByteVectorValues("test_field")).thenReturn(new TestVectorValues.PreDefinedByteVectorValues(byteArrayList));
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        byteVectorValues.nextDoc();
+        Assert.assertArrayEquals(byteArrayList.get(0), byteVectorValues.getVector());
+        Assert.assertNotNull(byteVectorValues);
+
+        // Checking for FloatVectorValues
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.FLOAT32);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.FLOAT.getValue());
+        Mockito.when(reader.getFloatVectorValues("test_field"))
+            .thenReturn(new TestVectorValues.PreDefinedFloatVectorValues(floatArrayList));
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        floatVectorValues.nextDoc();
+        Assert.assertArrayEquals(floatArrayList.get(0), floatVectorValues.getVector(), 0.0f);
+        Assert.assertNotNull(floatVectorValues);
+
+        // Checking for BinaryVectorValues
+        Mockito.when(fieldInfo.getVectorEncoding()).thenReturn(VectorEncoding.BYTE);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
+        Mockito.when(reader.getByteVectorValues("test_field"))
+            .thenReturn(new TestVectorValues.PreDefinedBinaryVectorValues(binaryArrayList));
+        final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        binaryVectorValues.nextDoc();
+        Assert.assertArrayEquals(binaryArrayList.get(0), binaryVectorValues.getVector());
+        Assert.assertNotNull(binaryVectorValues);
+
+    }
+
+    @SneakyThrows
+    public void testGetVectorValuesFromFieldInfo_whenVectorDimIsZero_thenSuccess() {
+        final List<byte[]> byteArrayList = List.of(new byte[] { 1, 2, 3 });
+        final List<float[]> floatArrayList = List.of(new float[] { 1.3f, 2.2f, 3.2f });
+        final List<byte[]> binaryArrayList = List.of(new byte[] { 3, 2, 3 });
+        final FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        final SegmentReader reader = Mockito.mock(SegmentReader.class);
+        Mockito.when(fieldInfo.hasVectorValues()).thenReturn(false);
+        Mockito.when(fieldInfo.getName()).thenReturn("test_field");
+
+        // Checking for ByteVectorValues
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BYTE.getValue());
+        Mockito.when(reader.getBinaryDocValues("test_field"))
+            .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(byteArrayList));
+
+        final KNNVectorValues<byte[]> byteVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        byteVectorValues.nextDoc();
+        Assert.assertArrayEquals(byteArrayList.get(0), byteVectorValues.getVector());
+        Assert.assertNotNull(byteVectorValues);
+
+        // Checking for Floats with BinaryDocValues
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.FLOAT.getValue());
+        Mockito.when(reader.getBinaryDocValues("test_field"))
+            .thenReturn(new TestVectorValues.PredefinedFloatVectorBinaryDocValues(floatArrayList));
+
+        final KNNVectorValues<float[]> floatVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        floatVectorValues.nextDoc();
+        Assert.assertArrayEquals(floatArrayList.get(0), floatVectorValues.getVector(), 0.0f);
+        Assert.assertNotNull(floatVectorValues);
+
+        // Checking for BinaryVectorValues
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
+        Mockito.when(reader.getBinaryDocValues("test_field"))
+            .thenReturn(new TestVectorValues.PredefinedByteVectorBinaryDocValues(binaryArrayList));
+
+        final KNNVectorValues<byte[]> binaryVectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        binaryVectorValues.nextDoc();
+        Assert.assertArrayEquals(binaryArrayList.get(0), binaryVectorValues.getVector());
+        Assert.assertNotNull(binaryVectorValues);
+
+        Mockito.verify(fieldInfo, Mockito.times(0)).getVectorEncoding();
     }
 
 }

--- a/src/test/java/org/opensearch/knn/indices/ModelUtilTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelUtilTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.indices;
+
+import org.junit.Assert;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+
+public class ModelUtilTests extends KNNTestCase {
+    private static final String MODEL_ID = "test-model";
+
+    public void testGetModelMetadata_whenVariousInputs_thenSuccess() {
+        Assert.assertNull(ModelUtil.getModelMetadata(null));
+        Assert.assertNull(ModelUtil.getModelMetadata(""));
+
+        ModelCache modelCache = Mockito.mock(ModelCache.class);
+        Model model = Mockito.mock(Model.class);
+        ModelMetadata modelMetadata = Mockito.mock(ModelMetadata.class);
+        MockedStatic<ModelCache> modelCacheMockedStatic = Mockito.mockStatic(ModelCache.class);
+
+        modelCacheMockedStatic.when(ModelCache::getInstance).thenReturn(modelCache);
+
+        Mockito.when(modelCache.get(MODEL_ID)).thenReturn(model);
+        Mockito.when(model.getModelMetadata()).thenReturn(null);
+        Assert.assertThrows(IllegalArgumentException.class, () -> ModelUtil.getModelMetadata(MODEL_ID));
+
+        Mockito.when(model.getModelMetadata()).thenReturn(modelMetadata);
+        Mockito.when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
+        Assert.assertNotNull(ModelUtil.getModelMetadata(MODEL_ID));
+        modelCacheMockedStatic.close();
+    }
+}


### PR DESCRIPTION
### Description
Integrate KNNVectorValues with vector ANN Search flow. I have not integrated KNNVectorValues in ScriptScore as currently I am doing more deep-dive to see if we really need it. Will followup on that in next PR.

### What changes are present:
1. While doing exact search during Efficient filtering I have switched from using BinaryDocValues to KNNVectorValues.
2. Added some utility functions which are also part of this PR: https://github.com/opensearch-project/k-NN/pull/1950. Whichever PR gets merged first the conflicts can be resolved based on that PR.

### Related Issues
Resolves #1853 


### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
