### PR TITLE
Bounds the transferLimit in OffheapVectorTransfer

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.codec.nativeindex;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.codec.transfer.OffHeapVectorTransfer;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
@@ -56,8 +55,13 @@ final class DefaultIndexBuildStrategy implements NativeIndexBuildStrategy {
         iterateVectorValuesOnce(knnVectorValues);
         IndexBuildSetup indexBuildSetup = QuantizationIndexUtils.prepareIndexBuild(knnVectorValues, indexInfo);
 
-        int transferLimit = (int) Math.max(1, KNNSettings.getVectorStreamingMemoryLimit().getBytes() / indexBuildSetup.getBytesPerVector());
-        try (final OffHeapVectorTransfer vectorTransfer = getVectorTransfer(indexInfo.getVectorDataType(), transferLimit)) {
+        try (
+            final OffHeapVectorTransfer vectorTransfer = getVectorTransfer(
+                indexInfo.getVectorDataType(),
+                indexBuildSetup.getBytesPerVector(),
+                indexInfo.getTotalLiveDocs()
+            )
+        ) {
             final List<Integer> transferredDocIds = new ArrayList<>(indexInfo.getTotalLiveDocs());
 
             while (knnVectorValues.docId() != NO_MORE_DOCS) {

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.codec.nativeindex;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.codec.transfer.OffHeapVectorTransfer;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -70,10 +69,15 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
             )
         );
 
-        int transferLimit = (int) Math.max(1, KNNSettings.getVectorStreamingMemoryLimit().getBytes() / indexBuildSetup.getBytesPerVector());
-        try (final OffHeapVectorTransfer vectorTransfer = getVectorTransfer(indexInfo.getVectorDataType(), transferLimit)) {
+        try (
+            final OffHeapVectorTransfer vectorTransfer = getVectorTransfer(
+                indexInfo.getVectorDataType(),
+                indexBuildSetup.getBytesPerVector(),
+                indexInfo.getTotalLiveDocs()
+            )
+        ) {
 
-            final List<Integer> transferredDocIds = new ArrayList<>(transferLimit);
+            final List<Integer> transferredDocIds = new ArrayList<>(vectorTransfer.getTransferLimit());
 
             while (knnVectorValues.docId() != NO_MORE_DOCS) {
                 Object vector = QuantizationIndexUtils.processAndReturnVector(knnVectorValues, indexBuildSetup);

--- a/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapBinaryVectorTransfer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapBinaryVectorTransfer.java
@@ -17,8 +17,8 @@ import java.util.List;
  */
 public final class OffHeapBinaryVectorTransfer extends OffHeapVectorTransfer<byte[]> {
 
-    public OffHeapBinaryVectorTransfer(int transferLimit) {
-        super(transferLimit);
+    public OffHeapBinaryVectorTransfer(int bytesPerVector, int totalVectorsToTransfer) {
+        super(bytesPerVector, totalVectorsToTransfer);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapByteVectorTransfer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapByteVectorTransfer.java
@@ -17,8 +17,8 @@ import java.util.List;
  */
 public final class OffHeapByteVectorTransfer extends OffHeapVectorTransfer<byte[]> {
 
-    public OffHeapByteVectorTransfer(int transferLimit) {
-        super(transferLimit);
+    public OffHeapByteVectorTransfer(int bytesPerVector, int totalVectorsToTransfer) {
+        super(bytesPerVector, totalVectorsToTransfer);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapFloatVectorTransfer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapFloatVectorTransfer.java
@@ -15,8 +15,8 @@ import java.util.List;
  */
 public final class OffHeapFloatVectorTransfer extends OffHeapVectorTransfer<float[]> {
 
-    public OffHeapFloatVectorTransfer(int transferLimit) {
-        super(transferLimit);
+    public OffHeapFloatVectorTransfer(int bytesPerVector, int totalVectorsToTransfer) {
+        super(bytesPerVector, totalVectorsToTransfer);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransferFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransferFactory.java
@@ -18,18 +18,23 @@ public final class OffHeapVectorTransferFactory {
     /**
      * Gets the right vector transfer object based on vector data type
      * @param vectorDataType {@link VectorDataType}
-     * @param transferLimit max number of vectors that can be transferred to off heap in one transfer
+     * @param bytesPerVector Bytes used per vector
+     * @param totalVectorsToTransfer total number of vectors that will be transferred off heap
      * @return Correct implementation of {@link OffHeapVectorTransfer}
      * @param <T> float[] or byte[]
      */
-    public static <T> OffHeapVectorTransfer<T> getVectorTransfer(final VectorDataType vectorDataType, final int transferLimit) {
+    public static <T> OffHeapVectorTransfer<T> getVectorTransfer(
+        final VectorDataType vectorDataType,
+        int bytesPerVector,
+        int totalVectorsToTransfer
+    ) {
         switch (vectorDataType) {
             case FLOAT:
-                return (OffHeapVectorTransfer<T>) new OffHeapFloatVectorTransfer(transferLimit);
+                return (OffHeapVectorTransfer<T>) new OffHeapFloatVectorTransfer(bytesPerVector, totalVectorsToTransfer);
             case BINARY:
-                return (OffHeapVectorTransfer<T>) new OffHeapBinaryVectorTransfer(transferLimit);
+                return (OffHeapVectorTransfer<T>) new OffHeapBinaryVectorTransfer(bytesPerVector, totalVectorsToTransfer);
             case BYTE:
-                return (OffHeapVectorTransfer<T>) new OffHeapByteVectorTransfer(transferLimit);
+                return (OffHeapVectorTransfer<T>) new OffHeapByteVectorTransfer(bytesPerVector, totalVectorsToTransfer);
             default:
                 throw new IllegalArgumentException("Unsupported vector data type: " + vectorDataType);
         }

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategyTests.java
@@ -57,14 +57,11 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
         final KNNVectorValues<byte[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
 
         try (
-            MockedStatic<KNNSettings> mockedKNNSettings = mockStatic(KNNSettings.class);
             MockedStatic<JNIService> mockedJNIService = mockStatic(JNIService.class);
             MockedStatic<OffHeapVectorTransferFactory> mockedOffHeapVectorTransferFactory = mockStatic(OffHeapVectorTransferFactory.class)
         ) {
-
-            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(16));
             OffHeapVectorTransfer offHeapVectorTransfer = mock(OffHeapVectorTransfer.class);
-            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 2))
+            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 8, 3))
                 .thenReturn(offHeapVectorTransfer);
 
             when(offHeapVectorTransfer.getVectorAddress()).thenReturn(200L);
@@ -131,7 +128,7 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
             mockedJNIService.when(() -> JNIService.initIndex(3, 2, Map.of("index", "param"), KNNEngine.FAISS)).thenReturn(100L);
 
             OffHeapVectorTransfer offHeapVectorTransfer = mock(OffHeapVectorTransfer.class);
-            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 2))
+            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 8, 3))
                 .thenReturn(offHeapVectorTransfer);
 
             QuantizationService quantizationService = mock(QuantizationService.class);
@@ -237,14 +234,12 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
             docs
         );
         try (
-            MockedStatic<KNNSettings> mockedKNNSettings = mockStatic(KNNSettings.class);
             MockedStatic<JNIService> mockedJNIService = mockStatic(JNIService.class);
             MockedStatic<OffHeapVectorTransferFactory> mockedOffHeapVectorTransferFactory = mockStatic(OffHeapVectorTransferFactory.class)
         ) {
 
-            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(16));
             OffHeapVectorTransfer offHeapVectorTransfer = mock(OffHeapVectorTransfer.class);
-            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 2))
+            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 8, 3))
                 .thenReturn(offHeapVectorTransfer);
 
             when(offHeapVectorTransfer.getVectorAddress()).thenReturn(200L);

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategyTests.java
@@ -9,8 +9,6 @@ import lombok.SneakyThrows;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.opensearch.core.common.unit.ByteSizeValue;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.codec.transfer.OffHeapVectorTransfer;
@@ -49,7 +47,6 @@ public class MemOptimizedNativeIndexBuildStrategyTests extends OpenSearchTestCas
         final KNNVectorValues<byte[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
 
         try (
-            MockedStatic<KNNSettings> mockedKNNSettings = Mockito.mockStatic(KNNSettings.class);
             MockedStatic<JNIService> mockedJNIService = Mockito.mockStatic(JNIService.class);
             MockedStatic<OffHeapVectorTransferFactory> mockedOffHeapVectorTransferFactory = Mockito.mockStatic(
                 OffHeapVectorTransferFactory.class
@@ -57,13 +54,13 @@ public class MemOptimizedNativeIndexBuildStrategyTests extends OpenSearchTestCas
         ) {
 
             // Limits transfer to 2 vectors
-            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(16));
             mockedJNIService.when(() -> JNIService.initIndex(3, 2, Map.of("index", "param"), KNNEngine.FAISS)).thenReturn(100L);
 
             OffHeapVectorTransfer offHeapVectorTransfer = mock(OffHeapVectorTransfer.class);
-            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 2))
+            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 8, 3))
                 .thenReturn(offHeapVectorTransfer);
 
+            when(offHeapVectorTransfer.getTransferLimit()).thenReturn(2);
             when(offHeapVectorTransfer.transfer(vectorTransferCapture.capture(), eq(false))).thenReturn(false)
                 .thenReturn(true)
                 .thenReturn(false);
@@ -145,7 +142,6 @@ public class MemOptimizedNativeIndexBuildStrategyTests extends OpenSearchTestCas
         final KNNVectorValues<byte[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
 
         try (
-            MockedStatic<KNNSettings> mockedKNNSettings = Mockito.mockStatic(KNNSettings.class);
             MockedStatic<JNIService> mockedJNIService = Mockito.mockStatic(JNIService.class);
             MockedStatic<OffHeapVectorTransferFactory> mockedOffHeapVectorTransferFactory = Mockito.mockStatic(
                 OffHeapVectorTransferFactory.class
@@ -154,11 +150,11 @@ public class MemOptimizedNativeIndexBuildStrategyTests extends OpenSearchTestCas
         ) {
 
             // Limits transfer to 2 vectors
-            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(16));
             mockedJNIService.when(() -> JNIService.initIndex(3, 2, Map.of("index", "param"), KNNEngine.FAISS)).thenReturn(100L);
 
             OffHeapVectorTransfer offHeapVectorTransfer = mock(OffHeapVectorTransfer.class);
-            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 2))
+            when(offHeapVectorTransfer.getTransferLimit()).thenReturn(2);
+            mockedOffHeapVectorTransferFactory.when(() -> OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 8, 3))
                 .thenReturn(offHeapVectorTransfer);
 
             QuantizationService quantizationService = mock(QuantizationService.class);

--- a/src/test/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransferFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransferFactoryTests.java
@@ -5,22 +5,30 @@
 
 package org.opensearch.knn.index.codec.transfer;
 
+import org.mockito.MockedStatic;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.Mockito.mockStatic;
 
 public class OffHeapVectorTransferFactoryTests extends OpenSearchTestCase {
 
     public void testOffHeapVectorTransferFactory() {
-        var floatVectorTransfer = OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 10);
-        assertEquals(OffHeapFloatVectorTransfer.class, floatVectorTransfer.getClass());
-        assertNotSame(floatVectorTransfer, OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 10));
+        try (MockedStatic<KNNSettings> mockedKNNSettings = mockStatic(KNNSettings.class)) {
+            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(16));
+            var floatVectorTransfer = OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 10, 10);
+            assertEquals(OffHeapFloatVectorTransfer.class, floatVectorTransfer.getClass());
+            assertNotSame(floatVectorTransfer, OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.FLOAT, 10, 10));
 
