### PR TITLE
Add support to build vector data structures greedily and perform exact search when there are no engine files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Features
-* Introduce new setting to configure whether to build vector data structure or not during segment creation [#2007](https://github.com/opensearch-project/k-NN/pull/2007)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
@@ -25,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update Default Rescore Context based on Dimension [#2149](https://github.com/opensearch-project/k-NN/pull/2149)
 * KNNIterators should support with and without filters [#2155](https://github.com/opensearch-project/k-NN/pull/2155)
 * Adding Support to Enable/Disble Share level Rescoring and Update Oversampling Factor[#2172](https://github.com/opensearch-project/k-NN/pull/2172)
-* Add exact search if no native engine files are available [#2136] (https://github.com/opensearch-project/k-NN/pull/2136)
+* Add support to build vector data structures greedily and perform exact search when there are no engine files [#1942](https://github.com/opensearch-project/k-NN/issues/1942)
 ### Bug Fixes
 * Add DocValuesProducers for releasing memory when close index [#1946](https://github.com/opensearch-project/k-NN/pull/1946)
 * KNN80DocValues should only be considered for BinaryDocValues fields [#2147](https://github.com/opensearch-project/k-NN/pull/2147)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update Default Rescore Context based on Dimension [#2149](https://github.com/opensearch-project/k-NN/pull/2149)
 * KNNIterators should support with and without filters [#2155](https://github.com/opensearch-project/k-NN/pull/2155)
 * Adding Support to Enable/Disble Share level Rescoring and Update Oversampling Factor[#2172](https://github.com/opensearch-project/k-NN/pull/2172)
+* Add exact search if no native engine files are available [#2136] (https://github.com/opensearch-project/k-NN/pull/2136)
 ### Bug Fixes
 * Add DocValuesProducers for releasing memory when close index [#1946](https://github.com/opensearch-project/k-NN/pull/1946)
 * KNN80DocValues should only be considered for BinaryDocValues fields [#2147](https://github.com/opensearch-project/k-NN/pull/2147)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Features
+* Introduce new setting to configure whether to build vector data structure or not during segment creation [#2007](https://github.com/opensearch-project/k-NN/pull/2007)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -67,6 +67,7 @@ public class KNNSettings {
      * Settings name
      */
     public static final String KNN_SPACE_TYPE = "index.knn.space_type";
+    public static final String INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = "index.knn.build_vector_data_structure_threshold";
     public static final String KNN_ALGO_PARAM_M = "index.knn.algo_param.m";
     public static final String KNN_ALGO_PARAM_EF_CONSTRUCTION = "index.knn.algo_param.ef_construction";
     public static final String KNN_ALGO_PARAM_EF_SEARCH = "index.knn.algo_param.ef_search";
@@ -97,6 +98,9 @@ public class KNNSettings {
     public static final boolean KNN_DEFAULT_FAISS_AVX2_DISABLED_VALUE = false;
     public static final boolean KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
+    public static final Integer INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = 0;
+    public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN = -1;
+    public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX = Integer.MAX_VALUE - 2;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hamming";
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_M = 16;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH = 100;
@@ -154,6 +158,21 @@ public class KNNSettings {
         new SpaceTypeValidator(),
         IndexScope,
         Setting.Property.Deprecated
+    );
+
+    /**
+     * build_vector_data_structure_threshold - This parameter determines when to build vector data structure for knn fields during indexing
+     * and merging. Setting -1 (min) will skip building graph, whereas on any other values, the graph will be built if
+     * number of live docs in segment is greater than this threshold. Since max number of documents in a segment can
+     * be Integer.MAX_VALUE - 1, this setting will allow threshold to be up to 1 less than max number of documents in a segment
+     */
+    public static final Setting<Integer> INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_SETTING = Setting.intSetting(
+        INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+        INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+        INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
+        INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX,
+        IndexScope,
+        Dynamic
     );
 
     /**
@@ -486,6 +505,7 @@ public class KNNSettings {
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
             INDEX_KNN_SPACE_TYPE,
+            INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_SETTING,
             INDEX_KNN_ALGO_PARAM_M_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING,

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -67,7 +67,7 @@ public class KNNSettings {
      * Settings name
      */
     public static final String KNN_SPACE_TYPE = "index.knn.space_type";
-    public static final String INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = "index.knn.build_vector_data_structure_threshold";
+    public static final String INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD = "index.knn.advanced.approximate_threshold";
     public static final String KNN_ALGO_PARAM_M = "index.knn.algo_param.m";
     public static final String KNN_ALGO_PARAM_EF_CONSTRUCTION = "index.knn.algo_param.ef_construction";
     public static final String KNN_ALGO_PARAM_EF_SEARCH = "index.knn.algo_param.ef_search";
@@ -98,7 +98,7 @@ public class KNNSettings {
     public static final boolean KNN_DEFAULT_FAISS_AVX2_DISABLED_VALUE = false;
     public static final boolean KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
-    public static final Integer INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = 0;
+    public static final Integer INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE = 0;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN = -1;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX = Integer.MAX_VALUE - 2;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hamming";
@@ -166,9 +166,9 @@ public class KNNSettings {
      * number of live docs in segment is greater than this threshold. Since max number of documents in a segment can
      * be Integer.MAX_VALUE - 1, this setting will allow threshold to be up to 1 less than max number of documents in a segment
      */
-    public static final Setting<Integer> INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_SETTING = Setting.intSetting(
-        INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
-        INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+    public static final Setting<Integer> INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING = Setting.intSetting(
+        INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD,
+        INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
         INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
         INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX,
         IndexScope,
@@ -505,7 +505,7 @@ public class KNNSettings {
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
             INDEX_KNN_SPACE_TYPE,
-            INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_SETTING,
+            INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING,
             INDEX_KNN_ALGO_PARAM_M_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING,

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -131,21 +131,21 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
     }
 
     private NativeEngines990KnnVectorsFormat nativeEngineVectorsFormat() {
-        int buildVectorDatastructureThreshold = getBuildVectorDatastructureThresholdSetting(mapperService.get());
+        int buildVectorDatastructureThreshold = getBuildVectorDataStructureThresholdSetting(mapperService.get());
         return new NativeEngines990KnnVectorsFormat(
             new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()),
             buildVectorDatastructureThreshold
         );
     }
 
-    private int getBuildVectorDatastructureThresholdSetting(final MapperService knnMapperService) {
+    private int getBuildVectorDataStructureThresholdSetting(final MapperService knnMapperService) {
         final IndexSettings indexSettings = knnMapperService.getIndexSettings();
-        final Integer buildVectorDatastructureThreshold = indexSettings.getValue(
-            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_SETTING
+        final Integer buildVectorDataStructureThreshold = indexSettings.getValue(
+            KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING
         );
-        return buildVectorDatastructureThreshold != null
-            ? buildVectorDatastructureThreshold
-            : KNNSettings.INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD;
+        return buildVectorDataStructureThreshold != null
+            ? buildVectorDataStructureThreshold
+            : KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -131,20 +131,22 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
     }
 
     private NativeEngines990KnnVectorsFormat nativeEngineVectorsFormat() {
-        int buildVectorDatastructureThreshold = getBuildVectorDataStructureThresholdSetting(mapperService.get());
+        // mapperService is already checked for null or valid instance type at caller, hence we don't need
+        // addition isPresent check here.
+        int approximateThreshold = getApproximateThresholdValue();
         return new NativeEngines990KnnVectorsFormat(
             new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()),
-            buildVectorDatastructureThreshold
+            approximateThreshold
         );
     }
 
-    private int getBuildVectorDataStructureThresholdSetting(final MapperService knnMapperService) {
-        final IndexSettings indexSettings = knnMapperService.getIndexSettings();
-        final Integer buildVectorDataStructureThreshold = indexSettings.getValue(
-            KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING
-        );
-        return buildVectorDataStructureThreshold != null
-            ? buildVectorDataStructureThreshold
+    private int getApproximateThresholdValue() {
+        // This is private method and mapperService is already checked for null or valid instance type before this call
+        // at caller, hence we don't need additional isPresent check here.
+        final IndexSettings indexSettings = mapperService.get().getIndexSettings();
+        final Integer approximateThresholdValue = indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING);
+        return approximateThresholdValue != null
+            ? approximateThresholdValue
             : KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -19,6 +19,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.knn.index.KNNSettings;
 
 import java.io.IOException;
 
@@ -30,15 +31,20 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     /** The format for storing, reading, merging vectors on disk */
     private static FlatVectorsFormat flatVectorsFormat;
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
+    private static int buildVectorDatastructureThreshold;
 
     public NativeEngines990KnnVectorsFormat() {
-        super(FORMAT_NAME);
-        flatVectorsFormat = new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer());
+        this(new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer()));
     }
 
-    public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat lucene99FlatVectorsFormat) {
+    public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat) {
+        this(flatVectorsFormat, KNNSettings.INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
+    }
+
+    public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat, int buildVectorDatastructureThreshold) {
         super(FORMAT_NAME);
-        flatVectorsFormat = lucene99FlatVectorsFormat;
+        NativeEngines990KnnVectorsFormat.flatVectorsFormat = flatVectorsFormat;
+        NativeEngines990KnnVectorsFormat.buildVectorDatastructureThreshold = buildVectorDatastructureThreshold;
     }
 
     /**
@@ -48,7 +54,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
      */
     @Override
     public KnnVectorsWriter fieldsWriter(final SegmentWriteState state) throws IOException {
-        return new NativeEngines990KnnVectorsWriter(state, flatVectorsFormat.fieldsWriter(state));
+        return new NativeEngines990KnnVectorsWriter(state, flatVectorsFormat.fieldsWriter(state), buildVectorDatastructureThreshold);
     }
 
     /**
@@ -63,6 +69,12 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
 
     @Override
     public String toString() {
-        return "NativeEngines99KnnVectorsFormat(name=" + this.getClass().getSimpleName() + ", flatVectorsFormat=" + flatVectorsFormat + ")";
+        return "NativeEngines99KnnVectorsFormat(name="
+            + this.getClass().getSimpleName()
+            + ", flatVectorsFormat="
+            + flatVectorsFormat
+            + ", buildVectorDatastructureThreshold"
+            + buildVectorDatastructureThreshold
+            + ")";
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -31,7 +31,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     /** The format for storing, reading, merging vectors on disk */
     private static FlatVectorsFormat flatVectorsFormat;
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
-    private static int buildVectorDatastructureThreshold;
+    private static int approximateThreshold;
 
     public NativeEngines990KnnVectorsFormat() {
         this(new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer()));
@@ -41,10 +41,10 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
         this(flatVectorsFormat, KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE);
     }
 
-    public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat, int buildVectorDatastructureThreshold) {
+    public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat, int approximateThreshold) {
         super(FORMAT_NAME);
         NativeEngines990KnnVectorsFormat.flatVectorsFormat = flatVectorsFormat;
-        NativeEngines990KnnVectorsFormat.buildVectorDatastructureThreshold = buildVectorDatastructureThreshold;
+        NativeEngines990KnnVectorsFormat.approximateThreshold = approximateThreshold;
     }
 
     /**
@@ -54,7 +54,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
      */
     @Override
     public KnnVectorsWriter fieldsWriter(final SegmentWriteState state) throws IOException {
-        return new NativeEngines990KnnVectorsWriter(state, flatVectorsFormat.fieldsWriter(state), buildVectorDatastructureThreshold);
+        return new NativeEngines990KnnVectorsWriter(state, flatVectorsFormat.fieldsWriter(state), approximateThreshold);
     }
 
     /**
@@ -73,8 +73,8 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
             + this.getClass().getSimpleName()
             + ", flatVectorsFormat="
             + flatVectorsFormat
-            + ", buildVectorDatastructureThreshold"
-            + buildVectorDatastructureThreshold
+            + ", approximateThreshold="
+            + approximateThreshold
             + ")";
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -38,7 +38,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     }
 
     public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat) {
-        this(flatVectorsFormat, KNNSettings.INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
+        this(flatVectorsFormat, KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE);
     }
 
     public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat, int buildVectorDatastructureThreshold) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -53,10 +53,16 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
     private KNN990QuantizationStateWriter quantizationStateWriter;
     private final List<NativeEngineFieldVectorsWriter<?>> fields = new ArrayList<>();
     private boolean finished;
+    private final Integer buildVectorDataStructureThreshold;
 
-    public NativeEngines990KnnVectorsWriter(SegmentWriteState segmentWriteState, FlatVectorsWriter flatVectorsWriter) {
+    public NativeEngines990KnnVectorsWriter(
+        SegmentWriteState segmentWriteState,
+        FlatVectorsWriter flatVectorsWriter,
+        Integer buildVectorDataStructureThreshold
+    ) {
         this.segmentWriteState = segmentWriteState;
         this.flatVectorsWriter = flatVectorsWriter;
+        this.buildVectorDataStructureThreshold = buildVectorDataStructureThreshold;
     }
 
     /**
@@ -98,6 +104,16 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
                 field.getVectors()
             );
             final QuantizationState quantizationState = train(field.getFieldInfo(), knnVectorValuesSupplier, totalLiveDocs);
+            // Will consider building vector data structure based on threshold only for non quantization indices
+            if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs)) {
+                log.info(
+                    "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during flush",
+                    fieldInfo.name,
+                    totalLiveDocs,
+                    buildVectorDataStructureThreshold
+                );
+                continue;
+            }
             final NativeIndexWriter writer = NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState);
             final KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
 
@@ -127,6 +143,16 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
         }
 
         final QuantizationState quantizationState = train(fieldInfo, knnVectorValuesSupplier, totalLiveDocs);
+        // Will consider building vector data structure based on threshold only for non quantization indices
+        if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs)) {
+            log.info(
+                "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during merge",
+                fieldInfo.name,
+                totalLiveDocs,
+                buildVectorDataStructureThreshold
+            );
+            return;
+        }
         final NativeIndexWriter writer = NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, quantizationState);
         final KNNVectorValues<?> knnVectorValues = knnVectorValuesSupplier.get();
 
@@ -256,5 +282,12 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
             quantizationStateWriter = new KNN990QuantizationStateWriter(segmentWriteState);
             quantizationStateWriter.writeHeader(segmentWriteState);
         }
+    }
+
+    private boolean shouldSkipBuildingVectorDataStructure(final long docCount) {
+        if (buildVectorDataStructureThreshold < 0) {
+            return true;
+        }
+        return docCount < buildVectorDataStructureThreshold;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -104,8 +104,9 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
                 field.getVectors()
             );
             final QuantizationState quantizationState = train(field.getFieldInfo(), knnVectorValuesSupplier, totalLiveDocs);
-            // Will consider building vector data structure based on threshold only for non quantization indices
-            if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs)) {
+            // Check only after quantization state writer finish writing its state, since it is required
+            // even if there are no graph files in segment, which will be later used by exact search
+            if (shouldSkipBuildingVectorDataStructure(totalLiveDocs)) {
                 log.info(
                     "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during flush",
                     fieldInfo.name,
@@ -143,8 +144,9 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
         }
 
         final QuantizationState quantizationState = train(fieldInfo, knnVectorValuesSupplier, totalLiveDocs);
-        // Will consider building vector data structure based on threshold only for non quantization indices
-        if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs)) {
+        // Check only after quantization state writer finish writing its state, since it is required
+        // even if there are no graph files in segment, which will be later used by exact search
+        if (shouldSkipBuildingVectorDataStructure(totalLiveDocs)) {
             log.info(
                 "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during merge",
                 fieldInfo.name,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -53,16 +53,16 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
     private KNN990QuantizationStateWriter quantizationStateWriter;
     private final List<NativeEngineFieldVectorsWriter<?>> fields = new ArrayList<>();
     private boolean finished;
-    private final Integer buildVectorDataStructureThreshold;
+    private final Integer approximateThreshold;
 
     public NativeEngines990KnnVectorsWriter(
         SegmentWriteState segmentWriteState,
         FlatVectorsWriter flatVectorsWriter,
-        Integer buildVectorDataStructureThreshold
+        Integer approximateThreshold
     ) {
         this.segmentWriteState = segmentWriteState;
         this.flatVectorsWriter = flatVectorsWriter;
-        this.buildVectorDataStructureThreshold = buildVectorDataStructureThreshold;
+        this.approximateThreshold = approximateThreshold;
     }
 
     /**
@@ -111,7 +111,7 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
                     "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during flush",
                     fieldInfo.name,
                     totalLiveDocs,
-                    buildVectorDataStructureThreshold
+                    approximateThreshold
                 );
                 continue;
             }
@@ -151,7 +151,7 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
                 "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during merge",
                 fieldInfo.name,
                 totalLiveDocs,
-                buildVectorDataStructureThreshold
+                approximateThreshold
             );
             return;
         }
@@ -287,9 +287,9 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
     }
 
     private boolean shouldSkipBuildingVectorDataStructure(final long docCount) {
-        if (buildVectorDataStructureThreshold < 0) {
+        if (approximateThreshold < 0) {
             return true;
         }
-        return docCount < buildVectorDataStructureThreshold;
+        return docCount < approximateThreshold;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
@@ -33,6 +34,7 @@ import org.opensearch.knn.index.memory.NativeMemoryEntryContext;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.index.query.ExactSearcher.ExactSearcherContext.ExactSearcherContextBuilder;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
@@ -129,42 +131,21 @@ public class KNNWeight extends Weight {
         if (filterWeight != null && cardinality == 0) {
             return Collections.emptyMap();
         }
-
         /*
-         * The idea for this optimization is to get K results, we need to atleast look at K vectors in the HNSW graph
+         * The idea for this optimization is to get K results, we need to at least look at K vectors in the HNSW graph
          * . Hence, if filtered results are less than K and filter query is present we should shift to exact search.
          * This improves the recall.
          */
-        Map<Integer, Float> docIdsToScoreMap;
-        final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
-            .k(k)
-            .isParentHits(true)
-            .matchedDocs(filterBitSet)
-            // setting to true, so that if quantization details are present we want to do search on the quantized
-            // vectors as this flow is used in first pass of search.
-            .useQuantizedVectorsForSearch(true)
-            .knnQuery(knnQuery)
-            .build();
-        if (filterWeight != null && canDoExactSearch(cardinality)) {
-            docIdsToScoreMap = exactSearch(context, exactSearcherContext);
-        } else {
-            docIdsToScoreMap = doANNSearch(context, filterBitSet, cardinality, k);
-            if (docIdsToScoreMap == null) {
-                return Collections.emptyMap();
-            }
-            if (canDoExactSearchAfterANNSearch(cardinality, docIdsToScoreMap.size())) {
-                log.debug(
-                    "Doing ExactSearch after doing ANNSearch as the number of documents returned are less than "
-                        + "K, even when we have more than K filtered Ids. K: {}, ANNResults: {}, filteredIdCount: {}",
-                    k,
-                    docIdsToScoreMap.size(),
-                    cardinality
-                );
-                docIdsToScoreMap = exactSearch(context, exactSearcherContext);
-            }
+        if (isFilteredExactSearchPreferred(cardinality)) {
+            return doExactSearch(context, filterBitSet, k);
         }
-        if (docIdsToScoreMap.isEmpty()) {
-            return Collections.emptyMap();
+        Map<Integer, Float> docIdsToScoreMap = doANNSearch(context, filterBitSet, cardinality, k);
+        // See whether we have to perform exact search based on approx search results
+        // This is required if there are no native engine files or if approximate search returned
+        // results less than K, though we have more than k filtered docs
+        if (isExactSearchRequire(context, cardinality, docIdsToScoreMap.size())) {
+            final BitSet docs = filterWeight != null ? filterBitSet : null;
+            return doExactSearch(context, docs, k);
         }
         return docIdsToScoreMap;
     }
@@ -221,6 +202,20 @@ public class KNNWeight extends Weight {
         return intArray;
     }
 
+    private Map<Integer, Float> doExactSearch(final LeafReaderContext context, final BitSet acceptedDocs, int k) throws IOException {
+        final ExactSearcherContextBuilder exactSearcherContextBuilder = ExactSearcher.ExactSearcherContext.builder()
+            .k(k)
+            .isParentHits(true)
+            // setting to true, so that if quantization details are present we want to do search on the quantized
+            // vectors as this flow is used in first pass of search.
+            .useQuantizedVectorsForSearch(true)
+            .knnQuery(knnQuery);
+        if (acceptedDocs != null) {
+            exactSearcherContextBuilder.matchedDocs(acceptedDocs);
+        }
+        return exactSearch(context, exactSearcherContextBuilder.build());
+    }
+
     private Map<Integer, Float> doANNSearch(
         final LeafReaderContext context,
         final BitSet filterIdsBitSet,
@@ -234,7 +229,7 @@ public class KNNWeight extends Weight {
 
         if (fieldInfo == null) {
             log.debug("[KNN] Field info not found for {}:{}", knnQuery.getField(), reader.getSegmentName());
-            return null;
+            return Collections.emptyMap();
         }
 
         KNNEngine knnEngine;
@@ -273,8 +268,8 @@ public class KNNWeight extends Weight {
 
         List<String> engineFiles = KNNCodecUtil.getEngineFiles(knnEngine.getExtension(), knnQuery.getField(), reader.getSegmentInfo().info);
         if (engineFiles.isEmpty()) {
-            log.debug("[KNN] No engine index found for field {} for segment {}", knnQuery.getField(), reader.getSegmentName());
-            return null;
+            log.debug("[KNN] No native engine files found for field {} for segment {}", knnQuery.getField(), reader.getSegmentName());
+            return Collections.emptyMap();
         }
 
         Path indexPath = PathUtils.get(directory, engineFiles.get(0));
@@ -364,16 +359,9 @@ public class KNNWeight extends Weight {
             indexAllocation.readUnlock();
             indexAllocation.decRef();
         }
-
-        /*
-         * Scores represent the distance of the documents with respect to given query vector.
-         * Lesser the score, the closer the document is to the query vector.
-         * Since by default results are retrieved in the descending order of scores, to get the nearest
-         * neighbors we are inverting the scores.
-         */
         if (results.length == 0) {
             log.debug("[KNN] Query yielded 0 results");
-            return null;
+            return Collections.emptyMap();
         }
 
         if (quantizedVector != null) {
@@ -386,7 +374,6 @@ public class KNNWeight extends Weight {
 
     /**
      * Execute exact search for the given matched doc ids and return the results as a map of docId to score.
-     *
      * @return Map of docId to score for the exact search results.
      * @throws IOException If an error occurs during the search.
      */
@@ -407,7 +394,10 @@ public class KNNWeight extends Weight {
         return -score + 1;
     }
 
-    private boolean canDoExactSearch(final int filterIdsCount) {
+    private boolean isFilteredExactSearchPreferred(final int filterIdsCount) {
+        if (filterWeight == null) {
+            return false;
+        }
         log.debug(
             "Info for doing exact search filterIdsLength : {}, Threshold value: {}",
             filterIdsCount,
@@ -447,13 +437,58 @@ public class KNNWeight extends Weight {
     }
 
     /**
-     * This condition mainly checks during filtered search we have more than K elements in filterIds but the ANN
-     * doesn't yeild K nearest neighbors.
+     * This condition mainly checks whether exact search should be performed or not
+     * @param context LeafReaderContext
      * @param filterIdsCount count of filtered Doc ids
      * @param annResultCount Count of Nearest Neighbours we got after doing filtered ANN Search.
      * @return boolean - true if exactSearch needs to be done after ANNSearch.
      */
-    private boolean canDoExactSearchAfterANNSearch(final int filterIdsCount, final int annResultCount) {
+    private boolean isExactSearchRequire(final LeafReaderContext context, final int filterIdsCount, final int annResultCount) {
+        if (annResultCount == 0 && isMissingNativeEngineFiles(context)) {
+            log.debug("Perform exact search after approximate search since no native engine files are available");
+            return true;
+        }
+        if (isFilteredExactSearchRequireAfterANNSearch(filterIdsCount, annResultCount)) {
+            log.debug(
+                "Doing ExactSearch after doing ANNSearch as the number of documents returned are less than "
+                    + "K, even when we have more than K filtered Ids. K: {}, ANNResults: {}, filteredIdCount: {}",
+                this.knnQuery.getK(),
+                annResultCount,
+                filterIdsCount
+            );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * This condition mainly checks during filtered search we have more than K elements in filterIds but the ANN
+     * doesn't yield K nearest neighbors.
+     * @param filterIdsCount count of filtered Doc ids
+     * @param annResultCount Count of Nearest Neighbours we got after doing filtered ANN Search.
+     * @return boolean - true if exactSearch needs to be done after ANNSearch.
+     */
+    private boolean isFilteredExactSearchRequireAfterANNSearch(final int filterIdsCount, final int annResultCount) {
         return filterWeight != null && filterIdsCount >= knnQuery.getK() && knnQuery.getK() > annResultCount;
+    }
+
+    /**
+     * This condition mainly checks whether segments has native engine files or not
+     * @return boolean - false if exactSearch needs to be done since no native engine files are in segments.
+     */
+    private boolean isMissingNativeEngineFiles(LeafReaderContext context) {
+        final SegmentReader reader = Lucene.segmentReader(context.reader());
+        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        // if segment has no documents with at least 1 vector field, field info will be null
+        if (fieldInfo == null) {
+            return false;
+        }
+        final KNNEngine knnEngine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
+        final List<String> engineFiles = KNNCodecUtil.getEngineFiles(
+            knnEngine.getExtension(),
+            knnQuery.getField(),
+            reader.getSegmentInfo().info
+        );
+        return engineFiles.isEmpty();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
@@ -95,8 +96,13 @@ public class KNNWeight extends Weight {
     }
 
     public static void initialize(ModelDao modelDao) {
+        initialize(modelDao, new ExactSearcher(modelDao));
+    }
+
+    @VisibleForTesting
+    static void initialize(ModelDao modelDao, ExactSearcher exactSearcher) {
         KNNWeight.modelDao = modelDao;
-        KNNWeight.DEFAULT_EXACT_SEARCHER = new ExactSearcher(modelDao);
+        KNNWeight.DEFAULT_EXACT_SEARCHER = exactSearcher;
     }
 
     @Override
@@ -204,8 +210,8 @@ public class KNNWeight extends Weight {
 
     private Map<Integer, Float> doExactSearch(final LeafReaderContext context, final BitSet acceptedDocs, int k) throws IOException {
         final ExactSearcherContextBuilder exactSearcherContextBuilder = ExactSearcher.ExactSearcherContext.builder()
-            .k(k)
             .isParentHits(true)
+            .k(k)
             // setting to true, so that if quantization details are present we want to do search on the quantized
             // vectors as this flow is used in first pass of search.
             .useQuantizedVectorsForSearch(true)
@@ -403,12 +409,9 @@ public class KNNWeight extends Weight {
             filterIdsCount,
             KNNSettings.getFilteredExactSearchThreshold(knnQuery.getIndexName())
         );
-        if (knnQuery.getRadius() != null) {
-            return false;
-        }
         int filterThresholdValue = KNNSettings.getFilteredExactSearchThreshold(knnQuery.getIndexName());
         // Refer this GitHub around more details https://github.com/opensearch-project/k-NN/issues/1049 on the logic
-        if (filterIdsCount <= knnQuery.getK()) {
+        if (knnQuery.getRadius() == null && filterIdsCount <= knnQuery.getK()) {
             return true;
         }
         // See user has defined Exact Search filtered threshold. if yes, then use that setting.

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -88,6 +88,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
                 .indexName(indexName)
                 .parentsFilter(parentFilter)
                 .radius(radius)
+                .vectorDataType(vectorDataType)
                 .methodParameters(methodParameters)
                 .context(knnQueryContext)
                 .filterQuery(filterQuery)

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -57,7 +57,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         List<LeafReaderContext> leafReaderContexts = reader.leaves();
         List<Map<Integer, Float>> perLeafResults;
         RescoreContext rescoreContext = knnQuery.getRescoreContext();
-        int finalK = knnQuery.getK();
+        final int finalK = knnQuery.getK();
         if (rescoreContext == null) {
             perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, finalK);
         } else {

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -92,6 +92,7 @@ public class FaissIT extends KNNRestTestCase {
     private static final String INTEGER_FIELD_NAME = "int_field";
     private static final String FILED_TYPE_INTEGER = "integer";
     private static final String NON_EXISTENT_INTEGER_FIELD_NAME = "nonexistent_int_field";
+    public static final int NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = -1;
 
     static TestUtils.TestData testData;
 
@@ -622,10 +623,11 @@ public class FaissIT extends KNNRestTestCase {
 
         // Assert we have the right number of documents in the index
         assertEquals(numDocs, getDocCount(indexName));
-        // KNN Query should return empty result
+
         final Response searchResponse = searchKNNIndex(indexName, buildSearchQuery(fieldName, 1, queryVector, null), 1);
         final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
-        assertEquals(0, results.size());
+        // expect result due to exact search
+        assertEquals(1, results.size());
 
         deleteKNNIndex(indexName);
         validateGraphEviction();
@@ -681,7 +683,7 @@ public class FaissIT extends KNNRestTestCase {
         // KNN Query should return empty result
         final Response searchResponse = searchKNNIndex(indexName, buildSearchQuery(fieldName, 1, queryVector, null), 1);
         final List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
-        assertEquals(0, results.size());
+        assertEquals(1, results.size());
 
         // update index setting to build graph and do force merge
         // update build vector data structure setting
@@ -1827,6 +1829,111 @@ public class FaissIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testEndToEnd_whenDoRadiusSearch_whenNoGraphFileIsCreated_whenDistanceThreshold_thenSucceed() {
+        final SpaceType spaceType = SpaceType.L2;
+
+        final List<Integer> mValues = ImmutableList.of(16, 32, 64, 128);
+        final List<Integer> efConstructionValues = ImmutableList.of(16, 32, 64, 128);
+        final List<Integer> efSearchValues = ImmutableList.of(16, 32, 64, 128);
+
+        final Integer dimension = testData.indexData.vectors[0].length;
+        final Settings knnIndexSettings = buildKNNIndexSettings(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
+
+        // Create an index
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_M, mValues.get(random().nextInt(mValues.size())))
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstructionValues.get(random().nextInt(efConstructionValues.size())))
+            .field(KNNConstants.METHOD_PARAMETER_EF_SEARCH, efSearchValues.get(random().nextInt(efSearchValues.size())))
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        createKnnIndex(INDEX_NAME, knnIndexSettings, builder.toString());
+
+        // Index the test data
+        for (int i = 0; i < testData.indexData.docs.length; i++) {
+            addKnnDoc(
+                INDEX_NAME,
+                Integer.toString(testData.indexData.docs[i]),
+                FIELD_NAME,
+                Floats.asList(testData.indexData.vectors[i]).toArray()
+            );
+        }
+
+        // Assert we have the right number of documents
+        refreshAllNonSystemIndices();
+        assertEquals(testData.indexData.docs.length, getDocCount(INDEX_NAME));
+
+        final float distance = 300000000000f;
+        final List<List<KNNResult>> resultsFromDistance = validateRadiusSearchResults(
+            INDEX_NAME,
+            FIELD_NAME,
+            testData.queries,
+            distance,
+            null,
+            spaceType,
+            null,
+            null
+        );
+        assertFalse(resultsFromDistance.isEmpty());
+        resultsFromDistance.forEach(result -> { assertFalse(result.isEmpty()); });
+        final float score = spaceType.scoreTranslation(distance);
+        final List<List<KNNResult>> resultsFromScore = validateRadiusSearchResults(
+            INDEX_NAME,
+            FIELD_NAME,
+            testData.queries,
+            null,
+            score,
+            spaceType,
+            null,
+            null
+        );
+        assertFalse(resultsFromScore.isEmpty());
+        resultsFromScore.forEach(result -> { assertFalse(result.isEmpty()); });
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testRadialQueryWithFilter_whenNoGraphIsCreated_thenSuccess() {
+        setupKNNIndexForFilterQuery(buildKNNIndexSettings(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD));
+
+        final float[][] searchVector = new float[][] { { 3.3f, 3.0f, 5.0f } };
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery("color", "red");
+        List<String> expectedDocIds = Arrays.asList(DOC_ID_3);
+
+        float distance = 15f;
+        List<List<KNNResult>> queryResult = validateRadiusSearchResults(
+            INDEX_NAME,
+            FIELD_NAME,
+            searchVector,
+            distance,
+            null,
+            SpaceType.L2,
+            termQueryBuilder,
+            null
+        );
+
+        assertEquals(1, queryResult.get(0).size());
+        assertEquals(expectedDocIds.get(0), queryResult.get(0).get(0).getDocId());
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
     public void testQueryWithFilter_whenNonExistingFieldUsedInFilter_thenSuccessful() {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
@@ -1898,6 +2005,10 @@ public class FaissIT extends KNNRestTestCase {
     }
 
     protected void setupKNNIndexForFilterQuery() throws Exception {
+        setupKNNIndexForFilterQuery(getKNNDefaultIndexSettings());
+    }
+
+    protected void setupKNNIndexForFilterQuery(Settings settings) throws Exception {
         // Create Mappings
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
@@ -1915,7 +2026,7 @@ public class FaissIT extends KNNRestTestCase {
             .endObject();
         final String mapping = builder.toString();
 
-        createKnnIndex(INDEX_NAME, mapping);
+        createKnnIndex(INDEX_NAME, settings, mapping);
 
         addKnnDocWithAttributes(
             DOC_ID_1,

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -626,7 +626,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         createKnnIndex(indexName, settings, knnIndexMapping);
         final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
             indexName,
-            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
+            KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD
         );
         assertNotNull("build_vector_data_structure_threshold index setting is not found", buildVectorDataStructureThresholdSetting);
         assertEquals(
@@ -643,7 +643,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         createKnnIndex(indexName, knnIndexMapping);
         final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
             indexName,
-            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
+            KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD
         );
         assertNull(
             "build_vector_data_structure_threshold index setting should not be added in index setting",
@@ -658,13 +658,13 @@ public class OpenSearchIT extends KNNRestTestCase {
         createKnnIndex(indexName, knnIndexMapping);
         final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
             indexName,
-            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD,
             true
         );
         assertNotNull("build_vector_data_structure index setting is not found", buildVectorDataStructureThresholdSetting);
         assertEquals(
             "incorrect default setting for build_vector_data_structure_threshold",
-            KNNSettings.INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE,
             Integer.valueOf(buildVectorDataStructureThresholdSetting)
         );
         deleteKNNIndex(indexName);
@@ -736,7 +736,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         assertEquals("unexpected neighbors are returned", faissNeighbors.size(), faissNeighbors.size());
 
         // update build vector data structure setting
-        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0));
         forceMergeKnnIndex(indexName, 1);
 
         final int k = 10;
@@ -881,7 +881,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         assertEquals("unexpected neighbors are returned", faissNeighbors.size(), faissNeighbors.size());
 
         // update build vector data structure setting
-        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0));
         forceMergeKnnIndex(indexName, 1);
 
         final int k = 10;

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -672,7 +672,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
     /*
         For this testcase, we will create index with setting build_vector_data_structure_threshold as -1, then index few documents, perform knn search,
-        then, confirm no hits since there are no graph. In next step, update setting to 0, force merge segment to 1, perform knn search and confirm expected
+        then, confirm hits because of exact search though there are no graph. In next step, update setting to 0, force merge segment to 1, perform knn search and confirm expected
         hits are returned.
      */
     public void testKNNIndex_whenBuildVectorGraphThresholdIsProvidedEndToEnd_thenBuildGraphBasedOnSetting() throws Exception {
@@ -730,10 +730,10 @@ public class OpenSearchIT extends KNNRestTestCase {
         assertEquals(testData.indexData.docs.length, getDocCount(indexName));
 
         final List<KNNResult> nmslibNeighbors = getResults(indexName, fieldName1, testData.queries[0], 1);
-        assertEquals("unexpected neighbors are returned", 0, nmslibNeighbors.size());
+        assertEquals("unexpected neighbors are returned", nmslibNeighbors.size(), nmslibNeighbors.size());
 
         final List<KNNResult> faissNeighbors = getResults(indexName, fieldName2, testData.queries[0], 1);
-        assertEquals("unexpected neighbors are returned", 0, faissNeighbors.size());
+        assertEquals("unexpected neighbors are returned", faissNeighbors.size(), faissNeighbors.size());
 
         // update build vector data structure setting
         updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
 import java.util.Locale;
 import lombok.SneakyThrows;
+import org.apache.hc.core5.http.ParseException;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.opensearch.knn.KNNRestTestCase;
@@ -42,6 +43,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN;
 
 public class OpenSearchIT extends KNNRestTestCase {
 
@@ -611,4 +614,211 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         fail("Graphs are not getting evicted");
     }
+
+    public void testKNNIndex_whenBuildGraphThresholdIsPresent_thenGetThresholdValue() throws Exception {
+        final Integer buildVectorDataStructureThreshold = randomIntBetween(
+            INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
+            INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX
+        );
+        final Settings settings = Settings.builder().put(buildKNNIndexSettings(buildVectorDataStructureThreshold)).build();
+        final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
+        final String indexName = "test-index-with-build-graph-settings";
+        createKnnIndex(indexName, settings, knnIndexMapping);
+        final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
+            indexName,
+            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
+        );
+        assertNotNull("build_vector_data_structure_threshold index setting is not found", buildVectorDataStructureThresholdSetting);
+        assertEquals(
+            "incorrect setting for build_vector_data_structure_threshold",
+            buildVectorDataStructureThreshold,
+            Integer.valueOf(buildVectorDataStructureThresholdSetting)
+        );
+        deleteKNNIndex(indexName);
+    }
+
+    public void testKNNIndex_whenBuildThresholdIsNotProvided_thenShouldNotReturnSetting() throws Exception {
+        final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
+        final String indexName = "test-index-with-build-graph-settings";
+        createKnnIndex(indexName, knnIndexMapping);
+        final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
+            indexName,
+            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
+        );
+        assertNull(
+            "build_vector_data_structure_threshold index setting should not be added in index setting",
+            buildVectorDataStructureThresholdSetting
+        );
+        deleteKNNIndex(indexName);
+    }
+
+    public void testKNNIndex_whenGetIndexSettingWithDefaultIsCalled_thenReturnDefaultBuildGraphThresholdValue() throws Exception {
+        final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
+        final String indexName = "test-index-with-build-vector-graph-settings";
+        createKnnIndex(indexName, knnIndexMapping);
+        final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
+            indexName,
+            KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            true
+        );
+        assertNotNull("build_vector_data_structure index setting is not found", buildVectorDataStructureThresholdSetting);
+        assertEquals(
+            "incorrect default setting for build_vector_data_structure_threshold",
+            KNNSettings.INDEX_KNN_DEFAULT_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            Integer.valueOf(buildVectorDataStructureThresholdSetting)
+        );
+        deleteKNNIndex(indexName);
+    }
+
+    /*
+        For this testcase, we will create index with setting build_vector_data_structure_threshold as -1, then index few documents, perform knn search,
+        then, confirm no hits since there are no graph. In next step, update setting to 0, force merge segment to 1, perform knn search and confirm expected
+        hits are returned.
+     */
+    public void testKNNIndex_whenBuildVectorGraphThresholdIsProvidedEndToEnd_thenBuildGraphBasedOnSetting() throws Exception {
+        final String indexName = "test-index-1";
+        final String fieldName1 = "test-field-1";
+        final String fieldName2 = "test-field-2";
+
+        final Integer dimension = testData.indexData.vectors[0].length;
+        final Settings knnIndexSettings = buildKNNIndexSettings(-1);
+
+        // Create an index
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName1)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.NMSLIB.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .endObject()
+            .endObject()
+            .endObject()
+            .startObject(fieldName2)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, knnIndexSettings, builder.toString());
+
+        // Index the test data
+        for (int i = 0; i < testData.indexData.docs.length; i++) {
+            addKnnDoc(
+                indexName,
+                Integer.toString(testData.indexData.docs[i]),
+                ImmutableList.of(fieldName1, fieldName2),
+                ImmutableList.of(
+                    Floats.asList(testData.indexData.vectors[i]).toArray(),
+                    Floats.asList(testData.indexData.vectors[i]).toArray()
+                )
+            );
+        }
+
+        refreshAllIndices();
+        // Assert we have the right number of documents in the index
+        assertEquals(testData.indexData.docs.length, getDocCount(indexName));
+
+        final List<KNNResult> nmslibNeighbors = getResults(indexName, fieldName1, testData.queries[0], 1);
+        assertEquals("unexpected neighbors are returned", 0, nmslibNeighbors.size());
+
+        final List<KNNResult> faissNeighbors = getResults(indexName, fieldName2, testData.queries[0], 1);
+        assertEquals("unexpected neighbors are returned", 0, faissNeighbors.size());
+
+        // update build vector data structure setting
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        forceMergeKnnIndex(indexName, 1);
+
+        final int k = 10;
+        for (int i = 0; i < testData.queries.length; i++) {
+            // Search nmslib field
+            final Response response = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName1, testData.queries[i], k), k);
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            final List<KNNResult> nmslibValidNeighbors = parseSearchResponse(responseBody, fieldName1);
+            assertEquals(k, nmslibValidNeighbors.size());
+            // Search faiss field
+            final List<KNNResult> faissValidNeighbors = getResults(indexName, fieldName2, testData.queries[i], k);
+            assertEquals(k, faissValidNeighbors.size());
+        }
+
+        // Delete index
+        deleteKNNIndex(indexName);
+    }
+
+    /*
+        For this testcase, we will create index with setting build_vector_data_structure_threshold number of documents to ingest, then index x documents, perform knn search,
+        then, confirm expected hits are returned. Here, we don't need force merge to build graph, since, threshold is less than
+        actual number of documents in segments
+     */
+    public void testKNNIndex_whenBuildVectorDataStructureIsLessThanDocCount_thenBuildGraphBasedSuccessfully() throws Exception {
+        final String indexName = "test-index-1";
+        final String fieldName = "test-field-1";
+
+        final Integer dimension = testData.indexData.vectors[0].length;
+        final Settings knnIndexSettings = buildKNNIndexSettings(testData.indexData.docs.length);
+
+        // Create an index
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.NMSLIB.getName())
+            .startObject(KNNConstants.PARAMETERS)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, knnIndexSettings, builder.toString());
+        // Disable refresh
+        updateIndexSettings(indexName, Settings.builder().put("index.refresh_interval", -1));
+
+        // Index the test data without refresh on every document
+        for (int i = 0; i < testData.indexData.docs.length; i++) {
+            addKnnDoc(
+                indexName,
+                Integer.toString(testData.indexData.docs[i]),
+                ImmutableList.of(fieldName),
+                ImmutableList.of(Floats.asList(testData.indexData.vectors[i]).toArray()),
+                false
+            );
+        }
+
+        refreshAllIndices();
+        // Assert we have the right number of documents in the index
+        assertEquals(testData.indexData.docs.length, getDocCount(indexName));
+
+        final int k = 10;
+        for (int i = 0; i < testData.queries.length; i++) {
+            final Response response = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName, testData.queries[i], k), k);
+            final String responseBody = EntityUtils.toString(response.getEntity());
+            final List<KNNResult> nmslibValidNeighbors = parseSearchResponse(responseBody, fieldName);
+            assertEquals(k, nmslibValidNeighbors.size());
+        }
+        // Delete index
+        deleteKNNIndex(indexName);
+    }
+
+    private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)
+        throws IOException, ParseException {
+        final Response searchResponseField = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName, vector, k), k);
+        final String searchResponseBody = EntityUtils.toString(searchResponseField.getEntity());
+        return parseSearchResponse(searchResponseBody, fieldName);
+    }
+
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngineFieldVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngineFieldVectorsWriterTests.java
@@ -126,6 +126,5 @@ public class NativeEngineFieldVectorsWriterTests extends KNNCodecTestCase {
         // testing for value > 0 as we don't have a concrete way to find out expected bytes. This can OS dependent too.
         Assert.assertTrue(byteWriter.ramBytesUsed() > 0);
         Mockito.verify(mockedFlatFieldVectorsWriter, Mockito.times(2)).ramBytesUsed();
-
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -31,10 +31,12 @@ import org.opensearch.knn.quantization.models.quantizationParams.QuantizationPar
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -52,6 +54,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RequiredArgsConstructor
@@ -76,12 +79,14 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
 
     private final String description;
     private final List<Map<Integer, float[]>> vectorsPerField;
+    private static final Integer BUILD_GRAPH_ALWAYS_THRESHOLD = 0;
+    private static final Integer BUILD_GRAPH_NEVER_THRESHOLD = -1;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter);
+        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter,BUILD_GRAPH_ALWAYS_THRESHOLD);
         mockedFlatFieldVectorsWriter = Mockito.mock(FlatFieldVectorsWriter.class);
         Mockito.doNothing().when(mockedFlatFieldVectorsWriter).addValue(Mockito.anyInt(), Mockito.any());
         Mockito.when(flatVectorsWriter.addField(Mockito.any())).thenReturn(mockedFlatFieldVectorsWriter);
@@ -296,6 +301,329 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 () -> KNNVectorValuesFactory.getVectorValues(any(VectorDataType.class), any(DocsWithFieldSet.class), any()),
                 times(Math.toIntExact(expectedTimesGetVectorValuesIsCalled) * 2)
             );
+        }
+    }
+
+    public void testFlush_whenThresholdIsNegative_thenNativeIndexWriterIsNeverCalled() throws IOException {
+        // Given
+        List<KNNVectorValues<float[]>> expectedVectorValues = new ArrayList<>();
+        IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+            final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                new ArrayList<>(vectorsPerField.get(i).values())
+            );
+            final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                randomVectorValues
+            );
+            expectedVectorValues.add(knnVectorValues);
+
+        });
+
+        final NativeEngines990KnnVectorsWriter nativeEngineWriter = new NativeEngines990KnnVectorsWriter(
+            segmentWriteState,
+            flatVectorsWriter,
+            BUILD_GRAPH_NEVER_THRESHOLD
+        );
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                final FieldInfo fieldInfo = fieldInfo(
+                    i,
+                    VectorEncoding.FLOAT32,
+                    Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+                );
+
+                NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
+                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                    .thenReturn(field);
+                try {
+                    nativeEngineWriter.addField(fieldInfo);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                DocsWithFieldSet docsWithFieldSet = field.getDocsWithField();
+                knnVectorValuesFactoryMockedStatic.when(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
+                ).thenReturn(expectedVectorValues.get(i));
+
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+                nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                    .thenReturn(nativeIndexWriter);
+            });
+
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).flushIndex(any(), anyInt());
+
+            // When
+            nativeEngineWriter.flush(5, null);
+
+            // Then
+            verify(flatVectorsWriter).flush(5, null);
+            if (vectorsPerField.size() > 0) {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+            }
+            verifyNoInteractions(nativeIndexWriter);
+        }
+    }
+
+    public void testFlush_whenThresholdIsGreaterThanVectorSize_thenNativeIndexWriterIsNeverCalled() throws IOException {
+        // Given
+        List<KNNVectorValues<float[]>> expectedVectorValues = new ArrayList<>();
+        final Map<Integer, Integer> sizeMap = new HashMap<>();
+        IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+            final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                new ArrayList<>(vectorsPerField.get(i).values())
+            );
+            final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                randomVectorValues
+            );
+            sizeMap.put(i, randomVectorValues.size());
+            expectedVectorValues.add(knnVectorValues);
+
+        });
+        final int maxThreshold = sizeMap.values().stream().filter(count -> count != 0).max(Integer::compareTo).orElse(0);
+        final NativeEngines990KnnVectorsWriter nativeEngineWriter = new NativeEngines990KnnVectorsWriter(
+            segmentWriteState,
+            flatVectorsWriter,
+            maxThreshold + 1
+        );
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                final FieldInfo fieldInfo = fieldInfo(
+                    i,
+                    VectorEncoding.FLOAT32,
+                    Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+                );
+
+                NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
+                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                    .thenReturn(field);
+                try {
+                    nativeEngineWriter.addField(fieldInfo);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                DocsWithFieldSet docsWithFieldSet = field.getDocsWithField();
+                knnVectorValuesFactoryMockedStatic.when(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
+                ).thenReturn(expectedVectorValues.get(i));
+
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+                nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                    .thenReturn(nativeIndexWriter);
+            });
+
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).flushIndex(any(), anyInt());
+
+            // When
+            nativeEngineWriter.flush(5, null);
+
+            // Then
+            verify(flatVectorsWriter).flush(5, null);
+            if (vectorsPerField.size() > 0) {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+            }
+            verifyNoInteractions(nativeIndexWriter);
+        }
+    }
+
+    public void testFlush_whenThresholdIsEqualToMinNumberOfVectors_thenNativeIndexWriterIsCalled() throws IOException {
+        // Given
+        List<KNNVectorValues<float[]>> expectedVectorValues = new ArrayList<>();
+        final Map<Integer, Integer> sizeMap = new HashMap<>();
+        IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+            final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                new ArrayList<>(vectorsPerField.get(i).values())
+            );
+            final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                randomVectorValues
+            );
+            sizeMap.put(i, randomVectorValues.size());
+            expectedVectorValues.add(knnVectorValues);
+
+        });
+
+        final int minThreshold = sizeMap.values().stream().filter(count -> count != 0).min(Integer::compareTo).orElse(0);
+        final NativeEngines990KnnVectorsWriter nativeEngineWriter = new NativeEngines990KnnVectorsWriter(
+            segmentWriteState,
+            flatVectorsWriter,
+            minThreshold
+        );
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                final FieldInfo fieldInfo = fieldInfo(
+                    i,
+                    VectorEncoding.FLOAT32,
+                    Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+                );
+
+                NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
+                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                    .thenReturn(field);
+                try {
+                    nativeEngineWriter.addField(fieldInfo);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                DocsWithFieldSet docsWithFieldSet = field.getDocsWithField();
+                knnVectorValuesFactoryMockedStatic.when(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
+                ).thenReturn(expectedVectorValues.get(i));
+
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+                nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                    .thenReturn(nativeIndexWriter);
+            });
+
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).flushIndex(any(), anyInt());
+
+            // When
+            nativeEngineWriter.flush(5, null);
+
+            // Then
+            verify(flatVectorsWriter).flush(5, null);
+            if (vectorsPerField.size() > 0) {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+                assertTrue((long) KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.getValue() > 0);
+            }
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                try {
+                    if (vectorsPerField.get(i).size() > 0) {
+                        verify(nativeIndexWriter).flushIndex(expectedVectorValues.get(i), vectorsPerField.get(i).size());
+                    } else {
+                        verify(nativeIndexWriter, never()).flushIndex(expectedVectorValues.get(i), vectorsPerField.get(i).size());
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    public void testFlush_whenThresholdIsEqualToFixedValue_thenRelevantNativeIndexWriterIsCalled() throws IOException {
+        // Given
+        List<KNNVectorValues<float[]>> expectedVectorValues = new ArrayList<>();
+        IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+            final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+                new ArrayList<>(vectorsPerField.get(i).values())
+            );
+            final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+                VectorDataType.FLOAT,
+                randomVectorValues
+            );
+            expectedVectorValues.add(knnVectorValues);
+
+        });
+        final int threshold = 4;
+        final NativeEngines990KnnVectorsWriter nativeEngineWriter = new NativeEngines990KnnVectorsWriter(
+            segmentWriteState,
+            flatVectorsWriter,
+            threshold
+        );
+
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                final FieldInfo fieldInfo = fieldInfo(
+                    i,
+                    VectorEncoding.FLOAT32,
+                    Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+                );
+
+                NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
+                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                    .thenReturn(field);
+                try {
+                    nativeEngineWriter.addField(fieldInfo);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+                DocsWithFieldSet docsWithFieldSet = field.getDocsWithField();
+                knnVectorValuesFactoryMockedStatic.when(
+                    () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
+                ).thenReturn(expectedVectorValues.get(i));
+
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+                nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                    .thenReturn(nativeIndexWriter);
+            });
+
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).flushIndex(any(), anyInt());
+
+            // When
+            nativeEngineWriter.flush(5, null);
+
+            // Then
+            verify(flatVectorsWriter).flush(5, null);
+            if (vectorsPerField.size() > 0) {
+                assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+                assertTrue((long) KNNGraphValue.REFRESH_TOTAL_TIME_IN_MILLIS.getValue() > 0);
+            }
+            IntStream.range(0, vectorsPerField.size()).forEach(i -> {
+                try {
+                    if (vectorsPerField.get(i).size() >= threshold) {
+                        verify(nativeIndexWriter).flushIndex(expectedVectorValues.get(i), vectorsPerField.get(i).size());
+                    } else {
+                        verify(nativeIndexWriter, never()).flushIndex(expectedVectorValues.get(i), vectorsPerField.get(i).size());
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -86,7 +86,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter,BUILD_GRAPH_ALWAYS_THRESHOLD);
+        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter, BUILD_GRAPH_ALWAYS_THRESHOLD);
         mockedFlatFieldVectorsWriter = Mockito.mock(FlatFieldVectorsWriter.class);
         Mockito.doNothing().when(mockedFlatFieldVectorsWriter).addValue(Mockito.anyInt(), Mockito.any());
         Mockito.when(flatVectorsWriter.addField(Mockito.any())).thenReturn(mockedFlatFieldVectorsWriter);
@@ -343,8 +343,9 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 );
 
                 NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
-                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                    .thenReturn(field);
+                fieldWriterMockedStatic.when(
+                    () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+                ).thenReturn(field);
                 try {
                     nativeEngineWriter.addField(fieldInfo);
                 } catch (Exception e) {
@@ -419,8 +420,9 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 );
 
                 NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
-                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                    .thenReturn(field);
+                fieldWriterMockedStatic.when(
+                    () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+                ).thenReturn(field);
                 try {
                     nativeEngineWriter.addField(fieldInfo);
                 } catch (Exception e) {
@@ -496,8 +498,9 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 );
 
                 NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
-                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                    .thenReturn(field);
+                fieldWriterMockedStatic.when(
+                    () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+                ).thenReturn(field);
                 try {
                     nativeEngineWriter.addField(fieldInfo);
                 } catch (Exception e) {
@@ -581,8 +584,9 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 );
 
                 NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
-                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                    .thenReturn(field);
+                fieldWriterMockedStatic.when(
+                    () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+                ).thenReturn(field);
                 try {
                     nativeEngineWriter.addField(fieldInfo);
                 } catch (Exception e) {
@@ -669,8 +673,9 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 );
 
                 NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
-                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                    .thenReturn(field);
+                fieldWriterMockedStatic.when(
+                    () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+                ).thenReturn(field);
 
                 try {
                     nativeEngineWriter.addField(fieldInfo);
@@ -771,8 +776,9 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                 );
 
                 NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, vectorsPerField.get(i));
