### PR TITLE
Minor code fixes to remove code inconsistencies.

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -188,7 +188,7 @@ public class KNNQuery extends Query {
 
     @Override
     public void visit(QueryVisitor visitor) {
-
+        visitor.visitLeaf(this);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -53,7 +53,7 @@ public class NativeEngineKnnVectorQuery extends Query {
     @Override
     public Weight createWeight(IndexSearcher indexSearcher, ScoreMode scoreMode, float boost) throws IOException {
         final IndexReader reader = indexSearcher.getIndexReader();
-        final KNNWeight knnWeight = (KNNWeight) knnQuery.createWeight(indexSearcher, ScoreMode.COMPLETE, 1);
+        final KNNWeight knnWeight = (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1);
         List<LeafReaderContext> leafReaderContexts = reader.leaves();
         List<Map<Integer, Float>> perLeafResults;
         RescoreContext rescoreContext = knnQuery.getRescoreContext();

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -76,6 +76,8 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
     @InjectMocks
     private NativeEngineKnnVectorQuery objectUnderTest;
 
+    private static ScoreMode scoreMode = ScoreMode.TOP_SCORES;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -85,7 +87,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         when(leaf2.reader()).thenReturn(leafReader2);
 
         when(searcher.getIndexReader()).thenReturn(reader);
-        when(knnQuery.createWeight(searcher, ScoreMode.COMPLETE, 1)).thenReturn(knnWeight);
+        when(knnQuery.createWeight(searcher, scoreMode, 1)).thenReturn(knnWeight);
 
         when(searcher.getTaskExecutor()).thenReturn(taskExecutor);
         when(taskExecutor.invokeAll(any())).thenAnswer(invocationOnMock -> {
@@ -135,7 +137,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         Query expected = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, 1);
 
         // When
-        Weight actual = objectUnderTest.createWeight(searcher, ScoreMode.COMPLETE, 1);
+        Weight actual = objectUnderTest.createWeight(searcher, scoreMode, 1);
 
         // Then
         assertEquals(expected, actual.getQuery());
@@ -176,7 +178,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
             mockedResultUtil.when(() -> ResultUtil.reduceToTopK(any(), anyInt())).thenCallRealMethod();
 
             // When
-            Weight actual = objectUnderTest.createWeight(searcher, ScoreMode.COMPLETE, 1);
+            Weight actual = objectUnderTest.createWeight(searcher, scoreMode, 1);
 
             // Then
             mockedResultUtil.verify(() -> ResultUtil.reduceToTopK(any(), anyInt()), times(2));
@@ -199,7 +201,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         Query expected = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, 1);
 
         // When
-        Weight actual = objectUnderTest.createWeight(searcher, ScoreMode.COMPLETE, 1);
+        Weight actual = objectUnderTest.createWeight(searcher, scoreMode, 1);
 
         // Then
         assertEquals(expected, actual.getQuery());
@@ -214,7 +216,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         when(knnQuery.getK()).thenReturn(4);
 
         // When
-        Weight actual = objectUnderTest.createWeight(searcher, ScoreMode.COMPLETE, 1);
+        Weight actual = objectUnderTest.createWeight(searcher, scoreMode, 1);
 
         // Then
         assertEquals(new MatchNoDocsQuery(), actual.getQuery());
@@ -260,7 +262,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
             try (MockedStatic<NativeEngineKnnVectorQuery> mockedStaticNativeKnnVectorQuery = mockStatic(NativeEngineKnnVectorQuery.class)) {
                 mockedStaticNativeKnnVectorQuery.when(() -> NativeEngineKnnVectorQuery.findSegmentStarts(any(), any()))
                     .thenReturn(new int[] { 0, 4, 2 });
-                Weight actual = objectUnderTest.createWeight(searcher, ScoreMode.COMPLETE, 1);
+                Weight actual = objectUnderTest.createWeight(searcher, scoreMode, 1);
                 assertEquals(expected, actual.getQuery());
             }
         }


### PR DESCRIPTION
### Description
Minor code fixes which includes:
* Passing correct score mode in NativeEnginekNNVectorQuery. NativeEnginekNNVectorQuery was always passing `ScoreMode.COMPLETE` ideally it should be the score mode which was passed to createWeight function. 
* Ensuring visitor is called in KnnQuery.


Both these fixes doesn't impact any query performance or fixes a bug, but these were inconsistencies in the code.

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