-        var byteVectorTransfer = OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BYTE, 10);
-        assertEquals(OffHeapByteVectorTransfer.class, byteVectorTransfer.getClass());
-        assertNotSame(byteVectorTransfer, OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BYTE, 10));
+            var byteVectorTransfer = OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BYTE, 10, 10);
+            assertEquals(OffHeapByteVectorTransfer.class, byteVectorTransfer.getClass());
+            assertNotSame(byteVectorTransfer, OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BYTE, 10, 10));
 
-        var binaryVectorTransfer = OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BINARY, 10);
-        assertEquals(OffHeapBinaryVectorTransfer.class, binaryVectorTransfer.getClass());
-        assertNotSame(binaryVectorTransfer, OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BINARY, 10));
+            var binaryVectorTransfer = OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BINARY, 10, 10);
+            assertEquals(OffHeapBinaryVectorTransfer.class, binaryVectorTransfer.getClass());
+            assertNotSame(binaryVectorTransfer, OffHeapVectorTransferFactory.getVectorTransfer(VectorDataType.BINARY, 10, 10));
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransferTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransferTests.java
@@ -6,9 +6,14 @@
 package org.opensearch.knn.index.codec.transfer;
 
 import lombok.SneakyThrows;
+import org.mockito.MockedStatic;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
 
 import java.util.List;
