### PR TITLE
Add version check 2.x

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -194,6 +194,8 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         @Setter
         @Getter
         private OriginalMappingParameters originalParameters;
+        @Setter
+        private boolean isKnnIndex;
 
         public Builder(
             String name,
@@ -207,6 +209,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             this.indexCreatedVersion = indexCreatedVersion;
             this.knnMethodConfigContext = knnMethodConfigContext;
             this.originalParameters = originalParameters;
+            this.isKnnIndex = true;
         }
 
         @Override
@@ -262,7 +265,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 );
             }
 
-            if (originalParameters.getResolvedKnnMethodContext() == null) {
+            if (originalParameters.getResolvedKnnMethodContext() == null || isKnnIndex == false) {
                 return FlatVectorFieldMapper.createFieldMapper(
                     buildFullName(context),
                     name,
@@ -374,10 +377,14 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                     String.format(Locale.ROOT, "Method and model can not be both specified in the mapping: %s", name)
                 );
             }
-
             // Check for flat configuration
             if (isKNNDisabled(parserContext.getSettings())) {
-                validateFromFlat(builder);
+                builder.setKnnIndex(false);
+                if (parserContext.indexVersionCreated().onOrAfter(Version.V_2_17_0)) {
+                    // on and after 2_17_0 we validate to makes sure that mapping doesn't contain parameters that are
+                    // specific to approximate knn search algorithms
+                    validateFromFlat(builder);
+                }
             } else if (builder.modelId.get() != null) {
                 validateFromModel(builder);
             } else {

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -907,4 +907,27 @@ public class OpenSearchIT extends KNNRestTestCase {
         return parseSearchResponse(searchResponseBody, fieldName);
     }
 
+    public void testCreateNonKNNIndex_withKNNModelID() throws Exception {
+        Settings settings = Settings.builder().put(createKNNDefaultScriptScoreSettings()).build();
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, "random-model-id"))
+        );
+        String expMessage = "Cannot set modelId or method parameters when index.knn setting is false";
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString(expMessage));
+    }
+
+    public void testCreateNonKNNIndex_withKNNMethodParams() throws Exception {
+        Settings settings = Settings.builder().put(createKNNDefaultScriptScoreSettings()).build();
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> createKnnIndex(
+                INDEX_NAME,
+                settings,
+                createKnnIndexMapping(FIELD_NAME, 2, "hnsw", KNNEngine.FAISS.getName(), SpaceType.DEFAULT.getValue(), false)
+            )
+        );
+        String expMessage = "Cannot set modelId or method parameters when index.knn setting is false";
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString(expMessage));
+    }
 }

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -412,6 +412,22 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Utility to create a Knn Index Mapping with model id
+     */
+    protected String createKnnIndexMapping(String fieldName, String modelId) throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("model_id", modelId)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+    }
+
+    /**
      * Utility to create a Knn Index Mapping with specific algorithm and engine
      */
     protected String createKnnIndexMapping(String fieldName, Integer dimensions, String algoName, String knnEngine) throws IOException {


### PR DESCRIPTION
### Description
k-NN introduced validation to prevent index creation api to accept method paramters that are used by approximate k-NN search algorithm. For ex: create index api accepts model_id, or, method params even if knn index setting was not true before 2.17.

However, for index that were created before 2.17 and upgraded to 2.17, will prevent cluster to parse those previously accepted index mapping.

Hence, k-NN will allow those paramters for indices that were created before 2.17, but doesn't support those parameters starting 2.17.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
