### PR TITLE
Remove outdated comment in integration tests

### DIFF
--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -249,8 +249,6 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
         expectThrows(ResponseException.class, () -> trainModel(modelId, builder2));
     }
 
-    // Training isnt currently supported for mode and compression because quantization framework does not quantize
-    // the training vectors. So, commenting out for now.
     @SneakyThrows
     public void testTraining_whenValid_thenSucceed() {
         setupTrainingIndex();


### PR DESCRIPTION
### Description
Removes a comment in ModeAndCompressionIT describing why a test was ignored temporarily.  Currently, the functionality has been fixed and the test is passing.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
