### PR TITLE
Added null checks for fieldInfo in ExactSearcher to avoid NPE while running exact search for segments with no vector field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 - Introduced a writing layer in native engines where relies on the writing interface to process IO. (#2241)[https://github.com/opensearch-project/k-NN/pull/2241]
 ### Bug Fixes
-* Fix NPE in ANN search when a segment doesn't contain vector field (#2278)[https://github.com/opensearch-project/k-NN/pull/2278]
+* Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)
 ### Documentation
 ### Maintenance
 * Select index settings based on cluster version[2236](https://github.com/opensearch-project/k-NN/pull/2236)
+* Added null checks for fieldInfo in ExactSearcher to avoid NPE while running exact search for segments with no vector field (#2278)[https://github.com/opensearch-project/k-NN/pull/2278]
 ### Refactoring

--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -8,6 +8,8 @@ package org.opensearch.knn.common;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -27,7 +29,7 @@ import java.util.Locale;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 /**
- * A utility class to extract information from FieldInfo.
+ * A utility class to extract information from FieldInfo and also provides utility functions to extract fieldInfo
  */
 @UtilityClass
 public class FieldInfoExtractor {
@@ -102,5 +104,16 @@ public class FieldInfoExtractor {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Unable to find the model metadata for model id %s", modelId));
         }
         return modelMetadata.getSpaceType();
+    }
+
+    /**
+     * Get the field info for the given field name, do a null check on the fieldInfo, as this function can return null,
+     * if the field is not found.
+     * @param leafReader {@link LeafReader}
+     * @param fieldName {@link String}
+     * @return {@link FieldInfo}
+     */
+    public static @Nullable FieldInfo getFieldInfo(final LeafReader leafReader, final String fieldName) {
+        return leafReader.getFieldInfos().fieldInfo(fieldName);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.index.fielddata.LeafFieldData;
 import org.opensearch.index.fielddata.ScriptDocValues;
 import org.opensearch.index.fielddata.SortedBinaryDocValues;
+import org.opensearch.knn.common.FieldInfoExtractor;
 
 import java.io.IOException;
 
@@ -40,7 +41,7 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
     @Override
     public ScriptDocValues<float[]> getScriptValues() {
         try {
-            FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(fieldName);
+            FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, fieldName);
             if (fieldInfo == null) {
                 return KNNVectorScriptDocValues.emptyValues(fieldName, vectorDataType);
             }

--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -38,6 +38,7 @@ import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -59,7 +60,11 @@ public class ExactSearcher {
      */
     public Map<Integer, Float> searchLeaf(final LeafReaderContext leafReaderContext, final ExactSearcherContext exactSearcherContext)
         throws IOException {
-        KNNIterator iterator = getKNNIterator(leafReaderContext, exactSearcherContext);
+        final KNNIterator iterator = getKNNIterator(leafReaderContext, exactSearcherContext);
+        // because of any reason if we are not able to get KNNIterator, return an empty map
+        if (iterator == null) {
+            return Collections.emptyMap();
+        }
         if (exactSearcherContext.getKnnQuery().getRadius() != null) {
             return doRadialSearch(leafReaderContext, exactSearcherContext, iterator);
         }
@@ -74,8 +79,8 @@ public class ExactSearcher {
      * Perform radial search by comparing scores with min score. Currently, FAISS from native engine supports radial search.
      * Hence, we assume that Radius from knnQuery is always distance, and we convert it to score since we do exact search uses scores
      * to filter out the documents that does not have given min score.
-     * @param leafReaderContext
-     * @param exactSearcherContext
+     * @param leafReaderContext {@link LeafReaderContext}
+     * @param exactSearcherContext {@link ExactSearcherContext}
      * @param iterator {@link KNNIterator}
      * @return Map of docId and score
      * @throws IOException exception raised by iterator during traversal
@@ -87,7 +92,10 @@ public class ExactSearcher {
     ) throws IOException {
         final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
         final KNNQuery knnQuery = exactSearcherContext.getKnnQuery();
-        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, knnQuery.getField());
+        if (fieldInfo == null) {
+            return Collections.emptyMap();
+        }
         final KNNEngine engine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
         if (KNNEngine.FAISS != engine) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support radial search", engine));
@@ -149,7 +157,11 @@ public class ExactSearcher {
         final KNNQuery knnQuery = exactSearcherContext.getKnnQuery();
         final BitSet matchedDocs = exactSearcherContext.getMatchedDocs();
         final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
-        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, knnQuery.getField());
+        if (fieldInfo == null) {
+            log.debug("[KNN] Cannot get KNNIterator as Field info not found for {}:{}", knnQuery.getField(), reader.getSegmentName());
+            return null;
+        }
         final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
 
         boolean isNestedRequired = exactSearcherContext.isParentHits() && knnQuery.getParentsFilter() != null;

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -227,7 +227,7 @@ public class KNNWeight extends Weight {
     ) throws IOException {
         final SegmentReader reader = Lucene.segmentReader(context.reader());
 
-        FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, knnQuery.getField());
 
         if (fieldInfo == null) {
             log.debug("[KNN] Field info not found for {}:{}", knnQuery.getField(), reader.getSegmentName());
@@ -479,7 +479,7 @@ public class KNNWeight extends Weight {
      */
     private boolean isMissingNativeEngineFiles(LeafReaderContext context) {
         final SegmentReader reader = Lucene.segmentReader(context.reader());
-        final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(knnQuery.getField());
+        final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, knnQuery.getField());
         // if segment has no documents with at least 1 vector field, field info will be null
         if (fieldInfo == null) {
             return false;

--- a/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
+++ b/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.common;
 
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.LeafReader;
 import org.junit.Assert;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -62,5 +64,16 @@ public class FieldInfoExtractorTests extends KNNTestCase {
 
         when(fieldInfo.getAttribute("model_id")).thenReturn(null);
         assertEquals(VectorDataType.DEFAULT, FieldInfoExtractor.extractVectorDataType(fieldInfo));
+    }
+
+    public void testGetFieldInfo_whenDifferentInput_thenSuccess() {
+        LeafReader leafReader = Mockito.mock(LeafReader.class);
+        FieldInfos fieldInfos = Mockito.mock(FieldInfos.class);
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(leafReader.getFieldInfos()).thenReturn(fieldInfos);
+        Mockito.when(fieldInfos.fieldInfo("invalid")).thenReturn(null);
+        Mockito.when(fieldInfos.fieldInfo("valid")).thenReturn(fieldInfo);
+        Assert.assertNull(FieldInfoExtractor.getFieldInfo(leafReader, "invalid"));
+        Assert.assertEquals(fieldInfo, FieldInfoExtractor.getFieldInfo(leafReader, "valid"));
     }
 }


### PR DESCRIPTION
### Description
Added null checks for fieldInfo in ExactSearcher to avoid NPE while running exact search for segments with no vector field


Ensured that in ExactSearcher class, if fieldInfo is null for a field no results are returned. This is similar to what we have to ANNSearch ref: https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/query/KNNWeight.java#L232-L236.

### Related Issues
Resolves #2277


### Check List
- [X] New functionality includes testing.
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
