### PR TITLE
Add support for qframework from interface

### DIFF
--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -15,6 +15,10 @@ import org.opensearch.knn.indices.ModelUtil;
 
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.indices.ModelUtil.getModelMetadata;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
+
+import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
 
 /**
  * A utility class to extract information from FieldInfo.
@@ -51,5 +55,19 @@ public class FieldInfoExtractor {
             }
         }
         return StringUtils.isNotEmpty(vectorDataTypeString) ? VectorDataType.get(vectorDataTypeString) : VectorDataType.DEFAULT;
+    }
+
+    /**
+     * Extract quantization config from fieldInfo
+     *
+     * @param fieldInfo {@link FieldInfo}
+     * @return {@link QuantizationConfig}
+     */
+    public static QuantizationConfig extractQuantizationConfig(final FieldInfo fieldInfo) {
+        String quantizationConfigString = fieldInfo.getAttribute(QFRAMEWORK_CONFIG);
+        if (StringUtils.isEmpty(quantizationConfigString)) {
+            return QuantizationConfig.EMPTY;
+        }
+        return QuantizationConfigParser.fromCsv(quantizationConfigString);
     }
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -66,6 +66,8 @@ public class KNNConstants {
     public static final String MAX_VECTOR_COUNT_PARAMETER = "max_training_vector_count";
     public static final String SEARCH_SIZE_PARAMETER = "search_size";
 
+    public static final String QFRAMEWORK_CONFIG = "qframe_config";
+
     public static final String VECTOR_DATA_TYPE_FIELD = "data_type";
     public static final String MODEL_VECTOR_DATA_TYPE_KEY = VECTOR_DATA_TYPE_FIELD;
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
@@ -16,7 +16,6 @@ import org.opensearch.knn.index.mapper.SpaceVectorValidator;
 import org.opensearch.knn.index.mapper.VectorValidator;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -112,12 +111,15 @@ public abstract class AbstractKNNMethod implements KNNMethod {
         KNNMethodContext knnMethodContext,
         KNNMethodConfigContext knnMethodConfigContext
     ) {
-        Map<String, Object> parameterMap = new HashMap<>(
-            methodComponent.getAsMap(knnMethodContext.getMethodComponentContext(), knnMethodConfigContext)
+        KNNLibraryIndexingContext knnLibraryIndexingContext = methodComponent.getKNNLibraryIndexingContext(
+            knnMethodContext.getMethodComponentContext(),
+            knnMethodConfigContext
         );
+        Map<String, Object> parameterMap = knnLibraryIndexingContext.getLibraryParameters();
         parameterMap.put(KNNConstants.SPACE_TYPE, knnMethodContext.getSpaceType().getValue());
         parameterMap.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, knnMethodConfigContext.getVectorDataType().getValue());
         return KNNLibraryIndexingContextImpl.builder()
+            .quantizationConfig(knnLibraryIndexingContext.getQuantizationConfig())
             .parameters(parameterMap)
             .vectorValidator(doGetVectorValidator(knnMethodContext, knnMethodConfigContext))
             .perDimensionValidator(doGetPerDimensionValidator(knnMethodContext, knnMethodConfigContext))

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.engine;
 
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.PerDimensionProcessor;
 import org.opensearch.knn.index.mapper.PerDimensionValidator;
 import org.opensearch.knn.index.mapper.VectorValidator;
@@ -21,6 +22,13 @@ public interface KNNLibraryIndexingContext {
      * @return Map of parameters
      */
     Map<String, Object> getLibraryParameters();
+
+    /**
+     * Get map of parameters that get passed to the quantization framework
+     *
+     * @return Map of parameters
+     */
+    QuantizationConfig getQuantizationConfig();
 
     /**
      *

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
@@ -6,10 +6,12 @@
 package org.opensearch.knn.index.engine;
 
 import lombok.Builder;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.PerDimensionProcessor;
 import org.opensearch.knn.index.mapper.PerDimensionValidator;
 import org.opensearch.knn.index.mapper.VectorValidator;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -21,11 +23,19 @@ public class KNNLibraryIndexingContextImpl implements KNNLibraryIndexingContext 
     private VectorValidator vectorValidator;
     private PerDimensionValidator perDimensionValidator;
     private PerDimensionProcessor perDimensionProcessor;
-    private Map<String, Object> parameters;
+    @Builder.Default
+    private Map<String, Object> parameters = Collections.emptyMap();
+    @Builder.Default
+    private QuantizationConfig quantizationConfig = QuantizationConfig.EMPTY;
 
     @Override
     public Map<String, Object> getLibraryParameters() {
         return parameters;
+    }
+
+    @Override
+    public QuantizationConfig getQuantizationConfig() {
+        return quantizationConfig;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFlatEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFlatEncoder.java
@@ -26,7 +26,7 @@ public class FaissFlatEncoder implements Encoder {
     );
 
     private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(KNNConstants.ENCODER_FLAT)
-        .setMapGenerator(
+        .setKnnLibraryIndexingContextGenerator(
             ((methodComponent, methodComponentContext, knnMethodConfigContext) -> MethodAsMapBuilder.builder(
                 KNNConstants.FAISS_FLAT_DESCRIPTION,
                 methodComponent,

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
@@ -29,7 +29,6 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
-import static org.opensearch.knn.index.engine.faiss.Faiss.FAISS_BINARY_INDEX_DESCRIPTION_PREFIX;
 
 /**
  * Faiss HNSW method implementation
@@ -49,7 +48,12 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
         KNNConstants.ENCODER_FLAT,
         Collections.emptyMap()
     );
-    private final static List<Encoder> SUPPORTED_ENCODERS = List.of(new FaissFlatEncoder(), new FaissSQEncoder(), new FaissHNSWPQEncoder());
+    private final static List<Encoder> SUPPORTED_ENCODERS = List.of(
+        new FaissFlatEncoder(),
+        new FaissSQEncoder(),
+        new FaissHNSWPQEncoder(),
+        new QFrameBitEncoder()
+    );
 
     /**
      * Constructor for FaissHNSWMethod
@@ -84,18 +88,14 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
                 )
             )
             .addParameter(METHOD_ENCODER_PARAMETER, initEncoderParameter())
-            .setMapGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
-                String prefix = "";
-                if (knnMethodConfigContext.getVectorDataType() == VectorDataType.BINARY) {
-                    prefix = FAISS_BINARY_INDEX_DESCRIPTION_PREFIX;
-                }
-
-                return MethodAsMapBuilder.builder(
-                    prefix + FAISS_HNSW_DESCRIPTION,
+            .setKnnLibraryIndexingContextGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
+                MethodAsMapBuilder methodAsMapBuilder = MethodAsMapBuilder.builder(
+                    FAISS_HNSW_DESCRIPTION,
                     methodComponent,
                     methodComponentContext,
                     knnMethodConfigContext
-                ).addParameter(METHOD_PARAMETER_M, "", "").addParameter(METHOD_ENCODER_PARAMETER, ",", "").build();
+                ).addParameter(METHOD_PARAMETER_M, "", "").addParameter(METHOD_ENCODER_PARAMETER, ",", "");
+                return adjustPrefix(methodAsMapBuilder, methodComponentContext, knnMethodConfigContext);
             }))
             .build();
     }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWPQEncoder.java
@@ -51,7 +51,7 @@ public class FaissHNSWPQEncoder implements Encoder {
             )
         )
         .setRequiresTraining(true)
-        .setMapGenerator(
+        .setKnnLibraryIndexingContextGenerator(
             ((methodComponent, methodComponentContext, knnMethodConfigContext) -> MethodAsMapBuilder.builder(
                 FAISS_PQ_DESCRIPTION,
                 methodComponent,

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFMethod.java
@@ -32,7 +32,6 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST_LIMI
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES_DEFAULT;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES_LIMIT;
-import static org.opensearch.knn.index.engine.faiss.Faiss.FAISS_BINARY_INDEX_DESCRIPTION_PREFIX;
 
 /**
  * Faiss ivf implementation
@@ -52,7 +51,12 @@ public class FaissIVFMethod extends AbstractFaissMethod {
         KNNConstants.ENCODER_FLAT,
         Collections.emptyMap()
     );
-    private final static List<Encoder> SUPPORTED_ENCODERS = List.of(new FaissFlatEncoder(), new FaissSQEncoder(), new FaissIVFPQEncoder());
+    private final static List<Encoder> SUPPORTED_ENCODERS = List.of(
+        new FaissFlatEncoder(),
+        new FaissSQEncoder(),
+        new FaissIVFPQEncoder(),
+        new QFrameBitEncoder()
+    );
 
     /**
      * Constructor for FaissIVFMethod
@@ -84,18 +88,14 @@ public class FaissIVFMethod extends AbstractFaissMethod {
             )
             .addParameter(METHOD_ENCODER_PARAMETER, initEncoderParameter())
             .setRequiresTraining(true)
-            .setMapGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
-                String prefix = "";
-                if (knnMethodConfigContext.getVectorDataType() == VectorDataType.BINARY) {
-                    prefix = FAISS_BINARY_INDEX_DESCRIPTION_PREFIX;
-                }
-
-                return MethodAsMapBuilder.builder(
-                    prefix + FAISS_IVF_DESCRIPTION,
+            .setKnnLibraryIndexingContextGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
+                MethodAsMapBuilder methodAsMapBuilder = MethodAsMapBuilder.builder(
+                    FAISS_IVF_DESCRIPTION,
                     methodComponent,
                     methodComponentContext,
                     knnMethodConfigContext
-                ).addParameter(METHOD_PARAMETER_NLIST, "", "").addParameter(METHOD_ENCODER_PARAMETER, ",", "").build();
+                ).addParameter(METHOD_PARAMETER_NLIST, "", "").addParameter(METHOD_ENCODER_PARAMETER, ",", "");
+                return adjustPrefix(methodAsMapBuilder, methodComponentContext, knnMethodConfigContext);
             }))
             .setOverheadInKBEstimator((methodComponent, methodComponentContext, dimension) -> {
                 // Size estimate formula: (4 * nlists * d) / 1024 + 1

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFPQEncoder.java
@@ -51,7 +51,7 @@ public class FaissIVFPQEncoder implements Encoder {
             })
         )
         .setRequiresTraining(true)
-        .setMapGenerator(
+        .setKnnLibraryIndexingContextGenerator(
             ((methodComponent, methodComponentContext, knnMethodConfigContext) -> MethodAsMapBuilder.builder(
                 FAISS_PQ_DESCRIPTION,
                 methodComponent,

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -35,7 +35,7 @@ public class FaissSQEncoder implements Encoder {
             new Parameter.StringParameter(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16, (v, context) -> FAISS_SQ_ENCODER_TYPES.contains(v))
         )
         .addParameter(FAISS_SQ_CLIP, new Parameter.BooleanParameter(FAISS_SQ_CLIP, false, (v, context) -> Objects.nonNull(v)))
-        .setMapGenerator(
+        .setKnnLibraryIndexingContextGenerator(
             ((methodComponent, methodComponentContext, knnMethodConfigContext) -> MethodAsMapBuilder.builder(
                 FAISS_SQ_DESCRIPTION,
                 methodComponent,

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/QFrameBitEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/QFrameBitEncoder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.faiss;
+
+import com.google.common.collect.ImmutableSet;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContextImpl;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.Parameter;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.FAISS_FLAT_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+
+/**
+ * Quantization framework binary encoder,
+ */
+public class QFrameBitEncoder implements Encoder {
+
+    public static final String NAME = "binary";
+    public static final String BITCOUNT_PARAM = "bits";
+    private static final int DEFAULT_BITS = 1;
+    private static final Set<Integer> validBitCounts = ImmutableSet.of(1, 2, 4);
+    private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT);
+
+    /**
+     * {
+     *   "encoder": {
+     *     "name": "binary",
+     *     "parameters": {
+     *       "bits": 2
+     *     }
+     *   }
+     * }
+     */
+    private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(NAME)
+        .addSupportedDataTypes(SUPPORTED_DATA_TYPES)
+        .addParameter(
+            BITCOUNT_PARAM,
+            new Parameter.IntegerParameter(BITCOUNT_PARAM, DEFAULT_BITS, (v, context) -> validBitCounts.contains(v))
+        )
+        .setKnnLibraryIndexingContextGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
+            QuantizationConfig quantizationConfig;
+            int bitCount = (int) methodComponentContext.getParameters().getOrDefault(BITCOUNT_PARAM, DEFAULT_BITS);
+            if (bitCount == 1) {
+                quantizationConfig = QuantizationConfig.builder().quantizationType(ScalarQuantizationType.ONE_BIT).build();
+            } else if (bitCount == 2) {
+                quantizationConfig = QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).build();
+            } else if (bitCount == 4) {
+                quantizationConfig = QuantizationConfig.builder().quantizationType(ScalarQuantizationType.FOUR_BIT).build();
+            } else {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid bit count: %d", bitCount));
+            }
+
+            // We use the flat description because we are doing the quantization
+            return KNNLibraryIndexingContextImpl.builder().quantizationConfig(quantizationConfig).parameters(new HashMap<>() {
+                {
+                    put(INDEX_DESCRIPTION_PARAMETER, FAISS_FLAT_DESCRIPTION);
+                }
+            }).build();
+        }))
+        .setRequiresTraining(false)
+        .build();
+
+    @Override
+    public MethodComponent getMethodComponent() {
+        return METHOD_COMPONENT;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfig.java
+++ b/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.qframe;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+/**
+ * Configuration for quantization
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+public class QuantizationConfig {
+    @Builder.Default
+    private ScalarQuantizationType quantizationType = null;
+    public static final QuantizationConfig EMPTY = QuantizationConfig.builder().build();
+}

--- a/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParser.java
+++ b/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParser.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.qframe;
+
+import org.apache.lucene.analysis.util.CSVUtil;
+import org.opensearch.knn.index.engine.faiss.QFrameBitEncoder;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+import java.util.Locale;
+
+/**
+ * Parse util for quantization config
+ */
+public class QuantizationConfigParser {
+
+    public static final String SEPARATOR = "=";
+    public static final String TYPE_NAME = "type";
+    public static final String BINARY_TYPE = QFrameBitEncoder.NAME;
+    public static final String BIT_COUNT_NAME = QFrameBitEncoder.BITCOUNT_PARAM;
+
+    /**
+     * Parse quantization config to csv format
+     * Example: type=binary,bits=2
+     * @param quantizationConfig Quantization config
+     * @return Csv format of quantization config
+     */
+    public static String toCsv(QuantizationConfig quantizationConfig) {
+        if (quantizationConfig == null
+            || quantizationConfig == QuantizationConfig.EMPTY
+            || quantizationConfig.getQuantizationType() == null) {
+            return "";
+        }
+        return String.format(
+            Locale.ROOT,
+            "%s=%s,%s=%d",
+            TYPE_NAME,
+            BINARY_TYPE,
+            BIT_COUNT_NAME,
+            quantizationConfig.getQuantizationType().getId()
+        );
+    }
+
+    /**
+     * Parse csv format to quantization config
+     *
+     * @param csv Csv format of quantization config
+     * @return Quantization config
+     */
+    public static QuantizationConfig fromCsv(String csv) {
+        if (csv == null || csv.isEmpty()) {
+            return QuantizationConfig.EMPTY;
+        }
+
+        String[] csvArray = CSVUtil.parse(csv);
+        if (csvArray.length != 2) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid csv for quantization config: \"%s\"", csv));
+        }
+
+        String typeValue = getValueOrThrow(TYPE_NAME, csvArray[0]);
+        if (!typeValue.equals(BINARY_TYPE)) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Unsupported quantization type: \"%s\"", typeValue));
+        }
+
+        String bitsValue = getValueOrThrow(BIT_COUNT_NAME, csvArray[1]);
+        int bitCount = Integer.parseInt(bitsValue);
+        ScalarQuantizationType quantizationType = ScalarQuantizationType.fromId(bitCount);
+        return QuantizationConfig.builder().quantizationType(quantizationType).build();
+    }
+
+    private static String getValueOrThrow(String expectedKey, String keyValue) {
+        String[] keyValueArr = keyValue.split(SEPARATOR);
+        if (keyValueArr.length != 2) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid csv value for quantization config: \"%s\"", keyValue));
+        }
+
+        if (!keyValueArr[0].equals(expectedKey)) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Expected: \"%s\" But got: \"%s\"", expectedKey, keyValue));
+        }
+
+        return keyValueArr[1];
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -27,10 +27,12 @@ import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
@@ -230,6 +232,9 @@ public class KNNWeight extends Weight {
             log.debug("[KNN] Field info not found for {}:{}", knnQuery.getField(), reader.getSegmentName());
             return null;
         }
