### PR TITLE
 Adding Support to Enable/Disble Share level Rescoring and Update Oversampling Factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optimize reduceToTopK in ResultUtil by removing pre-filling and reducing peek calls [#2146](https://github.com/opensearch-project/k-NN/pull/2146)
 * Update Default Rescore Context based on Dimension [#2149](https://github.com/opensearch-project/k-NN/pull/2149)
 * KNNIterators should support with and without filters [#2155](https://github.com/opensearch-project/k-NN/pull/2155)
+* Adding Support to Enable/Disble Share level Rescoring and Update Oversampling Factor[#2172](https://github.com/opensearch-project/k-NN/pull/2172)
 ### Bug Fixes
 * KNN80DocValues should only be considered for BinaryDocValues fields [#2147](https://github.com/opensearch-project/k-NN/pull/2147)
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -97,32 +97,35 @@ public enum CompressionLevel {
     /**
      * Returns the appropriate {@link RescoreContext} based on the given {@code mode} and {@code dimension}.
      *
-     * <p>If the {@code mode} is present in the valid {@code modesForRescore} set, the method checks the value of
-     * {@code dimension}:
+     * <p>If the {@code mode} is present in the valid {@code modesForRescore} set, the method adjusts the oversample factor based on the
+     * {@code dimension} value:
      * <ul>
-     *     <li>If {@code dimension} is less than or equal to 1000, it returns a {@link RescoreContext} with an
-     *         oversample factor of 5.0f.</li>
-     *     <li>If {@code dimension} is greater than 1000, it returns the default {@link RescoreContext} associated with
-     *         the {@link CompressionLevel}. If no default is set, it falls back to {@link RescoreContext#getDefault()}.</li>
+     *     <li>If {@code dimension} is greater than or equal to 1000, no oversampling is applied (oversample factor = 1.0).</li>
+     *     <li>If {@code dimension} is greater than or equal to 768 but less than 1000, a 2x oversample factor is applied (oversample factor = 2.0).</li>
+     *     <li>If {@code dimension} is less than 768, a 3x oversample factor is applied (oversample factor = 3.0).</li>
      * </ul>
-     * If the {@code mode} is not valid, the method returns {@code null}.
+     * If the {@code mode} is not present in the {@code modesForRescore} set, the method returns {@code null}.
      *
      * @param mode      The {@link Mode} for which to retrieve the {@link RescoreContext}.
      * @param dimension The dimensional value that determines the {@link RescoreContext} behavior.
-     * @return          A {@link RescoreContext} with an oversample factor of 5.0f if {@code dimension} is less than
-     *                  or equal to 1000, the default {@link RescoreContext} if greater, or {@code null} if the mode
-     *                  is invalid.
+     * @return          A {@link RescoreContext} with the appropriate oversample factor based on the dimension, or {@code null} if the mode
+     *                  is not valid.
      */
     public RescoreContext getDefaultRescoreContext(Mode mode, int dimension) {
         if (modesForRescore.contains(mode)) {
             // Adjust RescoreContext based on dimension
-            if (dimension <= RescoreContext.DIMENSION_THRESHOLD) {
-                // For dimensions <= 1000, return a RescoreContext with 5.0f oversample factor
-                return RescoreContext.builder().oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD).build();
+            if (dimension >= RescoreContext.DIMENSION_THRESHOLD_1000) {
+                // No oversampling for dimensions >= 1000
+                return RescoreContext.builder().oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_1000).build();
+            } else if (dimension >= RescoreContext.DIMENSION_THRESHOLD_768) {
+                // 2x oversampling for dimensions >= 768 but < 1000
+                return RescoreContext.builder().oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_768).build();
             } else {
-                return defaultRescoreContext;
+                // 3x oversampling for dimensions < 768
+                return RescoreContext.builder().oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_BELOW_768).build();
             }
         }
         return null;
     }
+
 }

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -24,6 +24,15 @@ public final class RescoreContext {
     public static final int DIMENSION_THRESHOLD = 1000;
     public static final float OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD = 5.0f;
 
+    // Dimension thresholds for adjusting oversample factor
+    public static final int DIMENSION_THRESHOLD_1000 = 1000;
+    public static final int DIMENSION_THRESHOLD_768 = 768;
+
+    // Oversample factors based on dimension thresholds
+    public static final float OVERSAMPLE_FACTOR_1000 = 1.0f;  // No oversampling for dimensions >= 1000
+    public static final float OVERSAMPLE_FACTOR_768 = 2.0f;   // 2x oversampling for dimensions >= 768 and < 1000
+    public static final float OVERSAMPLE_FACTOR_BELOW_768 = 3.0f; // 3x oversampling for dimensions < 768
+
     // Todo:- We will improve this in upcoming releases
     public static final int MIN_FIRST_PASS_RESULTS = 100;
 

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -159,6 +159,41 @@ public class KNNSettingsTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testShardLevelRescoringDisabled_whenNoValuesProvidedByUser_thenDefaultSettingsUsed() {
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        mockNode.client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        mockNode.client().admin().indices().create(new CreateIndexRequest(INDEX_NAME)).actionGet();
+        KNNSettings.state().setClusterService(clusterService);
+
+        boolean shardLevelRescoringDisabled = KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(INDEX_NAME);
+        mockNode.close();
+        assertTrue(shardLevelRescoringDisabled);
+    }
+
+    @SneakyThrows
+    public void testShardLevelRescoringDisabled_whenValueProvidedByUser_thenSettingApplied() {
+        boolean userDefinedRescoringDisabled = false;
+        Node mockNode = createMockNode(Collections.emptyMap());
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        mockNode.client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        mockNode.client().admin().indices().create(new CreateIndexRequest(INDEX_NAME)).actionGet();
+        KNNSettings.state().setClusterService(clusterService);
+
+        final Settings rescoringDisabledSetting = Settings.builder()
+            .put(KNNSettings.KNN_DISK_VECTOR_SHARD_LEVEL_RESCORING_DISABLED, userDefinedRescoringDisabled)
+            .build();
+
+        mockNode.client().admin().indices().updateSettings(new UpdateSettingsRequest(rescoringDisabledSetting, INDEX_NAME)).actionGet();
+
+        boolean shardLevelRescoringDisabled = KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(INDEX_NAME);
+        mockNode.close();
+        assertEquals(userDefinedRescoringDisabled, shardLevelRescoringDisabled);
+    }
+
+    @SneakyThrows
     public void testGetFaissAVX2DisabledSettingValueFromConfig_enableSetting_thenValidateAndSucceed() {
         boolean expectedKNNFaissAVX2Disabled = true;
         Node mockNode = createMockNode(Map.of(KNNSettings.KNN_FAISS_AVX2_DISABLED, expectedKNNFaissAVX2Disabled));

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -44,65 +44,84 @@ public class CompressionLevelTests extends KNNTestCase {
     public void testGetDefaultRescoreContext() {
         // Test rescore context for ON_DISK mode
         Mode mode = Mode.ON_DISK;
-        int belowThresholdDimension = 500; // A dimension below the threshold
-        int aboveThresholdDimension = 1500; // A dimension above the threshold
 
-        // x32 with dimension <= 1000 should have an oversample factor of 5.0f
+        // Test various dimensions based on the updated oversampling logic
+        int belowThresholdDimension = 500;  // A dimension below 768
+        int between768and1000Dimension = 800; // A dimension between 768 and 1000
+        int above1000Dimension = 1500; // A dimension above 1000
+
+        // Compression level x32 with dimension < 768 should have an oversample factor of 3.0f
         RescoreContext rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNotNull(rescoreContext);
-        assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
-
-        // x32 with dimension > 1000 should have an oversample factor of 3.0f
-        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, aboveThresholdDimension);
-        assertNotNull(rescoreContext);
         assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
 
-        // x16 with dimension <= 1000 should have an oversample factor of 5.0f
-        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, belowThresholdDimension);
-        assertNotNull(rescoreContext);
-        assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
-
-        // x16 with dimension > 1000 should have an oversample factor of 3.0f
-        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, aboveThresholdDimension);
-        assertNotNull(rescoreContext);
-        assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
-
-        // x8 with dimension <= 1000 should have an oversample factor of 5.0f
-        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, belowThresholdDimension);
-        assertNotNull(rescoreContext);
-        assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
-
-        // x8 with dimension > 1000 should have an oversample factor of 2.0f
-        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        // Compression level x32 with dimension between 768 and 1000 should have an oversample factor of 2.0f
+        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, between768and1000Dimension);
         assertNotNull(rescoreContext);
         assertEquals(2.0f, rescoreContext.getOversampleFactor(), 0.0f);
 
-        // x4 with dimension <= 1000 should have an oversample factor of 5.0f (though it doesn't have its own RescoreContext)
+        // Compression level x32 with dimension > 1000 should have no oversampling (1.0f)
+        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, above1000Dimension);
+        assertNotNull(rescoreContext);
+        assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x16 with dimension < 768 should have an oversample factor of 3.0f
+        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, belowThresholdDimension);
+        assertNotNull(rescoreContext);
+        assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x16 with dimension between 768 and 1000 should have an oversample factor of 2.0f
+        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, between768and1000Dimension);
+        assertNotNull(rescoreContext);
+        assertEquals(2.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x16 with dimension > 1000 should have no oversampling (1.0f)
+        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, above1000Dimension);
+        assertNotNull(rescoreContext);
+        assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x8 with dimension < 768 should have an oversample factor of 3.0f
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, belowThresholdDimension);
+        assertNotNull(rescoreContext);
+        assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x8 with dimension between 768 and 1000 should have an oversample factor of 2.0f
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, between768and1000Dimension);
+        assertNotNull(rescoreContext);
+        assertEquals(2.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x8 with dimension > 1000 should have no oversampling (1.0f)
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, above1000Dimension);
+        assertNotNull(rescoreContext);
+        assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // Compression level x4 with dimension < 768 should return null (no RescoreContext)
         rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNull(rescoreContext);
