### PR TITLE
[Backport 2.x] Makes NativeEngines990KnnVectorFormat as default for index version (#…

### DIFF
--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -80,12 +80,6 @@ public class KNNSettings {
     public static final String MODEL_CACHE_SIZE_LIMIT = "knn.model.cache.size.limit";
     public static final String ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD = "index.knn.advanced.filtered_exact_search_threshold";
     public static final String KNN_FAISS_AVX2_DISABLED = "knn.faiss.avx2.disabled";
-    /**
-     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
-     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
-     * for native engines.
-     */
-    public static final String KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED = "knn.use.format.enabled";
     public static final String QUANTIZATION_STATE_CACHE_SIZE_LIMIT = "knn.quantization.cache.size.limit";
     public static final String QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES = "knn.quantization.cache.expiry.minutes";
 
@@ -266,17 +260,6 @@ public class KNNSettings {
         NodeScope
     );
 
-    /**
-     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
-     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
-     * for native engines.
-     */
-    public static final Setting<Boolean> KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING = Setting.boolSetting(
-        KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED,
-        false,
-        NodeScope
-    );
-
     /*
      * Quantization state cache settings
      */
@@ -439,10 +422,6 @@ public class KNNSettings {
             return KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING;
         }
 
-        if (KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED.equals(key)) {
-            return KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING;
-        }
-
         if (QUANTIZATION_STATE_CACHE_SIZE_LIMIT.equals(key)) {
             return QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING;
         }
@@ -470,7 +449,6 @@ public class KNNSettings {
             ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_SETTING,
             KNN_FAISS_AVX2_DISABLED_SETTING,
             KNN_VECTOR_STREAMING_MEMORY_LIMIT_PCT_SETTING,
-            KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED_SETTING,
             QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
             QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING
         );
@@ -515,15 +493,6 @@ public class KNNSettings {
             .index(indexName)
             .getSettings()
             .getAsInt(ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_DEFAULT_VALUE);
-    }
-
-    /**
-     * TODO: This setting is only added to ensure that main branch of k_NN plugin doesn't break till other parts of the
-     * code is getting ready. Will remove this setting once all changes related to integration of KNNVectorsFormat is added
-     * for native engines.
-     */
-    public static boolean getIsLuceneVectorFormatEnabled() {
-        return KNNSettings.state().getSettingValue(KNNSettings.KNN_USE_LUCENE_VECTOR_FORMAT_ENABLED);
     }
 
     public void initialize(Client client, ClusterService clusterService) {

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -78,10 +78,13 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
             )
         ).fieldType(field);
 
-        KNNMappingConfig knnMappingConfig = mappedFieldType.getKnnMappingConfig();
-        KNNMethodContext knnMethodContext = knnMappingConfig.getKnnMethodContext()
-            .orElseThrow(() -> new IllegalArgumentException("KNN method context cannot be empty"));
+        final KNNMappingConfig knnMappingConfig = mappedFieldType.getKnnMappingConfig();
+        if (knnMappingConfig.getModelId().isPresent()) {
+            return nativeEngineVectorsFormat();
+        }
 
+        final KNNMethodContext knnMethodContext = knnMappingConfig.getKnnMethodContext()
+            .orElseThrow(() -> new IllegalArgumentException("KNN method context cannot be empty"));
         final KNNEngine engine = knnMethodContext.getKnnEngine();
         final Map<String, Object> params = knnMethodContext.getMethodComponentContext().getParameters();
 
@@ -122,6 +125,10 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
         }
 
         // All native engines to use NativeEngines990KnnVectorsFormat
+        return nativeEngineVectorsFormat();
+    }
+
+    private NativeEngines990KnnVectorsFormat nativeEngineVectorsFormat() {
         return new NativeEngines990KnnVectorsFormat(new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()));
     }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -143,7 +143,7 @@ public class KNNVectorFieldMapperUtil {
      * @return true if vector field should use KNNVectorsFormat
      */
     static boolean useLuceneKNNVectorsFormat(final Version indexCreatedVersion) {
-        return indexCreatedVersion.onOrAfter(Version.V_2_17_0) && KNNSettings.getIsLuceneVectorFormatEnabled();
+        return indexCreatedVersion.onOrAfter(Version.V_2_17_0);
     }
 
     private static SpaceType getSpaceType(final Settings indexSettings) {

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -14,11 +14,8 @@ package org.opensearch.knn.index.mapper;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Assert;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.util.KNNVectorSerializerFactory;
 
@@ -76,18 +73,8 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
     }
 
     public void testUseLuceneKNNVectorsFormat_withDifferentInputs_thenSuccess() {
-        final KNNSettings knnSettings = mock(KNNSettings.class);
-        final MockedStatic<KNNSettings> mockedStatic = Mockito.mockStatic(KNNSettings.class);
-        mockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
-
-        mockedStatic.when(KNNSettings::getIsLuceneVectorFormatEnabled).thenReturn(false);
         Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_16_0));
-        Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_17_0));
-
-        mockedStatic.when(KNNSettings::getIsLuceneVectorFormatEnabled).thenReturn(true);
         Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_17_0));
-        // making sure to close the static mock to ensure that for tests running on this thread are not impacted by
-        // this mocking
-        mockedStatic.close();
+        Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_3_0_0));
     }
 }


### PR DESCRIPTION
…2020)

starting 2.17

This removes the feature flag for the same

Signed-off-by: Tejas Shah <shatejas@amazon.com>
(cherry picked from commit 6b197be39be4dbe96417d9410b858a33f239ca10)

### Description
Backport for https://github.com/opensearch-project/k-NN/pull/2020

### Related Issues


### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
