### PR TITLE
Update knn index default to always do approximate search in test

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/AbstractRestartUpgradeTestCase.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/AbstractRestartUpgradeTestCase.java
@@ -58,4 +58,13 @@ public abstract class AbstractRestartUpgradeTestCase extends KNNRestTestCase {
     protected final Optional<String> getBWCVersion() {
         return Optional.ofNullable(System.getProperty(BWC_VERSION, null));
     }
+
+    @Override
+    protected Settings getKNNDefaultIndexSettings() {
+        if (isApproximateThresholdSupported(getBWCVersion())) {
+            return super.getKNNDefaultIndexSettings();
+        }
+        // for bwc will return old default setting without approximate value threshold setting
+        return getDefaultIndexSettings();
+    }
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/AbstractRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/AbstractRollingUpgradeTestCase.java
@@ -85,4 +85,13 @@ public abstract class AbstractRollingUpgradeTestCase extends KNNRestTestCase {
         return Optional.ofNullable(System.getProperty(BWC_VERSION, null));
     }
 
+    @Override
+    protected Settings getKNNDefaultIndexSettings() {
+        if (isApproximateThresholdSupported(getBWCVersion())) {
+            return super.getKNNDefaultIndexSettings();
+        }
+        // for bwc will return old default setting without approximate value threshold setting
+        return getDefaultIndexSettings();
+    }
+
 }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -21,7 +21,7 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         switch (getClusterType()) {
             case OLD:
-                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
+                createKnnIndex(testIndex, getDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS));
                 int docIdOld = 0;
                 addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, docIdOld, NUM_DOCS);
                 break;

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -96,7 +96,7 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
      * Create a k-NN index with default settings
      */
     protected IndexService createKNNIndex(String indexName) {
-        return createIndex(indexName, getKNNDefaultIndexSettings());
+        return createIndex(indexName, getKNNDefaultIndexSettingsBuildsGraphAlways());
     }
 
     /**
@@ -159,13 +159,6 @@ public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
         request.source(xContentBuilder);
 
         OpenSearchAssertions.assertAcked(client().admin().indices().putMapping(request).actionGet());
-    }
-
-    /**
-     * Get default k-NN settings for test cases
-     */
-    protected Settings getKNNDefaultIndexSettings() {
-        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", true).build();
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
@@ -106,7 +106,11 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
     }
 
     public void testUpdateIndexSetting() throws IOException {
-        Settings settings = Settings.builder().put("index.knn", true).put(KNNSettings.KNN_ALGO_PARAM_EF_SEARCH, 512).build();
+        Settings settings = Settings.builder()
+            .put("index.knn", true)
+            .put(KNNSettings.KNN_ALGO_PARAM_EF_SEARCH, 512)
+            .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
+            .build();
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
         assertEquals("512", getIndexSettingByName(INDEX_NAME, KNNSettings.KNN_ALGO_PARAM_EF_SEARCH));
 
@@ -122,7 +126,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testCacheRebuiltAfterUpdateIndexSettings() throws Exception {
-        createKnnIndex(INDEX_NAME, buildKNNIndexSettings(0), createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), createKnnIndexMapping(FIELD_NAME, 2));
 
         Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -640,7 +640,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     public void testKNNIndex_whenBuildThresholdIsNotProvided_thenShouldNotReturnSetting() throws Exception {
         final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
         final String indexName = "test-index-with-build-graph-settings";
-        createKnnIndex(indexName, knnIndexMapping);
+        createKnnIndex(indexName, getDefaultIndexSettings(), knnIndexMapping);
         final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
             indexName,
             KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD
@@ -655,7 +655,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     public void testKNNIndex_whenGetIndexSettingWithDefaultIsCalled_thenReturnDefaultBuildGraphThresholdValue() throws Exception {
         final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
         final String indexName = "test-index-with-build-vector-graph-settings";
-        createKnnIndex(indexName, knnIndexMapping);
+        createKnnIndex(indexName, getDefaultIndexSettings(), knnIndexMapping);
         final String buildVectorDataStructureThresholdSetting = getIndexSettingByName(
             indexName,
             KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD,

--- a/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
@@ -20,6 +20,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.NestedKnnDocBuilder;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.Mode;
@@ -323,6 +324,7 @@ public class ExpandNestedDocsIT extends KNNRestTestCase {
             .put("number_of_shards", numOfShards)
             .put("number_of_replicas", 0)
             .put("index.knn", true)
+            .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
             .build();
         createKnnIndex(INDEX_NAME, settings, mapping);
     }

--- a/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
@@ -840,7 +841,11 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        Settings settings = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", enableKnn).build();
+        Settings.Builder builder = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", enableKnn);
+        if (enableKnn) {
+            builder.put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0);
+        }
+        Settings settings = builder.build();
         createKnnIndex(INDEX_NAME, settings, mapper);
         try {
             final int numDocsWithField = randomIntBetween(4, 10);

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -9,6 +9,7 @@ import lombok.SneakyThrows;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
@@ -622,7 +623,11 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
         /*
          * Create knn index and populate data
          */
-        Settings settings = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", enableKnn).build();
+        Settings.Builder builder = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", enableKnn);
+        if (enableKnn) {
+            builder.put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0);
+        }
+        Settings settings = builder.build();
         createKnnIndex(INDEX_NAME, settings, mapper);
         try {
             for (Map.Entry<String, Float[]> data : documents.entrySet()) {

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -24,6 +24,7 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.plugin.stats.KNNStats;
@@ -292,7 +293,12 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
         // Create an index with a single vector
         createKnnIndex(
             INDEX_NAME,
-            Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 0).put("index.knn", true).build(),
+            Settings.builder()
+                .put("number_of_shards", 2)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
+                .build(),
             createKnnIndexMapping(FIELD_NAME, 2)
         );
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestLegacyKNNStatsHandlerIT.java
@@ -12,6 +12,7 @@
 package org.opensearch.knn.plugin.action;
 
 import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.KNNPlugin;
@@ -266,7 +267,12 @@ public class RestLegacyKNNStatsHandlerIT extends KNNRestTestCase {
         // Create an index with a single vector
         createKnnIndex(
             INDEX_NAME,
-            Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 0).put("index.knn", true).build(),
+            Settings.builder()
+                .put("number_of_shards", 2)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
+                .build(),
             createKnnIndexMapping(FIELD_NAME, 2)
         );
 

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -46,6 +46,7 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.TYPE;
 import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_EF_SEARCH;
 import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY;
 import static org.opensearch.knn.index.KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED;
@@ -152,6 +153,7 @@ public class RecallTestsIT extends KNNRestTestCase {
                     .put("number_of_shards", SHARD_COUNT)
                     .put("number_of_replicas", REPLICA_COUNT)
                     .put("index.knn", true)
+                    .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
                     .put(KNN_ALGO_PARAM_EF_SEARCH, HNSW_EF_SEARCH)
                     .build(),
                 builder.toString()
@@ -531,6 +533,7 @@ public class RecallTestsIT extends KNNRestTestCase {
             .put("number_of_shards", SHARD_COUNT)
             .put("number_of_replicas", REPLICA_COUNT)
             .put("index.knn", true)
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
             .build();
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -780,7 +780,14 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Return default index settings for index creation
      */
     protected Settings getKNNDefaultIndexSettings() {
-        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put("index.knn", true).build();
+        return buildKNNIndexSettings(0);
+    }
+
+    /**
+     * Return default index settings for index creation
+     */
+    protected Settings getDefaultIndexSettings() {
+        return Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put(KNN_INDEX, true).build();
     }
 
     protected Settings getKNNSegmentReplicatedIndexSettings() {


### PR DESCRIPTION
### Description
Update knn index default to always do approximate search in test cases

### Related Issues
Resolves #2329 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