-        // x4 with dimension > 1000 should return null (no RescoreContext is configured for x4)
-        rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, aboveThresholdDimension);
+
+        // Compression level x4 with dimension > 1000 should return null (no RescoreContext)
+        rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, above1000Dimension);
         assertNull(rescoreContext);
 
-        // Other compression levels should behave similarly with respect to dimension
-
+        // Compression level x2 with dimension < 768 should return null
         rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNull(rescoreContext);
 
-        // x2 with dimension > 1000 should return null
-        rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        // Compression level x2 with dimension > 1000 should return null
+        rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, above1000Dimension);
         assertNull(rescoreContext);
 
+        // Compression level x1 with dimension < 768 should return null
         rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNull(rescoreContext);
 
-        // x1 with dimension > 1000 should return null
-        rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        // Compression level x1 with dimension > 1000 should return null
+        rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, above1000Dimension);
         assertNull(rescoreContext);
 
-        // NOT_CONFIGURED with dimension <= 1000 should return a RescoreContext with an oversample factor of 5.0f
+        // NOT_CONFIGURED mode should return null for any dimension
         rescoreContext = CompressionLevel.NOT_CONFIGURED.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNull(rescoreContext);
-
     }
+
 }


### PR DESCRIPTION
### Description
Issue:- During rescoring at the shard level in a multi-segment case, the recall of the search results drops to zero.
Fix :- To address the issue of reduced recall during shard-level rescoring in multi-segment cases, we are introducing an index-level setting that allows users to enable or disable shard-level rescoring. This setting gives finer control over whether rescoring should be performed at the shard level or if the system should rely on a more global rescoring process across all segments. By disabling shard-level rescoring, the recall issue is mitigated, as the rescoring process will take into account the complete set of results from all segments, rather than focusing on top k results. 

Oversampling Update :- With this change we are updating default oversampling factor as well. For dimensions less than 768, an oversample factor of 3.0x is applied to ensure higher recall for smaller vector spaces. For dimensions between 768 and 1000, the oversampling factor is set to 2.0x to balance recall and performance. For dimensions above 1000, no oversampling (1.0x) is applied.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
