### PR TITLE
Select index settings based on cluster version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Select index settings based on cluster version[2236](https://github.com/opensearch-project/k-NN/pull/2236)
 ### Refactoring

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
@@ -5,7 +5,10 @@
 
 package org.opensearch.knn.bwc;
 
+import org.opensearch.common.settings.Settings;
+
 import java.util.Collections;
+
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
 
 public class ClearCacheIT extends AbstractRestartUpgradeTestCase {
@@ -20,7 +23,11 @@ public class ClearCacheIT extends AbstractRestartUpgradeTestCase {
     public void testClearCache() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         if (isRunningAgainstOldCluster()) {
-            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+            // if approximate threshold is supported, set value to 0, to build graph always
+            Settings indexSettings = isApproximateThresholdSupported(getBWCVersion())
+                ? buildKNNIndexSettings(0)
+                : getKNNDefaultIndexSettings();
+            createKnnIndex(testIndex, indexSettings, createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docId, NUM_DOCS);
             queryCnt = NUM_DOCS;
             int graphCount = getTotalGraphsInCache();

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -143,15 +143,15 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
         // When the cluster is in old version, create a KNN index with custom legacy field mapping settings
         // and add documents into that index
         if (isRunningAgainstOldCluster()) {
-            createKnnIndex(
-                testIndex,
-                createKNNIndexCustomLegacyFieldMappingSettings(
-                    SpaceType.LINF,
-                    KNN_ALGO_PARAM_M_MIN_VALUE,
-                    KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE
-                ),
-                createKnnIndexMapping(TEST_FIELD, DIMENSIONS)
+            Settings.Builder indexMappingSettings = createKNNIndexCustomLegacyFieldMappingIndexSettingsBuilder(
+                SpaceType.LINF,
+                KNN_ALGO_PARAM_M_MIN_VALUE,
+                KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE
             );
+            if (isApproximateThresholdSupported(getBWCVersion())) {
+                indexMappingSettings.put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0);
+            }
+            createKnnIndex(testIndex, indexMappingSettings.build(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
             addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
         } else {
             validateKNNIndexingOnUpgrade(NUM_DOCS);

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/ClearCacheIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.bwc;
 
+import org.opensearch.common.settings.Settings;
+
 import java.util.Collections;
 
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
@@ -22,7 +24,10 @@ public class ClearCacheIT extends AbstractRollingUpgradeTestCase {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
-                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+                Settings indexSettings = isApproximateThresholdSupported(getBWCVersion())
+                    ? buildKNNIndexSettings(0)
+                    : getKNNDefaultIndexSettings();
+                createKnnIndex(testIndex, indexSettings, createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
                 int docIdOld = 0;
                 addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docIdOld, NUM_DOCS);
                 int graphCount = getTotalGraphsInCache();

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -22,7 +22,10 @@ public class WarmupIT extends AbstractRollingUpgradeTestCase {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
-                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+                Settings indexSettings = isApproximateThresholdSupported(getBWCVersion())
+                    ? buildKNNIndexSettings(0)
+                    : getKNNDefaultIndexSettings();
+                createKnnIndex(testIndex, indexSettings, createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
                 addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
                 break;
             case MIXED:

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -13,6 +13,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.net.URIBuilder;
+import org.opensearch.Version;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -64,6 +65,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -1345,15 +1347,22 @@ public class KNNRestTestCase extends ODFERestTestCase {
         }
     }
 
-    protected Settings createKNNIndexCustomLegacyFieldMappingSettings(SpaceType spaceType, Integer m, Integer ef_construction) {
+    protected Settings.Builder createKNNIndexCustomLegacyFieldMappingIndexSettingsBuilder(
+        SpaceType spaceType,
+        Integer m,
+        Integer ef_construction
+    ) {
         return Settings.builder()
             .put(NUMBER_OF_SHARDS, 1)
             .put(NUMBER_OF_REPLICAS, 0)
             .put(INDEX_KNN, true)
             .put(KNNSettings.KNN_SPACE_TYPE, spaceType.getValue())
             .put(KNNSettings.KNN_ALGO_PARAM_M, m)
-            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, ef_construction)
-            .build();
+            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, ef_construction);
+    }
+
+    protected Settings createKNNIndexCustomLegacyFieldMappingIndexSettings(SpaceType spaceType, Integer m, Integer ef_construction) {
+        return createKNNIndexCustomLegacyFieldMappingIndexSettingsBuilder(spaceType, m, ef_construction).build();
     }
 
     public String createKNNIndexMethodFieldMapping(String fieldName, Integer dimensions) throws IOException {
@@ -1858,5 +1867,18 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         builder.endObject().endObject().endObject().endObject();
         return builder;
+    }
+
+    // approximate threshold parameter is only supported on or after V_2_18_0
+    protected boolean isApproximateThresholdSupported(final Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get();
+        if (versionString.endsWith("-SNAPSHOT")) {
+            versionString = versionString.substring(0, versionString.length() - 9);
+        }
+        final Version version = Version.fromString(versionString);
+        return version.onOrAfter(Version.V_2_18_0);
     }
 }


### PR DESCRIPTION
### Description
With https://github.com/opensearch-project/k-NN/pull/2229 , starting 2.18 no graphs will be built if number of document is less than 15K by using default knn index settings. Hence, select index settings based on cluster version, where starting 2.18 it will have "index.knn.advancend.approximate_threshold" set to 0, and uses old defaults for any other cluster that are before 2.18.

### Related Issues
#1942 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
