### PR TITLE
Optimizes live docs computes for force merge in NativeEngines990KNNVectorWriter

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -15,13 +15,10 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
-import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.common.StopWatch;
@@ -90,7 +87,7 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
                     field.getDocsWithField(),
                     field.getVectors()
                 );
-                final QuantizationState quantizationState = train(field.getFieldInfo(), knnVectorValuesSupplier, totalLiveDocs);
+                final QuantizationState quantizationState = train(field.getFieldInfo(), knnVectorValuesSupplier);
                 final NativeIndexWriter writer = NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState);
                 final KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
 
@@ -111,21 +108,16 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
         flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
 
         final VectorDataType vectorDataType = extractVectorDataType(fieldInfo);
-        final Supplier<KNNVectorValues<?>> knnVectorValuesSupplier = () -> getKNNVectorValuesForMerge(
-            vectorDataType,
-            fieldInfo,
-            mergeState
-        );
-        int totalLiveDocs = getLiveDocs(knnVectorValuesSupplier.get());
-        if (totalLiveDocs == 0) {
+        final Supplier<KNNVectorValues<?>> knnVectorValuesSupplier = () -> getVectorValues(vectorDataType, fieldInfo, mergeState);
+        final QuantizationState quantizationState = train(fieldInfo, knnVectorValuesSupplier);
+        final KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
+        final int totalLiveDocs = Math.toIntExact(knnVectorValues.totalLiveDocs());
+        if (totalLiveDocs <= 0) {
             log.debug("[Merge] No live docs for field {}", fieldInfo.getName());
             return;
         }
 
-        final QuantizationState quantizationState = train(fieldInfo, knnVectorValuesSupplier, totalLiveDocs);
         final NativeIndexWriter writer = NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState);
-        final KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
-
         StopWatch stopWatch = new StopWatch().start();
 
         writer.mergeIndex(knnVectorValues, totalLiveDocs);
@@ -181,70 +173,22 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
             .sum();
     }
 
