### PR TITLE
[Bug-Fix] Fix efficient filtering of vector search when quantization is used

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfo.java
+++ b/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.quantization.models.quantizationParams.QuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+
+import java.io.IOException;
+
+/**
+ * This class encapsulate the necessary details to do the quantization of the vectors present in a lucene segment.
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SegmentLevelQuantizationInfo {
+    private final QuantizationParams quantizationParams;
+    private final QuantizationState quantizationState;
+
+    /**
+     * A builder like function to build the {@link SegmentLevelQuantizationInfo}
+     * @param leafReader {@link LeafReader}
+     * @param fieldInfo {@link FieldInfo}
+     * @param fieldName {@link String}
+     * @return {@link SegmentLevelQuantizationInfo}
+     * @throws IOException exception while creating the {@link SegmentLevelQuantizationInfo} object.
+     */
+    public static SegmentLevelQuantizationInfo build(final LeafReader leafReader, final FieldInfo fieldInfo, final String fieldName)
+        throws IOException {
+        final QuantizationParams quantizationParams = QuantizationService.getInstance().getQuantizationParams(fieldInfo);
+        if (quantizationParams == null) {
+            return null;
+        }
+        final QuantizationState quantizationState = SegmentLevelQuantizationUtil.getQuantizationState(leafReader, fieldName);
+        return new SegmentLevelQuantizationInfo(quantizationParams, quantizationState);
+    }
+
+}

