### PR TITLE
[Backport 2.x] Adds index and query BWC tests for missing engines (#2035)

### DIFF
--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -27,6 +27,8 @@ testClusters {
     }
 }
 
+   def versionsBelow1_3 = ["1.1.", "1.2."]
+   def versionsBelow2_3 = ["1.", "2.0.", "2.1.", "2.2."]
 // Task to run BWC tests against the old cluster
     task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         dependsOn "zipBwcPlugin"
@@ -78,6 +80,20 @@ testClusters {
                 knn_bwc_version.startsWith("2.15.")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
+            }
+        }
+
+        if (versionsBelow2_3.any { knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
+            }
+        }
+
+        if (versionsBelow1_3.any { knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnFaissIndex"
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexFaissForceMerge"
             }
         }
 
@@ -144,6 +160,20 @@ testClusters {
                 knn_bwc_version.startsWith("2.15.")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
+            }
+        }
+
+        if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
+            }
+        }
+
+        if (versionsBelow1_3.any { knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnFaissIndex"
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexFaissForceMerge"
             }
         }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -23,6 +23,7 @@ import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
@@ -51,7 +52,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
             createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         } else {
-            validateKNNIndexingOnUpgrade();
+            validateKNNIndexingOnUpgrade(NUM_DOCS);
         }
     }
 
@@ -65,8 +66,41 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, 100);
             // Flush to ensure that index is not re-indexed when node comes back up
             flush(testIndex, true);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 100, K);
         } else {
-            forceMergeKnnIndex(testIndex);
+            validateKNNIndexingOnUpgrade(100);
+        }
+    }
+
+    public void testKNNIndexFaissForceMerge() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, METHOD_HNSW, FAISS_NAME));
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, 100);
+            // Flush to ensure that index is not re-indexed when node comes back up
+            flush(testIndex, true);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 100, K);
+        } else {
+            validateKNNIndexingOnUpgrade(100);
+        }
+    }
+
+    public void testKNNIndexLuceneForceMerge() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(
+                testIndex,
+                getKNNDefaultIndexSettings(),
+                createKnnIndexMapping(TEST_FIELD, DIMENSIONS, METHOD_HNSW, LUCENE_NAME)
+            );
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, 100);
+            // Flush to ensure that index is not re-indexed when node comes back up
+            flush(testIndex, true);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 100, K);
+        } else {
+            validateKNNIndexingOnUpgrade(100);
         }
     }
 
@@ -115,7 +149,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
             );
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         } else {
-            validateKNNIndexingOnUpgrade();
+            validateKNNIndexingOnUpgrade(NUM_DOCS);
         }
     }
 
@@ -126,7 +160,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
             createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKNNIndexMethodFieldMapping(TEST_FIELD, DIMENSIONS));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         } else {
-            validateKNNIndexingOnUpgrade();
+            validateKNNIndexingOnUpgrade(NUM_DOCS);
         }
     }
 
@@ -150,7 +184,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         } else {
             validateCustomMethodFieldMappingAfterUpgrade();
-            validateKNNIndexingOnUpgrade();
+            validateKNNIndexingOnUpgrade(NUM_DOCS);
         }
     }
 
@@ -240,11 +274,11 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
     }
 
     // KNN indexing tests when the cluster is upgraded to latest version
-    public void validateKNNIndexingOnUpgrade() throws Exception {
-        QUERY_COUNT = NUM_DOCS;
+    public void validateKNNIndexingOnUpgrade(int numOfDocs) throws Exception {
+        QUERY_COUNT = numOfDocs;
         validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, QUERY_COUNT, K);
         cleanUpCache();
-        DOC_ID = NUM_DOCS;
+        DOC_ID = numOfDocs;
         addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         QUERY_COUNT = QUERY_COUNT + NUM_DOCS;
         validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, QUERY_COUNT, K);

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/QueryANNIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/QueryANNIT.java
@@ -1,20 +1,19 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.knn.bwc;
 
 import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 
+/**
+ * Use case: Test queries on indexes created on older versions
+ */
 public class QueryANNIT extends AbstractRestartUpgradeTestCase {
 
     private static final String TEST_FIELD = "test-field";
@@ -22,10 +21,35 @@ public class QueryANNIT extends AbstractRestartUpgradeTestCase {
     private static final int K = 5;
     private static final Integer EF_SEARCH = 10;
     private static final int NUM_DOCS = 10;
+    private static final String ALGORITHM = "hnsw";
 
-    public void testQueryANN() throws Exception {
+    public void testQueryOnFaissIndex() throws Exception {
         if (isRunningAgainstOldCluster()) {
             createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K, Map.of(METHOD_PARAMETER_EF_SEARCH, EF_SEARCH));
+            deleteKNNIndex(testIndex);
+        }
+    }
+
+    public void testQueryOnNmslibIndex() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, ALGORITHM, NMSLIB_NAME));
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K, Map.of(METHOD_PARAMETER_EF_SEARCH, EF_SEARCH));
+            deleteKNNIndex(testIndex);
+        }
+    }
+
+    public void testQueryOnLuceneIndex() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, ALGORITHM, LUCENE_NAME));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
             validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
         } else {


### PR DESCRIPTION
This is done to make sure that KNN80DocsValueConsumer code path is hit

Signed-off-by: Tejas Shah <shatejas@amazon.com>
(cherry picked from commit e3200260e7360f6ff90600535ac759d11cb1fefb)

Backport of https://github.com/opensearch-project/k-NN/pull/2035


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