-                fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                    .thenReturn(field);
+                fieldWriterMockedStatic.when(
+                    () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+                ).thenReturn(field);
 
                 try {
                     nativeEngineWriter.addField(fieldInfo);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -34,6 +34,7 @@ import org.opensearch.knn.quantization.models.quantizationParams.QuantizationPar
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,12 +78,14 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
     private final String description;
     private final Map<Integer, float[]> mergedVectors;
     private FlatFieldVectorsWriter mockedFlatFieldVectorsWriter;
+    private static final Integer BUILD_GRAPH_ALWAYS_THRESHOLD = 0;
+    private static final Integer BUILD_GRAPH_NEVER_THRESHOLD = -1;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter);
+        objectUnderTest = new NativeEngines990KnnVectorsWriter(segmentWriteState, flatVectorsWriter, BUILD_GRAPH_ALWAYS_THRESHOLD);
         mockedFlatFieldVectorsWriter = Mockito.mock(FlatFieldVectorsWriter.class);
         Mockito.doNothing().when(mockedFlatFieldVectorsWriter).addValue(Mockito.anyInt(), Mockito.any());
         Mockito.when(flatVectorsWriter.addField(Mockito.any())).thenReturn(mockedFlatFieldVectorsWriter);
@@ -156,6 +159,124 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues),
                     times(2)
                 );
