### PR TITLE
Introduced writing layer, getting rid of writing logic that uses an absolute path in the filesystem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.18...2.x)
 ### Features
 ### Enhancements
+- Introduced a writing layer in native engines where relies on the writing interface to process IO. (#2241)[https://github.com/opensearch-project/k-NN/pull/2241]
 ### Bug Fixes
 ### Infrastructure
 ### Documentation

--- a/jni/cmake/init-nmslib.cmake
+++ b/jni/cmake/init-nmslib.cmake
@@ -19,6 +19,7 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0001-Initialize-maxlevel-during-add-from-enterpoint-level.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0002-Adds-ability-to-pass-ef-parameter-in-the-query-for-h.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0003-Added-streaming-apis-for-vector-index-loading-in-Hnsw.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0004-Added-a-new-save-apis-in-Hnsw-with-streaming-interfa.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib)

--- a/jni/include/commons.h
+++ b/jni/include/commons.h
@@ -8,6 +8,10 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
+
+#ifndef OPENSEARCH_KNN_COMMONS_H
+#define OPENSEARCH_KNN_COMMONS_H
+
 #include "jni_util.h"
 #include <jni.h>
 namespace knn_jni {
@@ -99,3 +103,5 @@ namespace knn_jni {
         int getIntegerMethodParameter(JNIEnv *, knn_jni::JNIUtilInterface *, std::unordered_map<std::string, jobject>, std::string, int);
     }
 }
+
+#endif

--- a/jni/include/faiss_methods.h
+++ b/jni/include/faiss_methods.h
@@ -10,6 +10,7 @@
 #ifndef OPENSEARCH_KNN_FAISS_METHODS_H
 #define OPENSEARCH_KNN_FAISS_METHODS_H
 
+#include "faiss/impl/io.h"
 #include "faiss/Index.h"
 #include "faiss/IndexBinary.h"
 #include "faiss/IndexIDMap.h"
@@ -26,14 +27,21 @@ namespace faiss_wrapper {
 class FaissMethods {
 public:
     FaissMethods() = default;
+
     virtual faiss::Index* indexFactory(int d, const char* description, faiss::MetricType metric);
+
     virtual faiss::IndexBinary* indexBinaryFactory(int d, const char* description);
+
     virtual faiss::IndexIDMapTemplate<faiss::Index>* indexIdMap(faiss::Index* index);
+
     virtual faiss::IndexIDMapTemplate<faiss::IndexBinary>* indexBinaryIdMap(faiss::IndexBinary* index);
-    virtual void writeIndex(const faiss::Index* idx, const char* fname);
-    virtual void writeIndexBinary(const faiss::IndexBinary* idx, const char* fname);
+
+    virtual void writeIndex(const faiss::Index* idx, faiss::IOWriter* writer);
+
+    virtual void writeIndexBinary(const faiss::IndexBinary* idx, faiss::IOWriter* writer);
+
     virtual ~FaissMethods() = default;
-};
+};  // class FaissMethods
 
 } //namespace faiss_wrapper
 } //namespace knn_jni

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -14,6 +14,7 @@
 
 #include "jni_util.h"
 #include "faiss_index_service.h"
+#include "faiss_stream_support.h"
 #include <jni.h>
 
 namespace knn_jni {
@@ -22,25 +23,25 @@ namespace knn_jni {
 
         void InsertToIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jintArray idsJ, jlong vectorsAddressJ, jint dimJ, jlong indexAddr, jint threadCount, IndexService *indexService);
 
-        void WriteIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jstring indexPathJ, jlong indexAddr, IndexService *indexService);
+        void WriteIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jobject output, jlong indexAddr, IndexService *indexService);
 
         // Create an index with ids and vectors. Instead of creating a new index, this function creates the index
         // based off of the template index passed in. The index is serialized to indexPathJ.
         void CreateIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
+                                     jlong vectorsAddressJ, jint dimJ, jobject output, jbyteArray templateIndexJ,
                                      jobject parametersJ);
 
         // Create an index with ids and vectors. Instead of creating a new index, this function creates the index
         // based off of the template index passed in. The index is serialized to indexPathJ.
         void CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
-                                     jobject parametersJ);
+                                           jlong vectorsAddressJ, jint dimJ, jobject output, jbyteArray templateIndexJ,
+                                           jobject parametersJ);
 
         // Create a index with ids and byte vectors. Instead of creating a new index, this function creates the index
         // based off of the template index passed in. The index is serialized to indexPathJ.
         void CreateByteIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ, jbyteArray templateIndexJ,
-                                     jobject parametersJ);
+                                         jlong vectorsAddressJ, jint dimJ, jobject output, jbyteArray templateIndexJ,
+                                         jobject parametersJ);
 
         // Load an index from indexPathJ into memory.
         //
@@ -74,28 +75,28 @@ namespace knn_jni {
         // Sets the sharedIndexState for an index
         void SetSharedIndexState(jlong indexPointerJ, jlong shareIndexStatePointerJ);
 
-         /**
+        /**
          *  Execute a query against the index located in memory at indexPointerJ
-         *  
+         *
          * Parameters:
          * methodParamsJ: introduces a map to have additional method parameters
-         * 
+         *
          * Return an array of KNNQueryResults
-        */
+         */
         jobjectArray QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
                                 jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ, jintArray parentIdsJ);
 
         /**
          *  Execute a query against the index located in memory at indexPointerJ along with Filters
-         *  
+         *
          * Parameters:
          * methodParamsJ: introduces a map to have additional method parameters
-         * 
+         *
          * Return an array of KNNQueryResults
         */
         jobjectArray QueryIndex_WithFilter(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
-                                                                jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ, jlongArray filterIdsJ,
-                                                                jint filterIdsTypeJ, jintArray parentIdsJ);
+                                           jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ, jlongArray filterIdsJ,
+                                           jint filterIdsTypeJ, jintArray parentIdsJ);
 
         // Execute a query against the binary index located in memory at indexPointerJ along with Filters
         //
@@ -124,14 +125,14 @@ namespace knn_jni {
         //
         // Return the serialized representation
         jbyteArray TrainBinaryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ, jint dimension,
-                         jlong trainVectorsPointerJ);
+                                    jlong trainVectorsPointerJ);
 
         // Create an empty byte index defined by the values in the Java map, parametersJ. Train the index with
         // the byte vectors located at trainVectorsPointerJ.
         //
         // Return the serialized representation
         jbyteArray TrainByteIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject parametersJ, jint dimension,
-                         jlong trainVectorsPointerJ);
+                                  jlong trainVectorsPointerJ);
 
         /*
          * Perform a range search with filter against the index located in memory at indexPointerJ.
@@ -163,7 +164,7 @@ namespace knn_jni {
          * @return an array of RangeQueryResults
          */
         jobjectArray RangeSearch(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jlong indexPointerJ, jfloatArray queryVectorJ,
-                    jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jintArray parentIdsJ);
+                                 jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ, jintArray parentIdsJ);
     }
 }
 

--- a/jni/include/memory_util.h
+++ b/jni/include/memory_util.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#ifndef KNNPLUGIN_JNI_INCLUDE_MEMORY_UTIL_H_
+#define KNNPLUGIN_JNI_INCLUDE_MEMORY_UTIL_H_
+
+#if defined(__GNUC__) || defined(__clang__)
+#define RESTRICT __restrict__
+#elif defined(_MSC_VER)
+#define RESTRICT __declspec(restrict)
+#else
+#define RESTRICT
+#endif
+
+#endif //KNNPLUGIN_JNI_INCLUDE_MEMORY_UTIL_H_

--- a/jni/include/nmslib_stream_support.h
+++ b/jni/include/nmslib_stream_support.h
@@ -13,11 +13,11 @@
 #define OPENSEARCH_KNN_JNI_NMSLIB_STREAM_SUPPORT_H
 
 #include "native_engines_stream_support.h"
