### PR TITLE
Fix string for qframe parser key to not use String.format

### DIFF
--- a/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParser.java
+++ b/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParser.java
@@ -33,14 +33,8 @@ public class QuantizationConfigParser {
             || quantizationConfig.getQuantizationType() == null) {
             return "";
         }
-        return String.format(
-            Locale.ROOT,
-            "%s=%s,%s=%d",
-            TYPE_NAME,
-            BINARY_TYPE,
-            BIT_COUNT_NAME,
-            quantizationConfig.getQuantizationType().getId()
-        );
+
+        return TYPE_NAME + SEPARATOR + BINARY_TYPE + "," + BIT_COUNT_NAME + SEPARATOR + quantizationConfig.getQuantizationType().getId();
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
@@ -246,7 +246,7 @@ public class FaissTests extends KNNTestCase {
             .vectorDataType(VectorDataType.FLOAT)
             .build();
         int m = 88;
-        String expectedIndexDescription = String.format(Locale.ROOT, "HNSW%d,Flat", m);
+        String expectedIndexDescription = "HNSW" + m + ",Flat";
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .field(NAME, METHOD_HNSW)
@@ -285,7 +285,7 @@ public class FaissTests extends KNNTestCase {
             .vectorDataType(VectorDataType.FLOAT)
             .build();
         int nlist = 88;
-        String expectedIndexDescription = String.format(Locale.ROOT, "IVF%d,Flat", nlist);
+        String expectedIndexDescription = "IVF" + nlist + ",Flat";
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .field(NAME, METHOD_IVF)

--- a/src/test/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParserTests.java
@@ -8,8 +8,6 @@ package org.opensearch.knn.index.engine.qframe;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
-import java.util.Locale;
-
 public class QuantizationConfigParserTests extends KNNTestCase {
 
     public void testFromCsv() {
@@ -18,64 +16,49 @@ public class QuantizationConfigParserTests extends KNNTestCase {
 
         expectThrows(
             IllegalArgumentException.class,
+            () -> QuantizationConfigParser.fromCsv(QuantizationConfigParser.TYPE_NAME + "=" + QuantizationConfigParser.BINARY_TYPE)
+        );
+
+        expectThrows(
+            IllegalArgumentException.class,
             () -> QuantizationConfigParser.fromCsv(
-                String.format(Locale.ROOT, "%s=%s", QuantizationConfigParser.TYPE_NAME, QuantizationConfigParser.BINARY_TYPE)
+                QuantizationConfigParser.TYPE_NAME + "=invalid," + QuantizationConfigParser.BIT_COUNT_NAME + "=4"
             )
         );
 
         expectThrows(
             IllegalArgumentException.class,
             () -> QuantizationConfigParser.fromCsv(
-                String.format(
-                    Locale.ROOT,
-                    "%s=%s,%s=%d",
-                    QuantizationConfigParser.TYPE_NAME,
-                    "invalid",
-                    QuantizationConfigParser.BIT_COUNT_NAME,
-                    4
-                )
+                QuantizationConfigParser.TYPE_NAME
+                    + "="
+                    + QuantizationConfigParser.BINARY_TYPE
+                    + ",invalid=4"
+                    + QuantizationConfigParser.BIT_COUNT_NAME
+                    + "=4"
             )
         );
 
         expectThrows(
             IllegalArgumentException.class,
             () -> QuantizationConfigParser.fromCsv(
-                String.format(
-                    Locale.ROOT,
-                    "%s=%s,%s=%d",
-                    QuantizationConfigParser.TYPE_NAME,
-                    QuantizationConfigParser.BINARY_TYPE,
-                    "invalid",
-                    4
-                )
-            )
-        );
-
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> QuantizationConfigParser.fromCsv(
-                String.format(
-                    Locale.ROOT,
-                    "%s=%s,%s=%s",
-                    QuantizationConfigParser.TYPE_NAME,
-                    QuantizationConfigParser.BINARY_TYPE,
-                    QuantizationConfigParser.BIT_COUNT_NAME,
-                    "invalid"
-                )
+                QuantizationConfigParser.TYPE_NAME
+                    + "="
+                    + QuantizationConfigParser.BINARY_TYPE
+                    + ","
+                    + QuantizationConfigParser.BIT_COUNT_NAME
+                    + "=invalid"
             )
         );
 
         assertEquals(
             QuantizationConfig.builder().quantizationType(ScalarQuantizationType.FOUR_BIT).build(),
             QuantizationConfigParser.fromCsv(
-                String.format(
-                    Locale.ROOT,
-                    "%s=%s,%s=%d",
-                    QuantizationConfigParser.TYPE_NAME,
-                    QuantizationConfigParser.BINARY_TYPE,
-                    QuantizationConfigParser.BIT_COUNT_NAME,
-                    4
-                )
+                QuantizationConfigParser.TYPE_NAME
+                    + "="
+                    + QuantizationConfigParser.BINARY_TYPE
+                    + ","
+                    + QuantizationConfigParser.BIT_COUNT_NAME
+                    + "=4"
             )
         );
     }


### PR DESCRIPTION
### Description
Fixes String for to/from csv parsing to not use String.format. This will ensure we do not run into Locale issues. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