+
+import static org.mockito.Mockito.mockStatic;
 
 public class OffHeapVectorTransferTests extends KNNTestCase {
 
@@ -22,21 +27,27 @@ public class OffHeapVectorTransferTests extends KNNTestCase {
             new float[] { 0.3f, 0.4f }
         );
 
-        OffHeapFloatVectorTransfer vectorTransfer = new OffHeapFloatVectorTransfer(2);
-        long vectorAddress = 0;
-        assertFalse(vectorTransfer.transfer(vectors.get(0), false));
-        assertEquals(0, vectorTransfer.getVectorAddress());
-        assertTrue(vectorTransfer.transfer(vectors.get(1), false));
-        vectorAddress = vectorTransfer.getVectorAddress();
-        assertFalse(vectorTransfer.transfer(vectors.get(2), false));
-        assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
-        assertTrue(vectorTransfer.transfer(vectors.get(3), false));
-        assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
-        assertFalse(vectorTransfer.transfer(vectors.get(4), false));
-        assertTrue(vectorTransfer.flush(false));
-        vectorTransfer.reset();
-        assertEquals(0, vectorTransfer.getVectorAddress());
-        vectorTransfer.close();
+        try (MockedStatic<KNNSettings> mockedKNNSettings = mockStatic(KNNSettings.class)) {
+            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(16));
+
+            OffHeapFloatVectorTransfer vectorTransfer = new OffHeapFloatVectorTransfer(8, 5);
+            long vectorAddress = 0;
+            assertFalse(vectorTransfer.transfer(vectors.get(0), false));
+            assertEquals(0, vectorTransfer.getVectorAddress());
+            assertTrue(vectorTransfer.transfer(vectors.get(1), false));
+            vectorAddress = vectorTransfer.getVectorAddress();
+            assertFalse(vectorTransfer.transfer(vectors.get(2), false));
+            assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
+            assertTrue(vectorTransfer.transfer(vectors.get(3), false));
+            assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
+            assertFalse(vectorTransfer.transfer(vectors.get(4), false));
+            assertTrue(vectorTransfer.flush(false));
+            vectorTransfer.reset();
+            assertEquals(0, vectorTransfer.getVectorAddress());
+            vectorTransfer.close();
+
+        }
+
     }
 
     @SneakyThrows