--- a/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.experimental.UtilityClass;
+import org.apache.lucene.index.LeafReader;
+import org.opensearch.knn.index.codec.KNN990Codec.QuantizationConfigKNNCollector;
+import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * A utility class for doing Quantization related operation at a segment level. We can move this utility in {@link SegmentLevelQuantizationInfo}
+ * but I am keeping it thinking that {@link SegmentLevelQuantizationInfo} free from these utility functions to reduce
+ * the responsibilities of {@link SegmentLevelQuantizationInfo} class.
+ */
+@UtilityClass
+public class SegmentLevelQuantizationUtil {
+
+    /**
+     * A simple function to convert a vector to a quantized vector for a segment.
+     * @param vector array of float
+     * @return array of byte
+     */
+    @SuppressWarnings("unchecked")
+    public static byte[] quantizeVector(final float[] vector, final SegmentLevelQuantizationInfo segmentLevelQuantizationInfo) {
+        if (segmentLevelQuantizationInfo == null) {
+            return null;
+        }
+        final QuantizationService quantizationService = QuantizationService.getInstance();
+        // TODO: We are converting the output of Quantize to byte array for now. But this needs to be fixed when
+        // other types of quantized outputs are returned like float[].
+        return (byte[]) quantizationService.quantize(
+            segmentLevelQuantizationInfo.getQuantizationState(),
+            vector,
+            quantizationService.createQuantizationOutput(segmentLevelQuantizationInfo.getQuantizationParams())
+        );
+    }
+
+    /**
+     * A utility function to get {@link QuantizationState} for a given segment and field.
+     * @param leafReader {@link LeafReader}
+     * @param fieldName {@link String}
+     * @return {@link QuantizationState}
+     * @throws IOException exception during reading the {@link QuantizationState}
+     */
+    static QuantizationState getQuantizationState(final LeafReader leafReader, String fieldName) throws IOException {
+        final QuantizationConfigKNNCollector tempCollector = new QuantizationConfigKNNCollector();
+        leafReader.searchNearestVectors(fieldName, new float[0], tempCollector, null);
+        if (tempCollector.getQuantizationState() == null) {
+            throw new IllegalStateException(String.format(Locale.ROOT, "No quantization state found for field %s", fieldName));
+        }
+        return tempCollector.getQuantizationState();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/filtered/NestedFilteredIdsKNNIterator.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.query.filtered;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BitSet;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.query.SegmentLevelQuantizationInfo;
 import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
 
 import java.io.IOException;
@@ -19,14 +20,26 @@ import java.io.IOException;
 public class NestedFilteredIdsKNNIterator extends FilteredIdsKNNIterator {
     private final BitSet parentBitSet;
 
-    public NestedFilteredIdsKNNIterator(
+    NestedFilteredIdsKNNIterator(
         final BitSet filterIdsArray,
         final float[] queryVector,
         final KNNFloatVectorValues knnFloatVectorValues,
         final SpaceType spaceType,
         final BitSet parentBitSet
     ) {
-        super(filterIdsArray, queryVector, knnFloatVectorValues, spaceType);
+        this(filterIdsArray, queryVector, knnFloatVectorValues, spaceType, parentBitSet, null, null);
+    }
+
+    public NestedFilteredIdsKNNIterator(
+        final BitSet filterIdsArray,
+        final float[] queryVector,
+        final KNNFloatVectorValues knnFloatVectorValues,
+        final SpaceType spaceType,
+        final BitSet parentBitSet,
+        final byte[] quantizedVector,
+        final SegmentLevelQuantizationInfo segmentLevelQuantizationInfo
+    ) {
+        super(filterIdsArray, queryVector, knnFloatVectorValues, spaceType, quantizedVector, segmentLevelQuantizationInfo);
         this.parentBitSet = parentBitSet;
     }
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -84,6 +84,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -1363,9 +1364,9 @@ public class KNNWeightTests extends KNNTestCase {
     public void testANNWithQuantizationParams_whenStateNotFound_thenFail() {
         try (MockedStatic<QuantizationService> quantizationServiceMockedStatic = Mockito.mockStatic(QuantizationService.class)) {
             QuantizationService quantizationService = Mockito.mock(QuantizationService.class);
+            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
             QuantizationParams quantizationParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
             Mockito.when(quantizationService.getQuantizationParams(any(FieldInfo.class))).thenReturn(quantizationParams);
-            quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
 
             // Given
             int k = 3;
@@ -1413,6 +1414,8 @@ public class KNNWeightTests extends KNNTestCase {
             when(reader.getFieldInfos()).thenReturn(fieldInfos);
             when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
             when(fieldInfo.attributes()).thenReturn(attributesMap);
+            // fieldName, new float[0], tempCollector, null)
+            doNothing().when(reader).searchNearestVectors(any(), eq(new float[0]), any(), any());
 
             expectThrows(IllegalStateException.class, () -> knnWeight.scorer(leafReaderContext));
         }

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -186,8 +185,9 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         when(knnWeight.getQuery()).thenReturn(knnQuery);
         when(knnWeight.searchLeaf(leaf1, firstPassK)).thenReturn(initialLeaf1Results);
         when(knnWeight.searchLeaf(leaf2, firstPassK)).thenReturn(initialLeaf2Results);
-        when(knnWeight.exactSearch(eq(leaf1), any(), anyBoolean(), anyInt())).thenReturn(rescoredLeaf1Results);
-        when(knnWeight.exactSearch(eq(leaf2), any(), anyBoolean(), anyInt())).thenReturn(rescoredLeaf2Results);
+
+        when(knnWeight.exactSearch(eq(leaf1), any())).thenReturn(rescoredLeaf1Results);
+        when(knnWeight.exactSearch(eq(leaf2), any())).thenReturn(rescoredLeaf2Results);
         try (MockedStatic<ResultUtil> mockedResultUtil = mockStatic(ResultUtil.class)) {
             mockedResultUtil.when(() -> ResultUtil.reduceToTopK(any(), anyInt())).thenAnswer(InvocationOnMock::callRealMethod);
             mockedResultUtil.when(() -> ResultUtil.resultMapToTopDocs(eq(rescoredLeaf1Results), anyInt())).thenAnswer(t -> topDocs1);


### PR DESCRIPTION
### Description
[Bug-Fix] Fix efficient filtering of vector search when quantization is used

### Issue
When efficient filtering happens then at per segment level k-NN plugin takes a decision to either do filtered ANN search or Exact search. But when quantization is present then the first pass search happens on the quantized vectors. Currently only ANN search happens with quantized vectors and not exact search. This can lead of different scores for a shard for first pass search if its segments takes different route to do the filtered search.

### What this PR do?
This PR adds the capability to do quantized exact search when exact search happens during filtered vector search. The way it is achieved is, by passing the segment level quantization information to KNNIterators which iterates over the vectors. It also add a capability now where we can specify if we want to search on quantized vectors or non quantized vectors. 

### Testing
Performed a Manual testing for filtered vector search. Will be adding more ITs and UTs for the change. Raising the PR for doing first pass on the code.

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
