### PR TITLE
[Backport 2.x]  Add model version to model metadata and change model metadata reads to be from cluster metadata

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.17.0.0.md
@@ -11,6 +11,7 @@ Compatible with OpenSearch 2.17.0
 * Add spaceType as a top level optional parameter while creating vector field. [#2044](https://github.com/opensearch-project/k-NN/pull/2044)
 ### Enhancements
 * Adds iterative graph build capability into a faiss index to improve the memory footprint during indexing and Integrates KNNVectorsFormat for native engines[#1950](https://github.com/opensearch-project/k-NN/pull/1950)
+* Add model version to model metadata and change model metadata reads to be from cluster metadata [#2005](https://github.com/opensearch-project/k-NN/pull/2005)
 ### Bug Fixes
 * Corrected search logic for scenario with non-existent fields in filter [#1874](https://github.com/opensearch-project/k-NN/pull/1874)
 * Add script_fields context to KNNAllowlist [#1917] (https://github.com/opensearch-project/k-NN/pull/1917)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -77,6 +77,7 @@ public class KNNConstants {
     public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
+    public static final String MODEL_VERSION = "model_version";
     public static final String QUANTIZATION_STATE_FILE_SUFFIX = "osknnqstate";
 
     // Lucene specific constants

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -290,7 +290,7 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
         return KNNMethodConfigContext.builder()
             .vectorDataType(modelMetadata.getVectorDataType())
             .dimension(modelMetadata.getDimension())
-            .versionCreated(Version.V_2_14_0)
+            .versionCreated(modelMetadata.getModelVersion())
             .mode(modelMetadata.getMode())
             .compressionLevel(modelMetadata.getCompressionLevel())
             .build();

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -54,6 +54,7 @@ public class IndexUtil {
     private static final Version MINIMAL_RESCORE_FEATURE = Version.V_2_17_0;
     private static final Version MINIMAL_MODE_AND_COMPRESSION_FEATURE = Version.V_2_17_0;
     private static final Version MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE = Version.V_2_17_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION = Version.V_2_17_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -394,6 +395,7 @@ public class IndexUtil {
                 put(RESCORE_PARAMETER, MINIMAL_RESCORE_FEATURE);
                 put(KNNConstants.MINIMAL_MODE_AND_COMPRESSION_FEATURE, MINIMAL_MODE_AND_COMPRESSION_FEATURE);
                 put(KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE, MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE);
+                put(KNNConstants.MODEL_VERSION, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION);
             }
         };
 

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -301,6 +301,7 @@ public interface ModelDao {
                     if (CompressionLevel.isConfigured(modelMetadata.getCompressionLevel())) {
                         put(KNNConstants.COMPRESSION_LEVEL_PARAMETER, modelMetadata.getCompressionLevel().getName());
                     }
+                    put(KNNConstants.MODEL_VERSION, modelMetadata.getModelVersion());
                     MethodComponentContext methodComponentContext = modelMetadata.getMethodComponentContext();
                     if (!methodComponentContext.getName().isEmpty()) {
                         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();

--- a/src/main/java/org/opensearch/knn/indices/ModelUtil.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelUtil.java
@@ -48,8 +48,8 @@ public class ModelUtil {
         if (StringUtils.isEmpty(modelId)) {
             return null;
         }
-        final Model model = ModelCache.getInstance().get(modelId);
-        final ModelMetadata modelMetadata = model.getModelMetadata();
+        ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
+        final ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
         if (isModelCreated(modelMetadata) == false) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Model ID '%s' is not created.", modelId));
         }

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -99,7 +99,8 @@ public class TrainingJob implements Runnable {
                 knnMethodContext.getMethodComponentContext(),
                 knnMethodConfigContext.getVectorDataType(),
                 mode,
-                compressionLevel
+                compressionLevel,
+                knnMethodConfigContext.getVersionCreated()
             ),
             null,
             this.modelId

--- a/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJobRunner.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.common.ValidationException;
-import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
@@ -166,11 +165,11 @@ public class TrainingJobRunner {
     private void serializeModel(TrainingJob trainingJob, ActionListener<IndexResponse> listener, boolean update) throws IOException,
         ExecutionException, InterruptedException {
         if (update) {
-            Model model = modelDao.get(trainingJob.getModelId());
-            if (model.getModelMetadata().getState().equals(ModelState.TRAINING)) {
+            ModelMetadata modelMetadata = modelDao.getMetadata(trainingJob.getModelId());
+            if (modelMetadata.getState().equals(ModelState.TRAINING)) {
                 modelDao.update(trainingJob.getModel(), listener);
             } else {
-                logger.info("Model state is {}. Skipping serialization of trained data", model.getModelMetadata().getState());
+                logger.info("Model state is {}. Skipping serialization of trained data", modelMetadata.getState());
             }
         } else {
             modelDao.put(trainingJob.getModel(), listener);

--- a/src/main/resources/mappings/model-index.json
+++ b/src/main/resources/mappings/model-index.json
@@ -38,6 +38,9 @@
     },
     "compression_level": {
       "type": "keyword"
+    },
+    "model_version": {
+      "type": "keyword"
     }
   }
 }

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.opensearch.common.settings.Settings;
@@ -69,7 +70,8 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.FLOAT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.V_EMPTY
         );
 
         Model model = new Model(modelMetadata, modelBlob, modelId);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.BytesRef;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Explicit;
 import org.opensearch.common.ValidationException;
@@ -223,7 +224,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.FLOAT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.V_EMPTY
         );
         builder.modelId.setValue(modelId);
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
@@ -815,7 +817,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.FLOAT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.V_EMPTY
         );
         when(mockModelDao.getMetadata(modelId)).thenReturn(mockModelMetadata);
 

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -13,6 +13,7 @@ package org.opensearch.knn.indices;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.opensearch.Version;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -51,7 +52,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             "hello".getBytes(),
             modelId
@@ -91,7 +93,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[BYTES_PER_KILOBYTES + 1],
             modelId
@@ -152,7 +155,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[size1],
             modelId1
@@ -171,7 +175,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[size2],
             modelId2
@@ -218,7 +223,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[size1],
             modelId1
@@ -237,7 +243,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[size2],
             modelId2
@@ -289,7 +296,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             "hello".getBytes(),
             modelId
@@ -338,7 +346,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[modelSize],
             modelId
@@ -410,7 +419,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[modelSize1],
             modelId1
@@ -455,7 +465,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[modelSize1],
             modelId1
@@ -476,7 +487,8 @@ public class ModelCacheTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.V_EMPTY
             ),
             new byte[modelSize2],
             modelId2
@@ -525,7 +537,8 @@ public class ModelCacheTests extends KNNTestCase {
                     MethodComponentContext.EMPTY,
                     VectorDataType.DEFAULT,
                     Mode.NOT_CONFIGURED,
-                    CompressionLevel.NOT_CONFIGURED
+                    CompressionLevel.NOT_CONFIGURED,
+                    Version.V_EMPTY
                 ),
                 new byte[BYTES_PER_KILOBYTES * 2],
                 modelId

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -18,6 +18,7 @@ import org.mockito.MockedStatic;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
+import org.opensearch.Version;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.DocWriteResponse;
@@ -145,7 +146,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -168,7 +170,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -199,7 +202,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 new MethodComponentContext("test", Collections.emptyMap()),
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -263,7 +267,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -328,7 +333,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             "any-id"
@@ -368,7 +374,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             null,
             modelId
@@ -410,7 +417,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -464,7 +472,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -486,7 +495,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             null,
             modelId
@@ -526,7 +536,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         Model model = new Model(modelMetadata, modelBlob, modelId);
@@ -606,7 +617,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -643,7 +655,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId1
@@ -714,7 +727,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId
@@ -759,7 +773,8 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId

--- a/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelMetadataTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.indices;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
@@ -51,7 +52,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
@@ -71,7 +73,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.ON_DISK,
-            CompressionLevel.x16
+            CompressionLevel.x16,
+            Version.CURRENT
         );
         streamOutput = new BytesStreamOutput();
         modelMetadata.writeTo(streamOutput);
@@ -93,7 +96,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(knnEngine, modelMetadata.getKnnEngine());
@@ -113,7 +117,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(spaceType, modelMetadata.getSpaceType());
@@ -133,7 +138,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(dimension, modelMetadata.getDimension());
@@ -153,7 +159,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(modelState, modelMetadata.getState());
@@ -173,7 +180,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(timeValue, modelMetadata.getTimestamp());
@@ -193,7 +201,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(description, modelMetadata.getDescription());
@@ -213,7 +222,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(error, modelMetadata.getError());
@@ -233,10 +243,32 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             vectorDataType,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(vectorDataType, modelMetadata.getVectorDataType());
+    }
+
+    public void testGetModelVersion() {
+        Version version = Version.CURRENT;
+        ModelMetadata modelMetadata = new ModelMetadata(
+            KNNEngine.DEFAULT,
+            SpaceType.L2,
+            12,
+            ModelState.CREATED,
+            ZonedDateTime.now(ZoneOffset.UTC).toString(),
+            "",
+            "",
+            "",
+            MethodComponentContext.EMPTY,
+            VectorDataType.DEFAULT,
+            Mode.NOT_CONFIGURED,
+            CompressionLevel.NOT_CONFIGURED,
+            version
+        );
+
+        assertEquals(version, modelMetadata.getModelVersion());
     }
 
     public void testSetState() {
@@ -253,7 +285,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(modelState, modelMetadata.getState());
@@ -277,7 +310,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(error, modelMetadata.getError());
@@ -297,6 +331,7 @@ public class ModelMetadataTests extends KNNTestCase {
         String error = "test-error";
         String nodeAssignment = "";
         MethodComponentContext methodComponentContext = MethodComponentContext.EMPTY;
+        Version version = Version.CURRENT;
 
         String expected = knnEngine.getName()
             + ","
@@ -318,7 +353,11 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + VectorDataType.DEFAULT.getValue()
             + ","
-            + ",";
+            + Mode.ON_DISK.getName()
+            + ","
+            + CompressionLevel.x32.getName()
+            + ","
+            + version;
 
         ModelMetadata modelMetadata = new ModelMetadata(
             knnEngine,
@@ -331,49 +370,9 @@ public class ModelMetadataTests extends KNNTestCase {
             nodeAssignment,
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
-            Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
-        );
-
-        assertEquals(expected, modelMetadata.toString());
-
-        expected = knnEngine.getName()
-            + ","
-            + spaceType.getValue()
-            + ","
-            + dimension
-            + ","
-            + modelState.getName()
-            + ","
-            + timestamp
-            + ","
-            + description
-            + ","
-            + error
-            + ","
-            + nodeAssignment
-            + ","
-            + methodComponentContext.toClusterStateString()
-            + ","
-            + VectorDataType.DEFAULT.getValue()
-            + ","
-            + Mode.ON_DISK.getName()
-            + ","
-            + CompressionLevel.x32.getName();
-
-        modelMetadata = new ModelMetadata(
-            knnEngine,
-            spaceType,
-            dimension,
-            modelState,
-            timestamp,
-            description,
-            error,
-            nodeAssignment,
-            MethodComponentContext.EMPTY,
-            VectorDataType.DEFAULT,
             Mode.ON_DISK,
-            CompressionLevel.x32
+            CompressionLevel.x32,
+            Version.CURRENT
         );
 
         assertEquals(expected, modelMetadata.toString());
@@ -396,7 +395,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata2 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -410,7 +410,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         ModelMetadata modelMetadata3 = new ModelMetadata(
@@ -425,7 +426,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata4 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -439,7 +441,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata5 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -453,7 +456,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata6 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -467,7 +471,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata7 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -481,7 +486,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata8 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -495,7 +501,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata9 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -509,7 +516,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         ModelMetadata modelMetadata10 = new ModelMetadata(
@@ -524,7 +532,8 @@ public class ModelMetadataTests extends KNNTestCase {
             new MethodComponentContext("test", Collections.emptyMap()),
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(modelMetadata1, modelMetadata1);
@@ -557,7 +566,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata2 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -571,7 +581,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         ModelMetadata modelMetadata3 = new ModelMetadata(
@@ -586,7 +597,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata4 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -600,7 +612,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata5 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -614,7 +627,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata6 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -628,7 +642,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata7 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -642,7 +657,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata8 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -656,7 +672,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         ModelMetadata modelMetadata9 = new ModelMetadata(
             KNNEngine.FAISS,
@@ -670,7 +687,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         ModelMetadata modelMetadata10 = new ModelMetadata(
@@ -685,7 +703,8 @@ public class ModelMetadataTests extends KNNTestCase {
             new MethodComponentContext("test", Collections.emptyMap()),
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         assertEquals(modelMetadata1.hashCode(), modelMetadata1.hashCode());
@@ -711,6 +730,7 @@ public class ModelMetadataTests extends KNNTestCase {
         String error = "test-error";
         String nodeAssignment = "test-node";
         MethodComponentContext methodComponentContext = MethodComponentContext.EMPTY;
+        Version version = Version.CURRENT;
 
         String stringRep1 = knnEngine.getName()
             + ","
@@ -730,7 +750,11 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + methodComponentContext.toClusterStateString()
             + ","
-            + VectorDataType.DEFAULT.getValue();
+            + VectorDataType.DEFAULT.getValue()
+            + ","
+            + ","
+            + ","
+            + version.toString();
 
         String stringRep2 = knnEngine.getName()
             + ","
@@ -768,7 +792,9 @@ public class ModelMetadataTests extends KNNTestCase {
             + ","
             + VectorDataType.DEFAULT.getValue()
             + ","
-            + ",";
+            + ","
+            + ","
+            + version;
 
         String stringRep4 = knnEngine.getName()
             + ","
@@ -806,7 +832,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.V_EMPTY
         );
 
         ModelMetadata expected2 = new ModelMetadata(
@@ -821,7 +848,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.V_EMPTY
         );
 
         ModelMetadata expected3 = new ModelMetadata(
@@ -836,7 +864,8 @@ public class ModelMetadataTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.ON_DISK,
-            CompressionLevel.x32
+            CompressionLevel.x32,
+            Version.CURRENT
         );
 
         ModelMetadata fromString1 = ModelMetadata.fromString(stringRep1);
@@ -863,6 +892,8 @@ public class ModelMetadataTests extends KNNTestCase {
         String nodeAssignment = "test-node";
         MethodComponentContext methodComponentContext = getMethodComponentContext();
         MethodComponentContext emptyMethodComponentContext = MethodComponentContext.EMPTY;
+        Version version = Version.CURRENT;
+        Version emptyVersion = Version.V_EMPTY;
 
         ModelMetadata expected = new ModelMetadata(
             knnEngine,
@@ -876,7 +907,8 @@ public class ModelMetadataTests extends KNNTestCase {
             methodComponentContext,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            version
         );
         ModelMetadata expected2 = new ModelMetadata(
             knnEngine,
@@ -890,7 +922,8 @@ public class ModelMetadataTests extends KNNTestCase {
             emptyMethodComponentContext,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            emptyVersion
         );
 
         ModelMetadata expected3 = new ModelMetadata(
@@ -905,7 +938,8 @@ public class ModelMetadataTests extends KNNTestCase {
             emptyMethodComponentContext,
             VectorDataType.DEFAULT,
             Mode.ON_DISK,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         ModelMetadata expected4 = new ModelMetadata(
@@ -920,7 +954,8 @@ public class ModelMetadataTests extends KNNTestCase {
             emptyMethodComponentContext,
             VectorDataType.DEFAULT,
             Mode.ON_DISK,
-            CompressionLevel.x16
+            CompressionLevel.x16,
+            Version.CURRENT
         );
         Map<String, Object> metadataAsMap = new HashMap<>();
         metadataAsMap.put(KNNConstants.KNN_ENGINE, knnEngine.getName());
@@ -936,12 +971,14 @@ public class ModelMetadataTests extends KNNTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         builder = methodComponentContext.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject();
         metadataAsMap.put(KNNConstants.MODEL_METHOD_COMPONENT_CONTEXT, builder.toString());
+        metadataAsMap.put(KNNConstants.MODEL_VERSION, version.toString());
 
         ModelMetadata fromMap = ModelMetadata.getMetadataFromSourceMap(metadataAsMap);
         assertEquals(expected, fromMap);
 
         metadataAsMap.put(KNNConstants.MODEL_NODE_ASSIGNMENT, null);
         metadataAsMap.put(KNNConstants.MODEL_METHOD_COMPONENT_CONTEXT, null);
+        metadataAsMap.put(KNNConstants.MODEL_VERSION, emptyVersion);
         assertEquals(expected2, fromMap);
 
         metadataAsMap.put(KNNConstants.MODE_PARAMETER, Mode.ON_DISK.getName());
@@ -978,7 +1015,8 @@ public class ModelMetadataTests extends KNNTestCase {
                 methodComponentContext,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             )
         );
         assertEquals("Model description cannot contain any commas: ','", e.getMessage());

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.indices;
 
+import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.MethodComponentContext;
@@ -47,7 +48,8 @@ public class ModelTests extends KNNTestCase {
                     MethodComponentContext.EMPTY,
                     VectorDataType.DEFAULT,
                     Mode.NOT_CONFIGURED,
-                    CompressionLevel.NOT_CONFIGURED
+                    CompressionLevel.NOT_CONFIGURED,
+                    Version.CURRENT
                 ),
                 null,
                 "test-model"
@@ -71,7 +73,8 @@ public class ModelTests extends KNNTestCase {
                     MethodComponentContext.EMPTY,
                     VectorDataType.DEFAULT,
                     Mode.NOT_CONFIGURED,
-                    CompressionLevel.NOT_CONFIGURED
+                    CompressionLevel.NOT_CONFIGURED,
+                    Version.CURRENT
                 ),
                 new byte[16],
                 "test-model"
@@ -92,7 +95,8 @@ public class ModelTests extends KNNTestCase {
                     MethodComponentContext.EMPTY,
                     VectorDataType.DEFAULT,
                     Mode.NOT_CONFIGURED,
-                    CompressionLevel.NOT_CONFIGURED
+                    CompressionLevel.NOT_CONFIGURED,
+                    Version.CURRENT
                 ),
                 new byte[16],
                 "test-model"
@@ -113,7 +117,8 @@ public class ModelTests extends KNNTestCase {
                     MethodComponentContext.EMPTY,
                     VectorDataType.DEFAULT,
                     Mode.NOT_CONFIGURED,
-                    CompressionLevel.NOT_CONFIGURED
+                    CompressionLevel.NOT_CONFIGURED,
+                    Version.CURRENT
                 ),
                 new byte[16],
                 "test-model"
@@ -135,7 +140,8 @@ public class ModelTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         Model model = new Model(modelMetadata, new byte[16], "test-model");
         assertEquals(modelMetadata, model.getModelMetadata());
@@ -156,7 +162,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             "test-model"
@@ -179,7 +186,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[size],
             "test-model"
@@ -199,7 +207,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             null,
             "test-model"
@@ -222,7 +231,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             blob1,
             "test-model"
@@ -251,7 +261,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[16],
             "test-model-1"
@@ -269,7 +280,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[16],
             "test-model-1"
@@ -287,13 +299,13 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[16],
             "test-model-2"
         );
 
-        assertEquals(model1, model1);
         assertEquals(model1, model2);
         assertNotEquals(model1, model3);
     }
@@ -315,7 +327,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[16],
             "test-model-1"
@@ -333,7 +346,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[16],
             "test-model-1"
@@ -351,7 +365,8 @@ public class ModelTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[16],
             "test-model-2"
@@ -385,7 +400,8 @@ public class ModelTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         Map<String, Object> modelAsMap = new HashMap<>();
         modelAsMap.put(KNNConstants.MODEL_ID, modelID);

--- a/src/test/java/org/opensearch/knn/indices/ModelUtilTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelUtilTests.java
@@ -23,14 +23,19 @@ public class ModelUtilTests extends KNNTestCase {
         MockedStatic<ModelCache> modelCacheMockedStatic = Mockito.mockStatic(ModelCache.class);
 
         modelCacheMockedStatic.when(ModelCache::getInstance).thenReturn(modelCache);
+        try (MockedStatic<ModelDao.OpenSearchKNNModelDao> modelDaoMockedStatic = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
+            ModelDao.OpenSearchKNNModelDao modelDao = Mockito.mock(ModelDao.OpenSearchKNNModelDao.class);
+            Mockito.when(modelDao.getMetadata(MODEL_ID)).thenReturn(modelMetadata);
+            Mockito.when(modelMetadata.getState()).thenReturn(ModelState.FAILED);
+            modelDaoMockedStatic.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(modelDao);
 
-        Mockito.when(modelCache.get(MODEL_ID)).thenReturn(model);
-        Mockito.when(model.getModelMetadata()).thenReturn(null);
-        Assert.assertThrows(IllegalArgumentException.class, () -> ModelUtil.getModelMetadata(MODEL_ID));
+            Mockito.when(modelCache.get(MODEL_ID)).thenReturn(model);
+            Mockito.when(model.getModelMetadata()).thenReturn(null);
+            Assert.assertThrows(IllegalArgumentException.class, () -> ModelUtil.getModelMetadata(MODEL_ID));
 
-        Mockito.when(model.getModelMetadata()).thenReturn(modelMetadata);
-        Mockito.when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
-        Assert.assertNotNull(ModelUtil.getModelMetadata(MODEL_ID));
+            Mockito.when(modelMetadata.getState()).thenReturn(ModelState.CREATED);
+            Assert.assertNotNull(ModelUtil.getModelMetadata(MODEL_ID));
+        }
         modelCacheMockedStatic.close();
     }
 }

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -50,7 +50,8 @@ public class GetModelResponseTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
     }
 
@@ -75,7 +76,7 @@ public class GetModelResponseTests extends KNNTestCase {
             Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
             String expectedResponseString =
-                "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\"}";
+                "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\",\"model_version\":\"3.0.0\"}";
             XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
             getModelResponse.toXContent(xContentBuilder, null);
             assertEquals(expectedResponseString, xContentBuilder.toString());
@@ -91,7 +92,7 @@ public class GetModelResponseTests extends KNNTestCase {
             Model model = new Model(getModelMetadata(ModelState.FAILED), null, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
             String expectedResponseString =
-                "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\"}";
+                "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\",\"model_version\":\"3.0.0\"}";
             XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
             getModelResponse.toXContent(xContentBuilder, null);
             assertEquals(expectedResponseString, xContentBuilder.toString());

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -75,8 +75,10 @@ public class GetModelResponseTests extends KNNTestCase {
             byte[] testModelBlob = "hello".getBytes();
             Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
-            String expectedResponseString =
-                "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\",\"model_version\":\"3.0.0\"}";
+            String expectedResponseString = String.format(
+                "{\"model_id\":\"test-model\",\"model_blob\":\"aGVsbG8=\",\"state\":\"created\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\",\"model_version\":\"%s\"}",
+                Version.CURRENT.toString()
+            );
             XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
             getModelResponse.toXContent(xContentBuilder, null);
             assertEquals(expectedResponseString, xContentBuilder.toString());
@@ -91,8 +93,10 @@ public class GetModelResponseTests extends KNNTestCase {
             String modelId = "test-model";
             Model model = new Model(getModelMetadata(ModelState.FAILED), null, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
-            String expectedResponseString =
-                "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\",\"model_version\":\"3.0.0\"}";
+            String expectedResponseString = String.format(
+                "{\"model_id\":\"test-model\",\"model_blob\":\"\",\"state\":\"failed\",\"timestamp\":\"2021-03-27 10:15:30 AM +05:30\",\"description\":\"test model\",\"error\":\"\",\"space_type\":\"l2\",\"dimension\":4,\"engine\":\"nmslib\",\"training_node_assignment\":\"\",\"model_definition\":{\"name\":\"\",\"parameters\":{}},\"data_type\":\"float\",\"model_version\":\"%s\"}",
+                Version.CURRENT.toString()
+            );
             XContentBuilder xContentBuilder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
             getModelResponse.toXContent(xContentBuilder, null);
             assertEquals(expectedResponseString, xContentBuilder.toString());

--- a/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/RemoveModelFromCacheTransportActionTests.java
@@ -13,6 +13,7 @@ package org.opensearch.knn.plugin.transport;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Ignore;
+import org.opensearch.Version;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -84,7 +85,8 @@ public class RemoveModelFromCacheTransportActionTests extends KNNSingleNodeTestC
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             new byte[128],
             modelId

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.plugin.transport;
 
 import com.google.common.collect.ImmutableMap;
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -222,7 +223,8 @@ public class TrainingModelRequestTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.plugin.transport;
 
+import org.opensearch.Version;
 import org.opensearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
@@ -216,7 +217,8 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             modelBlob,
             modelId

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataRequestTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.plugin.transport;
 
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.engine.MethodComponentContext;
@@ -48,7 +49,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest(modelId, isRemoveRequest, modelMetadata);
 
@@ -76,7 +78,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         UpdateModelMetadataRequest updateModelMetadataRequest1 = new UpdateModelMetadataRequest("test", true, null);
@@ -119,7 +122,8 @@ public class UpdateModelMetadataRequestTests extends KNNTestCase {
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
         UpdateModelMetadataRequest updateModelMetadataRequest = new UpdateModelMetadataRequest("test", true, modelMetadata);
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelMetadataTransportActionTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.plugin.transport;
 
+import org.opensearch.Version;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
@@ -74,7 +75,8 @@ public class UpdateModelMetadataTransportActionTests extends KNNSingleNodeTestCa
             MethodComponentContext.EMPTY,
             VectorDataType.DEFAULT,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            CompressionLevel.NOT_CONFIGURED,
+            Version.CURRENT
         );
 
         // Get update transport action

--- a/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobRunnerTests.java
@@ -65,7 +65,7 @@ public class TrainingJobRunnerTests extends KNNTestCase {
         // After put finishes, it should call the onResponse function that will call responseListener and then kickoff
         // training.
         ModelDao modelDao = mock(ModelDao.class);
-        when(modelDao.get(modelId)).thenReturn(model);
+        when(modelDao.getMetadata(modelId)).thenReturn(modelMetadata);
         doAnswer(invocationOnMock -> {
             assertEquals(1, trainingJobRunner.getJobCount()); // Make sure job count is correct
             IndexResponse indexResponse = new IndexResponse(new ShardId(MODEL_INDEX_NAME, "uuid", 0), modelId, 0, 0, 0, true);

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -124,7 +124,8 @@ public class TrainingJobTests extends KNNTestCase {
                 MethodComponentContext.EMPTY,
                 VectorDataType.DEFAULT,
                 Mode.NOT_CONFIGURED,
-                CompressionLevel.NOT_CONFIGURED
+                CompressionLevel.NOT_CONFIGURED,
+                Version.CURRENT
             ),
             null,
             modelID


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/k-NN/pull/2005, including fix from https://github.com/opensearch-project/k-NN/pull/2062

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
