### PR TITLE
Update approximate_threshold to 15K documents

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
@@ -22,14 +22,11 @@ public class ClearCacheIT extends AbstractRestartUpgradeTestCase {
         if (isRunningAgainstOldCluster()) {
             createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docId, NUM_DOCS);
-        } else {
             queryCnt = NUM_DOCS;
-            validateClearCacheOnUpgrade(queryCnt);
-
-            docId = NUM_DOCS;
-            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docId, NUM_DOCS);
-
-            queryCnt = queryCnt + NUM_DOCS;
+            int graphCount = getTotalGraphsInCache();
+            knnWarmup(Collections.singletonList(testIndex));
+            assertTrue(getTotalGraphsInCache() > graphCount);
+        } else {
             validateClearCacheOnUpgrade(queryCnt);
             deleteKNNIndex(testIndex);
         }
@@ -37,13 +34,7 @@ public class ClearCacheIT extends AbstractRestartUpgradeTestCase {
 
     // validation steps for Clear Cache API after upgrading node to new version
     private void validateClearCacheOnUpgrade(int queryCount) throws Exception {
-        int graphCount = getTotalGraphsInCache();
-        knnWarmup(Collections.singletonList(testIndex));
-        assertTrue(getTotalGraphsInCache() > graphCount);
-        validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, queryCount, K);
-
         clearCache(Collections.singletonList(testIndex));
         assertEquals(0, getTotalGraphsInCache());
-        validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, queryCount, K);
     }
 }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -9,6 +9,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.index.SpaceType;
 
 import java.util.Collections;
+import java.util.Locale;
 
 import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_M_MIN_VALUE;
 import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE;
@@ -87,7 +88,8 @@ public class WarmupIT extends AbstractRestartUpgradeTestCase {
     public void validateKNNWarmupOnUpgrade() throws Exception {
         int graphCount = getTotalGraphsInCache();
         knnWarmup(Collections.singletonList(testIndex));
-        assertTrue(getTotalGraphsInCache() > graphCount);
+        int totalGraph = getTotalGraphsInCache();
+        assertTrue(String.format(Locale.ROOT, "[%d] is not greater than [%d]", totalGraph, graphCount), totalGraph > graphCount);
 
         QUERY_COUNT = NUM_DOCS;
         validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, QUERY_COUNT, K);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
@@ -25,6 +25,9 @@ public class ClearCacheIT extends AbstractRollingUpgradeTestCase {
                 createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
                 int docIdOld = 0;
                 addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docIdOld, NUM_DOCS);
+                int graphCount = getTotalGraphsInCache();
+                knnWarmup(Collections.singletonList(testIndex));
+                assertTrue(getTotalGraphsInCache() > graphCount);
                 break;
             case UPGRADED:
                 queryCnt = NUM_DOCS;
@@ -42,14 +45,8 @@ public class ClearCacheIT extends AbstractRollingUpgradeTestCase {
 
     // validation steps for Clear Cache API after upgrading all nodes from old version to new version
     public void validateClearCacheOnUpgrade(int queryCount) throws Exception {
-        int graphCount = getTotalGraphsInCache();
-        knnWarmup(Collections.singletonList(testIndex));
-        assertTrue(getTotalGraphsInCache() > graphCount);
-        validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, queryCount, K);
-
         clearCache(Collections.singletonList(testIndex));
         assertEquals(0, getTotalGraphsInCache());
-        validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, queryCount, K);
     }
 
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.knn.bwc;
 
+import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.index.KNNSettings;
+
 import java.util.Collections;
 
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
@@ -33,6 +36,7 @@ public class WarmupIT extends AbstractRollingUpgradeTestCase {
                     docIdMixed = 2 * NUM_DOCS;
                     totalDocsCountMixed = 3 * NUM_DOCS;
                 }
+                updateIndexSettings(testIndex, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0));
                 validateKNNWarmupOnUpgrade(totalDocsCountMixed, docIdMixed);
                 break;
             case UPGRADED:

