### PR TITLE
Add log message for quantization state cache eviction due to full cache

### DIFF
--- a/src/main/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCache.java
+++ b/src/main/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCache.java
@@ -107,6 +107,11 @@ public class QuantizationStateCache {
     private void onRemoval(RemovalNotification<String, QuantizationState> removalNotification) {
         if (RemovalCause.SIZE == removalNotification.getCause()) {
             updateEvictedDueToSizeAt();
+            log.info(
+                "[KNN] Quantization state evicted from cache. Key {}, Reason: {}",
+                removalNotification.getKey(),
+                removalNotification.getCause()
+            );
         }
     }
 


### PR DESCRIPTION
### Description
Adds a log statement when a quantization state is evicted from the cache because the cache is full.  This can help users determine if cache thrashing is happening or if the cache is consistently full.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
