### PR TITLE
Switch type of expandNested from boolean to Boolean

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
@@ -50,7 +50,7 @@ public abstract class BaseQueryFactory {
         private QueryBuilder filter;
         private QueryShardContext context;
         private RescoreContext rescoreContext;
-        private boolean expandNested;
+        private Boolean expandNested;
 
         public Optional<QueryBuilder> getFilter() {
             return Optional.ofNullable(filter);
@@ -62,6 +62,10 @@ public abstract class BaseQueryFactory {
 
         public Optional<RescoreContext> getRescoreContext() {
             return Optional.ofNullable(rescoreContext);
+        }
+
+        public Optional<Boolean> getExpandNested() {
+            return Optional.ofNullable(expandNested);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -109,7 +109,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
     @Getter
     private RescoreContext rescoreContext;
     @Getter
-    private boolean expandNested;
+    private Boolean expandNested;
 
     /**
      * Constructs a new query with the given field name and vector
@@ -151,7 +151,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         private String queryName;
         private float boost = DEFAULT_BOOST;
         private RescoreContext rescoreContext;
-        private boolean expandNested;
+        private Boolean expandNested;
 
         public Builder() {}
 
@@ -210,7 +210,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             return this;
         }
 
-        public Builder expandNested(boolean expandNested) {
+        public Builder expandNested(Boolean expandNested) {
             this.expandNested = expandNested;
             return this;
         }
@@ -330,7 +330,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         this.maxDistance = null;
         this.minScore = null;
         this.rescoreContext = null;
-        this.expandNested = false;
+        this.expandNested = null;
     }
 
     public static void initialize(ModelDao modelDao) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -51,7 +51,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
         final Map<String, ?> methodParameters = createQueryRequest.getMethodParameters();
         final RescoreContext rescoreContext = createQueryRequest.getRescoreContext().orElse(null);
         final KNNEngine knnEngine = createQueryRequest.getKnnEngine();
-        final boolean expandNested = createQueryRequest.isExpandNested();
+        final boolean expandNested = createQueryRequest.getExpandNested().orElse(false);
         BitSetProducer parentFilter = null;
         if (createQueryRequest.getContext().isPresent()) {
             QueryShardContext context = createQueryRequest.getContext().get();

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -133,7 +133,7 @@ public final class KNNQueryBuilderParser {
         }
 
         if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
-            builder.expandNested(in.readBoolean());
+            builder.expandNested(in.readOptionalBoolean());
         }
 
         return builder;
@@ -169,7 +169,7 @@ public final class KNNQueryBuilderParser {
             RescoreParser.streamOutput(out, builder.getRescoreContext());
         }
         if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
-            out.writeBoolean(builder.isExpandNested());
+            out.writeOptionalBoolean(builder.getExpandNested());
         }
     }
 
@@ -245,8 +245,8 @@ public final class KNNQueryBuilderParser {
         if (knnQueryBuilder.queryName() != null) {
             builder.field(NAME_FIELD.getPreferredName(), knnQueryBuilder.queryName());
         }
-        if (knnQueryBuilder.isExpandNested()) {
-            builder.field(EXPAND_NESTED, knnQueryBuilder.isExpandNested());
+        if (knnQueryBuilder.getExpandNested() != null) {
+            builder.field(EXPAND_NESTED, knnQueryBuilder.getExpandNested());
         }
 
         builder.endObject();


### PR DESCRIPTION
### Description
Change the type of the `expandNested` variable from `boolean` to `Boolean`. This modification allows the neural search to pass the `expandNestedDocs` parameter as-is (`null`, `true`, or `false`), instead of converting `null` or `false` to `false` and `true` to `true`.
https://github.com/opensearch-project/neural-search/blob/main/src/main/java/org/opensearch/neuralsearch/query/NeuralQueryBuilder.java#L315


### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
