### PR TITLE
Adds in lazy execution for Lucene kNN queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 - Introduced a writing layer in native engines where relies on the writing interface to process IO. (#2241)[https://github.com/opensearch-project/k-NN/pull/2241]
 - Allow method parameter override for training based indices (#2290) https://github.com/opensearch-project/k-NN/pull/2290]
+- Optimizes lucene query execution to prevent unnecessary rewrites (#2305)[https://github.com/opensearch-project/k-NN/pull/2305]
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -15,6 +15,7 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.common.QueryUtils;
 import org.opensearch.knn.index.query.lucenelib.NestedKnnVectorQueryFactory;
+import org.opensearch.knn.index.query.lucene.LuceneEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
@@ -128,9 +129,13 @@ public class KNNQueryFactory extends BaseQueryFactory {
         log.debug(String.format("Creating Lucene k-NN query for index: %s \"\", field: %s \"\", k: %d", indexName, fieldName, k));
         switch (vectorDataType) {
             case BYTE:
-                return getKnnByteVectorQuery(fieldName, byteVector, luceneK, filterQuery, parentFilter, expandNested);
+                return new LuceneEngineKnnVectorQuery(
+                    getKnnByteVectorQuery(fieldName, byteVector, luceneK, filterQuery, parentFilter, expandNested)
+                );
             case FLOAT:
-                return getKnnFloatVectorQuery(fieldName, vector, luceneK, filterQuery, parentFilter, expandNested);
+                return new LuceneEngineKnnVectorQuery(
+                    getKnnFloatVectorQuery(fieldName, vector, luceneK, filterQuery, parentFilter, expandNested)
+                );
             default:
                 throw new IllegalArgumentException(
                     String.format(

--- a/src/main/java/org/opensearch/knn/index/query/lucene/LuceneEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucene/LuceneEngineKnnVectorQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+
+/**
+ * LuceneEngineKnnVectorQuery is a wrapper around a vector queries for the Lucene engine.
+ * This enables us to defer rewrites until weight creation to optimize repeated execution
+ * of Lucene based k-NN queries.
+ */
+@AllArgsConstructor
+@Log4j2
+public class LuceneEngineKnnVectorQuery extends Query {
+    @Getter
+    private final Query luceneQuery;
+
+    /*
+      Prevents repeated rewrites of the query for the Lucene engine.
+    */
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) {
+        return this;
+    }
+
+    /*
+       Rewrites the query just before weight creation.
+     */
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        Query rewrittenQuery = luceneQuery.rewrite(searcher);
+        return rewrittenQuery.createWeight(searcher, scoreMode, boost);
+    }
+
+    @Override
+    public String toString(String s) {
+        return luceneQuery.toString();
+    }
+
+    @Override
+    public void visit(QueryVisitor queryVisitor) {
+        queryVisitor.visitLeaf(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LuceneEngineKnnVectorQuery otherQuery = (LuceneEngineKnnVectorQuery) o;
+        return luceneQuery.equals(otherQuery.luceneQuery);
+    }
+
+    @Override
+    public int hashCode() {
+        return luceneQuery.hashCode();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.query;
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
 import org.apache.lucene.search.FloatVectorSimilarityQuery;
-import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.junit.Before;
@@ -33,6 +32,7 @@ import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.query.lucene.LuceneEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.knn.index.util.KNNClusterUtil;
 import org.opensearch.knn.index.engine.KNNMethodContext;
@@ -512,7 +512,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
         // Then
         assertNotNull(query);
-        assertTrue(query.getClass().isAssignableFrom(KnnFloatVectorQuery.class));
+        assertTrue(query.getClass().isAssignableFrom(LuceneEngineKnnVectorQuery.class));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/query/lucene/LuceneEngineKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucene/LuceneEngineKnnVectorQueryTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.opensearch.test.OpenSearchTestCase;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class LuceneEngineKnnVectorQueryTests extends OpenSearchTestCase {
+
+    @Mock
+    IndexSearcher indexSearcher;
+
+    @Mock
+    Query luceneQuery;
+
+    @Mock
+    Weight weight;
+
+    @Mock
+    QueryVisitor queryVisitor;
+
+    @Spy
+    @InjectMocks
+    LuceneEngineKnnVectorQuery objectUnderTest;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        openMocks(this);
+        when(luceneQuery.rewrite(any(IndexSearcher.class))).thenReturn(luceneQuery);
+        when(luceneQuery.createWeight(any(IndexSearcher.class), any(ScoreMode.class), anyFloat())).thenReturn(weight);
+    }
+
+    public void testRewrite() {
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        verifyNoInteractions(luceneQuery);
+        verify(objectUnderTest, times(3)).rewrite(indexSearcher);
+    }
+
+    public void testCreateWeight() throws Exception {
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        objectUnderTest.rewrite(indexSearcher);
+        verifyNoInteractions(luceneQuery);
+        Weight actualWeight = objectUnderTest.createWeight(indexSearcher, ScoreMode.TOP_DOCS, 1.0f);
+        verify(luceneQuery, times(1)).rewrite(indexSearcher);
+        verify(objectUnderTest, times(3)).rewrite(indexSearcher);
+        assertEquals(weight, actualWeight);
+    }
+
+    public void testVisit() {
+        objectUnderTest.visit(queryVisitor);
+        verify(queryVisitor).visitLeaf(objectUnderTest);
+    }
+
+    public void testEquals() {
+        LuceneEngineKnnVectorQuery mainQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        LuceneEngineKnnVectorQuery otherQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        assertEquals(mainQuery, otherQuery);
+        assertEquals(mainQuery, mainQuery);
+        assertNotEquals(mainQuery, null);
+        assertNotEquals(mainQuery, new Object());
+        LuceneEngineKnnVectorQuery otherQuery2 = new LuceneEngineKnnVectorQuery(null);
+        assertNotEquals(mainQuery, otherQuery2);
+    }
+
+    public void testHashCode() {
+        LuceneEngineKnnVectorQuery mainQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        assertEquals(mainQuery.hashCode(), luceneQuery.hashCode());
+    }
+
+    public void testToString() {
+        LuceneEngineKnnVectorQuery mainQuery = new LuceneEngineKnnVectorQuery(luceneQuery);
+        assertEquals(mainQuery.toString(), luceneQuery.toString());
+    }
+}


### PR DESCRIPTION
### Description
- Optimizes Lucene kNN query execution path in case of rewrites
- The caveat here is that the rewrites would be deferred until weight creation. Any underlying changes to Lucene `rewrite` method would potentially be skipped with this execution mechanism. 

### Setup and Dataset
- Opensearch docker container on a M1 Macbook Pro - Image ID: [e1d9151cce32](https://hub.docker.com/layers/opensearchproject/opensearch/latest/images/sha256-e1d9151cce329062fdb68e3bd74072df9ab8b97ce5e803cb53576269cb02c0a6?context=explore)
- Single node, default config
- Load Gen: OSB vectorsearch workload running on local node hosting the docker container
- Dataset: sift-128-euclidean.hdf5 (Params: https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/vectorsearch/params/faiss-sift-128-l2.json)
- Num docs: 1M, num shards: 2

### Flame Graph

Default 2.18 code
![2 18-default-code](https://github.com/user-attachments/assets/525974eb-2c25-4c31-ba36-e4b252ea62dc)

Patched 2.18 code
![2 18-patched-code](https://github.com/user-attachments/assets/92090fd6-83af-438a-879b-d8c24a0e4d0a)


### Benchmarks
 2.18 Default Code:
 |                                                         Metric |           Task |      Value |   Unit |
|---------------------------------------------------------------:|---------------:|-----------:|-------:|
|                                                 Min Throughput |   prod-queries |      20.93 |  ops/s |
|                                                Mean Throughput |   prod-queries |      63.23 |  ops/s |
|                                              Median Throughput |   prod-queries |      69.54 |  ops/s |
|                                                 Max Throughput |   prod-queries |      75.17 |  ops/s |
|                                        50th percentile latency |   prod-queries |    10.6464 |     ms |
|                                        90th percentile latency |   prod-queries |    13.7257 |     ms |
|                                        99th percentile latency |   prod-queries |    21.3663 |     ms |
|                                      99.9th percentile latency |   prod-queries |     71.429 |     ms |
|                                       100th percentile latency |   prod-queries |    269.424 |     ms |
|                                   50th percentile service time |   prod-queries |    10.6464 |     ms |
|                                   90th percentile service time |   prod-queries |    13.7257 |     ms |
|                                   99th percentile service time |   prod-queries |    21.3663 |     ms |
|                                 99.9th percentile service time |   prod-queries |     71.429 |     ms |
|                                  100th percentile service time |   prod-queries |    269.424 |     ms |
|                                                     error rate |   prod-queries |          0 |      % |
|                                                  Mean recall@k |   prod-queries |       0.97 |        |
|                                                  Mean recall@1 |   prod-queries |       0.98 |        |
 
 
Patched new 2.18 code:

|                                                         Metric |           Task |      Value |   Unit |
|---------------------------------------------------------------:|---------------:|-----------:|-------:| 
|                                                 Min Throughput |   prod-queries |      75.97 |  ops/s |
|                                                Mean Throughput |   prod-queries |      79.29 |  ops/s |
|                                              Median Throughput |   prod-queries |      78.68 |  ops/s |
|                                                 Max Throughput |   prod-queries |      83.04 |  ops/s |
|                                        50th percentile latency |   prod-queries |    8.66315 |     ms |
|                                        90th percentile latency |   prod-queries |    11.4286 |     ms |
|                                        99th percentile latency |   prod-queries |    21.4076 |     ms |
|                                      99.9th percentile latency |   prod-queries |    34.8355 |     ms |
|                                       100th percentile latency |   prod-queries |     53.219 |     ms |
|                                   50th percentile service time |   prod-queries |    8.66315 |     ms |
|                                   90th percentile service time |   prod-queries |    11.4286 |     ms |
|                                   99th percentile service time |   prod-queries |    21.4076 |     ms |
|                                 99.9th percentile service time |   prod-queries |    34.8355 |     ms |
|                                  100th percentile service time |   prod-queries |     53.219 |     ms |
|                                                     error rate |   prod-queries |          0 |      % |
|                                                  Mean recall@k |   prod-queries |       0.97 |        |
|                                                  Mean recall@1 |   prod-queries |       0.98 |        |

### JFRs
[JFR-patched-default.zip](https://github.com/user-attachments/files/18013154/JFR-patched-default.zip)


### Related Issues
Resolves #2115 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
