### PR TITLE
Add spaceType as a top level parameter while creating vector field.

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.17.0.0.md
@@ -8,6 +8,7 @@ Compatible with OpenSearch 2.17.0
 * Add support for byte vector with Faiss Engine HNSW algorithm [#1823](https://github.com/opensearch-project/k-NN/pull/1823)
 * Add support for byte vector with Faiss Engine IVF algorithm [#2002](https://github.com/opensearch-project/k-NN/pull/2002)
 * Add mode/compression configuration support for disk-based vector search [#2034](https://github.com/opensearch-project/k-NN/pull/2034)
+* Add spaceType as a top level optional parameter while creating vector field. 
 ### Enhancements
 * Adds iterative graph build capability into a faiss index to improve the memory footprint during indexing and Integrates KNNVectorsFormat for native engines[#1950](https://github.com/opensearch-project/k-NN/pull/1950)
 ### Bug Fixes

--- a/release-notes/opensearch-knn.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.17.0.0.md
@@ -8,7 +8,7 @@ Compatible with OpenSearch 2.17.0
 * Add support for byte vector with Faiss Engine HNSW algorithm [#1823](https://github.com/opensearch-project/k-NN/pull/1823)
 * Add support for byte vector with Faiss Engine IVF algorithm [#2002](https://github.com/opensearch-project/k-NN/pull/2002)
 * Add mode/compression configuration support for disk-based vector search [#2034](https://github.com/opensearch-project/k-NN/pull/2034)
-* Add spaceType as a top level optional parameter while creating vector field. 
+* Add spaceType as a top level optional parameter while creating vector field. [#2044](https://github.com/opensearch-project/k-NN/pull/2044)
 ### Enhancements
 * Adds iterative graph build capability into a faiss index to improve the memory footprint during indexing and Integrates KNNVectorsFormat for native engines[#1950](https://github.com/opensearch-project/k-NN/pull/1950)
 ### Bug Fixes

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -33,6 +33,8 @@ public class KNNConstants {
     public static final String METHOD_IVF = "ivf";
     public static final String METHOD_PARAMETER_NLIST = "nlist";
     public static final String METHOD_PARAMETER_SPACE_TYPE = "space_type"; // used for mapping parameter
+    // used for defining toplevel parameter
+    public static final String TOP_LEVEL_PARAMETER_SPACE_TYPE = METHOD_PARAMETER_SPACE_TYPE;
     public static final String COMPOUND_EXTENSION = "c";
     public static final String MODEL = "model";
     public static final String MODELS = "models";
@@ -72,6 +74,7 @@ public class KNNConstants {
     public static final String MODEL_VECTOR_DATA_TYPE_KEY = VECTOR_DATA_TYPE_FIELD;
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
     public static final String MINIMAL_MODE_AND_COMPRESSION_FEATURE = "mode_and_compression_feature";
+    public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
     public static final String QUANTIZATION_STATE_FILE_SUFFIX = "osknnqstate";

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -11,10 +11,12 @@
 
 package org.opensearch.knn.index;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNVectorUtil.isZeroVector;
 
@@ -149,6 +151,12 @@ public enum SpaceType {
     public static SpaceType DEFAULT = L2;
     public static SpaceType DEFAULT_BINARY = HAMMING;
 
+    private static final String[] VALID_VALUES = Arrays.stream(SpaceType.values())
+        .filter(space -> space != SpaceType.UNDEFINED)
+        .map(SpaceType::getValue)
+        .collect(Collectors.toList())
+        .toArray(new String[0]);
+
     private final String value;
 
     SpaceType(String value) {
@@ -221,7 +229,9 @@ public enum SpaceType {
                 return currentSpaceType;
             }
         }
-        throw new IllegalArgumentException("Unable to find space: " + spaceTypeName);
+        throw new IllegalArgumentException(
+            String.format(Locale.ROOT, "Unable to find space: %s . Valid values are: %s", spaceTypeName, Arrays.toString(VALID_VALUES))
+        );
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -193,10 +193,18 @@ public class KNNVectorFieldMapperUtil {
         return Integer.parseInt(efConstruction);
     }
 
-    static KNNMethodContext createKNNMethodContextFromLegacy(Settings indexSettings, Version indexCreatedVersion) {
+    static KNNMethodContext createKNNMethodContextFromLegacy(
+        Settings indexSettings,
+        Version indexCreatedVersion,
+        SpaceType topLevelSpaceType
+    ) {
+        // If top level spaceType is set then use that spaceType otherwise default to spaceType from index-settings
+        final SpaceType finalSpaceToSet = topLevelSpaceType != SpaceType.UNDEFINED
+            ? topLevelSpaceType
+            : KNNVectorFieldMapperUtil.getSpaceType(indexSettings);
         return new KNNMethodContext(
             KNNEngine.NMSLIB,
-            KNNVectorFieldMapperUtil.getSpaceType(indexSettings),
+            finalSpaceToSet,
             new MethodComponentContext(
                 METHOD_HNSW,
                 Map.of(

--- a/src/main/java/org/opensearch/knn/index/mapper/ModeBasedResolver.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModeBasedResolver.java
@@ -59,15 +59,19 @@ public final class ModeBasedResolver {
      * @param requiresTraining whether config requires trianing
      * @return {@link KNNMethodContext}
      */
-    public KNNMethodContext resolveKNNMethodContext(Mode mode, CompressionLevel compressionLevel, boolean requiresTraining) {
+    public KNNMethodContext resolveKNNMethodContext(
+        Mode mode,
+        CompressionLevel compressionLevel,
+        boolean requiresTraining,
+        SpaceType spaceType
+    ) {
         if (requiresTraining) {
-            return resolveWithTraining(mode, compressionLevel);
+            return resolveWithTraining(mode, compressionLevel, spaceType);
         }
-
-        return resolveWithoutTraining(mode, compressionLevel);
+        return resolveWithoutTraining(mode, compressionLevel, spaceType);
     }
 
-    private KNNMethodContext resolveWithoutTraining(Mode mode, CompressionLevel compressionLevel) {
+    private KNNMethodContext resolveWithoutTraining(Mode mode, CompressionLevel compressionLevel, final SpaceType spaceType) {
         CompressionLevel resolvedCompressionLevel = resolveCompressionLevel(mode, compressionLevel);
         MethodComponentContext encoderContext = resolveEncoder(resolvedCompressionLevel);
 
@@ -76,7 +80,7 @@ public final class ModeBasedResolver {
         if (encoderContext != null) {
             return new KNNMethodContext(
                 knnEngine,
-                SpaceType.DEFAULT,
+                spaceType,
                 new MethodComponentContext(
                     METHOD_HNSW,
                     Map.of(
@@ -96,7 +100,7 @@ public final class ModeBasedResolver {
         if (knnEngine == KNNEngine.FAISS) {
             return new KNNMethodContext(
                 knnEngine,
-                SpaceType.DEFAULT,
+                spaceType,
                 new MethodComponentContext(
                     METHOD_HNSW,
                     Map.of(
@@ -113,7 +117,7 @@ public final class ModeBasedResolver {
 
         return new KNNMethodContext(
             knnEngine,
-            SpaceType.DEFAULT,
+            spaceType,
             new MethodComponentContext(
                 METHOD_HNSW,
                 Map.of(
@@ -126,13 +130,13 @@ public final class ModeBasedResolver {
         );
     }
 
-    private KNNMethodContext resolveWithTraining(Mode mode, CompressionLevel compressionLevel) {
+    private KNNMethodContext resolveWithTraining(Mode mode, CompressionLevel compressionLevel, SpaceType spaceType) {
         CompressionLevel resolvedCompressionLevel = resolveCompressionLevel(mode, compressionLevel);
         MethodComponentContext encoderContext = resolveEncoder(resolvedCompressionLevel);
         if (encoderContext != null) {
             return new KNNMethodContext(
                 KNNEngine.FAISS,
-                SpaceType.DEFAULT,
+                spaceType,
                 new MethodComponentContext(
                     METHOD_IVF,
                     Map.of(
@@ -149,7 +153,7 @@ public final class ModeBasedResolver {
 
         return new KNNMethodContext(
             KNNEngine.FAISS,
-            SpaceType.DEFAULT,
+            spaceType,
             new MethodComponentContext(
                 METHOD_IVF,
                 Map.of(METHOD_PARAMETER_NLIST, METHOD_PARAMETER_NLIST_DEFAULT, METHOD_PARAMETER_NPROBES, METHOD_PARAMETER_NPROBES_DEFAULT)

--- a/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
@@ -42,6 +42,7 @@ public final class OriginalMappingParameters {
     private final String mode;
     private final String compressionLevel;
     private final String modelId;
+    private final String topLevelSpaceType;
 
     /**
      * Initialize the parameters from the builder
@@ -56,6 +57,7 @@ public final class OriginalMappingParameters {
         this.mode = builder.mode.get();
         this.compressionLevel = builder.compressionLevel.get();
         this.modelId = builder.modelId.get();
+        this.topLevelSpaceType = builder.topLevelSpaceType.get();
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -52,6 +52,7 @@ public class IndexUtil {
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VECTOR_DATA_TYPE = Version.V_2_16_0;
     private static final Version MINIMAL_RESCORE_FEATURE = Version.V_2_17_0;
     private static final Version MINIMAL_MODE_AND_COMPRESSION_FEATURE = Version.V_2_17_0;
+    private static final Version MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE = Version.V_2_17_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -390,6 +391,7 @@ public class IndexUtil {
                 put(KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VECTOR_DATA_TYPE);
                 put(RESCORE_PARAMETER, MINIMAL_RESCORE_FEATURE);
                 put(KNNConstants.MINIMAL_MODE_AND_COMPRESSION_FEATURE, MINIMAL_MODE_AND_COMPRESSION_FEATURE);
+                put(KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE, MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE);
             }
         };
 

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -21,6 +21,7 @@ import org.opensearch.common.ValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
@@ -56,6 +57,33 @@ public class TrainingModelRequest extends ActionRequest {
     private final Mode mode;
     private final CompressionLevel compressionLevel;
 
+    TrainingModelRequest(
+        String modelId,
+        KNNMethodContext knnMethodContext,
+        int dimension,
+        String trainingIndex,
+        String trainingField,
+        String preferredNodeId,
+        String description,
+        VectorDataType vectorDataType,
+        Mode mode,
+        CompressionLevel compressionLevel
+    ) {
+        this(
+            modelId,
+            knnMethodContext,
+            dimension,
+            trainingIndex,
+            trainingField,
+            preferredNodeId,
+            description,
+            vectorDataType,
+            mode,
+            compressionLevel,
+            SpaceType.DEFAULT
+        );
+    }
+
     /**
      * Constructor.
      *
@@ -77,7 +105,8 @@ public class TrainingModelRequest extends ActionRequest {
         String description,
         VectorDataType vectorDataType,
         Mode mode,
-        CompressionLevel compressionLevel
+        CompressionLevel compressionLevel,
+        SpaceType spaceType
     ) {
         super();
         this.modelId = modelId;
@@ -107,7 +136,7 @@ public class TrainingModelRequest extends ActionRequest {
             .build();
 
         if (knnMethodContext == null && (Mode.isConfigured(mode) || CompressionLevel.isConfigured(compressionLevel))) {
-            this.knnMethodContext = ModeBasedResolver.INSTANCE.resolveKNNMethodContext(mode, compressionLevel, true);
+            this.knnMethodContext = ModeBasedResolver.INSTANCE.resolveKNNMethodContext(mode, compressionLevel, true, spaceType);
         } else {
             this.knnMethodContext = knnMethodContext;
         }
@@ -143,6 +172,12 @@ public class TrainingModelRequest extends ActionRequest {
             this.mode = Mode.NOT_CONFIGURED;
             this.compressionLevel = CompressionLevel.NOT_CONFIGURED;
         }
+
+        // SpaceType topLevelSpaceType = SpaceType.DEFAULT;
+        //
+        // if(IndexUtil.isVersionOnOrAfterMinRequiredVersion(in.getVersion(), KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE)) {
+        // topLevelSpaceType = SpaceType.getSpace(in.readOptionalString());
+        // }
 
         this.knnMethodConfigContext = KNNMethodConfigContext.builder()
             .vectorDataType(vectorDataType)

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -173,12 +173,6 @@ public class TrainingModelRequest extends ActionRequest {
             this.compressionLevel = CompressionLevel.NOT_CONFIGURED;
         }
 
-        // SpaceType topLevelSpaceType = SpaceType.DEFAULT;
-        //
-        // if(IndexUtil.isVersionOnOrAfterMinRequiredVersion(in.getVersion(), KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE)) {
-        // topLevelSpaceType = SpaceType.getSpace(in.readOptionalString());
-        // }
-
         this.knnMethodConfigContext = KNNMethodConfigContext.builder()
             .vectorDataType(vectorDataType)
             .dimension(dimension)

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -36,6 +36,7 @@ import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -117,10 +118,10 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             modelDao,
             CURRENT,
             null,
-            new OriginalMappingParameters(VectorDataType.DEFAULT, TEST_DIMENSION, null, null, null, null)
+            new OriginalMappingParameters(VectorDataType.DEFAULT, TEST_DIMENSION, null, null, null, null, SpaceType.UNDEFINED.getValue())
         );
 
-        assertEquals(9, builder.getParameters().size());
+        assertEquals(10, builder.getParameters().size());
         List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
         List<String> expectedParams = Arrays.asList(
             "store",
@@ -131,7 +132,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             KNN_METHOD,
             MODEL_ID,
             MODE_PARAMETER,
-            COMPRESSION_LEVEL_PARAMETER
+            COMPRESSION_LEVEL_PARAMETER,
+            KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE
         );
         assertEquals(expectedParams, actualParams);
     }
@@ -899,7 +901,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     knnMethodContext,
                     Mode.NOT_CONFIGURED.getName(),
                     CompressionLevel.NOT_CONFIGURED.getName(),
-                    null
+                    null,
+                    SpaceType.UNDEFINED.getValue()
                 );
                 originalMappingParameters.setResolvedKnnMethodContext(knnMethodContext);
                 MethodFieldMapper methodFieldMapper = MethodFieldMapper.createFieldMapper(
@@ -1000,7 +1003,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     null,
                     Mode.NOT_CONFIGURED.getName(),
                     CompressionLevel.NOT_CONFIGURED.getName(),
-                    MODEL_ID
+                    MODEL_ID,
+                    SpaceType.UNDEFINED.getValue()
                 );
 
                 ModelFieldMapper modelFieldMapper = ModelFieldMapper.createFieldMapper(
@@ -1092,7 +1096,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             getDefaultKNNMethodContext(),
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
-            null
+            null,
+            SpaceType.UNDEFINED.getValue()
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
 
@@ -1151,7 +1156,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             knnMethodContext,
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
-            null
+            null,
+            SpaceType.UNDEFINED.getValue()
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
         luceneFieldMapper = LuceneFieldMapper.createFieldMapper(
@@ -1191,7 +1197,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             getDefaultByteKNNMethodContext(),
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
-            null
+            null,
+            SpaceType.UNDEFINED.getValue()
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
 

--- a/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
@@ -17,11 +17,35 @@ import java.util.Collections;
 public class OriginalMappingParametersTests extends KNNTestCase {
 
     public void testIsLegacy() {
-        assertTrue(new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, null).isLegacyMapping());
-        assertFalse(new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, "model-id").isLegacyMapping());
-        assertFalse(new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, Mode.ON_DISK.getName(), null, null).isLegacyMapping());
+        assertTrue(
+            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, null, SpaceType.UNDEFINED.getValue())
+                .isLegacyMapping()
+        );
         assertFalse(
-            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, CompressionLevel.x2.getName(), null).isLegacyMapping()
+            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, "model-id", SpaceType.UNDEFINED.getValue())
+                .isLegacyMapping()
+        );
+        assertFalse(
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                123,
+                null,
+                Mode.ON_DISK.getName(),
+                null,
+                null,
+                SpaceType.UNDEFINED.getValue()
+            ).isLegacyMapping()
+        );
+        assertFalse(
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                123,
+                null,
+                null,
+                CompressionLevel.x2.getName(),
+                null,
+                SpaceType.UNDEFINED.getValue()
+            ).isLegacyMapping()
         );
         assertFalse(
             new OriginalMappingParameters(
@@ -30,7 +54,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.L2, new MethodComponentContext(null, Collections.emptyMap())),
                 null,
                 null,
-                null
+                null,
+                SpaceType.UNDEFINED.getValue()
             ).isLegacyMapping()
         );
     }


### PR DESCRIPTION
### Description
Add spaceType as a top level parameter while creating vector field. With this change a user can change the spaceType for the vector field without defining the `method` parameter in the mapping. With this change Disk based vector search OOB experience is improved.

## Things to be added:

Tests will be added in followup PRs

## How testing is done:
I have performed manual testing by running following create index request.

Success
```
{
	"settings": {
		"index": {
			"number_of_shards": 1,
			"number_of_replicas": 0,
			"refresh_interval": "1s",
			"knn": true
		}
	},
	"mappings": {
		"properties": {
			"my_vector2": {
				"type": "knn_vector",
				"dimension": 4,
				"mode": "on_disk",
				"compression_level": "32x",
				"space_type": "innerproduct"
			}
		}
	}
}
```

Success and hits the legacy method and use the innerproduct space type
```
{
	"settings": {
		"index": {
			"number_of_shards": 1,
			"number_of_replicas": 0,
			"refresh_interval": "1s",
			"knn": true
		}
	},
	"mappings": {
		"properties": {
			"my_vector2": {
				"type": "knn_vector",
				"dimension": 4,
				"space_type": "innerproduct"
			}
		}
	}
}
```

### Related Issues
https://github.com/opensearch-project/k-NN/issues/1949

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
