### PR TITLE
[Backport 2.x] Block a vector field to have invalid characters for a physical file n…

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -13,6 +13,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -23,6 +25,7 @@ import org.opensearch.Version;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.ValidationException;
 import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -219,6 +222,8 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public KNNVectorFieldMapper build(BuilderContext context) {
+            validateFullFieldName(context);
+
             final MultiFields multiFieldsBuilder = this.multiFieldsBuilder.build(this, context);
             final CopyTo copyToBuilder = copyTo.build();
             final Explicit<Boolean> ignoreMalformed = ignoreMalformed(context);
@@ -412,6 +417,32 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 throw new IllegalArgumentException("Dimension should be multiply of 8 for binary vector data type");
             }
             return knnEngine;
+        }
+
+        /**
+         * Validate whether provided full field name contain any invalid characters for physical file name.
+         * At the moment, we use a field name as a part of file name while we throw an exception
+         * if a physical file name contains any invalid characters when creating snapshot.
+         * To prevent from this happening, we restrict vector field name and make sure generated file to have a valid name.
+         *
+         * @param context : Builder context to have field name info.
+         */
+        private void validateFullFieldName(final BuilderContext context) {
+            final String fullFieldName = buildFullName(context);
+            for (char ch : fullFieldName.toCharArray()) {
+                if (Strings.INVALID_FILENAME_CHARS.contains(ch)) {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            Locale.ROOT,
+                            "Vector field name must not include invalid characters of %s. "
+                                + "Provided field name=[%s] had a disallowed character [%c]",
+                            Strings.INVALID_FILENAME_CHARS.stream().map(c -> "'" + c + "'").collect(Collectors.toList()),
+                            fullFieldName,
+                            ch
+                        )
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
…ame.

### Description
Issue : https://github.com/opensearch-project/k-NN/issues/1859.

#### Issue
While OpenSearch does allow for a field name to have an empty space within it and it disallows an empty space to be contained in a physical file name, [KNNCodecUtil::buildEngineFileName](https://github.com/opensearch-project/k-NN/blob/a16b8aa965f66268799c001756c78174c7baba19/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java#L106C26-L106C45) uses the field name directly as a part of a vector file name. As a result, in case where the field name had one of disallowed character for a physical file name, it fails in validation of [BlobStoreIndexShardSnapshot](https://github.com/opensearch-project/OpenSearch/blob/7cbff4f9fd8ae53b1672aa8e2582e23bb2c16def/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java). For example, `_0_2011_my vector.hnswc` (where 'my vector' is the field name). As a result, [BlobStoreIndexShardSnapshot](https://github.com/opensearch-project/OpenSearch/blob/7cbff4f9fd8ae53b1672aa8e2582e23bb2c16def/server/src/main/java/org/opensearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java#L343) throws an exception complaining file name is not valid.

#### Solution
Add a validation logic to throw an exception in case provided vector field name has any invalid characters.

```
private void validateFullFieldName(BuilderContext context) {
    final String fullFieldName = buildFullName(context);
    for (char ch : fullFieldName.toCharArray()) {
        if (Strings.INVALID_FILENAME_CHARS.contains(ch)) {
            throw new IllegalArgumentException(...);
        }
    }
}


public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
    ...
    public static class Builder extends ParametrizedFieldMapper.Builder {
        @Override
        public KNNVectorFieldMapper build(BuilderContext context) {
            validateFullFieldName(context);
            ...
```

### Related Issues
Issue : https://github.com/opensearch-project/k-NN/issues/1859.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