-    /**
-     * Retrieves the {@link KNNVectorValues} for a specific field during a merge operation, based on the vector data type.
-     *
-     * @param vectorDataType The {@link VectorDataType} representing the type of vectors stored.
-     * @param fieldInfo      The {@link FieldInfo} object containing metadata about the field.
-     * @param mergeState     The {@link MergeState} representing the state of the merge operation.
-     * @param <T>            The type of vectors being processed.
-     * @return The {@link KNNVectorValues} associated with the field during the merge.
-     * @throws IOException If an I/O error occurs during the retrieval.
-     */
-    private <T> KNNVectorValues<T> getKNNVectorValuesForMerge(
-        final VectorDataType vectorDataType,
-        final FieldInfo fieldInfo,
-        final MergeState mergeState
-    ) {
-        try {
-            switch (fieldInfo.getVectorEncoding()) {
-                case FLOAT32:
-                    FloatVectorValues mergedFloats = MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
-                    return getVectorValues(vectorDataType, mergedFloats);
-                case BYTE:
-                    ByteVectorValues mergedBytes = MergedVectorValues.mergeByteVectorValues(fieldInfo, mergeState);
-                    return getVectorValues(vectorDataType, mergedBytes);
-                default:
-                    throw new IllegalStateException("Unsupported vector encoding [" + fieldInfo.getVectorEncoding() + "]");
-            }
-        } catch (final IOException e) {
-            log.error("Unable to merge vectors for field [{}]", fieldInfo.getName(), e);
-            throw new IllegalStateException("Unable to merge vectors for field [" + fieldInfo.getName() + "]", e);
-        }
-    }
-
-    private QuantizationState train(
-        final FieldInfo fieldInfo,
-        final Supplier<KNNVectorValues<?>> knnVectorValuesSupplier,
-        final int totalLiveDocs
-    ) throws IOException {
+    private QuantizationState train(final FieldInfo fieldInfo, final Supplier<KNNVectorValues<?>> knnVectorValuesSupplier)
+        throws IOException {
 
         final QuantizationService quantizationService = QuantizationService.getInstance();
         final QuantizationParams quantizationParams = quantizationService.getQuantizationParams(fieldInfo);
         QuantizationState quantizationState = null;
-        if (quantizationParams != null && totalLiveDocs > 0) {
-            initQuantizationStateWriterIfNecessary();
-            KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
-            quantizationState = quantizationService.train(quantizationParams, knnVectorValues, totalLiveDocs);
-            quantizationStateWriter.writeState(fieldInfo.getFieldNumber(), quantizationState);
+        if (quantizationParams != null) {
+            final KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
+            long totalLiveDocs = knnVectorValues.totalLiveDocs();
+            if (totalLiveDocs > 0) {
+                initQuantizationStateWriterIfNecessary();
+                quantizationState = quantizationService.train(quantizationParams, knnVectorValues);
+                quantizationStateWriter.writeState(fieldInfo.getFieldNumber(), quantizationState);
+            }
         }
-
         return quantizationState;
-    }
-
-    /**
-     * The {@link KNNVectorValues} will be exhausted after this function run. So make sure that you are not sending the
-     * vectorsValues object which you plan to use later
-     */
-    private int getLiveDocs(KNNVectorValues<?> vectorValues) throws IOException {
-        // Count all the live docs as there vectorValues.totalLiveDocs() just gives the cost for the FloatVectorValues,
-        // and doesn't tell the correct number of docs, if there are deleted docs in the segment. So we are counting
-        // the total live docs here.
-        int liveDocs = 0;
-        while (vectorValues.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            liveDocs++;
-        }
-        return liveDocs;
     }
 
     private void initQuantizationStateWriterIfNecessary() throws IOException {

--- a/src/main/java/org/opensearch/knn/index/quantizationservice/QuantizationService.java
+++ b/src/main/java/org/opensearch/knn/index/quantizationservice/QuantizationService.java
@@ -57,15 +57,15 @@ public final class QuantizationService<T, R> {
      * @return The {@link QuantizationState} containing the state of the trained quantizer.
      * @throws IOException If an I/O error occurs during the training process.
      */
-    public QuantizationState train(
-        final QuantizationParams quantizationParams,
-        final KNNVectorValues<T> knnVectorValues,
-        final long liveDocs
-    ) throws IOException {
+    public QuantizationState train(final QuantizationParams quantizationParams, final KNNVectorValues<T> knnVectorValues)
+        throws IOException {
         Quantizer<T, R> quantizer = QuantizerFactory.getQuantizer(quantizationParams);
 
         // Create the training request from the vector values
-        KNNVectorQuantizationTrainingRequest<T> trainingRequest = new KNNVectorQuantizationTrainingRequest<>(knnVectorValues, liveDocs);
+        KNNVectorQuantizationTrainingRequest<T> trainingRequest = new KNNVectorQuantizationTrainingRequest<>(
+            knnVectorValues,
+            knnVectorValues.totalLiveDocs()
+        );
 
         // Train the quantizer and return the quantization state
         return quantizer.train(trainingRequest);

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNBinaryVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNBinaryVectorValues.java
@@ -34,7 +34,8 @@ public class KNNBinaryVectorValues extends KNNVectorValues<byte[]> {
     @Override
     public byte[] conditionalCloneVector() throws IOException {
         byte[] vector = getVector();
-        if (vectorValuesIterator.getDocIdSetIterator() instanceof ByteVectorValues) {
+        if (vectorValuesIterator instanceof KNNVectorValuesIterator.MergeByteVectorValuesIterator
+            || vectorValuesIterator.getDocIdSetIterator() instanceof ByteVectorValues) {
             return Arrays.copyOf(vector, vector.length);
         }
         return vector;

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNByteVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNByteVectorValues.java
@@ -34,7 +34,8 @@ public class KNNByteVectorValues extends KNNVectorValues<byte[]> {
     @Override
     public byte[] conditionalCloneVector() throws IOException {
         byte[] vector = getVector();
-        if (vectorValuesIterator.getDocIdSetIterator() instanceof ByteVectorValues) {
+        if (vectorValuesIterator instanceof KNNVectorValuesIterator.MergeByteVectorValuesIterator
+            || vectorValuesIterator.getDocIdSetIterator() instanceof ByteVectorValues) {
             return Arrays.copyOf(vector, vector.length);
 
         }

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNFloatVectorValues.java
@@ -32,7 +32,8 @@ public class KNNFloatVectorValues extends KNNVectorValues<float[]> {
     @Override
     public float[] conditionalCloneVector() throws IOException {
         float[] vector = getVector();
-        if (vectorValuesIterator.getDocIdSetIterator() instanceof FloatVectorValues) {
+        if (vectorValuesIterator instanceof KNNVectorValuesIterator.MergeFloat32VectorValuesIterator
+            || vectorValuesIterator.getDocIdSetIterator() instanceof FloatVectorValues) {
             return Arrays.copyOf(vector, vector.length);
         }
         return vector;

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNMergeVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNMergeVectorValues.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.vectorvalues;
+
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DocIDMerger;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class to get merged VectorValues from MergeState
+ */
+public final class KNNMergeVectorValues {
+
+    /**
+     * Gets list of {@link KNNVectorValuesSub} for {@link FloatVectorValues} from a merge state and returns the iterator which
+     * iterates over live docs from all segments while mapping docIds.
+     *
+     * @param fieldInfo
+     * @param mergeState
+     * @return List of KNNVectorSub
+     * @throws IOException
+     */
+    public static KNNVectorValuesIterator.MergeFloat32VectorValuesIterator mergeFloatVectorValues(
+        FieldInfo fieldInfo,
+        MergeState mergeState
+    ) throws IOException {
+        assert fieldInfo != null && fieldInfo.hasVectorValues();
+        if (fieldInfo.getVectorEncoding() != VectorEncoding.FLOAT32) {
+            throw new UnsupportedOperationException("Cannot merge vectors encoded as [" + fieldInfo.getVectorEncoding() + "] as FLOAT32");
+        }
+        final List<KNNVectorValuesSub<FloatVectorValues>> subs = new ArrayList<>();
+        for (int i = 0; i < mergeState.knnVectorsReaders.length; i++) {
+            KnnVectorsReader knnVectorsReader = mergeState.knnVectorsReaders[i];
+            if (knnVectorsReader != null) {
+                FloatVectorValues values = knnVectorsReader.getFloatVectorValues(fieldInfo.getName());
+                if (values != null) {
+                    final Bits liveDocs = mergeState.liveDocs[i];
+                    final int liveDocsCardinality = cardinality(liveDocs, Math.toIntExact(values.cost()));
+                    subs.add(new KNNVectorValuesSub<>(mergeState.docMaps[i], values, liveDocsCardinality));
+                }
+            }
+        }
+        return new KNNVectorValuesIterator.MergeFloat32VectorValuesIterator(subs, mergeState);
+    }
+
+    /**
+     * Gets list of {@link KNNVectorValuesSub} for {@link ByteVectorValues} from a merge state. This can be further
+     * used to create an iterator for getting the docs and its vector values
+     * @param fieldInfo
+     * @param mergeState
+     * @return List of KNNVectorSub
+     * @throws IOException
+     */
+    public static KNNVectorValuesIterator.MergeByteVectorValuesIterator mergeByteVectorValues(FieldInfo fieldInfo, MergeState mergeState)
+        throws IOException {
+        assert fieldInfo != null && fieldInfo.hasVectorValues();
+        if (fieldInfo.getVectorEncoding() != VectorEncoding.BYTE) {
+            throw new UnsupportedOperationException("Cannot merge vectors encoded as [" + fieldInfo.getVectorEncoding() + "] as BYTE");
+        }
+        final List<KNNVectorValuesSub<ByteVectorValues>> subs = new ArrayList<>();
+        for (int i = 0; i < mergeState.knnVectorsReaders.length; i++) {
+            KnnVectorsReader knnVectorsReader = mergeState.knnVectorsReaders[i];
+            if (knnVectorsReader != null) {
+                ByteVectorValues values = knnVectorsReader.getByteVectorValues(fieldInfo.getName());
+                if (values != null) {
+                    final Bits liveDocs = mergeState.liveDocs[i];
+                    final int liveDocsCardinality = cardinality(liveDocs, Math.toIntExact(values.cost()));
+                    subs.add(new KNNVectorValuesSub<>(mergeState.docMaps[i], values, liveDocsCardinality));
+                }
+            }
+        }
+        return new KNNVectorValuesIterator.MergeByteVectorValuesIterator(subs, mergeState);
+    }
+
+    private static int cardinality(final Bits liveDocs, final int defaultCount) {
+        if (liveDocs == null) {
+            return defaultCount;
+        }
+
+        if (liveDocs instanceof FixedBitSet) {
+            return ((FixedBitSet) liveDocs).cardinality();
+        }
+
+        int count = 0;
+        for (int index = 0; index < liveDocs.length(); index++) {
+            count += liveDocs.get(index) ? 1 : 0;
+        }
+        return count;
+    }
+
+    static class KNNVectorValuesSub<T extends DocIdSetIterator> extends DocIDMerger.Sub {
+        final T values;
+        final int liveDocs;
+
+        KNNVectorValuesSub(MergeState.DocMap docMap, T values, int liveDocs) {
+            super(docMap);
+            this.values = values;
+            this.liveDocs = liveDocs;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return values.nextDoc();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValues.java
@@ -82,7 +82,6 @@ public abstract class KNNVectorValues<T> {
      * </pre>
      * @return long
      */
-    @Deprecated
     public long totalLiveDocs() {
         return vectorValuesIterator.liveDocs();
     }

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategy.java
@@ -123,4 +123,23 @@ interface VectorValueExtractorStrategy {
         }
     }
 
+    /**
+     * Strategy to extract the vector from {@link KNNVectorValuesIterator.MergeSegmentVectorValuesIterator}
+     */
+    class MergeSegmentValuesExtractor implements VectorValueExtractorStrategy {
+        @Override
+        public <T> T extract(final VectorDataType vectorDataType, final KNNVectorValuesIterator vectorValuesIterator) throws IOException {
+            switch (vectorDataType) {
+                case FLOAT:
+                    return (T) ((KNNVectorValuesIterator.MergeFloat32VectorValuesIterator) vectorValuesIterator).vectorValue();
+                case BYTE:
+                case BINARY:
+                    return (T) ((KNNVectorValuesIterator.MergeByteVectorValuesIterator) vectorValuesIterator).vectorValue();
+            }
+            throw new IllegalArgumentException(
+                "Valid Vector data type not passed to extract vector from FieldWriterIteratorVectorExtractor strategy"
+            );
+        }
+    }
+
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -176,6 +177,10 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     throw new RuntimeException(e);
                 }
             });
+            knnVectorValuesFactoryMockedStatic.verify(
+                () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
+                times(expectedVectorValues.size())
+            );
         }
     }
 
@@ -230,8 +235,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
                 when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
                 try {
-                    when(quantizationService.train(quantizationParams, expectedVectorValues.get(i), vectorsPerField.get(i).size()))
-                        .thenReturn(quantizationState);
+                    when(quantizationService.train(quantizationParams, expectedVectorValues.get(i))).thenReturn(quantizationState);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -264,6 +268,11 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     throw new RuntimeException(e);
                 }
             });
+
+            knnVectorValuesFactoryMockedStatic.verify(
+                () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
+                times(expectedVectorValues.size() * 2)
+            );
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/quantizationservice/QuantizationServiceTests.java
+++ b/src/test/java/org/opensearch/knn/index/quantizationservice/QuantizationServiceTests.java
@@ -46,7 +46,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testTrain_oneBitQuantizer_success() throws IOException {
         ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
-        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues);
 
         assertTrue(quantizationState instanceof OneBitScalarQuantizationState);
         OneBitScalarQuantizationState oneBitState = (OneBitScalarQuantizationState) quantizationState;
@@ -62,7 +62,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testTrain_twoBitQuantizer_success() throws IOException {
         ScalarQuantizationParams twoBitParams = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
-        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues);
 
         assertTrue(quantizationState instanceof MultiBitScalarQuantizationState);
         MultiBitScalarQuantizationState multiBitState = (MultiBitScalarQuantizationState) quantizationState;
@@ -85,7 +85,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testTrain_fourBitQuantizer_success() throws IOException {
         ScalarQuantizationParams fourBitParams = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
-        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues);
 
         assertTrue(quantizationState instanceof MultiBitScalarQuantizationState);
         MultiBitScalarQuantizationState multiBitState = (MultiBitScalarQuantizationState) quantizationState;
@@ -110,7 +110,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_oneBitQuantizer_success() throws IOException {
         ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
-        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues);
 
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(oneBitParams);
 
@@ -125,7 +125,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_twoBitQuantizer_success() throws IOException {
         ScalarQuantizationParams twoBitParams = new ScalarQuantizationParams(ScalarQuantizationType.TWO_BIT);
-        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(twoBitParams, knnVectorValues);
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(twoBitParams);
         byte[] quantizedVector = quantizationService.quantize(quantizationState, new float[] { 4.0f, 5.0f, 6.0f }, quantizationOutput);
 
@@ -138,7 +138,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_fourBitQuantizer_success() throws IOException {
         ScalarQuantizationParams fourBitParams = new ScalarQuantizationParams(ScalarQuantizationType.FOUR_BIT);
-        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(fourBitParams, knnVectorValues);
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(fourBitParams);
 
         byte[] quantizedVector = quantizationService.quantize(quantizationState, new float[] { 7.0f, 8.0f, 9.0f }, quantizationOutput);
@@ -152,7 +152,7 @@ public class QuantizationServiceTests extends KNNTestCase {
 
     public void testQuantize_whenInvalidInput_thenThrows() throws IOException {
         ScalarQuantizationParams oneBitParams = new ScalarQuantizationParams(ScalarQuantizationType.ONE_BIT);
-        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues, knnVectorValues.totalLiveDocs());
+        QuantizationState quantizationState = quantizationService.train(oneBitParams, knnVectorValues);
         QuantizationOutput quantizationOutput = quantizationService.createQuantizationOutput(oneBitParams);
         assertThrows(IllegalArgumentException.class, () -> quantizationService.quantize(quantizationState, null, quantizationOutput));
     }

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNMergeVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNMergeVectorValuesTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.vectorvalues;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.mockito.Mock;
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KNNMergeVectorValuesTests extends KNNTestCase {
+
+    private static final String FIELD = "field";
+
+    @Mock
+    private KnnVectorsReader knnVectorsReader1;
+    @Mock
+    private KnnVectorsReader knnVectorsReader2;
+    @Mock
+    private KnnVectorsReader knnVectorsReader3;
+    @Mock
+    private FixedBitSet fixedBitSetLiveDocs;
+    @Mock
+    private Bits fixedBitsLiveDocs;
+
+    @SneakyThrows
+    public void testFloatMergeVectorValues() {
+        // Given
+        final KnnVectorsReader[] knnVectorsReaders = { knnVectorsReader1, knnVectorsReader2, knnVectorsReader3 };
+        final Bits[] liveDocs = { fixedBitSetLiveDocs, fixedBitsLiveDocs, null };
+        final Map<Integer, float[]> floats1 = Map.of(0, new float[] { 1, 2 }, 1, new float[] { 2, 3 });
+        final List<float[]> floats1List = List.of(new float[] { 1, 2 }, new float[] { 2, 3 });
+        final Map<Integer, float[]> floats2 = Map.of(0, new float[] { 3, 4 }, 1, new float[] { 4, 6 });
+        final List<float[]> floats2List = List.of(new float[] { 3, 4 }, new float[] { 4, 6 });
+        final Map<Integer, float[]> floats3 = Map.of(0, new float[] { 1, 2 });
+        final List<float[]> floats3List = List.of(new float[] { 1, 2 });
+        final MergeState.DocMap[] docMaps = {
+            (docId) -> floats1.get(docId) != null ? docId : -1,
+            (docId) -> floats2.get(docId) != null ? docId + 2 : -1,
+            (docId) -> floats3.get(docId) != null ? docId + 4 : -1 };
+
+        Map<Integer, float[]> floats = Map.of(
+            0,
+            new float[] { 1, 2 },
+            1,
+            new float[] { 2, 3 },
+            2,
+            new float[] { 3, 4 },
+            3,
+            new float[] { 4, 6 },
+            4,
+            new float[] { 1, 2 }
+        );
+        final TestVectorValues.PreDefinedFloatVectorValues vectorValues1 = new TestVectorValues.PreDefinedFloatVectorValues(floats1List);
+        final TestVectorValues.PreDefinedFloatVectorValues vectorValues2 = new TestVectorValues.PreDefinedFloatVectorValues(floats2List);
+        final TestVectorValues.PreDefinedFloatVectorValues vectorValues3 = new TestVectorValues.PreDefinedFloatVectorValues(floats3List);
+
+        FieldInfo fieldInfo = fieldInfo(0, VectorEncoding.FLOAT32);
+        when(knnVectorsReader1.getFloatVectorValues(FIELD)).thenReturn(vectorValues1);
+        when(knnVectorsReader2.getFloatVectorValues(FIELD)).thenReturn(vectorValues2);
+        when(knnVectorsReader3.getFloatVectorValues(FIELD)).thenReturn(vectorValues3);
+        when(fixedBitSetLiveDocs.cardinality()).thenReturn(2);
+        when(fixedBitsLiveDocs.length()).thenReturn(3);
+        when(fixedBitsLiveDocs.get(0)).thenReturn(true);
+        when(fixedBitsLiveDocs.get(1)).thenReturn(false);
+        when(fixedBitsLiveDocs.get(2)).thenReturn(true);
+
+        final MergeState mergeState = mergeState(knnVectorsReaders, liveDocs, docMaps);
+
+        // When
+        KNNVectorValuesIterator.MergeFloat32VectorValuesIterator iterator = KNNMergeVectorValues.mergeFloatVectorValues(
+            fieldInfo,
+            mergeState
+        );
+
+        // Then
+        assertEquals(5, iterator.liveDocs());
+        int size = 0;
+        while (iterator.nextDoc() != NO_MORE_DOCS) {
+            assertArrayEquals(floats.get(iterator.docId()), iterator.vectorValue(), 0.01f);
+            size++;
+        }
+        assertEquals(floats.size(), size);
+    }
+
+    @SneakyThrows
+    public void testByteMergeVectorValues() {
+        // Given
+        final KnnVectorsReader[] knnVectorsReaders = { knnVectorsReader1, knnVectorsReader2, knnVectorsReader3 };
+        final Bits[] liveDocs = { fixedBitSetLiveDocs, fixedBitsLiveDocs, null };
+        final Map<Integer, byte[]> floats1 = Map.of(0, new byte[] { 1, 2 }, 1, new byte[] { 2, 3 });
+        final List<byte[]> floats1List = List.of(new byte[] { 1, 2 }, new byte[] { 2, 3 });
+        final Map<Integer, byte[]> floats2 = Map.of(0, new byte[] { 3, 4 }, 1, new byte[] { 4, 6 });
+        final List<byte[]> floats2List = List.of(new byte[] { 3, 4 }, new byte[] { 4, 6 });
+        final Map<Integer, byte[]> floats3 = Map.of(0, new byte[] { 1, 2 });
+        final List<byte[]> floats3List = List.of(new byte[] { 1, 2 });
+        final MergeState.DocMap[] docMaps = {
+            (docId) -> floats1.get(docId) != null ? docId : -1,
+            (docId) -> floats2.get(docId) != null ? docId + 2 : -1,
+            (docId) -> floats3.get(docId) != null ? docId + 4 : -1 };
+
+        Map<Integer, byte[]> floats = Map.of(
+            0,
+            new byte[] { 1, 2 },
+            1,
+            new byte[] { 2, 3 },
+            2,
+            new byte[] { 3, 4 },
+            3,
+            new byte[] { 4, 6 },
+            4,
+            new byte[] { 1, 2 }
+        );
+        final TestVectorValues.PreDefinedByteVectorValues vectorValues1 = new TestVectorValues.PreDefinedByteVectorValues(floats1List);
+        final TestVectorValues.PreDefinedByteVectorValues vectorValues2 = new TestVectorValues.PreDefinedByteVectorValues(floats2List);
+        final TestVectorValues.PreDefinedByteVectorValues vectorValues3 = new TestVectorValues.PreDefinedByteVectorValues(floats3List);
+
+        FieldInfo fieldInfo = fieldInfo(0, VectorEncoding.BYTE);
+        when(knnVectorsReader1.getByteVectorValues(FIELD)).thenReturn(vectorValues1);
+        when(knnVectorsReader2.getByteVectorValues(FIELD)).thenReturn(vectorValues2);
+        when(knnVectorsReader3.getByteVectorValues(FIELD)).thenReturn(vectorValues3);
+        when(fixedBitSetLiveDocs.cardinality()).thenReturn(2);
+        when(fixedBitsLiveDocs.length()).thenReturn(3);
+        when(fixedBitsLiveDocs.get(0)).thenReturn(true);
+        when(fixedBitsLiveDocs.get(1)).thenReturn(false);
+        when(fixedBitsLiveDocs.get(2)).thenReturn(true);
+
+        final MergeState mergeState = mergeState(knnVectorsReaders, liveDocs, docMaps);
+
+        // When
+        KNNVectorValuesIterator.MergeByteVectorValuesIterator iterator = KNNMergeVectorValues.mergeByteVectorValues(fieldInfo, mergeState);
+
+        // Then
+        assertEquals(5, iterator.liveDocs());
+        int size = 0;
+        while (iterator.nextDoc() != NO_MORE_DOCS) {
+            assertArrayEquals(floats.get(iterator.docId()), iterator.vectorValue());
+            size++;
+        }
+        assertEquals(floats.size(), size);
+    }
+
+    private MergeState mergeState(KnnVectorsReader[] knnVectorsReaders, Bits[] liveDocs, MergeState.DocMap[] docMaps) {
+        return new MergeState(
+            docMaps,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            liveDocs,
+            null,
+            null,
+            knnVectorsReaders,
+            null,
+            null,
+            null,
+            false
+        );
+    }
+
+    private FieldInfo fieldInfo(int fieldNumber, VectorEncoding vectorEncoding) {
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getFieldNumber()).thenReturn(fieldNumber);
+        when(fieldInfo.getVectorEncoding()).thenReturn(vectorEncoding);
+        when(fieldInfo.getName()).thenReturn(FIELD);
+        when(fieldInfo.hasVectorValues()).thenReturn(true);
+        return fieldInfo;
+    }
+}


### PR DESCRIPTION
### Description
Currently live docs are computed with linear complexity even when it does not have deleted docs. This PR skips computing it

#### Testing 
- UTs and javadocs in progression. Need initial feed back

#### Related Issues
https://github.com/opensearch-project/k-NN/issues/2134

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