+
+        // TODO: Use this to get quantization config
+        QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo);
 
         KNNEngine knnEngine;
         SpaceType spaceType;

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractKNNLibraryTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractKNNLibraryTests.java
@@ -44,7 +44,11 @@ public class AbstractKNNLibraryTests extends KNNTestCase {
     private final static Map<String, Object> VALID_EXPECTED_MAP = ImmutableMap.of("test-key", "test-param");
     private final static KNNMethod VALID_METHOD = new AbstractKNNMethod(
         MethodComponent.Builder.builder(VALID_METHOD_NAME)
-            .setMapGenerator((methodComponent, methodComponentContext, knnMethodConfigContext) -> VALID_EXPECTED_MAP)
+            .setKnnLibraryIndexingContextGenerator(
+                (methodComponent, methodComponentContext, knnMethodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                    .parameters(new HashMap<>(VALID_EXPECTED_MAP))
+                    .build()
+            )
             .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
             .build(),
         Set.of(SpaceType.DEFAULT),

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractKNNMethodTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractKNNMethodTests.java
@@ -154,9 +154,13 @@ public class AbstractKNNMethodTests extends KNNTestCase {
             .build();
         SpaceType spaceType = SpaceType.DEFAULT;
         String methodName = "test-method";
-        Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-value");
+        Map<String, Object> generatedMap = new HashMap<>(ImmutableMap.of("test-key", "test-value"));
         MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
-            .setMapGenerator(((methodComponent1, methodComponentContext, methodConfigContext) -> methodComponentContext.getParameters()))
+            .setKnnLibraryIndexingContextGenerator(
+                ((methodComponent1, methodComponentContext, methodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                    .parameters(methodComponentContext.getParameters())
+                    .build())
+            )
             .build();
 
         KNNMethod knnMethod = new TestKNNMethod(methodComponent, Set.of(SpaceType.L2), EMPTY_ENGINE_SPECIFIC_CONTEXT);

--- a/src/test/java/org/opensearch/knn/index/engine/MethodComponentTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/MethodComponentTests.java
@@ -143,19 +143,22 @@ public class MethodComponentTests extends KNNTestCase {
 
         assertEquals(
             in,
-            methodComponent.getAsMap(methodComponentContext, KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build())
+            methodComponent.getKNNLibraryIndexingContext(
+                methodComponentContext,
+                KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build()
+            ).getLibraryParameters()
         );
 
         xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName).endObject();
         in = xContentBuilderToMap(xContentBuilder);
         methodComponentContext = MethodComponentContext.parse(in);
 
-        Map<String, Object> methodAsMap = methodComponent.getAsMap(
+        KNNLibraryIndexingContext methodAsMap = methodComponent.getKNNLibraryIndexingContext(
             methodComponentContext,
             KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build()
         );
-        assertEquals(default1, ((Map<String, Object>) methodAsMap.get(PARAMETERS)).get(parameterName1));
-        assertEquals(default2, ((Map<String, Object>) methodAsMap.get(PARAMETERS)).get(parameterName2));
+        assertEquals(default1, ((Map<String, Object>) methodAsMap.getLibraryParameters().get(PARAMETERS)).get(parameterName1));
+        assertEquals(default2, ((Map<String, Object>) methodAsMap.getLibraryParameters().get(PARAMETERS)).get(parameterName2));
     }
 
     public void testGetAsMap_withGenerator() throws IOException {
@@ -164,7 +167,11 @@ public class MethodComponentTests extends KNNTestCase {
         MethodComponent methodComponent = MethodComponent.Builder.builder(methodName)
             .addParameter("valid1", new Parameter.IntegerParameter("valid1", 1, (v, context) -> v > 0))
             .addParameter("valid2", new Parameter.IntegerParameter("valid2", 1, (v, context) -> v > 0))
-            .setMapGenerator((methodComponent1, methodComponentContext, knnMethodConfigContext) -> generatedMap)
+            .setKnnLibraryIndexingContextGenerator(
+                (methodComponent1, methodComponentContext, knnMethodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                    .parameters(generatedMap)
+                    .build()
+            )
             .build();
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().field(NAME, methodName).endObject();
@@ -173,7 +180,10 @@ public class MethodComponentTests extends KNNTestCase {
 
         assertEquals(
             generatedMap,
-            methodComponent.getAsMap(methodComponentContext, KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build())
+            methodComponent.getKNNLibraryIndexingContext(
+                methodComponentContext,
+                KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build()
+            ).getLibraryParameters()
         );
     }
 
@@ -191,12 +201,17 @@ public class MethodComponentTests extends KNNTestCase {
         assertEquals(1, methodComponent.getParameters().size());
 
         Map<String, Object> generatedMap = ImmutableMap.of("test-key", "test-value");
-        builder.setMapGenerator((methodComponent1, methodComponentContext, knnMethodConfigContext) -> generatedMap);
+        builder.setKnnLibraryIndexingContextGenerator(
+            (methodComponent1, methodComponentContext, knnMethodConfigContext) -> KNNLibraryIndexingContextImpl.builder()
+                .parameters(generatedMap)
+                .build()
+        );
         methodComponent = builder.build();
 
         assertEquals(
             generatedMap,
-            methodComponent.getAsMap(null, KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build())
+            methodComponent.getKNNLibraryIndexingContext(null, KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build())
+                .getLibraryParameters()
         );
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/QFrameBitEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/QFrameBitEncoderTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.faiss;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+import static org.opensearch.knn.common.KNNConstants.FAISS_FLAT_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.index.engine.faiss.QFrameBitEncoder.BITCOUNT_PARAM;
+
+public class QFrameBitEncoderTests extends KNNTestCase {
+    public void testGetLibraryIndexingContext() {
+        QFrameBitEncoder qFrameBitEncoder = new QFrameBitEncoder();
+        MethodComponent methodComponent = qFrameBitEncoder.getMethodComponent();
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(10)
+            .build();
+
+        MethodComponentContext methodComponentContext = new MethodComponentContext(
+            QFrameBitEncoder.NAME,
+            ImmutableMap.of(BITCOUNT_PARAM, 4)
+        );
+
+        KNNLibraryIndexingContext knnLibraryIndexingContext = methodComponent.getKNNLibraryIndexingContext(
+            methodComponentContext,
+            knnMethodConfigContext
+        );
+        assertEquals(
+            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, FAISS_FLAT_DESCRIPTION),
+            knnLibraryIndexingContext.getLibraryParameters()
+        );
+        assertEquals(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.FOUR_BIT).build(),
+            knnLibraryIndexingContext.getQuantizationConfig()
+        );
+
+        methodComponentContext = new MethodComponentContext(QFrameBitEncoder.NAME, ImmutableMap.of(BITCOUNT_PARAM, 2));
+        knnLibraryIndexingContext = methodComponent.getKNNLibraryIndexingContext(methodComponentContext, knnMethodConfigContext);
+        assertEquals(
+            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, FAISS_FLAT_DESCRIPTION),
+            knnLibraryIndexingContext.getLibraryParameters()
+        );
+        assertEquals(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).build(),
+            knnLibraryIndexingContext.getQuantizationConfig()
+        );
+    }
+
+    public void testValidate() {
+        QFrameBitEncoder qFrameBitEncoder = new QFrameBitEncoder();
+        MethodComponent methodComponent = qFrameBitEncoder.getMethodComponent();
+
+        // Invalid data type
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.BYTE)
+            .dimension(10)
+            .build();
+        MethodComponentContext methodComponentContext = new MethodComponentContext(
+            QFrameBitEncoder.NAME,
+            ImmutableMap.of(BITCOUNT_PARAM, 4)
+        );
+
+        assertNotNull(methodComponent.validate(methodComponentContext, knnMethodConfigContext));
+
+        // Invalid param
+        knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(10)
+            .build();
+        methodComponentContext = new MethodComponentContext(QFrameBitEncoder.NAME, ImmutableMap.of(BITCOUNT_PARAM, 4, "invalid", 4));
+        assertNotNull(methodComponent.validate(methodComponentContext, knnMethodConfigContext));
+
+        // Invalid param type
+        knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(10)
+            .build();
+        methodComponentContext = new MethodComponentContext(QFrameBitEncoder.NAME, ImmutableMap.of(BITCOUNT_PARAM, "invalid"));
+        assertNotNull(methodComponent.validate(methodComponentContext, knnMethodConfigContext));
+
+        // Invalid param value
+        knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(10)
+            .build();
+        methodComponentContext = new MethodComponentContext(QFrameBitEncoder.NAME, ImmutableMap.of(BITCOUNT_PARAM, 5));
+        assertNotNull(methodComponent.validate(methodComponentContext, knnMethodConfigContext));
+    }
+
+    public void testIsTrainingRequired() {
+        QFrameBitEncoder qFrameBitEncoder = new QFrameBitEncoder();
+        assertFalse(
+            qFrameBitEncoder.getMethodComponent()
+                .isTrainingRequired(new MethodComponentContext(QFrameBitEncoder.NAME, ImmutableMap.of(BITCOUNT_PARAM, 4)))
+        );
+    }
+
+    public void testEstimateOverheadInKB() {
+        QFrameBitEncoder qFrameBitEncoder = new QFrameBitEncoder();
+        assertEquals(
+            0,
+            qFrameBitEncoder.getMethodComponent()
+                .estimateOverheadInKB(new MethodComponentContext(QFrameBitEncoder.NAME, ImmutableMap.of(BITCOUNT_PARAM, 4)), 8)
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParserTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.qframe;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+import java.util.Locale;
+
+public class QuantizationConfigParserTests extends KNNTestCase {
+
+    public void testFromCsv() {
+        assertEquals(QuantizationConfig.EMPTY, QuantizationConfigParser.fromCsv(""));
+        assertEquals(QuantizationConfig.EMPTY, QuantizationConfigParser.fromCsv(null));
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> QuantizationConfigParser.fromCsv(
+                String.format(Locale.ROOT, "%s=%s", QuantizationConfigParser.TYPE_NAME, QuantizationConfigParser.BINARY_TYPE)
+            )
+        );
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> QuantizationConfigParser.fromCsv(
+                String.format(
+                    Locale.ROOT,
+                    "%s=%s,%s=%d",
+                    QuantizationConfigParser.TYPE_NAME,
+                    "invalid",
+                    QuantizationConfigParser.BIT_COUNT_NAME,
+                    4
+                )
+            )
+        );
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> QuantizationConfigParser.fromCsv(
+                String.format(
+                    Locale.ROOT,
+                    "%s=%s,%s=%d",
+                    QuantizationConfigParser.TYPE_NAME,
+                    QuantizationConfigParser.BINARY_TYPE,
+                    "invalid",
+                    4
+                )
+            )
+        );
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> QuantizationConfigParser.fromCsv(
+                String.format(
+                    Locale.ROOT,
+                    "%s=%s,%s=%s",
+                    QuantizationConfigParser.TYPE_NAME,
+                    QuantizationConfigParser.BINARY_TYPE,
+                    QuantizationConfigParser.BIT_COUNT_NAME,
+                    "invalid"
+                )
+            )
+        );
+
+        assertEquals(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.FOUR_BIT).build(),
+            QuantizationConfigParser.fromCsv(
+                String.format(
+                    Locale.ROOT,
+                    "%s=%s,%s=%d",
+                    QuantizationConfigParser.TYPE_NAME,
+                    QuantizationConfigParser.BINARY_TYPE,
+                    QuantizationConfigParser.BIT_COUNT_NAME,
+                    4
+                )
+            )
+        );
+    }
+
+    public void testToCsv() {
+        assertEquals("", QuantizationConfigParser.toCsv(null));
+        assertEquals("", QuantizationConfigParser.toCsv(QuantizationConfig.EMPTY));
+        assertEquals(
+            "type=binary,bits=2",
+            QuantizationConfigParser.toCsv(QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).build())
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/QFrameworkIT.java
+++ b/src/test/java/org/opensearch/knn/integ/QFrameworkIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.engine.faiss.QFrameBitEncoder;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+
+public class QFrameworkIT extends KNNRestTestCase {
+
+    private final static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f };
+    private final static int DIMENSION = 2;
+    private final static int K = 1;
+
+    public void testBaseCase() throws IOException {
+        createTestIndex(4);
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, TEST_VECTOR);
+        Response response = searchKNNIndex(
+            INDEX_NAME,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(FIELD_NAME)
+                .field("vector", TEST_VECTOR)
+                .field("k", K)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            1
+        );
+        assertOK(response);
+    }
+
+    private void createTestIndex(int bitCount) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .startObject(PARAMETERS)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, QFrameBitEncoder.NAME)
+            .startObject(PARAMETERS)
+            .field(QFrameBitEncoder.BITCOUNT_PARAM, bitCount)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+}


### PR DESCRIPTION
### Description
Adds support for parsing qframework for faiss in the interface for IVF and HNSW. Does not yet integrate them with the framework.

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