@@ -49,20 +60,23 @@ public class OffHeapVectorTransferTests extends KNNTestCase {
             new byte[] { 8, 9 }
         );
 
-        OffHeapByteVectorTransfer vectorTransfer = new OffHeapByteVectorTransfer(2);
-        long vectorAddress = 0;
-        assertFalse(vectorTransfer.transfer(vectors.get(0), false));
-        assertEquals(0, vectorTransfer.getVectorAddress());
-        assertTrue(vectorTransfer.transfer(vectors.get(1), false));
-        vectorAddress = vectorTransfer.getVectorAddress();
-        assertFalse(vectorTransfer.transfer(vectors.get(2), false));
-        assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
-        assertTrue(vectorTransfer.transfer(vectors.get(3), false));
-        assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
-        assertFalse(vectorTransfer.transfer(vectors.get(4), false));
-        assertTrue(vectorTransfer.flush(false));
-        vectorTransfer.close();
-        assertEquals(0, vectorTransfer.getVectorAddress());
+        try (MockedStatic<KNNSettings> mockedKNNSettings = mockStatic(KNNSettings.class)) {
+            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(4));
+            OffHeapByteVectorTransfer vectorTransfer = new OffHeapByteVectorTransfer(2, 5);
+            long vectorAddress = 0;
+            assertFalse(vectorTransfer.transfer(vectors.get(0), false));
+            assertEquals(0, vectorTransfer.getVectorAddress());
+            assertTrue(vectorTransfer.transfer(vectors.get(1), false));
+            vectorAddress = vectorTransfer.getVectorAddress();
+            assertFalse(vectorTransfer.transfer(vectors.get(2), false));
+            assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
+            assertTrue(vectorTransfer.transfer(vectors.get(3), false));
+            assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
+            assertFalse(vectorTransfer.transfer(vectors.get(4), false));
+            assertTrue(vectorTransfer.flush(false));
+            vectorTransfer.close();
+            assertEquals(0, vectorTransfer.getVectorAddress());
+        }
     }
 
     @SneakyThrows
