### PR TITLE
Concurrency optimization for native graph loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Remote Vector Index Build] Introduce Remote Native Index Build feature flag, settings, and initial skeleton [#2525](https://github.com/opensearch-project/k-NN/pull/2525)
 * [Remote Vector Index Build] Implement vector data upload and vector data size threshold setting [#2550](https://github.com/opensearch-project/k-NN/pull/2550)
 * [Remote Vector Index Build] Implement data download and IndexOutput write functionality [#2554](https://github.com/opensearch-project/k-NN/pull/2554)
+* Add concurrency optimizations with native memory graph loading and force eviction (#2265) [https://github.com/opensearch-project/k-NN/pull/2345]
 ### Enhancements
 * Introduce node level circuit breakers for k-NN [#2509](https://github.com/opensearch-project/k-NN/pull/2509)
 ### Bug Fixes

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -35,12 +35,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Manages native memory allocations made by JNI.
@@ -56,6 +58,7 @@ public class NativeMemoryCacheManager implements Closeable {
 
     private Cache<String, NativeMemoryAllocation> cache;
     private Deque<String> accessRecencyQueue;
+    private final ConcurrentHashMap<String, ReentrantLock> indexLocks = new ConcurrentHashMap<>();
     private final ExecutorService executor;
     private AtomicBoolean cacheCapacityReached;
     private long maxWeight;
@@ -307,6 +310,55 @@ public class NativeMemoryCacheManager implements Closeable {
     }
 
     /**
+     * Opens a vector index with proper locking mechanism to ensure thread safety.
+     * The method uses a ReentrantLock to synchronize access to the index file and
+     * cleans up the lock when no other threads are waiting.
+     *
+     * @param key the unique identifier for the index
+     * @param nativeMemoryEntryContext the context containing vector index information
+     */
+    private void open(String key, NativeMemoryEntryContext nativeMemoryEntryContext) {
+        ReentrantLock indexFileLock = indexLocks.computeIfAbsent(key, k -> new ReentrantLock());
+        try {
+            indexFileLock.lock();
+            nativeMemoryEntryContext.open();
+        } finally {
+            indexFileLock.unlock();
+            if (!indexFileLock.hasQueuedThreads()) {
+                indexLocks.remove(key, indexFileLock);
+            }
+        }
+    }
+
+    /**
+     * Retrieves an entry from the cache and updates its access recency if found.
+     * This method combines cache access with recency queue management to maintain
+     * the least recently used (LRU) order of cached entries.
+     *
+     * @param key the unique identifier for the cached entry
+     * @return the cached NativeMemoryAllocation if present, null otherwise
+     */
+    private NativeMemoryAllocation getFromCacheAndUpdateRecency(String key) {
+        NativeMemoryAllocation result = cache.getIfPresent(key);
+        if (result != null) {
+            updateAccessRecency(key);
+        }
+        return result;
+    }
+
+    /**
+     * Updates the access recency of a cached entry by moving it to the end of the queue.
+     * This method maintains the least recently used (LRU) order by removing the entry
+     * from its current position and adding it to the end of the queue.
+     *
+     * @param key the unique identifier for the cached entry whose recency needs to be updated
+     */
+    private void updateAccessRecency(String key) {
+        accessRecencyQueue.remove(key);
+        accessRecencyQueue.addLast(key);
+    }
+
+    /**
      * Retrieves NativeMemoryAllocation associated with the nativeMemoryEntryContext.
      *
      * @param nativeMemoryEntryContext Context from which to get NativeMemoryAllocation
@@ -338,7 +390,6 @@ public class NativeMemoryCacheManager implements Closeable {
             // In case of a cache miss, least recently accessed entries are evicted in a blocking manner
             // before the new entry can be added to the cache.
             String key = nativeMemoryEntryContext.getKey();
-            NativeMemoryAllocation result = cache.getIfPresent(key);
 
             // Cache Hit
             // In case of a cache hit, moving the item to the end of the recency queue adds
@@ -346,15 +397,21 @@ public class NativeMemoryCacheManager implements Closeable {
             // as lightweight as possible. Multiple approaches and their outcomes were documented
             // before moving forward with the current solution.
             // The details are outlined here: https://github.com/opensearch-project/k-NN/pull/2015#issuecomment-2327064680
+            NativeMemoryAllocation result = getFromCacheAndUpdateRecency(key);
             if (result != null) {
-                accessRecencyQueue.remove(key);
-                accessRecencyQueue.addLast(key);
                 return result;
             }
 
             // Cache Miss
             // Evict before put
+            // open the graph file before proceeding to load the graph into memory
+            open(key, nativeMemoryEntryContext);
             synchronized (this) {
+                // recheck if another thread already loaded this entry into the cache
+                result = getFromCacheAndUpdateRecency(key);
+                if (result != null) {
+                    return result;
+                }
                 if (getCacheSizeInKilobytes() + nativeMemoryEntryContext.calculateSizeInKB() >= maxWeight) {
                     Iterator<String> lruIterator = accessRecencyQueue.iterator();
                     while (lruIterator.hasNext()
@@ -376,7 +433,12 @@ public class NativeMemoryCacheManager implements Closeable {
                 return result;
             }
         } else {
-            return cache.get(nativeMemoryEntryContext.getKey(), nativeMemoryEntryContext::load);
+            // open graphFile before load
+            try (nativeMemoryEntryContext) {
+                String key = nativeMemoryEntryContext.getKey();
+                open(key, nativeMemoryEntryContext);
+                return cache.get(key, nativeMemoryEntryContext::load);
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryEntryContext.java
@@ -12,12 +12,16 @@
 package org.opensearch.knn.index.memory;
 
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.codec.util.NativeMemoryCacheKeyHelper;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.store.IndexInputWithBuffer;
 
 import java.io.IOException;
 import java.util.Map;
@@ -26,7 +30,7 @@ import java.util.UUID;
 /**
  * Encapsulates all information needed to load a component into native memory.
  */
-public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation> {
+public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation> implements AutoCloseable {
 
     protected final String key;
 
@@ -56,12 +60,26 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
     public abstract Integer calculateSizeInKB();
 
     /**
+     * Opens the graph file by opening the corresponding indexInput so
+     * that it is available for graph loading
+     */
+
+    public void open() {}
+
+    /**
+     * Provides the capability to close the closable objects in the {@link NativeMemoryEntryContext}
+     */
+    @Override
+    public void close() {}
+
+    /**
      * Loads entry into memory.
      *
      * @return NativeMemoryAllocation associated with NativeMemoryEntryContext
      */
     public abstract T load() throws IOException;
 
+    @Log4j2
     public static class IndexEntryContext extends NativeMemoryEntryContext<NativeMemoryAllocation.IndexAllocation> {
 
         @Getter
@@ -74,6 +92,17 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         @Nullable
         @Getter
         private final String modelId;
+
+        @Getter
+        private boolean indexGraphFileOpened = false;
+        @Getter
+        private int indexSizeKb;
+
+        @Getter
+        private IndexInput readStream;
+
+        @Getter
+        IndexInputWithBuffer indexInputWithBuffer;
 
         /**
          * Constructor
@@ -132,8 +161,59 @@ public abstract class NativeMemoryEntryContext<T extends NativeMemoryAllocation>
         }
 
         @Override
+        public void open() {
+            // if graph file is already opened for index, do nothing
+            if (isIndexGraphFileOpened()) {
+                return;
+            }
+            // Extract vector file name from the given cache key.
+            // Ex: _0_165_my_field.faiss@1vaqiupVUwvkXAG4Qc/RPg==
+            final String cacheKey = this.getKey();
+            final String vectorFileName = NativeMemoryCacheKeyHelper.extractVectorIndexFileName(cacheKey);
+            if (vectorFileName == null) {
+                throw new IllegalStateException(
+                    "Invalid cache key was given. The key [" + cacheKey + "] does not contain the corresponding vector file name."
+                );
+            }
+
+            // Prepare for opening index input from directory.
+            final Directory directory = this.getDirectory();
+
+            // Try to open an index input then pass it down to native engine for loading an index.
+            try {
+                indexSizeKb = Math.toIntExact(directory.fileLength(vectorFileName) / 1024);
+                readStream = directory.openInput(vectorFileName, IOContext.READONCE);
+                readStream.seek(0);
+                indexInputWithBuffer = new IndexInputWithBuffer(readStream);
+                indexGraphFileOpened = true;
+                log.debug("[KNN] NativeMemoryCacheManager open successful");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to open the index " + openSearchIndexName);
+            }
+        }
+
+        @Override
         public NativeMemoryAllocation.IndexAllocation load() throws IOException {
+            if (!isIndexGraphFileOpened()) {
+                throw new IllegalStateException("Index graph file is not open");
+            }
             return indexLoadStrategy.load(this);
+        }
+
+        // close the indexInput
+        @Override
+        public void close() {
+            if (readStream != null) {
+                try {
+                    readStream.close();
+                    indexGraphFileOpened = false;
+                } catch (IOException e) {
+                    throw new RuntimeException(
+                        "Exception while closing the indexInput index [" + openSearchIndexName + "] for loading the graph file.",
+                        e
+                    );
+                }
+            }
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
@@ -12,10 +12,22 @@
 package org.opensearch.knn.index.memory;
 
 import com.google.common.cache.CacheStats;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexInput;
+import org.junit.After;
 import org.junit.Before;
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.exception.OutOfNativeMemoryException;
+import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.plugin.KNNPlugin;
@@ -28,10 +40,24 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.spy;
 import static org.opensearch.knn.index.memory.NativeMemoryCacheManager.GRAPH_COUNT;
 import static org.opensearch.knn.plugin.stats.StatNames.GRAPH_MEMORY_USAGE;
 
@@ -39,10 +65,36 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
 
     private ThreadPool threadPool;
 
+    @Mock
+    protected ClusterService clusterService;
+    @Mock
+    protected ClusterSettings clusterSettings;
+
+    protected AutoCloseable openMocks;
+
     @Before
-    public void setThreadPool() {
+    public void setUp() throws Exception {
+        super.setUp();
+        openMocks = MockitoAnnotations.openMocks(this);
+        clusterService = mock(ClusterService.class);
+        Set<Setting<?>> defaultClusterSettings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        defaultClusterSettings.addAll(
+            KNNSettings.state()
+                .getSettings()
+                .stream()
+                .filter(s -> s.getProperties().contains(Setting.Property.NodeScope))
+                .collect(Collectors.toList())
+        );
+        KNNSettings.state().setClusterService(clusterService);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(Settings.EMPTY, defaultClusterSettings));
         threadPool = new ThreadPool(Settings.builder().put("node.name", "NativeMemoryCacheManagerTests").build());
         NativeMemoryCacheManager.setThreadPool(threadPool);
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        terminate(threadPool);
+        tearDown();
     }
 
     @Override
@@ -53,7 +105,6 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         clusterUpdateSettingsRequest.persistentSettings(circuitBreakerSettings);
         client().admin().cluster().updateSettings(clusterUpdateSettingsRequest).get();
         NativeMemoryCacheManager.getInstance().close();
-        terminate(threadPool);
         super.tearDown();
     }
 
@@ -493,6 +544,242 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         assertTrue(maintenanceTask.isCancelled());
     }
 
+    @Test
+    public void checkFeatureFlag() {
+        KNNSettings.state().setClusterService(clusterService);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterSettings.get(KNNFeatureFlags.KNN_FORCE_EVICT_CACHE_ENABLED_SETTING)).thenReturn(true);
+        assertTrue(KNNFeatureFlags.isForceEvictCacheEnabled());
+        when(clusterSettings.get(KNNFeatureFlags.KNN_FORCE_EVICT_CACHE_ENABLED_SETTING)).thenReturn(false);
+        assertFalse(KNNFeatureFlags.isForceEvictCacheEnabled());
+    }
+
+    @SneakyThrows
+    @Test
+    public void testGet() {
+        NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
+        Map<String, Map<String, Object>> indicesStats = nativeMemoryCacheManager.getIndicesCacheStats();
+        assertTrue(indicesStats.isEmpty());
+
+        String indexName1 = "test-index-1";
+        String testKey1 = "test-1";
+        int size1 = 3;
+        NativeMemoryAllocation.IndexAllocation indexAllocation1 = new NativeMemoryAllocation.IndexAllocation(
+            null,
+            0,
+            size1,
+            null,
+            testKey1,
+            indexName1
+        );
+
+        NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy = mock(NativeMemoryLoadStrategy.IndexLoadStrategy.class);
+        NativeMemoryEntryContext.IndexEntryContext indexEntryContext1 = spy(
+            new NativeMemoryEntryContext.IndexEntryContext(
+                (Directory) null,
+                TestUtils.createFakeNativeMamoryCacheKey("test"),
+                indexLoadStrategy,
+                null,
+                "test"
+            )
+        );
+
+        doReturn(indexAllocation1).when(indexEntryContext1).load();
+
+        doReturn(0).when(indexEntryContext1).calculateSizeInKB();
+        Directory mockDirectory = mock(Directory.class);
+        IndexInput mockReadStream = mock(IndexInput.class);
+        when(mockDirectory.openInput(any(), any())).thenReturn(mockReadStream);
+        // Add this line to handle the fileLength call
+        when(mockDirectory.fileLength(any())).thenReturn(1024L); // 1KB for testing
+        doReturn(mockDirectory).when(indexEntryContext1).getDirectory();
+        assertFalse(indexEntryContext1.isIndexGraphFileOpened());
+        assertEquals(indexAllocation1, nativeMemoryCacheManager.get(indexEntryContext1, false));
+        // try-with-resources will anyway close the resources opened by indexEntryContext1
+        assertFalse(indexEntryContext1.isIndexGraphFileOpened());
+        assertEquals(indexAllocation1, nativeMemoryCacheManager.get(indexEntryContext1, false));
+
+        verify(mockDirectory, times(2)).openInput(any(), any());
+        verify(mockReadStream, times(2)).seek(0);
+        verify(mockReadStream, times(2)).close();
+
+    }
+
+    @SneakyThrows
+    @Test(expected = NullPointerException.class)
+    public void testGetWithInvalidFile_NullPointerException() {
+        NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
+
+        NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy = mock(NativeMemoryLoadStrategy.IndexLoadStrategy.class);
+        NativeMemoryEntryContext.IndexEntryContext indexEntryContext = spy(
+            new NativeMemoryEntryContext.IndexEntryContext((Directory) null, "invalid-cache-key", indexLoadStrategy, null, "test")
+        );
+
+        Directory mockDirectory = mock(Directory.class);
+        // This should throw the exception
+        nativeMemoryCacheManager.get(indexEntryContext, false);
+    }
+
+    @SneakyThrows
+    @Test(expected = IllegalStateException.class)
+    public void testGetWithInvalidFile_IllegalStateException() {
+        NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
+
+        NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy = mock(NativeMemoryLoadStrategy.IndexLoadStrategy.class);
+        NativeMemoryEntryContext.IndexEntryContext indexEntryContext = spy(
+            new NativeMemoryEntryContext.IndexEntryContext((Directory) null, "invalid-cache-key", indexLoadStrategy, null, "test")
+        );
+
+        doReturn(0).when(indexEntryContext).calculateSizeInKB();
+        Directory mockDirectory = mock(Directory.class);
+        // This should throw the exception
+        nativeMemoryCacheManager.get(indexEntryContext, false);
+    }
+
+    @SneakyThrows
+    @Test
+    public void getWithForceEvictEnabled() {
+        NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
+        clusterService = mock(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        clusterSettings = mock(ClusterSettings.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterSettings.get(KNNFeatureFlags.KNN_FORCE_EVICT_CACHE_ENABLED_SETTING)).thenReturn(true);
+
+        String testKey1 = "test-1";
+        String indexName1 = "test-index-1";
+        int size1 = 3;
+
+        NativeMemoryAllocation.IndexAllocation indexAllocation1 = new NativeMemoryAllocation.IndexAllocation(
+            null,
+            0,
+            size1,
+            null,
+            testKey1,
+            indexName1
+        );
+
+        NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy = mock(NativeMemoryLoadStrategy.IndexLoadStrategy.class);
+        NativeMemoryEntryContext.IndexEntryContext indexEntryContext1 = spy(
+            new NativeMemoryEntryContext.IndexEntryContext(
+                (Directory) null,
+                TestUtils.createFakeNativeMamoryCacheKey("test"),
+                indexLoadStrategy,
+                null,
+                "test"
+            )
+        );
+
+        doReturn(indexAllocation1).when(indexEntryContext1).load();
+        doReturn(0).when(indexEntryContext1).calculateSizeInKB();
+        Directory mockDirectory = mock(Directory.class);
+        IndexInput mockReadStream = mock(IndexInput.class);
+        when(mockDirectory.openInput(any(), any())).thenReturn(mockReadStream);
+        when(mockDirectory.fileLength(any())).thenReturn(1024L);
+        doReturn(mockDirectory).when(indexEntryContext1).getDirectory();
+
+        assertFalse(indexEntryContext1.isIndexGraphFileOpened());
+        assertEquals(indexAllocation1, nativeMemoryCacheManager.get(indexEntryContext1, false));
+        // In force evict path, the file should stay open since it's not in a try-with-resources
+        assertTrue(indexEntryContext1.isIndexGraphFileOpened());
+
+        assertEquals(indexAllocation1, nativeMemoryCacheManager.get(indexEntryContext1, false));
+        assertTrue(indexEntryContext1.isIndexGraphFileOpened());
+
+        // Should only be called once since second call is a cache hit
+        verify(mockDirectory, times(1)).openInput(any(), any());
+        verify(mockReadStream, times(1)).seek(0);
+        // Since we're not closing in try-with-resources, close shouldn't be called
+        verify(mockReadStream, never()).close();
+    }
+
+    @Test
+    @SneakyThrows
+    public void testConcurrentVectorIndexOpening() {
+        NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
+        clusterService = mock(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        clusterSettings = mock(ClusterSettings.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterSettings.get(KNNFeatureFlags.KNN_FORCE_EVICT_CACHE_ENABLED_SETTING)).thenReturn(true);
+
+        int numThreads = 5;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(numThreads);
+        AtomicInteger openVectorIndexCalls = new AtomicInteger(0);
+
+        // Create test allocation
+        NativeMemoryAllocation.IndexAllocation indexAllocation = new NativeMemoryAllocation.IndexAllocation(
+            null,
+            0,
+            3,
+            null,
+            "test-1",
+            "test-index-1"
+        );
+
+        // Create and set up the spy context that will be shared across threads
+        NativeMemoryLoadStrategy.IndexLoadStrategy indexLoadStrategy = mock(NativeMemoryLoadStrategy.IndexLoadStrategy.class);
+        NativeMemoryEntryContext.IndexEntryContext sharedContext = spy(
+            new NativeMemoryEntryContext.IndexEntryContext(
+                (Directory) null,
+                TestUtils.createFakeNativeMamoryCacheKey("test"),
+                indexLoadStrategy,
+                null,
+                "test"
+            )
+        );
+
+        // Set up mocks
+        doReturn(indexAllocation).when(sharedContext).load();
+        doReturn(0).when(sharedContext).calculateSizeInKB();
+        Directory mockDirectory = mock(Directory.class);
+        IndexInput mockReadStream = mock(IndexInput.class);
+        when(mockDirectory.openInput(any(), any())).thenReturn(mockReadStream);
+        when(mockDirectory.fileLength(any())).thenReturn(1024L);
+        doReturn(mockDirectory).when(sharedContext).getDirectory();
+
+        // Add a delay in open to make concurrent access more likely
+        doAnswer(invocation -> {
+            openVectorIndexCalls.incrementAndGet();
+            // Add a small delay to simulate work
+            Thread.sleep(1000);
+            return invocation.callRealMethod();
+        }).when(sharedContext).open();
+
+        // Create threads that will try to get the same context concurrently
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+                    nativeMemoryCacheManager.get(sharedContext, false);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+            threads.add(t);
+            t.start();
+        }
+
+        startLatch.countDown();
+
+        // Wait for all threads to complete
+        completionLatch.await();
+
+        // open is called for each of the threads
+        verify(sharedContext, times(numThreads)).open();
+        assertEquals(numThreads, openVectorIndexCalls.get());
+
+        // but opening of the indexInput and seek only happens once, since rest of the threads will wait for first
+        // thread and then pick up from cache
+        verify(mockDirectory, times(1)).openInput(any(), any());
+        verify(mockReadStream, times(1)).seek(0);
+
+    }
+
     private static class TestNativeMemoryAllocation implements NativeMemoryAllocation {
 
         int size;
@@ -570,6 +857,9 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         public Integer calculateSizeInKB() {
             return size;
         }
+
+        @Override
+        public void open() {}
 
         @Override
         public TestNativeMemoryAllocation load() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryLoadStrategyTests.java
@@ -68,9 +68,10 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
                 "test"
             );
 
+            // open graph file before load
+            indexEntryContext.open();
             // Load
-            NativeMemoryAllocation.IndexAllocation indexAllocation = NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance()
-                .load(indexEntryContext);
+            NativeMemoryAllocation.IndexAllocation indexAllocation = indexEntryContext.load();
 
             // Confirm that the file was loaded by querying
             float[] query = new float[dimension];
@@ -114,9 +115,10 @@ public class NativeMemoryLoadStrategyTests extends KNNTestCase {
                 "test"
             );
 
+            // open graph file before load
+            indexEntryContext.open();
             // Load
-            NativeMemoryAllocation.IndexAllocation indexAllocation = NativeMemoryLoadStrategy.IndexLoadStrategy.getInstance()
-                .load(indexEntryContext);
+            NativeMemoryAllocation.IndexAllocation indexAllocation = indexEntryContext.load();
 
             // Verify
             assertTrue(indexAllocation.isBinaryIndex());


### PR DESCRIPTION
### Description
Fixes https://github.com/opensearch-project/k-NN/issues/2265 

Refactors the graph load into a 2 step approach detailed here - https://github.com/opensearch-project/k-NN/issues/2265#issuecomment-2518306522 

This will help to move out the opening of indexInput file outside of the synchronized block so that the graphfile can be downloaded in parallel even if the graph load and createIndexAllocation are inside synchronized block.

### Related Issues
Resolves #2265 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
