### PR TITLE
Fix the force merge with Quantization failures when a segment has deleted docs in it

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -69,10 +69,12 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
         final VectorDataType vectorDataType = extractVectorDataType(field);
         final KNNVectorValues<?> knnVectorValues = KNNVectorValuesFactory.getVectorValues(vectorDataType, valuesProducer.getBinary(field));
 
+        // For BDV it is fine to use knnVectorValues.totalLiveDocs() as we already run the full loop to calculate total
+        // live docs
         if (isMerge) {
-            NativeIndexWriter.getWriter(field, state).mergeIndex(knnVectorValues);
+            NativeIndexWriter.getWriter(field, state).mergeIndex(knnVectorValues, (int) knnVectorValues.totalLiveDocs());
         } else {
-            NativeIndexWriter.getWriter(field, state).flushIndex(knnVectorValues);
+            NativeIndexWriter.getWriter(field, state).flushIndex(knnVectorValues, (int) knnVectorValues.totalLiveDocs());
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
@@ -48,17 +48,17 @@ final class DefaultIndexBuildStrategy implements NativeIndexBuildStrategy {
      * flushed and used to build the index. The index is then written to the specified path using JNI calls.</p>
      *
      * @param indexInfo        The {@link BuildIndexParams} containing the parameters and configuration for building the index.
-     * @param knnVectorValues  The {@link KNNVectorValues} representing the vectors to be indexed.
      * @throws IOException     If an I/O error occurs during the process of building and writing the index.
      */
-    public void buildAndWriteIndex(final BuildIndexParams indexInfo, final KNNVectorValues<?> knnVectorValues) throws IOException {
+    public void buildAndWriteIndex(final BuildIndexParams indexInfo) throws IOException {
+        final KNNVectorValues<?> knnVectorValues = indexInfo.getVectorValues();
         // Needed to make sure we don't get 0 dimensions while initializing index
         iterateVectorValuesOnce(knnVectorValues);
         IndexBuildSetup indexBuildSetup = QuantizationIndexUtils.prepareIndexBuild(knnVectorValues, indexInfo);
 
         int transferLimit = (int) Math.max(1, KNNSettings.getVectorStreamingMemoryLimit().getBytes() / indexBuildSetup.getBytesPerVector());
         try (final OffHeapVectorTransfer vectorTransfer = getVectorTransfer(indexInfo.getVectorDataType(), transferLimit)) {
-            final List<Integer> transferredDocIds = new ArrayList<>((int) knnVectorValues.totalLiveDocs());
+            final List<Integer> transferredDocIds = new ArrayList<>(indexInfo.getTotalLiveDocs());
 
             while (knnVectorValues.docId() != NO_MORE_DOCS) {
                 Object vector = QuantizationIndexUtils.processAndReturnVector(knnVectorValues, indexBuildSetup);

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -52,7 +52,8 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
      * @param knnVectorValues  The {@link KNNVectorValues} representing the vectors to be indexed.
      * @throws IOException     If an I/O error occurs during the process of building and writing the index.
      */
-    public void buildAndWriteIndex(final BuildIndexParams indexInfo, final KNNVectorValues<?> knnVectorValues) throws IOException {
+    public void buildAndWriteIndex(final BuildIndexParams indexInfo) throws IOException {
+        final KNNVectorValues<?> knnVectorValues = indexInfo.getVectorValues();
         // Needed to make sure we don't get 0 dimensions while initializing index
         iterateVectorValuesOnce(knnVectorValues);
         KNNEngine engine = indexInfo.getKnnEngine();
@@ -62,7 +63,7 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
         // Initialize the index
         long indexMemoryAddress = AccessController.doPrivileged(
             (PrivilegedAction<Long>) () -> JNIService.initIndex(
-                knnVectorValues.totalLiveDocs(),
+                indexInfo.getTotalLiveDocs(),
                 indexBuildSetup.getDimensions(),
                 indexParameters,
                 engine

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategy.java
@@ -6,7 +6,6 @@
 package org.opensearch.knn.index.codec.nativeindex;
 
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
 import java.io.IOException;
 
@@ -15,5 +14,5 @@ import java.io.IOException;
  */
 public interface NativeIndexBuildStrategy {
 
-    void buildAndWriteIndex(BuildIndexParams indexInfo, final KNNVectorValues<?> knnVectorValues) throws IOException;
+    void buildAndWriteIndex(BuildIndexParams indexInfo) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
@@ -11,6 +11,7 @@ import lombok.Value;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 
 import java.util.Map;
@@ -29,4 +30,6 @@ public class BuildIndexParams {
      */
     @Nullable
     QuantizationState quantizationState;
+    KNNVectorValues<?> vectorValues;
+    int totalLiveDocs;
 }

--- a/src/main/java/org/opensearch/knn/index/quantizationservice/KNNVectorQuantizationTrainingRequest.java
+++ b/src/main/java/org/opensearch/knn/index/quantizationservice/KNNVectorQuantizationTrainingRequest.java
@@ -28,8 +28,8 @@ final class KNNVectorQuantizationTrainingRequest<T> extends TrainingRequest<T> {
      *
      * @param knnVectorValues the KNNVectorValues instance containing the vectors.
      */
-    KNNVectorQuantizationTrainingRequest(KNNVectorValues<T> knnVectorValues) {
-        super((int) knnVectorValues.totalLiveDocs());
+    KNNVectorQuantizationTrainingRequest(KNNVectorValues<T> knnVectorValues, long liveDocs) {
+        super((int) liveDocs);
         this.knnVectorValues = knnVectorValues;
         this.lastIndex = 0;
     }

--- a/src/main/java/org/opensearch/knn/index/quantizationservice/QuantizationService.java
+++ b/src/main/java/org/opensearch/knn/index/quantizationservice/QuantizationService.java
@@ -57,12 +57,15 @@ public final class QuantizationService<T, R> {
      * @return The {@link QuantizationState} containing the state of the trained quantizer.
      * @throws IOException If an I/O error occurs during the training process.
      */
-    public QuantizationState train(final QuantizationParams quantizationParams, final KNNVectorValues<T> knnVectorValues)
-        throws IOException {
+    public QuantizationState train(
+        final QuantizationParams quantizationParams,
+        final KNNVectorValues<T> knnVectorValues,
+        final long liveDocs
+    ) throws IOException {
         Quantizer<T, R> quantizer = QuantizerFactory.getQuantizer(quantizationParams);
 
         // Create the training request from the vector values
-        KNNVectorQuantizationTrainingRequest<T> trainingRequest = new KNNVectorQuantizationTrainingRequest<>(knnVectorValues);
+        KNNVectorQuantizationTrainingRequest<T> trainingRequest = new KNNVectorQuantizationTrainingRequest<>(knnVectorValues, liveDocs);
 
         // Train the quantizer and return the quantization state
         return quantizer.train(trainingRequest);

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValues.java
@@ -71,9 +71,18 @@ public abstract class KNNVectorValues<T> {
     }
 
     /**
-     * Returns the total live docs for KNNVectorValues.
+     * Returns the total live docs for KNNVectorValues. This function is broken and doesn't always give the accurate
+     * live docs count when iterators are {@link FloatVectorValues}, {@link ByteVectorValues}. Avoid using this iterator,
+     * rather use a simple function like this:
+     * <pre class="prettyprint">
+     *     int liveDocs = 0;
+     *     while(vectorValues.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+     *         liveDocs++;
+     *     }
+     * </pre>
      * @return long
      */
+    @Deprecated
     public long totalLiveDocs() {
         return vectorValuesIterator.liveDocs();
     }

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategyTests.java
@@ -74,10 +74,12 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
                 .knnEngine(KNNEngine.NMSLIB)
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("index", "param"))
+                .vectorValues(knnVectorValues)
+                .totalLiveDocs((int) knnVectorValues.totalLiveDocs())
                 .build();
 
             // When
-            DefaultIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams, knnVectorValues);
+            DefaultIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams);
 
             // Then
             mockedJNIService.verify(
@@ -166,10 +168,12 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("index", "param"))
                 .quantizationState(quantizationState)
+                .vectorValues(knnVectorValues)
+                .totalLiveDocs((int) knnVectorValues.totalLiveDocs())
                 .build();
 
             // When
-            MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams, knnVectorValues);
+            MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams);
 
             // Then
             mockedJNIService.verify(
@@ -250,10 +254,12 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
                 .knnEngine(KNNEngine.NMSLIB)
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("model_id", "id", "model_blob", modelBlob))
+                .vectorValues(knnVectorValues)
+                .totalLiveDocs((int) knnVectorValues.totalLiveDocs())
                 .build();
 
             // When
-            DefaultIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams, knnVectorValues);
+            DefaultIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams);
 
             // Then
             mockedJNIService.verify(

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategyTests.java
@@ -75,10 +75,12 @@ public class MemOptimizedNativeIndexBuildStrategyTests extends OpenSearchTestCas
                 .knnEngine(KNNEngine.FAISS)
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("index", "param"))
+                .vectorValues(knnVectorValues)
+                .totalLiveDocs((int) knnVectorValues.totalLiveDocs())
                 .build();
 
             // When
-            MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams, knnVectorValues);
+            MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams);
 
             // Then
             mockedJNIService.verify(
@@ -193,10 +195,12 @@ public class MemOptimizedNativeIndexBuildStrategyTests extends OpenSearchTestCas
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("index", "param"))
                 .quantizationState(quantizationState)
+                .vectorValues(knnVectorValues)
+                .totalLiveDocs((int) knnVectorValues.totalLiveDocs())
                 .build();
 
             // When
-            MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams, knnVectorValues);
+            MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(buildIndexParams);
 
             // Then
             mockedJNIService.verify(

--- a/src/test/java/org/opensearch/knn/index/quantizationservice/QuantizationServiceTests.java
+++ b/src/test/java/org/opensearch/knn/index/quantizationservice/QuantizationServiceTests.java
@@ -46,7 +46,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testTrain_oneBitQuantizer_success() throws IOException {
         ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
-        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
 
         assertTrue(quantizationState instanceof OneBitScalarQuantizationState);
         OneBitScalarQuantizationState oneBitState = (OneBitScalarQuantizationState) quantizationState;
@@ -62,7 +62,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testTrain_twoBitQuantizer_success() throws IOException {
         ScalarQuantizationParams twoBitParams = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
-        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
 
         assertTrue(quantizationState instanceof MultiBitScalarQuantizationState);
         MultiBitScalarQuantizationState multiBitState = (MultiBitScalarQuantizationState) quantizationState;
@@ -85,7 +85,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testTrain_fourBitQuantizer_success() throws IOException {
         ScalarQuantizationParams fourBitParams = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
-        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
 
         assertTrue(quantizationState instanceof MultiBitScalarQuantizationState);
         MultiBitScalarQuantizationState multiBitState = (MultiBitScalarQuantizationState) quantizationState;
@@ -110,7 +110,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_oneBitQuantizer_success() throws IOException {
         ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
-        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
 
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(oneBitParams);
 
@@ -125,7 +125,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_twoBitQuantizer_success() throws IOException {
         ScalarQuantizationParams twoBitParams = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
-        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(twoBitParams);
         byte[] quantizedVector = quantizationService.quantize(quantizationState, new float[] { 4.0f, 5.0f, 6.0f }, quantizationOutput);
 
@@ -138,7 +138,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_fourBitQuantizer_success() throws IOException {
         ScalarQuantizationParams fourBitParams = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
-        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(fourBitParams);
 
         byte[] quantizedVector = quantizationService.quantize(quantizationState, new float[] { 7.0f, 8.0f, 9.0f }, quantizationOutput);
@@ -152,7 +152,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_whenInvalidInput_thenThrows() throws IOException {
         ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
-        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues);
+        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(oneBitParams);
         assertThrows(IllegalArgumentException.class, () -> quantizationService.quantize(quantizationState, null, quantizationOutput));
     }


### PR DESCRIPTION
### Description
Fix the force merge with Quantization failures when a segment has deleted docs in it.

#### Issue:
When documents are deleted from the segment and segments are force merged, the FlatVectorValues are getting merged to 1 vectorValues but that `vectorvalue.getLiveDocs()` doesn't provide correct live docs but it provides the `cost` which includes the deleted docs too. 

Due to this when we are doing quantization, we are hitting the vectors which are not present and leading to NPE. 

```
org.apache.lucene.index.MergePolicy$MergeException: java.lang.IllegalStateException: this writer hit an unrecoverable error; cannot merge
        at org.opensearch.index.engine.InternalEngine$EngineMergeScheduler$2.doRun(InternalEngine.java:2494) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:982) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.IllegalStateException: this writer hit an unrecoverable error; cannot merge
        at org.apache.lucene.index.IndexWriter.hasPendingMerges(IndexWriter.java:2436) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.opensearch.index.engine.InternalEngine$EngineMergeScheduler.afterMerge(InternalEngine.java:2452) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.OpenSearchConcurrentMergeScheduler.doMerge(OpenSearchConcurrentMergeScheduler.java:125) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:721) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
Caused by: java.lang.NullPointerException: Cannot read field "values" because "this.current" is null
        at org.apache.lucene.codecs.KnnVectorsWriter$MergedVectorValues$MergedFloat32VectorValues.vectorValue(KnnVectorsWriter.java:225) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy$DISIVectorExtractor.extract(VectorValueExtractorStrategy.java:78) ~[?:?]
        at org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy.extractFloatVector(VectorValueExtractorStrategy.java:32) ~[?:?]
        at org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues.getVector(KNNFloatVectorValues.java:26) ~[?:?]
        at org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues.getVector(KNNFloatVectorValues.java:19) ~[?:?]
        at org.opensearch.knn.index.quantizationservice.KNNVectorQuantizationTrainingRequest.getVectorAtThePosition(KNNVectorQuantizationTrainingRequest.java:53) ~[?:?]
        at org.opensearch.knn.quantization.quantizer.QuantizerHelper.calculateMeanThresholds(QuantizerHelper.java:35) ~[?:?]
        at org.opensearch.knn.quantization.quantizer.OneBitScalarQuantizer.train(OneBitScalarQuantizer.java:63) ~[?:?]
        at org.opensearch.knn.index.quantizationservice.QuantizationService.train(QuantizationService.java:69) ~[?:?]
        at org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsWriter.trainAndIndex(NativeEngines990KnnVectorsWriter.java:262) ~[?:?]
        at org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsWriter.mergeOneField(NativeEngines990KnnVectorsWriter.java:104) ~[?:?]
        at org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat$FieldsWriter.mergeOneField(PerFieldKnnVectorsFormat.java:121) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.codecs.KnnVectorsWriter.merge(KnnVectorsWriter.java:99) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.SegmentMerger.mergeVectorValues(SegmentMerger.java:282) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.SegmentMerger.mergeWithLogging(SegmentMerger.java:325) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.SegmentMerger.merge(SegmentMerger.java:171) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.IndexWriter.mergeMiddle(IndexWriter.java:5293) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.IndexWriter.merge(IndexWriter.java:4761) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.IndexWriter$IndexWriterMergeSource.merge(IndexWriter.java:6582) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.apache.lucene.index.ConcurrentMergeScheduler.doMerge(ConcurrentMergeScheduler.java:660) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
        at org.opensearch.index.engine.OpenSearchConcurrentMergeScheduler.doMerge(OpenSearchConcurrentMergeScheduler.java:120) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread.run(ConcurrentMergeScheduler.java:721) ~[lucene-core-9.12.0-snapshot-847316d.jar:9.12.0-snapshot-847316d 847316dd1eec2258ccf5da52dca51c01b9df1c4c - 2024-06-27 17:07:28]
[2024-09-05T02:44:02,224][WARN ][o.o.i.c.IndicesClusterStateService] [integTest-0] [my-knn-index-1][0] marking and sending shard failed due to [failed recovery]
org.opensearch.indices.recovery.RecoveryFailedException: [my-knn-index-1][0]: Recovery failed on {integTest-0}{FZH6cEHdT167xfsFW4y9Gg}{EmKDYp9tSyaQcRhQxPwCUg}{127.0.0.1}{127.0.0.1:9300}{dimr}{testattr=test, shard_indexing_pressure_enabled=true}
        at org.opensearch.index.shard.IndexShard.lambda$executeRecovery$32(IndexShard.java:3878) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.lambda$recoveryListener$10(StoreRecovery.java:626) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener$1.onFailure(ActionListener.java:90) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener.completeWith(ActionListener.java:347) [opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.recoverFromStore(StoreRecovery.java:123) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.recoverFromStore(IndexShard.java:2895) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:982) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: org.opensearch.index.shard.IndexShardRecoveryException: failed recovery
        ... 11 more
Caused by: org.apache.lucene.store.AlreadyClosedException: translog is already closed
        at org.opensearch.index.translog.Translog.ensureOpen(Translog.java:1882) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.translog.Translog.getMaxSeqNo(Translog.java:1959) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.translog.InternalTranslogManager.getMaxSeqNo(InternalTranslogManager.java:398) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.InternalEngine.<init>(InternalEngine.java:337) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.InternalEngine.<init>(InternalEngine.java:223) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.engine.InternalEngineFactory.newReadWriteEngine(InternalEngineFactory.java:43) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.innerOpenEngineAndTranslog(IndexShard.java:2605) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.openEngineAndRecoverFromTranslog(IndexShard.java:2511) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.IndexShard.openEngineAndRecoverFromTranslog(IndexShard.java:2483) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.internalRecoverFromStore(StoreRecovery.java:750) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.index.shard.StoreRecovery.lambda$recoverFromStore$0(StoreRecovery.java:125) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.action.ActionListener.completeWith(ActionListener.java:344) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        ... 8 more

```

With this change, we are ensuring that we are iterating over the vector values to find the correct live docs and then pass it to Quantization and NativeIndexWriter.


## Testing
I added an IT that simulate this buggy nature, but due to some race conditions it doesn't work 100% of the time. I will follow up on fixing the IT and make it more strict.

### Manual Testing
**Currently I tested manually by below flow, which always create exceptions without this fix.**

```
curl --request PUT \
  --url http://localhost:9200/my-knn-index-1 \
  --header 'Content-Type: application/json' \
  --data '{
	"settings": {
		"index": {
			"number_of_shards": 1,
			"number_of_replicas": 0,
			"refresh_interval": "1s",
			"knn": true
		}
	},
	"mappings": {
		"properties": {
			"my_vector2": {
				"type": "knn_vector",
				"dimension": 4,
				"space_type": "innerproduct"
			},
			"my_vector3": {
				"type": "knn_vector",
				"dimension": 4,
				"space_type": "innerproduct",
				"mode": "on_disk",
				"compression_level": "32x"
			}
		}
	}
}'
```
**Index Data**
```
curl --request POST \
  --url 'http://localhost:9200/_bulk?refresh=' \
  --header 'Content-Type: application/json' \
  --data '{ "index": { "_index": "my-knn-index-1", "_id": "111" } }
{ "my_vector2": [-1.5, -5.5, -4.5, -6.4], "my_vector3": [1.5, 5.5, 4.5, 6.4], "price": 12.2 }
{ "index": { "_index": "my-knn-index-1", "_id": "9111" } }
{ "my_vector2": [1.5, 5.5, 4.5, 6.4], "my_vector3": [-1.5, -5.5, -4.5, -6.4], "price": 8.9, "message": "OpenSearch" }
'
```

**Index data again to simulate deletes**
```
curl --request POST \
  --url 'http://localhost:9200/_bulk?refresh=' \
  --header 'Content-Type: application/json' \
  --data '{ "index": { "_index": "my-knn-index-1", "_id": "111" } }
{ "my_vector2": [-1.5, -5.5, -4.5, -6.4], "my_vector3": [1.5, 5.5, 4.5, 6.4], "price": 12.2 }
{ "index": { "_index": "my-knn-index-1", "_id": "9111" } }
{ "my_vector2": [1.5, 5.5, 4.5, 6.4], "my_vector3": [-1.5, -5.5, -4.5, -6.4], "price": 8.9, "message": "OpenSearch" }
'
```

**Do force merge**
```
curl --request POST \
  --url 'http://localhost:9200/my-knn-index-1/_forcemerge?max_num_segments=1&wait_for_completion=true' \
  --header 'Content-Type: application/json'
```

check logs to see the errors.

** Do Search it fails without this fix**
```
curl --request POST \
  --url http://localhost:9200/my-knn-index-1/_search \
  --header 'Content-Type: application/json' \
  --data '{
	"query":{
		"knn":{
			"my_vector2": {
				"vector": [1,1,1,1],
				"k": 10
			}
		}
	}
}'
```

### Related Issues
NA

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
