### PR TITLE
[Backport 2.17] Makes sure KNNVectorValues aren't recreated unnecessarily when quantization isn't needed (#2133)

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.17.0.0.md
@@ -20,6 +20,7 @@ Compatible with OpenSearch 2.17.0
 * Fix memory overflow caused by cache behavior [#2015](https://github.com/opensearch-project/k-NN/pull/2015)
 * Use correct type for binary vector in ivf training [#2086](https://github.com/opensearch-project/k-NN/pull/2086)
 * Switch MINGW32 to MINGW64 [#2090](https://github.com/opensearch-project/k-NN/pull/2090)
+* Does not create additional KNNVectorValues in NativeEngines990KNNVectorWriter when quantization is not needed [#2133](https://github.com/opensearch-project/k-NN/pull/2133)
 ### Infrastructure
 * Parallelize make to reduce build time [#2006] (https://github.com/opensearch-project/k-NN/pull/2006)
 ### Maintenance

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorEncoding;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.nativeindex.NativeIndexWriter;
+import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+import org.opensearch.knn.index.vectorvalues.TestVectorValues;
+import org.opensearch.knn.plugin.stats.KNNGraphValue;
+import org.opensearch.knn.quantization.models.quantizationParams.QuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RequiredArgsConstructor
+public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCase {
+
+    @Mock
+    private FlatVectorsWriter flatVectorsWriter;
+    @Mock
+    private SegmentWriteState segmentWriteState;
+    @Mock
+    private QuantizationParams quantizationParams;
+    @Mock
+    private QuantizationState quantizationState;
+    @Mock
+    private QuantizationService quantizationService;
+    @Mock
+    private NativeIndexWriter nativeIndexWriter;
+
+    private NativeEngines990KnnVectorsWriter objectUnderTest;
+
+    private final String description;
+    private final List<Map<Integer, float[]>> vectorsPerField;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter);
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+            $$(
+                $("Single field", List.of(Map.of(0, new float[] { 1, 2, 3 }, 1, new float[] { 2, 3, 4 }, 2, new float[] { 3, 4, 5 }))),
+                $("Single field, no total live docs", List.of()),
+                $(
+                    "Multi Field",
+                    List.of(
+                        Map.of(0, new float[] { 1, 2, 3 }, 1, new float[] { 2, 3, 4 }, 2, new float[] { 3, 4, 5 }),
+                        Map.of(
+                            0,
+                            new float[] { 1, 2, 3, 4 },
+                            1,
+                            new float[] { 2, 3, 4, 5 },
+                            2,
+                            new float[] { 3, 4, 5, 6 },
+                            3,
+                            new float[] { 4, 5, 6, 7 }
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    @SneakyThrows
+    public void testFlush() {
+        // Given
+        List<KNNVectorValues<float[]>> expectedVectorValues = new ArrayList<>();
+        IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+            final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                new ArrayList<>(vectorsPerField.get(i).values())
+            );
+            final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                randomVectorValues
+            );
+            expectedVectorValues.add(knnVectorValues);
+
+        });
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                final FieldInfo fieldInfo = fieldInfo(
+                    i,
+                    VectorEncoding.FLOAT32,
+                    Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+                );
+
+                NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
+                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                    .thenReturn(field);
+
+                try {
+                    objectUnderTest.addField(fieldInfo);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                DocsWithFieldSet docsWithFieldSet = field.getDocsWithField();
+                knnVectorValuesFactoryMockedStatic.when(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
+                ).thenReturn(expectedVectorValues.get(i));
+
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+                nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                    .thenReturn(nativeIndexWriter);
+            });
+
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).flushIndex(any(), anyInt());
+
+            // When
+            objectUnderTest.flush(5, null);
+
+            // Then
+            verify(flatVectorsWriter).flush(5, null);
+            if (vectorsPerField.size() > 0) {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+                assertNotEquals(0L, (long) KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.getValue());
+            }
+
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                try {
+                    verify(nativeIndexWriter).flushIndex(expectedVectorValues.get(i), vectorsPerField.get(i).size());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            knnVectorValuesFactoryMockedStatic.verify(
+                () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
+                times(expectedVectorValues.size())
+            );
+        }
+    }
+
+    @SneakyThrows
+    public void testFlush_WithQuantization() {
+        // Given
+        List<KNNVectorValues<float[]>> expectedVectorValues = new ArrayList<>();
+        IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+            final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                new ArrayList<>(vectorsPerField.get(i).values())
+            );
+            final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                randomVectorValues
+            );
+            expectedVectorValues.add(knnVectorValues);
+
+        });
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                final FieldInfo fieldInfo = fieldInfo(
+                    i,
+                    VectorEncoding.FLOAT32,
+                    Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+                );
+
+                NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
+                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                    .thenReturn(field);
+
+                try {
+                    objectUnderTest.addField(fieldInfo);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                DocsWithFieldSet docsWithFieldSet = field.getDocsWithField();
+                knnVectorValuesFactoryMockedStatic.when(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
+                ).thenReturn(expectedVectorValues.get(i));
+
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
+                try {
+                    when(quantizationService.train(quantizationParams, expectedVectorValues.get(i), vectorsPerField.get(i).size()))
+                        .thenReturn(quantizationState);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState))
+                    .thenReturn(nativeIndexWriter);
+            });
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).flushIndex(any(), anyInt());
+
+            // When
+            objectUnderTest.flush(5, null);
+
+            // Then
+            verify(flatVectorsWriter).flush(5, null);
+            if (vectorsPerField.size() > 0) {
+                verify(knn990QuantWriterMockedConstruction.constructed().get(0)).writeHeader(segmentWriteState);
+                assertTrue(KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.getValue() > 0L);
+            } else {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+            }
+
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                try {
+                    verify(knn990QuantWriterMockedConstruction.constructed().get(0)).writeState(i, quantizationState);
+                    verify(nativeIndexWriter).flushIndex(expectedVectorValues.get(i), vectorsPerField.get(i).size());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            knnVectorValuesFactoryMockedStatic.verify(
+                () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
+                times(expectedVectorValues.size() * 2)
+            );
+        }
+    }
+
+    private FieldInfo fieldInfo(int fieldNumber, VectorEncoding vectorEncoding, Map<String, String> attributes) {
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getFieldNumber()).thenReturn(fieldNumber);
+        when(fieldInfo.getVectorEncoding()).thenReturn(vectorEncoding);
+        when(fieldInfo.attributes()).thenReturn(attributes);
+        attributes.forEach((key, value) -> when(fieldInfo.getAttribute(key)).thenReturn(value));
+        return fieldInfo;
+    }
+
+    private <T> NativeEngineFieldVectorsWriter nativeEngineFieldVectorsWriter(FieldInfo fieldInfo, Map<Integer, T> vectors) {
+        NativeEngineFieldVectorsWriter fieldVectorsWriter = mock(NativeEngineFieldVectorsWriter.class);
+        DocsWithFieldSet docsWithFieldSet = new DocsWithFieldSet();
+        vectors.keySet().stream().sorted().forEach(docsWithFieldSet::add);
+        when(fieldVectorsWriter.getFieldInfo()).thenReturn(fieldInfo);
+        when(fieldVectorsWriter.getVectors()).thenReturn(vectors);
+        when(fieldVectorsWriter.getDocsWithField()).thenReturn(docsWithFieldSet);
+        return fieldVectorsWriter;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorEncoding;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.nativeindex.NativeIndexWriter;
+import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+import org.opensearch.knn.index.vectorvalues.TestVectorValues;
+import org.opensearch.knn.plugin.stats.KNNGraphValue;
+import org.opensearch.knn.quantization.models.quantizationParams.QuantizationParams;
+import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RequiredArgsConstructor
+public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCase {
+
+    @Mock
+    private FlatVectorsWriter flatVectorsWriter;
+    @Mock
+    private SegmentWriteState segmentWriteState;
+    @Mock
+    private QuantizationParams quantizationParams;
+    @Mock
+    private QuantizationState quantizationState;
+    @Mock
+    private QuantizationService quantizationService;
+    @Mock
+    private NativeIndexWriter nativeIndexWriter;
+    @Mock
+    private FloatVectorValues floatVectorValues;
+    @Mock
+    private MergeState mergeState;
+
+    private NativeEngines990KnnVectorsWriter objectUnderTest;
+
+    private final String description;
+    private final Map<Integer, float[]> mergedVectors;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter);
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+            $$(
+                $("Merge one field", Map.of(0, new float[] { 1, 2, 3 }, 1, new float[] { 2, 3, 4 }, 2, new float[] { 3, 4, 5 })),
+                $("Merge, no live docs", Map.of())
+            )
+        );
+    }
+
+    @SneakyThrows
+    public void testMerge() {
+        // Given
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            new ArrayList<>(mergedVectors.values())
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedStatic<KnnVectorsWriter.MergedVectorValues> mergedVectorValuesMockedStatic = mockStatic(
+                KnnVectorsWriter.MergedVectorValues.class
+            );
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            final FieldInfo fieldInfo = fieldInfo(
+                0,
+                VectorEncoding.FLOAT32,
+                Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+            );
+
+            NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, mergedVectors);
+            fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                .thenReturn(field);
+
+            mergedVectorValuesMockedStatic.when(() -> KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState))
+                .thenReturn(floatVectorValues);
+            knnVectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues))
+                .thenReturn(knnVectorValues);
+
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+            nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                .thenReturn(nativeIndexWriter);
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).mergeIndex(any(), anyInt());
+
+            // When
+            objectUnderTest.mergeOneField(fieldInfo, mergeState);
+
+            // Then
+            verify(flatVectorsWriter).mergeOneField(fieldInfo, mergeState);
+            assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+            if (!mergedVectors.isEmpty()) {
+                verify(nativeIndexWriter).mergeIndex(knnVectorValues, mergedVectors.size());
+                assertTrue(KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.getValue() > 0L);
+                knnVectorValuesFactoryMockedStatic.verify(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues),
+                    times(2)
+                );
+            } else {
+                verifyNoInteractions(nativeIndexWriter);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testMerge_WithQuantization() {
+        // Given
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            new ArrayList<>(mergedVectors.values())
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+            MockedStatic<KnnVectorsWriter.MergedVectorValues> mergedVectorValuesMockedStatic = mockStatic(
+                KnnVectorsWriter.MergedVectorValues.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+
+            final FieldInfo fieldInfo = fieldInfo(
+                0,
+                VectorEncoding.FLOAT32,
+                Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+            );
+
+            NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, mergedVectors);
+            fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                .thenReturn(field);
+
+            mergedVectorValuesMockedStatic.when(() -> KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState))
+                .thenReturn(floatVectorValues);
+            knnVectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues))
+                .thenReturn(knnVectorValues);
+
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
+            try {
+                when(quantizationService.train(quantizationParams, knnVectorValues, mergedVectors.size())).thenReturn(quantizationState);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState))
+                .thenReturn(nativeIndexWriter);
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).mergeIndex(any(), anyInt());
+
+            // When
+            objectUnderTest.mergeOneField(fieldInfo, mergeState);
+
+            // Then
+            verify(flatVectorsWriter).mergeOneField(fieldInfo, mergeState);
+            if (!mergedVectors.isEmpty()) {
+                verify(knn990QuantWriterMockedConstruction.constructed().get(0)).writeHeader(segmentWriteState);
+                verify(knn990QuantWriterMockedConstruction.constructed().get(0)).writeState(0, quantizationState);
+                verify(nativeIndexWriter).mergeIndex(knnVectorValues, mergedVectors.size());
+                assertTrue(KNNGraphValue.MERGE_TOTAL_TIME_IN_MILLIS.getValue() > 0L);
+                knnVectorValuesFactoryMockedStatic.verify(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues),
+                    times(3)
+                );
+            } else {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+                verifyNoInteractions(nativeIndexWriter);
+            }
+
+        }
+    }
+
+    private FieldInfo fieldInfo(int fieldNumber, VectorEncoding vectorEncoding, Map<String, String> attributes) {
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getFieldNumber()).thenReturn(fieldNumber);
+        when(fieldInfo.getVectorEncoding()).thenReturn(vectorEncoding);
+        when(fieldInfo.attributes()).thenReturn(attributes);
+        attributes.forEach((key, value) -> when(fieldInfo.getAttribute(key)).thenReturn(value));
+        return fieldInfo;
+    }
+
+    private <T> NativeEngineFieldVectorsWriter nativeEngineFieldVectorsWriter(FieldInfo fieldInfo, Map<Integer, T> vectors) {
+        NativeEngineFieldVectorsWriter fieldVectorsWriter = mock(NativeEngineFieldVectorsWriter.class);
+        DocsWithFieldSet docsWithFieldSet = new DocsWithFieldSet();
+        vectors.keySet().stream().sorted().forEach(docsWithFieldSet::add);
+        when(fieldVectorsWriter.getFieldInfo()).thenReturn(fieldInfo);
+        when(fieldVectorsWriter.getVectors()).thenReturn(vectors);
+        when(fieldVectorsWriter.getDocsWithField()).thenReturn(docsWithFieldSet);
+        return fieldVectorsWriter;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
@@ -184,7 +184,11 @@ public class TestVectorValues {
         public PreDefinedFloatVectorValues(final List<float[]> vectors) {
             super();
             this.count = vectors.size();
-            this.dimension = vectors.get(0).length;
+            if (!vectors.isEmpty()) {
+                this.dimension = vectors.get(0).length;
+            } else {
+                this.dimension = 0;
+            }
             this.vectors = vectors;
             this.current = -1;
             vector = new float[dimension];


### PR DESCRIPTION
[Backport 2.17] Makes sure KNNVectorValues aren't recreated unnecessarily when quantization isn't needed (#2133)

Signed-off-by: Tejas Shah <shatejas@amazon.com>
(cherry picked from commit e33afa5de5f8658ad7fbe71125707436e81cc5b8)

### Description
Backport PR for https://github.com/opensearch-project/k-NN/pull/2133

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
