### PR TITLE
Added more detailed error messages for KNN model training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduced a writing layer in native engines where relies on the writing interface to process IO. (#2241)[https://github.com/opensearch-project/k-NN/pull/2241]
 - Allow method parameter override for training based indices (#2290) https://github.com/opensearch-project/k-NN/pull/2290]
 - Optimizes lucene query execution to prevent unnecessary rewrites (#2305)[https://github.com/opensearch-project/k-NN/pull/2305]
+- Added more detailed error messages for KNN model training (#2378)[https://github.com/opensearch-project/k-NN/pull/2378]
 - Add check to directly use ANN Search when filters match all docs. (#2320)[https://github.com/opensearch-project/k-NN/pull/2320]
 - Use one formula to calculate cosine similarity (#2357)[https://github.com/opensearch-project/k-NN/pull/2357]
 - Remove DocsWithFieldSet reference from NativeEngineFieldVectorsWriter (#2408)[https://github.com/opensearch-project/k-NN/pull/2408]

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/FaissSQIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/FaissSQIT.java
@@ -225,7 +225,7 @@ public class FaissSQIT extends AbstractRestartUpgradeTestCase {
 
             // Add training data
             createBasicKnnIndex(TRAIN_INDEX, TRAIN_TEST_FIELD, DIMENSION);
-            int trainingDataCount = 200;
+            int trainingDataCount = 1100;
             bulkIngestRandomVectors(TRAIN_INDEX, TRAIN_TEST_FIELD, trainingDataCount, DIMENSION);
 
             XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -278,7 +278,7 @@ public class FaissSQIT extends AbstractRestartUpgradeTestCase {
 
             // Add training data
             createBasicKnnIndex(TRAIN_INDEX, TRAIN_TEST_FIELD, dimension);
-            int trainingDataCount = 200;
+            int trainingDataCount = 1100;
             bulkIngestRandomVectors(TRAIN_INDEX, TRAIN_TEST_FIELD, trainingDataCount, dimension);
 
             XContentBuilder builder = XContentFactory.jsonBuilder()

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
@@ -22,6 +22,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 
 /**
  * Abstract class for KNN methods. This class provides the common functionality for all KNN methods.
@@ -108,6 +114,55 @@ public abstract class AbstractKNNMethod implements KNNMethod {
         return PerDimensionProcessor.NOOP_PROCESSOR;
     }
 
+    protected Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> doGetTrainingConfigValidationSetup() {
+        return (trainingConfigValidationInput) -> {
+
+            KNNMethodContext knnMethodContext = trainingConfigValidationInput.getKnnMethodContext();
+            KNNMethodConfigContext knnMethodConfigContext = trainingConfigValidationInput.getKnnMethodConfigContext();
+            Long trainingVectors = trainingConfigValidationInput.getTrainingVectorsCount();
+
+            TrainingConfigValidationOutput.TrainingConfigValidationOutputBuilder builder = TrainingConfigValidationOutput.builder();
+
+            // validate ENCODER_PARAMETER_PQ_M is divisible by vector dimension
+            if (knnMethodContext != null && knnMethodConfigContext != null) {
+                if (knnMethodContext.getMethodComponentContext().getParameters().containsKey(ENCODER_PARAMETER_PQ_M)
+                    && knnMethodConfigContext.getDimension() % (Integer) knnMethodContext.getMethodComponentContext()
+                        .getParameters()
+                        .get(ENCODER_PARAMETER_PQ_M) != 0) {
+                    builder.valid(false);
+                    return builder.build();
+                } else {
+                    builder.valid(true);
+                }
+            }
+
+            // validate number of training points should be greater than minimum clustering criteria defined in faiss
+            if (knnMethodContext != null && trainingVectors != null) {
+                long minTrainingVectorCount = 1000;
+
+                MethodComponentContext encoderContext = (MethodComponentContext) knnMethodContext.getMethodComponentContext()
+                    .getParameters()
+                    .get(METHOD_ENCODER_PARAMETER);
+
+                if (knnMethodContext.getMethodComponentContext().getParameters().containsKey(METHOD_PARAMETER_NLIST)
+                    && encoderContext.getParameters().containsKey(ENCODER_PARAMETER_PQ_CODE_SIZE)) {
+
+                    int nlist = ((Integer) knnMethodContext.getMethodComponentContext().getParameters().get(METHOD_PARAMETER_NLIST));
+                    int code_size = ((Integer) encoderContext.getParameters().get(ENCODER_PARAMETER_PQ_CODE_SIZE));
+                    minTrainingVectorCount = (long) Math.max(nlist, Math.pow(2, code_size));
+                }
+
+                if (trainingVectors < minTrainingVectorCount) {
+                    builder.valid(false).minTrainingVectorCount(minTrainingVectorCount);
+                    return builder.build();
+                } else {
+                    builder.valid(true);
+                }
+            }
+            return builder.build();
+        };
+    }
+
     protected VectorTransformer getVectorTransformer(SpaceType spaceType) {
         return VectorTransformerFactory.NOOP_VECTOR_TRANSFORMER;
     }
@@ -131,6 +186,7 @@ public abstract class AbstractKNNMethod implements KNNMethod {
             .perDimensionValidator(doGetPerDimensionValidator(knnMethodContext, knnMethodConfigContext))
             .perDimensionProcessor(doGetPerDimensionProcessor(knnMethodContext, knnMethodConfigContext))
             .vectorTransformer(getVectorTransformer(knnMethodContext.getSpaceType()))
+            .trainingConfigValidationSetup(doGetTrainingConfigValidationSetup())
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
@@ -12,6 +12,7 @@ import org.opensearch.knn.index.mapper.VectorTransformer;
 import org.opensearch.knn.index.mapper.VectorValidator;
 
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Context a library gives to build one of its indices
@@ -48,6 +49,12 @@ public interface KNNLibraryIndexingContext {
      * @return Get the per dimension processor
      */
     PerDimensionProcessor getPerDimensionProcessor();
+
+    /**
+     *
+     * @return Get function that validates training model parameters
+     */
+    Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> getTrainingConfigValidationSetup();
 
     /**
      * Get the vector transformer that will be used to transform the vector before indexing.

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
@@ -14,6 +14,7 @@ import org.opensearch.knn.index.mapper.VectorValidator;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Simple implementation of {@link KNNLibraryIndexingContext}
@@ -29,6 +30,7 @@ public class KNNLibraryIndexingContextImpl implements KNNLibraryIndexingContext 
     private Map<String, Object> parameters = Collections.emptyMap();
     @Builder.Default
     private QuantizationConfig quantizationConfig = QuantizationConfig.EMPTY;
+    private Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> trainingConfigValidationSetup;
 
     @Override
     public Map<String, Object> getLibraryParameters() {
@@ -58,5 +60,10 @@ public class KNNLibraryIndexingContextImpl implements KNNLibraryIndexingContext 
     @Override
     public PerDimensionProcessor getPerDimensionProcessor() {
         return perDimensionProcessor;
+    }
+
+    @Override
+    public Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> getTrainingConfigValidationSetup() {
+        return trainingConfigValidationSetup;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/TrainingConfigValidationInput.java
+++ b/src/main/java/org/opensearch/knn/index/engine/TrainingConfigValidationInput.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This object provides the input of the validation checks for training model inputs.
+ * The values in this object need to be dynamically set and calling code needs to handle
+ * the possibility that the values have not been set.
+ */
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+public class TrainingConfigValidationInput {
+    private Long trainingVectorsCount;
+    private KNNMethodContext knnMethodContext;
+    private KNNMethodConfigContext knnMethodConfigContext;
+}

--- a/src/main/java/org/opensearch/knn/index/engine/TrainingConfigValidationOutput.java
+++ b/src/main/java/org/opensearch/knn/index/engine/TrainingConfigValidationOutput.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This object provides the output of the validation checks for training model inputs.
+ * The values in this object need to be dynamically set and calling code needs to handle
+ * the possibility that the values have not been set.
+ */
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+public class TrainingConfigValidationOutput {
+    private boolean valid;
+    private long minTrainingVectorCount;
+}

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
@@ -23,6 +23,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ValidationException;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportRequestOptions;
@@ -31,6 +32,9 @@ import org.opensearch.transport.TransportService;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.BYTES_PER_KILOBYTES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.search.internal.SearchContext.DEFAULT_TERMINATE_AFTER;
 
 /**
@@ -132,6 +136,30 @@ public class TrainingJobRouterTransportAction extends HandledTransportAction<Tra
             // If there are more docs in the index than what the user wants to use for training, take the min
             if (trainingModelRequest.getMaximumVectorCount() < trainingVectors) {
                 trainingVectors = trainingModelRequest.getMaximumVectorCount();
+            }
+
+            long minTrainingVectorCount = 1000;
+            MethodComponentContext encoderContext = (MethodComponentContext) trainingModelRequest.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER);
+
+            if (trainingModelRequest.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_PARAMETER_NLIST)
+                && encoderContext.getParameters().containsKey(ENCODER_PARAMETER_PQ_CODE_SIZE)) {
+
+                int nlist = ((Integer) trainingModelRequest.getKnnMethodContext()
+                    .getMethodComponentContext()
+                    .getParameters()
+                    .get(METHOD_PARAMETER_NLIST));
+                int code_size = ((Integer) encoderContext.getParameters().get(ENCODER_PARAMETER_PQ_CODE_SIZE));
+                minTrainingVectorCount = (long) Math.max(nlist, Math.pow(2, code_size));
+            }
+
+            if (trainingVectors < minTrainingVectorCount) {
+                ValidationException exception = new ValidationException();
+                exception.addValidationError("Number of training points should be greater than " + minTrainingVectorCount);
+                listener.onFailure(exception);
+                return;
             }
 
             listener.onResponse(

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -35,6 +35,8 @@ import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
+
 /**
  * Request to train and serialize a model
  */
@@ -281,6 +283,15 @@ public class TrainingModelRequest extends ActionRequest {
         if (description != null && description.length() > KNNConstants.MAX_MODEL_DESCRIPTION_LENGTH) {
             exception = exception == null ? new ActionRequestValidationException() : exception;
             exception.addValidationError("Description exceeds limit of " + KNNConstants.MAX_MODEL_DESCRIPTION_LENGTH + " characters");
+        }
+
+        // Check if ENCODER_PARAMETER_PQ_M is divisible by vector dimension
+        if (knnMethodContext.getMethodComponentContext().getParameters().containsKey(ENCODER_PARAMETER_PQ_M)
+            && knnMethodConfigContext.getDimension() % (Integer) knnMethodContext.getMethodComponentContext()
+                .getParameters()
+                .get(ENCODER_PARAMETER_PQ_M) != 0) {
+            exception = exception == null ? new ActionRequestValidationException() : exception;
+            exception.addValidationError("Training request ENCODER_PARAMETER_PQ_M is not divisible by vector dimensions");
         }
 
         // Validate training index exists

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -30,12 +30,14 @@ import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.index.engine.EngineResolver;
 import org.opensearch.knn.index.util.IndexUtil;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.TrainingConfigValidationInput;
+import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
-
-import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
+import java.util.function.Function;
 
 /**
  * Request to train and serialize a model
@@ -285,11 +287,17 @@ public class TrainingModelRequest extends ActionRequest {
             exception.addValidationError("Description exceeds limit of " + KNNConstants.MAX_MODEL_DESCRIPTION_LENGTH + " characters");
         }
 
+        KNNLibraryIndexingContext knnLibraryIndexingContext = knnMethodContext.getKnnEngine()
+            .getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext);
+        Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> validateTrainingConfig = knnLibraryIndexingContext
+            .getTrainingConfigValidationSetup();
+        TrainingConfigValidationInput.TrainingConfigValidationInputBuilder inputBuilder = TrainingConfigValidationInput.builder();
+        TrainingConfigValidationOutput validation = validateTrainingConfig.apply(
+            inputBuilder.knnMethodConfigContext(knnMethodConfigContext).knnMethodContext(knnMethodContext).build()
+        );
+
         // Check if ENCODER_PARAMETER_PQ_M is divisible by vector dimension
-        if (knnMethodContext.getMethodComponentContext().getParameters().containsKey(ENCODER_PARAMETER_PQ_M)
-            && knnMethodConfigContext.getDimension() % (Integer) knnMethodContext.getMethodComponentContext()
-                .getParameters()
-                .get(ENCODER_PARAMETER_PQ_M) != 0) {
+        if (!validation.isValid()) {
             exception = exception == null ? new ActionRequestValidationException() : exception;
             exception.addValidationError("Training request ENCODER_PARAMETER_PQ_M is not divisible by vector dimensions");
         }

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -203,9 +203,7 @@ public class TrainingJob implements Runnable {
         } catch (Exception e) {
             logger.error("Failed to run training job for model \"" + modelId + "\": ", e);
             modelMetadata.setState(ModelState.FAILED);
-            modelMetadata.setError(
-                "Failed to execute training. May be caused by an invalid method definition or " + "not enough memory to perform training."
-            );
+            modelMetadata.setError("Failed to execute training. " + e.getMessage());
 
             KNNCounter.TRAINING_ERRORS.increment();
 

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -304,7 +304,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // training data needs to be at least equal to the number of centroids for PQ
         // which is 2^8 = 256. 8 because that's the only valid code_size for HNSWPQ
-        int trainingDataCount = 256;
+        int trainingDataCount = 1100;
 
         SpaceType spaceType = SpaceType.L2;
 
@@ -468,7 +468,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // training data needs to be at least equal to the number of centroids for PQ
         // which is 2^8 = 256. 8 because thats the only valid code_size for HNSWPQ
-        int trainingDataCount = 256;
+        int trainingDataCount = 1100;
 
         SpaceType spaceType = SpaceType.L2;
 
@@ -736,7 +736,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // Add training data
         createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-        int trainingDataCount = 200;
+        int trainingDataCount = 1100;
         bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
 
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -960,7 +960,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // Add training data
         createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-        int trainingDataCount = 200;
+        int trainingDataCount = 1100;
         bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
 
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -1064,7 +1064,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // Add training data
         createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-        int trainingDataCount = 200;
+        int trainingDataCount = 1100;
         bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
 
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -1144,7 +1144,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // training data needs to be at least equal to the number of centroids for PQ
         // which is 2^8 = 256. 8 because thats the only valid code_size for HNSWPQ
-        int trainingDataCount = 256;
+        int trainingDataCount = 1100;
 
         SpaceType spaceType = SpaceType.L2;
 
@@ -1412,7 +1412,7 @@ public class FaissIT extends KNNRestTestCase {
 
         // Add training data
         createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-        int trainingDataCount = 200;
+        int trainingDataCount = 1100;
         bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
 
         // Call train API - IVF with nlists = 1 is brute force, but will require training
@@ -1767,7 +1767,7 @@ public class FaissIT extends KNNRestTestCase {
 
         createKnnIndex(trainingIndexName, trainIndexMapping);
 
-        int trainingDataCount = 40;
+        int trainingDataCount = 1100;
         bulkIngestRandomBinaryVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
 
         XContentBuilder trainModelXContentBuilder = XContentFactory.jsonBuilder()

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -603,7 +603,7 @@ public class VectorDataTypeIT extends KNNRestTestCase {
             .toString();
         createKnnIndex(INDEX_NAME, trainIndexMapping);
 
-        int trainingDataCount = 100;
+        int trainingDataCount = 1100;
         bulkIngestRandomByteVectors(INDEX_NAME, FIELD_NAME, trainingDataCount, dimension);
 
         XContentBuilder trainModelXContentBuilder = XContentFactory.jsonBuilder()

--- a/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
@@ -620,7 +620,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         int dimensions = randomIntBetween(2, 10);
         String trainMapping = createKnnIndexMapping(TRAIN_FIELD_PARAMETER, dimensions);
         createKnnIndex(TRAIN_INDEX_PARAMETER, trainMapping);
-        bulkIngestRandomVectors(TRAIN_INDEX_PARAMETER, TRAIN_FIELD_PARAMETER, dimensions * 3, dimensions);
+        bulkIngestRandomVectors(TRAIN_INDEX_PARAMETER, TRAIN_FIELD_PARAMETER, 1100, dimensions);
 
         XContentBuilder methodBuilder = XContentFactory.jsonBuilder()
             .startObject()

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -52,7 +52,7 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
 
     private static final String TRAINING_INDEX_NAME = "training_index";
     private static final String TRAINING_FIELD_NAME = "training_field";
-    private static final int TRAINING_VECS = 20;
+    private static final int TRAINING_VECS = 1100;
 
     private static final int DIMENSION = 16;
     private static final int NUM_DOCS = 20;

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -71,7 +71,7 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
     private static final String FIELD_LUCENE_NAME = "lucene_test_field";
     private static final int DIMENSION = 4;
     private static int DOC_ID = 0;
-    private static final int NUM_DOCS = 10;
+    private static final int NUM_DOCS = 1100;
     private static final int DELAY_MILLI_SEC = 1000;
     private static final int NUM_OF_ATTEMPTS = 30;
 

--- a/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestTrainModelHandlerIT.java
@@ -97,28 +97,11 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
             .endObject();
         Map<String, Object> method = xContentBuilderToMap(builder);
 
-        Response trainResponse = trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description");
-
-        assertEquals(RestStatus.OK, RestStatus.fromCode(trainResponse.getStatusLine().getStatusCode()));
-
-        // Grab the model id from the response
-        String trainResponseBody = EntityUtils.toString(trainResponse.getEntity());
-        assertNotNull(trainResponseBody);
-
-        Map<String, Object> trainResponseMap = createParser(XContentType.JSON.xContent(), trainResponseBody).map();
-        String modelId = (String) trainResponseMap.get(MODEL_ID);
-        assertNotNull(modelId);
-
-        // Confirm that the model fails to create
-        Response getResponse = getModel(modelId, null);
-        String responseBody = EntityUtils.toString(getResponse.getEntity());
-        assertNotNull(responseBody);
-
-        Map<String, Object> responseMap = createParser(XContentType.JSON.xContent(), responseBody).map();
-
-        assertEquals(modelId, responseMap.get(MODEL_ID));
-
-        assertTrainingFails(modelId, 30, 1000);
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> trainModel(null, trainingIndexName, trainingFieldName, dimension, method, "dummy description")
+        );
+        assertTrue(exception.getMessage().contains("Number of training points should be greater than"));
     }
 
     public void testTrainModel_fail_tooMuchData() throws Exception {
@@ -132,7 +115,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
 
         // Create a training index and randomly ingest data into it
         createBasicKnnIndex(trainingIndexName, trainingFieldName, dimension);
-        int trainingDataCount = 20; // 20 * 16 * 4 ~= 10 kb
+        int trainingDataCount = 128;
         bulkIngestRandomVectors(trainingIndexName, trainingFieldName, trainingDataCount, dimension);
 
         // Call the train API with this definition:
@@ -491,7 +474,7 @@ public class RestTrainModelHandlerIT extends KNNRestTestCase {
         // Create a training index and randomly ingest data into it
         String mapping = createKnnIndexNestedMapping(dimension, nestedFieldPath);
         createKnnIndex(trainingIndexName, mapping);
-        int trainingDataCount = 200;
+        int trainingDataCount = 1100;
         bulkIngestRandomVectorsWithNestedField(trainingIndexName, nestedFieldPath, trainingDataCount, dimension);
 
         // Call the train API with this definition:

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingModelRequestTests.java
@@ -621,9 +621,59 @@ public class TrainingModelRequestTests extends KNNTestCase {
         ActionRequestValidationException exception = trainingModelRequest.validate();
         assertNotNull(exception);
         List<String> validationErrors = exception.validationErrors();
-        logger.error("Validation errorsa " + validationErrors);
+        logger.error("Validation errors " + validationErrors);
         assertEquals(1, validationErrors.size());
         assertTrue(validationErrors.get(0).contains("Description exceeds limit"));
+    }
+
+    public void testValidation_invalid_mNotDivisibleByDimension() {
+
+        // Setup the training request
+        String modelId = "test-model-id";
+        int dimension = 10;
+        String trainingIndex = "test-training-index";
+        String trainingField = "test-training-field";
+        String trainingFieldModeId = "training-field-model-id";
+
+        Map<String, Object> parameters = Map.of("m", 3);
+
+        MethodComponentContext methodComponentContext = new MethodComponentContext(METHOD_HNSW, parameters);
+        final KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.DEFAULT, methodComponentContext);
+
+        TrainingModelRequest trainingModelRequest = new TrainingModelRequest(
+            modelId,
+            knnMethodContext,
+            dimension,
+            trainingIndex,
+            trainingField,
+            null,
+            null,
+            VectorDataType.DEFAULT,
+            Mode.NOT_CONFIGURED,
+            CompressionLevel.NOT_CONFIGURED
+        );
+
+        // Mock the model dao to return metadata for modelId to recognize it is a duplicate
+        ModelMetadata trainingFieldModelMetadata = mock(ModelMetadata.class);
+        when(trainingFieldModelMetadata.getDimension()).thenReturn(dimension);
+
+        ModelDao modelDao = mock(ModelDao.class);
+        when(modelDao.getMetadata(modelId)).thenReturn(null);
+        when(modelDao.getMetadata(trainingFieldModeId)).thenReturn(trainingFieldModelMetadata);
+
+        // Cluster service that wont produce validation exception
+        ClusterService clusterService = getClusterServiceForValidReturns(trainingIndex, trainingField, dimension);
+
+        // Initialize static components with the mocks
+        TrainingModelRequest.initialize(modelDao, clusterService);
+
+        // Test that validation produces m not divisible by vector dimension error message
+        ActionRequestValidationException exception = trainingModelRequest.validate();
+        assertNotNull(exception);
+        List<String> validationErrors = exception.validationErrors();
+        logger.error("Validation errors " + validationErrors);
+        assertEquals(2, validationErrors.size());
+        assertTrue(validationErrors.get(1).contains("Training request ENCODER_PARAMETER_PQ_M"));
     }
 
     public void testValidation_valid_trainingIndexBuiltFromMethod() {

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -67,7 +67,7 @@ public class RecallTestsIT extends KNNRestTestCase {
     private final static String TRAIN_FIELD_NAME = "train_field";
     private final static String TEST_MODEL_ID = "test_model_id";
     private final static int TEST_DIMENSION = 32;
-    private final static int DOC_COUNT = 500;
+    private final static int DOC_COUNT = 1100;
     private final static int QUERY_COUNT = 100;
     private final static int TEST_K = 100;
     private final static double PERFECT_RECALL = 1.0;


### PR DESCRIPTION
### Description
Previously, a consistent feedback we get around PQ and IVF is that there is limited visibility into the failure cases. Part of this is because the errors are thrown on the Faiss side and we don't return stack traces in Rest response. So, this makes it difficult to use PQ and IVF. Thus, this PR provides improved error messages by adding explicit checks for the most common errors:

[ ] For PQ, explicitly check in OpenSearch an invalid configuration where m does not divide dimension
[ ] For PQ/IVF, check the number of training points matches the minimum clustering criteria defined in faiss
[ ] If there is not enough memory, explicitly say that there is not enough memory.

Adding these 3 checks will cover 90% of the training failures that occur. 

### Related Issues
Resolves #2268 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