@@ -75,18 +89,21 @@ public class OffHeapVectorTransferTests extends KNNTestCase {
             new byte[] { 8, 9 }
         );
 
-        OffHeapBinaryVectorTransfer vectorTransfer = new OffHeapBinaryVectorTransfer(2);
-        long vectorAddress = 0;
-        assertFalse(vectorTransfer.transfer(vectors.get(0), false));
-        assertEquals(0, vectorTransfer.getVectorAddress());
-        assertTrue(vectorTransfer.transfer(vectors.get(1), false));
-        vectorAddress = vectorTransfer.getVectorAddress();
-        assertFalse(vectorTransfer.transfer(vectors.get(2), false));
-        assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
-        assertTrue(vectorTransfer.transfer(vectors.get(3), false));
-        assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
-        assertFalse(vectorTransfer.transfer(vectors.get(4), false));
-        assertTrue(vectorTransfer.flush(false));
-        vectorTransfer.close();
+        try (MockedStatic<KNNSettings> mockedKNNSettings = mockStatic(KNNSettings.class)) {
+            mockedKNNSettings.when(KNNSettings::getVectorStreamingMemoryLimit).thenReturn(new ByteSizeValue(4));
+            OffHeapBinaryVectorTransfer vectorTransfer = new OffHeapBinaryVectorTransfer(2, 5);
+            long vectorAddress = 0;
+            assertFalse(vectorTransfer.transfer(vectors.get(0), false));
+            assertEquals(0, vectorTransfer.getVectorAddress());
+            assertTrue(vectorTransfer.transfer(vectors.get(1), false));
+            vectorAddress = vectorTransfer.getVectorAddress();
+            assertFalse(vectorTransfer.transfer(vectors.get(2), false));
+            assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
+            assertTrue(vectorTransfer.transfer(vectors.get(3), false));
+            assertEquals(vectorAddress, vectorTransfer.getVectorAddress());
+            assertFalse(vectorTransfer.transfer(vectors.get(4), false));
+            assertTrue(vectorTransfer.flush(false));
+            vectorTransfer.close();
+        }
     }
 }


### PR DESCRIPTION
The array list buffer was unnecessarily allocated a large memory irrespective of the number of vectors to transfer. This change considers total vectors

### Description

Attached below is the heap usage for the duration of `BinaryIndexIT.testFaissHnswBinary_when1000Data_thenCreateIngestQueryWorks` test

[transferLimitNotCapped.log](https://github.com/user-attachments/files/16920119/transferLimitNotCapped.log): This is the current code in main. The max heap usage is 1.8 gb
[transferLimitCapped.log](https://github.com/user-attachments/files/16920120/transferLimitCapped.log): This is code with the current PR. The max heap usage is 1.2 gb
[NoPreallocation.log](https://github.com/user-attachments/files/16920121/NoPreallocation.log): This is without allocating the transferLimit as a size for arraylist. The max heap usage is comparable to the code in PR which 1.1 gb

Capping the transfer limit is chosen as a solution over not preallocating to avoid fragmentation due to constant resizing of arraylist

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
