### PR TITLE
Refactor scoring to map leaf reader context with results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Select index settings based on cluster version[2236](https://github.com/opensearch-project/k-NN/pull/2236)
 ### Refactoring
+* Refactor scoring to map leaf reader context with results[2271](https://github.com/opensearch-project/k-NN/pull/2271)

--- a/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -30,14 +31,15 @@ public final class ResultUtil {
      * @param perLeafResults Results from the list
      * @param k the number of results across all leaf results to return
      */
-    public static void reduceToTopK(List<Map<Integer, Float>> perLeafResults, int k) {
+    public static void reduceToTopK(List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> perLeafResults, int k) {
         // Iterate over all scores to get min competitive score
         PriorityQueue<Float> topKMinQueue = new PriorityQueue<>(k);
 
         int count = 0;
-        for (Map<Integer, Float> perLeafResult : perLeafResults) {
-            count += perLeafResult.size();
-            for (Float score : perLeafResult.values()) {
+        for (Map.Entry<LeafReaderContext, Map<Integer, Float>> perLeafResult : perLeafResults) {
+            Map<Integer, Float> docIdScoreMap = perLeafResult.getValue();
+            count += docIdScoreMap.size();
+            for (Float score : docIdScoreMap.values()) {
                 if (topKMinQueue.size() < k) {
                     topKMinQueue.add(score);
                 } else if (topKMinQueue.peek() != null && score > topKMinQueue.peek()) {
@@ -54,7 +56,7 @@ public final class ResultUtil {
 
         // Reduce the results based on min competitive score
         float minScore = topKMinQueue.peek() == null ? -Float.MAX_VALUE : topKMinQueue.peek();
-        perLeafResults.forEach(results -> results.entrySet().removeIf(entry -> entry.getValue() < minScore));
+        perLeafResults.forEach(results -> results.getValue().entrySet().removeIf(entry -> entry.getValue() < minScore));
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -91,9 +91,9 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
 
         when(searcher.getTaskExecutor()).thenReturn(taskExecutor);
         when(taskExecutor.invokeAll(any())).thenAnswer(invocationOnMock -> {
-            List<Callable<Map<Integer, Float>>> callables = invocationOnMock.getArgument(0);
-            List<Map<Integer, Float>> results = new ArrayList<>();
-            for (Callable<Map<Integer, Float>> callable : callables) {
+            List<Callable<Map.Entry<LeafReaderContext, Map<Integer, Float>>>> callables = invocationOnMock.getArgument(0);
+            List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> results = new ArrayList<>();
+            for (Callable<Map.Entry<LeafReaderContext, Map<Integer, Float>>> callable : callables) {
                 results.add(callable.call());
             }
             return results;


### PR DESCRIPTION
### Description
We map order of results to order of segments, and finally rely on that order to build top docs. Refactor method to use map.Entry to map leaf reader context with results from those leaves.
This is required when we want to split segments based on approx search or exact search to reduce rescoring twice by exact search

### Related Issues
Prerequisite for  #2215 
### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
