### PR TITLE
Preloads .vec and .vex files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introducing a loading layer in FAISS [#2033](https://github.com/opensearch-project/k-NN/issues/2033)
 ### Bug Fixes 
 * Add DocValuesProducers for releasing memory when close index [#1946](https://github.com/opensearch-project/k-NN/pull/1946)
+* Prelaods vec and vex files to address regression in force merge latencies [#2186](https://github.com/opensearch-project/k-NN/pull/2186)
 ### Infrastructure
 * Removed JDK 11 and 17 version from CI runs [#1921](https://github.com/opensearch-project/k-NN/pull/1921)
 ### Documentation

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibrary.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.engine;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.SpaceType;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -137,6 +136,6 @@ public interface KNNLibrary extends MethodResolver {
      * @return list of file extensions that will be read/write with mmap
      */
     default List<String> mmapFileExtensions() {
-        return Collections.emptyList();
+        return List.of("vec", "vex");
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/Lucene.java
@@ -15,7 +15,6 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodResolver;
 import org.opensearch.knn.index.engine.ResolvedMethodContext;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -87,11 +86,6 @@ public class Lucene extends JVMLibrary {
     public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
         // Lucene engine uses distance as is and does not need transformation
         return score;
-    }
-
-    @Override
-    public List<String> mmapFileExtensions() {
-        return List.of("vec", "vex");
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -365,6 +366,14 @@ public class FaissTests extends KNNTestCase {
         assertEquals(expectedKNNMethodContext.getPerDimensionProcessor(), actualKNNLibraryIndexingContext.getPerDimensionProcessor());
         assertEquals(expectedKNNMethodContext.getPerDimensionValidator(), actualKNNLibraryIndexingContext.getPerDimensionValidator());
         assertEquals(expectedKNNMethodContext.getVectorValidator(), actualKNNLibraryIndexingContext.getVectorValidator());
+    }
+
+    public void testMmapFileExtensions() {
+        final List<String> mMapExtensions = Faiss.INSTANCE.mmapFileExtensions();
+        assertNotNull(mMapExtensions);
+        final List<String> expectedSettings = List.of("vex", "vec");
+        assertTrue(expectedSettings.containsAll(mMapExtensions));
+        assertTrue(mMapExtensions.containsAll(expectedSettings));
     }
 
 }

--- a/src/test/java/org/opensearch/knn/index/engine/nmslib/NMSLibTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/nmslib/NMSLibTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.nmslib;
+
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.List;
+
+public class NMSLibTests extends KNNTestCase {
+
+    public void testMmapFileExtensions() {
+        final List<String> mmapExtensions = Nmslib.INSTANCE.mmapFileExtensions();
+        assertNotNull(mmapExtensions);
+        final List<String> expectedSettings = List.of("vex", "vec");
+        assertTrue(expectedSettings.containsAll(mmapExtensions));
+        assertTrue(mmapExtensions.containsAll(expectedSettings));
+    }
+}

--- a/src/test/java/org/opensearch/knn/plugin/KNNPluginTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/KNNPluginTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.plugin;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+public class KNNPluginTests extends OpenSearchTestCase {
+
+    public void testKNNPlugin_additionalIndexProviderSettings() throws IOException {
+        try (KNNPlugin knnPlugin = new KNNPlugin()) {
+            Settings additionalSettings = knnPlugin.getAdditionalIndexSettingProviders()
+                .iterator()
+                .next()
+                .getAdditionalIndexSettings("index", false, Settings.builder().put(KNNSettings.KNN_INDEX, Boolean.TRUE).build());
+
+            Settings settings = Settings.builder().putList("index.store.preload", List.of("vec", "vex")).build();
+            assertEquals(settings, additionalSettings);
+
+            additionalSettings = knnPlugin.getAdditionalIndexSettingProviders()
+                .iterator()
+                .next()
+                .getAdditionalIndexSettings("index", false, Settings.builder().build());
+
+            assertEquals(Settings.EMPTY, additionalSettings);
+        }
+    }
+}


### PR DESCRIPTION
LuceneFlatVectorReader uses IOContext.Random to open the read. IOContext.Random indicates the kernel to not read ahead the pages on to physical memory. This causes an increase in merge time due to increase of read ops at runtime.

The preload settings signals the kernal to preload the files when the reader is opened

### Description

<h3>Experiment setup</h3><ul><li>3 nodes: 6 shards 1 replica</li><li>Dataset: Cohere-10m </li><li>index thread: 2</li></ul>

Baseline is without preloading in the table below

Description |   | vCPU | Mem (GB) | Storage Type | Total force merge time | Read ops | Time between merges | Index CPU% (max) | Merge CPU % (max)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Without quantization | Baseline | 16 | 128 | EBS | 5hr 15mins | 115K | 10 mins | 90 | 12
  | Preload | 16 | 128 | EBS | 4hrs 55mins | 60K | 4 mins | 90 | 12
1 bit quantization | Baseline | 8 | 64 | EBS | 1hr 35mins | 117K | 3 mins | 45 | 23
  | Preload | 8 | 64 | EBS | 1hr 24mins | 60K | 0 mins | 40 | 23
1 bit quantization | Baseline | 8 | 64 | Instance | 1hr 2mins | 253K | 0 mins | 82 | 27
  | Preload | 8 | 64 | Instance | 58 mins | 55K-70K | 0 mins | 75 | 27
1 bit quantization | Baseline | 4 | 32 | Instance | 1hr 7 mins | 1M | 0min | 99 | 50
  | Preload | 4 | 32 | Instance | 1hr 17 mins | 105K - 145k | 0 mins | 99 | 50

<h2>Observation</h2>A decrease in read ops along with a decrease in total force merge time is seen for experiments where data is preloaded and there is enough memory to hold the data. <br><br>As the memory is constrained, there is an increase in read ops. This is expected as the memory will not be able to hold all the pages. The baseline performs better for merge operations in terms of amount of total time taken for force merge compared to preload for these cases. 

### Testing

#### Scenario 1: No `store.preload` in settings
```
{
  "settings": {
    "index": {
      "knn": true,
      "knn.algo_param.ef_search": 100,
      "number_of_shards": 1,
      "number_of_replicas": 0
    }
  },
  "mappings": {
    "properties": {
      "location": {
        "type": "knn_vector",
        "dimension": 2,
        "method": {
          "name": "hnsw",
          "space_type": "l2",
          "engine": "faiss",
          "parameters": {
            "ef_construction": 100,
            "m": 16
          }
        }
      }
    }
  }
}
```
Get index response 
```
{
	"hotels-index-faiss": {
		"aliases": {},
		"mappings": {
			"properties": {
				"location": {
					"type": "knn_vector",
					"dimension": 2,
					"method": {
						"engine": "faiss",
						"space_type": "l2",
						"name": "hnsw",
						"parameters": {
							"ef_construction": 100,
							"m": 16
						}
					}
				}
			}
		},
		"settings": {
			"index": {
				"replication": {
					"type": "DOCUMENT"
				},
				"number_of_shards": "1",
				"knn.algo_param": {
					"ef_search": "100"
				},
				"provided_name": "hotels-index-faiss",
				"knn": "true",
				"creation_date": "1728085803212",
				"store": {
					"preload": [
						"vec",
						"vex"
					]
				},
				"number_of_replicas": "0",
				"uuid": "WawO8OR2S2WmvTr6K0gpRw",
				"version": {
					"created": "137217827"
				}
			}
		}
	}
}
```

#### Scenario 2: Preload override

```
{
  "settings": {
    "index": {
      "store.preload": [ "dvd" ],
      "knn": true,
      "knn.algo_param.ef_search": 100,
      "number_of_shards": 1,
      "number_of_replicas": 0
    }
  },
  "mappings": {
    "properties": {
      "location": {
        "type": "knn_vector",
        "dimension": 2,
        "method": {
          "name": "hnsw",
          "space_type": "l2",
          "engine": "faiss",
          "parameters": {
            "ef_construction": 100,
            "m": 16
          }
        }
      }
    }
  }
}
```
Get response
```
{
	"hotels-index-faiss": {
		"aliases": {},
		"mappings": {
			"properties": {
				"location": {
					"type": "knn_vector",
					"dimension": 2,
					"method": {
						"engine": "faiss",
						"space_type": "l2",
						"name": "hnsw",
						"parameters": {
							"ef_construction": 100,
							"m": 16
						}
					}
				}
			}
		},
		"settings": {
			"index": {
				"replication": {
					"type": "DOCUMENT"
				},
				"number_of_shards": "1",
				"knn.algo_param": {
					"ef_search": "100"
				},
				"provided_name": "hotels-index-faiss",
				"knn": "true",
				"creation_date": "1728087079416",
				"store": {
					"preload": [
						"dvd"
					]
				},
				"number_of_replicas": "0",
				"uuid": "g9TsdOXkTluokbuupwyQSA",
				"version": {
					"created": "137217827"
				}
			}
		}
	}
}

```

### Related Issues
Resolves [#2134](https://github.com/opensearch-project/k-NN/issues/2134)
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
