### PR TITLE
Switch MINGW32 to MINGW64

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.17.0.0.md
@@ -19,6 +19,7 @@ Compatible with OpenSearch 2.17.0
 * Disallow a vector field to have an invalid character for a physical file name. [#1936](https://github.com/opensearch-project/k-NN/pull/1936)
 * Fix memory overflow caused by cache behavior [#2015](https://github.com/opensearch-project/k-NN/pull/2015)
 * Use correct type for binary vector in ivf training [#2086](https://github.com/opensearch-project/k-NN/pull/2086)
+* Switch MINGW32 to MINGW64 [#2090](https://github.com/opensearch-project/k-NN/pull/2090)
 ### Infrastructure
 * Parallelize make to reduce build time [#2006] (https://github.com/opensearch-project/k-NN/pull/2006)
 ### Maintenance

--- a/scripts/windowsScript.ps1
+++ b/scripts/windowsScript.ps1
@@ -7,14 +7,14 @@ git submodule update --init -- jni/external/nmslib
 git submodule update --init -- jni/external/faiss
 
 # _MSC_VER is a predefined macro which defines the version of Visual Studio Compiler
-# As we are using x86_64-w64-mingw32-gcc compiler we need to replace this macro with __MINGW32__
-(Get-Content jni/external/faiss/faiss/impl/index_read.cpp).replace('_MSC_VER', '__MINGW32__') | Set-Content jni/external/faiss/faiss/impl/index_read.cpp
-(Get-Content jni/external/faiss/faiss/impl/index_write.cpp).replace('_MSC_VER', '__MINGW32__') | Set-Content jni/external/faiss/faiss/impl/index_write.cpp
-(Get-Content jni/external/faiss/faiss/impl/platform_macros.h).replace('_MSC_VER', '__MINGW32__') | Set-Content jni/external/faiss/faiss/impl/platform_macros.h
+# As we are using x86_64-w64-mingw32-gcc compiler we need to replace this macro with __MINGW64__
+(Get-Content jni/external/faiss/faiss/impl/index_read.cpp).replace('_MSC_VER', '__MINGW64__') | Set-Content jni/external/faiss/faiss/impl/index_read.cpp
+(Get-Content jni/external/faiss/faiss/impl/index_write.cpp).replace('_MSC_VER', '__MINGW64__') | Set-Content jni/external/faiss/faiss/impl/index_write.cpp
+(Get-Content jni/external/faiss/faiss/impl/platform_macros.h).replace('_MSC_VER', '__MINGW64__') | Set-Content jni/external/faiss/faiss/impl/platform_macros.h
 (Get-Content jni/external/faiss/faiss/impl/platform_macros.h).replace('#define __PRETTY_FUNCTION__ __FUNCSIG__', ' ') | Set-Content jni/external/faiss/faiss/impl/platform_macros.h
-(Get-Content jni/external/faiss/faiss/utils/utils.cpp).replace('_MSC_VER', '__MINGW32__') | Set-Content jni/external/faiss/faiss/utils/utils.cpp
-(Get-Content jni/external/faiss/faiss/utils/prefetch.h).replace('_MSC_VER', '__MINGW32__') | Set-Content jni/external/faiss/faiss/utils/prefetch.h
-(Get-Content jni/external/faiss/faiss/invlists/InvertedListsIOHook.cpp).replace('_MSC_VER', '__MINGW32__') | Set-Content jni/external/faiss/faiss/invlists/InvertedListsIOHook.cpp
+(Get-Content jni/external/faiss/faiss/utils/utils.cpp).replace('_MSC_VER', '__MINGW64__') | Set-Content jni/external/faiss/faiss/utils/utils.cpp
+(Get-Content jni/external/faiss/faiss/utils/prefetch.h).replace('_MSC_VER', '__MINGW64__') | Set-Content jni/external/faiss/faiss/utils/prefetch.h
+(Get-Content jni/external/faiss/faiss/invlists/InvertedListsIOHook.cpp).replace('_MSC_VER', '__MINGW64__') | Set-Content jni/external/faiss/faiss/invlists/InvertedListsIOHook.cpp
 (Get-Content jni/external/faiss/faiss/AutoTune.cpp).replace('__PRETTY_FUNCTION__', 'NULL') | Set-Content jni/external/faiss/faiss/AutoTune.cpp
 (Get-Content jni/external/faiss/faiss/utils/distances_simd.cpp).replace('FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN', ' ') | Set-Content jni/external/faiss/faiss/utils/distances_simd.cpp
 (Get-Content jni/external/faiss/faiss/utils/distances_simd.cpp).replace('FAISS_PRAGMA_IMPRECISE_FUNCTION_END', ' ') | Set-Content jni/external/faiss/faiss/utils/distances_simd.cpp
@@ -23,17 +23,17 @@ git submodule update --init -- jni/external/faiss
 
 # <sys/mman.h> is a Unix header and is not available on Windows. So, adding condition to include it if not running on Windows
 # Replace '#include <sys/mman.h>' with
-#  #ifndef __MINGW32__
+#  #ifndef __MINGW64__
 #    #include <sys/mman.h>
 #  #endif
-(Get-Content jni/external/faiss/faiss/invlists/OnDiskInvertedLists.cpp).replace('#include <sys/mman.h>', "#ifndef __MINGW32__`n#include <sys/mman.h>`n#endif") | Set-Content jni/external/faiss/faiss/invlists/OnDiskInvertedLists.cpp
-# intrin.h function like __builtin_ctz, __builtin_clzll is not available in MINGW32. So, adding condition to include it if not running on Windows
+(Get-Content jni/external/faiss/faiss/invlists/OnDiskInvertedLists.cpp).replace('#include <sys/mman.h>', "#ifndef __MINGW64__`n#include <sys/mman.h>`n#endif") | Set-Content jni/external/faiss/faiss/invlists/OnDiskInvertedLists.cpp
+# intrin.h function like __builtin_ctz, __builtin_clzll is not available in MINGW64. So, adding condition to include it if not running on Windows
 # Replace '#include <intrin.h>' with
-#  #ifndef __MINGW32__
+#  #ifndef __MINGW64__
 #    include <intrin.h>
 # and
 # Closing the above #ifndef with
 # #define __builtin_popcountl __popcnt64
 # #endif
-(Get-Content jni/external/faiss/faiss/impl/platform_macros.h).replace('#include <intrin.h>', "#ifndef __MINGW32__`n#include <intrin.h>`n") | Set-Content jni/external/faiss/faiss/impl/platform_macros.h
+(Get-Content jni/external/faiss/faiss/impl/platform_macros.h).replace('#include <intrin.h>', "#ifndef __MINGW64__`n#include <intrin.h>`n") | Set-Content jni/external/faiss/faiss/impl/platform_macros.h
 (Get-Content jni/external/faiss/faiss/impl/platform_macros.h).replace('#define __builtin_popcountl __popcnt64', "#define __builtin_popcountl __popcnt64`n#endif`n") | Set-Content jni/external/faiss/faiss/impl/platform_macros.h


### PR DESCRIPTION
### Description
In the CI, we uses MINGW64. With MINGW32, the hamming distance calculation is not correct which result in bad recall for binary vector in window platform.


### Related Issues
N/A
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
