### PR TITLE
Adding shatejas as the maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @ryanbogan @luyuncheng
+*   @heemin32 @navneet1v @VijayanB @vamshin @jmazanec15 @naveentatikonda @junqiu-lei @martin-gaievski @ryanbogan @luyuncheng @shatejas

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Naveen Tatikonda        | [naveentatikonda](https://github.com/naveentatikonda) | Amazon      |
 | Navneet Verma           | [navneet1v](https://github.com/navneet1v)             | Amazon      |
 | Ryan Bogan              | [ryanbogan](https://github.com/ryanbogan)             | Amazon      |
+| Tejas Shah              | [shatejas](https://github.com/shatejas)               | Amazon      |
 | Vamshi Vijay Nakkirtha  | [vamshin](https://github.com/vamshin)                 | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      |
 | Yuncheng Lu             | [luyuncheng](https://github.com/luyuncheng)           | Bytedance   |
+


### PR DESCRIPTION
### Description
Adding shatejas as the maintainer. The approval was taken from the maintainer of k-NN repo over email. 

Process followed: https://github.com/opensearch-project/.github/blob/main/ADMINS.md#addremove-maintainers

### Related Issues
NA

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