--- a/release-notes/opensearch-knn.release-notes-2.18.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.18.0.0.md
@@ -14,6 +14,7 @@ Compatible with OpenSearch 2.18.0
 * Add support to build vector data structures greedily and perform exact search when there are no engine files [#1942](https://github.com/opensearch-project/k-NN/issues/1942)
 * Add CompressionLevel Calculation for PQ [#2200](https://github.com/opensearch-project/k-NN/pull/2200)
 * Remove FSDirectory dependency from native engine constructing side and deprecated FileWatcher [#2182](https://github.com/opensearch-project/k-NN/pull/2182)
+* Update approximate_threshold to 15K documents [#2229](https://github.com/opensearch-project/k-NN/pull/2229)
 ### Bug Fixes
 * Add DocValuesProducers for releasing memory when close index [#1946](https://github.com/opensearch-project/k-NN/pull/1946)
 * KNN80DocValues should only be considered for BinaryDocValues fields [#2147](https://github.com/opensearch-project/k-NN/pull/2147)

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -98,7 +98,7 @@ public class KNNSettings {
     public static final boolean KNN_DEFAULT_FAISS_AVX2_DISABLED_VALUE = false;
     public static final boolean KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE = false;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE = "l2";
-    public static final Integer INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE = 0;
+    public static final Integer INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE = 15_000;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN = -1;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX = Integer.MAX_VALUE - 2;
     public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hamming";

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -37,6 +37,10 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
         this(new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer()));
     }
 
+    public NativeEngines990KnnVectorsFormat(int approximateThreshold) {
+        this(new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer()), approximateThreshold);
+    }
+
     public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat) {
         this(flatVectorsFormat, KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/UnitTestCodec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/UnitTestCodec.java
@@ -21,6 +21,8 @@ import org.opensearch.knn.index.codec.KNNCodecVersion;
  * able to pick this class if its in test folder. Don't use this codec outside of testing
  */
 public class UnitTestCodec extends FilterCodec {
+    private static final Integer BUILD_GRAPH_ALWAYS = 0;
+
     public UnitTestCodec() {
         super("UnitTestCodec", KNNCodecVersion.current().getDefaultKnnCodecSupplier().get());
     }
@@ -30,7 +32,7 @@ public class UnitTestCodec extends FilterCodec {
         return new PerFieldKnnVectorsFormat() {
             @Override
             public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-                return new NativeEngines990KnnVectorsFormat();
+                return new NativeEngines990KnnVectorsFormat(BUILD_GRAPH_ALWAYS);
             }
         };
     }

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn;
 
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.cluster.ClusterName;
@@ -14,6 +15,7 @@ import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
@@ -105,6 +107,14 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
     }
 
     /**
+     * Create simple k-NN mapping with engine
+     */
+    protected void updateIndexSetting(String indexName, Settings setting) {
+        UpdateSettingsRequest request = new UpdateSettingsRequest(setting, indexName);
+        OpenSearchAssertions.assertAcked(client().admin().indices().updateSettings(request).actionGet());
+    }
+
+    /**
      * Create simple k-NN mapping which can be nested.
      * e.g. fieldPath = "a.b.c" will create mapping for "c" as knn_vector
      */
@@ -138,6 +148,18 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
      */
     protected Settings getKNNDefaultIndexSettings() {
         return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", true).build();
+    }
+
+    /**
+     * Get default k-NN settings for test cases with build graph always
+     */
+    protected Settings getKNNDefaultIndexSettingsBuildsGraphAlways() {
+        return Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
+            .build();
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
@@ -20,6 +20,8 @@ import static org.opensearch.knn.index.KNNCircuitBreaker.CB_TIME_INTERVAL;
  * Integration tests to test Circuit Breaker functionality
  */
 public class KNNCircuitBreakerIT extends KNNRestTestCase {
+    private static final Integer ALWAYS_BUILD_GRAPH = 0;
+
     /**
      * To trip the circuit breaker, we will create two indices and index documents. Each index will be small enough so
      * that individually they fit into the cache, but together they do not. To prevent Lucene conditions where
@@ -39,6 +41,7 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
             .put("number_of_shards", 1)
             .put("number_of_replicas", numNodes - 1)
             .put("index.knn", true)
+            .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, ALWAYS_BUILD_GRAPH)
             .build();
 
         String indexName1 = INDEX_NAME + "1";

--- a/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
@@ -119,7 +119,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testCacheRebuiltAfterUpdateIndexSettings() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, buildKNNIndexSettings(0), createKnnIndexMapping(FIELD_NAME, 2));
 
         Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);

--- a/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
@@ -21,6 +21,9 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 
 public class KNNESSettingsTestIT extends KNNRestTestCase {
+
+    public static final int ALWAYS_BUILD_GRAPH = 0;
+
     /**
      * KNN Index writes should be blocked when the plugin disabled
      * @throws Exception Exception from test
@@ -72,7 +75,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
     }
 
     public void testItemRemovedFromCache_expiration() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(FIELD_NAME, 2));
         updateClusterSettings(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED, true);
         updateClusterSettings(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES, "1m");
 

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
 import org.mockito.Mockito;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.Engine;
@@ -71,6 +72,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testWarmup_shardPresentInCache() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 2.5F, 3.5F });
 
         searchKNNIndex(testIndexName, testFieldName, new float[] { 1.0f, 2.0f }, 1);
@@ -85,6 +87,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testWarmup_shardNotPresentInCache() throws InterruptedException, ExecutionException, IOException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
         IndexShard indexShard;
         KNNIndexShard knnIndexShard;
 
@@ -106,6 +109,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testGetAllEngineFileContexts() throws IOException, ExecutionException, InterruptedException {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
 
         IndexShard indexShard = indexService.iterator().next();
         KNNIndexShard knnIndexShard = new KNNIndexShard(indexShard);
@@ -204,6 +208,7 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
     public void testClearCache_shardPresentInCache() {
         IndexService indexService = createKNNIndex(testIndexName);
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
+        updateIndexSetting(testIndexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0).build());
         addKnnDoc(testIndexName, String.valueOf(randomInt()), testFieldName, new Float[] { randomFloat(), randomFloat() });
 
         IndexShard indexShard = indexService.iterator().next();

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -155,7 +155,7 @@ public class NmslibIT extends KNNRestTestCase {
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
 
-        createKnnIndex(indexName, mapping);
+        createKnnIndex(indexName, buildKNNIndexSettings(0), mapping);
         assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
 
         // Index the test data

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -113,7 +113,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
-        createKnnIndex(indexName, mapping);
+        createKnnIndex(indexName, buildKNNIndexSettings(0), mapping);
         assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
 
         // Index the test data

--- a/src/test/java/org/opensearch/knn/plugin/action/RestClearCacheHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestClearCacheHandlerIT.java
@@ -25,6 +25,7 @@ import static org.opensearch.knn.common.KNNConstants.CLEAR_CACHE;
 public class RestClearCacheHandlerIT extends KNNRestTestCase {
     private static final String TEST_FIELD = "test-field";
     private static final int DIMENSIONS = 2;
+    public static final int ALWAYS_BUILD_GRAPH = 0;
 
     @SneakyThrows
     public void testNonExistentIndex() {
@@ -53,7 +54,7 @@ public class RestClearCacheHandlerIT extends KNNRestTestCase {
     public void testClearCacheSingleIndex() {
         String testIndex = getTestName().toLowerCase();
         int graphCountBefore = getTotalGraphsInCache();
-        createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+        createKnnIndex(testIndex, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
         addKnnDoc(testIndex, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
 
         knnWarmup(Collections.singletonList(testIndex));
@@ -70,10 +71,10 @@ public class RestClearCacheHandlerIT extends KNNRestTestCase {
         String testIndex2 = getTestName().toLowerCase() + 1;
         int graphCountBefore = getTotalGraphsInCache();
 
-        createKnnIndex(testIndex1, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+        createKnnIndex(testIndex1, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
         addKnnDoc(testIndex1, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
 
-        createKnnIndex(testIndex2, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+        createKnnIndex(testIndex2, buildKNNIndexSettings(0), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
         addKnnDoc(testIndex2, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
 
         knnWarmup(Arrays.asList(testIndex1, testIndex2));
@@ -91,13 +92,13 @@ public class RestClearCacheHandlerIT extends KNNRestTestCase {
         String testIndex3 = "abc" + getTestName().toLowerCase();
         int graphCountBefore = getTotalGraphsInCache();
 
-        createKnnIndex(testIndex1, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+        createKnnIndex(testIndex1, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
         addKnnDoc(testIndex1, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
 
-        createKnnIndex(testIndex2, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+        createKnnIndex(testIndex2, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
         addKnnDoc(testIndex2, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
 
-        createKnnIndex(testIndex3, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+        createKnnIndex(testIndex3, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
         addKnnDoc(testIndex3, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
 
         knnWarmup(Arrays.asList(testIndex1, testIndex2, testIndex3));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -109,7 +109,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
         Integer knnQueryWithFilterCount0 = (Integer) nodeStats0.get(StatNames.KNN_QUERY_WITH_FILTER_REQUESTS.getName());
 
         // Setup index
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, buildKNNIndexSettings(0), createKnnIndexMapping(FIELD_NAME, 2));
 
         // Index test document
         Float[] vector = { 6.0f, 6.0f };
@@ -392,7 +392,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      * @throws IOException throws IOException
      */
     public void testFieldByEngineStats() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2, METHOD_HNSW, NMSLIB_NAME));
+        createKnnIndex(INDEX_NAME, buildKNNIndexSettings(0), createKnnIndexMapping(FIELD_NAME, 2, METHOD_HNSW, NMSLIB_NAME));
         putMappingRequest(INDEX_NAME, createKnnIndexMapping(FIELD_NAME_2, 3, METHOD_HNSW, LUCENE_NAME));
         putMappingRequest(INDEX_NAME, createKnnIndexMapping(FIELD_NAME_3, 3, METHOD_HNSW, FAISS_NAME));
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNWarmupHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNWarmupHandlerIT.java
@@ -47,7 +47,7 @@ public class RestKNNWarmupHandlerIT extends KNNRestTestCase {
 
     public void testSingleIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
-        createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName, buildKNNIndexSettings(0), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         knnWarmup(Collections.singletonList(testIndexName));
@@ -58,10 +58,10 @@ public class RestKNNWarmupHandlerIT extends KNNRestTestCase {
     public void testMultipleIndices() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
 
-        createKnnIndex(testIndexName + "1", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName + "1", buildKNNIndexSettings(0), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName + "1", "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
-        createKnnIndex(testIndexName + "2", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName + "2", buildKNNIndexSettings(0), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName + "2", "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         knnWarmup(Arrays.asList(testIndexName + "1", testIndexName + "2"));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
@@ -82,7 +82,7 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         Integer missCount0 = (Integer) nodeStats0.get(StatNames.MISS_COUNT.getName());
 
         // Setup index
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, buildKNNIndexSettings(0), createKnnIndexMapping(FIELD_NAME, 2));
 
         // Index test document
         Float[] vector = { 6.0f, 6.0f };

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNWarmupHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNWarmupHandlerIT.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 
 public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
 
+    public static final int ALWAYS_BUILD_GRAPH = 0;
     private final String testIndexName = "test-index";
     private final String testFieldName = "test-field";
     private final int dimensions = 2;
@@ -45,7 +46,7 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
 
     public void testEmptyIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
-        createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(testFieldName, dimensions));
 
         executeWarmupRequest(Collections.singletonList(testIndexName), KNNPlugin.LEGACY_KNN_BASE_URI);
 
@@ -54,7 +55,7 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
 
     public void testSingleIndex() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
-        createKnnIndex(testIndexName, getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName, buildKNNIndexSettings(ALWAYS_BUILD_GRAPH), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName, "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         executeWarmupRequest(Collections.singletonList(testIndexName), KNNPlugin.LEGACY_KNN_BASE_URI);
@@ -65,10 +66,10 @@ public class RestLegacyKNNWarmupHandlerIT extends KNNRestTestCase {
     public void testMultipleIndices() throws Exception {
         int graphCountBefore = getTotalGraphsInCache();
 
-        createKnnIndex(testIndexName + "1", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName + "1", buildKNNIndexSettings(0), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName + "1", "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
-        createKnnIndex(testIndexName + "2", getKNNDefaultIndexSettings(), createKnnIndexMapping(testFieldName, dimensions));
+        createKnnIndex(testIndexName + "2", buildKNNIndexSettings(0), createKnnIndexMapping(testFieldName, dimensions));
         addKnnDoc(testIndexName + "2", "1", testFieldName, new Float[] { 6.0f, 6.0f });
 
         executeWarmupRequest(Arrays.asList(testIndexName + "1", testIndexName + "2"), KNNPlugin.LEGACY_KNN_BASE_URI);

--- a/src/test/java/org/opensearch/knn/plugin/transport/ClearCacheTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/ClearCacheTransportActionTests.java
@@ -33,7 +33,7 @@ public class ClearCacheTransportActionTests extends KNNSingleNodeTestCase {
         KNNWarmupTransportAction knnWarmupTransportAction = node().injector().getInstance(KNNWarmupTransportAction.class);
         assertEquals(0, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().size());
 
-        IndexService indexService = createKNNIndex(testIndex);
+        IndexService indexService = createIndex(testIndex, getKNNDefaultIndexSettingsBuildsGraphAlways());
         createKnnIndexMapping(testIndex, TEST_FIELD, DIMENSIONS);
         addKnnDoc(testIndex, String.valueOf(randomInt()), TEST_FIELD, new Float[] { randomFloat(), randomFloat() });
         ShardRouting shardRouting = indexService.iterator().next().routingEntry();

--- a/src/test/java/org/opensearch/knn/plugin/transport/KNNWarmupTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/KNNWarmupTransportActionTests.java
@@ -37,7 +37,7 @@ public class KNNWarmupTransportActionTests extends KNNSingleNodeTestCase {
         KNNWarmupTransportAction knnWarmupTransportAction = node().injector().getInstance(KNNWarmupTransportAction.class);
         assertEquals(0, NativeMemoryCacheManager.getInstance().getIndicesCacheStats().size());
 
-        indexService = createKNNIndex(testIndexName);
+        indexService = createIndex(testIndexName, getKNNDefaultIndexSettingsBuildsGraphAlways());
         createKnnIndexMapping(testIndexName, testFieldName, dimensions);
         shardRouting = indexService.iterator().next().routingEntry();
 

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1309,6 +1309,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             Arrays.fill(indexVector, (float) i);
             addKnnDoc(testIndex, Integer.toString(i), testField, indexVector);
         }
+        flushIndex(testIndex);
     }
 
     public void addKNNByteDocs(String testIndex, String testField, int dimension, int firstDocID, int numDocs) throws IOException {
@@ -1317,6 +1318,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
             Arrays.fill(indexVector, (byte) i);
             addKnnDoc(testIndex, Integer.toString(i), testField, indexVector);
         }
+        flushIndex(testIndex);
     }
 
     public void validateKNNSearch(String testIndex, String testField, int dimension, int numDocs, int k) throws Exception {
@@ -1787,6 +1789,13 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
     protected void refreshIndex(final String index) throws IOException {
         Request request = new Request("POST", "/" + index + "/_refresh");
+
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    protected void flushIndex(final String index) throws IOException {
+        Request request = new Request("POST", "/" + index + "/_flush");
 
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));


### PR DESCRIPTION
### Description
After comparing indexing and search performance, we are updating default value to be 15000.
Updated bwc rolling upgrade test and restart test to reset threshold to 0 to build graph always. Few tests checks
for graph in cache and having 15K will break that test. Hence, when new cluster comes up, we will update the setting to 0, force merge if require, before doing any new indexing.

### Related Issues
#1942 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
