### PR TITLE
Fixing the format name for NativeEngines990KnnVectorsFormat

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     /** The format for storing, reading, merging vectors on disk */
     private static FlatVectorsFormat flatVectorsFormat;
-    private static final String FORMAT_NAME = "NativeEngines99KnnVectorsFormat";
+    private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
 
     public NativeEngines990KnnVectorsFormat() {
         super(FORMAT_NAME);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormatTests.java
@@ -14,6 +14,7 @@ package org.opensearch.knn.index.codec.KNN990Codec;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
@@ -224,6 +225,16 @@ public class NativeEngines990KnnVectorsFormatTests extends KNNTestCase {
         assertEquals(1, floatVectorValues.size());
         assertEquals(8, floatVectorValues.dimension());
         indexReader.close();
+    }
+
+    public void testFormatName_withValidInput_thenSuccess() {
+        final String validFormatName = "NativeEngines990KnnVectorsFormat";
+        Assert.assertEquals(validFormatName, new NativeEngines990KnnVectorsFormat().getName());
+        Assert.assertEquals(
+            validFormatName,
+            new NativeEngines990KnnVectorsFormat(new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))
+                .getName()
+        );
     }
 
     private List<String> getFilesFromSegment(Directory dir, String fileFormat) throws IOException {


### PR DESCRIPTION
### Description
Fixing the format name for NativeEngines990KnnVectorsFormat

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
