### PR TITLE
Split segment by search type

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -153,6 +153,26 @@ public class KNNWeight extends Weight {
         return docIdsToScoreMap;
     }
 
+    /**
+     * For given {@link LeafReaderContext}, this api will return will KNNWeight perform exact search or not
+     * always. This decision is based on two properties, 1) if there are no native engine files in segments,
+     * exact search will always be performed, 2) if number of docs after filter is less than 'k'
+     * @param context
+     * @return
+     * @throws IOException
+     */
+    public boolean isExactSearchPreferred(LeafReaderContext context) throws IOException {
+        final BitSet filterBitSet = getFilteredDocsBitSet(context);
+        int cardinality = filterBitSet.cardinality();
+        if (isFilteredExactSearchPreferred(cardinality)) {
+            return true;
+        }
+        if (isMissingNativeEngineFiles(context)) {
+            return true;
+        }
+        return false;
+    }
+
     private BitSet getFilteredDocsBitSet(final LeafReaderContext ctx) throws IOException {
         if (this.filterWeight == null) {
             return new FixedBitSet(0);

--- a/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -30,14 +31,15 @@ public final class ResultUtil {
      * @param perLeafResults Results from the list
      * @param k the number of results across all leaf results to return
      */
-    public static void reduceToTopK(List<Map<Integer, Float>> perLeafResults, int k) {
+    public static void reduceToTopK(List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> perLeafResults, int k) {
         // Iterate over all scores to get min competitive score
         PriorityQueue<Float> topKMinQueue = new PriorityQueue<>(k);
 
         int count = 0;
-        for (Map<Integer, Float> perLeafResult : perLeafResults) {
-            count += perLeafResult.size();
-            for (Float score : perLeafResult.values()) {
+        for (Map.Entry<LeafReaderContext, Map<Integer, Float>> perLeafResult : perLeafResults) {
+            Map<Integer, Float> docIdScoreMap = perLeafResult.getValue();
+            count += docIdScoreMap.size();
+            for (Float score : docIdScoreMap.values()) {
                 if (topKMinQueue.size() < k) {
                     topKMinQueue.add(score);
                 } else if (topKMinQueue.peek() != null && score > topKMinQueue.peek()) {
@@ -54,7 +56,7 @@ public final class ResultUtil {
 
         // Reduce the results based on min competitive score
         float minScore = topKMinQueue.peek() == null ? -Float.MAX_VALUE : topKMinQueue.peek();
-        perLeafResults.forEach(results -> results.entrySet().removeIf(entry -> entry.getValue() < minScore));
+        perLeafResults.forEach(results -> results.getValue().entrySet().removeIf(entry -> entry.getValue() < minScore));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -28,6 +28,7 @@ import org.opensearch.knn.index.query.ResultUtil;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -55,7 +56,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         final IndexReader reader = indexSearcher.getIndexReader();
         final KNNWeight knnWeight = (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1);
         List<LeafReaderContext> leafReaderContexts = reader.leaves();
-        List<Map<Integer, Float>> perLeafResults;
+        List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> perLeafResults;
         RescoreContext rescoreContext = knnQuery.getRescoreContext();
         final int finalK = knnQuery.getK();
         if (rescoreContext == null) {
@@ -70,14 +71,15 @@ public class NativeEngineKnnVectorQuery extends Query {
             }
 
             StopWatch stopWatch = new StopWatch().start();
-            perLeafResults = doRescore(indexSearcher, leafReaderContexts, knnWeight, perLeafResults, finalK);
+            perLeafResults = doRescore(indexSearcher, knnWeight, perLeafResults, finalK);
             long rescoreTime = stopWatch.stop().totalTime().millis();
             log.debug("Rescoring results took {} ms. oversampled k:{}, segments:{}", rescoreTime, firstPassK, leafReaderContexts.size());
         }
         ResultUtil.reduceToTopK(perLeafResults, finalK);
         TopDocs[] topDocs = new TopDocs[perLeafResults.size()];
-        for (int i = 0; i < perLeafResults.size(); i++) {
-            topDocs[i] = ResultUtil.resultMapToTopDocs(perLeafResults.get(i), leafReaderContexts.get(i).docBase);
+        int i = 0;
+        for (Map.Entry<LeafReaderContext, Map<Integer, Float>> entry : perLeafResults) {
+            topDocs[i++] = ResultUtil.resultMapToTopDocs(entry.getValue(), entry.getKey().docBase);
         }
 
         TopDocs topK = TopDocs.merge(knnQuery.getK(), topDocs);
@@ -87,32 +89,29 @@ public class NativeEngineKnnVectorQuery extends Query {
         return createDocAndScoreQuery(reader, topK).createWeight(indexSearcher, scoreMode, boost);
     }
 
-    private List<Map<Integer, Float>> doSearch(
+    private List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> doSearch(
         final IndexSearcher indexSearcher,
         List<LeafReaderContext> leafReaderContexts,
         KNNWeight knnWeight,
         int k
     ) throws IOException {
-        List<Callable<Map<Integer, Float>>> tasks = new ArrayList<>(leafReaderContexts.size());
+        List<Callable<Map.Entry<LeafReaderContext, Map<Integer, Float>>>> tasks = new ArrayList<>(leafReaderContexts.size());
         for (LeafReaderContext leafReaderContext : leafReaderContexts) {
             tasks.add(() -> searchLeaf(leafReaderContext, knnWeight, k));
         }
         return indexSearcher.getTaskExecutor().invokeAll(tasks);
     }
 
-    private List<Map<Integer, Float>> doRescore(
+    private List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> doRescore(
         final IndexSearcher indexSearcher,
-        List<LeafReaderContext> leafReaderContexts,
         KNNWeight knnWeight,
-        List<Map<Integer, Float>> perLeafResults,
+        List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> perLeafResults,
         int k
     ) throws IOException {
-        List<Callable<Map<Integer, Float>>> rescoreTasks = new ArrayList<>(leafReaderContexts.size());
-        for (int i = 0; i < perLeafResults.size(); i++) {
-            LeafReaderContext leafReaderContext = leafReaderContexts.get(i);
-            int finalI = i;
+        List<Callable<Map.Entry<LeafReaderContext, Map<Integer, Float>>>> rescoreTasks = new ArrayList<>(perLeafResults.size());
+        for (Map.Entry<LeafReaderContext, Map<Integer, Float>> entry : perLeafResults) {
             rescoreTasks.add(() -> {
-                BitSet convertedBitSet = ResultUtil.resultMapToMatchBitSet(perLeafResults.get(finalI));
+                BitSet convertedBitSet = ResultUtil.resultMapToMatchBitSet(entry.getValue());
                 final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
                     .matchedDocs(convertedBitSet)
                     // setting to false because in re-scoring we want to do exact search on full precision vectors
@@ -121,7 +120,8 @@ public class NativeEngineKnnVectorQuery extends Query {
                     .isParentHits(false)
                     .knnQuery(knnQuery)
                     .build();
-                return knnWeight.exactSearch(leafReaderContext, exactSearcherContext);
+                final Map<Integer, Float> docIdScoreMap = knnWeight.exactSearch(entry.getKey(), exactSearcherContext);
+                return new AbstractMap.SimpleEntry<>(entry.getKey(), docIdScoreMap);
             });
         }
         return indexSearcher.getTaskExecutor().invokeAll(rescoreTasks);
@@ -158,13 +158,14 @@ public class NativeEngineKnnVectorQuery extends Query {
         return starts;
     }
 
-    private Map<Integer, Float> searchLeaf(LeafReaderContext ctx, KNNWeight queryWeight, int k) throws IOException {
+    private Map.Entry<LeafReaderContext, Map<Integer, Float>> searchLeaf(LeafReaderContext ctx, KNNWeight queryWeight, int k)
+        throws IOException {
         final Map<Integer, Float> leafDocScores = queryWeight.searchLeaf(ctx, k);
         final Bits liveDocs = ctx.reader().getLiveDocs();
         if (liveDocs != null) {
             leafDocScores.entrySet().removeIf(entry -> liveDocs.get(entry.getKey()) == false);
         }
-        return leafDocScores;
+        return new AbstractMap.SimpleEntry<>(ctx, leafDocScores);
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -91,9 +91,9 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
 
         when(searcher.getTaskExecutor()).thenReturn(taskExecutor);
         when(taskExecutor.invokeAll(any())).thenAnswer(invocationOnMock -> {
-            List<Callable<Map<Integer, Float>>> callables = invocationOnMock.getArgument(0);
-            List<Map<Integer, Float>> results = new ArrayList<>();
-            for (Callable<Map<Integer, Float>> callable : callables) {
+            List<Callable<Map.Entry<LeafReaderContext, Map<Integer, Float>>>> callables = invocationOnMock.getArgument(0);
+            List<Map.Entry<LeafReaderContext, Map<Integer, Float>>> results = new ArrayList<>();
+            for (Callable<Map.Entry<LeafReaderContext, Map<Integer, Float>>> callable : callables) {
                 results.add(callable.call());
             }
             return results;


### PR DESCRIPTION
### Description
For exact search, it is not required to perform
qunatization during rescore with oversamples.
However, to avoid normalization between segments from
approx search and exact search, we will first identify
segments that needs approxsearch and will perform oversamples
and, at end, after rescore, we will add scores from segments that
will perform exact search.

### Related Issues
#2215 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
