### PR TITLE
Fix sequence of NativeMemory/QuantizationState cache test setup/teardown

### DIFF
--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
@@ -12,7 +12,6 @@
 package org.opensearch.knn.index.memory;
 
 import com.google.common.cache.CacheStats;
-import org.junit.After;
 import org.junit.Before;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.common.settings.Settings;
@@ -41,16 +40,9 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     private ThreadPool threadPool;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setThreadPool() {
         threadPool = new ThreadPool(Settings.builder().put("node.name", "NativeMemoryCacheManagerTests").build());
         NativeMemoryCacheManager.setThreadPool(threadPool);
-    }
-
-    @After
-    public void shutdown() throws Exception {
-        super.tearDown();
-        terminate(threadPool);
     }
 
     @Override
@@ -61,6 +53,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         clusterUpdateSettingsRequest.persistentSettings(circuitBreakerSettings);
         client().admin().cluster().updateSettings(clusterUpdateSettingsRequest).get();
         NativeMemoryCacheManager.getInstance().close();
+        terminate(threadPool);
         super.tearDown();
     }
 

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
@@ -36,15 +36,13 @@ public class QuantizationStateCacheTests extends KNNTestCase {
     private ThreadPool threadPool;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void setThreadPool() {
         threadPool = new ThreadPool(Settings.builder().put("node.name", "QuantizationStateCacheTests").build());
         QuantizationStateCache.setThreadPool(threadPool);
     }
 
     @After
-    public void shutdown() throws Exception {
-        super.tearDown();
+    public void terminateThreadPool() {
         terminate(threadPool);
     }
 


### PR DESCRIPTION
### Description
While looking into my backport PR's [test failure](https://github.com/opensearch-project/k-NN/actions/runs/12754493243/job/35548447356) I found that the new setUp/tearDown flow conflicts with the existing NativeMemoryCacheTests class cleanup. This is what caused the odd failure. This new revision scopes down the change to the setup/teardown flow and overall keeps things more simple.

### Related Issues
#2308 
#2390 (manual backport)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
