### PR TITLE
 Makes sure KNNVectorValues aren't recreated unnecessarily when

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 ### Maintenance
 ### Refactoring
+* Does not create additional KNNVectorValues in NativeEngines990KNNVectorWriter when quantization is not needed [#2133](https://github.com/opensearch-project/k-NN/pull/2133)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.17...2.x)
 ### Features

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -176,6 +177,11 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     throw new RuntimeException(e);
                 }
             });
+
+            knnVectorValuesFactoryMockedStatic.verify(
+                () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
+                times(expectedVectorValues.size())
+            );
         }
     }
 
@@ -264,6 +270,11 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     throw new RuntimeException(e);
                 }
             });
+
+            knnVectorValuesFactoryMockedStatic.verify(
+                () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
+                times(expectedVectorValues.size() * 2)
+            );
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -144,6 +145,10 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
             if (!mergedVectors.isEmpty()) {
                 verify(nativeIndexWriter).mergeIndex(knnVectorValues, mergedVectors.size());
                 assertTrue(KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.getValue() > 0L);
+                knnVectorValuesFactoryMockedStatic.verify(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues),
+                    times(2)
+                );
             } else {
                 verifyNoInteractions(nativeIndexWriter);
             }
@@ -211,6 +216,10 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
                 verify(knn990QuantWriterMockedConstruction.constructed().get(0)).writeState(0, quantizationState);
                 verify(nativeIndexWriter).mergeIndex(knnVectorValues, mergedVectors.size());
                 assertTrue(KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.getValue() > 0L);
+                knnVectorValuesFactoryMockedStatic.verify(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues),
+                    times(3)
+                );
             } else {
                 assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
                 verifyNoInteractions(nativeIndexWriter);


### PR DESCRIPTION
quantization isn't needed

### Description
An attempt to address the regression seen in force-merge time for cohere-10m dataset. 

#### KNNVectorValues creation is optimized to skip for non-quantization cases
The perf for force merge showed improvements in 1m dataset

 | number of index segments | force merge time (minutes) | force merge segments
  -- | -- | -- | --
2.17 code | 75 | 15.68263 | 3
Current PR | 92 | 12.51252 | 3

### Related Issues

https://github.com/opensearch-project/k-NN/issues/2134

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
