### PR TITLE
Add tests for top level spaceType parameter with different combinations

### DIFF
--- a/src/test/java/org/opensearch/knn/integ/TopLevelSpaceTypeParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelSpaceTypeParameterIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class TopLevelSpaceTypeParameterIT extends KNNRestTestCase {
+    private final static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f };
+    private final static int DIMENSION = 2;
+    private final static int K = 1;
+    private static final String INDEX_NAME = "top-level-space-type-index";
+
+    @SneakyThrows
+    public void testBaseCase() {
+        createTestIndexWithTopLevelSpaceTypeOnly();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+
+        createTestIndexWithTopLevelSpaceTypeAndMethodSpaceType();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+
+        createTestIndexWithNoSpaceType();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+    }
+
+    private void createTestIndexWithTopLevelSpaceTypeOnly() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createTestIndexWithTopLevelSpaceTypeAndMethodSpaceType() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createTestIndexWithNoSpaceType() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+}


### PR DESCRIPTION
### Description
Add tests for top level spaceType parameter with different combinations

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
