### PR TITLE
Add support for radial search in exact search

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.iterators.BinaryVectorIdsKNNIterator;
+import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.iterators.ByteVectorIdsKNNIterator;
 import org.opensearch.knn.index.query.iterators.NestedBinaryVectorIdsKNNIterator;
 import org.opensearch.knn.index.query.iterators.VectorIdsKNNIterator;
@@ -36,7 +37,9 @@ import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @Log4j2
 @AllArgsConstructor
@@ -55,11 +58,41 @@ public class ExactSearcher {
     public Map<Integer, Float> searchLeaf(final LeafReaderContext leafReaderContext, final ExactSearcherContext exactSearcherContext)
         throws IOException {
         KNNIterator iterator = getKNNIterator(leafReaderContext, exactSearcherContext);
+        if (exactSearcherContext.getKnnQuery().getRadius() != null) {
+            return doRadialSearch(leafReaderContext, exactSearcherContext, iterator);
+        }
         if (exactSearcherContext.getMatchedDocs() != null
             && exactSearcherContext.getMatchedDocs().cardinality() <= exactSearcherContext.getK()) {
             return scoreAllDocs(iterator);
         }
         return searchTopK(iterator, exactSearcherContext.getK());
+    }
+
+    /**
+     * Perform radial search by comparing scores with min score. Currently, FAISS from native engine supports radial search.
+     * Hence, we assume that Radius from knnQuery is always distance, and we convert it to score since we do exact search uses scores
+     * to filter out the documents that does not have given min score.
+     * @param leafReaderContext
+     * @param exactSearcherContext
+     * @param iterator {@link KNNIterator}
+     * @return Map of docId and score
+     * @throws IOException exception raised by iterator during traversal
+     */
+    private Map<Integer, Float> doRadialSearch(
+        LeafReaderContext leafReaderContext,
+        ExactSearcherContext exactSearcherContext,
+        KNNIterator iterator
+    ) throws IOException {
+        final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
+        final KNNQuery knnQuery = exactSearcherContext.getKnnQuery();
+        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        final KNNEngine engine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
+        if (KNNEngine.FAISS != engine) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support radial search", engine));
+        }
+        final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
+        final float minScore = spaceType.scoreTranslation(knnQuery.getRadius());
+        return filterDocsByMinScore(exactSearcherContext, iterator, minScore);
     }
 
     private Map<Integer, Float> scoreAllDocs(KNNIterator iterator) throws IOException {
@@ -71,15 +104,19 @@ public class ExactSearcher {
         return docToScore;
     }
 
-    private Map<Integer, Float> searchTopK(KNNIterator iterator, int k) throws IOException {
+    private Map<Integer, Float> searchTopCandidates(KNNIterator iterator, int limit, Predicate<Float> filterScore) throws IOException {
         // Creating min heap and init with MAX DocID and Score as -INF.
-        final HitQueue queue = new HitQueue(k, true);
+        final HitQueue queue = new HitQueue(limit, true);
         ScoreDoc topDoc = queue.top();
         final Map<Integer, Float> docToScore = new HashMap<>();
         int docId;
         while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-            if (iterator.score() > topDoc.score) {
-                topDoc.score = iterator.score();
+            final float currentScore = iterator.score();
+            if (filterScore != null && Predicate.not(filterScore).test(currentScore)) {
+                continue;
+            }
+            if (currentScore > topDoc.score) {
+                topDoc.score = currentScore;
                 topDoc.doc = docId;
                 // As the HitQueue is min heap, updating top will bring the doc with -INF score or worst score we
                 // have seen till now on top.
@@ -98,8 +135,18 @@ public class ExactSearcher {
             final ScoreDoc doc = queue.pop();
             docToScore.put(doc.doc, doc.score);
         }
-
         return docToScore;
+    }
+
+    private Map<Integer, Float> searchTopK(KNNIterator iterator, int k) throws IOException {
+        return searchTopCandidates(iterator, k, null);
+    }
+
+    private Map<Integer, Float> filterDocsByMinScore(ExactSearcherContext context, KNNIterator iterator, float minScore)
+        throws IOException {
+        int maxResultWindow = context.getKnnQuery().getContext().getMaxResultWindow();
+        Predicate<Float> scoreGreaterThanOrEqualToMinScore = score -> score >= minScore;
+        return searchTopCandidates(iterator, maxResultWindow, scoreGreaterThanOrEqualToMinScore);
     }
 
     private KNNIterator getKNNIterator(LeafReaderContext leafReaderContext, ExactSearcherContext exactSearcherContext) throws IOException {

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
@@ -95,8 +96,13 @@ public class KNNWeight extends Weight {
     }
 
     public static void initialize(ModelDao modelDao) {
+        initialize(modelDao, new ExactSearcher(modelDao));
+    }
+
+    @VisibleForTesting
+    static void initialize(ModelDao modelDao, ExactSearcher exactSearcher) {
         KNNWeight.modelDao = modelDao;
-        KNNWeight.DEFAULT_EXACT_SEARCHER = new ExactSearcher(modelDao);
+        KNNWeight.DEFAULT_EXACT_SEARCHER = exactSearcher;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -204,8 +204,8 @@ public class KNNWeight extends Weight {
 
     private Map<Integer, Float> doExactSearch(final LeafReaderContext context, final BitSet acceptedDocs, int k) throws IOException {
         final ExactSearcherContextBuilder exactSearcherContextBuilder = ExactSearcher.ExactSearcherContext.builder()
-            .k(k)
             .isParentHits(true)
+            .k(k)
             // setting to true, so that if quantization details are present we want to do search on the quantized
             // vectors as this flow is used in first pass of search.
             .useQuantizedVectorsForSearch(true)
@@ -398,12 +398,9 @@ public class KNNWeight extends Weight {
             filterIdsCount,
             KNNSettings.getFilteredExactSearchThreshold(knnQuery.getIndexName())
         );
-        if (knnQuery.getRadius() != null) {
-            return false;
-        }
         int filterThresholdValue = KNNSettings.getFilteredExactSearchThreshold(knnQuery.getIndexName());
         // Refer this GitHub around more details https://github.com/opensearch-project/k-NN/issues/1049 on the logic
-        if (filterIdsCount <= knnQuery.getK()) {
+        if (knnQuery.getRadius() == null && filterIdsCount <= knnQuery.getK()) {
             return true;
         }
         // See user has defined Exact Search filtered threshold. if yes, then use that setting.

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -88,6 +88,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
                 .indexName(indexName)
                 .parentsFilter(parentFilter)
                 .radius(radius)
+                .vectorDataType(vectorDataType)
                 .methodParameters(methodParameters)
                 .context(knnQueryContext)
                 .filterQuery(filterQuery)

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -623,10 +623,11 @@ public class FaissIT extends KNNRestTestCase {
 
         // Assert we have the right number of documents in the index
         assertEquals(numDocs, getDocCount(indexName));
-        // KNN Query should return empty result
+
         final Response searchResponse = searchKNNIndex(indexName, buildSearchQuery(fieldName, 1, queryVector, null), 1);
         final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
-        assertEquals(0, results.size());
+        // expect result due to exact search
+        assertEquals(1, results.size());
 
         deleteKNNIndex(indexName);
         validateGraphEviction();
@@ -682,7 +683,7 @@ public class FaissIT extends KNNRestTestCase {
         // KNN Query should return empty result
         final Response searchResponse = searchKNNIndex(indexName, buildSearchQuery(fieldName, 1, queryVector, null), 1);
         final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
-        assertEquals(0, results.size());
+        assertEquals(1, results.size());
 
         // update index setting to build graph and do force merge
         // update build vector data structure setting

--- a/src/test/java/org/opensearch/knn/index/query/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExactSearcherTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.KNNCodecVersion;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.KNNRestTestCase.FIELD_NAME;
+import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+
+public class ExactSearcherTests extends KNNTestCase {
+
+    private static final String SEGMENT_NAME = "0";
+
+    @SneakyThrows
+    public void testRadialSearch_whenNoEngineFiles_thenSuccess() {
+        try (MockedStatic<KNNVectorValuesFactory> valuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+            final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+            final List<float[]> dataVectors = Arrays.asList(
+                new float[] { 11.0f, 12.0f, 13.0f },
+                new float[] { 14.0f, 15.0f, 16.0f },
+                new float[] { 17.0f, 18.0f, 19.0f }
+            );
+            final List<Float> expectedScores = dataVectors.stream()
+                .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
+                .collect(Collectors.toList());
+            final Float score = Collections.min(expectedScores);
+            final float radius = KNNEngine.FAISS.scoreToRadialThreshold(score, spaceType);
+            final int maxResults = 1000;
+            final KNNQuery.Context context = mock(KNNQuery.Context.class);
+            when(context.getMaxResultWindow()).thenReturn(maxResults);
+            KNNWeight.initialize(null);
+
+            final KNNQuery query = KNNQuery.builder()
+                .field(FIELD_NAME)
+                .queryVector(queryVector)
+                .radius(radius)
+                .indexName(INDEX_NAME)
+                .context(context)
+                .build();
+
+            final ExactSearcher.ExactSearcherContext.ExactSearcherContextBuilder exactSearcherContextBuilder =
+                ExactSearcher.ExactSearcherContext.builder()
+                    // setting to true, so that if quantization details are present we want to do search on the quantized
+                    // vectors as this flow is used in first pass of search.
+                    .useQuantizedVectorsForSearch(false)
+                    .knnQuery(query);
+
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FSDirectory directory = mock(FSDirectory.class);
+            when(reader.directory()).thenReturn(directory);
+            final SegmentInfo segmentInfo = new SegmentInfo(
+                directory,
+                Version.LATEST,
+                Version.LATEST,
+                SEGMENT_NAME,
+                100,
+                false,
+                false,
+                KNNCodecVersion.current().getDefaultCodecDelegate(),
+                Map.of(),
+                new byte[StringHelper.ID_LENGTH],
+                Map.of(),
+                Sort.RELEVANCE
+            );
+            segmentInfo.setFiles(Set.of());
+            final SegmentCommitInfo segmentCommitInfo = new SegmentCommitInfo(segmentInfo, 0, 0, 0, 0, 0, new byte[StringHelper.ID_LENGTH]);
+            when(reader.getSegmentInfo()).thenReturn(segmentCommitInfo);
+
+            final Path path = mock(Path.class);
+            when(directory.getDirectory()).thenReturn(path);
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
+            when(fieldInfo.attributes()).thenReturn(
+                Map.of(
+                    SPACE_TYPE,
+                    spaceType.getValue(),
+                    KNN_ENGINE,
+                    KNNEngine.FAISS.getName(),
+                    PARAMETERS,
+                    String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+                )
+            );
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            KNNFloatVectorValues floatVectorValues = mock(KNNFloatVectorValues.class);
+            valuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader)).thenReturn(floatVectorValues);
+            when(floatVectorValues.nextDoc()).thenReturn(0, 1, 2, NO_MORE_DOCS);
+            when(floatVectorValues.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
+            final Map<Integer, Float> integerFloatMap = exactSearcher.searchLeaf(leafReaderContext, exactSearcherContextBuilder.build());
+            assertEquals(integerFloatMap.size(), dataVectors.size());
+            assertEquals(expectedScores, new ArrayList<>(integerFloatMap.values()));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -89,6 +89,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
@@ -760,6 +761,83 @@ public class KNNWeightTests extends KNNTestCase {
             assertEquals(docIdSetIterator.cost(), actualDocIds.size());
             assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
         }
+    }
+
+    @SneakyThrows
+    public void testRadialSearch_whenNoEngineFiles_thenPerformExactSearch() {
+        ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        KNNWeight.initialize(null, mockedExactSearcher);
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .indexName(INDEX_NAME)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .build();
+        final KNNWeight knnWeight = new KNNWeight(query, 1.0f);
+
+        final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        final SegmentReader reader = mock(SegmentReader.class);
+        when(leafReaderContext.reader()).thenReturn(reader);
+
+        final FSDirectory directory = mock(FSDirectory.class);
+        when(reader.directory()).thenReturn(directory);
+        final SegmentInfo segmentInfo = new SegmentInfo(
+            directory,
+            Version.LATEST,
+            Version.LATEST,
+            SEGMENT_NAME,
+            100,
+            false,
+            false,
+            KNNCodecVersion.current().getDefaultCodecDelegate(),
+            Map.of(),
+            new byte[StringHelper.ID_LENGTH],
+            Map.of(),
+            Sort.RELEVANCE
+        );
+        segmentInfo.setFiles(Set.of());
+        final SegmentCommitInfo segmentCommitInfo = new SegmentCommitInfo(segmentInfo, 0, 0, 0, 0, 0, new byte[StringHelper.ID_LENGTH]);
+        when(reader.getSegmentInfo()).thenReturn(segmentCommitInfo);
+
+        final Path path = mock(Path.class);
+        when(directory.getDirectory()).thenReturn(path);
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(reader.getFieldInfos()).thenReturn(fieldInfos);
+        when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+        when(fieldInfo.attributes()).thenReturn(
+            Map.of(
+                SPACE_TYPE,
+                spaceType.getValue(),
+                KNN_ENGINE,
+                KNNEngine.FAISS.getName(),
+                PARAMETERS,
+                String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+            )
+        );
+        final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
+            .isParentHits(true)
+            // setting to true, so that if quantization details are present we want to do search on the quantized
+            // vectors as this flow is used in first pass of search.
+            .useQuantizedVectorsForSearch(true)
+            .knnQuery(query)
+            .build();
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            assertEquals(DOC_ID_TO_SCORES.get(docId), knnScorer.score(), 0.00000001f);
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+        // verify JNI Service is not called
+        jniServiceMockedStatic.verifyNoInteractions();
+        verify(mockedExactSearcher).searchLeaf(leafReaderContext, exactSearchContext);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -360,7 +360,6 @@ public class KNNWeightTests extends KNNTestCase {
         final Path path = mock(Path.class);
         when(directory.getDirectory()).thenReturn(path);
         final FieldInfos fieldInfos = mock(FieldInfos.class);
-        final FieldInfo fieldInfo = mock(FieldInfo.class);
         when(reader.getFieldInfos()).thenReturn(fieldInfos);
         // When no knn fields are available , field info for vector field will be null
         when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(null);

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
@@ -155,17 +155,6 @@ public class BinaryIndexIT extends KNNRestTestCase {
         }
     }
 
-    @SneakyThrows
-    public void testFaissHnswBinary_whenRadialSearch_thenThrowException() {
-        // Create Index
-        createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 16);
-
-        // Query
-        float[] queryVector = { (byte) 0b10001111, (byte) 0b10000000 };
-        Exception e = expectThrows(Exception.class, () -> runRnnQuery(INDEX_NAME, FIELD_NAME, queryVector, 1, 4));
-        assertTrue(e.getMessage(), e.getMessage().contains("Binary data type does not support radial search"));
-    }
-
     private float getRecall(final Set<String> truth, final Set<String> result) {
         // Count the number of relevant documents retrieved
         result.retainAll(truth);
@@ -176,23 +165,6 @@ public class BinaryIndexIT extends KNNRestTestCase {
 
         // Calculate recall
         return (float) relevantRetrieved / totalRelevant;
-    }
-
-    private List<KNNResult> runRnnQuery(
-        final String indexName,
-        final String fieldName,
-        final float[] queryVector,
-        final float minScore,
-        final int size
-    ) throws Exception {
-        String query = KNNJsonQueryBuilder.builder()
-            .fieldName(fieldName)
-            .vector(ArrayUtils.toObject(queryVector))
-            .minScore(minScore)
-            .build()
-            .getQueryString();
-        Response response = searchKNNIndex(indexName, query, size);
-        return parseSearchResponse(EntityUtils.toString(response.getEntity()), fieldName);
     }
 
     private List<KNNResult> runKnnQuery(final String indexName, final String fieldName, final float[] queryVector, final int k)


### PR DESCRIPTION
### Description
When threshold value is set, knn plugin will not be creating graph. Hence, when search request is trigged during that time, exact search will return valid results. However, radial search was never included as part of exact search. This will break radial search when threshold is added and radial search is requested. In this commit, new method
is introduced to accept min score and return documents that are greater than min score, similar to how radial search is performed by native engines. This search is independent of engine, but, radial search is supported only for FAISS engine out of all native engines.

### Related Issues
Part of #1942 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
