### PR TITLE
Lucene99 to backward_codecs per bump to 9.12 in core

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
@@ -12,7 +12,7 @@ import org.apache.lucene.backward_codecs.lucene92.Lucene92Codec;
 import org.apache.lucene.backward_codecs.lucene94.Lucene94Codec;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.backward_codecs.lucene95.Lucene95Codec;
-import org.apache.lucene.codecs.lucene99.Lucene99Codec;
+import org.apache.lucene.backward_codecs.lucene99.Lucene99Codec;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;


### PR DESCRIPTION
### Description
Lucene bumped in Opensearch here: https://github.com/opensearch-project/OpenSearch/pull/15333
It looks like Lucene99Codec is deprecated and needs to be updated to use the backwards compatible implementation.

https://github.com/opensearch-project/OpenSearch/commit/146b0f7264b1426d475e757729d213097b776212#diff-48f2642fce5a8906ea46c9d4796ed3477e49c6fd91eaaa9ba03f6b840837930bL12

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
