### PR TITLE
Adds integration tests for NativeEngineKnnVectorsFormat code path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ jni/lib/
 jni/jni_test*
 jni/googletest*
 jni/cmake/*.cmake-e
+jni/.cmake
+jni/.idea
+jni/build.ninja
+jni/.ninja_deps
+jni/.ninja_log
 
 benchmarks/perf-tool/okpt/output
 benchmarks/perf-tool/okpt/dev

--- a/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
+++ b/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
@@ -28,6 +28,13 @@ public class KNNFeatureFlags {
     private static final String KNN_LAUNCH_QUERY_REWRITE_ENABLED = "knn.feature.query.rewrite.enabled";
     private static final boolean KNN_LAUNCH_QUERY_REWRITE_ENABLED_DEFAULT = false;
 
+    /**
+     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
+     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
+     * for native engines.
+     */
+    public static final String KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED = "knn.use.format.enabled";
+
     @VisibleForTesting
     public static final Setting<Boolean> KNN_LAUNCH_QUERY_REWRITE_ENABLED_SETTING = Setting.boolSetting(
         KNN_LAUNCH_QUERY_REWRITE_ENABLED,
@@ -36,8 +43,30 @@ public class KNNFeatureFlags {
         Dynamic
     );
 
+    /**
+     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
+     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
+     * for native engines.
+     */
+    public static final Setting<Boolean> KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING = Setting.boolSetting(
+        KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED,
+        true,
+        NodeScope,
+        Dynamic
+    );
+
+    /**
+     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
+     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
+     * for native engines.
+     */
+    public static boolean getIsLuceneVectorFormatEnabled() {
+        return KNNSettings.state().getSettingValue(KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED);
+    }
+
     public static List<Setting<?>> getFeatureFlags() {
-        return Stream.of(KNN_LAUNCH_QUERY_REWRITE_ENABLED_SETTING).collect(Collectors.toUnmodifiableList());
+        return Stream.of(KNN_LAUNCH_QUERY_REWRITE_ENABLED_SETTING, KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING)
+            .collect(Collectors.toUnmodifiableList());
     }
 
     public static boolean isKnnQueryRewriteEnabled() {

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -83,12 +83,6 @@ public class KNNSettings {
     public static final String MODEL_CACHE_SIZE_LIMIT = "knn.model.cache.size.limit";
     public static final String ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD = "index.knn.advanced.filtered_exact_search_threshold";
     public static final String KNN_FAISS_AVX2_DISABLED = "knn.faiss.avx2.disabled";
-    /**
-     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
-     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
-     * for native engines.
-     */
-    public static final String KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED = "knn.use.format.enabled";
     public static final String QUANTIZATION_STATE_CACHE_SIZE_LIMIT = "knn.quantization.cache.size.limit";
     public static final String QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES = "knn.quantization.cache.expiry.minutes";
 
@@ -269,17 +263,6 @@ public class KNNSettings {
         NodeScope
     );
 
-    /**
-     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
-     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
-     * for native engines.
-     */
-    public static final Setting<Boolean> KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING = Setting.boolSetting(
-        KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED,
-        false,
-        NodeScope
-    );
-
     /*
      * Quantization state cache settings
      */
@@ -449,10 +432,6 @@ public class KNNSettings {
             return KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING;
         }
 
-        if (KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED.equals(key)) {
-            return KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING;
-        }
-
         if (QUANTIZATION_STATE_CACHE_SIZE_LIMIT.equals(key)) {
             return QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING;
         }
@@ -480,7 +459,6 @@ public class KNNSettings {
             ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_SETTING,
             KNN_FAISS_AVX2_DISABLED_SETTING,
             KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING,
-            KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING,
             QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
             QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING
         );
@@ -526,15 +504,6 @@ public class KNNSettings {
             .index(indexName)
             .getSettings()
             .getAsInt(ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_DEFAULT_VALUE);
-    }
-
-    /**
-     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
-     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
-     * for native engines.
-     */
-    public static boolean getIsLuceneVectorFormatEnabled() {
-        return KNNSettings.state().getSettingValue(KNNSettings.KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED);
     }
 
     public void initialize(Client client, ClusterService clusterService) {

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -20,6 +20,7 @@ import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.Version;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.KnnCircuitBreakerException;
 import org.opensearch.knn.index.SpaceType;
@@ -143,7 +144,7 @@ public class KNNVectorFieldMapperUtil {
      * @return true if vector field should use KNNVectorsFormat
      */
     static boolean useLuceneKNNVectorsFormat(final Version indexCreatedVersion) {
-        return indexCreatedVersion.onOrAfter(Version.V_2_17_0) && KNNSettings.getIsLuceneVectorFormatEnabled();
+        return indexCreatedVersion.onOrAfter(Version.V_2_17_0) && KNNFeatureFlags.getIsLuceneVectorFormatEnabled();
     }
 
     private static SpaceType getSpaceType(final Settings indexSettings) {

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.mapper;
 
 import lombok.Getter;
+import lombok.ToString;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -29,6 +30,7 @@ import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.deseriali
 /**
  * A KNNVector field type to represent the vector field in Opensearch
  */
+@ToString
 @Getter
 public class KNNVectorFieldType extends MappedFieldType {
     KNNMappingConfig knnMappingConfig;

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -228,7 +228,12 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
         parseCreateField(context, modelMetadata.getDimension(), modelMetadata.getVectorDataType());
     }
 
-    private static KNNMethodContext getKNNMethodContextFromModelMetadata(ModelMetadata modelMetadata) {
+    /**
+     * Extracts knnMethodContext from model metadata
+     * @param modelMetadata
+     * @return null if MethodComponentContext is empty else returns a new object of KNNMethodContext
+     */
+    public static KNNMethodContext getKNNMethodContextFromModelMetadata(ModelMetadata modelMetadata) {
         MethodComponentContext methodComponentContext = modelMetadata.getMethodComponentContext();
         if (methodComponentContext == MethodComponentContext.EMPTY) {
             return null;

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -11,10 +11,13 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
+import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -31,15 +34,34 @@ import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.knn.common.featureflags.KNNFeatureFlags.KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED;
 
+@AllArgsConstructor
 public class NmslibIT extends KNNRestTestCase {
 
     static TestUtils.TestData testData;
+
+    private Boolean knnUseLuceneVectorFormat;
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList($$($(false), $(true)));
+    }
+
+    @Before
+    public void init() throws Exception {
+        super.setUp();
+        updateClusterSettings(KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED, knnUseLuceneVectorFormat);
+    }
 
     @BeforeClass
     public static void setUpClass() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat;
+import org.opensearch.knn.index.codec.params.KNNVectorsFormatParams;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.mapper.KNNMappingConfig;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.mapper.ModelFieldMapper;
+import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.indices.ModelUtil;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class BasePerFieldKnnVectorsFormatTests extends OpenSearchTestCase {
+
+    private static final String FIELD = "field";
+    private static final String MODEL_ID = "model_id";
+
+    @Mock
+    private MapperService mapperService;
+    @Mock
+    private Function<KNNVectorsFormatParams, KnnVectorsFormat> vectorsFormatSupplier;
+    @Mock
+    private KNNMappingConfig knnMappingConfig;
+    @Mock
+    private KNNMethodContext knnMethodContext;
+    @Mock
+    private MethodComponentContext methodComponentContext;
+
+    private BasePerFieldKnnVectorsFormat basePerFieldKnnVectorsFormat;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        openMocks(this);
+        basePerFieldKnnVectorsFormat = new BasePerFieldKnnVectorsFormat(
+            Optional.of(mapperService),
+            10,
+            10,
+            Lucene99HnswVectorsFormat::new,
+            vectorsFormatSupplier
+        ) {
+        };
+    }
+
+    public void testGetKNNVectorsFormatForField() {
+        MappedFieldType mappedFieldType = mock(MappedFieldType.class);
+        when(mapperService.fieldType(FIELD)).thenReturn(mappedFieldType);
+
+        KnnVectorsFormat knnVectorsFormat = basePerFieldKnnVectorsFormat.getKnnVectorsFormatForField(FIELD);
+        assertEquals(Lucene99HnswVectorsFormat.class, knnVectorsFormat.getClass());
+
+        KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldType.class);
+        when(knnVectorFieldType.getKnnMappingConfig()).thenReturn(knnMappingConfig);
+        when(knnMappingConfig.getKnnMethodContext()).thenReturn(Optional.of(knnMethodContext));
+        when(knnMethodContext.getMethodComponentContext()).thenReturn(methodComponentContext);
+        when(mapperService.fieldType(FIELD)).thenReturn(knnVectorFieldType);
+
+        KnnVectorsFormat expected = new Lucene99HnswVectorsFormat(10, 10);
+        when(vectorsFormatSupplier.apply(new KNNVectorsFormatParams(null, 10, 10))).thenReturn(expected);
+        assertEquals(NativeEngines990KnnVectorsFormat.class, basePerFieldKnnVectorsFormat.getKnnVectorsFormatForField(FIELD).getClass());
+    }
+
+    public void testGetKNNVectorsFormatForFieldWithModel() {
+        ModelMetadata metadata = mock(ModelMetadata.class);
+        try (
+            MockedStatic<ModelUtil> modelUtilMock = mockStatic(ModelUtil.class);
+            MockedStatic<ModelFieldMapper> modelFieldMapperMock = mockStatic(ModelFieldMapper.class)
+        ) {
+            KNNVectorFieldType knnVectorFieldType = mock(KNNVectorFieldType.class);
+            when(knnVectorFieldType.getKnnMappingConfig()).thenReturn(knnMappingConfig);
+            when(knnMappingConfig.getModelId()).thenReturn(Optional.of(MODEL_ID));
+            modelUtilMock.when(() -> ModelUtil.getModelMetadata(MODEL_ID)).thenReturn(metadata);
+            modelFieldMapperMock.when(() -> ModelFieldMapper.getKNNMethodContextFromModelMetadata(metadata)).thenReturn(knnMethodContext);
+            when(knnMethodContext.getMethodComponentContext()).thenReturn(methodComponentContext);
+            when(mapperService.fieldType(FIELD)).thenReturn(knnVectorFieldType);
+
+            assertEquals(
+                NativeEngines990KnnVectorsFormat.class,
+                basePerFieldKnnVectorsFormat.getKnnVectorsFormatForField(FIELD).getClass()
+            );
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -18,7 +18,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
@@ -76,15 +76,13 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
     }
 
     public void testUseLuceneKNNVectorsFormat_withDifferentInputs_thenSuccess() {
-        final KNNSettings knnSettings = mock(KNNSettings.class);
-        final MockedStatic<KNNSettings> mockedStatic = Mockito.mockStatic(KNNSettings.class);
-        mockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
+        final MockedStatic<KNNFeatureFlags> mockedStatic = Mockito.mockStatic(KNNFeatureFlags.class);
 
-        mockedStatic.when(KNNSettings::getIsLuceneVectorFormatEnabled).thenReturn(false);
+        mockedStatic.when(KNNFeatureFlags::getIsLuceneVectorFormatEnabled).thenReturn(false);
         Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_16_0));
         Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_3_0_0));
 
-        mockedStatic.when(KNNSettings::getIsLuceneVectorFormatEnabled).thenReturn(true);
+        mockedStatic.when(KNNFeatureFlags::getIsLuceneVectorFormatEnabled).thenReturn(true);
         Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_17_0));
         Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_3_0_0));
         // making sure to close the static mock to ensure that for tests running on this thread are not impacted by


### PR DESCRIPTION
### Description
This adds integration test for https://github.com/opensearch-project/k-NN/pull/1950

This also turns on the flag to use native index writer

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
