### PR TITLE
[Backport 2.x] Allow method parameter override for training based indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 - Introduced a writing layer in native engines where relies on the writing interface to process IO. (#2241)[https://github.com/opensearch-project/k-NN/pull/2241]
+- Allow method parameter override for training based indices (#2290) https://github.com/opensearch-project/k-NN/pull/2290]
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
 ### Infrastructure

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -135,8 +135,6 @@ public class RestTrainModelHandler extends BaseRestHandler {
         }
 
         ensureAtleastOneSet(KNN_METHOD, knnMethodContext, MODE_PARAMETER, mode, COMPRESSION_LEVEL_PARAMETER, compressionLevel);
-        ensureMutualExclusion(KNN_METHOD, knnMethodContext, MODE_PARAMETER, mode);
-        ensureMutualExclusion(KNN_METHOD, knnMethodContext, COMPRESSION_LEVEL_PARAMETER, compressionLevel);
 
         ensureSet(DIMENSION, dimension);
         ensureSet(TRAIN_INDEX_PARAMETER, trainingIndex);

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -26,17 +26,23 @@ import org.opensearch.knn.index.query.parser.RescoreParser;
 import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST_DEFAULT;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
@@ -260,17 +266,31 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
     public void testTraining_whenInvalid_thenFail() {
         setupTrainingIndex();
         String modelId = "test";
+
         XContentBuilder builder1 = XContentFactory.jsonBuilder()
             .startObject()
             .field(TRAIN_INDEX_PARAMETER, TRAINING_INDEX_NAME)
             .field(TRAIN_FIELD_PARAMETER, TRAINING_FIELD_NAME)
             .field(KNNConstants.DIMENSION, DIMENSION)
+            .field(VECTOR_DATA_TYPE_FIELD, "float")
+            .field(MODEL_DESCRIPTION, "")
+            .field(MODE_PARAMETER, Mode.ON_DISK)
+            .field(COMPRESSION_LEVEL_PARAMETER, "16x")
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_IVF)
             .field(KNN_ENGINE, FAISS_NAME)
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 8)
             .endObject()
-            .field(MODEL_DESCRIPTION, "")
-            .field(MODE_PARAMETER, Mode.ON_DISK)
+            .endObject()
+            .endObject()
+            .endObject()
             .endObject();
         expectThrows(ResponseException.class, () -> trainModel(modelId, builder1));
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -80,21 +80,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .field(KNN_ENGINE, "faiss")
-            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 128)
-            .startObject(METHOD_ENCODER_PARAMETER)
-            .field(NAME, "pq")
-            .startObject(PARAMETERS)
-            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-            .field(ENCODER_PARAMETER_PQ_M, 2)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 128)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -160,21 +160,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .field(KNN_ENGINE, "faiss")
-            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 128)
-            .startObject(METHOD_ENCODER_PARAMETER)
-            .field(NAME, "pq")
-            .startObject(PARAMETERS)
-            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-            .field(ENCODER_PARAMETER_PQ_M, 2)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 128)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -237,26 +237,26 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .field(KNN_ENGINE, "faiss")
-            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 1)
-            .startObject(METHOD_ENCODER_PARAMETER)
-            .field(NAME, "pq")
-            .startObject(PARAMETERS)
-            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-            .field(ENCODER_PARAMETER_PQ_M, 2)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 1)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Exception e = expectThrows(
-            ResponseException.class,
-            () -> trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "dummy description, with comma")
+                ResponseException.class,
+                () -> trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "dummy description, with comma")
         );
         assertTrue(e.getMessage().contains("Model description cannot contain any commas: ','"));
     }
@@ -299,21 +299,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .field(KNN_ENGINE, "faiss")
-            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 1)
-            .startObject(METHOD_ENCODER_PARAMETER)
-            .field(NAME, "pq")
-            .startObject(PARAMETERS)
-            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-            .field(ENCODER_PARAMETER_PQ_M, 2)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 1)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -370,21 +370,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .field(KNN_ENGINE, "faiss")
-            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 2)
-            .startObject(METHOD_ENCODER_PARAMETER)
-            .field(NAME, "pq")
-            .startObject(PARAMETERS)
-            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-            .field(ENCODER_PARAMETER_PQ_M, 2)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 2)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -449,21 +449,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
              }
          */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .field(KNN_ENGINE, "faiss")
-            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 1)
-            .startObject(METHOD_ENCODER_PARAMETER)
-            .field(NAME, "pq")
-            .startObject(PARAMETERS)
-            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-            .field(ENCODER_PARAMETER_PQ_M, 2)
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .field(KNN_ENGINE, "faiss")
+                .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 1)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "pq")
+                .startObject(PARAMETERS)
+                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+                .field(ENCODER_PARAMETER_PQ_M, 2)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(modelId, trainingIndexName, nestedFieldPath, dimension, method, "dummy description");
@@ -515,24 +515,24 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
          */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(NAME, "ivf")
