### PR TITLE
[Backport 2.x] Add BWC tests for Lucene Engine (#2313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,5 +30,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Select index settings based on cluster version[2236](https://github.com/opensearch-project/k-NN/pull/2236)
 * Added null checks for fieldInfo in ExactSearcher to avoid NPE while running exact search for segments with no vector field (#2278)[https://github.com/opensearch-project/k-NN/pull/2278]
+* Added Lucene BWC tests (#2313)[https://github.com/opensearch-project/k-NN/pull/2313]
 * Upgrade jsonpath from 2.8.0 to 2.9.0[2325](https://github.com/opensearch-project/k-NN/pull/2325)
 ### Refactoring

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -60,7 +60,21 @@ testClusters {
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
             }
         }
-        
+
+        if (knn_bwc_version.startsWith("1.") ||
+                knn_bwc_version.startsWith("2.0.") ||
+                knn_bwc_version.startsWith("2.1.") ||
+                knn_bwc_version.startsWith("2.2.") ||
+                knn_bwc_version.startsWith("2.3.") ||
+                knn_bwc_version.startsWith("2.4")  ||
+                knn_bwc_version.startsWith("2.5.") ||
+                knn_bwc_version.startsWith("2.6.") ||
+                knn_bwc_version.startsWith("2.7.") ||
+                knn_bwc_version.startsWith("2.8.")) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneByteVector"
+            }
+        }
         if (knn_bwc_version.startsWith("1.") ||
                 knn_bwc_version.startsWith("2.0.") ||
                 knn_bwc_version.startsWith("2.1.") ||
@@ -79,6 +93,7 @@ testClusters {
                 knn_bwc_version.startsWith("2.14.") ||
                 knn_bwc_version.startsWith("2.15.")) {
             filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
             }
         }
@@ -150,6 +165,20 @@ testClusters {
                 knn_bwc_version.startsWith("2.5.") ||
                 knn_bwc_version.startsWith("2.6.") ||
                 knn_bwc_version.startsWith("2.7.") ||
+                knn_bwc_version.startsWith("2.8.")) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneByteVector"
+            }
+        }
+        if (knn_bwc_version.startsWith("1.") ||
+                knn_bwc_version.startsWith("2.0.") ||
+                knn_bwc_version.startsWith("2.1.") ||
+                knn_bwc_version.startsWith("2.2.") ||
+                knn_bwc_version.startsWith("2.3.") ||
+                knn_bwc_version.startsWith("2.4")  ||
+                knn_bwc_version.startsWith("2.5.") ||
+                knn_bwc_version.startsWith("2.6.") ||
+                knn_bwc_version.startsWith("2.7.") ||
                 knn_bwc_version.startsWith("2.8.") ||
                 knn_bwc_version.startsWith("2.9.") ||
                 knn_bwc_version.startsWith("2.10.") ||
@@ -159,6 +188,7 @@ testClusters {
                 knn_bwc_version.startsWith("2.14.") ||
                 knn_bwc_version.startsWith("2.15.")) {
             filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
                 excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
             }
         }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.bwc;
 
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -134,7 +134,6 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
 
     public void testKNNIndexLuceneByteVector() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
