### PR TITLE
k-NN query rescore support for native engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.16...2.x)
 ### Features
 * Integrate Lucene Vector field with native engines to use KNNVectorFormat during segment creation [#1945](https://github.com/opensearch-project/k-NN/pull/1945)
+* k-NN query rescore support for native engines [#1984](https://github.com/opensearch-project/k-NN/pull/1984)
 ### Enhancements
 * Adds iterative graph build capability into a faiss index to improve the memory footprint during indexing and Integrates KNNVectorsFormat for native engines[#1950](https://github.com/opensearch-project/k-NN/pull/1950)
 ### Bug Fixes

--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.common;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.index.FieldInfo;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.indices.ModelMetadata;
@@ -19,6 +20,11 @@ import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
 
 import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
+import org.opensearch.knn.indices.ModelDao;
+
+import java.util.Locale;
+
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 /**
  * A utility class to extract information from FieldInfo.
@@ -69,5 +75,32 @@ public class FieldInfoExtractor {
             return QuantizationConfig.EMPTY;
         }
         return QuantizationConfigParser.fromCsv(quantizationConfigString);
+    }
+
+    /**
+     * Get the space type for the given field info.
+     *
+     * @param modelDao ModelDao instance to retrieve model metadata
+     * @param fieldInfo FieldInfo instance to extract space type from
+     * @return SpaceType for the given field info
+     */
+    public static SpaceType getSpaceType(final ModelDao modelDao, final FieldInfo fieldInfo) {
+        final String spaceTypeString = fieldInfo.getAttribute(SPACE_TYPE);
+        if (StringUtils.isNotEmpty(spaceTypeString)) {
+            return SpaceType.getSpace(spaceTypeString);
+        }
+
+        final String modelId = fieldInfo.getAttribute(MODEL_ID);
+        if (StringUtils.isEmpty(modelId)) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Unable to find the Space Type from Field Info attribute for field %s", fieldInfo.getName())
+            );
+        }
+
+        ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
+        if (modelMetadata == null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Unable to find the model metadata for model id %s", modelId));
+        }
+        return modelMetadata.getSpaceType();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
@@ -18,6 +18,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.search.NestedHelper;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -48,6 +49,7 @@ public abstract class BaseQueryFactory {
         private Float radius;
         private QueryBuilder filter;
         private QueryShardContext context;
+        private RescoreContext rescoreContext;
 
         public Optional<QueryBuilder> getFilter() {
             return Optional.ofNullable(filter);
@@ -55,6 +57,10 @@ public abstract class BaseQueryFactory {
 
         public Optional<QueryShardContext> getContext() {
             return Optional.ofNullable(context);
+        }
+
+        public Optional<RescoreContext> getRescoreContext() {
+            return Optional.ofNullable(rescoreContext);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.HitQueue;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.util.BitSet;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.query.filtered.FilteredIdsKNNByteIterator;
+import org.opensearch.knn.index.query.filtered.FilteredIdsKNNIterator;
+import org.opensearch.knn.index.query.filtered.KNNIterator;
+import org.opensearch.knn.index.query.filtered.NestedFilteredIdsKNNByteIterator;
+import org.opensearch.knn.index.query.filtered.NestedFilteredIdsKNNIterator;
+import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+import org.opensearch.knn.indices.ModelDao;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Log4j2
+@AllArgsConstructor
+public class ExactSearcher {
+
+    private final ModelDao modelDao;
+
+    /**
+     * Execute an exact search on a subset of documents of a leaf
+     *
+     * @param leafReaderContext LeafReaderContext to be searched over
+     * @param matchedDocs matched documents
+     * @param knnQuery KNN Query
+     * @param k number of results to return
+     * @param isParentHits whether the matchedDocs contains parent ids or child ids. This is relevant in the case of
+     *                     filtered nested search where the matchedDocs contain the parent ids and {@link NestedFilteredIdsKNNIterator}
+     *                     needs to be used.
+     * @return Map of re-scored results
+     */
+    public Map<Integer, Float> searchLeaf(
+        final LeafReaderContext leafReaderContext,
+        final BitSet matchedDocs,
+        final KNNQuery knnQuery,
+        int k,
+        boolean isParentHits
+    ) throws IOException {
+        KNNIterator iterator = getMatchedKNNIterator(leafReaderContext, matchedDocs, knnQuery, isParentHits);
+        if (matchedDocs.cardinality() <= k) {
+            return scoreAllDocs(iterator);
+        }
+        return searchTopK(iterator, k);
+    }
+
+    private Map<Integer, Float> scoreAllDocs(KNNIterator iterator) throws IOException {
+        final Map<Integer, Float> docToScore = new HashMap<>();
+        int docId;
+        while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            docToScore.put(docId, iterator.score());
+        }
+        return docToScore;
+    }
+
+    private Map<Integer, Float> searchTopK(KNNIterator iterator, int k) throws IOException {
+        // Creating min heap and init with MAX DocID and Score as -INF.
+        final HitQueue queue = new HitQueue(k, true);
+        ScoreDoc topDoc = queue.top();
+        final Map<Integer, Float> docToScore = new HashMap<>();
+        int docId;
+        while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            if (iterator.score() > topDoc.score) {
+                topDoc.score = iterator.score();
+                topDoc.doc = docId;
+                // As the HitQueue is min heap, updating top will bring the doc with -INF score or worst score we
+                // have seen till now on top.
+                topDoc = queue.updateTop();
+            }
+        }
+
+        // If scores are negative we will remove them.
+        // This is done, because there can be negative values in the Heap as we init the heap with Score as -INF.
+        // If filterIds < k, the some values in heap can have a negative score.
+        while (queue.size() > 0 && queue.top().score < 0) {
+            queue.pop();
+        }
+
+        while (queue.size() > 0) {
+            final ScoreDoc doc = queue.pop();
+            docToScore.put(doc.doc, doc.score);
+        }
+
+        return docToScore;
+    }
+
+    private KNNIterator getMatchedKNNIterator(
+        final LeafReaderContext leafReaderContext,
+        final BitSet matchedDocs,
+        KNNQuery knnQuery,
+        boolean isParentHits
+    ) throws IOException {
+        final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
+        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
+
+        boolean isNestedRequired = isParentHits && knnQuery.getParentsFilter() != null;
+
+        if (VectorDataType.BINARY == knnQuery.getVectorDataType() && isNestedRequired) {
+            final KNNVectorValues<byte[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+            return new NestedFilteredIdsKNNByteIterator(
+                matchedDocs,
+                knnQuery.getByteQueryVector(),
+                (KNNBinaryVectorValues) vectorValues,
+                spaceType,
+                knnQuery.getParentsFilter().getBitSet(leafReaderContext)
+            );
+        }
+
+        if (VectorDataType.BINARY == knnQuery.getVectorDataType()) {
+            final KNNVectorValues<byte[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+            return new FilteredIdsKNNByteIterator(
+                matchedDocs,
+                knnQuery.getByteQueryVector(),
+                (KNNBinaryVectorValues) vectorValues,
+                spaceType
+            );
+        }
+
+        final KNNVectorValues<float[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
+        if (isNestedRequired) {
+            return new NestedFilteredIdsKNNIterator(
+                matchedDocs,
+                knnQuery.getQueryVector(),
+                (KNNFloatVectorValues) vectorValues,
+                spaceType,
+                knnQuery.getParentsFilter().getBitSet(leafReaderContext)
+            );
+        }
+
+        return new FilteredIdsKNNIterator(matchedDocs, knnQuery.getQueryVector(), (KNNFloatVectorValues) vectorValues, spaceType);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -38,13 +39,12 @@ public class KNNQuery extends Query {
 
     private final String field;
     private final float[] queryVector;
-    @Getter
     private final byte[] byteQueryVector;
     private int k;
     private Map<String, ?> methodParameters;
     private final String indexName;
-    @Getter
     private final VectorDataType vectorDataType;
+    private final RescoreContext rescoreContext;
 
     @Setter
     private Query filterQuery;
@@ -59,7 +59,7 @@ public class KNNQuery extends Query {
         final String indexName,
         final BitSetProducer parentsFilter
     ) {
-        this(field, queryVector, null, k, indexName, null, parentsFilter, VectorDataType.FLOAT);
+        this(field, queryVector, null, k, indexName, null, parentsFilter, VectorDataType.FLOAT, null);
     }
 
     public KNNQuery(
@@ -68,9 +68,10 @@ public class KNNQuery extends Query {
         final int k,
         final String indexName,
         final Query filterQuery,
-        final BitSetProducer parentsFilter
+        final BitSetProducer parentsFilter,
+        final RescoreContext rescoreContext
     ) {
-        this(field, queryVector, null, k, indexName, filterQuery, parentsFilter, VectorDataType.FLOAT);
+        this(field, queryVector, null, k, indexName, filterQuery, parentsFilter, VectorDataType.FLOAT, rescoreContext);
     }
 
     public KNNQuery(
@@ -80,9 +81,10 @@ public class KNNQuery extends Query {
         final String indexName,
         final Query filterQuery,
         final BitSetProducer parentsFilter,
-        final VectorDataType vectorDataType
+        final VectorDataType vectorDataType,
+        final RescoreContext rescoreContext
     ) {
-        this(field, null, byteQueryVector, k, indexName, filterQuery, parentsFilter, vectorDataType);
+        this(field, null, byteQueryVector, k, indexName, filterQuery, parentsFilter, vectorDataType, rescoreContext);
     }
 
     private KNNQuery(
@@ -93,7 +95,8 @@ public class KNNQuery extends Query {
         final String indexName,
         final Query filterQuery,
         final BitSetProducer parentsFilter,
-        final VectorDataType vectorDataType
+        final VectorDataType vectorDataType,
+        final RescoreContext rescoreContext
     ) {
         this.field = field;
         this.queryVector = queryVector;
@@ -103,6 +106,7 @@ public class KNNQuery extends Query {
         this.filterQuery = filterQuery;
         this.parentsFilter = parentsFilter;
         this.vectorDataType = vectorDataType;
+        this.rescoreContext = rescoreContext;
     }
 
     /**
@@ -114,7 +118,7 @@ public class KNNQuery extends Query {
      * @param parentsFilter parent filter
      */
     public KNNQuery(String field, float[] queryVector, String indexName, BitSetProducer parentsFilter) {
-        this(field, queryVector, null, 0, indexName, null, parentsFilter, VectorDataType.FLOAT);
+        this(field, queryVector, null, 0, indexName, null, parentsFilter, VectorDataType.FLOAT, null);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -519,6 +519,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
                 .methodParameters(this.methodParameters)
                 .filter(this.filter)
                 .context(context)
+                .rescoreContext(rescoreContext)
                 .build();
             return KNNQueryFactory.create(createQueryRequest);
         }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.query;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.KnnFloatVectorQuery;
@@ -17,6 +16,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.util.Locale;
 import java.util.Map;
@@ -31,39 +31,6 @@ import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPE
  */
 @Log4j2
 public class KNNQueryFactory extends BaseQueryFactory {
-
-    /**
-     * Note. This method should be used only for test.
-     * Should use {@link #create(CreateQueryRequest)} instead.
-     *
-     * Creates a Lucene query for a particular engine.
-     *
-     * @param knnEngine Engine to create the query for
-     * @param indexName Name of the OpenSearch index that is being queried
-     * @param fieldName Name of the field in the OpenSearch index that will be queried
-     * @param vector The query vector to get the nearest neighbors for
-     * @param k the number of nearest neighbors to return
-     * @return Lucene Query
-     */
-    @VisibleForTesting
-    public static Query create(
-        KNNEngine knnEngine,
-        String indexName,
-        String fieldName,
-        float[] vector,
-        int k,
-        VectorDataType vectorDataType
-    ) {
-        final CreateQueryRequest createQueryRequest = CreateQueryRequest.builder()
-            .knnEngine(knnEngine)
-            .indexName(indexName)
-            .fieldName(fieldName)
-            .vector(vector)
-            .vectorDataType(vectorDataType)
-            .k(k)
-            .build();
-        return create(createQueryRequest);
-    }
 
     /**
      * Creates a Lucene query for a particular engine.
@@ -81,6 +48,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
         final VectorDataType vectorDataType = createQueryRequest.getVectorDataType();
         final Query filterQuery = getFilterQuery(createQueryRequest);
         final Map<String, ?> methodParameters = createQueryRequest.getMethodParameters();
+        final RescoreContext rescoreContext = createQueryRequest.getRescoreContext().orElse(null);
 
         BitSetProducer parentFilter = null;
         if (createQueryRequest.getContext().isPresent()) {
@@ -112,6 +80,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
                         .methodParameters(methodParameters)
                         .filterQuery(validatedFilterQuery)
                         .vectorDataType(vectorDataType)
+                        .rescoreContext(rescoreContext)
                         .build();
                     break;
                 default:
@@ -124,6 +93,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
                         .methodParameters(methodParameters)
                         .filterQuery(validatedFilterQuery)
                         .vectorDataType(vectorDataType)
+                        .rescoreContext(rescoreContext)
                         .build();
             }
             return isKnnQueryRewriteEnabled() ? new NativeEngineKnnVectorQuery(knnQuery) : knnQuery;

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -7,15 +7,12 @@ package org.opensearch.knn.index.query;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.FilteredDocIdSetIterator;
-import org.apache.lucene.search.HitQueue;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.FSDirectory;
@@ -23,7 +20,6 @@ import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.lucene.Lucene;
@@ -37,16 +33,7 @@ import org.opensearch.knn.index.memory.NativeMemoryAllocation;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
-import org.opensearch.knn.index.query.filtered.FilteredIdsKNNByteIterator;
-import org.opensearch.knn.index.query.filtered.FilteredIdsKNNIterator;
-import org.opensearch.knn.index.query.filtered.KNNIterator;
-import org.opensearch.knn.index.query.filtered.NestedFilteredIdsKNNByteIterator;
-import org.opensearch.knn.index.query.filtered.NestedFilteredIdsKNNIterator;
 import org.opensearch.knn.index.engine.KNNEngine;
-import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
-import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
@@ -58,9 +45,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -84,6 +69,9 @@ public class KNNWeight extends Weight {
 
     private final NativeMemoryCacheManager nativeMemoryCacheManager;
     private final Weight filterWeight;
+    private final ExactSearcher exactSearcher;
+
+    private static ExactSearcher DEFAULT_EXACT_SEARCHER;
 
     public KNNWeight(KNNQuery query, float boost) {
         super(query);
@@ -91,6 +79,7 @@ public class KNNWeight extends Weight {
         this.boost = boost;
         this.nativeMemoryCacheManager = NativeMemoryCacheManager.getInstance();
         this.filterWeight = null;
+        this.exactSearcher = DEFAULT_EXACT_SEARCHER;
     }
 
     public KNNWeight(KNNQuery query, float boost, Weight filterWeight) {
@@ -99,10 +88,12 @@ public class KNNWeight extends Weight {
         this.boost = boost;
         this.nativeMemoryCacheManager = NativeMemoryCacheManager.getInstance();
         this.filterWeight = filterWeight;
+        this.exactSearcher = DEFAULT_EXACT_SEARCHER;
     }
 
     public static void initialize(ModelDao modelDao) {
         KNNWeight.modelDao = modelDao;
+        KNNWeight.DEFAULT_EXACT_SEARCHER = new ExactSearcher(modelDao);
     }
 
     @Override
@@ -112,12 +103,12 @@ public class KNNWeight extends Weight {
 
     @Override
     public Scorer scorer(LeafReaderContext context) throws IOException {
-        final Map<Integer, Float> docIdToScoreMap = searchLeaf(context);
+        final Map<Integer, Float> docIdToScoreMap = searchLeaf(context, knnQuery.getK());
         if (docIdToScoreMap.isEmpty()) {
             return KNNScorer.emptyScorer(this);
         }
-
-        return convertSearchResponseToScorer(docIdToScoreMap);
+        final int maxDoc = Collections.max(docIdToScoreMap.keySet()) + 1;
+        return new KNNScorer(this, ResultUtil.resultMapToDocIds(docIdToScoreMap, maxDoc), docIdToScoreMap, boost);
     }
 
     /**
@@ -125,10 +116,10 @@ public class KNNWeight extends Weight {
      * This is made public purely to be able to be reused in {@link org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery}
      *
      * @param context LeafReaderContext
+     * @param k Number of results to return
      * @return A Map of docId to scores for top k results
      */
-    public Map<Integer, Float> searchLeaf(LeafReaderContext context) throws IOException {
-
+    public Map<Integer, Float> searchLeaf(LeafReaderContext context, int k) throws IOException {
         final BitSet filterBitSet = getFilteredDocsBitSet(context);
         int cardinality = filterBitSet.cardinality();
         // We don't need to go to JNI layer if no documents are found which satisfy the filters
@@ -137,31 +128,30 @@ public class KNNWeight extends Weight {
         if (filterWeight != null && cardinality == 0) {
             return Collections.emptyMap();
         }
-        final Map<Integer, Float> docIdsToScoreMap = new HashMap<>();
 
         /*
          * The idea for this optimization is to get K results, we need to atleast look at K vectors in the HNSW graph
          * . Hence, if filtered results are less than K and filter query is present we should shift to exact search.
          * This improves the recall.
          */
+        Map<Integer, Float> docIdsToScoreMap;
         if (filterWeight != null && canDoExactSearch(cardinality)) {
-            docIdsToScoreMap.putAll(doExactSearch(context, filterBitSet, cardinality));
+            docIdsToScoreMap = exactSearch(context, filterBitSet, true, k);
         } else {
-            Map<Integer, Float> annResults = doANNSearch(context, filterBitSet, cardinality);
-            if (annResults == null) {
+            docIdsToScoreMap = doANNSearch(context, filterBitSet, cardinality, k);
+            if (docIdsToScoreMap == null) {
                 return Collections.emptyMap();
             }
-            if (canDoExactSearchAfterANNSearch(cardinality, annResults.size())) {
+            if (canDoExactSearchAfterANNSearch(cardinality, docIdsToScoreMap.size())) {
                 log.debug(
                     "Doing ExactSearch after doing ANNSearch as the number of documents returned are less than "
                         + "K, even when we have more than K filtered Ids. K: {}, ANNResults: {}, filteredIdCount: {}",
-                    knnQuery.getK(),
-                    annResults.size(),
+                    k,
+                    docIdsToScoreMap.size(),
                     cardinality
                 );
-                annResults = doExactSearch(context, filterBitSet, cardinality);
+                docIdsToScoreMap = exactSearch(context, filterBitSet, true, k);
             }
-            docIdsToScoreMap.putAll(annResults);
         }
         if (docIdsToScoreMap.isEmpty()) {
             return Collections.emptyMap();
@@ -221,8 +211,12 @@ public class KNNWeight extends Weight {
         return intArray;
     }
 
-    private Map<Integer, Float> doANNSearch(final LeafReaderContext context, final BitSet filterIdsBitSet, final int cardinality)
-        throws IOException {
+    private Map<Integer, Float> doANNSearch(
+        final LeafReaderContext context,
+        final BitSet filterIdsBitSet,
+        final int cardinality,
+        final int k
+    ) throws IOException {
         final SegmentReader reader = Lucene.segmentReader(context.reader());
         String directory = ((FSDirectory) FilterDirectory.unwrap(reader.directory())).getDirectory().toString();
 
@@ -301,12 +295,12 @@ public class KNNWeight extends Weight {
                 throw new RuntimeException("Index has already been closed");
             }
             int[] parentIds = getParentIdsArray(context);
-            if (knnQuery.getK() > 0) {
+            if (k > 0) {
                 if (knnQuery.getVectorDataType() == VectorDataType.BINARY) {
                     results = JNIService.queryBinaryIndex(
                         indexAllocation.getMemoryAddress(),
                         knnQuery.getByteQueryVector(),
-                        knnQuery.getK(),
+                        k,
                         knnQuery.getMethodParameters(),
                         knnEngine,
                         filterIds,
@@ -317,7 +311,7 @@ public class KNNWeight extends Weight {
                     results = JNIService.queryIndex(
                         indexAllocation.getMemoryAddress(),
                         knnQuery.getQueryVector(),
-                        knnQuery.getK(),
+                        k,
                         knnQuery.getMethodParameters(),
                         knnEngine,
                         filterIds,
@@ -379,86 +373,19 @@ public class KNNWeight extends Weight {
         return engineFiles;
     }
 
-    private Map<Integer, Float> doExactSearch(final LeafReaderContext leafReaderContext, final BitSet filterIdsBitSet, int cardinality) {
-        try {
-            // Creating min heap and init with MAX DocID and Score as -INF.
-            final HitQueue queue = new HitQueue(Math.min(this.knnQuery.getK(), cardinality), true);
-            ScoreDoc topDoc = queue.top();
-            final Map<Integer, Float> docToScore = new HashMap<>();
-            KNNIterator iterator = getFilteredKNNIterator(leafReaderContext, filterIdsBitSet);
-            int docId;
-            while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-                if (iterator.score() > topDoc.score) {
-                    topDoc.score = iterator.score();
-                    topDoc.doc = docId;
-                    // As the HitQueue is min heap, updating top will bring the doc with -INF score or worst score we
-                    // have seen till now on top.
-                    topDoc = queue.updateTop();
-                }
-            }
-
-            // If scores are negative we will remove them.
-            // This is done, because there can be negative values in the Heap as we init the heap with Score as -INF.
-            // If filterIds < k, the some values in heap can have a negative score.
-            while (queue.size() > 0 && queue.top().score < 0) {
-                queue.pop();
-            }
-
-            while (queue.size() > 0) {
-                final ScoreDoc doc = queue.pop();
-                docToScore.put(doc.doc, doc.score);
-            }
-
-            return docToScore;
-        } catch (Exception e) {
-            log.error("Error while getting the doc values to do the k-NN Search for query : {}", this.knnQuery, e);
-        }
-        return Collections.emptyMap();
-    }
-
-    private KNNIterator getFilteredKNNIterator(final LeafReaderContext leafReaderContext, final BitSet filterIdsBitSet) throws IOException {
-        final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
-        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
-        final SpaceType spaceType = getSpaceType(fieldInfo);
-        if (VectorDataType.BINARY == knnQuery.getVectorDataType()) {
-            final KNNVectorValues<byte[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, leafReaderContext.reader());
-            return knnQuery.getParentsFilter() == null
-                ? new FilteredIdsKNNByteIterator(
-                    filterIdsBitSet,
-                    knnQuery.getByteQueryVector(),
-                    (KNNBinaryVectorValues) vectorValues,
-                    spaceType
-                )
-                : new NestedFilteredIdsKNNByteIterator(
-                    filterIdsBitSet,
-                    knnQuery.getByteQueryVector(),
-                    (KNNBinaryVectorValues) vectorValues,
-                    spaceType,
-                    knnQuery.getParentsFilter().getBitSet(leafReaderContext)
-                );
-        } else {
-            final KNNVectorValues<float[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, leafReaderContext.reader());
-            return knnQuery.getParentsFilter() == null
-                ? new FilteredIdsKNNIterator(filterIdsBitSet, knnQuery.getQueryVector(), (KNNFloatVectorValues) vectorValues, spaceType)
-                : new NestedFilteredIdsKNNIterator(
-                    filterIdsBitSet,
-                    knnQuery.getQueryVector(),
-                    (KNNFloatVectorValues) vectorValues,
-                    spaceType,
-                    knnQuery.getParentsFilter().getBitSet(leafReaderContext)
-                );
-        }
-    }
-
-    private Scorer convertSearchResponseToScorer(final Map<Integer, Float> docsToScore) throws IOException {
-        final int maxDoc = Collections.max(docsToScore.keySet()) + 1;
-        final DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(maxDoc);
-        // The docIdSetIterator will contain the docids of the returned results. So, before adding results to
-        // the builder, we can grow to docsToScore.size()
-        final DocIdSetBuilder.BulkAdder setAdder = docIdSetBuilder.grow(docsToScore.size());
-        docsToScore.keySet().forEach(setAdder::add);
-        final DocIdSetIterator docIdSetIter = docIdSetBuilder.build().iterator();
-        return new KNNScorer(this, docIdSetIter, docsToScore, boost);
+    /**
+     * Execute exact search for the given matched doc ids and return the results as a map of docId to score.
+     *
+     * @param leafReaderContext The leaf reader context for the current segment.
+     * @param matchSet The filterIds to search for.
+     * @param isParentHits Whether the matchedDocs contains parent ids or child ids.
+     * @param k The number of results to return.
+     * @return Map of docId to score for the exact search results.
+     * @throws IOException If an error occurs during the search.
+     */
+    public Map<Integer, Float> exactSearch(final LeafReaderContext leafReaderContext, final BitSet matchSet, boolean isParentHits, int k)
+        throws IOException {
+        return exactSearcher.searchLeaf(leafReaderContext, matchSet, knnQuery, k, isParentHits);
     }
 
     @Override
@@ -469,22 +396,6 @@ public class KNNWeight extends Weight {
     public static float normalizeScore(float score) {
         if (score >= 0) return 1 / (1 + score);
         return -score + 1;
-    }
-
-    private SpaceType getSpaceType(final FieldInfo fieldInfo) {
-        final String spaceTypeString = fieldInfo.getAttribute(SPACE_TYPE);
-        if (StringUtils.isNotEmpty(spaceTypeString)) {
-            return SpaceType.getSpace(spaceTypeString);
-        }
-
-        final String modelId = fieldInfo.getAttribute(MODEL_ID);
-        if (StringUtils.isNotEmpty(modelId)) {
-            ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
-            return modelMetadata.getSpaceType();
-        }
-        throw new IllegalArgumentException(
-            String.format(Locale.ROOT, "Unable to find the Space Type from Field Info attribute for field %s", fieldInfo.getName())
-        );
     }
 
     private boolean canDoExactSearch(final int filterIdsCount) {

--- a/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
@@ -37,7 +37,9 @@ public final class ResultUtil {
             topKMinQueue.add(-Float.MAX_VALUE);
         }
 
+        int count = 0;
         for (Map<Integer, Float> perLeafResult : perLeafResults) {
+            count += perLeafResult.size();
             for (Float score : perLeafResult.values()) {
                 if (topKMinQueue.peek() != null && score > topKMinQueue.peek()) {
                     topKMinQueue.poll();
@@ -46,18 +48,14 @@ public final class ResultUtil {
             }
         }
 
-        // Reduce the results based on min competitive scor
-        float minScore = -Float.MAX_VALUE;
-        while (topKMinQueue.isEmpty() == false) {
-            float score = topKMinQueue.poll();
-            if (score > minScore) {
-                minScore = score;
-                break;
-            }
+        // If there are at most k results across everything, then no need to filter anything out
+        if (count <= k) {
+            return;
         }
 
-        float finalMinScore = minScore;
-        perLeafResults.forEach(results -> results.entrySet().removeIf(entry -> entry.getValue() < finalMinScore));
+        // Reduce the results based on min competitive score
+        float minScore = topKMinQueue.peek() == null ? -Float.MAX_VALUE : topKMinQueue.peek();
+        perLeafResults.forEach(results -> results.entrySet().removeIf(entry -> entry.getValue() < minScore));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.DocIdSetBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * Utility class used for processing results
+ */
+public final class ResultUtil {
+
+    /**
+     * Reduce the results to only include the top k results across all leaf results
+     *
+     * @param perLeafResults Results from the list
+     * @param k the number of results across all leaf results to return
+     */
+    public static void reduceToTopK(List<Map<Integer, Float>> perLeafResults, int k) {
+        // Iterate over all scores to get min competitive score
+        PriorityQueue<Float> topKMinQueue = new PriorityQueue<>(k);
+        for (int i = 0; i < k; i++) {
+            topKMinQueue.add(-Float.MAX_VALUE);
+        }
+
+        for (Map<Integer, Float> perLeafResult : perLeafResults) {
+            for (Float score : perLeafResult.values()) {
+                if (topKMinQueue.peek() != null && score > topKMinQueue.peek()) {
+                    topKMinQueue.poll();
+                    topKMinQueue.add(score);
+                }
+            }
+        }
+
+        // Reduce the results based on min competitive scor
+        float minScore = -Float.MAX_VALUE;
+        while (topKMinQueue.isEmpty() == false) {
+            float score = topKMinQueue.poll();
+            if (score > minScore) {
+                minScore = score;
+                break;
+            }
+        }
+
+        float finalMinScore = minScore;
+        perLeafResults.forEach(results -> results.entrySet().removeIf(entry -> entry.getValue() < finalMinScore));
+    }
+
+    /**
+     * Convert map to bit set
+     *
+     * @param resultMap Map of results
+     * @return BitSet of results
+     * @throws IOException If an error occurs during the search.
+     */
+    public static BitSet resultMapToMatchBitSet(Map<Integer, Float> resultMap) throws IOException {
+        if (resultMap.isEmpty()) {
+            return BitSet.of(DocIdSetIterator.empty(), 0);
+        }
+
+        final int maxDoc = Collections.max(resultMap.keySet()) + 1;
+        return BitSet.of(resultMapToDocIds(resultMap, maxDoc), maxDoc);
+    }
+
+    /**
+     * Convert map of docs to doc id set iterator
+     *
+     * @param resultMap Map of results
+     * @param maxDoc Max doc id
+     * @return Doc id set iterator
+     * @throws IOException If an error occurs during the search.
+     */
+    public static DocIdSetIterator resultMapToDocIds(Map<Integer, Float> resultMap, final int maxDoc) throws IOException {
+        if (resultMap.isEmpty()) {
+            return DocIdSetIterator.empty();
+        }
+        final DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(maxDoc);
+        final DocIdSetBuilder.BulkAdder setAdder = docIdSetBuilder.grow(resultMap.size());
+        resultMap.keySet().forEach(setAdder::add);
+        return docIdSetBuilder.build().iterator();
+    }
+
+    /**
+     * COnvert map of results to top docs. Doc ids have proper offset
+     *
+     * @param resultMap map of scores for the leafs
+     * @param segmentOffset Offset to apply to ids to make them shard ids
+     * @return Top docs
+     */
+    public static TopDocs resultMapToTopDocs(Map<Integer, Float> resultMap, int segmentOffset) {
+        if (resultMap.isEmpty()) {
+            return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+        }
+
+        int totalHits = 0;
+        final List<ScoreDoc> scoreDocs = new ArrayList<>();
+        final List<Map.Entry<Integer, Float>> topScores = new ArrayList<>(resultMap.entrySet());
+        topScores.sort(Map.Entry.<Integer, Float>comparingByValue().reversed());
+        for (Map.Entry<Integer, Float> entry : topScores) {
+            ScoreDoc scoreDoc = new ScoreDoc(entry.getKey() + segmentOffset, entry.getValue());
+            scoreDocs.add(scoreDoc);
+            totalHits++;
+        }
+
+        return new TopDocs(new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), scoreDocs.toArray(ScoreDoc[]::new));
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -13,13 +13,14 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.Bits;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
+import org.opensearch.knn.index.query.ResultUtil;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,17 +50,60 @@ public class NativeEngineKnnVectorQuery extends Query {
         final KNNWeight knnWeight = (KNNWeight) knnQuery.createWeight(indexSearcher, ScoreMode.COMPLETE, 1);
         List<LeafReaderContext> leafReaderContexts = reader.leaves();
 
-        List<Callable<TopDocs>> tasks = new ArrayList<>(leafReaderContexts.size());
-        for (LeafReaderContext leafReaderContext : leafReaderContexts) {
-            tasks.add(() -> searchLeaf(leafReaderContext, knnWeight));
+        List<Map<Integer, Float>> perLeafResults;
+        RescoreContext rescoreContext = knnQuery.getRescoreContext();
+        int finalK = knnQuery.getK();
+        if (rescoreContext == null) {
+            perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, finalK);
+        } else {
+            int firstPassK = rescoreContext.getFirstPassK(finalK);
+            perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, firstPassK);
+            ResultUtil.reduceToTopK(perLeafResults, firstPassK);
+            perLeafResults = doRescore(indexSearcher, leafReaderContexts, knnWeight, perLeafResults, finalK);
         }
-        TopDocs[] perLeafResults = indexSearcher.getTaskExecutor().invokeAll(tasks).toArray(TopDocs[]::new);
-        // TopDocs.merge requires perLeafResults to be sorted in descending order.
-        TopDocs topK = TopDocs.merge(knnQuery.getK(), perLeafResults);
+        ResultUtil.reduceToTopK(perLeafResults, finalK);
+        TopDocs[] topDocs = new TopDocs[perLeafResults.size()];
+        for (int i = 0; i < perLeafResults.size(); i++) {
+            topDocs[i] = ResultUtil.resultMapToTopDocs(perLeafResults.get(i), leafReaderContexts.get(i).docBase);
+        }
+
+        TopDocs topK = TopDocs.merge(knnQuery.getK(), topDocs);
         if (topK.scoreDocs.length == 0) {
             return new MatchNoDocsQuery();
         }
         return createRewrittenQuery(reader, topK);
+    }
+
+    private List<Map<Integer, Float>> doSearch(
+        final IndexSearcher indexSearcher,
+        List<LeafReaderContext> leafReaderContexts,
+        KNNWeight knnWeight,
+        int k
+    ) throws IOException {
+        List<Callable<Map<Integer, Float>>> tasks = new ArrayList<>(leafReaderContexts.size());
+        for (LeafReaderContext leafReaderContext : leafReaderContexts) {
+            tasks.add(() -> searchLeaf(leafReaderContext, knnWeight, k));
+        }
+        return indexSearcher.getTaskExecutor().invokeAll(tasks);
+    }
+
+    private List<Map<Integer, Float>> doRescore(
+        final IndexSearcher indexSearcher,
+        List<LeafReaderContext> leafReaderContexts,
+        KNNWeight knnWeight,
+        List<Map<Integer, Float>> perLeafResults,
+        int k
+    ) throws IOException {
+        List<Callable<Map<Integer, Float>>> rescoreTasks = new ArrayList<>(leafReaderContexts.size());
+        for (int i = 0; i < perLeafResults.size(); i++) {
+            LeafReaderContext leafReaderContext = leafReaderContexts.get(i);
+            int finalI = i;
+            rescoreTasks.add(() -> {
+                BitSet convertedBitSet = ResultUtil.resultMapToMatchBitSet(perLeafResults.get(finalI));
+                return knnWeight.exactSearch(leafReaderContext, convertedBitSet, false, k);
+            });
+        }
+        return indexSearcher.getTaskExecutor().invokeAll(rescoreTasks);
     }
 
     private Query createRewrittenQuery(IndexReader reader, TopDocs topK) {
@@ -75,7 +119,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         return new DocAndScoreQuery(knnQuery.getK(), docs, scores, segmentStarts, reader.getContext().id());
     }
 
-    private static int[] findSegmentStarts(IndexReader reader, int[] docs) {
+    static int[] findSegmentStarts(IndexReader reader, int[] docs) {
         int[] starts = new int[reader.leaves().size() + 1];
         starts[starts.length - 1] = docs.length;
         if (starts.length == 2) {
@@ -93,26 +137,13 @@ public class NativeEngineKnnVectorQuery extends Query {
         return starts;
     }
 
-    private TopDocs searchLeaf(LeafReaderContext ctx, KNNWeight queryWeight) throws IOException {
-        int totalHits = 0;
-        final Map<Integer, Float> leafDocScores = queryWeight.searchLeaf(ctx);
-        final List<ScoreDoc> scoreDocs = new ArrayList<>();
+    private Map<Integer, Float> searchLeaf(LeafReaderContext ctx, KNNWeight queryWeight, int k) throws IOException {
+        final Map<Integer, Float> leafDocScores = queryWeight.searchLeaf(ctx, k);
         final Bits liveDocs = ctx.reader().getLiveDocs();
-
-        if (!leafDocScores.isEmpty()) {
-            final List<Map.Entry<Integer, Float>> topScores = new ArrayList<>(leafDocScores.entrySet());
-            topScores.sort(Map.Entry.<Integer, Float>comparingByValue().reversed());
-
-            for (Map.Entry<Integer, Float> entry : topScores) {
-                if (liveDocs == null || liveDocs.get(entry.getKey())) {
-                    ScoreDoc scoreDoc = new ScoreDoc(entry.getKey() + ctx.docBase, entry.getValue());
-                    scoreDocs.add(scoreDoc);
-                    totalHits++;
-                }
-            }
+        if (liveDocs != null) {
+            leafDocScores.entrySet().removeIf(entry -> liveDocs.get(entry.getKey()) == false);
         }
-
-        return new TopDocs(new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), scoreDocs.toArray(ScoreDoc[]::new));
+        return leafDocScores;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -20,6 +20,8 @@ public final class RescoreContext {
     public static final float MAX_OVERSAMPLE_FACTOR = 100.0f;
     public static final float MIN_OVERSAMPLE_FACTOR = 0.0f;
 
+    public static final int MAX_FIRST_PASS_RESULTS = 10000;
+
     @Builder.Default
     private float oversampleFactor = DEFAULT_OVERSAMPLE_FACTOR;
 
@@ -29,5 +31,15 @@ public final class RescoreContext {
      */
     public static RescoreContext getDefault() {
         return RescoreContext.builder().build();
+    }
+
+    /**
+     * Gets the number of results to return for the first pass of rescoring.
+     *
+     * @param finalK The final number of results to return for the entire shard
+     * @return The number of results to return for the first pass of rescoring
+     */
+    public int getFirstPassK(int finalK) {
+        return Math.min(MAX_FIRST_PASS_RESULTS, (int) Math.ceil(finalK * oversampleFactor));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -30,6 +30,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.query.BaseQueryFactory;
 import org.opensearch.knn.index.query.KNNQueryFactory;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.query.KNNQuery;
@@ -380,13 +381,16 @@ public class KNNCodecTestCase extends KNNTestCase {
         verify(perFieldKnnVectorsFormatSpy, atLeastOnce()).getMaxDimensions(eq(FIELD_NAME_ONE));
 
         IndexSearcher searcher = new IndexSearcher(reader);
+
         Query query = KNNQueryFactory.create(
-            KNNEngine.LUCENE,
-            "dummy",
-            FIELD_NAME_ONE,
-            new float[] { 1.0f, 0.0f, 0.0f },
-            1,
-            DEFAULT_VECTOR_DATA_TYPE_FIELD
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .indexName("dummy")
+                .fieldName(FIELD_NAME_ONE)
+                .vector(new float[] { 1.0f, 0.0f, 0.0f })
+                .k(1)
+                .vectorDataType(DEFAULT_VECTOR_DATA_TYPE_FIELD)
+                .build()
         );
 
         assertEquals(1, searcher.count(query));
@@ -416,12 +420,14 @@ public class KNNCodecTestCase extends KNNTestCase {
 
         IndexSearcher searcher1 = new IndexSearcher(reader1);
         Query query1 = KNNQueryFactory.create(
-            KNNEngine.LUCENE,
-            "dummy",
-            FIELD_NAME_TWO,
-            new float[] { 1.0f, 0.0f },
-            1,
-            DEFAULT_VECTOR_DATA_TYPE_FIELD
+            BaseQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(KNNEngine.LUCENE)
+                .indexName("dummy")
+                .fieldName(FIELD_NAME_TWO)
+                .vector(new float[] { 1.0f, 0.0f })
+                .k(1)
+                .vectorDataType(DEFAULT_VECTOR_DATA_TYPE_FIELD)
+                .build()
         );
 
         assertEquals(1, searcher1.count(query1));

--- a/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.util.BitSet;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ResultUtilTests extends KNNTestCase {
+
+    public void testReduceToTopK() {
+        int firstPassK = 20;
+        int finalK = 10;
+        int segmentCount = 5;
+
+        List<Map<Integer, Float>> initialLeafResults = getRandomListOfResults(firstPassK, segmentCount);
+        List<Map<Integer, Float>> reducedLeafResults = initialLeafResults.stream().map(HashMap::new).collect(Collectors.toList());
+        ResultUtil.reduceToTopK(reducedLeafResults, finalK);
+        assertTopK(initialLeafResults, reducedLeafResults, finalK);
+
+        firstPassK = 5;
+        finalK = 20;
+        segmentCount = 1;
+
+        initialLeafResults = getRandomListOfResults(firstPassK, segmentCount);
+        reducedLeafResults = initialLeafResults.stream().map(HashMap::new).collect(Collectors.toList());
+        ResultUtil.reduceToTopK(reducedLeafResults, finalK);
+        assertTopK(initialLeafResults, reducedLeafResults, firstPassK);
+    }
+
+    public void testResultMapToMatchBitSet() throws IOException {
+        int firstPassK = 35;
+        Map<Integer, Float> perLeafResults = getRandomResults(firstPassK);
+        BitSet resultBitset = ResultUtil.resultMapToMatchBitSet(perLeafResults);
+        assertResultMapToMatchBitSet(perLeafResults, resultBitset);
+    }
+
+    public void testResultMapToDocIds() throws IOException {
+        int firstPassK = 42;
+        Map<Integer, Float> perLeafResults = getRandomResults(firstPassK);
+        final int maxDoc = Collections.max(perLeafResults.keySet()) + 1;
+        DocIdSetIterator resultDocIdSetIterator = ResultUtil.resultMapToDocIds(perLeafResults, maxDoc);
+        assertResultMapToDocIdSetIterator(perLeafResults, resultDocIdSetIterator);
+    }
+
+    public void testResultMapToTopDocs() {
+        int k = 18;
+        int offset = 121;
+        Map<Integer, Float> perLeafResults = getRandomResults(k);
+        TopDocs topDocs = ResultUtil.resultMapToTopDocs(perLeafResults, offset);
+        assertResultMapToTopDocs(perLeafResults, topDocs, k, offset);
+    }
+
+    private void assertResultMapToTopDocs(Map<Integer, Float> perLeafResults, TopDocs topDocs, int k, int offset) {
+        assertEquals(k, topDocs.totalHits.value);
+        float previousScore = Float.MAX_VALUE;
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            assertTrue(perLeafResults.containsKey(scoreDoc.doc - offset));
+            assertEquals(perLeafResults.get(scoreDoc.doc - offset), scoreDoc.score, 0.0001);
+            assertTrue(previousScore > scoreDoc.score);
+            previousScore = scoreDoc.score;
+        }
+    }
+
+    private void assertTopK(List<Map<Integer, Float>> beforeResults, List<Map<Integer, Float>> reducedResults, int expectedK) {
+        assertEquals(beforeResults.size(), reducedResults.size());
+        assertEquals(expectedK, reducedResults.stream().map(Map::size).reduce(Integer::sum).orElse(-1).intValue());
+        float minScore = getMinScore(reducedResults);
+        int count = 0;
+        for (Map<Integer, Float> result : beforeResults) {
+            for (float score : result.values()) {
+                if (score >= minScore) {
+                    count++;
+                }
+            }
+        }
+        assertEquals(expectedK, count);
+    }
+
+    private void assertResultMapToMatchBitSet(Map<Integer, Float> resultsMap, BitSet resultBitset) {
+        assertEquals(resultsMap.size(), resultBitset.cardinality());
+        for (Integer docId : resultsMap.keySet()) {
+            assertTrue(resultBitset.get(docId));
+        }
+    }
+
+    private void assertResultMapToDocIdSetIterator(Map<Integer, Float> resultsMap, DocIdSetIterator resultDocIdSetIterator)
+        throws IOException {
+        int count = 0;
+        int docId = resultDocIdSetIterator.nextDoc();
+        while (docId != DocIdSetIterator.NO_MORE_DOCS) {
+            assertTrue(resultsMap.containsKey(docId));
+            count++;
+            docId = resultDocIdSetIterator.nextDoc();
+        }
+        assertEquals(resultsMap.size(), count);
+    }
+
+    private List<Map<Integer, Float>> getRandomListOfResults(int k, int segments) {
+        List<Map<Integer, Float>> perLeafResults = new ArrayList<>();
+        for (int i = 0; i < segments; i++) {
+            perLeafResults.add(getRandomResults(k));
+        }
+        return perLeafResults;
+    }
+
+    private Map<Integer, Float> getRandomResults(int k) {
+        Map<Integer, Float> results = new HashMap<>();
+        for (int i = 0; i < k; i++) {
+            results.put(i, random().nextFloat());
+        }
+
+        return results;
+    }
+
+    private float getMinScore(List<Map<Integer, Float>> perLeafResults) {
+        float minScore = Float.MAX_VALUE;
+        for (Map<Integer, Float> result : perLeafResults) {
+            for (float score : result.values()) {
+                if (score < minScore) {
+                    minScore = score;
+                }
+            }
+        }
+        return minScore;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -17,21 +17,29 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TaskExecutor;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
+import org.opensearch.knn.index.query.ResultUtil;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -73,13 +81,13 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         when(knnQuery.createWeight(searcher, ScoreMode.COMPLETE, 1)).thenReturn(knnWeight);
 
         when(searcher.getTaskExecutor()).thenReturn(taskExecutor);
-        when(taskExecutor.invokeAll(ArgumentMatchers.<Callable<TopDocs>>anyList())).thenAnswer(invocationOnMock -> {
-            List<Callable<TopDocs>> callables = invocationOnMock.getArgument(0);
-            List<TopDocs> topDocs = new ArrayList<>();
-            for (Callable<TopDocs> callable : callables) {
-                topDocs.add(callable.call());
+        when(taskExecutor.invokeAll(any())).thenAnswer(invocationOnMock -> {
+            List<Callable<Map<Integer, Float>>> callables = invocationOnMock.getArgument(0);
+            List<Map<Integer, Float>> results = new ArrayList<>();
+            for (Callable<Map<Integer, Float>> callable : callables) {
+                results.add(callable.call());
             }
-            return topDocs;
+            return results;
         });
 
         when(reader.getContext()).thenReturn(indexReaderContext);
@@ -91,8 +99,8 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         List<LeafReaderContext> leaves = List.of(leaf1, leaf2);
         when(reader.leaves()).thenReturn(leaves);
 
-        when(knnWeight.searchLeaf(leaf1)).thenReturn(Map.of(0, 1.2f, 1, 5.1f, 2, 2.2f));
-        when(knnWeight.searchLeaf(leaf2)).thenReturn(Map.of(4, 3.4f, 3, 5.1f));
+        when(knnWeight.searchLeaf(leaf1, 4)).thenReturn(new HashMap<>(Map.of(0, 1.2f, 1, 5.1f, 2, 2.2f)));
+        when(knnWeight.searchLeaf(leaf2, 4)).thenReturn(new HashMap<>(Map.of(4, 3.4f, 3, 5.1f)));
 
         // Making sure there is deleted docs in one of the segments
         Bits liveDocs = mock(Bits.class);
@@ -124,7 +132,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         // Given
         List<LeafReaderContext> leaves = List.of(leaf1);
         when(reader.leaves()).thenReturn(leaves);
-        when(knnWeight.searchLeaf(leaf1)).thenReturn(Map.of(0, 1.2f, 1, 5.1f, 2, 2.2f));
+        when(knnWeight.searchLeaf(leaf1, 4)).thenReturn(new HashMap<>(Map.of(0, 1.2f, 1, 5.1f, 2, 2.2f)));
         when(knnQuery.getK()).thenReturn(4);
 
         when(indexReaderContext.id()).thenReturn(1);
@@ -145,12 +153,49 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         // Given
         List<LeafReaderContext> leaves = List.of(leaf1);
         when(reader.leaves()).thenReturn(leaves);
-        when(knnWeight.searchLeaf(leaf1)).thenReturn(Collections.emptyMap());
+        when(knnWeight.searchLeaf(leaf1, 4)).thenReturn(Collections.emptyMap());
         when(knnQuery.getK()).thenReturn(4);
         // When
         Query actual = objectUnderTest.rewrite(searcher);
 
         // Then
         assertEquals(new MatchNoDocsQuery(), actual);
+    }
+
+    @SneakyThrows
+    public void testRescore() {
+        // Given
+        List<LeafReaderContext> leaves = List.of(leaf1, leaf2);
+        when(reader.leaves()).thenReturn(leaves);
+
+        int k = 2;
+        int firstPassK = 3;
+        Map<Integer, Float> initialLeaf1Results = new HashMap<>(Map.of(0, 21f, 1, 19f, 2, 17f, 3, 15f));
+        Map<Integer, Float> initialLeaf2Results = new HashMap<>(Map.of(0, 20f, 1, 18f, 2, 16f, 3, 14f));
+        Map<Integer, Float> rescoredLeaf1Results = new HashMap<>(Map.of(0, 18f, 1, 20f));
+        Map<Integer, Float> rescoredLeaf2Results = new HashMap<>(Map.of(0, 21f));
+        TopDocs topDocs1 = ResultUtil.resultMapToTopDocs(Map.of(1, 20f), 0);
+        TopDocs topDocs2 = ResultUtil.resultMapToTopDocs(Map.of(0, 21f), 4);
+        DocAndScoreQuery expected = new DocAndScoreQuery(2, new int[] { 1, 4 }, new float[] { 20f, 21f }, new int[] { 0, 4, 2 }, 1);
+
+        when(indexReaderContext.id()).thenReturn(1);
+        when(knnQuery.getRescoreContext()).thenReturn(RescoreContext.builder().oversampleFactor(1.5f).build());
+        when(knnQuery.getK()).thenReturn(k);
+        when(knnWeight.getQuery()).thenReturn(knnQuery);
+        when(knnWeight.searchLeaf(leaf1, firstPassK)).thenReturn(initialLeaf1Results);
+        when(knnWeight.searchLeaf(leaf2, firstPassK)).thenReturn(initialLeaf2Results);
+        when(knnWeight.exactSearch(eq(leaf1), any(), anyBoolean(), anyInt())).thenReturn(rescoredLeaf1Results);
+        when(knnWeight.exactSearch(eq(leaf2), any(), anyBoolean(), anyInt())).thenReturn(rescoredLeaf2Results);
+        try (MockedStatic<ResultUtil> mockedResultUtil = mockStatic(ResultUtil.class)) {
+            mockedResultUtil.when(() -> ResultUtil.reduceToTopK(any(), anyInt())).thenAnswer(InvocationOnMock::callRealMethod);
+            mockedResultUtil.when(() -> ResultUtil.resultMapToTopDocs(eq(rescoredLeaf1Results), anyInt())).thenAnswer(t -> topDocs1);
+            mockedResultUtil.when(() -> ResultUtil.resultMapToTopDocs(eq(rescoredLeaf2Results), anyInt())).thenAnswer(t -> topDocs2);
+            try (MockedStatic<NativeEngineKnnVectorQuery> mockedStaticNativeKnnVectorQuery = mockStatic(NativeEngineKnnVectorQuery.class)) {
+                mockedStaticNativeKnnVectorQuery.when(() -> NativeEngineKnnVectorQuery.findSegmentStarts(any(), any()))
+                    .thenReturn(new int[] { 0, 4, 2 });
+                Query actual = objectUnderTest.rewrite(searcher);
+                assertEquals(expected, actual);
+            }
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/rescore/RescoreContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/rescore/RescoreContextTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.rescore;
+
+import org.opensearch.knn.KNNTestCase;
+
+import static org.opensearch.knn.index.query.rescore.RescoreContext.MAX_FIRST_PASS_RESULTS;
+
+public class RescoreContextTests extends KNNTestCase {
+
+    public void testGetFirstPassK() {
+        float oversample = 2.6f;
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(oversample).build();
+        int finalK = 100;
+        assertEquals(260, rescoreContext.getFirstPassK(finalK));
+        finalK = 1;
+        assertEquals(3, rescoreContext.getFirstPassK(finalK));
+        finalK = 0;
+        assertEquals(0, rescoreContext.getFirstPassK(finalK));
+        finalK = MAX_FIRST_PASS_RESULTS;
+        assertEquals(MAX_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK));
+    }
+}


### PR DESCRIPTION
### Description
Implements re-scoring. It uses the rescoring context in the query builder to execute a two-phased search. First, it oversamples the ANN index and then reduces the results down to the oversample factor, and then rescores and returns.

Shared code for exact search was pulled out into a class called exact searcher. Rescore search functionality is included in a class called RescoreSearcher. A few sanity integ tests have been added along with existing ones, but intend to add more once quantization framework is integrated. 

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
