### PR TITLE
Fix memory overflow caused by cache behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add script_fields context to KNNAllowlist [#1917] (https://github.com/opensearch-project/k-NN/pull/1917)
 * Fix graph merge stats size calculation [#1844](https://github.com/opensearch-project/k-NN/pull/1844)
 * Disallow a vector field to have an invalid character for a physical file name. [#1936](https://github.com/opensearch-project/k-NN/pull/1936)
+* Fix memory overflow caused by cache behavior [#2015](https://github.com/opensearch-project/k-NN/pull/2015)
 ### Infrastructure
 * Parallelize make to reduce build time [#2006] (https://github.com/opensearch-project/k-NN/pull/2006)
 ### Documentation

--- a/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
+++ b/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.knn.common.featureflags;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import lombok.experimental.UtilityClass;
+import org.opensearch.common.Booleans;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.knn.index.KNNSettings;
+
+import java.util.List;
+
+import static org.opensearch.common.settings.Setting.Property.Dynamic;
+import static org.opensearch.common.settings.Setting.Property.NodeScope;
+
+/**
+ * Class to manage KNN feature flags
+ */
+@UtilityClass
+public class KNNFeatureFlags {
+
+    // Feature flags
+    private static final String KNN_FORCE_EVICT_CACHE_ENABLED = "knn.feature.cache.force_evict.enabled";
+
+    @VisibleForTesting
+    public static final Setting<Boolean> KNN_FORCE_EVICT_CACHE_ENABLED_SETTING = Setting.boolSetting(
+        KNN_FORCE_EVICT_CACHE_ENABLED,
+        false,
+        NodeScope,
+        Dynamic
+    );
+
+    public static List<Setting<?>> getFeatureFlags() {
+        return ImmutableList.of(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING);
+    }
+
+    /**
+     * Checks if force evict for cache is enabled by executing a check against cluster settings
+     * @return true if force evict setting is set to true
+     */
+    public static boolean isForceEvictCacheEnabled() {
+        return Booleans.parseBoolean(KNNSettings.state().getSettingValue(KNN_FORCE_EVICT_CACHE_ENABLED).toString(), false);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -34,14 +34,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.opensearch.common.settings.Setting.Property.Dynamic;
 import static org.opensearch.common.settings.Setting.Property.IndexScope;
 import static org.opensearch.common.settings.Setting.Property.NodeScope;
 import static org.opensearch.common.unit.MemorySizeValue.parseBytesSizeValueOrHeapRatio;
 import static org.opensearch.core.common.unit.ByteSizeValue.parseBytesSizeValue;
+import static org.opensearch.knn.common.featureflags.KNNFeatureFlags.getFeatureFlags;
 
 /**
  * This class defines
@@ -351,6 +354,9 @@ public class KNNSettings {
         }
     };
 
+    private final static Map<String, Setting<?>> FEATURE_FLAGS = getFeatureFlags().stream()
+        .collect(toUnmodifiableMap(Setting::getKey, Function.identity()));
+
     private ClusterService clusterService;
     private Client client;
 
@@ -388,7 +394,7 @@ public class KNNSettings {
             );
 
             NativeMemoryCacheManager.getInstance().rebuildCache(builder.build());
-        }, dynamicCacheSettings.values().stream().collect(Collectors.toUnmodifiableList()));
+        }, Stream.concat(dynamicCacheSettings.values().stream(), FEATURE_FLAGS.values().stream()).collect(Collectors.toUnmodifiableList()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, it -> {
             QuantizationStateCache.getInstance().setMaxCacheSizeInKB(it.getKb());
             QuantizationStateCache.getInstance().rebuildCache();
@@ -413,6 +419,10 @@ public class KNNSettings {
     private Setting<?> getSetting(String key) {
         if (dynamicCacheSettings.containsKey(key)) {
             return dynamicCacheSettings.get(key);
+        }
+
+        if (FEATURE_FLAGS.containsKey(key)) {
+            return FEATURE_FLAGS.get(key);
         }
 
         if (KNN_CIRCUIT_BREAKER_TRIGGERED.equals(key)) {
@@ -474,7 +484,8 @@ public class KNNSettings {
             QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
             QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING
         );
-        return Stream.concat(settings.stream(), dynamicCacheSettings.values().stream()).collect(Collectors.toList());
+        return Stream.concat(settings.stream(), Stream.concat(getFeatureFlags().stream(), dynamicCacheSettings.values().stream()))
+            .collect(Collectors.toList());
     }
 
     public static boolean isKNNPluginEnabled() {

--- a/src/test/java/org/opensearch/knn/common/featureflags/KNNFeatureFlagsTests.java
+++ b/src/test/java/org/opensearch/knn/common/featureflags/KNNFeatureFlagsTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common.featureflags;
+
+import org.mockito.Mock;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.featureflags.KNNFeatureFlags.KNN_FORCE_EVICT_CACHE_ENABLED_SETTING;
+import static org.opensearch.knn.common.featureflags.KNNFeatureFlags.isForceEvictCacheEnabled;
+
+public class KNNFeatureFlagsTests extends KNNTestCase {
+
+    @Mock
+    ClusterSettings clusterSettings;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        KNNSettings.state().setClusterService(clusterService);
+    }
+
+    public void testIsForceEvictCacheEnabled() throws Exception {
+        when(clusterSettings.get(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING)).thenReturn(false);
+        assertFalse(isForceEvictCacheEnabled());
+        when(clusterSettings.get(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING)).thenReturn(true);
+        assertTrue(isForceEvictCacheEnabled());
+    }
+}


### PR DESCRIPTION
### Description
- Adds in a force evict mechanism before entry to prevent memory overflow for native memory usage within the cache
- This solution works in tandem with `jemalloc` enabled. In case of default `malloc`, there are potential delays with memory free up operations leading to similar scenarios
- The solution has been tested and benchmarked - described in the Testing section below

### Problem
- The problem stems from the behavior of the cache where in entries of the cache might not be cleaned up as soon as they are evictable
- This delay between new entry and cleanup can, in our case, cause the memory to overflow - leading to a node failure

### Solution
- This solution aims at maintaining an additional recency list within the cache manager
- On every `get` call - 
  - in case of a cache hit - it just marks the key as recent, returns the value
  - in case of a cache miss - it adds the key to the recency list, loads the item into the cache and returns
  - in case of a cache miss & a potential overflow - eviction process kicks off before the item is loaded into the cache 

### Testing

1. **Case: Enough memory available**
  - Scenario description: Indexed 1M 768d vectors on a 3 node cluster with 16GB memory - 8GB heap, 8GB for graph files, ran an OSB query load with and without the fix
  - TLDR; Not a ton of deviation from current code in terms of raw numbers. Results below

| Index Type    | Dimension | Number Of Vectors | Min Throughput | Mean Throughput | Median Throughput | Max Throughput | 50th percentile latency | 90th percentile latency | 99th percentile latency | 100th percentile latency | 50th percentile service time | 90th percentile service time | 99th percentile service time | 100th percentile service time | Mean recall@k | Mean recall@1 |
| ------------- | --------- | ----------------- | -------------- | --------------- | ----------------- | -------------- | ----------------------- | ----------------------- | ----------------------- | ------------------------ | ---------------------------- | ---------------------------- | ---------------------------- | ----------------------------- | ------------- | ------------- |
| Current Code  | 768       | 1,000,000         | 2.46           | 2.68            | 2.69              | 2.74           | 358.268                 | 382.036                 | 414.636                 | 482.332                  | 358.268                      | 382.036                      | 414.636                      | 482.332                       | 0.98          | 1             |
| Code with Fix | 768       | 1,000,000         | 2.55           | 2.71            | 2.7               | 2.75           | 363.62                  | 398.338                 | 432.811                 | 447.278                  | 363.62                       | 398.338                      | 432.811                      | 447.278                       | 0.98          | 1             |


2. **Case: Heavy query load scenario**
  - Scenario: Created 3 indexes (2 FAISS, 1 NMSLIB), Indexed 1M 768d vectors on a 3 node cluster with 16GB memory - 8GB heap, 8GB for graph files, ran 3 parallel query workloads for all the indexes at once. 
  - TLDR; **Without the fix** - noticed node crashes. **With the fix** - there was an uptick in error due to timeouts, latency increased but no node crash was observed

| Index Type      | Dimension | Number Of Vectors | Min Throughput | Mean Throughput | Median Throughput | Max Throughput | 50th percentile latency | 90th percentile latency | 99th percentile latency | 100th percentile latency | 50th percentile service time | 90th percentile service time | 99th percentile service time | 100th percentile service time | Error rate % | Mean recall@k | Mean recall@1 |
| --------------- | --------- | ----------------- | -------------- | --------------- | ----------------- | -------------- | ----------------------- | ----------------------- | ----------------------- | ------------------------ | ---------------------------- | ---------------------------- | ---------------------------- | ----------------------------- | ------------ | ------------- | ------------- |
| Index1 with fix | 768       | 1,000,000         | 0.05           | 0.06            | 0.06              | 0.09           | 13228.9                 | 19363.3                 | 24602.8                 | 35710.1                  | 13228.9                      | 19363.3                      | 24602.8                      | 35710.1                       | 11           | 0.99          | 1             |
| Index2 with fix | 768       | 1,000,000         | 0.1            | 0.25            | 0.14              | 1.02           | 11728.5                 | 15634.2                 | 23228.2                 | 34283.1                  | 11728.5                      | 15634.2                      | 23228.2                      | 34283.1                       | 0            | 0.98          | 1             |
| Index3 with fix | 768       | 1,000,000         | 0.06           | 0.07            | 0.07              | 0.09           | 12575                   | 17641.8                 | 25928.4                 | 27722.8                  | 12575                        | 17641.8                      | 25928.4                      | 27722.8                       | 3            | 0.98          | 1             |

### Related Issues
Partially resolves #1582 (Case 3)
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
