### PR TITLE
Added the fix for NPE happening during merges when all vector fields docs are deleted in the segments getting merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use one formula to calculate cosine similarity (#2357)[https://github.com/opensearch-project/k-NN/pull/2357]
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
+* Fix for NPE while merging segments after all the vector fields docs are deleted (#2365)[https://github.com/opensearch-project/k-NN/pull/2365]
 * Allow validation for non knn index only after 2.17.0 (#2315)[https://github.com/opensearch-project/k-NN/pull/2315]
 * Release query vector memory after execution (#2346)[https://github.com/opensearch-project/k-NN/pull/2346]
 * Fix shard level rescoring disabled setting flag (#2352)[https://github.com/opensearch-project/k-NN/pull/2352]

--- a/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
+++ b/src/main/java/org/opensearch/knn/common/KNNVectorUtil.java
@@ -7,9 +7,7 @@ package org.opensearch.knn.common;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
@@ -61,18 +59,5 @@ public class KNNVectorUtil {
             intArray[i] = integerList.get(i);
         }
         return intArray;
-    }
-
-    /**
-     * Iterates vector values once if it is not at start of the location,
-     * Intended to be done to make sure dimension and bytesPerVector are available
-     * @param vectorValues
-     * @throws IOException
-     */
-    public static void iterateVectorValuesOnce(final KNNVectorValues<?> vectorValues) throws IOException {
-        if (vectorValues.docId() == -1) {
-            vectorValues.nextDoc();
-            vectorValues.getVector();
-        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNVectorUtil.intListToArray;
-import static org.opensearch.knn.common.KNNVectorUtil.iterateVectorValuesOnce;
+import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 import static org.opensearch.knn.index.codec.transfer.OffHeapVectorTransferFactory.getVectorTransfer;
 
 /**
@@ -52,7 +52,7 @@ final class DefaultIndexBuildStrategy implements NativeIndexBuildStrategy {
     public void buildAndWriteIndex(final BuildIndexParams indexInfo) throws IOException {
         final KNNVectorValues<?> knnVectorValues = indexInfo.getVectorValues();
         // Needed to make sure we don't get 0 dimensions while initializing index
-        iterateVectorValuesOnce(knnVectorValues);
+        initializeVectorValues(knnVectorValues);
         IndexBuildSetup indexBuildSetup = QuantizationIndexUtils.prepareIndexBuild(knnVectorValues, indexInfo);
 
         try (

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.opensearch.knn.common.KNNVectorUtil.intListToArray;
-import static org.opensearch.knn.common.KNNVectorUtil.iterateVectorValuesOnce;
+import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 import static org.opensearch.knn.index.codec.transfer.OffHeapVectorTransferFactory.getVectorTransfer;
 
 /**
@@ -53,7 +53,7 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
     public void buildAndWriteIndex(final BuildIndexParams indexInfo) throws IOException {
         final KNNVectorValues<?> knnVectorValues = indexInfo.getVectorValues();
         // Needed to make sure we don't get 0 dimensions while initializing index
-        iterateVectorValuesOnce(knnVectorValues);
+        initializeVectorValues(knnVectorValues);
         KNNEngine engine = indexInfo.getKnnEngine();
         Map<String, Object> indexParameters = indexInfo.getParameters();
         IndexBuildSetup indexBuildSetup = QuantizationIndexUtils.prepareIndexBuild(knnVectorValues, indexInfo);

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -43,7 +43,7 @@ import static org.opensearch.knn.common.FieldInfoExtractor.extractKNNEngine;
 import static org.opensearch.knn.common.FieldInfoExtractor.extractVectorDataType;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
-import static org.opensearch.knn.common.KNNVectorUtil.iterateVectorValuesOnce;
+import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.buildEngineFileName;
 import static org.opensearch.knn.index.engine.faiss.Faiss.FAISS_BINARY_INDEX_DESCRIPTION_PREFIX;
 
@@ -100,7 +100,7 @@ public class NativeIndexWriter {
      * @throws IOException
      */
     public void flushIndex(final KNNVectorValues<?> knnVectorValues, int totalLiveDocs) throws IOException {
-        iterateVectorValuesOnce(knnVectorValues);
+        initializeVectorValues(knnVectorValues);
         buildAndWriteIndex(knnVectorValues, totalLiveDocs);
         recordRefreshStats();
     }
@@ -111,7 +111,7 @@ public class NativeIndexWriter {
      * @throws IOException
      */
     public void mergeIndex(final KNNVectorValues<?> knnVectorValues, int totalLiveDocs) throws IOException {
-        iterateVectorValuesOnce(knnVectorValues);
+        initializeVectorValues(knnVectorValues);
         if (knnVectorValues.docId() == NO_MORE_DOCS) {
             // This is in place so we do not add metrics
             log.debug("Skipping mergeIndex, vector values are already iterated for {}", fieldInfo.name);

--- a/src/test/java/org/opensearch/knn/common/KNNVectorUtilTests.java
+++ b/src/test/java/org/opensearch/knn/common/KNNVectorUtilTests.java
@@ -11,16 +11,9 @@
 
 package org.opensearch.knn.common;
 
-import lombok.SneakyThrows;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
-import org.opensearch.knn.index.vectorvalues.TestVectorValues;
 
 import java.util.List;
-
-import static org.opensearch.knn.common.KNNVectorUtil.iterateVectorValuesOnce;
 
 public class KNNVectorUtilTests extends KNNTestCase {
     public void testByteZeroVector() {
@@ -37,24 +30,5 @@ public class KNNVectorUtilTests extends KNNTestCase {
         assertArrayEquals(new int[] { 1, 2, 3 }, KNNVectorUtil.intListToArray(List.of(1, 2, 3)));
         assertNull(KNNVectorUtil.intListToArray(List.of()));
         assertNull(KNNVectorUtil.intListToArray(null));
-    }
-
-    @SneakyThrows
-    public void testInit() {
-        // Give
-        final List<float[]> floatArray = List.of(new float[] { 1, 2 }, new float[] { 2, 3 });
-        final int dimension = floatArray.get(0).length;
-        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
-            floatArray
-        );
-        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
-
-        // When
-        iterateVectorValuesOnce(knnVectorValues);
-
-        // Then
-        assertNotEquals(-1, knnVectorValues.docId());
-        assertArrayEquals(floatArray.get(0), knnVectorValues.getVector(), 0.001f);
-        assertEquals(dimension, knnVectorValues.dimension());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/util/KNNCodecUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/util/KNNCodecUtilTests.java
@@ -6,16 +6,24 @@
 package org.opensearch.knn.index.codec.util;
 
 import junit.framework.TestCase;
+import lombok.SneakyThrows;
 import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.junit.Assert;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+import org.opensearch.knn.index.vectorvalues.TestVectorValues;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.calculateArraySize;
+import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 
 public class KNNCodecUtilTests extends TestCase {
 
@@ -45,5 +53,39 @@ public class KNNCodecUtilTests extends TestCase {
         List<String> engineFiles = KNNCodecUtil.getEngineFiles(knnEngine.getExtension(), "target_field", segmentInfo);
         assertEquals(engineFiles.size(), 2);
         assertTrue(engineFiles.get(0).equals("_0_2011_target_field.faissc"));
+    }
+
+    @SneakyThrows
+    public void testInitializeVectorValues_whenValidVectorValues_thenSuccess() {
+        // Give
+        final List<float[]> floatArray = List.of(new float[] { 1, 2 }, new float[] { 2, 3 });
+        final int dimension = floatArray.get(0).length;
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            floatArray
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+
+        // When
+        initializeVectorValues(knnVectorValues);
+
+        // Then
+        Assert.assertNotEquals(-1, knnVectorValues.docId());
+        Assert.assertArrayEquals(floatArray.get(0), knnVectorValues.getVector(), 0.001f);
+        assertEquals(dimension, knnVectorValues.dimension());
+    }
+
+    @SneakyThrows
+    public void testInitializeVectorValues_whenNoDocs_thenSuccess() {
+        // Give
+        final List<float[]> floatArray = Collections.emptyList();
+        final TestVectorValues.PreDefinedFloatVectorValues randomVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            floatArray
+        );
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, randomVectorValues);
+
+        // When
+        initializeVectorValues(knnVectorValues);
+        // Then
+        Assert.assertEquals(DocIdSetIterator.NO_MORE_DOCS, knnVectorValues.docId());
     }
 }


### PR DESCRIPTION
### Description
Added the fix for NPE happening during merges when all vector fields docs are deleted in the segments getting merged.

### What is the bug:
Where there are a lot of deleted docs and we are trying to merge the segments, we are seeing the NPE exception coming as there were not docs containing vector and we are trying to iterate over vector values.

The issue is not always reproducible hence adding an IT is not possible here. Also with the changes add in 2.18 related to threshold based graph creation, the issue is now only limited to indices created <=2.16 version of Opensearch using BDV.

Attaching a script here(author: @jmazanec15 ) that helped in reproducing the issue. 
[merge-failure-2.sh.zip](https://github.com/user-attachments/files/18304323/merge-failure-2.sh.zip)



### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
