### PR TITLE
Fixed a bug that does not get a space type from index setting when its value is empty for compatibility.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,6 @@ on:
       - 'jni/**'
       - 'micro-benchmarks/**'
       - '.github/workflows/CI.yml'
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:
@@ -42,7 +40,7 @@ jobs:
   Build-k-NN-Linux:
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [21]
 
     name: Build and Test k-NN Plugin on Linux
     runs-on: ubuntu-latest
@@ -52,11 +50,14 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
+
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -65,41 +66,46 @@ jobs:
           su `id -un 1000` -c 'git config --global user.email "github-actions[bot]@users.noreply.github.com"'
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
 
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           chown -R 1000:1000 `pwd`
-          if lscpu  | grep -i avx2
+          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
+          then
+            echo "avx512 available on system"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Dnproc.count=`nproc`"
+          elif lscpu  | grep -i avx2
           then
             echo "avx2 available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Dnproc.count=`nproc`"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Dnproc.count=`nproc` -Davx512.enabled=false"
           else
-            echo "avx2 not available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Dsimd.enabled=false -Dnproc.count=`nproc`"
+            echo "avx512 and avx2 not available on system"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Dnproc.count=`nproc`"
           fi  
 
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   Build-k-NN-MacOS:
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 21 ]
 
     name: Build and Test k-NN Plugin on MacOS
     needs: Get-CI-Image-Tag
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -108,12 +114,14 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
 
       - name: Install dependencies on macos
         run: |
+          brew install libomp
           brew reinstall gcc
           export FC=/usr/local/Cellar/gcc/12.2.0/bin/gfortran
 
@@ -126,13 +134,13 @@ jobs:
               ./gradlew build -Dnproc.count=3
           else
               echo "avx2 not available on system"
-              ./gradlew build -Dsimd.enabled=false -Dnproc.count=3
+              ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Dnproc.count=3
           fi
 
   Build-k-NN-Windows:
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 21 ]
 
     name: Build and Test k-NN Plugin on Windows
     needs: Get-CI-Image-Tag
@@ -140,7 +148,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -149,9 +157,10 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
 
       - name: Install MinGW Using Scoop
         run: |
@@ -187,4 +196,4 @@ jobs:
       # TODO: Detect processor count and set the value of nproc.count
       - name: Run build
         run: |
-          ./gradlew.bat build -D'simd.enabled=false' -D'nproc.count=4'
+          ./gradlew.bat build -D'avx2.enabled=false' -D'avx512.enabled=false' -D'nproc.count=4'

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -28,8 +28,6 @@ on:
       - 'gradle/**'
       - 'jni/**'
       - '.github/workflows/test_security.yml'
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:
@@ -50,11 +48,13 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
         run: |
@@ -62,12 +62,24 @@ jobs:
           su `id -un 1000` -c 'git config --global user.email "github-actions[bot]@users.noreply.github.com"'
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
 
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
         run: |
           chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "whoami && java -version && ./gradlew integTest -Dsecurity.enabled=true -Dsimd.enabled=true -Dnproc.count=`nproc`"
+          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
+          then
+            echo "avx512 available on system"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Dnproc.count=`nproc`"
+          elif lscpu  | grep -i avx2
+          then
+            echo "avx2 available on system"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Dnproc.count=`nproc` -Davx512.enabled=false"
+          else
+            echo "avx512 and avx2 not available on system"
+            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Dnproc.count=`nproc`"
+          fi  

