### PR TITLE
Fixing the dimension for the vector when using Lucene field in ModelFieldMapper

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -196,8 +196,8 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
         ModelMetadata modelMetadata = getModelMetadata(modelDao, modelId);
         if (useLuceneBasedVectorField) {
             int adjustedDimension = modelMetadata.getVectorDataType() == VectorDataType.BINARY
-                ? modelMetadata.getDimension()
-                : modelMetadata.getDimension() / 8;
+                ? modelMetadata.getDimension() / Byte.SIZE
+                : modelMetadata.getDimension();
             final VectorEncoding encoding = modelMetadata.getVectorDataType() == VectorDataType.FLOAT
                 ? VectorEncoding.FLOAT32
                 : VectorEncoding.BYTE;

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -13,6 +13,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNLibrarySearchContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
@@ -145,5 +146,26 @@ public class KNNTestCase extends OpenSearchTestCase {
                 return dimension;
             }
         };
+    }
+
+    /**
+     * Adjust the provided dimension based on {@link VectorDataType} during ingestion.
+     * @param dimension int
+     * @param vectorDataType {@link VectorDataType}
+     * @return int
+     */
+    protected int adjustDimensionForIndexing(final int dimension, final VectorDataType vectorDataType) {
+        return VectorDataType.BINARY == vectorDataType ? dimension * Byte.SIZE : dimension;
+    }
+
+    /**
+     * Adjust the provided dimension based on {@link VectorDataType} for search.
+     *
+     * @param dimension int
+     * @param vectorDataType {@link VectorDataType}
+     * @return int
+     */
+    protected int adjustDimensionForSearch(final int dimension, final VectorDataType vectorDataType) {
+        return VectorDataType.BINARY == vectorDataType ? dimension / Byte.SIZE : dimension;
     }
 }

--- a/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
+++ b/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
@@ -20,25 +20,23 @@ public class FieldInfoExtractorTests extends KNNTestCase {
 
     public void testExtractVectorDataType_whenDifferentConditions_thenSuccess() {
         FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
-        MockedStatic<ModelUtil> modelUtilMockedStatic = Mockito.mockStatic(ModelUtil.class);
+        try (MockedStatic<ModelUtil> modelUtilMockedStatic = Mockito.mockStatic(ModelUtil.class)) {
+            // default case
+            Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(null);
+            Mockito.when(fieldInfo.getAttribute(KNNConstants.MODEL_ID)).thenReturn(MODEL_ID);
+            modelUtilMockedStatic.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(null);
+            Assert.assertEquals(VectorDataType.DEFAULT, FieldInfoExtractor.extractVectorDataType(fieldInfo));
 
-        // default case
-        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(null);
-        Mockito.when(fieldInfo.getAttribute(KNNConstants.MODEL_ID)).thenReturn(MODEL_ID);
-        modelUtilMockedStatic.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(null);
-        Assert.assertEquals(VectorDataType.DEFAULT, FieldInfoExtractor.extractVectorDataType(fieldInfo));
+            // VectorDataType present in fieldInfo
+            Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
+            Assert.assertEquals(VectorDataType.BINARY, FieldInfoExtractor.extractVectorDataType(fieldInfo));
 
-        // VectorDataType present in fieldInfo
-        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BINARY.getValue());
-        Assert.assertEquals(VectorDataType.BINARY, FieldInfoExtractor.extractVectorDataType(fieldInfo));
-
-        // VectorDataType present in ModelMetadata
-        ModelMetadata modelMetadata = Mockito.mock(ModelMetadata.class);
-        Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(null);
-        modelUtilMockedStatic.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(modelMetadata);
-        Mockito.when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.BYTE);
-        Assert.assertEquals(VectorDataType.BYTE, FieldInfoExtractor.extractVectorDataType(fieldInfo));
-
-        modelUtilMockedStatic.close();
+            // VectorDataType present in ModelMetadata
+            ModelMetadata modelMetadata = Mockito.mock(ModelMetadata.class);
+            Mockito.when(fieldInfo.getAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD)).thenReturn(null);
+            modelUtilMockedStatic.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(modelMetadata);
+            Mockito.when(modelMetadata.getVectorDataType()).thenReturn(VectorDataType.BYTE);
+            Assert.assertEquals(VectorDataType.BYTE, FieldInfoExtractor.extractVectorDataType(fieldInfo));
+        }
     }
 }


### PR DESCRIPTION
### Description
Fixing the dimension for the vector when using Lucene field in ModelFieldMapper. To ensure that bug doesn't happen again I have added UTs for the same.

This bug is not in production as the feature is not launched. Hence I am also not adding any entry in changelog.

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
