### PR TITLE
Adds index and query BWC tests for missing engines

### DIFF
--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -35,6 +35,7 @@ testClusters {
     }
 }
 
+   def versionsBelow2_3 = ["1.", "2.0.", "2.1.", "2.2."]
 // Task to run BWC tests against the old cluster
     task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         dependsOn "zipBwcPlugin"
@@ -86,6 +87,13 @@ testClusters {
                 knn_bwc_version.startsWith("2.15.")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
+            }
+        }
+
+        if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
             }
         }
 
@@ -152,6 +160,13 @@ testClusters {
                 knn_bwc_version.startsWith("2.15.")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
+            }
+        }
+
+        if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
             }
         }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/QueryANNIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/QueryANNIT.java
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.knn.bwc;
@@ -14,8 +8,13 @@ package org.opensearch.knn.bwc;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 
+/**
+ * Use case: Test queries on indexes created on older versions
+ */
 public class QueryANNIT extends AbstractRestartUpgradeTestCase {
 
     private static final String TEST_FIELD = "test-field";
@@ -25,9 +24,33 @@ public class QueryANNIT extends AbstractRestartUpgradeTestCase {
     private static final int NUM_DOCS = 10;
     private static final String ALGORITHM = "hnsw";
 
-    public void testQueryANN() throws Exception {
+    public void testQueryOnFaissIndex() throws Exception {
         if (isRunningAgainstOldCluster()) {
             createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, ALGORITHM, FAISS_NAME));
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K, Map.of(METHOD_PARAMETER_EF_SEARCH, EF_SEARCH));
+            deleteKNNIndex(testIndex);
+        }
+    }
+
+    public void testQueryOnNmslibIndex() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, ALGORITHM, NMSLIB_NAME));
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K, Map.of(METHOD_PARAMETER_EF_SEARCH, EF_SEARCH));
+            deleteKNNIndex(testIndex);
+        }
+    }
+
+    public void testQueryOnLuceneIndex() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, ALGORITHM, LUCENE_NAME));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
             validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
         } else {


### PR DESCRIPTION
### Description

This is done to make sure that KNN80DocsValueConsumer code path is hit

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