-            .startObject(PARAMETERS)
-            .field(METHOD_PARAMETER_NLIST, 16)
-            .endObject()
-            .endObject();
+                .startObject()
+                .field(NAME, "ivf")
+                .startObject(PARAMETERS)
+                .field(METHOD_PARAMETER_NLIST, 16)
+                .endObject()
+                .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         XContentBuilder outerParams = XContentFactory.jsonBuilder()
-            .startObject()
-            .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
-            .field(TRAIN_FIELD_PARAMETER, nestedFieldPath)
-            .field(DIMENSION, dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "16x")
-            .field(MODE_PARAMETER, "on_disk")
-            .field(KNN_METHOD, method)
-            .field(MODEL_DESCRIPTION, "dummy description")
-            .endObject();
+                .startObject()
+                .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
+                .field(TRAIN_FIELD_PARAMETER, nestedFieldPath)
+                .field(DIMENSION, dimension)
+                .field(COMPRESSION_LEVEL_PARAMETER, "16x")
+                .field(MODE_PARAMETER, "on_disk")
+                .field(KNN_METHOD, method)
+                .field(MODEL_DESCRIPTION, "dummy description")
+                .endObject();
 
         Request request = new Request("POST", "/_plugins/_knn/models/" + modelId + "/_train");
         request.setJsonEntity(outerParams.toString());

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -80,21 +80,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .field(KNN_ENGINE, "faiss")
-                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 128)
-                .startObject(METHOD_ENCODER_PARAMETER)
-                .field(NAME, "pq")
-                .startObject(PARAMETERS)
-                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-                .field(ENCODER_PARAMETER_PQ_M, 2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 128)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -160,21 +160,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .field(KNN_ENGINE, "faiss")
-                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 128)
-                .startObject(METHOD_ENCODER_PARAMETER)
-                .field(NAME, "pq")
-                .startObject(PARAMETERS)
-                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-                .field(ENCODER_PARAMETER_PQ_M, 2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 128)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -237,26 +237,26 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .field(KNN_ENGINE, "faiss")
-                .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 1)
-                .startObject(METHOD_ENCODER_PARAMETER)
-                .field(NAME, "pq")
-                .startObject(PARAMETERS)
-                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-                .field(ENCODER_PARAMETER_PQ_M, 2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Exception e = expectThrows(
-                ResponseException.class,
-                () -> trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "dummy description, with comma")
+            ResponseException.class,
+            () -> trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "dummy description, with comma")
         );
         assertTrue(e.getMessage().contains("Model description cannot contain any commas: ','"));
     }
@@ -299,21 +299,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .field(KNN_ENGINE, "faiss")
-                .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 1)
-                .startObject(METHOD_ENCODER_PARAMETER)
-                .field(NAME, "pq")
-                .startObject(PARAMETERS)
-                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-                .field(ENCODER_PARAMETER_PQ_M, 2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(modelId, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -370,21 +370,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             }
         */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .field(KNN_ENGINE, "faiss")
-                .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 2)
-                .startObject(METHOD_ENCODER_PARAMETER)
-                .field(NAME, "pq")
-                .startObject(PARAMETERS)
-                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-                .field(ENCODER_PARAMETER_PQ_M, 2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "innerproduct")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 2)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
@@ -449,21 +449,21 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
              }
          */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .field(KNN_ENGINE, "faiss")
-                .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 1)
-                .startObject(METHOD_ENCODER_PARAMETER)
-                .field(NAME, "pq")
-                .startObject(PARAMETERS)
-                .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
-                .field(ENCODER_PARAMETER_PQ_M, 2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .field(KNN_ENGINE, "faiss")
+            .field(METHOD_PARAMETER_SPACE_TYPE, "l2")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 1)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "pq")
+            .startObject(PARAMETERS)
+            .field(ENCODER_PARAMETER_PQ_CODE_SIZE, 2)
+            .field(ENCODER_PARAMETER_PQ_M, 2)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         Response trainResponse = trainModel(modelId, trainingIndexName, nestedFieldPath, dimension, method, "dummy description");
@@ -515,24 +515,24 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
          */
         XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, "ivf")
-                .startObject(PARAMETERS)
-                .field(METHOD_PARAMETER_NLIST, 16)
-                .endObject()
-                .endObject();
+            .startObject()
+            .field(NAME, "ivf")
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 16)
+            .endObject()
+            .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
         XContentBuilder outerParams = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
-                .field(TRAIN_FIELD_PARAMETER, nestedFieldPath)
-                .field(DIMENSION, dimension)
-                .field(COMPRESSION_LEVEL_PARAMETER, "16x")
-                .field(MODE_PARAMETER, "on_disk")
-                .field(KNN_METHOD, method)
-                .field(MODEL_DESCRIPTION, "dummy description")
-                .endObject();
+            .startObject()
+            .field(TRAIN_INDEX_PARAMETER, trainingIndexName)
+            .field(TRAIN_FIELD_PARAMETER, nestedFieldPath)
+            .field(DIMENSION, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "16x")
+            .field(MODE_PARAMETER, "on_disk")
+            .field(KNN_METHOD, method)
+            .field(MODEL_DESCRIPTION, "dummy description")
+            .endObject();
 
         Request request = new Request("POST", "/_plugins/_knn/models/" + modelId + "/_train");
         request.setJsonEntity(outerParams.toString());

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -545,7 +545,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(getResponse.getEntity());
         assertNotNull(responseBody);
 
-        Map<String, Object> responseMap = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
 
         assertEquals(modelId, responseMap.get(MODEL_ID));
 


### PR DESCRIPTION
Backport 2.x PR for this Pull Request: https://github.com/opensearch-project/k-NN/pull/2290

### Description
Backport 2.x PR for this Pull Request: https://github.com/opensearch-project/k-NN/pull/2290

### Check List
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [N/A] Commits are signed per the DCO using `--signoff`.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
