### PR TITLE
Ensure consistent filter query in KNNQueryBuilder across multiple shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Allow validation for non knn index only after 2.17.0 (#2315)[https://github.com/opensearch-project/k-NN/pull/2315]
 * Release query vector memory after execution (#2346)[https://github.com/opensearch-project/k-NN/pull/2346]
 * Fix shard level rescoring disabled setting flag (#2352)[https://github.com/opensearch-project/k-NN/pull/2352]
-* Fix filter rewrite logic getting inconsistent / incorrect results (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
+* Fix filter rewrite logic which was resulting in getting inconsistent / incorrect results for cases where filter was getting rewritten for shards (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
 * Allow validation for non knn index only after 2.17.0 (#2315)[https://github.com/opensearch-project/k-NN/pull/2315]
+* Release query vector memory after execution (#2346)[https://github.com/opensearch-project/k-NN/pull/2346]
+* Fix shard level rescoring disabled setting flag (#2352)[https://github.com/opensearch-project/k-NN/pull/2352]
+* Fix filter rewrite logic getting inconsistent / incorrect results (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -667,17 +667,17 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
             rewrittenFilter = filter.rewrite(queryShardContext);
             if (rewrittenFilter != filter) {
                 KNNQueryBuilder rewrittenQueryBuilder = KNNQueryBuilder.builder()
-                        .fieldName(this.fieldName)
-                        .vector(this.vector)
-                        .k(this.k)
-                        .maxDistance(this.maxDistance)
-                        .minScore(this.minScore)
-                        .methodParameters(this.methodParameters)
-                        .filter(rewrittenFilter)
-                        .ignoreUnmapped(this.ignoreUnmapped)
-                        .rescoreContext(this.rescoreContext)
-                        .expandNested(this.expandNested)
-                        .build();
+                    .fieldName(this.fieldName)
+                    .vector(this.vector)
+                    .k(this.k)
+                    .maxDistance(this.maxDistance)
+                    .minScore(this.minScore)
+                    .methodParameters(this.methodParameters)
+                    .filter(rewrittenFilter)
+                    .ignoreUnmapped(this.ignoreUnmapped)
+                    .rescoreContext(this.rescoreContext)
+                    .expandNested(this.expandNested)
+                    .build();
                 return rewrittenQueryBuilder;
             }
         }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -23,7 +23,6 @@ import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
-import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.model.QueryContext;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
@@ -661,21 +660,29 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         return NAME;
     }
 
-
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryShardContext) throws IOException {
         QueryBuilder rewrittenFilter;
         if (Objects.nonNull(filter)) {
             rewrittenFilter = filter.rewrite(queryShardContext);
             if (rewrittenFilter != filter) {
-                KNNQueryBuilder newKNNQuery = new KNNQueryBuilder(this.fieldName, this.vector, this.k, this.maxDistance, this.minScore,
-                        this.methodParameters, rewrittenFilter, this.ignoreUnmapped, this.rescoreContext, this.expandNested);
+                KNNQueryBuilder newKNNQuery = new KNNQueryBuilder(
+                    this.fieldName,
+                    this.vector,
+                    this.k,
+                    this.maxDistance,
+                    this.minScore,
+                    this.methodParameters,
+                    rewrittenFilter,
+                    this.ignoreUnmapped,
+                    this.rescoreContext,
+                    this.expandNested
+                );
                 return newKNNQuery;
             }
         }
         return super.doRewrite(queryShardContext);
     }
-
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -666,19 +666,19 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> {
         if (Objects.nonNull(filter)) {
             rewrittenFilter = filter.rewrite(queryShardContext);
             if (rewrittenFilter != filter) {
-                KNNQueryBuilder newKNNQuery = new KNNQueryBuilder(
-                    this.fieldName,
-                    this.vector,
-                    this.k,
-                    this.maxDistance,
-                    this.minScore,
-                    this.methodParameters,
-                    rewrittenFilter,
-                    this.ignoreUnmapped,
-                    this.rescoreContext,
-                    this.expandNested
-                );
-                return newKNNQuery;
+                KNNQueryBuilder rewrittenQueryBuilder = KNNQueryBuilder.builder()
+                        .fieldName(this.fieldName)
+                        .vector(this.vector)
+                        .k(this.k)
+                        .maxDistance(this.maxDistance)
+                        .minScore(this.minScore)
+                        .methodParameters(this.methodParameters)
+                        .filter(rewrittenFilter)
+                        .ignoreUnmapped(this.ignoreUnmapped)
+                        .rescoreContext(this.rescoreContext)
+                        .expandNested(this.expandNested)
+                        .build();
+                return rewrittenQueryBuilder;
             }
         }
         return super.doRewrite(queryShardContext);

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -1956,7 +1956,8 @@ public class FaissIT extends KNNRestTestCase {
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
 
-        createKnnIndex(INDEX_NAME, mapping);
+        createIndex(INDEX_NAME, Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 1).put("index.knn", true).build());
+        putMappingRequest(INDEX_NAME, mapping);
 
         Float[] vector = new Float[] { 2.0f, 4.5f, 6.5f };
 

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -15,6 +15,7 @@ import org.junit.After;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.query.QueryBuilder;
@@ -304,7 +305,8 @@ public class LuceneEngineIT extends KNNRestTestCase {
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
 
-        createKnnIndex(INDEX_NAME, mapping);
+        createIndex(INDEX_NAME, Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 1).put("index.knn", true).build());
+        putMappingRequest(INDEX_NAME, mapping);
 
         Float[] vector = new Float[] { 2.0f, 4.5f, 6.5f };
 

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -284,6 +284,51 @@ public class LuceneEngineIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testQueryWithFilterMultipleShards() {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD_NAME)
+            .startObject(FIELD_NAME)
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, DIMENSION)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .endObject()
+            .endObject()
+            .startObject(INTEGER_FIELD_NAME)
+            .field(TYPE_FIELD_NAME, FILED_TYPE_INTEGER)
+            .endObject()
+            .endObject()
+            .endObject();
+        String mapping = builder.toString();
+
+        createIndex(INDEX_NAME, Settings.builder().put("number_of_shards", 10).put("number_of_replicas", 0).put("index.knn", true).build());
+        putMappingRequest(INDEX_NAME, mapping);
+
+        addKnnDocWithAttributes("doc1", new float[] { 7.0f, 7.0f, 3.0f }, ImmutableMap.of("dateReceived", "2024-10-01"));
+
+        refreshIndex(INDEX_NAME);
+
+        final float[] searchVector = { 6.0f, 7.0f, 3.0f };
+        final Response response = searchKNNIndex(
+            INDEX_NAME,
+            new KNNQueryBuilder(
+                FIELD_NAME,
+                searchVector,
+                1,
+                QueryBuilders.boolQuery().must(QueryBuilders.rangeQuery("dateReceived").gte("2023-11-01"))
+            ),
+            10
+        );
+        final String responseBody = EntityUtils.toString(response.getEntity());
+        final List<KNNResult> knnResults = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(1, knnResults.size());
+    }
+
+    @SneakyThrows
     public void testQueryWithFilter_whenNonExistingFieldUsedInFilter_thenSuccessful() {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
@@ -305,8 +350,7 @@ public class LuceneEngineIT extends KNNRestTestCase {
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
 
-        createIndex(INDEX_NAME, Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 1).put("index.knn", true).build());
-        putMappingRequest(INDEX_NAME, mapping);
+        createKnnIndex(INDEX_NAME, mapping);
 
         Float[] vector = new Float[] { 2.0f, 4.5f, 6.5f };
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -1067,16 +1067,12 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .k(K)
             .build();
 
-        QueryBuilder filterBefore = filter;
-
         // When
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).filter(filter).k(K).build();
 
         QueryBuilder actual = knnQueryBuilder.rewrite(context);
 
-        QueryBuilder filterAfter = knnQueryBuilder.getFilter();
-
-        assertEquals(filterBefore, filterAfter);
+        assertEquals(knnQueryBuilder, KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).filter(filter).k(K).build());
 
         // Then
         assertEquals(expected, actual);

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -1066,10 +1066,17 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .filter(rewrittenFilter)
             .k(K)
             .build();
+
+        QueryBuilder filterBefore = filter;
+
         // When
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).filter(filter).k(K).build();
 
         QueryBuilder actual = knnQueryBuilder.rewrite(context);
+
+        QueryBuilder filterAfter = knnQueryBuilder.getFilter();
+
+        assertEquals(filterBefore, filterAfter);
 
         // Then
         assertEquals(expected, actual);


### PR DESCRIPTION
### Description
This change is to resolve issue #2339.  This PR addresses it by changing some flawed logic in the rewrite function of the KNNQueryBuilder class, introduced in this PR: https://github.com/opensearch-project/k-NN/pull/1874. What was happening before was the filter for the KNNQueryBuilder object was being rewritten upon contact with first shard, and since this instance is getting shared across all shards, other shards are using the rewritten filter from the first shard. 

What this causes is, if shard id 0 has no documents and shard id 1 has 1 document, if query lands on shard 0, the filter is rewritten to return none, as shard id 0 has no documents, so the filter is adjusted. However, since we were changing the filter in the KNN query object, rather than creating a new rewritten object for shard 0, when the query lands on shard 1, the filter has been rewritten to return none from shard 0, so even though the document is on shard 1, we will return no hits.

Now it is changed so that the rewrite class returns a new KNNQueryBuilder with the rewritten filter per shard.

### Related Issues
Resolves #2339 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
