### PR TITLE
Change min oversample to 1

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -18,7 +18,7 @@ public final class RescoreContext {
 
     public static final float DEFAULT_OVERSAMPLE_FACTOR = 1.0f;
     public static final float MAX_OVERSAMPLE_FACTOR = 100.0f;
-    public static final float MIN_OVERSAMPLE_FACTOR = 0.0f;
+    public static final float MIN_OVERSAMPLE_FACTOR = 1.0f;
 
     public static final int MAX_FIRST_PASS_RESULTS = 10000;
 


### PR DESCRIPTION
### Description
Changes minimum oversample factor from 0 to 1. Having an oversample factor that will return less results than the second pass needs to return will always result in less than k results being returned. This is a bug.

From a bwc perspective, we could check if index is created on 2.17 for validation. However, given this is a bug, I think its better to document it as 1.0f and not look at index versioning. 

### Related Issues
#2112 

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