+            } else {
+                verifyNoInteractions(nativeIndexWriter);
+            }
+        }
+    }
+
+    public void testMerge_whenThresholdIsNegative_thenNativeIndexWriterIsNeverCalled() throws IOException {
+        // Given
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            new ArrayList<>(mergedVectors.values())
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+        final NativeEngines990KnnVectorsWriter nativeEngineWriter = new NativeEngines990KnnVectorsWriter(
+            segmentWriteState,
+            flatVectorsWriter,
+            BUILD_GRAPH_NEVER_THRESHOLD
+        );
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedStatic<KnnVectorsWriter.MergedVectorValues> mergedVectorValuesMockedStatic = mockStatic(
+                KnnVectorsWriter.MergedVectorValues.class
+            );
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            final FieldInfo fieldInfo = fieldInfo(
+                0,
+                VectorEncoding.FLOAT32,
+                Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+            );
+
+            NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, mergedVectors);
+            fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                .thenReturn(field);
+
+            mergedVectorValuesMockedStatic.when(() -> KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState))
+                .thenReturn(floatVectorValues);
+            knnVectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues))
+                .thenReturn(knnVectorValues);
+
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+            nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                .thenReturn(nativeIndexWriter);
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).mergeIndex(any(), anyInt());
+
+            // When
+            nativeEngineWriter.mergeOneField(fieldInfo, mergeState);
+
+            // Then
+            verify(flatVectorsWriter).mergeOneField(fieldInfo, mergeState);
+            assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+            verifyNoInteractions(nativeIndexWriter);
+        }
+    }
+
+    public void testMerge_whenThresholdIsEqualToNumberOfVectors_thenNativeIndexWriterIsCalled() throws IOException {
+        // Given
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            new ArrayList<>(mergedVectors.values())
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+        final NativeEngines990KnnVectorsWriter nativeEngineWriter = new NativeEngines990KnnVectorsWriter(
+            segmentWriteState,
+            flatVectorsWriter,
+            mergedVectors.size()
+        );
+        try (
+            MockedStatic<NativeEngineFieldVectorsWriter> fieldWriterMockedStatic = mockStatic(NativeEngineFieldVectorsWriter.class);
+            MockedStatic<KNNVectorValuesFactory> knnVectorValuesFactoryMockedStatic = mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<QuantizationService> quantizationServiceMockedStatic = mockStatic(QuantizationService.class);
+            MockedStatic<NativeIndexWriter> nativeIndexWriterMockedStatic = mockStatic(NativeIndexWriter.class);
+            MockedStatic<KnnVectorsWriter.MergedVectorValues> mergedVectorValuesMockedStatic = mockStatic(
+                KnnVectorsWriter.MergedVectorValues.class
+            );
+            MockedConstruction<KNN990QuantizationStateWriter> knn990QuantWriterMockedConstruction = mockConstruction(
+                KNN990QuantizationStateWriter.class
+            );
+        ) {
+            quantizationServiceMockedStatic.when(() -> QuantizationService.getInstance()).thenReturn(quantizationService);
+            final FieldInfo fieldInfo = fieldInfo(
+                0,
+                VectorEncoding.FLOAT32,
+                Map.of(KNNConstants.VECTOR_DATA_TYPE_FIELD, "float", KNNConstants.KNN_ENGINE, "faiss")
+            );
+
+            NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, mergedVectors);
+            fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
+                .thenReturn(field);
+
+            mergedVectorValuesMockedStatic.when(() -> KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState))
+                .thenReturn(floatVectorValues);
+            knnVectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues))
+                .thenReturn(knnVectorValues);
+
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
+            nativeIndexWriterMockedStatic.when(() -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null))
+                .thenReturn(nativeIndexWriter);
+            doAnswer(answer -> {
+                Thread.sleep(2); // Need this for KNNGraph value assertion, removing this will fail the assertion
+                return null;
+            }).when(nativeIndexWriter).mergeIndex(any(), anyInt());
+
+            // When
+            nativeEngineWriter.mergeOneField(fieldInfo, mergeState);
+
+            // Then
+            verify(flatVectorsWriter).mergeOneField(fieldInfo, mergeState);
+            assertEquals(0, knn990QuantWriterMockedConstruction.constructed().size());
+            if (!mergedVectors.isEmpty()) {
+                verify(nativeIndexWriter).mergeIndex(knnVectorValues, mergedVectors.size());
             } else {
                 verifyNoInteractions(nativeIndexWriter);
             }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -196,8 +196,9 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
             );
 
             NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, mergedVectors);
