### PR TITLE
Added 'j' option to use multiple cpus to build JNI library.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,10 +18,11 @@ function usage() {
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-j NPROC_COUNT\t[Optional] Number of CPUs to use when building JNI library. Default is 1."
     echo -e "-h help"
 }
 
-while getopts ":h:v:q:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:j:" arg; do
     case $arg in
         h)
             usage
@@ -44,6 +45,9 @@ while getopts ":h:v:q:s:o:p:a:" arg; do
             ;;
         a)
             ARCHITECTURE=$OPTARG
+            ;;
+        j)
+            NPROC_COUNT=$OPTARG
             ;;
         :)
             echo "Error: -${OPTARG} requires an argument"
@@ -118,7 +122,7 @@ fi
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir
 ./gradlew build --no-daemon --refresh-dependencies -x integTest -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Dbuild.lib.commit_patches=false
-./gradlew :buildJniLib -Davx512.enabled=false -Davx2.enabled=false -Dbuild.lib.commit_patches=false
+./gradlew :buildJniLib -Davx512.enabled=false -Davx2.enabled=false -Dbuild.lib.commit_patches=false -Dnproc.count=${NPROC_COUNT:-1}
 
 if [ "$PLATFORM" != "windows" ] && [ "$ARCHITECTURE" = "x64" ]; then
   echo "Building k-NN library after enabling AVX2"


### PR DESCRIPTION
### Description
Current plugin build script is not enabled with parallel compile, only using one single core to build the whole libraries.
This PR is to add an option for user to specify the number of cpus for building. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
