### PR TITLE
[Backport 2.x] Preloads .vec and .vex files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 ### Bug Fixes 
 * Add DocValuesProducers for releasing memory when close index [#1946](https://github.com/opensearch-project/k-NN/pull/1946)
+* Prelaods vec and vex files to address regression in force merge latencies [#2186](https://github.com/opensearch-project/k-NN/pull/2186)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibrary.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.engine;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.SpaceType;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -137,6 +136,6 @@ public interface KNNLibrary extends MethodResolver {
      * @return list of file extensions that will be read/write with mmap
      */
     default List<String> mmapFileExtensions() {
-        return Collections.emptyList();
+        return List.of("vec", "vex");
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/Lucene.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/Lucene.java
@@ -15,7 +15,6 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodResolver;
 import org.opensearch.knn.index.engine.ResolvedMethodContext;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -87,11 +86,6 @@ public class Lucene extends JVMLibrary {
     public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
         // Lucene engine uses distance as is and does not need transformation
         return score;
-    }
-
-    @Override
-    public List<String> mmapFileExtensions() {
-        return List.of("vec", "vex");
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -365,6 +366,14 @@ public class FaissTests extends KNNTestCase {
         assertEquals(expectedKNNMethodContext.getPerDimensionProcessor(), actualKNNLibraryIndexingContext.getPerDimensionProcessor());
         assertEquals(expectedKNNMethodContext.getPerDimensionValidator(), actualKNNLibraryIndexingContext.getPerDimensionValidator());
         assertEquals(expectedKNNMethodContext.getVectorValidator(), actualKNNLibraryIndexingContext.getVectorValidator());
+    }
+
+    public void testMmapFileExtensions() {
+        final List<String> mMapExtensions = Faiss.INSTANCE.mmapFileExtensions();
+        assertNotNull(mMapExtensions);
+        final List<String> expectedSettings = List.of("vex", "vec");
+        assertTrue(expectedSettings.containsAll(mMapExtensions));
+        assertTrue(mMapExtensions.containsAll(expectedSettings));
     }
 
 }

--- a/src/test/java/org/opensearch/knn/index/engine/nmslib/NMSLibTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/nmslib/NMSLibTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.nmslib;
+
+import org.opensearch.knn.KNNTestCase;
+
+import java.util.List;
+
+public class NMSLibTests extends KNNTestCase {
+
+    public void testMmapFileExtensions() {
+        final List<String> mmapExtensions = Nmslib.INSTANCE.mmapFileExtensions();
+        assertNotNull(mmapExtensions);
+        final List<String> expectedSettings = List.of("vex", "vec");
+        assertTrue(expectedSettings.containsAll(mmapExtensions));
+        assertTrue(mmapExtensions.containsAll(expectedSettings));
+    }
+}

--- a/src/test/java/org/opensearch/knn/plugin/KNNPluginTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/KNNPluginTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.plugin;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+public class KNNPluginTests extends OpenSearchTestCase {
+
+    public void testKNNPlugin_additionalSettings() throws IOException {
+        try (KNNPlugin knnPlugin = new KNNPlugin()) {
+            Settings additionalSettings = knnPlugin.additionalSettings();
+            List<String> expectedHybrid = List.of("nvd", "dvd", "tim", "tip", "dim", "kdd", "kdi", "cfs", "doc", "vec", "vex");
+
+            Settings settings = Settings.builder().putList("index.store.hybrid.mmap.extensions", expectedHybrid).build();
+            assertEquals(settings, additionalSettings);
+        }
+    }
+
+    public void testKNNPlugin_additionalIndexProviderSettings() throws IOException {
+        try (KNNPlugin knnPlugin = new KNNPlugin()) {
+            Settings additionalSettings = knnPlugin.getAdditionalIndexSettingProviders()
+                .iterator()
+                .next()
+                .getAdditionalIndexSettings("index", false, Settings.builder().put(KNNSettings.KNN_INDEX, Boolean.TRUE).build());
+
+            Settings settings = Settings.builder().putList("index.store.preload", List.of("vec", "vex")).build();
+            assertEquals(settings, additionalSettings);
+
+            additionalSettings = knnPlugin.getAdditionalIndexSettingProviders()
+                .iterator()
+                .next()
+                .getAdditionalIndexSettings("index", false, Settings.builder().build());
+
+            assertEquals(Settings.EMPTY, additionalSettings);
+        }
+    }
+}


### PR DESCRIPTION
LuceneFlatVectorReader uses IOContext.Random to open the read. IOContext.Random indicates the kernel to not read ahead the pages on to physical memory. This causes an increase in merge time due to increase of read ops at runtime.

The preload settings signals the kernal to preload the files when the reader is opened

### Description
Backport for https://github.com/opensearch-project/k-NN/pull/2186/files

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