+#include "utils.h"  // This is from NMSLIB
+#include "parameter_utils.h"
 
 namespace knn_jni {
 namespace stream {
-
-
 
 /**
  * NmslibIOReader implementation delegating NativeEngineIndexInputMediator to read bytes.
@@ -25,7 +25,8 @@ namespace stream {
 class NmslibOpenSearchIOReader final : public similarity::NmslibIOReader {
  public:
   explicit NmslibOpenSearchIOReader(NativeEngineIndexInputMediator *_mediator)
-      : mediator(_mediator) {
+      : similarity::NmslibIOReader(),
+        mediator(knn_jni::util::ParameterCheck::require_non_null(_mediator, "mediator")) {
   }
 
   void read(char *bytes, size_t len) final {
@@ -43,6 +44,27 @@ class NmslibOpenSearchIOReader final : public similarity::NmslibIOReader {
   NativeEngineIndexInputMediator *mediator;
 };  // class NmslibOpenSearchIOReader
 
+
+class NmslibOpenSearchIOWriter final : public similarity::NmslibIOWriter {
+ public:
+  explicit NmslibOpenSearchIOWriter(NativeEngineIndexOutputMediator *_mediator)
+      : similarity::NmslibIOWriter(),
+        mediator(knn_jni::util::ParameterCheck::require_non_null(_mediator, "mediator")) {
+  }
+
+  void write(char *bytes, size_t len) final {
+    if (len > 0) {
+      mediator->writeBytes((uint8_t *) bytes, len);
+    }
+  }
+
+  void flush() final {
+    mediator->flush();
+  }
+
+ private:
+  NativeEngineIndexOutputMediator *mediator;
+};  // class NmslibOpenSearchIOWriter
 
 
 }

--- a/jni/include/nmslib_wrapper.h
+++ b/jni/include/nmslib_wrapper.h
@@ -26,7 +26,7 @@ namespace knn_jni {
         // Create an index with ids and vectors. The configuration is defined by values in the Java map, parametersJ.
         // The index is serialized to indexPathJ.
         void CreateIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ, jlong vectorsAddress, jint dim,
-                         jstring indexPathJ, jobject parametersJ);
+                         jobject output, jobject parametersJ);
 
         // Load an index from indexPathJ into memory. Use parametersJ to set any query time parameters
         //

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -24,16 +24,16 @@ extern "C" {
  * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initIndex(JNIEnv * env, jclass cls,
-                                                                            jlong numDocs, jint dimJ,
-                                                                            jobject parametersJ);
+                                                                           jlong numDocs, jint dimJ,
+                                                                           jobject parametersJ);
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    initBinaryIndex
  * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initBinaryIndex(JNIEnv * env, jclass cls,
-                                                                            jlong numDocs, jint dimJ,
-                                                                            jobject parametersJ);
+                                                                                 jlong numDocs, jint dimJ,
+                                                                                 jobject parametersJ);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
@@ -41,8 +41,8 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initBinaryIndex
  * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initByteIndex(JNIEnv * env, jclass cls,
-                                                                            jlong numDocs, jint dimJ,
-                                                                            jobject parametersJ);
+                                                                               jlong numDocs, jint dimJ,
+                                                                               jobject parametersJ);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
@@ -50,16 +50,16 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initByteIndex(J
  * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToIndex(JNIEnv * env, jclass cls, jintArray idsJ,
-                                                                            jlong vectorsAddressJ, jint dimJ,
-                                                                            jlong indexAddress, jint threadCount);
+                                                                              jlong vectorsAddressJ, jint dimJ,
+                                                                              jlong indexAddress, jint threadCount);
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    insertToBinaryIndex
  * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToBinaryIndex(JNIEnv * env, jclass cls, jintArray idsJ,
-                                                                            jlong vectorsAddressJ, jint dimJ,
-                                                                            jlong indexAddress, jint threadCount);
+                                                                                    jlong vectorsAddressJ, jint dimJ,
+                                                                                    jlong indexAddress, jint threadCount);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
@@ -67,58 +67,54 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToBinaryIn
  * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteIndex(JNIEnv * env, jclass cls, jintArray idsJ,
-                                                                            jlong vectorsAddressJ, jint dimJ,
-                                                                            jlong indexAddress, jint threadCount);
+                                                                                  jlong vectorsAddressJ, jint dimJ,
+                                                                                  jlong indexAddress, jint threadCount);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    writeIndex
- * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
+ * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;)V
  */
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv * env, jclass cls,
-                                                                            jlong indexAddress,
-                                                                            jstring indexPathJ);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv *, jclass, jlong, jobject);
+
+
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    writeBinaryIndex
- * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
+ * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;)V
  */
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeBinaryIndex(JNIEnv * env, jclass cls,
-                                                                            jlong indexAddress,
-                                                                            jstring indexPathJ);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeBinaryIndex(JNIEnv *, jclass, jlong, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    writeByteIndex
- * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
+ * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;)V
  */
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeByteIndex(JNIEnv * env, jclass cls,
-                                                                            jlong indexAddress,
-                                                                            jstring indexPathJ);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeByteIndex(JNIEnv *, jclass, jlong, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    createIndexFromTemplate
- * Signature: ([IJILjava/lang/String;[BLjava/util/Map;)V
+ * Signature: ([IJILorg/opensearch/knn/index/store/IndexOutputWithBuffer;[BLjava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromTemplate
-  (JNIEnv *, jclass, jintArray, jlong, jint, jstring, jbyteArray, jobject);
+    (JNIEnv *, jclass, jintArray, jlong, jint, jobject, jbyteArray, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    createBinaryIndexFromTemplate
- * Signature: ([IJILjava/lang/String;[BLjava/util/Map;)V
+ * Signature: ([IJILorg/opensearch/knn/index/store/IndexOutputWithBuffer;[BLjava/util/Map;)V
  */
-    JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryIndexFromTemplate
-      (JNIEnv *, jclass, jintArray, jlong, jint, jstring, jbyteArray, jobject);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryIndexFromTemplate
+    (JNIEnv *, jclass, jintArray, jlong, jint, jobject, jbyteArray, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    createByteIndexFromTemplate
- * Signature: ([IJILjava/lang/String;[BLjava/util/Map;)V
+ * Signature: ([IJILorg/opensearch/knn/index/store/IndexOutputWithBuffer;[BLjava/util/Map;)V
  */
-    JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createByteIndexFromTemplate
-      (JNIEnv *, jclass, jintArray, jlong, jint, jstring, jbyteArray, jobject);
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createByteIndexFromTemplate
+    (JNIEnv *, jclass, jintArray, jlong, jint, jobject, jbyteArray, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService

--- a/jni/include/org_opensearch_knn_jni_NmslibService.h
+++ b/jni/include/org_opensearch_knn_jni_NmslibService.h
@@ -21,10 +21,10 @@ extern "C" {
 /*
  * Class:     org_opensearch_knn_jni_NmslibService
  * Method:    createIndex
- * Signature: ([IJILjava/lang/String;Ljava/util/Map;)V
+ * Signature: ([IJILorg/opensearch/knn/index/store/IndexOutputWithBuffer;Ljava/util/Map;)V
  */
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_NmslibService_createIndex
-        (JNIEnv *, jclass, jintArray, jlong, jint, jstring, jobject);
+    (JNIEnv *, jclass, jintArray, jlong, jint, jobject, jobject);
 
 /*
  * Class:     org_opensearch_knn_jni_NmslibService

--- a/jni/include/parameter_utils.h
+++ b/jni/include/parameter_utils.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#ifndef KNNPLUGIN_JNI_INCLUDE_PARAMETER_UTILS_H_
+#define KNNPLUGIN_JNI_INCLUDE_PARAMETER_UTILS_H_
+
+#include <stdexcept>
+#include <string>
+
+namespace knn_jni {
+namespace util {
+
+struct ParameterCheck {
+  template<typename PtrType>
+  static PtrType *require_non_null(PtrType *ptr, const char *parameter_name) {
+    if (ptr == nullptr) {
+      throw std::invalid_argument(std::string("Parameter [") + parameter_name + "] should not be null.");
+    }
+    return ptr;
+  }
+
+ private:
+  ParameterCheck() = default;
+};  // class ParameterCheck
+
+
+
+}
+}  // namespace knn_jni
+
+#endif //KNNPLUGIN_JNI_INCLUDE_PARAMETER_UTILS_H_

--- a/jni/patches/nmslib/0004-Added-a-new-save-apis-in-Hnsw-with-streaming-interfa.patch
+++ b/jni/patches/nmslib/0004-Added-a-new-save-apis-in-Hnsw-with-streaming-interfa.patch
@@ -1,0 +1,165 @@
+From eb9ceb60c695f795895b80ea66b251aea1fbf781 Mon Sep 17 00:00:00 2001
+From: Dooyong Kim <kdooyong@amazon.com>
+Date: Wed, 30 Oct 2024 15:44:34 -0700
+Subject: [PATCH] Added a new IOWriter interface in Hnsw node to support
+ streaming writing.
+
+Signed-off-by: Dooyong Kim <kdooyong@amazon.com>
+---
+ similarity_search/include/method/hnsw.h |  3 ++
+ similarity_search/include/utils.h       | 20 ++++++++--
+ similarity_search/src/method/hnsw.cc    | 52 +++++++++++++++++++++++--
+ 3 files changed, 68 insertions(+), 7 deletions(-)
+
+diff --git a/similarity_search/include/method/hnsw.h b/similarity_search/include/method/hnsw.h
+index 433f98f..d235c15 100644
+--- a/similarity_search/include/method/hnsw.h
++++ b/similarity_search/include/method/hnsw.h
+@@ -459,6 +459,8 @@ namespace similarity {
+ 
+         void LoadIndexWithStream(similarity::NmslibIOReader& in);
+ 
++        void SaveIndexWithStream(similarity::NmslibIOWriter& out);
++
+         Hnsw(bool PrintProgress, const Space<dist_t> &space, const ObjectVector &data);
+         void CreateIndex(const AnyParams &IndexParams) override;
+ 
+@@ -501,6 +503,7 @@ namespace similarity {
+ 
+ 
+         void SaveOptimizedIndex(std::ostream& output);
++        void SaveOptimizedIndex(NmslibIOWriter& output);
+         void LoadOptimizedIndex(std::istream& input);
+         void LoadOptimizedIndex(NmslibIOReader& input);
+ 
+diff --git a/similarity_search/include/utils.h b/similarity_search/include/utils.h
+index a3931b7..1cc55b2 100644
+--- a/similarity_search/include/utils.h
++++ b/similarity_search/include/utils.h
+@@ -305,19 +305,33 @@ struct NmslibIOReader {
+   virtual void read(char* bytes, size_t len) = 0;
+ 
+   virtual size_t remainingBytes() = 0;
+-};
++};  // class NmslibIOReader
++
++struct NmslibIOWriter {
++  virtual ~NmslibIOWriter() = default;
++
++  virtual void write(char* bytes, size_t len) = 0;
++
++  virtual void flush() {
++  }
++};  // class NmslibIOWriter
+ 
+ template <typename T> 
+ void writeBinaryPOD(ostream& out, const T& podRef) {
+   out.write((char*)&podRef, sizeof(T));
+ }
+ 
+-template <typename T> 
++template <typename T>
++void writeBinaryPOD(NmslibIOWriter& out, const T& podRef) {
++  out.write((char*)&podRef, sizeof(T));
++}
++
++template <typename T>
+ static void readBinaryPOD(NmslibIOReader& in, T& podRef) {
+   in.read((char*)&podRef, sizeof(T));
+ }
+ 
+-template <typename T> 
++template <typename T>
+ static void readBinaryPOD(istream& in, T& podRef) {
+   in.read((char*)&podRef, sizeof(T));
+ }
+diff --git a/similarity_search/src/method/hnsw.cc b/similarity_search/src/method/hnsw.cc
+index 662f06c..bfa3a23 100644
+--- a/similarity_search/src/method/hnsw.cc
++++ b/similarity_search/src/method/hnsw.cc
+@@ -784,6 +784,19 @@ namespace similarity {
+         output.close();
+     }
+ 
++    template <typename dist_t>
++    void Hnsw<dist_t>::SaveIndexWithStream(NmslibIOWriter& output) {
++        unsigned int optimIndexFlag = data_level0_memory_ != nullptr;
++
++        writeBinaryPOD(output, optimIndexFlag);
++
++        if (!optimIndexFlag) {
++            throw std::runtime_error("With stream, we only support optimized index type.");
++        } else {
++            SaveOptimizedIndex(output);
++        }
++    }
++
+     template <typename dist_t>
+     void
+     Hnsw<dist_t>::SaveOptimizedIndex(std::ostream& output) {
+@@ -818,6 +831,37 @@ namespace similarity {
+ 
+     }
+ 
++    template <typename dist_t>
++    void
++    Hnsw<dist_t>::SaveOptimizedIndex(NmslibIOWriter& output) {
++        totalElementsStored_ = ElList_.size();
++
++        writeBinaryPOD(output, totalElementsStored_);
++        writeBinaryPOD(output, memoryPerObject_);
++        writeBinaryPOD(output, offsetLevel0_);
++        writeBinaryPOD(output, offsetData_);
++        writeBinaryPOD(output, maxlevel_);
++        writeBinaryPOD(output, enterpointId_);
++        writeBinaryPOD(output, maxM_);
++        writeBinaryPOD(output, maxM0_);
++        writeBinaryPOD(output, dist_func_type_);
++        writeBinaryPOD(output, searchMethod_);
++
++        const size_t data_plus_links0_size = memoryPerObject_ * totalElementsStored_;
++        LOG(LIB_INFO) << "writing " << data_plus_links0_size << " bytes";
++        output.write(data_level0_memory_, data_plus_links0_size);
++
++        for (size_t i = 0; i < totalElementsStored_; i++) {
++            // TODO Can this one overflow? I really doubt
++            const SIZEMASS_TYPE sizemass = ((ElList_[i]->level) * (maxM_ + 1)) * sizeof(int);
++            writeBinaryPOD(output, sizemass);
++            if (sizemass) {
++                output.write(linkLists_[i], sizemass);
++            }
++        }
++        output.flush();
++    }
++
+     template <typename dist_t>
+     void
+     Hnsw<dist_t>::SaveRegularIndexBin(std::ostream& output) {
+@@ -1036,20 +1080,20 @@ namespace similarity {
+     constexpr bool _isLittleEndian() {
+         return (((uint32_t) 1) & 0xFFU) == 1;
+     }
+-                        
++
+     SIZEMASS_TYPE _readIntBigEndian(uint8_t byte0, uint8_t byte1, uint8_t byte2, uint8_t byte3) noexcept {
+         return (static_cast<SIZEMASS_TYPE>(byte0) << 24) |
+                (static_cast<SIZEMASS_TYPE>(byte1) << 16) |
+                (static_cast<SIZEMASS_TYPE>(byte2) << 8)  |
+                static_cast<SIZEMASS_TYPE>(byte3);
+-    }                   
+-                            
++    }
++
+     SIZEMASS_TYPE _readIntLittleEndian(uint8_t byte0, uint8_t byte1, uint8_t byte2, uint8_t byte3) noexcept {
+         return (static_cast<SIZEMASS_TYPE>(byte3) << 24) |
+                (static_cast<SIZEMASS_TYPE>(byte2) << 16) |
+                (static_cast<SIZEMASS_TYPE>(byte1) << 8)  |
+                static_cast<SIZEMASS_TYPE>(byte0);
+-    } 
++    }
+ 
+     template <typename dist_t>
+     void Hnsw<dist_t>::LoadIndexWithStream(NmslibIOReader& input) {
+-- 
+2.39.5 (Apple Git-154)
+

--- a/jni/src/commons.cpp
+++ b/jni/src/commons.cpp
@@ -8,8 +8,6 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-#ifndef OPENSEARCH_KNN_COMMONS_H
-#define OPENSEARCH_KNN_COMMONS_H
 #include <jni.h>
 
 #include <vector>
@@ -109,4 +107,3 @@ int knn_jni::commons::getIntegerMethodParameter(JNIEnv * env, knn_jni::JNIUtilIn
 
     return defaultValue;
 }
-#endif //OPENSEARCH_KNN_COMMONS_H

--- a/jni/src/faiss_methods.cpp
+++ b/jni/src/faiss_methods.cpp
@@ -29,11 +29,12 @@ faiss::IndexIDMapTemplate<faiss::IndexBinary>* FaissMethods::indexBinaryIdMap(fa
     return new faiss::IndexBinaryIDMap(index);
 }
 
-void FaissMethods::writeIndex(const faiss::Index* idx, const char* fname) {
-    faiss::write_index(idx, fname);
+void FaissMethods::writeIndex(const faiss::Index* idx, faiss::IOWriter* writer) {
+    faiss::write_index(idx, writer);
 }
-void FaissMethods::writeIndexBinary(const faiss::IndexBinary* idx, const char* fname) {
-    faiss::write_index_binary(idx, fname);
+
+void FaissMethods::writeIndexBinary(const faiss::IndexBinary* idx, faiss::IOWriter* writer) {
+    faiss::write_index_binary(idx, writer);
 }
 
 } // namespace faiss_wrapper

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -13,13 +13,13 @@
 #include "faiss_wrapper.h"
 #include "faiss_util.h"
 #include "faiss_index_service.h"
+#include "faiss_stream_support.h"
 
 #include "faiss/impl/io.h"
 #include "faiss/index_factory.h"
 #include "faiss/index_io.h"
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexIVFFlat.h"
-#include "faiss/MetaIndexes.h"
 #include "faiss/Index.h"
 #include "faiss/impl/IDSelector.h"
 #include "faiss/IndexIVFPQ.h"
@@ -48,18 +48,25 @@ struct IDSelectorJlongBitmap : IDSelector {
      * @param n size of the bitmap array
      * @param bitmap id like Lucene FixedBitSet bits
      */
-    IDSelectorJlongBitmap(size_t n, const jlong* bitmap) : n(n), bitmap(bitmap) {};
+    IDSelectorJlongBitmap(size_t _n, const jlong* _bitmap)
+      : IDSelector(),
+        n(_n),
+        bitmap(_bitmap) {
+    }
+
     bool is_member(idx_t id) const final {
-        uint64_t index = id;
-        uint64_t i = index >> 6;  // div 64
-        if (i >= n ) {
+        const uint64_t index = id;
+        const uint64_t i = index >> 6ULL;  // div 64
+        if (i >= n) {
             return false;
         }
-        return (bitmap[i] >> ( index & 63)) & 1L;
+        return (bitmap[i] >> (index & 63ULL)) & 1ULL;
     }
-    ~IDSelectorJlongBitmap() override {}
-};
-}
+};  // class IDSelectorJlongBitmap
+
+}  // namespace faiss
+
+
 // Translate space type to faiss metric
 faiss::MetricType TranslateSpaceToMetric(const std::string& spaceType);
 
@@ -136,7 +143,14 @@ jlong knn_jni::faiss_wrapper::InitIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
     // end parameters to pass
 
     // Create index
-    return indexService->initIndex(jniUtil, env, metric, indexDescriptionCpp, dim, numDocs, threadCount, subParametersCpp);
+    return indexService->initIndex(jniUtil,
+                                   env,
+                                   metric,
+                                   std::move(indexDescriptionCpp),
+                                   dim,
+                                   numDocs,
+                                   threadCount,
+                                   std::move(subParametersCpp));
 }
 
 void knn_jni::faiss_wrapper::InsertToIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ, jlong vectorsAddressJ, jint dimJ,
@@ -170,21 +184,22 @@ void knn_jni::faiss_wrapper::InsertToIndex(knn_jni::JNIUtilInterface * jniUtil, 
 }
 
 void knn_jni::faiss_wrapper::WriteIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env,
-                                         jstring indexPathJ, jlong index_ptr, IndexService* indexService) {
+                                        jobject output, jlong index_ptr, IndexService* indexService) {
 
-    if (indexPathJ == nullptr) {
-        throw std::runtime_error("Index path cannot be null");
+    if (output == nullptr) {
+        throw std::runtime_error("Index output stream cannot be null");
     }
 
-    // Index path
-    std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
+    // IndexOutput wrapper.
+    knn_jni::stream::NativeEngineIndexOutputMediator mediator {jniUtil, env, output};
+    knn_jni::stream::FaissOpenSearchIOWriter writer {&mediator};
 
-    // Create index
-    indexService->writeIndex(indexPathCpp, index_ptr);
+    // Create index.
+    indexService->writeIndex(&writer, index_ptr);
 }
 
 void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ,
+                                                     jlong vectorsAddressJ, jint dimJ, jobject output,
                                                      jbyteArray templateIndexJ, jobject parametersJ) {
     if (idsJ == nullptr) {
         throw std::runtime_error("IDs cannot be null");
@@ -198,8 +213,8 @@ void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface *
         throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
     }
 
-    if (indexPathJ == nullptr) {
-        throw std::runtime_error("Index path cannot be null");
+    if (output == nullptr) {
+        throw std::runtime_error("Index output stream cannot be null");
     }
 
     if (templateIndexJ == nullptr) {
@@ -245,14 +260,17 @@ void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface *
     // This is not the ideal approach, please refer this gh issue for long term solution:
     // https://github.com/opensearch-project/k-NN/issues/1600
     delete inputVectors;
+
     // Write the index to disk
-    std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
-    faiss::write_index(&idMap, indexPathCpp.c_str());
+    knn_jni::stream::NativeEngineIndexOutputMediator mediator {jniUtil, env, output};
+    knn_jni::stream::FaissOpenSearchIOWriter writer {&mediator};
+    faiss::write_index(&idMap, &writer);
+    mediator.flush();
 }
 
 void knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ,
-                                                     jbyteArray templateIndexJ, jobject parametersJ) {
+                                                           jlong vectorsAddressJ, jint dimJ, jobject output,
+                                                           jbyteArray templateIndexJ, jobject parametersJ) {
     if (idsJ == nullptr) {
         throw std::runtime_error("IDs cannot be null");
     }
@@ -261,12 +279,12 @@ void knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInter
         throw std::runtime_error("VectorsAddress cannot be less than 0");
     }
 
-    if(dimJ <= 0) {
+    if (dimJ <= 0) {
         throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
     }
 
-    if (indexPathJ == nullptr) {
-        throw std::runtime_error("Index path cannot be null");
+    if (output == nullptr) {
+        throw std::runtime_error("Index output stream cannot be null");
     }
 
     if (templateIndexJ == nullptr) {
@@ -315,14 +333,17 @@ void knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInter
     // This is not the ideal approach, please refer this gh issue for long term solution:
     // https://github.com/opensearch-project/k-NN/issues/1600
     delete inputVectors;
+
     // Write the index to disk
-    std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
-    faiss::write_index_binary(&idMap, indexPathCpp.c_str());
+    knn_jni::stream::NativeEngineIndexOutputMediator mediator {jniUtil, env, output};
+    knn_jni::stream::FaissOpenSearchIOWriter writer {&mediator};
+    faiss::write_index_binary(&idMap, &writer);
+    mediator.flush();
 }
 
 void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
-                                                     jlong vectorsAddressJ, jint dimJ, jstring indexPathJ,
-                                                     jbyteArray templateIndexJ, jobject parametersJ) {
+                                                         jlong vectorsAddressJ, jint dimJ, jobject output,
+                                                         jbyteArray templateIndexJ, jobject parametersJ) {
     if (idsJ == nullptr) {
         throw std::runtime_error("IDs cannot be null");
     }
@@ -331,12 +352,12 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
         throw std::runtime_error("VectorsAddress cannot be less than 0");
     }
 
-    if(dimJ <= 0) {
+    if (dimJ <= 0) {
         throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
     }
 
-    if (indexPathJ == nullptr) {
-        throw std::runtime_error("Index path cannot be null");
+    if (output == nullptr) {
+        throw std::runtime_error("Index output stream cannot be null");
     }
 
     if (templateIndexJ == nullptr) {
@@ -345,8 +366,9 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
 
     // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
     auto parametersCpp = jniUtil->ConvertJavaMapToCppMap(env, parametersJ);
-    if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
-        auto threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
+    auto it = parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY);
+    if (it != parametersCpp.end()) {
+        auto threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, it->second);
         omp_set_num_threads(threadCount);
     }
     jniUtil->DeleteLocalRef(env, parametersJ);
@@ -354,8 +376,8 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
     // Read data set
     // Read vectors from memory address
     auto *inputVectors = reinterpret_cast<std::vector<int8_t>*>(vectorsAddressJ);
-    int dim = (int)dimJ;
-    int numVectors = (int) (inputVectors->size() / (uint64_t) dim);
+    auto dim = (int) dimJ;
+    auto numVectors = (int) (inputVectors->size() / (uint64_t) dim);
     int numIds = jniUtil->GetJavaIntArrayLength(env, idsJ);
 
     if (numIds != numVectors) {
@@ -367,14 +389,14 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
     jbyte * indexBytesJ = jniUtil->GetByteArrayElements(env, templateIndexJ, nullptr);
 
     faiss::VectorIOReader vectorIoReader;
+    vectorIoReader.data.reserve(indexBytesCount);
     for (int i = 0; i < indexBytesCount; i++) {
         vectorIoReader.data.push_back((uint8_t) indexBytesJ[i]);
     }
     jniUtil->ReleaseByteArrayElements(env, templateIndexJ, indexBytesJ, JNI_ABORT);
 
     // Create faiss index
-    std::unique_ptr<faiss::Index> indexWriter;
-    indexWriter.reset(faiss::read_index(&vectorIoReader, 0));
+    std::unique_ptr<faiss::Index> indexWriter (faiss::read_index(&vectorIoReader, 0));
 
     auto ids = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexIDMap idMap =  faiss::IndexIDMap(indexWriter.get());
@@ -405,9 +427,12 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
     // This is not the ideal approach, please refer this gh issue for long term solution:
     // https://github.com/opensearch-project/k-NN/issues/1600
     delete inputVectors;
+
     // Write the index to disk
-    std::string indexPathCpp(jniUtil->ConvertJavaStringToCppString(env, indexPathJ));
-    faiss::write_index(&idMap, indexPathCpp.c_str());
+    knn_jni::stream::NativeEngineIndexOutputMediator mediator {jniUtil, env, output};
+    knn_jni::stream::FaissOpenSearchIOWriter writer {&mediator};
+    faiss::write_index(&idMap, &writer);
+    mediator.flush();
 }
 
 jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jstring indexPathJ) {
@@ -424,7 +449,7 @@ jlong knn_jni::faiss_wrapper::LoadIndex(knn_jni::JNIUtilInterface * jniUtil, JNI
 }
 
 jlong knn_jni::faiss_wrapper::LoadIndexWithStream(faiss::IOReader* ioReader) {
-    if (ioReader == nullptr)  [[unlikely]] {
+    if (ioReader == nullptr)  {
         throw std::runtime_error("IOReader cannot be null");
     }
 
@@ -451,7 +476,7 @@ jlong knn_jni::faiss_wrapper::LoadBinaryIndex(knn_jni::JNIUtilInterface * jniUti
 }
 
 jlong knn_jni::faiss_wrapper::LoadBinaryIndexWithStream(faiss::IOReader* ioReader) {
-    if (ioReader == nullptr) [[unlikely]] {
+    if (ioReader == nullptr) {
         throw std::runtime_error("IOReader cannot be null");
     }
 
@@ -820,13 +845,13 @@ jbyteArray knn_jni::faiss_wrapper::TrainIndex(knn_jni::JNIUtilInterface * jniUti
     }
 
     // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
-    if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
+    if (parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
         auto threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
         omp_set_num_threads(threadCount);
     }
 
     // Add extra parameters that cant be configured with the index factory
-    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
+    if (parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
         jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
         auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
         SetExtraParameters(jniUtil, env, subParametersCpp, indexWriter.get());
@@ -934,13 +959,13 @@ jbyteArray knn_jni::faiss_wrapper::TrainByteIndex(knn_jni::JNIUtilInterface * jn
     indexWriter.reset(faiss::index_factory((int) dimensionJ, indexDescriptionCpp.c_str(), metric));
 
     // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
-    if(parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
+    if (parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
         auto threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
         omp_set_num_threads(threadCount);
     }
 
     // Add extra parameters that cant be configured with the index factory
-    if(parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
+    if (parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
         jobject subParametersJ = parametersCpp[knn_jni::PARAMETERS];
         auto subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, subParametersJ);
         SetExtraParameters(jniUtil, env, subParametersCpp, indexWriter.get());
@@ -957,7 +982,7 @@ jbyteArray knn_jni::faiss_wrapper::TrainByteIndex(knn_jni::JNIUtilInterface * jn
     trainingFloatVectors[i] = static_cast<float>(*iter);
     }
 
-    if(!indexWriter->is_trained) {
+    if (!indexWriter->is_trained) {
      InternalTrainIndex(indexWriter.get(), numVectors, trainingFloatVectors.data());
     }
     jniUtil->DeleteLocalRef(env, parametersJ);
@@ -1115,11 +1140,11 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
     // The second parameter is always true, as lims is allocated by FAISS
     faiss::RangeSearchResult res(1, true);
 
-    if(filterIdsJ != nullptr) {
+    if (filterIdsJ != nullptr) {
         jlong *filteredIdsArray = jniUtil->GetLongArrayElements(env, filterIdsJ, nullptr);
         int filterIdsLength = jniUtil->GetJavaLongArrayLength(env, filterIdsJ);
         std::unique_ptr<faiss::IDSelector> idSelector;
-        if(filterIdsTypeJ == BITMAP) {
+        if (filterIdsTypeJ == BITMAP) {
             idSelector.reset(new faiss::IDSelectorJlongBitmap(filterIdsLength, filteredIdsArray));
         } else {
             faiss::idx_t* batchIndices = reinterpret_cast<faiss::idx_t*>(filteredIdsArray);
@@ -1131,7 +1156,7 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
         std::unique_ptr<faiss::IDGrouperBitmap> idGrouper;
         std::vector<uint64_t> idGrouperBitmap;
         auto hnswReader = dynamic_cast<const faiss::IndexHNSW*>(indexReader->index);
-        if(hnswReader) {
+        if (hnswReader) {
             // Query param ef_search supersedes ef_search provided during index setting.
             hnswParams.efSearch = knn_jni::commons::getIntegerMethodParameter(env, jniUtil, methodParams, EF_SEARCH, hnswReader->hnsw.efSearch);
             hnswParams.sel = idSelector.get();
@@ -1195,7 +1220,7 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
     jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
 
     jobject result;
-    for(int i = 0; i < resultSize; ++i) {
+    for (int i = 0; i < resultSize; ++i) {
         result = jniUtil->NewObject(env, resultClass, allArgs, res.labels[i], res.distances[i]);
         jniUtil->SetObjectArrayElement(env, results, i, result);
     }

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -88,7 +88,7 @@ void knn_jni::JNIUtil::HasExceptionInStack(JNIEnv* env) {
     this->HasExceptionInStack(env, "Exception in jni occurred");
 }
 
-void knn_jni::JNIUtil::HasExceptionInStack(JNIEnv* env, const std::string& message) {
+void knn_jni::JNIUtil::HasExceptionInStack(JNIEnv* env, const char* message) {
     if (env->ExceptionCheck() == JNI_TRUE) {
         throw std::runtime_error(message);
     }
@@ -252,11 +252,11 @@ void knn_jni::JNIUtil::Convert2dJavaObjectArrayAndStoreToFloatVector(JNIEnv *env
             throw std::runtime_error("Unable to get float array elements");
         }
 
-        for(int j = 0; j < dim; ++j) {
+        for (int j = 0; j < dim; ++j) {
             vect->push_back(vector[j]);
         }
         env->ReleaseFloatArrayElements(vectorArray, vector, JNI_ABORT);
-    }
+    }  // End for
     this->HasExceptionInStack(env);
     env->DeleteLocalRef(array2dJ);
 }
@@ -285,7 +285,7 @@ void knn_jni::JNIUtil::Convert2dJavaObjectArrayAndStoreToBinaryVector(JNIEnv *en
             throw std::runtime_error("Unable to get byte array elements");
         }
 
-        for(int j = 0; j < dim; ++j) {
+        for (int j = 0; j < dim; ++j) {
             vect->push_back(vector[j]);
         }
         env->ReleaseByteArrayElements(vectorArray, reinterpret_cast<int8_t*>(vector), JNI_ABORT);
@@ -573,6 +573,11 @@ jlong knn_jni::JNIUtil::CallNonvirtualLongMethodA(JNIEnv * env, jobject obj, jcl
   return env->CallNonvirtualLongMethodA(obj, clazz, methodID, args);
 }
 
+void knn_jni::JNIUtil::CallNonvirtualVoidMethodA(JNIEnv * env, jobject obj, jclass clazz,
+                                                 jmethodID methodID, jvalue* args) {
+  return env->CallNonvirtualVoidMethodA(obj, clazz, methodID, args);
+}
+
 void * knn_jni::JNIUtil::GetPrimitiveArrayCritical(JNIEnv * env, jarray array, jboolean *isCopy) {
     return env->GetPrimitiveArrayCritical(array, isCopy);
 }
@@ -582,10 +587,11 @@ void knn_jni::JNIUtil::ReleasePrimitiveArrayCritical(JNIEnv * env, jarray array,
 }
 
 jobject knn_jni::GetJObjectFromMapOrThrow(std::unordered_map<std::string, jobject> map, std::string key) {
-    if(map.find(key) == map.end()) {
-        throw std::runtime_error(key + " not found");
+    auto it = map.find(key);
+    if (it != map.end()) {
+        return it->second;
     }
-    return map[key];
+    throw std::runtime_error(key + " not found");
 }
 
 //TODO: This potentially should use const char *

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -41,8 +41,8 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
 }
 
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initIndex(JNIEnv * env, jclass cls,
-                                                                            jlong numDocs, jint dimJ,
-                                                                            jobject parametersJ)
+                                                                           jlong numDocs, jint dimJ,
+                                                                           jobject parametersJ)
 {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
@@ -55,8 +55,8 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initIndex(JNIEn
 }
 
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initBinaryIndex(JNIEnv * env, jclass cls,
-                                                                            jlong numDocs, jint dimJ,
-                                                                            jobject parametersJ)
+                                                                                 jlong numDocs, jint dimJ,
+                                                                                 jobject parametersJ)
 {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
@@ -69,8 +69,8 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initBinaryIndex
 }
 
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initByteIndex(JNIEnv * env, jclass cls,
-                                                                            jlong numDocs, jint dimJ,
-                                                                            jobject parametersJ)
+                                                                               jlong numDocs, jint dimJ,
+                                                                               jobject parametersJ)
 {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
@@ -83,8 +83,8 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initByteIndex(J
 }
 
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToIndex(JNIEnv * env, jclass cls, jintArray idsJ,
-                                                                            jlong vectorsAddressJ, jint dimJ,
-                                                                            jlong indexAddress, jint threadCount)
+                                                                              jlong vectorsAddressJ, jint dimJ,
+                                                                              jlong indexAddress, jint threadCount)
 {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
@@ -97,8 +97,8 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToIndex(JN
 }
 
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToBinaryIndex(JNIEnv * env, jclass cls, jintArray idsJ,
-                                                                            jlong vectorsAddressJ, jint dimJ,
-                                                                            jlong indexAddress, jint threadCount)
+                                                                                    jlong vectorsAddressJ, jint dimJ,
+                                                                                    jlong indexAddress, jint threadCount)
 {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
@@ -111,8 +111,8 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToBinaryIn
 }
 
 JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteIndex(JNIEnv * env, jclass cls, jintArray idsJ,
-                                                                            jlong vectorsAddressJ, jint dimJ,
-                                                                            jlong indexAddress, jint threadCount)
+                                                                                  jlong vectorsAddressJ, jint dimJ,
+                                                                                  jlong indexAddress, jint threadCount)
 {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
@@ -124,85 +124,112 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteInde
     }
 }
 
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv * env, jclass cls,
-                                                                            jlong indexAddress,
-                                                                            jstring indexPathJ)
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeIndex(JNIEnv * env,
+                                                                           jclass cls,
+                                                                           jlong indexAddress,
+                                                                           jobject output)
 {
-    try {
-        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
-        knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
-        knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, indexPathJ, indexAddress, &indexService);
-    } catch (...) {
-        jniUtil.CatchCppExceptionAndThrowJava(env);
-    }
+  try {
+      std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+      knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
+      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &indexService);
+  } catch (...) {
+      jniUtil.CatchCppExceptionAndThrowJava(env);
+  }
 }
 
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeBinaryIndex(JNIEnv * env, jclass cls,
-                                                                            jlong indexAddress,
-                                                                            jstring indexPathJ)
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeBinaryIndex(JNIEnv * env,
+                                                                                 jclass cls,
+                                                                                 jlong indexAddress,
+                                                                                 jobject output)
 {
-    try {
-        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
-        knn_jni::faiss_wrapper::BinaryIndexService binaryIndexService(std::move(faissMethods));
-        knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, indexPathJ, indexAddress, &binaryIndexService);
-    } catch (...) {
-        jniUtil.CatchCppExceptionAndThrowJava(env);
-    }
+  try {
+      std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+      knn_jni::faiss_wrapper::BinaryIndexService binaryIndexService(std::move(faissMethods));
+      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &binaryIndexService);
+  } catch (...) {
+      jniUtil.CatchCppExceptionAndThrowJava(env);
+  }
 }
 
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeByteIndex(JNIEnv * env, jclass cls,
-                                                                            jlong indexAddress,
-                                                                            jstring indexPathJ)
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_writeByteIndex(JNIEnv * env,
+                                                                               jclass cls,
+                                                                               jlong indexAddress,
+                                                                               jobject output)
 {
-    try {
-        std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
-        knn_jni::faiss_wrapper::ByteIndexService byteIndexService(std::move(faissMethods));
-        knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, indexPathJ, indexAddress, &byteIndexService);
-    } catch (...) {
-        jniUtil.CatchCppExceptionAndThrowJava(env);
-    }
+  try {
+      std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
+      knn_jni::faiss_wrapper::ByteIndexService byteIndexService(std::move(faissMethods));
+      knn_jni::faiss_wrapper::WriteIndex(&jniUtil, env, output, indexAddress, &byteIndexService);
+  } catch (...) {
+      jniUtil.CatchCppExceptionAndThrowJava(env);
+  }
 }
 
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromTemplate(JNIEnv * env, jclass cls,
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromTemplate(JNIEnv * env,
+                                                                                        jclass cls,
                                                                                         jintArray idsJ,
                                                                                         jlong vectorsAddressJ,
                                                                                         jint dimJ,
-                                                                                        jstring indexPathJ,
+                                                                                        jobject output,
                                                                                         jbyteArray templateIndexJ,
                                                                                         jobject parametersJ)
 {
     try {
-        knn_jni::faiss_wrapper::CreateIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ);
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(&jniUtil,
+                                                        env,
+                                                        idsJ,
+                                                        vectorsAddressJ,
+                                                        dimJ,
+                                                        output,
+                                                        templateIndexJ,
+                                                        parametersJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
 }
 
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryIndexFromTemplate(JNIEnv * env, jclass cls,
-                                                                                        jintArray idsJ,
-                                                                                        jlong vectorsAddressJ,
-                                                                                        jint dimJ,
-                                                                                        jstring indexPathJ,
-                                                                                        jbyteArray templateIndexJ,
-                                                                                        jobject parametersJ)
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryIndexFromTemplate(JNIEnv * env,
+                                                                                              jclass cls,
+                                                                                              jintArray idsJ,
+                                                                                              jlong vectorsAddressJ,
+                                                                                              jint dimJ,
+                                                                                              jobject output,
+                                                                                              jbyteArray templateIndexJ,
+                                                                                              jobject parametersJ)
 {
     try {
-        knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ);
+        knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(&jniUtil,
+                                                              env,
+                                                              idsJ,
+                                                              vectorsAddressJ,
+                                                              dimJ,
+                                                              output,
+                                                              templateIndexJ,
+                                                              parametersJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
 }
 
-JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createByteIndexFromTemplate(JNIEnv * env, jclass cls,
-                                                                                        jintArray idsJ,
-                                                                                        jlong vectorsAddressJ,
-                                                                                        jint dimJ,
-                                                                                        jstring indexPathJ,
-                                                                                        jbyteArray templateIndexJ,
-                                                                                        jobject parametersJ)
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createByteIndexFromTemplate(JNIEnv * env,
+                                                                                            jclass cls,
+                                                                                            jintArray idsJ,
+                                                                                            jlong vectorsAddressJ,
+                                                                                            jint dimJ,
+                                                                                            jobject output,
+                                                                                            jbyteArray templateIndexJ,
+                                                                                            jobject parametersJ)
 {
     try {
-        knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, templateIndexJ, parametersJ);
+        knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(&jniUtil,
+                                                            env,
+                                                            idsJ,
+                                                            vectorsAddressJ,
+                                                            dimJ,
+                                                            output,
+                                                            templateIndexJ,
+                                                            parametersJ);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -210,16 +237,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createByteIndexF
 
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndex(JNIEnv * env, jclass cls, jstring indexPathJ)
 {
-    try {
-        return knn_jni::faiss_wrapper::LoadIndex(&jniUtil, env, indexPathJ);
-    } catch (...) {
-        jniUtil.CatchCppExceptionAndThrowJava(env);
-    }
-    return NULL;
+  try {
+      return knn_jni::faiss_wrapper::LoadIndex(&jniUtil, env, indexPathJ);
+  } catch (...) {
+      jniUtil.CatchCppExceptionAndThrowJava(env);
+  }
+  return NULL;
 }
 
-JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndexWithStream
-  (JNIEnv * env, jclass cls, jobject readStream)
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadIndexWithStream(JNIEnv * env,
+                                                                                     jclass cls,
+                                                                                     jobject readStream)
 {
     try {
         // Create a mediator locally.
@@ -249,8 +277,9 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadBinaryIndex
     return NULL;
 }
 
-JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadBinaryIndexWithStream
-  (JNIEnv * env, jclass cls, jobject readStream)
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadBinaryIndexWithStream(JNIEnv * env,
+                                                                                           jclass cls,
+                                                                                           jobject readStream)
 {
     try {
         // Create a mediator locally.
@@ -262,7 +291,7 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadBinaryIndex
 
         // Pass IOReader to Faiss for loading vector index.
         return knn_jni::faiss_wrapper::LoadBinaryIndexWithStream(
-                 &faissOpenSearchIOReader);
+            &faissOpenSearchIOReader);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -270,8 +299,9 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_loadBinaryIndex
     return NULL;
 }
 
-JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isSharedIndexStateRequired
-        (JNIEnv * env, jclass cls, jlong indexPointerJ)
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_jni_FaissService_isSharedIndexStateRequired(JNIEnv * env,
+                                                                                               jclass cls,
+                                                                                               jlong indexPointerJ)
 {
     try {
         return knn_jni::faiss_wrapper::IsSharedIndexStateRequired(indexPointerJ);
@@ -425,10 +455,10 @@ JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_transferVectors
 }
 
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex(JNIEnv * env, jclass cls,
-                                                                                   jlong indexPointerJ,
-                                                                                   jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jobject methodParamsJ,
-                                                                                   jint maxResultWindowJ, jintArray parentIdsJ)
+                                                                                         jlong indexPointerJ,
+                                                                                         jfloatArray queryVectorJ,
+                                                                                         jfloat radiusJ, jobject methodParamsJ,
+                                                                                         jint maxResultWindowJ, jintArray parentIdsJ)
 {
     try {
         return knn_jni::faiss_wrapper::RangeSearch(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, parentIdsJ);
@@ -439,10 +469,10 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
 }
 
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndexWithFilter(JNIEnv * env, jclass cls,
-                                                                                   jlong indexPointerJ,
-                                                                                   jfloatArray queryVectorJ,
-                                                                                   jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ,
-                                                                                   jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ)
+                                                                                                   jlong indexPointerJ,
+                                                                                                   jfloatArray queryVectorJ,
+                                                                                                   jfloat radiusJ, jobject methodParamsJ, jint maxResultWindowJ,
+                                                                                                   jlongArray filterIdsJ, jint filterIdsTypeJ, jintArray parentIdsJ)
 {
     try {
         return knn_jni::faiss_wrapper::RangeSearchWithFilter(&jniUtil, env, indexPointerJ, queryVectorJ, radiusJ, methodParamsJ, maxResultWindowJ, filterIdsJ, filterIdsTypeJ, parentIdsJ);

--- a/jni/src/org_opensearch_knn_jni_NmslibService.cpp
+++ b/jni/src/org_opensearch_knn_jni_NmslibService.cpp
@@ -41,10 +41,10 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_NmslibService_createIndex(JNI
                                                                              jintArray idsJ,
                                                                              jlong vectorsAddressJ,
                                                                              jint dimJ,
-                                                                             jstring indexPathJ,
+                                                                             jobject output,
                                                                              jobject parametersJ) {
   try {
-    knn_jni::nmslib_wrapper::CreateIndex(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexPathJ, parametersJ);
+    knn_jni::nmslib_wrapper::CreateIndex(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, output, parametersJ);
   } catch (...) {
     jniUtil.CatchCppExceptionAndThrowJava(env);
   }

--- a/jni/tests/faiss_index_service_test.cpp
+++ b/jni/tests/faiss_index_service_test.cpp
@@ -19,9 +19,9 @@
 #include "gtest/gtest.h"
 #include "commons.h"
 
-using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
+using ::testing::_;
 
 TEST(CreateIndexTest, BasicAssertions) {
     // Define the data
@@ -38,6 +38,7 @@ TEST(CreateIndexTest, BasicAssertions) {
     }
 
     std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::FileIOWriter fileIOWriter {indexPath.c_str()};
     faiss::MetricType metricType = faiss::METRIC_L2;
     std::string indexDescription = "HNSW32,Flat";
     int threadCount = 1;
@@ -59,14 +60,14 @@ TEST(CreateIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::StrEq(indexPath.c_str())))
+    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter)))
         .Times(1);
 
     // Create the index
     knn_jni::faiss_wrapper::IndexService indexService(std::move(mockFaissMethods));
     long indexAddress = indexService.initIndex(&mockJNIUtil, jniEnv, metricType, indexDescription, dim, numIds, threadCount, parametersMap);
     indexService.insertToIndex(dim, numIds, threadCount, (int64_t) &vectors, ids, indexAddress);
-    indexService.writeIndex(indexPath, indexAddress);
+    indexService.writeIndex(&fileIOWriter, indexAddress);
 }
 
 TEST(CreateBinaryIndexTest, BasicAssertions) {
@@ -84,6 +85,7 @@ TEST(CreateBinaryIndexTest, BasicAssertions) {
     }
 
     std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::FileIOWriter fileIOWriter {indexPath.c_str()};
     faiss::MetricType metricType = faiss::METRIC_L2;
     std::string indexDescription = "BHNSW32";
     int threadCount = 1;
@@ -105,14 +107,14 @@ TEST(CreateBinaryIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexBinaryIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndexBinary(indexIdMap, ::testing::StrEq(indexPath.c_str())))
+    EXPECT_CALL(*mockFaissMethods, writeIndexBinary(indexIdMap, ::testing::Eq(&fileIOWriter)))
         .Times(1);
 
     // Create the index
     knn_jni::faiss_wrapper::BinaryIndexService indexService(std::move(mockFaissMethods));
     long indexAddress = indexService.initIndex(&mockJNIUtil, jniEnv, metricType, indexDescription, dim, numIds, threadCount, parametersMap);
     indexService.insertToIndex(dim, numIds, threadCount, (int64_t) &vectors, ids, indexAddress);
-    indexService.writeIndex(indexPath, indexAddress);
+    indexService.writeIndex(&fileIOWriter, indexAddress);
 }
 
 TEST(CreateByteIndexTest, BasicAssertions) {
@@ -130,6 +132,7 @@ TEST(CreateByteIndexTest, BasicAssertions) {
     }
 
     std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    faiss::FileIOWriter fileIOWriter {indexPath.c_str()};
     faiss::MetricType metricType = faiss::METRIC_L2;
     std::string indexDescription = "HNSW16,SQ8_direct_signed";
     int threadCount = 1;
@@ -149,12 +152,12 @@ TEST(CreateByteIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::StrEq(indexPath.c_str())))
+    EXPECT_CALL(*mockFaissMethods, writeIndex(indexIdMap, ::testing::Eq(&fileIOWriter)))
         .Times(1);
 
     // Create the index
     knn_jni::faiss_wrapper::ByteIndexService indexService(std::move(mockFaissMethods));
     long indexAddress = indexService.initIndex(&mockJNIUtil, jniEnv, metricType, indexDescription, dim, numIds, threadCount, parametersMap);
     indexService.insertToIndex(dim, numIds, threadCount, (int64_t) &vectors, ids, indexAddress);
-    indexService.writeIndex(indexPath, indexAddress);
+    indexService.writeIndex(&fileIOWriter, indexAddress);
 }

--- a/jni/tests/faiss_stream_support_test.cpp
+++ b/jni/tests/faiss_stream_support_test.cpp
@@ -62,7 +62,10 @@ TEST(FaissStreamSupportTest, NativeEngineIndexInputMediatorCopyWhenEmpty) {
     setUpMockJNIUtil(javaIndexInputMock, mockJni);
 
     // Prepare copying
-    NativeEngineIndexInputMediator mediator{&mockJni, nullptr, nullptr};
+    NiceMock<JNIEnv> jniEnv;
+    // It's a dummy value, which will not be used. If we pass a null, then NPE will be raised.
+    jobject jobjectDummy = reinterpret_cast<jobject>(1);
+    NativeEngineIndexInputMediator mediator{&mockJni, &jniEnv, jobjectDummy};
     std::string readBuffer(javaIndexInputMock.readTargetBytes.size(), '\0');
 
     // Call copyBytes
@@ -82,7 +85,10 @@ TEST(FaissStreamSupportTest, FaissOpenSearchIOReaderCopy) {
     setUpMockJNIUtil(javaIndexInputMock, mockJni);
 
     // Prepare copying
-    NativeEngineIndexInputMediator mediator{&mockJni, nullptr, nullptr};
+    NiceMock<JNIEnv> jniEnv;
+    // It's a dummy value, which will not be used. If we pass a null, then NPE will be raised.
+    jobject jobjectDummy = reinterpret_cast<jobject>(1);
+    NativeEngineIndexInputMediator mediator{&mockJni, &jniEnv, jobjectDummy};
     std::string readBuffer;
     readBuffer.resize(javaIndexInputMock.readTargetBytes.size());
     FaissOpenSearchIOReader ioReader{&mediator};

--- a/jni/tests/mocks/faiss_index_service_mock.h
+++ b/jni/tests/mocks/faiss_index_service_mock.h
@@ -21,7 +21,10 @@ typedef std::unordered_map<std::string, jobject> StringToJObjectMap;
 
 class MockIndexService : public IndexService {
 public:
-    MockIndexService(std::unique_ptr<FaissMethods> faissMethods) : IndexService(std::move(faissMethods)) {};
+    explicit MockIndexService(std::unique_ptr<FaissMethods> _faissMethods)
+      : IndexService(std::move(_faissMethods)) {
+    }
+
     MOCK_METHOD(
         long,
         initIndex,
@@ -36,6 +39,7 @@ public:
             StringToJObjectMap parameters
         ),
         (override));
+
     MOCK_METHOD(
         void,
         insertToIndex,
@@ -48,11 +52,12 @@ public:
             long indexPtr
         ),
         (override));
+
     MOCK_METHOD(
         void,
         writeIndex,
         (
-            std::string indexPath,
+            faiss::IOWriter* writer,
             long indexPtr
         ),
         (override));

--- a/jni/tests/mocks/faiss_methods_mock.h
+++ b/jni/tests/mocks/faiss_methods_mock.h
@@ -21,8 +21,8 @@ public:
     MOCK_METHOD(faiss::IndexBinary*, indexBinaryFactory, (int d, const char* description), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::Index>*, indexIdMap, (faiss::Index* index), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::IndexBinary>*, indexBinaryIdMap, (faiss::IndexBinary* index), (override));
-    MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, const char* fname), (override));
-    MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, const char* fname), (override));
+    MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, faiss::IOWriter* writer), (override));
+    MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, faiss::IOWriter* writer), (override));
 };
 
 #endif  // OPENSEARCH_KNN_FAISS_METHODS_MOCK_H

--- a/jni/tests/nmslib_stream_support_test.cpp
+++ b/jni/tests/nmslib_stream_support_test.cpp
@@ -17,11 +17,13 @@
 #include "test_util.h"
 #include "native_stream_support_util.h"
 
-using ::testing::_;
+using ::test_util::JavaFileIndexInputMock;
+using ::test_util::JavaFileIndexOutputMock;
+using ::test_util::MockJNIUtil;
+using ::test_util::StreamIOError;
 using ::testing::NiceMock;
 using ::testing::Return;
-using ::test_util::MockJNIUtil;
-using ::test_util::JavaFileIndexInputMock;
+using ::testing::_;
 
 void setUpJavaFileInputMocking(JavaFileIndexInputMock &java_index_input, MockJNIUtil &mockJni) {
   // Set up mocking values + mocking behavior in a method.
@@ -35,86 +37,100 @@ void setUpJavaFileInputMocking(JavaFileIndexInputMock &java_index_input, MockJNI
       });
   EXPECT_CALL(mockJni, CallNonvirtualLongMethodA(_, _, _, _, _))
       .WillRepeatedly([&java_index_input](JNIEnv *env,
-                                          jobject obj,
-                                          jclass clazz,
-                                          jmethodID methodID,
-                                          jvalue *args) {
+                                                 jobject obj,
+                                                 jclass clazz,
+                                                 jmethodID methodID,
+                                                 jvalue *args) {
         return java_index_input.remainingBytes();
       });
-  EXPECT_CALL(mockJni, GetPrimitiveArrayCritical(_, _, _)).WillRepeatedly([&java_index_input](JNIEnv *env,
-                                                                                              jarray array,
-                                                                                              jboolean *isCopy) {
-    return (jbyte *) java_index_input.buffer.data();
-  });
+  EXPECT_CALL(mockJni, GetPrimitiveArrayCritical(_, _, _))
+      .WillRepeatedly([&java_index_input](JNIEnv *env,
+                                                 jarray array,
+                                                 jboolean *isCopy) {
+        return (jbyte *) java_index_input.buffer.data();
+      });
   EXPECT_CALL(mockJni, ReleasePrimitiveArrayCritical(_, _, _, _)).WillRepeatedly(Return());
 }
 
 TEST(NmslibStreamLoadingTest, BasicAssertions) {
-  // Initialize nmslib
-  similarity::initLibrary();
+  for (auto throwIOException : std::array<bool, 2> {false, true}) {
+      // Initialize nmslib
+      similarity::initLibrary();
 
-  // Define index data
-  int numIds = 100;
-  std::vector<int> ids;
-  auto vectors = new std::vector<float>();
-  int dim = 2;
-  vectors->reserve(dim * numIds);
-  for (int i = 0; i < numIds; ++i) {
-    ids.push_back(i);
-    for (int j = 0; j < dim; ++j) {
-      vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
-    }
-  }
+      // Define index data
+      int numIds = 100;
+      std::vector<int> ids;
+      auto vectors = new std::vector<float>();
+      int dim = 2;
+      vectors->reserve(dim * numIds);
+      for (int i = 0; i < numIds; ++i) {
+        ids.push_back(i);
+        for (int j = 0; j < dim; ++j) {
+          vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
+        }
+      }
 
-  std::string spaceType = knn_jni::L2;
-  std::string indexPath = test_util::RandomString(
-      10, "/tmp/", ".nmslib");
+      std::string spaceType = knn_jni::L2;
+      std::string indexPath = test_util::RandomString(
+          10, "/tmp/", ".nmslib");
 
-  std::unordered_map<std::string, jobject> parametersMap;
-  int efConstruction = 512;
-  int m = 96;
+      std::unordered_map<std::string, jobject> parametersMap;
+      int efConstruction = 512;
+      int m = 96;
 
-  parametersMap[knn_jni::SPACE_TYPE] = (jobject) &spaceType;
-  parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject) &efConstruction;
-  parametersMap[knn_jni::M] = (jobject) &m;
+      parametersMap[knn_jni::SPACE_TYPE] = (jobject) &spaceType;
+      parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject) &efConstruction;
+      parametersMap[knn_jni::M] = (jobject) &m;
 
-  // Set up jni
-  JNIEnv *jniEnv = nullptr;
-  NiceMock<MockJNIUtil> mockJNIUtil;
+      // Set up jni
+      NiceMock<JNIEnv> jniEnv;
 
-  EXPECT_CALL(mockJNIUtil,
-              GetJavaObjectArrayLength(
-                  jniEnv, reinterpret_cast<jobjectArray>(vectors)))
-      .WillRepeatedly(Return(vectors->size()));
+      NiceMock<MockJNIUtil> mockJNIUtil;
+      JavaFileIndexOutputMock javaFileIndexOutputMock {indexPath};
+      setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, throwIOException);
+      knn_jni::stream::NativeEngineIndexOutputMediator mediator {&mockJNIUtil, &jniEnv, (jobject) (&javaFileIndexOutputMock)};
+      knn_jni::stream::NmslibOpenSearchIOWriter writer {&mediator};
 
-  EXPECT_CALL(mockJNIUtil,
-              GetJavaIntArrayLength(jniEnv, reinterpret_cast<jintArray>(&ids)))
-      .WillRepeatedly(Return(ids.size()));
+      EXPECT_CALL(mockJNIUtil,
+                  GetJavaObjectArrayLength(
+                      &jniEnv, reinterpret_cast<jobjectArray>(vectors)))
+          .WillRepeatedly(Return(vectors->size()));
 
-  EXPECT_CALL(mockJNIUtil,
-              ConvertJavaMapToCppMap(jniEnv, reinterpret_cast<jobject>(&parametersMap)))
-      .WillRepeatedly(Return(parametersMap));
+      EXPECT_CALL(mockJNIUtil,
+                  GetJavaIntArrayLength(&jniEnv, reinterpret_cast<jintArray>(&ids)))
+          .WillRepeatedly(Return(ids.size()));
 
-  // Create the index
-  knn_jni::nmslib_wrapper::CreateIndex(
-      &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
-      (jlong) vectors, dim, (jstring) &indexPath,
-      (jobject) &parametersMap);
+      EXPECT_CALL(mockJNIUtil,
+                  ConvertJavaMapToCppMap(&jniEnv, reinterpret_cast<jobject>(&parametersMap)))
+          .WillRepeatedly(Return(parametersMap));
 
-  // Create Java index input mock.
-  std::ifstream file_input{indexPath, std::ios::binary};
-  const int32_t buffer_size = 128;
-  JavaFileIndexInputMock java_file_index_input_mock{file_input, buffer_size};
-  setUpJavaFileInputMocking(java_file_index_input_mock, mockJNIUtil);
+      // Create the index
+      try {
+          knn_jni::nmslib_wrapper::CreateIndex(
+              &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+              (jlong) vectors, dim, (jobject) (&javaFileIndexOutputMock),
+              (jobject) &parametersMap);
+          javaFileIndexOutputMock.file_writer.close();
+      } catch (const StreamIOError& e) {
+          continue;
+      }
 
-  // Make sure index can be loaded
-  jlong index = knn_jni::nmslib_wrapper::LoadIndexWithStream(
-      &mockJNIUtil, jniEnv,
-      (jobject) (&java_file_index_input_mock),
-      (jobject) (&parametersMap));
+      // Create Java index input mock.
+      std::ifstream file_input{indexPath, std::ios::binary};
+      const int32_t buffer_size = 128;
+      JavaFileIndexInputMock java_file_index_input_mock{file_input, buffer_size};
+      setUpJavaFileInputMocking(java_file_index_input_mock, mockJNIUtil);
 
-  knn_jni::nmslib_wrapper::Free(index);
+      // Make sure index can be loaded
+      jlong index = knn_jni::nmslib_wrapper::LoadIndexWithStream(
+          &mockJNIUtil, &jniEnv,
+          (jobject) (&java_file_index_input_mock),
+          (jobject) (&parametersMap));
 
-  // Clean up
-  std::remove(indexPath.c_str());
+      knn_jni::nmslib_wrapper::Free(index);
+
+      // Clean up
+      file_input.close();
+      std::remove(indexPath.c_str());
+  }  // End for
 }

--- a/jni/tests/nmslib_wrapper_test.cpp
+++ b/jni/tests/nmslib_wrapper_test.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "nmslib_wrapper.h"
+#include "nmslib_stream_support.h"
 
 #include <vector>
 
@@ -17,7 +18,11 @@
 #include "gtest/gtest.h"
 #include "jni_util.h"
 #include "test_util.h"
+#include "native_stream_support_util.h"
 
+using ::test_util::JavaFileIndexOutputMock;
+using ::test_util::StreamIOError;
+using ::test_util::setUpJavaFileOutputMocking;
 using ::testing::NiceMock;
 using ::testing::Return;
 
@@ -33,117 +38,146 @@ TEST(NmslibIndexWrapperSearchTest, BasicAssertions) {
 }
 
 TEST(NmslibCreateIndexTest, BasicAssertions) {
-    // Initialize nmslib
-    similarity::initLibrary();
+    for (auto throwIOException : std::array<bool, 2> {false, true}) {
+        // Initialize nmslib
+        similarity::initLibrary();
 
-    // Define index data
-    int numIds = 100;
-    std::vector<int> ids;
-    auto *vectors = new std::vector<float>();
-    int dim = 2;
-    vectors->reserve(dim * numIds);
-    for (int64_t i = 0; i < numIds; ++i) {
-        ids.push_back(i);
-        for (int j = 0; j < dim; ++j) {
+        // Define index data
+        int numIds = 100;
+        std::vector<int> ids;
+        auto *vectors = new std::vector<float>();
+        int dim = 2;
+        vectors->reserve(dim * numIds);
+        for (int64_t i = 0; i < numIds; ++i) {
+          ids.push_back(i);
+          for (int j = 0; j < dim; ++j) {
             vectors->push_back(test_util::RandomFloat(-500.0, 500.0));
+          }
         }
-    }
 
-    std::string indexPath = test_util::RandomString(10, "tmp/", ".nmslib");
-    std::string spaceType = knn_jni::L2;
+        std::string indexPath = test_util::RandomString(10, "tmp/", ".nmslib");
+        std::string spaceType = knn_jni::L2;
 
-    std::unordered_map<std::string, jobject> parametersMap;
-    int efConstruction = 512;
-    int m = 96;
+        std::unordered_map<std::string, jobject> parametersMap;
+        int efConstruction = 512;
+        int m = 96;
 
-    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
-    parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject)&efConstruction;
-    parametersMap[knn_jni::M] = (jobject)&m;
+        parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+        parametersMap[knn_jni::EF_CONSTRUCTION] = (jobject)&efConstruction;
+        parametersMap[knn_jni::M] = (jobject)&m;
 
-    // Set up jni
-    JNIEnv *jniEnv = nullptr;
-    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+        // Set up jni
+        NiceMock<JNIEnv> jniEnv;
+        NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+        JavaFileIndexOutputMock javaFileIndexOutputMock {indexPath};
+        setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, throwIOException);
 
-    EXPECT_CALL(mockJNIUtil,
-                GetJavaObjectArrayLength(
-                        jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
+        EXPECT_CALL(mockJNIUtil,
+                    GetJavaObjectArrayLength(
+                        &jniEnv, reinterpret_cast<jobjectArray>(&vectors)))
             .WillRepeatedly(Return(vectors->size()));
 
-    EXPECT_CALL(mockJNIUtil,
-                GetJavaIntArrayLength(jniEnv, reinterpret_cast<jintArray>(&ids)))
+        EXPECT_CALL(mockJNIUtil,
+                    GetJavaIntArrayLength(&jniEnv, reinterpret_cast<jintArray>(&ids)))
             .WillRepeatedly(Return(ids.size()));
 
-    // Create the index
-    knn_jni::nmslib_wrapper::CreateIndex(
-            &mockJNIUtil, jniEnv, reinterpret_cast<jintArray>(&ids),
-            (jlong) vectors, dim, (jstring)&indexPath,
-            (jobject)&parametersMap);
+        // Create the index
+        try {
+            knn_jni::nmslib_wrapper::CreateIndex(
+                &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+                (jlong) vectors, dim, (jobject)(&javaFileIndexOutputMock),
+                (jobject)&parametersMap);
+        } catch (const StreamIOError& e) {
+            ASSERT_TRUE(throwIOException);
+            continue;
+        }
+        ASSERT_FALSE(throwIOException);
 
-    // Make sure index can be loaded
-    std::unique_ptr<similarity::Space<float>> space(
+        // Make sure we close a file stream before reopening the created file.
+        javaFileIndexOutputMock.file_writer.close();
+
+        // Make sure index can be loaded
+        std::unique_ptr<similarity::Space<float>> space(
             similarity::SpaceFactoryRegistry<float>::Instance().CreateSpace(
-                    spaceType, similarity::AnyParams()));
-    std::vector<std::string> params;
-    std::unique_ptr<similarity::Index<float>> loadedIndex(
+                spaceType, similarity::AnyParams()));
+        std::vector<std::string> params;
+        std::unique_ptr<similarity::Index<float>> loadedIndex(
             test_util::NmslibLoadIndex(indexPath, space.get(), spaceType, params));
 
-    // Clean up
-    std::remove(indexPath.c_str());
+        // Clean up
+        std::remove(indexPath.c_str());
+    }
 }
 
 TEST(NmslibLoadIndexTest, BasicAssertions) {
-    // Initialize nmslib
-    similarity::initLibrary();
+    for (auto throwIOException : std::array<bool, 2> {false, true}) {
+        // Initialize nmslib
+        similarity::initLibrary();
 
-    // Define index data
-    int numIds = 100;
-    std::vector<int> ids;
-    std::vector<std::vector<float>> vectors;
-    int dim = 2;
-    for (int i = 0; i < numIds; ++i) {
-        ids.push_back(i);
+        // Define index data
+        int numIds = 100;
+        std::vector<int> ids;
+        std::vector<std::vector<float>> vectors;
+        int dim = 2;
+        for (int i = 0; i < numIds; ++i) {
+          ids.push_back(i);
 
-        std::vector<float> vect;
-        vect.reserve(dim);
-        for (int j = 0; j < dim; ++j) {
+          std::vector<float> vect;
+          vect.reserve(dim);
+          for (int j = 0; j < dim; ++j) {
             vect.push_back(test_util::RandomFloat(-500.0, 500.0));
+          }
+          vectors.push_back(vect);
         }
-        vectors.push_back(vect);
-    }
 
-    std::string indexPath = test_util::RandomString(10, "tmp/", ".nmslib");
-    std::string spaceType = knn_jni::L2;
-    std::unique_ptr<similarity::Space<float>> space(
+        std::string indexPath = test_util::RandomString(10, "tmp/", ".nmslib");
+        std::string spaceType = knn_jni::L2;
+        std::unique_ptr<similarity::Space<float>> space(
             similarity::SpaceFactoryRegistry<float>::Instance().CreateSpace(
-                    spaceType, similarity::AnyParams()));
+                spaceType, similarity::AnyParams()));
 
-    std::vector<std::string> indexParameters;
+        std::vector<std::string> indexParameters;
 
-    // Create index and write to disk
-    std::unique_ptr<similarity::Index<float>> createdIndex(
+        // Setup jni
+        NiceMock<JNIEnv> jniEnv;
+        NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+        JavaFileIndexOutputMock javaFileIndexOutputMock {indexPath};
+        setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, throwIOException);
+        knn_jni::stream::NativeEngineIndexOutputMediator mediator {&mockJNIUtil, &jniEnv, (jobject) (&javaFileIndexOutputMock)};
+        knn_jni::stream::NmslibOpenSearchIOWriter writer {&mediator};
+
+        // Create index and write to disk
+        std::unique_ptr<similarity::Index<float>> createdIndex(
             test_util::NmslibCreateIndex(ids.data(), vectors, space.get(), spaceType,
                                          indexParameters));
 
-    test_util::NmslibWriteIndex(createdIndex.get(), indexPath);
-    // Setup jni
-    JNIEnv *jniEnv = nullptr;
-    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+        try {
+            test_util::NmslibWriteIndex(createdIndex.get(), writer);
 
-    // Load index
-    std::unordered_map<std::string, jobject> parametersMap;
-    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+            // Make sure we close a file stream before reopening the created file.
+            javaFileIndexOutputMock.file_writer.close();
+        } catch (const StreamIOError& e) {
+            ASSERT_TRUE(throwIOException);
+            continue;
+        }
+        ASSERT_FALSE(throwIOException);
 
-    std::unique_ptr<knn_jni::nmslib_wrapper::IndexWrapper> loadedIndex(
+        // Load index
+        std::unordered_map<std::string, jobject> parametersMap;
+        parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+        std::unique_ptr<knn_jni::nmslib_wrapper::IndexWrapper> loadedIndex(
             reinterpret_cast<knn_jni::nmslib_wrapper::IndexWrapper *>(
-                    knn_jni::nmslib_wrapper::LoadIndex(&mockJNIUtil, jniEnv,
-                                                       (jstring)&indexPath,
-                                                       (jobject)&parametersMap)));
+                knn_jni::nmslib_wrapper::LoadIndex(&mockJNIUtil, &jniEnv,
+                                                   (jstring)&indexPath,
+                                                   (jobject)&parametersMap)));
 
-    // Check that load succeeds
-    ASSERT_EQ(createdIndex->StrDesc(), loadedIndex->index->StrDesc());
+        // Check that load succeeds
+        ASSERT_EQ(createdIndex->StrDesc(), loadedIndex->index->StrDesc());
 
-    // Clean up
-    std::remove(indexPath.c_str());
+        // Clean up
+        std::remove(indexPath.c_str());
+    }
 }
 
 TEST(NmslibQueryIndexTest, BasicAssertions) {
@@ -166,7 +200,6 @@ TEST(NmslibQueryIndexTest, BasicAssertions) {
         vectors.push_back(vect);
     }
 
-    std::string indexPath = test_util::RandomString(10, "tmp/", ".nmslib");
     std::string spaceType = knn_jni::L2;
     std::unique_ptr<similarity::Space<float>> space(
             similarity::SpaceFactoryRegistry<float>::Instance().CreateSpace(
@@ -239,7 +272,6 @@ TEST(NmslibFreeTest, BasicAssertions) {
         vectors.push_back(vect);
     }
 
-    std::string indexPath = test_util::RandomString(10, "tmp/", ".nmslib");
     std::string spaceType = knn_jni::L2;
     std::unique_ptr<similarity::Space<float>> space(
             similarity::SpaceFactoryRegistry<float>::Instance().CreateSpace(

--- a/jni/tests/test_util.cpp
+++ b/jni/tests/test_util.cpp
@@ -29,6 +29,7 @@
 #include "methodfactory.h"
 #include "params.h"
 #include "space.h"
+#include "method/hnsw.h"
 
 test_util::MockJNIUtil::MockJNIUtil() {
     // Set default for calls. If necessary, these can be overriden with
@@ -374,8 +375,13 @@ similarity::Index<float> *test_util::NmslibCreateIndex(
 }
 
 void test_util::NmslibWriteIndex(similarity::Index<float> *index,
-                                 const std::string &indexPath) {
-    index->SaveIndex(indexPath);
+                                 knn_jni::stream::NmslibOpenSearchIOWriter& writer) {
+    if (auto hnswFloatIndex = dynamic_cast<similarity::Hnsw<float> *>(index)) {
+        hnswFloatIndex->SaveIndexWithStream(writer);
+        writer.flush();
+    } else {
+      throw std::runtime_error("We only support similarity::Hnsw<float> in NMSLIB.");
+    }
 }
 
 similarity::Index<float> *test_util::NmslibLoadIndex(

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -24,6 +24,7 @@
 #include "faiss/MetaIndexes.h"
 #include "faiss/MetricType.h"
 #include "faiss/impl/io.h"
+#include "nmslib_stream_support.h"
 #include "index.h"
 #include "init.h"
 #include "jni_util.h"
@@ -84,7 +85,7 @@ namespace test_util {
                     (JNIEnv * env, jobjectArray arrayJ, jsize index));
         MOCK_METHOD(void, HasExceptionInStack, (JNIEnv * env));
         MOCK_METHOD(void, HasExceptionInStack,
-                    (JNIEnv * env, const std::string& message));
+                    (JNIEnv * env, const char* message));
         MOCK_METHOD(jbyteArray, NewByteArray, (JNIEnv * env, jsize len));
         MOCK_METHOD(jobject, NewObject,
                     (JNIEnv * env, jclass clazz, jmethodID methodId, int id,
@@ -115,6 +116,7 @@ namespace test_util {
         MOCK_METHOD(jlong, CallNonvirtualLongMethodA, (JNIEnv * env, jobject obj, jclass clazz, jmethodID methodID, jvalue* args));
         MOCK_METHOD(void *, GetPrimitiveArrayCritical, (JNIEnv * env, jarray array, jboolean *isCopy));
         MOCK_METHOD(void, ReleasePrimitiveArrayCritical, (JNIEnv * env, jarray array, void *carray, jint mode));
+        MOCK_METHOD(void, CallNonvirtualVoidMethodA, (JNIEnv * env, jobject obj, jclass clazz, jmethodID methodID, jvalue* args));
     };
 
 // For our unit tests, we want to ensure that each test tests one function in
@@ -160,7 +162,7 @@ namespace test_util {
             const std::vector<std::string>& indexParameters);
 
     void NmslibWriteIndex(similarity::Index<float>* index,
-                          const std::string& indexPath);
+                          knn_jni::stream::NmslibOpenSearchIOWriter& writer);
 
     similarity::Index<float>* NmslibLoadIndex(
             const std::string& indexPath, similarity::Space<float>* space,

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
@@ -83,7 +83,7 @@ final class DefaultIndexBuildStrategy implements NativeIndexBuildStrategy {
                         intListToArray(transferredDocIds),
                         vectorAddress,
                         indexBuildSetup.getDimensions(),
-                        indexInfo.getIndexPath(),
+                        indexInfo.getIndexOutputWithBuffer(),
                         (byte[]) params.get(KNNConstants.MODEL_BLOB_PARAMETER),
                         params,
                         indexInfo.getKnnEngine()
@@ -96,7 +96,7 @@ final class DefaultIndexBuildStrategy implements NativeIndexBuildStrategy {
                         intListToArray(transferredDocIds),
                         vectorAddress,
                         indexBuildSetup.getDimensions(),
-                        indexInfo.getIndexPath(),
+                        indexInfo.getIndexOutputWithBuffer(),
                         params,
                         indexInfo.getKnnEngine()
                     );

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -48,7 +48,6 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
      * flushed and used to build the index. The index is then written to the specified path using JNI calls.</p>
      *
      * @param indexInfo        The {@link BuildIndexParams} containing the parameters and configuration for building the index.
-     * @param knnVectorValues  The {@link KNNVectorValues} representing the vectors to be indexed.
      * @throws IOException     If an I/O error occurs during the process of building and writing the index.
      */
     public void buildAndWriteIndex(final BuildIndexParams indexInfo) throws IOException {
@@ -123,7 +122,7 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
 
             // Write vector
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                JNIService.writeIndex(indexInfo.getIndexPath(), indexMemoryAddress, engine, indexParameters);
+                JNIService.writeIndex(indexInfo.getIndexOutputWithBuffer(), indexMemoryAddress, engine, indexParameters);
                 return null;
             });
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
@@ -11,6 +11,7 @@ import lombok.Value;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 
@@ -22,7 +23,7 @@ import java.util.Map;
 public class BuildIndexParams {
     String fieldName;
     KNNEngine knnEngine;
-    String indexPath;
+    IndexOutputWithBuffer indexOutputWithBuffer;
     VectorDataType vectorDataType;
     Map<String, Object> parameters;
     /**

--- a/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
+++ b/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.store;
+
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+
+public class IndexOutputWithBuffer {
+    // Underlying `IndexOutput` obtained from Lucene's Directory.
+    private IndexOutput indexOutput;
+    // Write buffer. Native engine will copy bytes into this buffer.
+    // Allocating 64KB here since it show better performance in NMSLIB with the size. (We had slightly improvement in FAISS than having 4KB)
+    // NMSLIB writes an adjacent list size first, then followed by serializing the list. Since we usually have more adjacent lists, having
+    // 64KB to accumulate bytes as possible to reduce the times of calling `writeBytes`.
+    private byte[] buffer = new byte[64 * 1024];
+
+    public IndexOutputWithBuffer(IndexOutput indexOutput) {
+        this.indexOutput = indexOutput;
+    }
+
+    // This method will be called in JNI layer which precisely knows
+    // the amount of bytes need to be written.
+    public void writeBytes(int length) {
+        try {
+            // Delegate Lucene `indexOuptut` to write bytes.
+            indexOutput.writeBytes(buffer, 0, length);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{indexOutput=" + indexOutput + ", len(buffer)=" + buffer.length + "}";
+    }
+}

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -12,9 +12,10 @@
 package org.opensearch.knn.jni;
 
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.query.KNNQueryResult;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNQueryResult;
 import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -23,11 +24,11 @@ import java.util.Map;
 import static org.opensearch.knn.index.KNNSettings.isFaissAVX2Disabled;
 import static org.opensearch.knn.index.KNNSettings.isFaissAVX512Disabled;
 import static org.opensearch.knn.jni.PlatformUtils.isAVX2SupportedBySystem;
-import static org.opensearch.knn.jni.PlatformUtils.isAVX512SupportedBySystem;;
+import static org.opensearch.knn.jni.PlatformUtils.isAVX512SupportedBySystem;
 
 /**
  * Service to interact with faiss jni layer. Class dependencies should be minimal
- *
+ * <p>
  * In order to compile C++ header file, run:
  * javac -h jni/include src/main/java/org/opensearch/knn/jni/FaissService.java
  *      src/main/java/org/opensearch/knn/index/query/KNNQueryResult.java
@@ -129,9 +130,9 @@ class FaissService {
      * NOTE: This will always free the index. Do not call free after this.
      *
      * @param indexAddress address of native memory where index is stored
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      */
-    public static native void writeIndex(long indexAddress, String indexPath);
+    public static native void writeIndex(long indexAddress, IndexOutputWithBuffer output);
 
     /**
      * Writes a faiss index.
@@ -139,9 +140,9 @@ class FaissService {
      * NOTE: This will always free the index. Do not call free after this.
      *
      * @param indexAddress address of native memory where index is stored
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      */
-    public static native void writeBinaryIndex(long indexAddress, String indexPath);
+    public static native void writeBinaryIndex(long indexAddress, IndexOutputWithBuffer output);
 
     /**
      * Writes a faiss index.
@@ -149,9 +150,9 @@ class FaissService {
      * NOTE: This will always free the index. Do not call free after this.
      *
      * @param indexAddress address of native memory where index is stored
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      */
-    public static native void writeByteIndex(long indexAddress, String indexPath);
+    public static native void writeByteIndex(long indexAddress, IndexOutputWithBuffer output);
 
     /**
      * Create an index for the native library with a provided template index
@@ -159,7 +160,7 @@ class FaissService {
      * @param ids array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored
      * @param dim dimension of the vector to be indexed
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      * @param templateIndex empty template index
      * @param parameters additional build time parameters
      */
@@ -167,7 +168,7 @@ class FaissService {
         int[] ids,
         long vectorsAddress,
         int dim,
-        String indexPath,
+        IndexOutputWithBuffer output,
         byte[] templateIndex,
         Map<String, Object> parameters
     );
@@ -178,7 +179,7 @@ class FaissService {
      * @param ids array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored
      * @param dim dimension of the vector to be indexed
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      * @param templateIndex empty template index
      * @param parameters additional build time parameters
      */
@@ -186,7 +187,7 @@ class FaissService {
         int[] ids,
         long vectorsAddress,
         int dim,
-        String indexPath,
+        IndexOutputWithBuffer output,
         byte[] templateIndex,
         Map<String, Object> parameters
     );
@@ -197,7 +198,7 @@ class FaissService {
      * @param ids array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored
      * @param dim dimension of the vector to be indexed
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      * @param templateIndex empty template index
      * @param parameters additional build time parameters
      */
@@ -205,7 +206,7 @@ class FaissService {
         int[] ids,
         long vectorsAddress,
         int dim,
-        String indexPath,
+        IndexOutputWithBuffer output,
         byte[] templateIndex,
         Map<String, Object> parameters
     );

--- a/src/main/java/org/opensearch/knn/jni/NmslibService.java
+++ b/src/main/java/org/opensearch/knn/jni/NmslibService.java
@@ -12,9 +12,10 @@
 package org.opensearch.knn.jni;
 
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.query.KNNQueryResult;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNQueryResult;
 import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -22,7 +23,7 @@ import java.util.Map;
 
 /**
  * Service to interact with nmslib jni layer. Class dependencies should be minimal
- *
+ * <p>
  * In order to compile C++ header file, run:
  * javac -h jni/include src/main/java/org/opensearch/knn/jni/NmslibService.java
  *      src/main/java/org/opensearch/knn/index/KNNQueryResult.java
@@ -48,19 +49,16 @@ class NmslibService {
      * @param ids array of ids mapping to the data passed in
      * @param vectorsAddress address of native memory where vectors are stored
      * @param dim dimension of the vector to be indexed
-     * @param indexPath path to save index file to
+     * @param output Index output wrapper having Lucene's IndexOutput to be used to flush bytes in native engines.
      * @param parameters parameters to build index
      */
-    public static native void createIndex(int[] ids, long vectorsAddress, int dim, String indexPath, Map<String, Object> parameters);
-
-    /**
-     * Load an index into memory
-     *
-     * @param indexPath path to index file
-     * @param parameters parameters to be used when loading index
-     * @return pointer to location in memory the index resides in
-     */
-    public static native long loadIndex(String indexPath, Map<String, Object> parameters);
+    public static native void createIndex(
+        int[] ids,
+        long vectorsAddress,
+        int dim,
+        IndexOutputWithBuffer output,
+        Map<String, Object> parameters
+    );
 
     /**
      * Load an index into memory through the provided read stream wrapping Lucene's IndexInput.

--- a/src/test/java/org/opensearch/knn/common/RaisingIOExceptionIndexInput.java
+++ b/src/test/java/org/opensearch/knn/common/RaisingIOExceptionIndexInput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common;
+
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+public class RaisingIOExceptionIndexInput extends IndexInput {
+    public RaisingIOExceptionIndexInput() {
+        super(RaisingIOExceptionIndexInput.class.getSimpleName());
+    }
+
+    @Override
+    public void close() throws IOException {
+        throw new IOException("RaisingIOExceptionIndexInput::readBytes failed.");
+    }
+
+    @Override
+    public long getFilePointer() {
+        throw new RuntimeException("RaisingIOExceptionIndexInput::readBytes failed.");
+    }
+
+    @Override
+    public void seek(long l) throws IOException {
+        throw new IOException("RaisingIOExceptionIndexInput::readBytes failed.");
+    }
+
+    @Override
+    public long length() {
+        return 0;
+    }
+
+    @Override
+    public IndexInput slice(String s, long l, long l1) throws IOException {
+        throw new IOException("RaisingIOExceptionIndexInput::readBytes failed.");
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        throw new IOException("RaisingIOExceptionIndexInput::readBytes failed.");
+    }
+
+    @Override
+    public void readBytes(byte[] bytes, int i, int i1) throws IOException {
+        throw new IOException("RaisingIOExceptionIndexInput::readBytes failed.");
+    }
+}

--- a/src/test/java/org/opensearch/knn/common/RasingIOExceptionIndexOutput.java
+++ b/src/test/java/org/opensearch/knn/common/RasingIOExceptionIndexOutput.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common;
+
+import org.apache.lucene.store.IndexOutput;
+
+import java.io.IOException;
+
+public class RasingIOExceptionIndexOutput extends IndexOutput {
+    public RasingIOExceptionIndexOutput() {
+        super("Always throws IOException", RasingIOExceptionIndexOutput.class.getSimpleName());
+    }
+
+    @Override
+    public void close() throws IOException {
+        throw new IOException("RaiseIOExceptionIndexInput::close failed.");
+    }
+
+    @Override
+    public long getFilePointer() {
+        throw new RuntimeException("RaiseIOExceptionIndexInput::getFilePointer failed.");
+    }
+
+    @Override
+    public long getChecksum() throws IOException {
+        throw new IOException("RaiseIOExceptionIndexInput::getChecksum failed.");
+    }
+
+    @Override
+    public void writeByte(byte b) throws IOException {
+        throw new IOException("RaiseIOExceptionIndexInput::writeByte failed.");
+    }
+
+    @Override
+    public void writeBytes(byte[] bytes, int i, int i1) throws IOException {
+        throw new IOException("RaiseIOExceptionIndexInput::writeBytes failed.");
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -154,64 +154,67 @@ public class KNNCodecTestCase extends KNNTestCase {
 
     public void testMultiFieldsKnnIndex(Codec codec) throws Exception {
         setUpMockClusterService();
-        Directory dir = newFSDirectory(createTempDir());
-        IndexWriterConfig iwc = newIndexWriterConfig();
-        iwc.setMergeScheduler(new SerialMergeScheduler());
-        iwc.setCodec(codec);
-        // Set merge policy to no merges so that we create a predictable number of segments.
-        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        try (Directory dir = newFSDirectory(createTempDir())) {
+            IndexWriterConfig iwc = newIndexWriterConfig();
+            iwc.setMergeScheduler(new SerialMergeScheduler());
+            iwc.setCodec(codec);
+            // Set merge policy to no merges so that we create a predictable number of segments.
+            iwc.setMergePolicy(NoMergePolicy.INSTANCE);
 
-        /**
-         * Add doc with field "test_vector"
-         */
-        float[] array = { 1.0f, 3.0f, 4.0f };
-        VectorField vectorField = new VectorField("test_vector", array, sampleFieldType);
-        RandomIndexWriter writer = new RandomIndexWriter(random(), dir, iwc);
-        Document doc = new Document();
-        doc.add(vectorField);
-        writer.addDocument(doc);
-        // ensuring the refresh happens, to create the segment and hnsw file
-        writer.flush();
+            /**
+             * Add doc with field "test_vector"
+             */
+            float[] array = { 1.0f, 3.0f, 4.0f };
+            VectorField vectorField = new VectorField("test_vector", array, sampleFieldType);
+            RandomIndexWriter writer = new RandomIndexWriter(random(), dir, iwc);
+            Document doc = new Document();
+            doc.add(vectorField);
+            writer.addDocument(doc);
+            // ensuring the refresh happens, to create the segment and hnsw file
+            writer.flush();
 
-        /**
-         * Add doc with field "my_vector"
-         */
-        float[] array1 = { 6.0f, 14.0f };
-        VectorField vectorField1 = new VectorField("my_vector", array1, sampleFieldType);
-        Document doc1 = new Document();
-        doc1.add(vectorField1);
-        writer.addDocument(doc1);
-        // ensuring the refresh happens, to create the segment and hnsw file
-        writer.flush();
-        IndexReader reader = writer.getReader();
-        writer.close();
-        List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
+            /**
+             * Add doc with field "my_vector"
+             */
+            float[] array1 = { 6.0f, 14.0f };
+            VectorField vectorField1 = new VectorField("my_vector", array1, sampleFieldType);
+            Document doc1 = new Document();
+            doc1.add(vectorField1);
+            writer.addDocument(doc1);
+            // ensuring the refresh happens, to create the segment and hnsw file
+            writer.flush();
+            IndexReader reader = writer.getReader();
+            writer.close();
+            List<String> hnswfiles = Arrays.stream(dir.listAll()).filter(x -> x.contains("hnsw")).collect(Collectors.toList());
 
-        // there should be 2 hnsw index files created. one for test_vector and one for my_vector
-        assertEquals(2, hnswfiles.size());
-        assertEquals(hnswfiles.stream().filter(x -> x.contains("test_vector")).collect(Collectors.toList()).size(), 1);
-        assertEquals(hnswfiles.stream().filter(x -> x.contains("my_vector")).collect(Collectors.toList()).size(), 1);
+            // there should be 2 hnsw index files created. one for test_vector and one for my_vector
+            assertEquals(2, hnswfiles.size());
+            assertEquals(hnswfiles.stream().filter(x -> x.contains("test_vector")).collect(Collectors.toList()).size(), 1);
+            assertEquals(hnswfiles.stream().filter(x -> x.contains("my_vector")).collect(Collectors.toList()).size(), 1);
 
-        // query to verify distance for each of the field
-        IndexSearcher searcher = new IndexSearcher(reader);
-        float score = searcher.search(
-            new KNNQuery("test_vector", new float[] { 1.0f, 0.0f, 0.0f }, 1, "dummy", (BitSetProducer) null),
-            10
-        ).scoreDocs[0].score;
-        float score1 = searcher.search(
-            new KNNQuery("my_vector", new float[] { 1.0f, 2.0f }, 1, "dummy", (BitSetProducer) null),
-            10
-        ).scoreDocs[0].score;
-        assertEquals(1.0f / (1 + 25), score, 0.01f);
-        assertEquals(1.0f / (1 + 169), score1, 0.01f);
+            // query to verify distance for each of the field
+            IndexSearcher searcher = new IndexSearcher(reader);
+            float score = searcher.search(
+                new KNNQuery("test_vector", new float[] { 1.0f, 0.0f, 0.0f }, 1, "dummy", (BitSetProducer) null),
+                10
+            ).scoreDocs[0].score;
+            float score1 = searcher.search(
+                new KNNQuery("my_vector", new float[] { 1.0f, 2.0f }, 1, "dummy", (BitSetProducer) null),
+                10
+            ).scoreDocs[0].score;
+            assertEquals(1.0f / (1 + 25), score, 0.01f);
+            assertEquals(1.0f / (1 + 169), score1, 0.01f);
 
-        // query to determine the hits
-        assertEquals(1, searcher.count(new KNNQuery("test_vector", new float[] { 1.0f, 0.0f, 0.0f }, 1, "dummy", (BitSetProducer) null)));
-        assertEquals(1, searcher.count(new KNNQuery("my_vector", new float[] { 1.0f, 1.0f }, 1, "dummy", (BitSetProducer) null)));
+            // query to determine the hits
+            assertEquals(
+                1,
+                searcher.count(new KNNQuery("test_vector", new float[] { 1.0f, 0.0f, 0.0f }, 1, "dummy", (BitSetProducer) null))
+            );
+            assertEquals(1, searcher.count(new KNNQuery("my_vector", new float[] { 1.0f, 1.0f }, 1, "dummy", (BitSetProducer) null)));
 
-        reader.close();
-        dir.close();
-        NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance().close();
+            reader.close();
+            NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance().close();
+        }
     }
 
     public void testBuildFromModelTemplate(Codec codec) throws IOException, ExecutionException, InterruptedException {

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategyTests.java
@@ -10,6 +10,7 @@ import org.apache.lucene.index.DocsWithFieldSet;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
@@ -18,6 +19,7 @@ import org.opensearch.knn.index.codec.transfer.OffHeapVectorTransfer;
 import org.opensearch.knn.index.codec.transfer.OffHeapVectorTransferFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
@@ -66,8 +68,9 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
 
             when(offHeapVectorTransfer.getVectorAddress()).thenReturn(200L);
 
+            IndexOutputWithBuffer indexOutputWithBuffer = Mockito.mock(IndexOutputWithBuffer.class);
             BuildIndexParams buildIndexParams = BuildIndexParams.builder()
-                .indexPath("indexPath")
+                .indexOutputWithBuffer(indexOutputWithBuffer)
                 .knnEngine(KNNEngine.NMSLIB)
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("index", "param"))
@@ -84,7 +87,7 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
                     eq(new int[] { 0, 1, 2 }),
                     eq(200L),
                     eq(knnVectorValues.dimension()),
-                    eq("indexPath"),
+                    eq(indexOutputWithBuffer),
                     eq(Map.of("index", "param")),
                     eq(KNNEngine.NMSLIB)
                 )
@@ -159,8 +162,9 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
             when(offHeapVectorTransfer.flush(false)).thenReturn(true);
             when(offHeapVectorTransfer.getVectorAddress()).thenReturn(200L);
 
+            IndexOutputWithBuffer indexOutputWithBuffer = Mockito.mock(IndexOutputWithBuffer.class);
             BuildIndexParams buildIndexParams = BuildIndexParams.builder()
-                .indexPath("indexPath")
+                .indexOutputWithBuffer(indexOutputWithBuffer)
                 .knnEngine(KNNEngine.FAISS)
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("index", "param"))
@@ -206,7 +210,7 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
             );
 
             mockedJNIService.verify(
-                () -> JNIService.writeIndex(eq("indexPath"), eq(100L), eq(KNNEngine.FAISS), eq(Map.of("index", "param")))
+                () -> JNIService.writeIndex(eq(indexOutputWithBuffer), eq(100L), eq(KNNEngine.FAISS), eq(Map.of("index", "param")))
             );
             assertEquals(200L, vectorAddressCaptor.getValue().longValue());
             assertEquals(vectorAddressCaptor.getValue().longValue(), vectorAddressCaptor.getAllValues().get(0).longValue());
@@ -244,8 +248,9 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
 
             when(offHeapVectorTransfer.getVectorAddress()).thenReturn(200L);
 
+            IndexOutputWithBuffer indexOutputWithBuffer = Mockito.mock(IndexOutputWithBuffer.class);
             BuildIndexParams buildIndexParams = BuildIndexParams.builder()
-                .indexPath("indexPath")
+                .indexOutputWithBuffer(indexOutputWithBuffer)
                 .knnEngine(KNNEngine.NMSLIB)
                 .vectorDataType(VectorDataType.FLOAT)
                 .parameters(Map.of("model_id", "id", "model_blob", modelBlob))
@@ -262,7 +267,7 @@ public class DefaultIndexBuildStrategyTests extends OpenSearchTestCase {
                     eq(new int[] { 0, 1, 2 }),
                     eq(200L),
                     eq(2),
-                    eq("indexPath"),
+                    eq(indexOutputWithBuffer),
                     eq(modelBlob),
                     eq(Map.of("model_id", "id", "model_blob", modelBlob)),
                     eq(KNNEngine.NMSLIB)

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -9,6 +9,9 @@ import com.google.common.collect.ImmutableMap;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -20,6 +23,7 @@ import java.io.IOException;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.util.SerializationMode;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.jni.JNICommons;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
@@ -422,14 +426,32 @@ public class TestUtils {
         }
     }
 
-    public static void createIndex(int[] ids, long address, int dimension, String name, Map<String, Object> parameters, KNNEngine engine) {
+    public static void createIndex(
+        int[] ids,
+        long address,
+        int dimension,
+        Directory directory,
+        String fileName,
+        Map<String, Object> parameters,
+        KNNEngine engine
+    ) {
         if (engine != KNNEngine.FAISS) {
-            JNIService.createIndex(ids, address, dimension, name, parameters, engine);
+            try (IndexOutput indexOutput = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                final IndexOutputWithBuffer indexOutputWithBuffer = new IndexOutputWithBuffer(indexOutput);
+                JNIService.createIndex(ids, address, dimension, indexOutputWithBuffer, parameters, engine);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         } else {
             // We can initialize numDocs as 0, this will just not reserve anything.
             long indexAddress = JNIService.initIndex(0, dimension, parameters, engine);
             JNIService.insertToIndex(ids, address, dimension, parameters, indexAddress, engine);
-            JNIService.writeIndex(name, indexAddress, engine, parameters);
+            try (IndexOutput indexOutput = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                final IndexOutputWithBuffer indexOutputWithBuffer = new IndexOutputWithBuffer(indexOutput);
+                JNIService.writeIndex(indexOutputWithBuffer, indexAddress, engine, parameters);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
This PR introduces an abstract writing layer into native engines (NMSLIB, Faiss). 
In which, made native engines rely on an write interface to do the IO instead of directly depending on File API.
Due to this layer, we can use a different kind of underlying storage to save vector index. The default one that is currently being used is FSDirectory saving the index in the local file system.

### Related Issues
RFC : https://github.com/opensearch-project/k-NN/issues/2033

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