--- a/src/main/java/org/opensearch/knn/index/engine/SpaceTypeResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/SpaceTypeResolver.java
@@ -42,7 +42,7 @@ public final class SpaceTypeResolver {
         SpaceType topLevelSpaceType = getSpaceTypeFromString(topLevelSpaceTypeString);
 
         if (isSpaceTypeConfigured(methodSpaceType) == false && isSpaceTypeConfigured(topLevelSpaceType) == false) {
-            return getSpaceTypeFromVectorDataType(vectorDataType);
+            return SpaceType.UNDEFINED;
         }
 
         if (isSpaceTypeConfigured(methodSpaceType) == false) {
@@ -75,13 +75,6 @@ public final class SpaceTypeResolver {
         return knnMethodContext.getSpaceType();
     }
 
-    private SpaceType getSpaceTypeFromVectorDataType(final VectorDataType vectorDataType) {
-        if (vectorDataType == VectorDataType.BINARY) {
-            return SpaceType.DEFAULT_BINARY;
-        }
-        return SpaceType.DEFAULT;
-    }
-
     private SpaceType getSpaceTypeFromString(final String spaceType) {
         if (Strings.isEmpty(spaceType)) {
             return SpaceType.UNDEFINED;
@@ -92,5 +85,16 @@ public final class SpaceTypeResolver {
 
     private boolean isSpaceTypeConfigured(final SpaceType spaceType) {
         return spaceType != null && spaceType != SpaceType.UNDEFINED;
+    }
+
+    public SpaceType pickDefaultSpaceTypeWhenEmpty(SpaceType resolvedSpaceType, VectorDataType vectorDataType) {
+        if (resolvedSpaceType != SpaceType.UNDEFINED) {
+            return resolvedSpaceType;
+        } else {
+            if (vectorDataType == VectorDataType.BINARY) {
+                return SpaceType.DEFAULT_BINARY;
+            }
+            return SpaceType.DEFAULT;
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -385,7 +385,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                     SpaceTypeResolver.INSTANCE.pickDefaultSpaceTypeWhenEmpty(resolvedSpaceType, builder.vectorDataType.get())
                 );
                 validateSpaceType(builder);
-                resolveKNNMethodComponents(builder, parserContext, resolvedSpaceType);
+                resolveKNNMethodComponents(builder, parserContext, resolvedSpaceType, builder.vectorDataType.get());
                 validateFromKNNMethod(builder);
             }
 
@@ -476,9 +476,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         }
 
         private void resolveKNNMethodComponents(
-            KNNVectorFieldMapper.Builder builder,
+            Builder builder,
             ParserContext parserContext,
-            SpaceType resolvedSpaceType
+            SpaceType resolvedSpaceType,
+            VectorDataType vectorDataType
         ) {
             // Setup the initial configuration that is used to help resolve parameters.
             builder.setKnnMethodConfigContext(
@@ -512,7 +513,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 builder.originalParameters.getResolvedKnnMethodContext(),
                 builder.knnMethodConfigContext,
                 false,
-                resolvedSpaceType
+                SpaceTypeResolver.INSTANCE.pickDefaultSpaceTypeWhenEmpty(resolvedSpaceType, vectorDataType)
             );
 
             // The original parameters stores both the resolveMethodContext as well as the original provided by the

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -375,12 +375,15 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 // If the original knnMethodContext is not null, resolve its space type and engine from the rest of the
                 // configuration. This is consistent with the existing behavior for space type in 2.16 where we modify the
                 // parsed value
-                SpaceType resolvedSpaceType = SpaceTypeResolver.INSTANCE.resolveSpaceType(
+                final SpaceType resolvedSpaceType = SpaceTypeResolver.INSTANCE.resolveSpaceType(
                     builder.originalParameters.getKnnMethodContext(),
                     builder.vectorDataType.get(),
                     builder.topLevelSpaceType.get()
                 );
-                setSpaceType(builder.originalParameters.getKnnMethodContext(), resolvedSpaceType);
+                setSpaceType(
+                    builder.originalParameters.getKnnMethodContext(),
+                    SpaceTypeResolver.INSTANCE.pickDefaultSpaceTypeWhenEmpty(resolvedSpaceType, builder.vectorDataType.get())
+                );
                 validateSpaceType(builder);
                 resolveKNNMethodComponents(builder, parserContext, resolvedSpaceType);
                 validateFromKNNMethod(builder);

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -199,9 +199,7 @@ public class KNNVectorFieldMapperUtil {
         SpaceType topLevelSpaceType
     ) {
         // If top level spaceType is set then use that spaceType otherwise default to spaceType from index-settings
-        final SpaceType finalSpaceToSet = topLevelSpaceType != SpaceType.UNDEFINED
-            ? topLevelSpaceType
-            : KNNVectorFieldMapperUtil.getSpaceType(indexSettings);
+        final SpaceType finalSpaceToSet = topLevelSpaceType != SpaceType.UNDEFINED ? topLevelSpaceType : getSpaceType(indexSettings);
         return new KNNMethodContext(
             KNNEngine.NMSLIB,
             finalSpaceToSet,

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -165,6 +165,7 @@ public class RestTrainModelHandler extends BaseRestHandler {
             vectorDataType,
             topLevelSpaceType.getValue()
         );
+        resolvedSpaceType = SpaceTypeResolver.INSTANCE.pickDefaultSpaceTypeWhenEmpty(resolvedSpaceType, vectorDataType);
         setSpaceType(knnMethodContext, resolvedSpaceType);
         TrainingModelRequest trainingModelRequest = new TrainingModelRequest(
             modelId,

--- a/src/test/java/org/opensearch/knn/index/engine/SpaceTypeResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/SpaceTypeResolverTests.java
@@ -16,23 +16,47 @@ public class SpaceTypeResolverTests extends KNNTestCase {
     private static final SpaceTypeResolver SPACE_TYPE_RESOLVER = SpaceTypeResolver.INSTANCE;
 
     public void testResolveSpaceType_whenNoConfigProvided_thenFallbackToVectorDataType() {
-        assertEquals(SpaceType.DEFAULT, SPACE_TYPE_RESOLVER.resolveSpaceType(null, VectorDataType.FLOAT, ""));
-        assertEquals(SpaceType.DEFAULT, SPACE_TYPE_RESOLVER.resolveSpaceType(null, VectorDataType.BYTE, ""));
         assertEquals(
             SpaceType.DEFAULT,
-            SPACE_TYPE_RESOLVER.resolveSpaceType(
-                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
-                VectorDataType.FLOAT,
-                ""
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(null, VectorDataType.FLOAT, ""),
+                VectorDataType.FLOAT
             )
         );
-        assertEquals(SpaceType.DEFAULT_BINARY, SPACE_TYPE_RESOLVER.resolveSpaceType(null, VectorDataType.BINARY, ""));
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(null, VectorDataType.BYTE, ""),
+                VectorDataType.FLOAT
+            )
+        );
+        assertEquals(
+            SpaceType.DEFAULT,
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                    VectorDataType.FLOAT,
+                    ""
+                ),
+                VectorDataType.FLOAT
+            )
+        );
         assertEquals(
             SpaceType.DEFAULT_BINARY,
-            SPACE_TYPE_RESOLVER.resolveSpaceType(
-                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
-                VectorDataType.BINARY,
-                ""
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(null, VectorDataType.BINARY, ""),
+                VectorDataType.BINARY
+            )
+        );
+        assertEquals(
+            SpaceType.DEFAULT_BINARY,
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                    VectorDataType.BINARY,
+                    ""
+                ),
+                VectorDataType.BINARY
             )
         );
     }
@@ -49,34 +73,46 @@ public class SpaceTypeResolverTests extends KNNTestCase {
         );
         assertEquals(
             SpaceType.DEFAULT,
-            SPACE_TYPE_RESOLVER.resolveSpaceType(
-                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                VectorDataType.FLOAT,
-                SpaceType.DEFAULT.getValue()
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                    VectorDataType.FLOAT,
+                    SpaceType.DEFAULT.getValue()
+                ),
+                VectorDataType.FLOAT
             )
         );
         assertEquals(
             SpaceType.DEFAULT,
-            SPACE_TYPE_RESOLVER.resolveSpaceType(
-                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                VectorDataType.FLOAT,
-                SpaceType.UNDEFINED.getValue()
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                    VectorDataType.FLOAT,
+                    SpaceType.UNDEFINED.getValue()
+                ),
+                VectorDataType.FLOAT
             )
         );
         assertEquals(
             SpaceType.DEFAULT,
-            SPACE_TYPE_RESOLVER.resolveSpaceType(
-                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
-                VectorDataType.FLOAT,
-                SpaceType.DEFAULT.getValue()
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                    VectorDataType.FLOAT,
+                    SpaceType.DEFAULT.getValue()
+                ),
+                VectorDataType.FLOAT
             )
         );
         assertEquals(
             SpaceType.DEFAULT,
-            SPACE_TYPE_RESOLVER.resolveSpaceType(
-                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
-                VectorDataType.FLOAT,
-                SpaceType.UNDEFINED.getValue()
+            SPACE_TYPE_RESOLVER.pickDefaultSpaceTypeWhenEmpty(
+                SPACE_TYPE_RESOLVER.resolveSpaceType(
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY),
+                    VectorDataType.FLOAT,
+                    SpaceType.UNDEFINED.getValue()
+                ),
+                VectorDataType.FLOAT
             )
         );
     }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1635,7 +1635,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             typeParser.parse(fieldName, xContentBuilderToMap(xContentBuilder), buildParserContext(indexName, settings));
         });
 
-        assertTrue(ex.getMessage(), ex.getMessage().contains("does not support space type"));
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Space type [l2] is not supported with [binary] data type"));
     }
 
     public void testBuild_whenInvalidCharsInFieldName_thenThrowException() {


### PR DESCRIPTION
### Description
Issue : https://github.com/opensearch-project/k-NN/issues/2296

This PR is to fix the mapper to acquire the space type value from index setting for legacy case.
It is deprecated, but it is still available to set the space type at index level. But the current logic picks the default L2 metric when it failed to find the one from top level and method causing the score discrepancy. Even cosine similarity metric was configured at index level, it is not being considered in 2.17 because of the bug.
Hence, this PR is to fix the bug to be backward compatibility.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
[<!-- List any other related issues here -->](https://github.com/opensearch-project/k-NN/issues/2296)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