-            fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                .thenReturn(field);
+            fieldWriterMockedStatic.when(
+                () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+            ).thenReturn(field);
 
             mergedVectorValuesMockedStatic.when(() -> KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState))
                 .thenReturn(floatVectorValues);
@@ -253,8 +254,9 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
             );
 
             NativeEngineFieldVectorsWriter field = nativeEngineFieldVectorsWriter(fieldInfo, mergedVectors);
-            fieldWriterMockedStatic.when(() -> NativeEngineFieldVectorsWriter.create(fieldInfo, segmentWriteState.infoStream))
-                .thenReturn(field);
+            fieldWriterMockedStatic.when(
+                () -> NativeEngineFieldVectorsWriter.create(fieldInfo, mockedFlatFieldVectorsWriter, segmentWriteState.infoStream)
+            ).thenReturn(field);
 
             mergedVectorValuesMockedStatic.when(() -> KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState))
                 .thenReturn(floatVectorValues);

--- a/src/test/java/org/opensearch/knn/index/query/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExactSearcherTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.KNNCodecVersion;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.KNNRestTestCase.FIELD_NAME;
+import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+
+public class ExactSearcherTests extends KNNTestCase {
+
+    private static final String SEGMENT_NAME = "0";
+
+    @SneakyThrows
+    public void testRadialSearch_whenNoEngineFiles_thenSuccess() {
+        try (MockedStatic<KNNVectorValuesFactory> valuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+            final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+            final List<float[]> dataVectors = Arrays.asList(
+                new float[] { 11.0f, 12.0f, 13.0f },
+                new float[] { 14.0f, 15.0f, 16.0f },
+                new float[] { 17.0f, 18.0f, 19.0f }
+            );
+            final List<Float> expectedScores = dataVectors.stream()
+                .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
+                .collect(Collectors.toList());
+            final Float score = Collections.min(expectedScores);
+            final float radius = KNNEngine.FAISS.scoreToRadialThreshold(score, spaceType);
+            final int maxResults = 1000;
+            final KNNQuery.Context context = mock(KNNQuery.Context.class);
+            when(context.getMaxResultWindow()).thenReturn(maxResults);
+            KNNWeight.initialize(null);
+
+            final KNNQuery query = KNNQuery.builder()
+                .field(FIELD_NAME)
+                .queryVector(queryVector)
+                .radius(radius)
+                .indexName(INDEX_NAME)
+                .context(context)
+                .build();
+
+            final ExactSearcher.ExactSearcherContext.ExactSearcherContextBuilder exactSearcherContextBuilder =
+                ExactSearcher.ExactSearcherContext.builder()
+                    // setting to true, so that if quantization details are present we want to do search on the quantized
+                    // vectors as this flow is used in first pass of search.
+                    .useQuantizedVectorsForSearch(false)
+                    .knnQuery(query);
+
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FSDirectory directory = mock(FSDirectory.class);
+            when(reader.directory()).thenReturn(directory);
+            final SegmentInfo segmentInfo = new SegmentInfo(
+                directory,
+                Version.LATEST,
+                Version.LATEST,
+                SEGMENT_NAME,
+                100,
+                false,
+                false,
+                KNNCodecVersion.current().getDefaultCodecDelegate(),
+                Map.of(),
+                new byte[StringHelper.ID_LENGTH],
+                Map.of(),
+                Sort.RELEVANCE
+            );
+            segmentInfo.setFiles(Set.of());
+            final SegmentCommitInfo segmentCommitInfo = new SegmentCommitInfo(segmentInfo, 0, 0, 0, 0, 0, new byte[StringHelper.ID_LENGTH]);
+            when(reader.getSegmentInfo()).thenReturn(segmentCommitInfo);
+
+            final Path path = mock(Path.class);
+            when(directory.getDirectory()).thenReturn(path);
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
+            when(fieldInfo.attributes()).thenReturn(
+                Map.of(
+                    SPACE_TYPE,
+                    spaceType.getValue(),
+                    KNN_ENGINE,
+                    KNNEngine.FAISS.getName(),
+                    PARAMETERS,
+                    String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+                )
+            );
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            KNNFloatVectorValues floatVectorValues = mock(KNNFloatVectorValues.class);
+            valuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader)).thenReturn(floatVectorValues);
+            when(floatVectorValues.nextDoc()).thenReturn(0, 1, 2, NO_MORE_DOCS);
+            when(floatVectorValues.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
+            final Map<Integer, Float> integerFloatMap = exactSearcher.searchLeaf(leafReaderContext, exactSearcherContextBuilder.build());
+            assertEquals(integerFloatMap.size(), dataVectors.size());
+            assertEquals(expectedScores, new ArrayList<>(integerFloatMap.values()));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -90,6 +90,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
@@ -361,7 +362,6 @@ public class KNNWeightTests extends KNNTestCase {
         final Path path = mock(Path.class);
         when(directory.getDirectory()).thenReturn(path);
         final FieldInfos fieldInfos = mock(FieldInfos.class);
-        final FieldInfo fieldInfo = mock(FieldInfo.class);
         when(reader.getFieldInfos()).thenReturn(fieldInfos);
         // When no knn fields are available , field info for vector field will be null
         when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(null);
@@ -867,6 +867,83 @@ public class KNNWeightTests extends KNNTestCase {
             assertEquals(docIdSetIterator.cost(), actualDocIds.size());
             assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
         }
+    }
+
+    @SneakyThrows
+    public void testRadialSearch_whenNoEngineFiles_thenPerformExactSearch() {
+        ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        KNNWeight.initialize(null, mockedExactSearcher);
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .indexName(INDEX_NAME)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .build();
+        final KNNWeight knnWeight = new KNNWeight(query, 1.0f);
+
+        final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        final SegmentReader reader = mock(SegmentReader.class);
+        when(leafReaderContext.reader()).thenReturn(reader);
+
+        final FSDirectory directory = mock(FSDirectory.class);
+        when(reader.directory()).thenReturn(directory);
+        final SegmentInfo segmentInfo = new SegmentInfo(
+            directory,
+            Version.LATEST,
+            Version.LATEST,
+            SEGMENT_NAME,
+            100,
+            false,
+            false,
+            KNNCodecVersion.current().getDefaultCodecDelegate(),
+            Map.of(),
+            new byte[StringHelper.ID_LENGTH],
+            Map.of(),
+            Sort.RELEVANCE
+        );
+        segmentInfo.setFiles(Set.of());
+        final SegmentCommitInfo segmentCommitInfo = new SegmentCommitInfo(segmentInfo, 0, 0, 0, 0, 0, new byte[StringHelper.ID_LENGTH]);
+        when(reader.getSegmentInfo()).thenReturn(segmentCommitInfo);
+
+        final Path path = mock(Path.class);
+        when(directory.getDirectory()).thenReturn(path);
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(reader.getFieldInfos()).thenReturn(fieldInfos);
+        when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+        when(fieldInfo.attributes()).thenReturn(
+            Map.of(
+                SPACE_TYPE,
+                spaceType.getValue(),
+                KNN_ENGINE,
+                KNNEngine.FAISS.getName(),
+                PARAMETERS,
+                String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+            )
+        );
+        final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
+            .isParentHits(true)
+            // setting to true, so that if quantization details are present we want to do search on the quantized
+            // vectors as this flow is used in first pass of search.
+            .useQuantizedVectorsForSearch(true)
+            .knnQuery(query)
+            .build();
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            assertEquals(DOC_ID_TO_SCORES.get(docId), knnScorer.score(), 0.00000001f);
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+        // verify JNI Service is not called
+        jniServiceMockedStatic.verifyNoInteractions();
+        verify(mockedExactSearcher).searchLeaf(leafReaderContext, exactSearchContext);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -328,8 +328,9 @@ public class KNNWeightTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testShardWithoutFiles() {
+    public void testScorer_whenNoVectorFieldsInDocument_thenEmptyScorerIsReturned() {
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, (BitSetProducer) null);
+        KNNWeight.initialize(null);
         final KNNWeight knnWeight = new KNNWeight(query, 0.0f);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
@@ -362,8 +363,8 @@ public class KNNWeightTests extends KNNTestCase {
         final FieldInfos fieldInfos = mock(FieldInfos.class);
         final FieldInfo fieldInfo = mock(FieldInfo.class);
         when(reader.getFieldInfos()).thenReturn(fieldInfos);
-        when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
-
+        // When no knn fields are available , field info for vector field will be null
+        when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(null);
         final Scorer knnScorer = knnWeight.scorer(leafReaderContext);
         assertEquals(KNNScorer.emptyScorer(knnWeight), knnScorer);
     }

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
@@ -118,10 +118,7 @@ public class BinaryIndexIT extends KNNRestTestCase {
         assertEquals(1, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
 
         // update build vector data structure setting
-        updateIndexSettings(
-            INDEX_NAME,
-            Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, ALWAYS_BUILD_GRAPH)
-        );
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, ALWAYS_BUILD_GRAPH));
         forceMergeKnnIndex(INDEX_NAME, 1);
 
         int k = 100;
@@ -144,10 +141,7 @@ public class BinaryIndexIT extends KNNRestTestCase {
         assertEquals(1, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
 
         // update build vector data structure setting
-        updateIndexSettings(
-            INDEX_NAME,
-            Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, ALWAYS_BUILD_GRAPH)
-        );
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, ALWAYS_BUILD_GRAPH));
         forceMergeKnnIndex(INDEX_NAME, 1);
 
         int k = 100;

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
@@ -118,7 +118,10 @@ public class BinaryIndexIT extends KNNRestTestCase {
         assertEquals(1, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
 
         // update build vector data structure setting
-        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        updateIndexSettings(
+            INDEX_NAME,
+            Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, ALWAYS_BUILD_GRAPH)
+        );
         forceMergeKnnIndex(INDEX_NAME, 1);
 
         int k = 100;
@@ -133,7 +136,7 @@ public class BinaryIndexIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testFaissHnswBinary_whenBuildVectorGraphThresholdIsProvidedEndToEnd_thenBuildGraphBasedOnSetting() throws Exception {
+    public void testFaissHnswBinary_whenBuildVectorGraphThresholdIsProvidedEndToEnd_thenBuildGraphBasedOnSetting() {
         // Create Index
         createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 128, testData.indexData.docs.length);
         ingestTestData(INDEX_NAME, FIELD_NAME, false);
@@ -141,7 +144,10 @@ public class BinaryIndexIT extends KNNRestTestCase {
         assertEquals(1, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
 
         // update build vector data structure setting
-        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        updateIndexSettings(
+            INDEX_NAME,
+            Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, ALWAYS_BUILD_GRAPH)
+        );
         forceMergeKnnIndex(INDEX_NAME, 1);
 
         int k = 100;

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
@@ -13,11 +14,13 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNJsonIndexMappingsBuilder;
 import org.opensearch.knn.KNNJsonQueryBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -36,6 +39,8 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 @Log4j2
 public class BinaryIndexIT extends KNNRestTestCase {
     private static TestUtils.TestData testData;
+    private static final int NEVER_BUILD_GRAPH = -1;
+    private static final int ALWAYS_BUILD_GRAPH = 0;
 
     @BeforeClass
     public static void setUpClass() throws IOException {
@@ -105,6 +110,52 @@ public class BinaryIndexIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testFaissHnswBinary_whenBuildVectorGraphThresholdIsNegativeEndToEnd_thenBuildGraphBasedOnSetting() {
+        // Create Index
+        createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 128, NEVER_BUILD_GRAPH);
+        ingestTestData(INDEX_NAME, FIELD_NAME);
+
+        assertEquals(0, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
+
+        // update build vector data structure setting
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        int k = 100;
+        for (int i = 0; i < testData.queries.length; i++) {
+            List<KNNResult> knnResults = runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[i], k);
+            float recall = getRecall(
+                Set.of(Arrays.copyOf(testData.groundTruthValues[i], k)),
+                knnResults.stream().map(KNNResult::getDocId).collect(Collectors.toSet())
+            );
+            assertTrue("Recall: " + recall, recall > 0.1);
+        }
+    }
+
+    @SneakyThrows
+    public void testFaissHnswBinary_whenBuildVectorGraphThresholdIsProvidedEndToEnd_thenBuildGraphBasedOnSetting() throws Exception {
+        // Create Index
+        createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 128, testData.indexData.docs.length);
+        ingestTestData(INDEX_NAME, FIELD_NAME, false);
+
+        assertEquals(0, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
+
+        // update build vector data structure setting
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
+        forceMergeKnnIndex(INDEX_NAME, 1);
+
+        int k = 100;
+        for (int i = 0; i < testData.queries.length; i++) {
+            List<KNNResult> knnResults = runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[i], k);
+            float recall = getRecall(
+                Set.of(Arrays.copyOf(testData.groundTruthValues[i], k)),
+                knnResults.stream().map(KNNResult::getDocId).collect(Collectors.toSet())
+            );
+            assertTrue("Recall: " + recall, recall > 0.1);
+        }
+    }
+
+    @SneakyThrows
     public void testFaissHnswBinary_whenRadialSearch_thenThrowException() {
         // Create Index
         createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 16);
@@ -157,13 +208,18 @@ public class BinaryIndexIT extends KNNRestTestCase {
     }
 
     private void ingestTestData(final String indexName, final String fieldName) throws Exception {
+        ingestTestData(indexName, fieldName, true);
+    }
+
+    private void ingestTestData(final String indexName, final String fieldName, boolean refresh) throws Exception {
         // Index the test data
         for (int i = 0; i < testData.indexData.docs.length; i++) {
             addKnnDoc(
                 indexName,
                 Integer.toString(testData.indexData.docs[i]),
-                fieldName,
-                Floats.asList(testData.indexData.vectors[i]).toArray()
+                ImmutableList.of(fieldName),
+                ImmutableList.of(Floats.asList(testData.indexData.vectors[i]).toArray()),
+                refresh
             );
         }
 
@@ -172,8 +228,13 @@ public class BinaryIndexIT extends KNNRestTestCase {
         assertEquals(testData.indexData.docs.length, getDocCount(indexName));
     }
 
-    private void createKnnHnswBinaryIndex(final KNNEngine knnEngine, final String indexName, final String fieldName, final int dimension)
-        throws IOException {
+    private void createKnnHnswBinaryIndex(
+        final KNNEngine knnEngine,
+        final String indexName,
+        final String fieldName,
+        final int dimension,
+        final int threshold
+    ) throws IOException {
         KNNJsonIndexMappingsBuilder.Method method = KNNJsonIndexMappingsBuilder.Method.builder()
             .methodName(METHOD_HNSW)
             .engine(knnEngine.getName())
@@ -186,7 +247,11 @@ public class BinaryIndexIT extends KNNRestTestCase {
             .method(method)
             .build()
             .getIndexMapping();
+        createKnnIndex(indexName, buildKNNIndexSettings(threshold), knnIndexMapping);
+    }
 
-        createKnnIndex(indexName, knnIndexMapping);
+    private void createKnnHnswBinaryIndex(final KNNEngine knnEngine, final String indexName, final String fieldName, final int dimension)
+        throws IOException {
+        createKnnHnswBinaryIndex(knnEngine, indexName, fieldName, dimension, ALWAYS_BUILD_GRAPH);
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
@@ -115,7 +115,7 @@ public class BinaryIndexIT extends KNNRestTestCase {
         createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 128, NEVER_BUILD_GRAPH);
         ingestTestData(INDEX_NAME, FIELD_NAME);
 
-        assertEquals(0, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
+        assertEquals(1, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
 
         // update build vector data structure setting
         updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));
@@ -138,7 +138,7 @@ public class BinaryIndexIT extends KNNRestTestCase {
         createKnnHnswBinaryIndex(KNNEngine.FAISS, INDEX_NAME, FIELD_NAME, 128, testData.indexData.docs.length);
         ingestTestData(INDEX_NAME, FIELD_NAME, false);
 
-        assertEquals(0, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
+        assertEquals(1, runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[0], 1).size());
 
         // update build vector data structure setting
         updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0));

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -775,12 +775,12 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .build();
     }
 
-    protected Settings buildKNNIndexSettings(int buildVectorDatastructureThreshold) {
+    protected Settings buildKNNIndexSettings(int approximateThreshold) {
         return Settings.builder()
             .put("number_of_shards", 1)
             .put("number_of_replicas", 0)
             .put(KNN_INDEX, true)
-            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, buildVectorDatastructureThreshold)
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, approximateThreshold)
             .build();
     }
 

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -100,6 +100,8 @@ import static org.opensearch.knn.TestUtils.QUERY_VALUE;
 import static org.opensearch.knn.TestUtils.computeGroundTruthValues;
 
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
 import static org.opensearch.knn.index.SpaceType.L2;
 import static org.opensearch.knn.index.memory.NativeMemoryCacheManager.GRAPH_COUNT;
 import static org.opensearch.knn.index.engine.KNNEngine.FAISS;
@@ -638,7 +640,12 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Add a single KNN Doc to an index with multiple fields
      */
     protected void addKnnDoc(String index, String docId, List<String> fieldNames, List<Object[]> vectors) throws IOException {
-        Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
+        addKnnDoc(index, docId, fieldNames, vectors, true);
+    }
+
+    protected void addKnnDoc(String index, String docId, List<String> fieldNames, List<Object[]> vectors, boolean refresh)
+        throws IOException {
+        Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=" + refresh);
 
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         for (int i = 0; i < fieldNames.size(); i++) {
@@ -765,6 +772,15 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .put("number_of_replicas", 1)
             .put("index.knn", true)
             .put("index.replication.type", "SEGMENT")
+            .build();
+    }
+
+    protected Settings buildKNNIndexSettings(int buildVectorDatastructureThreshold) {
+        return Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put(KNN_INDEX, true)
+            .put(INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, buildVectorDatastructureThreshold)
             .build();
     }
 

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -100,7 +100,7 @@ import static org.opensearch.knn.TestUtils.QUERY_VALUE;
 import static org.opensearch.knn.TestUtils.computeGroundTruthValues;
 
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
-import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
 import static org.opensearch.knn.index.SpaceType.L2;
 import static org.opensearch.knn.index.memory.NativeMemoryCacheManager.GRAPH_COUNT;
@@ -780,7 +780,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             .put("number_of_shards", 1)
             .put("number_of_replicas", 0)
             .put(KNN_INDEX, true)
-            .put(INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, buildVectorDatastructureThreshold)
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, buildVectorDatastructureThreshold)
             .build();
     }
 


### PR DESCRIPTION
### Description
Added new updatable index setting "approximate_threshold", which will be
considered when to build graph or not for native engines. This is noop for lucene. 
When graph is not available, plugin will return empty results. With this change, exact search will be performed when only no engine file is available in segment. 
Radial search was never included as part of exact search. This will break radial search when threshold
is added and radial search is requested. Hence, introduce exact search during radial search similar to Approx search.

### Related Issues
#1942 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
