### PR TITLE
Bump byte-buddy to 1.15.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,9 +295,9 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version:'32.1.3-jre'
     api group: 'commons-lang', name: 'commons-lang', version: '2.6'
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.9'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.15.4'
     testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.2'
-    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.14.9'
+    testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: '1.15.4'
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     implementation 'com.github.oshi:oshi-core:6.4.13'
     api "net.java.dev.jna:jna:5.13.0"


### PR DESCRIPTION
### Description
Bump byte-buddy to 1.15.4 to fix build failure and keep it [consistent with core](https://github.com/opensearch-project/OpenSearch/pull/16257/files#diff-ffefe72fc1ee096585e9d66d31384a4c489667cdc2e4a752e9c3183eaad6621fR65)

https://github.com/opensearch-project/k-NN/actions/runs/11296486595/job/31421473604?pr=2203
```
> Conflict found for the following module:
For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
       - net.bytebuddy:byte-buddy between versions 1.15.4 and 1.14.9
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