-
         if (isRunningAgainstOldCluster()) {
             createKnnIndex(
                 testIndex,

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -5,13 +5,17 @@
 
 package org.opensearch.knn.bwc;
 
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Assert;
+import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +36,8 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRU
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
@@ -123,6 +129,85 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
             validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 100, K);
         } else {
             validateKNNIndexingOnUpgrade(100);
+        }
+    }
+
+    public void testKNNIndexLuceneByteVector() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(
+                testIndex,
+                getKNNDefaultIndexSettings(),
+                createKnnIndexMapping(TEST_FIELD, DIMENSIONS, METHOD_HNSW, LUCENE_NAME, SpaceType.L2.getValue(), true, VectorDataType.BYTE)
+            );
+            addKNNByteDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, 50);
+            // Flush to ensure that index is not re-indexed when node comes back up
+            flush(testIndex, true);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 50, 5);
+        } else {
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 50, 5);
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 50, 25);
+            validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, 75, 5);
+            deleteKNNIndex(testIndex);
+        }
+    }
+
+    public void testKNNIndexLuceneQuantization() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        int k = 4;
+        int dimension = 2;
+
+        if (isRunningAgainstOldCluster()) {
+            String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(TEST_FIELD)
+                .field(VECTOR_TYPE, KNN_VECTOR)
+                .field(DIMENSION, dimension)
+                .startObject(KNN_METHOD)
+                .field(NAME, METHOD_HNSW)
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+                .field(KNN_ENGINE, LUCENE_NAME)
+                .startObject(PARAMETERS)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_SQ)
+                .endObject()
+                .field(METHOD_PARAMETER_EF_CONSTRUCTION, 256)
+                .field(METHOD_PARAMETER_M, 16)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .toString();
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping);
+
+            Float[] vector1 = { -10.6f, 25.48f };
+            Float[] vector2 = { -10.8f, 25.48f };
+            Float[] vector3 = { -11.0f, 25.48f };
+            Float[] vector4 = { -11.2f, 25.48f };
+            addKnnDoc(testIndex, "1", TEST_FIELD, vector1);
+            addKnnDoc(testIndex, "2", TEST_FIELD, vector2);
+            addKnnDoc(testIndex, "3", TEST_FIELD, vector3);
+            addKnnDoc(testIndex, "4", TEST_FIELD, vector4);
+
+            float[] queryVector = { -10.5f, 25.48f };
+            Response searchResponse = searchKNNIndex(testIndex, new KNNQueryBuilder(TEST_FIELD, queryVector, k), k);
+            List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), TEST_FIELD);
+            assertEquals(k, results.size());
+            for (int i = 0; i < k; i++) {
+                assertEquals(k - i, Integer.parseInt(results.get(i).getDocId()));
+            }
+        } else {
+            float[] queryVector = { -10.5f, 25.48f };
+            Response searchResponse = searchKNNIndex(testIndex, new KNNQueryBuilder(TEST_FIELD, queryVector, k), k);
+            List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), TEST_FIELD);
+            assertEquals(k, results.size());
+            for (int i = 0; i < k; i++) {
+                assertEquals(k - i, Integer.parseInt(results.get(i).getDocId()));
+            }
+            deleteKNNIndex(testIndex);
         }
     }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -134,6 +134,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
 
     public void testKNNIndexLuceneByteVector() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
         if (isRunningAgainstOldCluster()) {
             createKnnIndex(
                 testIndex,

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -68,6 +68,7 @@ task testAgainstOneThirdUpgradedCluster(type: StandaloneRestIntegTestTask) {
     if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.0") || knn_bwc_version.startsWith("2.1")) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.LuceneFilteringIT.testLuceneFiltering"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNLuceneIndexCreation_withMethodMapper"
         }
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -39,6 +39,7 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.0") || knn_bwc_version.startsWith("2.1")) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.LuceneFilteringIT.testLuceneFiltering"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNLuceneIndexCreation_withMethodMapper"
         }
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
@@ -92,6 +93,7 @@ task testAgainstTwoThirdsUpgradedCluster(type: StandaloneRestIntegTestTask) {
     if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.0") || knn_bwc_version.startsWith("2.1")) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.LuceneFilteringIT.testLuceneFiltering"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNLuceneIndexCreation_withMethodMapper"
         }
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
@@ -117,6 +119,8 @@ task testRollingUpgrade(type: StandaloneRestIntegTestTask) {
     if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.0") || knn_bwc_version.startsWith("2.1")) {
         filter {
             excludeTestsMatching "org.opensearch.knn.bwc.LuceneFilteringIT.testLuceneFiltering"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNLuceneIndexCreation_withMethodMapper"
+
         }
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")


### PR DESCRIPTION
Added backward compatibility tests for Lucene engine

Signed-off-by: Sahil Buddharaju <sahilbud@amazon.com>
Co-authored-by: Sahil Buddharaju <sahilbud@amazon.com>
(cherry picked from commit f50a8f5383935435784711c124715efcff871b48)

### Description
Manual backport PR for PR (#2313)

### Check List
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [N/A] Commits are signed per the DCO using `--signoff`.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
