### PR TITLE
Add binary index support for Lucene engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.18...2.x)
 ### Features
 - Add Support for Multi Values in innerHit for Nested k-NN Fields in Lucene and FAISS (#2283)[https://github.com/opensearch-project/k-NN/pull/2283]
+- Add binary index support for Lucene engine. (#2292)[https://github.com/opensearch-project/k-NN/pull/2292]
 ### Enhancements
 - Introduced a writing layer in native engines where relies on the writing interface to process IO. (#2241)[https://github.com/opensearch-project/k-NN/pull/2241]
 - Allow method parameter override for training based indices (#2290) https://github.com/opensearch-project/k-NN/pull/2290]

--- a/src/main/java/org/opensearch/knn/index/KNNVectorSimilarityFunction.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorSimilarityFunction.java
@@ -29,6 +29,7 @@ public enum KNNVectorSimilarityFunction {
 
         @Override
         public VectorSimilarityFunction getVectorSimilarityFunction() {
+            // For binary vectors using Lucene engine we instead implement a custom BinaryVectorScorer
             throw new IllegalStateException("VectorSimilarityFunction is not available for Hamming space");
         }
     };

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -30,7 +30,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 /**
  * Enum contains data_type of vectors
- * Lucene supports byte and float data type
+ * Lucene supports binary, byte and float data type
  * NMSLib supports only float data type
  * Faiss supports binary and float data type
  */
@@ -39,8 +39,10 @@ public enum VectorDataType {
     BINARY("binary") {
 
         @Override
-        public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
-            throw new IllegalStateException("Unsupported method");
+        public FieldType createKnnVectorFieldType(int dimension, KNNVectorSimilarityFunction knnVectorSimilarityFunction) {
+            // For binary vectors using Lucene engine we instead implement a custom BinaryVectorScorer so the VectorSimilarityFunction will
+            // not be used.
+            return KnnByteVectorField.createFieldType(dimension / Byte.SIZE, VectorSimilarityFunction.EUCLIDEAN);
         }
 
         @Override
@@ -68,8 +70,8 @@ public enum VectorDataType {
     BYTE("byte") {
 
         @Override
-        public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
-            return KnnByteVectorField.createFieldType(dimension, vectorSimilarityFunction);
+        public FieldType createKnnVectorFieldType(int dimension, KNNVectorSimilarityFunction knnVectorSimilarityFunction) {
+            return KnnByteVectorField.createFieldType(dimension, knnVectorSimilarityFunction.getVectorSimilarityFunction());
         }
 
         @Override
@@ -97,8 +99,8 @@ public enum VectorDataType {
     FLOAT("float") {
 
         @Override
-        public FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction) {
-            return KnnVectorField.createFieldType(dimension, vectorSimilarityFunction);
+        public FieldType createKnnVectorFieldType(int dimension, KNNVectorSimilarityFunction knnVectorSimilarityFunction) {
+            return KnnVectorField.createFieldType(dimension, knnVectorSimilarityFunction.getVectorSimilarityFunction());
         }
 
         @Override
@@ -129,11 +131,11 @@ public enum VectorDataType {
      * Creates a KnnVectorFieldType based on the VectorDataType using the provided dimension and
      * VectorSimilarityFunction.
      *
-     * @param dimension Dimension of the vector
-     * @param vectorSimilarityFunction VectorSimilarityFunction for a given spaceType
+     * @param dimension                   Dimension of the vector
+     * @param knnVectorSimilarityFunction KNNVectorSimilarityFunction for a given spaceType
      * @return FieldType
      */
-    public abstract FieldType createKnnVectorFieldType(int dimension, VectorSimilarityFunction vectorSimilarityFunction);
+    public abstract FieldType createKnnVectorFieldType(int dimension, KNNVectorSimilarityFunction knnVectorSimilarityFunction);
 
     /**
      * Deserializes float vector from BytesRef.

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -114,7 +114,12 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
                 }
             }
 
-            KNNVectorsFormatParams knnVectorsFormatParams = new KNNVectorsFormatParams(params, defaultMaxConnections, defaultBeamWidth);
+            KNNVectorsFormatParams knnVectorsFormatParams = new KNNVectorsFormatParams(
+                params,
+                defaultMaxConnections,
+                defaultBeamWidth,
+                knnMethodContext.getSpaceType()
+            );
             log.debug(
                 "Initialize KNN vector format for field [{}] with params [{}] = \"{}\" and [{}] = \"{}\"",
                 field,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120BinaryVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120BinaryVectorScorer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.RandomAccessVectorValues;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+
+import java.io.IOException;
+
+/**
+ * A FlatVectorsScorer to be used for scoring binary vectors. Meant to be used with {@link KNN9120BinaryVectorScorer}
+ */
+public class KNN9120BinaryVectorScorer implements FlatVectorsScorer {
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        RandomAccessVectorValues randomAccessVectorValues
+    ) throws IOException {
+        if (randomAccessVectorValues instanceof RandomAccessVectorValues.Bytes) {
+            return new BinaryRandomVectorScorerSupplier((RandomAccessVectorValues.Bytes) randomAccessVectorValues);
+        }
+        throw new IllegalArgumentException("vectorValues must be an instance of RandomAccessVectorValues.Bytes");
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        RandomAccessVectorValues randomAccessVectorValues,
+        float[] queryVector
+    ) throws IOException {
+        throw new IllegalArgumentException("binary vectors do not support float[] targets");
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        RandomAccessVectorValues randomAccessVectorValues,
+        byte[] queryVector
+    ) throws IOException {
+        if (randomAccessVectorValues instanceof RandomAccessVectorValues.Bytes) {
+            return new BinaryRandomVectorScorer((RandomAccessVectorValues.Bytes) randomAccessVectorValues, queryVector);
+        }
+        throw new IllegalArgumentException("vectorValues must be an instance of RandomAccessVectorValues.Bytes");
+    }
+
+    static class BinaryRandomVectorScorer implements RandomVectorScorer {
+        private final RandomAccessVectorValues.Bytes vectorValues;
+        private final byte[] queryVector;
+
+        BinaryRandomVectorScorer(RandomAccessVectorValues.Bytes vectorValues, byte[] query) {
+            this.queryVector = query;
+            this.vectorValues = vectorValues;
+        }
+
+        @Override
+        public float score(int node) throws IOException {
+            return KNNVectorSimilarityFunction.HAMMING.compare(queryVector, vectorValues.vectorValue(node));
+        }
+
+        @Override
+        public int maxOrd() {
+            return vectorValues.size();
+        }
+
+        @Override
+        public int ordToDoc(int ord) {
+            return vectorValues.ordToDoc(ord);
+        }
+
+        @Override
+        public Bits getAcceptOrds(Bits acceptDocs) {
+            return vectorValues.getAcceptOrds(acceptDocs);
+        }
+    }
+
+    static class BinaryRandomVectorScorerSupplier implements RandomVectorScorerSupplier {
+        protected final RandomAccessVectorValues.Bytes vectorValues;
+        protected final RandomAccessVectorValues.Bytes vectorValues1;
+        protected final RandomAccessVectorValues.Bytes vectorValues2;
+
+        public BinaryRandomVectorScorerSupplier(RandomAccessVectorValues.Bytes vectorValues) throws IOException {
+            this.vectorValues = vectorValues;
+            this.vectorValues1 = vectorValues.copy();
+            this.vectorValues2 = vectorValues.copy();
+        }
+
+        @Override
+        public RandomVectorScorer scorer(int ord) throws IOException {
+            byte[] queryVector = vectorValues1.vectorValue(ord);
+            return new BinaryRandomVectorScorer(vectorValues2, queryVector);
+        }
+
+        @Override
+        public RandomVectorScorerSupplier copy() throws IOException {
+            return new BinaryRandomVectorScorerSupplier(vectorValues.copy());
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.search.TaskExecutor;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_NUM_MERGE_WORKER;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.MAXIMUM_BEAM_WIDTH;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.MAXIMUM_MAX_CONN;
+import static org.opensearch.knn.index.engine.KNNEngine.getMaxDimensionByEngine;
+
+/**
+ * Custom KnnVectorsFormat implementation to support binary vectors. This class is mostly identical to
+ * {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat}, however we use the custom {@link KNN9120BinaryVectorScorer}
+ * to perform hamming bit scoring.
+ */
+public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
+
+    private final int maxConn;
+    private final int beamWidth;
+    private static final FlatVectorsFormat flatVectorsFormat = new Lucene99FlatVectorsFormat(new KNN9120BinaryVectorScorer());
+    private final int numMergeWorkers;
+    private final TaskExecutor mergeExec;
+
+    private static final String NAME = "KNN990HnswBinaryVectorsFormat";
+
+    /**
+     * Constructor logic is identical to {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat#Lucene99HnswVectorsFormat()}
+     */
+    public KNN9120HnswBinaryVectorsFormat() {
+        this(DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null);
+    }
+
+    /**
+     * Constructor logic is identical to {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat#Lucene99HnswVectorsFormat(int, int)}
+     */
+    public KNN9120HnswBinaryVectorsFormat(int maxConn, int beamWidth) {
+        this(maxConn, beamWidth, 1, null);
+    }
+
+    /**
+     * Constructor logic is identical to {@link org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat#Lucene99HnswVectorsFormat(int, int, int, java.util.concurrent.ExecutorService)}
+     */
+    public KNN9120HnswBinaryVectorsFormat(int maxConn, int beamWidth, int numMergeWorkers, ExecutorService mergeExec) {
+        super(NAME);
+        if (maxConn <= 0 || maxConn > MAXIMUM_MAX_CONN) {
+            throw new IllegalArgumentException(
+                "maxConn must be positive and less than or equal to " + MAXIMUM_MAX_CONN + "; maxConn=" + maxConn
+            );
+        }
+        if (beamWidth <= 0 || beamWidth > MAXIMUM_BEAM_WIDTH) {
+            throw new IllegalArgumentException(
+                "beamWidth must be positive and less than or equal to " + MAXIMUM_BEAM_WIDTH + "; beamWidth=" + beamWidth
+            );
+        }
+        this.maxConn = maxConn;
+        this.beamWidth = beamWidth;
+        if (numMergeWorkers == 1 && mergeExec != null) {
+            throw new IllegalArgumentException("No executor service is needed as we'll use single thread to merge");
+        }
+        this.numMergeWorkers = numMergeWorkers;
+        if (mergeExec != null) {
+            this.mergeExec = new TaskExecutor(mergeExec);
+        } else {
+            this.mergeExec = null;
+        }
+    }
+
+    @Override
+    public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new Lucene99HnswVectorsWriter(
+            state,
+            this.maxConn,
+            this.beamWidth,
+            flatVectorsFormat.fieldsWriter(state),
+            this.numMergeWorkers,
+            this.mergeExec
+        );
+    }
+
+    @Override
+    public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return new Lucene99HnswVectorsReader(state, flatVectorsFormat.fieldsReader(state));
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    @Override
+    public String toString() {
+        return "KNN990HnswBinaryVectorsFormat(name=KNN990HnswBinaryVectorsFormat, maxConn="
+            + this.maxConn
+            + ", beamWidth="
+            + this.beamWidth
+            + ", flatVectorFormat="
+            + flatVectorsFormat
+            + ")";
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.KNN990Codec;
+package org.opensearch.knn.index.codec.KNN9120Codec;
 
 import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.BasePerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -16,19 +17,27 @@ import java.util.Optional;
 /**
  * Class provides per field format implementation for Lucene Knn vector type
  */
-public class KNN990PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat {
+public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat {
     private static final int NUM_MERGE_WORKERS = 1;
 
-    public KNN990PerFieldKnnVectorsFormat(final Optional<MapperService> mapperService) {
+    public KNN9120PerFieldKnnVectorsFormat(final Optional<MapperService> mapperService) {
         super(
             mapperService,
             Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN,
             Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
             Lucene99HnswVectorsFormat::new,
-            knnVectorsFormatParams -> new Lucene99HnswVectorsFormat(
-                knnVectorsFormatParams.getMaxConnections(),
-                knnVectorsFormatParams.getBeamWidth()
-            ),
+            knnVectorsFormatParams -> {
+                // There is an assumption here that hamming space will only be used for binary vectors. This will need to be fixed if that
+                // changes in the future.
+                if (knnVectorsFormatParams.getSpaceType() == SpaceType.HAMMING) {
+                    return new KNN9120HnswBinaryVectorsFormat(
+                        knnVectorsFormatParams.getMaxConnections(),
+                        knnVectorsFormatParams.getBeamWidth()
+                    );
+                } else {
+                    return new Lucene99HnswVectorsFormat(knnVectorsFormatParams.getMaxConnections(), knnVectorsFormatParams.getBeamWidth());
+                }
+            },
             knnScalarQuantizedVectorsFormatParams -> new Lucene99HnswScalarQuantizedVectorsFormat(
                 knnScalarQuantizedVectorsFormatParams.getMaxConnections(),
                 knnScalarQuantizedVectorsFormatParams.getBeamWidth(),

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80DocValuesFormat;
 import org.opensearch.knn.index.codec.KNN910Codec.KNN910Codec;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120Codec;
+import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920Codec;
 import org.opensearch.knn.index.codec.KNN920Codec.KNN920PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNN940Codec.KNN940Codec;
@@ -117,14 +118,14 @@ public enum KNNCodecVersion {
     V_9_12_0(
         "KNN9120Codec",
         new Lucene912Codec(),
-        new KNN990PerFieldKnnVectorsFormat(Optional.empty()),
+        new KNN9120PerFieldKnnVectorsFormat(Optional.empty()),
         (delegate) -> new KNNFormatFacade(
             new KNN80DocValuesFormat(delegate.docValuesFormat()),
             new KNN80CompoundFormat(delegate.compoundFormat())
         ),
         (userCodec, mapperService) -> KNN9120Codec.builder()
             .delegate(userCodec)
-            .knnVectorsFormat(new KNN990PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService)))
+            .knnVectorsFormat(new KNN9120PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService)))
             .build(),
         KNN9120Codec::new
     );

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNVectorsFormatParams.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.params;
 
 import lombok.Getter;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
 
 import java.util.Map;
 
@@ -17,10 +18,16 @@ import java.util.Map;
 public class KNNVectorsFormatParams {
     private int maxConnections;
     private int beamWidth;
+    private final SpaceType spaceType;
 
     public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth) {
+        this(params, defaultMaxConnections, defaultBeamWidth, SpaceType.UNDEFINED);
+    }
+
+    public KNNVectorsFormatParams(final Map<String, Object> params, int defaultMaxConnections, int defaultBeamWidth, SpaceType spaceType) {
         initMaxConnections(params, defaultMaxConnections);
         initBeamWidth(params, defaultBeamWidth);
+        this.spaceType = spaceType;
     }
 
     public boolean validate(final Map<String, Object> params) {

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethod.java
@@ -30,13 +30,18 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
  */
 public class LuceneHNSWMethod extends AbstractKNNMethod {
 
-    private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT, VectorDataType.BYTE);
+    private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(
+        VectorDataType.FLOAT,
+        VectorDataType.BYTE,
+        VectorDataType.BINARY
+    );
 
     public final static List<SpaceType> SUPPORTED_SPACES = Arrays.asList(
         SpaceType.UNDEFINED,
         SpaceType.L2,
         SpaceType.COSINESIMIL,
-        SpaceType.INNER_PRODUCT
+        SpaceType.INNER_PRODUCT,
+        SpaceType.HAMMING
     );
 
     final static Encoder SQ_ENCODER = new LuceneSQEncoder();

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -17,8 +17,8 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.common.Explicit;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -100,11 +100,10 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
         KNNMethodContext resolvedKnnMethodContext = originalMappingParameters.getResolvedKnnMethodContext();
         VectorDataType vectorDataType = mappedFieldType.getVectorDataType();
 
-        final VectorSimilarityFunction vectorSimilarityFunction = resolvedKnnMethodContext.getSpaceType()
-            .getKnnVectorSimilarityFunction()
-            .getVectorSimilarityFunction();
+        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = resolvedKnnMethodContext.getSpaceType()
+            .getKnnVectorSimilarityFunction();
 
-        this.fieldType = vectorDataType.createKnnVectorFieldType(knnMappingConfig.getDimension(), vectorSimilarityFunction);
+        this.fieldType = vectorDataType.createKnnVectorFieldType(knnMappingConfig.getDimension(), knnVectorSimilarityFunction);
 
         if (this.hasDocValues) {
             this.vectorFieldType = buildDocValuesFieldType(resolvedKnnMethodContext.getKnnEngine());

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -129,6 +129,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
         log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
         switch (vectorDataType) {
             case BYTE:
+            case BINARY:
                 return new LuceneEngineKnnVectorQuery(
                     getKnnByteVectorQuery(fieldName, byteVector, luceneK, filterQuery, parentFilter, expandNested)
                 );

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -10,3 +10,4 @@
 #
 
 org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat
+org.opensearch.knn.index.codec.KNN9120Codec.KNN9120HnswBinaryVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.util.BytesRef;
@@ -107,14 +106,6 @@ public class VectorDataTypeTests extends KNNTestCase {
         writer.addDocument(knnDocument);
         writer.commit();
         writer.close();
-    }
-
-    public void testCreateKnnVectorFieldType_whenBinary_thenException() {
-        Exception ex = expectThrows(
-            IllegalStateException.class,
-            () -> VectorDataType.BINARY.createKnnVectorFieldType(1, VectorSimilarityFunction.EUCLIDEAN)
-        );
-        assertTrue(ex.getMessage().contains("Unsupported method"));
     }
 
     public void testGetVectorFromBytesRef_whenBinary_thenException() {

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -284,13 +284,6 @@ public class KNNMethodContextTests extends KNNTestCase {
 
     public void testValidateVectorDataType_whenBinaryNonFaiss_thenException() {
         validateValidateVectorDataType(
-            KNNEngine.LUCENE,
-            KNNConstants.METHOD_HNSW,
-            VectorDataType.BINARY,
-            SpaceType.HAMMING,
-            "UnsupportedMethod"
-        );
-        validateValidateVectorDataType(
             KNNEngine.NMSLIB,
             KNNConstants.METHOD_HNSW,
             VectorDataType.BINARY,

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1528,8 +1528,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         }
     }
 
-    public void testTypeParser_whenBinaryNonFaiss_thenException() throws IOException {
-        testTypeParserWithBinaryDataType(KNNEngine.LUCENE, SpaceType.HAMMING, METHOD_HNSW, 8, "is not supported for vector data type");
+    public void testTypeParser_whenBinaryNmslib_thenException() throws IOException {
         testTypeParserWithBinaryDataType(KNNEngine.NMSLIB, SpaceType.HAMMING, METHOD_HNSW, 8, "is not supported for vector data type");
     }
 

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexInvalidMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexInvalidMappingIT.java
@@ -47,11 +47,6 @@ public class BinaryIndexInvalidMappingIT extends KNNRestTestCase {
         return Arrays.asList(
             $$(
                 $(
-                    "Creation of binary index with lucene engine should fail",
-                    createKnnHnswBinaryIndexMapping(KNNEngine.LUCENE, FIELD_NAME, 16, null),
-                    "Validation Failed"
-                ),
-                $(
                     "Creation of binary index with nmslib engine should fail",
                     createKnnHnswBinaryIndexMapping(KNNEngine.NMSLIB, FIELD_NAME, 16, null),
                     "Validation Failed"

--- a/src/test/java/org/opensearch/knn/integ/FilteredSearchBinaryIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FilteredSearchBinaryIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
@@ -19,12 +20,25 @@ import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 @Log4j2
 public class FilteredSearchBinaryIT extends KNNRestTestCase {
+    private final KNNEngine engine;
+
+    public FilteredSearchBinaryIT(KNNEngine engine) {
+        this.engine = engine;
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[] { KNNEngine.LUCENE }, new Object[] { KNNEngine.FAISS });
+    }
+
     @After
     public void cleanUp() {
         try {
@@ -35,18 +49,18 @@ public class FilteredSearchBinaryIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testFilteredSearchWithFaissHnswBinary_whenDoingApproximateSearch_thenReturnCorrectResults() {
-        validateFilteredSearchWithFaissHnswBinary(INDEX_NAME, false);
+    public void testFilteredSearchHnswBinary_whenDoingApproximateSearch_thenReturnCorrectResults() {
+        validateFilteredSearchHnswBinary(INDEX_NAME, false);
     }
 
     @SneakyThrows
-    public void testFilteredSearchWithFaissHnswBinary_whenDoingExactSearch_thenReturnCorrectResults() {
-        validateFilteredSearchWithFaissHnswBinary(INDEX_NAME, true);
+    public void testFilteredSearchHnswBinary_whenDoingExactSearch_thenReturnCorrectResults() {
+        validateFilteredSearchHnswBinary(INDEX_NAME, true);
     }
 
-    private void validateFilteredSearchWithFaissHnswBinary(final String indexName, final boolean doExactSearch) throws Exception {
+    private void validateFilteredSearchHnswBinary(final String indexName, final boolean doExactSearch) throws Exception {
         String filterFieldName = "parking";
-        createKnnBinaryIndex(indexName, FIELD_NAME, 24, KNNEngine.FAISS);
+        createKnnBinaryIndex(indexName, FIELD_NAME, 24, engine);
 
         for (byte i = 1; i < 4; i++) {
             addKnnDocWithAttributes(

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchBinaryIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchBinaryIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -19,12 +20,25 @@ import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 @Log4j2
 public class NestedSearchBinaryIT extends KNNRestTestCase {
+    private final KNNEngine engine;
+
+    public NestedSearchBinaryIT(KNNEngine engine) {
+        this.engine = engine;
+    }
+
+    @ParametersFactory
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[] { KNNEngine.LUCENE }, new Object[] { KNNEngine.FAISS });
+    }
+
     @After
     public void cleanUp() {
         try {
@@ -35,9 +49,10 @@ public class NestedSearchBinaryIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testNestedSearchWithFaissHnswBinary_whenKIsTwo_thenReturnTwoResults() {
+    public void testNestedSearchHnswBinary_whenKIsTwo_thenReturnTwoResults() {
+
         String nestedFieldName = "nested";
-        createKnnBinaryIndexWithNestedField(INDEX_NAME, nestedFieldName, FIELD_NAME, 16, KNNEngine.FAISS);
+        createKnnBinaryIndexWithNestedField(INDEX_NAME, nestedFieldName, FIELD_NAME, 16, engine);
 
         int totalDocCount = 15;
         for (byte i = 0; i < totalDocCount; i++) {
@@ -93,10 +108,10 @@ public class NestedSearchBinaryIT extends KNNRestTestCase {
      *
      */
     @SneakyThrows
-    public void testNestedSearchWithFaissHnswBinary_whenDoingExactSearch_thenReturnCorrectResults() {
+    public void testNestedSearchHnswBinary_whenDoingExactSearch_thenReturnCorrectResults() {
         String nestedFieldName = "nested";
         String filterFieldName = "parking";
-        createKnnBinaryIndexWithNestedField(INDEX_NAME, nestedFieldName, FIELD_NAME, 24, KNNEngine.FAISS);
+        createKnnBinaryIndexWithNestedField(INDEX_NAME, nestedFieldName, FIELD_NAME, 24, engine);
 
         for (byte i = 1; i < 4; i++) {
             String doc = NestedKnnDocBuilder.create(nestedFieldName)


### PR DESCRIPTION
### Description
Add binary vector support for Lucene engine. For testing I parameterized `BinaryIndexIT.java` to run with both `FAISS` and `LUCENE` engines.

### Related Issues
Resolves #1857
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
    - [x] https://github.com/opensearch-project/documentation-website/issues/8955

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
