### PR TITLE
Optimize reduceToTopK in ResultUtil by removing pre-filling and reducing peek calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add AVX512 support to k-NN for FAISS library [#2069](https://github.com/opensearch-project/k-NN/pull/2069)
 ### Enhancements
 * Add short circuit if no live docs are in segments [#2059](https://github.com/opensearch-project/k-NN/pull/2059)
+* Optimize reduceToTopK in ResultUtil by removing pre-filling and reducing peek calls [#2146](https://github.com/opensearch-project/k-NN/pull/2146)
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
@@ -33,15 +33,14 @@ public final class ResultUtil {
     public static void reduceToTopK(List<Map<Integer, Float>> perLeafResults, int k) {
         // Iterate over all scores to get min competitive score
         PriorityQueue<Float> topKMinQueue = new PriorityQueue<>(k);
-        for (int i = 0; i < k; i++) {
-            topKMinQueue.add(-Float.MAX_VALUE);
-        }
 
         int count = 0;
         for (Map<Integer, Float> perLeafResult : perLeafResults) {
             count += perLeafResult.size();
             for (Float score : perLeafResult.values()) {
-                if (topKMinQueue.peek() != null && score > topKMinQueue.peek()) {
+                if (topKMinQueue.size() < k) {
+                    topKMinQueue.add(score);
+                } else if (topKMinQueue.peek() != null && score > topKMinQueue.peek()) {
                     topKMinQueue.poll();
                     topKMinQueue.add(score);
                 }


### PR DESCRIPTION
### Description

This PR optimizes the reduceToTopK method by eliminating unnecessary pre-filling of the priority queue, reducing redundant peek() calls, and adding null safety checks for better performance.

### Related Issues
Closes https://github.com/opensearch-project/k-NN/issues/2145

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
