### PR TITLE
Remove explicit K from exact search context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Refactoring
 * Does not create additional KNNVectorValues in NativeEngines990KNNVectorWriter when quantization is not needed [#2133](https://github.com/opensearch-project/k-NN/pull/2133)
 * Minor refactoring and refactored some unit test [#2167](https://github.com/opensearch-project/k-NN/pull/2167)
+* Remove explicit K from exact search context  [#2212](https://github.com/opensearch-project/k-NN/pull/2212)

--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -63,11 +63,11 @@ public class ExactSearcher {
         if (exactSearcherContext.getKnnQuery().getRadius() != null) {
             return doRadialSearch(leafReaderContext, exactSearcherContext, iterator);
         }
-        if (exactSearcherContext.getMatchedDocs() != null
-            && exactSearcherContext.getMatchedDocs().cardinality() <= exactSearcherContext.getK()) {
+        final int k = exactSearcherContext.getKnnQuery().getK();
+        if (exactSearcherContext.getMatchedDocs() != null && exactSearcherContext.getMatchedDocs().cardinality() <= k) {
             return scoreAllDocs(iterator);
         }
-        return searchTopCandidates(iterator, exactSearcherContext.getK(), Predicates.alwaysTrue());
+        return searchTopCandidates(iterator, k, Predicates.alwaysTrue());
     }
 
     /**
@@ -232,7 +232,6 @@ public class ExactSearcher {
          * re-scoring we need to re-score using full precision vectors and not quantized vectors.
          */
         boolean useQuantizedVectorsForSearch;
-        int k;
         BitSet matchedDocs;
         KNNQuery knnQuery;
         /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -143,7 +143,7 @@ public class KNNWeight extends Weight {
          * This improves the recall.
          */
         if (isFilteredExactSearchPreferred(cardinality)) {
-            return doExactSearch(context, filterBitSet, k);
+            return doExactSearch(context, filterBitSet);
         }
         Map<Integer, Float> docIdsToScoreMap = doANNSearch(context, filterBitSet, cardinality, k);
         // See whether we have to perform exact search based on approx search results
@@ -151,7 +151,7 @@ public class KNNWeight extends Weight {
         // results less than K, though we have more than k filtered docs
         if (isExactSearchRequire(context, cardinality, docIdsToScoreMap.size())) {
             final BitSet docs = filterWeight != null ? filterBitSet : null;
-            return doExactSearch(context, docs, k);
+            return doExactSearch(context, docs);
         }
         return docIdsToScoreMap;
     }
@@ -208,10 +208,9 @@ public class KNNWeight extends Weight {
         return intArray;
     }
 
-    private Map<Integer, Float> doExactSearch(final LeafReaderContext context, final BitSet acceptedDocs, int k) throws IOException {
+    private Map<Integer, Float> doExactSearch(final LeafReaderContext context, final BitSet acceptedDocs) throws IOException {
         final ExactSearcherContextBuilder exactSearcherContextBuilder = ExactSearcher.ExactSearcherContext.builder()
             .isParentHits(true)
-            .k(k)
             // setting to true, so that if quantization details are present we want to do search on the quantized
             // vectors as this flow is used in first pass of search.
             .useQuantizedVectorsForSearch(true)

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -70,7 +70,7 @@ public class NativeEngineKnnVectorQuery extends Query {
             }
 
             StopWatch stopWatch = new StopWatch().start();
-            perLeafResults = doRescore(indexSearcher, leafReaderContexts, knnWeight, perLeafResults, finalK);
+            perLeafResults = doRescore(indexSearcher, leafReaderContexts, knnWeight, perLeafResults);
             long rescoreTime = stopWatch.stop().totalTime().millis();
             log.debug("Rescoring results took {} ms. oversampled k:{}, segments:{}", rescoreTime, firstPassK, leafReaderContexts.size());
         }
@@ -104,8 +104,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         final IndexSearcher indexSearcher,
         List<LeafReaderContext> leafReaderContexts,
         KNNWeight knnWeight,
-        List<Map<Integer, Float>> perLeafResults,
-        int k
+        List<Map<Integer, Float>> perLeafResults
     ) throws IOException {
         List<Callable<Map<Integer, Float>>> rescoreTasks = new ArrayList<>(leafReaderContexts.size());
         for (int i = 0; i < perLeafResults.size(); i++) {
@@ -117,7 +116,6 @@ public class NativeEngineKnnVectorQuery extends Query {
                     .matchedDocs(convertedBitSet)
                     // setting to false because in re-scoring we want to do exact search on full precision vectors
                     .useQuantizedVectorsForSearch(false)
-                    .k(k)
                     .isParentHits(false)
                     .knnQuery(knnQuery)
                     .build();


### PR DESCRIPTION
### Description
K can be extracted from knn query instead of explicitly passing as input to ExactSearch Context. Previously this was
added mainly with assumption that 'k' can be different from Query if rescore context is not null. However, the main reason we have different K from Query is due to quantization. Having larger K is apt for Approx search, for exact search we don't need to collect more than expected top k from query.

### Related Issues

<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
