### PR TITLE
Explain API for Exact/ANN/Radial/Disk based KNN search on Faiss

### DIFF
--- a/release-notes/opensearch-knn.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/opensearch-knn.release-notes-3.0.0.0-beta1.md
@@ -8,6 +8,7 @@ Compatible with OpenSearch 3.0.0.beta1
 * Add filter function to KNNQueryBuilder with unit tests and integration tests [#2599](https://github.com/opensearch-project/k-NN/pull/2599)
 * [Lucene On Faiss] Add a new mode, memory-optimized-search enable user to run vector search on FAISS index under memory constrained environment. [#2630](https://github.com/opensearch-project/k-NN/pull/2630)
 * [Remote Vector Index Build] Add metric collection for remote build process [#2615](https://github.com/opensearch-project/k-NN/pull/2615)
+* [Explain API Support] Added Explain API support for Exact/ANN/Radial/Disk based KNN search on Faiss Engine [#2403] (https://github.com/opensearch-project/k-NN/pull/2403)
 ### Enhancements
 ### Bug Fixes
 * Fixing bug to prevent NullPointerException while doing PUT mappings [#2556](https://github.com/opensearch-project/k-NN/issues/2556)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -22,6 +22,10 @@ public class KNNConstants {
     public static final String PATH = "path";
     public static final String QUERY = "query";
     public static final String KNN = "knn";
+    public static final String EXACT_SEARCH = "Exact";
+    public static final String ANN_SEARCH = "Approximate-NN";
+    public static final String RADIAL_SEARCH = "Radial";
+    public static final String DISK_BASED_SEARCH = "Disk-based";
     public static final String VECTOR = "vector";
     public static final String K = "k";
     public static final String TYPE_KNN_VECTOR = "knn_vector";

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -40,7 +40,7 @@ public enum SpaceType {
             throw new IllegalStateException("Unsupported method");
         }
     },
-    L2("l2") {
+    L2("l2", SpaceType.GENERIC_SCORE_TRANSLATION) {
         @Override
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
@@ -59,7 +59,7 @@ public enum SpaceType {
             return 1 / score - 1;
         }
     },
-    COSINESIMIL("cosinesimil") {
+    COSINESIMIL("cosinesimil", "`Math.max((2.0F - rawScore) / 2.0F, 0.0F)`") {
         /**
          * Cosine similarity has range of [-1, 1] where -1 represents vectors are at diametrically opposite, and 1 is where
          * they are identical in direction and perfectly similar. In Lucene, scores have to be in the range of [0, Float.MAX_VALUE].
@@ -100,13 +100,13 @@ public enum SpaceType {
             }
         }
     },
-    L1("l1") {
+    L1("l1", SpaceType.GENERIC_SCORE_TRANSLATION) {
         @Override
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
         }
     },
-    LINF("linf") {
+    LINF("linf", SpaceType.GENERIC_SCORE_TRANSLATION) {
         @Override
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
@@ -130,11 +130,16 @@ public enum SpaceType {
         }
 
         @Override
+        public String explainScoreTranslation(float rawScore) {
+            return rawScore >= 0 ? GENERIC_SCORE_TRANSLATION : "`-rawScore + 1`";
+        }
+
+        @Override
         public KNNVectorSimilarityFunction getKnnVectorSimilarityFunction() {
             return KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
         }
     },
-    HAMMING("hamming") {
+    HAMMING("hamming", SpaceType.GENERIC_SCORE_TRANSLATION) {
         @Override
         public float scoreTranslation(float rawScore) {
             return 1 / (1 + rawScore);
@@ -169,13 +174,28 @@ public enum SpaceType {
         .collect(Collectors.toList())
         .toArray(new String[0]);
 
+    private static final String GENERIC_SCORE_TRANSLATION = "`1 / (1 + rawScore)`";
     private final String value;
+    private final String explanationFormula;
 
     SpaceType(String value) {
         this.value = value;
+        this.explanationFormula = null;
+    }
+
+    SpaceType(String value, String explanationFormula) {
+        this.value = value;
+        this.explanationFormula = explanationFormula;
     }
 
     public abstract float scoreTranslation(float rawScore);
+
+    public String explainScoreTranslation(float rawScore) {
+        if (explanationFormula != null) {
+            return explanationFormula;
+        }
+        throw new UnsupportedOperationException("explainScoreTranslation is not defined for this space type.");
+    }
 
     /**
      * Get KNNVectorSimilarityFunction that maps to this SpaceType

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -53,6 +53,9 @@ public class KNNQuery extends Query {
     private BitSetProducer parentsFilter;
     private Float radius;
     private Context context;
+    @Setter
+    @Getter
+    private boolean explain;
 
     // Note: ideally query should not have to deal with shard level information. Adding it for logging purposes only
     // TODO: ThreadContext does not work with logger, remove this from here once its figured out

--- a/src/main/java/org/opensearch/knn/index/query/common/DocAndScoreQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/DocAndScoreQuery.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.opensearch.knn.index.query.KNNScorer;
+import org.opensearch.knn.index.query.KNNWeight;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -30,13 +31,15 @@ final class DocAndScoreQuery extends Query {
     private final float[] scores;
     private final int[] segmentStarts;
     private final Object contextIdentity;
+    private final KNNWeight knnWeight;
 
-    public DocAndScoreQuery(int k, int[] docs, float[] scores, int[] segmentStarts, Object contextIdentity) {
+    public DocAndScoreQuery(int k, int[] docs, float[] scores, int[] segmentStarts, Object contextIdentity, KNNWeight knnWeight) {
         this.k = k;
         this.docs = docs;
         this.scores = scores;
         this.segmentStarts = segmentStarts;
         this.contextIdentity = contextIdentity;
+        this.knnWeight = knnWeight;
     }
 
     @Override
@@ -52,7 +55,19 @@ final class DocAndScoreQuery extends Query {
                 if (found < 0) {
                     return Explanation.noMatch("not in top " + k);
                 }
-                return Explanation.match(scores[found] * boost, "within top " + k);
+                float score = 0;
+                try {
+                    final Scorer scorer = scorer(context);
+                    assert scorer != null;
+                    int resDoc = scorer.iterator().advance(doc);
+                    if (resDoc == doc) {
+                        score = scorer.score();
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                return knnWeight.explain(context, doc, score);
             }
 
             @Override

--- a/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
@@ -18,6 +18,7 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
+import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.query.iterators.GroupedNestedDocIdSetIterator;
 
 import java.io.IOException;
@@ -46,6 +47,10 @@ public class QueryUtils {
      * @return a query representing the given TopDocs
      */
     public Query createDocAndScoreQuery(final IndexReader reader, final TopDocs topDocs) {
+        return createDocAndScoreQuery(reader, topDocs, null);
+    }
+
+    public Query createDocAndScoreQuery(final IndexReader reader, final TopDocs topDocs, final KNNWeight knnWeight) {
         int len = topDocs.scoreDocs.length;
         Arrays.sort(topDocs.scoreDocs, Comparator.comparingInt(a -> a.doc));
         int[] docs = new int[len];
@@ -55,7 +60,7 @@ public class QueryUtils {
             scores[i] = topDocs.scoreDocs[i].score;
         }
         int[] segmentStarts = findSegmentStarts(reader, docs);
-        return new DocAndScoreQuery(len, docs, scores, segmentStarts, reader.getContext().id());
+        return new DocAndScoreQuery(len, docs, scores, segmentStarts, reader.getContext().id(), knnWeight);
     }
 
     private int[] findSegmentStarts(final IndexReader reader, final int[] docs) {

--- a/src/main/java/org/opensearch/knn/index/query/explain/KnnExplanation.java
+++ b/src/main/java/org/opensearch/knn/index/query/explain/KnnExplanation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.explain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.opensearch.knn.index.query.KNNScorer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This class captures details around knn explain queries that is used
+ * by explain API to generate explanation for knn queries
+ */
+public class KnnExplanation {
+
+    private final Map<Object, Integer> annResultPerLeaf;
+
+    private final Map<Integer, Float> rawScores;
+
+    private final Map<Object, KNNScorer> knnScorerPerLeaf;
+
+    @Setter
+    @Getter
+    private int cardinality;
+
+    public KnnExplanation() {
+        this.annResultPerLeaf = new ConcurrentHashMap<>();
+        this.rawScores = new ConcurrentHashMap<>();
+        this.knnScorerPerLeaf = new ConcurrentHashMap<>();
+        this.cardinality = 0;
+    }
+
+    public void addLeafResult(Object leafId, int annResult) {
+        this.annResultPerLeaf.put(leafId, annResult);
+    }
+
+    public void addRawScore(int docId, float rawScore) {
+        this.rawScores.put(docId, rawScore);
+    }
+
+    public void addKnnScorer(Object leafId, KNNScorer knnScorer) {
+        this.knnScorerPerLeaf.put(leafId, knnScorer);
+    }
+
+    public Integer getAnnResult(Object leafId) {
+        return this.annResultPerLeaf.get(leafId);
+    }
+
+    public Float getRawScore(int docId) {
+        return this.rawScores.get(docId);
+    }
+
+    public KNNScorer getKnnScorer(Object leafId) {
+        return this.knnScorerPerLeaf.get(leafId);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -98,7 +98,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         if (topK.scoreDocs.length == 0) {
             return new MatchNoDocsQuery().createWeight(indexSearcher, scoreMode, boost);
         }
-        return queryUtils.createDocAndScoreQuery(reader, topK).createWeight(indexSearcher, scoreMode, boost);
+        return queryUtils.createDocAndScoreQuery(reader, topK, knnWeight).createWeight(indexSearcher, scoreMode, boost);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/ExplainIT.java
+++ b/src/test/java/org/opensearch/knn/index/ExplainIT.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.parser.RescoreParser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ANN_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.DISK_BASED_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.EXACT_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.RADIAL_SEARCH;
+
+public class ExplainIT extends KNNRestTestCase {
+
+    @SneakyThrows
+    public void testAnnSearch() {
+        int dimension = 128;
+        int numDocs = 100;
+        createDefaultKnnIndex(dimension);
+        indexTestData(INDEX_NAME, FIELD_NAME, dimension, numDocs);
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, (float) numDocs);
+        XContentBuilder queryBuilder = buildSearchQuery(FIELD_NAME, 10, queryVector, null);
+        // validate primaries are working
+        validateExplainSearchResponse(
+            queryBuilder,
+            ANN_SEARCH,
+            VectorDataType.FLOAT.name(),
+            SpaceType.L2.getValue(),
+            SpaceType.L2.explainScoreTranslation(0)
+        );
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testANNWithExactSearch() {
+        createDefaultKnnIndex(2);
+        indexTestData(INDEX_NAME, FIELD_NAME, 2, 2);
+
+        // Execute the search request with a match all query to ensure exact logic gets called
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 1000));
+
+        float[] queryVector = new float[] { 1.0f, 1.0f };
+
+        KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, 2, QueryBuilders.matchAllQuery());
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        knnQueryBuilder.doXContent(queryBuilder, ToXContent.EMPTY_PARAMS);
+        queryBuilder.endObject().endObject();
+
+        validateExplainSearchResponse(
+            queryBuilder,
+            ANN_SEARCH,
+            EXACT_SEARCH,
+            VectorDataType.FLOAT.name(),
+            SpaceType.L2.getValue(),
+            "since filteredIds",
+            "is less than or equal to K"
+        );
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testRadialWithANNSearch() {
+        int dimension = 128;
+        int numDocs = 100;
+        createDefaultKnnIndex(dimension);
+        indexTestData(INDEX_NAME, FIELD_NAME, dimension, numDocs);
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, (float) numDocs);
+
+        float distance = 15f;
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field(MAX_DISTANCE, distance)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        validateExplainSearchResponse(
+            queryBuilder,
+            RADIAL_SEARCH,
+            ANN_SEARCH,
+            VectorDataType.FLOAT.name(),
+            SpaceType.L2.getValue(),
+            SpaceType.L2.explainScoreTranslation(0),
+            String.valueOf(distance)
+        );
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testRadialWithExactSearch() {
+        setupKNNIndexForFilterQuery();
+
+        final float[] queryVector = new float[] { 3.3f, 3.0f, 5.0f };
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery("color", "red");
+        float distance = 15f;
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field(MAX_DISTANCE, distance)
+            .field("filter", termQueryBuilder)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        validateExplainSearchResponse(
+            queryBuilder,
+            RADIAL_SEARCH,
+            EXACT_SEARCH,
+            VectorDataType.FLOAT.name(),
+            SpaceType.L2.getValue(),
+            String.valueOf(distance)
+        );
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testDiskBasedSearchWithDefaultRescoring() {
+        int dimension = 16;
+        float[] queryVector = new float[] {
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x32.getName())
+            .endObject()
+            .endObject()
+            .endObject();
+        createKnnIndex(INDEX_NAME, builder.toString());
+        addKNNDocs(INDEX_NAME, FIELD_NAME, dimension, 0, 5);
+
+        // Search with default rescore
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field("k", 5)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        validateExplainSearchResponse(
+            queryBuilder,
+            DISK_BASED_SEARCH,
+            ANN_SEARCH,
+            VectorDataType.FLOAT.name(),
+            SpaceType.L2.getValue(),
+            "shard level rescoring enabled",
+            String.valueOf(dimension)
+        );
+    }
+
+    @SneakyThrows
+    public void testDiskBasedSearchWithRescoringDisabled() {
+        int dimension = 16;
+        float[] queryVector = new float[] {
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f,
+            1.0f,
+            2.0f };
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x32.getName())
+            .endObject()
+            .endObject()
+            .endObject();
+        createKnnIndex(INDEX_NAME, builder.toString());
+        addKNNDocs(INDEX_NAME, FIELD_NAME, dimension, 0, 5);
+
+        // Search without rescore
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field("k", 5)
+            .field(RescoreParser.RESCORE_PARAMETER, false)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        validateExplainSearchResponse(
+            queryBuilder,
+            DISK_BASED_SEARCH,
+            ANN_SEARCH,
+            VectorDataType.FLOAT.name(),
+            SpaceType.L2.getValue(),
+            "shard level rescoring disabled",
+            String.valueOf(dimension)
+        );
+    }
+
+    private void validateExplainSearchResponse(XContentBuilder queryBuilder, String... descriptions) throws IOException, ParseException {
+        String responseBody = EntityUtils.toString(performSearch(INDEX_NAME, queryBuilder.toString(), "explain=true").getEntity());
+        List<Object> searchResponseHits = parseSearchResponseHits(responseBody);
+        searchResponseHits.stream().forEach(hit -> {
+            Map<String, Object> hitMap = (Map<String, Object>) hit;
+            Double score = (Double) hitMap.get("_score");
+            String explanation = hitMap.get("_explanation").toString();
+            assertNotNull(explanation);
+            for (String description : descriptions) {
+                assertTrue(explanation.contains(description));
+            }
+            assertTrue(explanation.contains(String.valueOf(score)));
+        });
+    }
+
+    private void createDefaultKnnIndex(int dimension) throws IOException {
+        // Create Mappings
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        final String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void setupKNNIndexForFilterQuery() throws Exception {
+        createDefaultKnnIndex(3);
+        addKnnDocWithAttributes("doc1", new float[] { 6.0f, 7.9f, 3.1f }, ImmutableMap.of("color", "red", "taste", "sweet"));
+        addKnnDocWithAttributes("doc2", new float[] { 3.2f, 2.1f, 4.8f }, ImmutableMap.of("color", "green"));
+        addKnnDocWithAttributes("doc3", new float[] { 4.1f, 5.0f, 7.1f }, ImmutableMap.of("color", "red"));
+
+        refreshIndex(INDEX_NAME);
+    }
+
+    private void indexTestData(final String indexName, final String fieldName, final int dimension, final int numDocs) throws Exception {
+        for (int i = 0; i < numDocs; i++) {
+            float[] indexVector = new float[dimension];
+            Arrays.fill(indexVector, (float) i);
+            addKnnDocWithAttributes(indexName, Integer.toString(i), fieldName, indexVector, ImmutableMap.of("rating", String.valueOf(i)));
+        }
+
+        // Assert that all docs are ingested
+        refreshAllNonSystemIndices();
+        assertEquals(numDocs, getDocCount(indexName));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -1,0 +1,849 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import com.google.common.collect.Comparators;
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FixedBitSet;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfFloatsSerializer;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.jni.JNIService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.ANN_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.EXACT_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.RADIAL_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+
+public class ExplainTests extends KNNWeightTestCase {
+
+    @Mock
+    private Weight filterQueryWeight;
+    @Mock
+    private LeafReaderContext leafReaderContext;
+
+    private void setupTest(final int[] filterDocIds, final Map<String, String> attributesMap) throws IOException {
+        setupTest(filterDocIds, attributesMap, filterDocIds != null ? filterDocIds.length : 0, SpaceType.L2, true, null, null, null);
+    }
+
+    private void setupTest(
+        final int[] filterDocIds,
+        final Map<String, String> attributesMap,
+        final int maxDoc,
+        final SpaceType spaceType,
+        final boolean isCompoundFile,
+        final byte[] byteVector,
+        final float[] floatVector,
+        final MockedStatic<KNNVectorValuesFactory> vectorValuesFactoryMockedStatic
+    ) throws IOException {
+
+        final Scorer filterScorer = mock(Scorer.class);
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+
+        Bits liveDocsBits = null;
+        if (filterDocIds != null) {
+            FixedBitSet filterBitSet = new FixedBitSet(filterDocIds.length);
+            for (int docId : filterDocIds) {
+                filterBitSet.set(docId);
+            }
+            liveDocsBits = mock(Bits.class);
+            for (int filterDocId : filterDocIds) {
+                when(liveDocsBits.get(filterDocId)).thenReturn(true);
+            }
+            when(liveDocsBits.length()).thenReturn(1000);
+
+            when(filterQueryWeight.scorer(leafReaderContext)).thenReturn(filterScorer);
+            when(filterScorer.iterator()).thenReturn(DocIdSetIterator.all(filterDocIds.length + 1));
+        }
+        final SegmentReader reader = mockSegmentReader(isCompoundFile);
+        when(reader.maxDoc()).thenReturn(maxDoc);
+        when(reader.getLiveDocs()).thenReturn(liveDocsBits);
+
+        when(leafReaderContext.reader()).thenReturn(reader);
+        when(leafReaderContext.id()).thenReturn(new Object());
+
+        when(reader.getFieldInfos()).thenReturn(fieldInfos);
+        when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
+        when(fieldInfo.attributes()).thenReturn(attributesMap);
+        when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+        when(fieldInfo.getName()).thenReturn(FIELD_NAME);
+
+        if (floatVector != null) {
+            final BinaryDocValues binaryDocValues = mock(BinaryDocValues.class);
+            when(reader.getBinaryDocValues(FIELD_NAME)).thenReturn(binaryDocValues);
+            when(binaryDocValues.advance(0)).thenReturn(0);
+            BytesRef vectorByteRef = new BytesRef(KNNVectorAsCollectionOfFloatsSerializer.INSTANCE.floatToByteArray(floatVector));
+            when(binaryDocValues.binaryValue()).thenReturn(vectorByteRef);
+        }
+
+        if (byteVector != null) {
+            final KNNBinaryVectorValues knnBinaryVectorValues = mock(KNNBinaryVectorValues.class);
+            vectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnBinaryVectorValues);
+            when(knnBinaryVectorValues.advance(0)).thenReturn(0);
+            when(knnBinaryVectorValues.getVector()).thenReturn(byteVector);
+        }
+    }
+
+    private void assertExplanation(Explanation explanation, float expectedScore, String topSearch, String... leafDescription) {
+        assertNotNull(explanation);
+        assertTrue(explanation.isMatch());
+        assertEquals(expectedScore, explanation.getValue().floatValue(), 0.01f);
+        assertTrue(explanation.getDescription().contains(topSearch));
+        assertEquals(1, explanation.getDetails().length);
+        Explanation explanationDetail = explanation.getDetails()[0];
+        assertEquals(expectedScore, explanation.getValue().floatValue(), 0.01f);
+        for (String description : leafDescription) {
+            assertTrue(explanationDetail.getDescription().contains(description));
+        }
+    }
+
+    private void assertDiskSearchExplanation(Explanation explanation, String[] topSearchDesc, String... leafDescription) {
+        assertNotNull(explanation);
+        assertTrue(explanation.isMatch());
+        for (String description : topSearchDesc) {
+            assertTrue(explanation.getDescription().contains(description));
+        }
+        assertEquals(1, explanation.getDetails().length);
+        Explanation explanationDetail = explanation.getDetails()[0];
+        for (String description : leafDescription) {
+            assertTrue(explanationDetail.getDescription().contains(description));
+        }
+    }
+
+    @SneakyThrows
+    public void testDiskBasedSearchWithShardRescoringEnabledANN() {
+        int k = 3;
+        knnSettingsMockedStatic.when(() -> KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(INDEX_NAME)).thenReturn(false);
+
+        jniServiceMockedStatic.when(
+            () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), eq(null), anyInt(), any())
+        ).thenReturn(getFilteredKNNQueryResults());
+
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(RescoreContext.MIN_OVERSAMPLE_FACTOR - 1).build();
+
+        final int[] filterDocIds = new int[] { 0, 1, 2, 3, 4, 5 };
+
+        final Map<String, String> attributesMap = ImmutableMap.of(
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            SPACE_TYPE,
+            SpaceType.L2.getValue()
+        );
+
+        setupTest(filterDocIds, attributesMap);
+
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(QUERY_VECTOR)
+            .k(k)
+            .indexName(INDEX_NAME)
+            .filterQuery(FILTER_QUERY)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .vectorDataType(VectorDataType.FLOAT)
+            .rescoreContext(rescoreContext)
+            .explain(true)
+            .build();
+        query.setExplain(true);
+
+        final float boost = 1;
+        final KNNWeight knnWeight = new KNNWeight(query, boost, filterQueryWeight);
+
+        // When
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+
+        // Then
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        assertNotNull(docIdSetIterator);
+        assertEquals(FILTERED_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
+
+        jniServiceMockedStatic.verify(
+            () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), any(), anyInt(), any()),
+            times(1)
+        );
+
+        final List<Integer> actualDocIds = new ArrayList<>();
+        final Map<Integer, Float> translatedScores = getTranslatedScores(SpaceType.L2::scoreTranslation);
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = translatedScores.get(docId) * boost;
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            String[] expectedTopDescription = new String[] {
+                KNNConstants.DISK_BASED_SEARCH,
+                "the first pass k was " + rescoreContext.getFirstPassK(k, false, QUERY_VECTOR.length),
+                "over sampling factor of " + rescoreContext.getOversampleFactor(),
+                "with vector dimension of " + QUERY_VECTOR.length,
+                "shard level rescoring enabled" };
+            assertDiskSearchExplanation(
+                explanation,
+                expectedTopDescription,
+                ANN_SEARCH,
+                VectorDataType.FLOAT.name(),
+                SpaceType.L2.getValue()
+            );
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+    }
+
+    @SneakyThrows
+    public void testDiskBasedSearchWithShardRescoringDisabledExact() {
+        knnSettingsMockedStatic.when(() -> KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(INDEX_NAME)).thenReturn(true);
+        RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(RescoreContext.MAX_OVERSAMPLE_FACTOR - 1).build();
+
+        ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
+        KNNWeight.initialize(null, mockedExactSearcher);
+
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+
+        Map<String, String> attributesMap = Map.of(
+            SPACE_TYPE,
+            spaceType.getValue(),
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+        );
+
+        setupTest(null, attributesMap, 1, spaceType, false, null, null, null);
+
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .indexName(INDEX_NAME)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .vectorDataType(VectorDataType.FLOAT)
+            .rescoreContext(rescoreContext)
+            .explain(true)
+            .build();
+        final KNNWeight knnWeight = new KNNWeight(query, 1.0f);
+
+        final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
+            .isParentHits(true)
+            // setting to true, so that if quantization details are present we want to do search on the quantized
+            // vectors as this flow is used in first pass of search.
+            .useQuantizedVectorsForSearch(true)
+            .knnQuery(query)
+            .build();
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = DOC_ID_TO_SCORES.get(docId);
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            String[] expectedTopDescription = new String[] {
+                KNNConstants.DISK_BASED_SEARCH,
+                "the first pass k was " + rescoreContext.getFirstPassK(0, true, queryVector.length),
+                "over sampling factor of " + rescoreContext.getOversampleFactor(),
+                "with vector dimension of " + queryVector.length,
+                "shard level rescoring disabled" };
+            assertDiskSearchExplanation(
+                explanation,
+                expectedTopDescription,
+                EXACT_SEARCH,
+                VectorDataType.FLOAT.name(),
+                spaceType.getValue(),
+                "no native engine files"
+            );
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+        // verify JNI Service is not called
+        jniServiceMockedStatic.verifyNoInteractions();
+        verify(mockedExactSearcher).searchLeaf(leafReaderContext, exactSearchContext);
+    }
+
+    @SneakyThrows
+    public void testDefaultANNSearch() {
+        // Given
+        int k = 3;
+        jniServiceMockedStatic.when(
+            () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), eq(null), anyInt(), any())
+        ).thenReturn(getFilteredKNNQueryResults());
+
+        final int[] filterDocIds = new int[] { 0, 1, 2, 3, 4, 5 };
+        final Map<String, String> attributesMap = ImmutableMap.of(
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            SPACE_TYPE,
+            SpaceType.L2.getValue()
+        );
+
+        setupTest(filterDocIds, attributesMap);
+
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(QUERY_VECTOR)
+            .k(k)
+            .indexName(INDEX_NAME)
+            .filterQuery(FILTER_QUERY)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .vectorDataType(VectorDataType.FLOAT)
+            .explain(true)
+            .build();
+        query.setExplain(true);
+
+        final float boost = 1;
+
+        final KNNWeight knnWeight = new KNNWeight(query, boost, filterQueryWeight);
+
+        // When
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+
+        // Then
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        assertNotNull(docIdSetIterator);
+        assertEquals(FILTERED_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
+
+        jniServiceMockedStatic.verify(
+            () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), any(), anyInt(), any()),
+            times(1)
+        );
+
+        final List<Integer> actualDocIds = new ArrayList<>();
+        final Map<Integer, Float> translatedScores = getTranslatedScores(SpaceType.L2::scoreTranslation);
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = translatedScores.get(docId) * boost;
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(
+                explanation,
+                score,
+                ANN_SEARCH,
+                ANN_SEARCH,
+                VectorDataType.FLOAT.name(),
+                SpaceType.L2.getValue(),
+                SpaceType.L2.explainScoreTranslation(DOC_ID_TO_SCORES.get(docId))
+            );
+            Explanation nestedDetail = explanation.getDetails()[0].getDetails()[0];
+            assertTrue(nestedDetail.getDescription().contains(KNNEngine.FAISS.name()));
+            assertEquals(DOC_ID_TO_SCORES.get(docId), nestedDetail.getValue().floatValue(), 0.01f);
+            assertEquals(score, knnScorer.score(), 0.01f);
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+    }
+
+    @SneakyThrows
+    public void testANN_FilteredExactSearchAfterANN() {
+        ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
+        KNNWeight.initialize(null, mockedExactSearcher);
+        final Map<Integer, Float> translatedScores = getTranslatedScores(SpaceType.L2::scoreTranslation);
+        when(mockedExactSearcher.searchLeaf(any(), any())).thenReturn(translatedScores);
+        // Given
+        int k = 4;
+        jniServiceMockedStatic.when(
+            () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), eq(null), anyInt(), any())
+        ).thenReturn(getFilteredKNNQueryResults());
+
+        final int[] filterDocIds = new int[] { 0, 1, 2, 3, 4, 5 };
+        final Map<String, String> attributesMap = ImmutableMap.of(
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            SPACE_TYPE,
+            SpaceType.L2.getValue()
+        );
+
+        setupTest(filterDocIds, attributesMap);
+
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(QUERY_VECTOR)
+            .k(k)
+            .indexName(INDEX_NAME)
+            .filterQuery(FILTER_QUERY)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .vectorDataType(VectorDataType.FLOAT)
+            .explain(true)
+            .build();
+        query.setExplain(true);
+
+        final float boost = 1;
+        KNNWeight knnWeight = new KNNWeight(query, boost, filterQueryWeight);
+
+        // When
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+
+        // Then
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        assertNotNull(docIdSetIterator);
+        assertEquals(DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
+
+        jniServiceMockedStatic.verify(
+            () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), any(), anyInt(), any()),
+            times(1)
+        );
+
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = translatedScores.get(docId) * boost;
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(
+                explanation,
+                score,
+                ANN_SEARCH,
+                EXACT_SEARCH,
+                VectorDataType.FLOAT.name(),
+                SpaceType.L2.getValue(),
+                "since the number of documents returned are less than K",
+                "there are more than K filtered Ids"
+            );
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+    }
+
+    @SneakyThrows
+    public void testANN_whenNoEngineFiles_thenPerformExactSearch() {
+        ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        KNNWeight.initialize(null, mockedExactSearcher);
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .indexName(INDEX_NAME)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .vectorDataType(VectorDataType.FLOAT)
+            .explain(true)
+            .build();
+        final KNNWeight knnWeight = new KNNWeight(query, 1.0f);
+
+        Map<String, String> attributesMap = Map.of(
+            SPACE_TYPE,
+            spaceType.getValue(),
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+        );
+
+        setupTest(null, attributesMap, 1, spaceType, false, null, null, null);
+
+        final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
+            .isParentHits(true)
+            // setting to true, so that if quantization details are present we want to do search on the quantized
+            // vectors as this flow is used in first pass of search.
+            .useQuantizedVectorsForSearch(true)
+            .knnQuery(query)
+            .build();
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = DOC_ID_TO_SCORES.get(docId);
+            assertEquals(score, knnScorer.score(), 0.00000001f);
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(
+                explanation,
+                score,
+                ANN_SEARCH,
+                EXACT_SEARCH,
+                VectorDataType.FLOAT.name(),
+                spaceType.getValue(),
+                "no native engine files"
+            );
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+        // verify JNI Service is not called
+        jniServiceMockedStatic.verifyNoInteractions();
+        verify(mockedExactSearcher).searchLeaf(leafReaderContext, exactSearchContext);
+    }
+
+    @SneakyThrows
+    public void testANNWithFilterQuery_whenFTVGreaterThanFilterId() {
+
+        KNNWeight.initialize(null);
+        knnSettingsMockedStatic.when(() -> KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME)).thenReturn(10);
+        byte[] vector = new byte[] { 1, 3 };
+        int k = 1;
+        final int[] filterDocIds = new int[] { 0, 1, 2, 3, 4, 5 };
+        final Map<String, String> attributesMap = ImmutableMap.of(
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            SPACE_TYPE,
+            SpaceType.HAMMING.name(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "BHNSW32")
+        );
+
+        try (MockedStatic<KNNVectorValuesFactory> vectorValuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            setupTest(filterDocIds, attributesMap, 100, SpaceType.HAMMING, true, vector, null, vectorValuesFactoryMockedStatic);
+            final KNNQuery query = new KNNQuery(
+                FIELD_NAME,
+                BYTE_QUERY_VECTOR,
+                k,
+                INDEX_NAME,
+                FILTER_QUERY,
+                null,
+                VectorDataType.BINARY,
+                null
+            );
+
+            query.setExplain(true);
+            final float boost = (float) randomDoubleBetween(0, 10, true);
+            final KNNWeight knnWeight = new KNNWeight(query, boost, filterQueryWeight);
+
+            final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+            assertNotNull(knnScorer);
+            knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+            final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+            assertNotNull(docIdSetIterator);
+            assertEquals(EXACT_SEARCH_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
+
+            final List<Integer> actualDocIds = new ArrayList<>();
+            for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+                actualDocIds.add(docId);
+                float score = BINARY_EXACT_SEARCH_DOC_ID_TO_SCORES.get(docId) * boost;
+                assertEquals(score, knnScorer.score(), 0.01f);
+                Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+                assertExplanation(
+                    explanation,
+                    score,
+                    ANN_SEARCH,
+                    EXACT_SEARCH,
+                    VectorDataType.BINARY.name(),
+                    SpaceType.HAMMING.getValue(),
+                    "is greater than or equal to cardinality",
+                    "since filtered threshold value"
+                );
+            }
+            assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+            assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+        }
+    }
+
+    @SneakyThrows
+    public void testANNWithFilterQuery_whenMDCGreaterThanFilterId() {
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNWeight.initialize(modelDao);
+        knnSettingsMockedStatic.when(() -> KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME)).thenReturn(-1);
+        float[] vector = new float[] { 0.1f, 0.3f };
+        int k = 1;
+        final int[] filterDocIds = new int[] { 0, 1, 2, 3, 4, 5 };
+        final Map<String, String> attributesMap = ImmutableMap.of(
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            SPACE_TYPE,
+            SpaceType.L2.name(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+        );
+
+        setupTest(filterDocIds, attributesMap, 100, SpaceType.L2, true, null, vector, null);
+
+        final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, k, INDEX_NAME, FILTER_QUERY, null, null);
+        query.setExplain(true);
+
+        final float boost = (float) randomDoubleBetween(0, 10, true);
+        final KNNWeight knnWeight = new KNNWeight(query, boost, filterQueryWeight);
+
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        assertNotNull(docIdSetIterator);
+        assertEquals(EXACT_SEARCH_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
+
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = EXACT_SEARCH_DOC_ID_TO_SCORES.get(docId) * boost;
+            assertEquals(EXACT_SEARCH_DOC_ID_TO_SCORES.get(docId) * boost, knnScorer.score(), 0.01f);
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(
+                explanation,
+                score,
+                ANN_SEARCH,
+                EXACT_SEARCH,
+                VectorDataType.FLOAT.name(),
+                SpaceType.L2.getValue(),
+                "since max distance computation",
+                "is greater than or equal to cardinality"
+            );
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+    }
+
+    @SneakyThrows
+    public void testANNWithFilterQuery_whenFilterIdLessThanK() {
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNWeight.initialize(modelDao);
+        knnSettingsMockedStatic.when(() -> KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME)).thenReturn(-1);
+        float[] vector = new float[] { 0.1f, 0.3f };
+        final int[] filterDocIds = new int[] { 0 };
+        final Map<String, String> attributesMap = ImmutableMap.of(
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            SPACE_TYPE,
+            SpaceType.L2.name(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+        );
+
+        setupTest(filterDocIds, attributesMap, 100, SpaceType.L2, true, null, vector, null);
+
+        final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, FILTER_QUERY, null, null);
+        query.setExplain(true);
+
+        final float boost = 1;
+        final KNNWeight knnWeight = new KNNWeight(query, boost, filterQueryWeight);
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        assertNotNull(docIdSetIterator);
+        assertEquals(EXACT_SEARCH_DOC_ID_TO_SCORES.size(), docIdSetIterator.cost());
+
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = EXACT_SEARCH_DOC_ID_TO_SCORES.get(docId) * boost;
+            assertEquals(EXACT_SEARCH_DOC_ID_TO_SCORES.get(docId) * boost, knnScorer.score(), 0.01f);
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(
+                explanation,
+                score,
+                ANN_SEARCH,
+                EXACT_SEARCH,
+                VectorDataType.FLOAT.name(),
+                SpaceType.L2.getValue(),
+                "since filteredIds",
+                "is less than or equal to K"
+            );
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+    }
+
+    @SneakyThrows
+    public void testRadialANNSearch() {
+        final float[] queryVector = new float[] { 0.1f, 0.3f };
+        final float radius = 0.5f;
+        final int maxResults = 1000;
+        jniServiceMockedStatic.when(
+            () -> JNIService.radiusQueryIndex(
+                anyLong(),
+                eq(queryVector),
+                eq(radius),
+                eq(HNSW_METHOD_PARAMETERS),
+                any(),
+                eq(maxResults),
+                any(),
+                anyInt(),
+                any()
+            )
+        ).thenReturn(getKNNQueryResults());
+
+        Map<String, String> attributesMap = Map.of(
+            SPACE_TYPE,
+            SpaceType.L2.getValue(),
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+        );
+
+        setupTest(null, attributesMap);
+
+        KNNQuery.Context context = mock(KNNQuery.Context.class);
+        when(context.getMaxResultWindow()).thenReturn(maxResults);
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .radius(radius)
+            .indexName(INDEX_NAME)
+            .context(context)
+            .explain(true)
+            .vectorDataType(VectorDataType.FLOAT)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .build();
+        final float boost = 1;
+        final KNNWeight knnWeight = new KNNWeight(query, boost);
+
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        jniServiceMockedStatic.verify(
+            () -> JNIService.radiusQueryIndex(
+                anyLong(),
+                eq(queryVector),
+                eq(radius),
+                eq(HNSW_METHOD_PARAMETERS),
+                any(),
+                eq(maxResults),
+                any(),
+                anyInt(),
+                any()
+            )
+        );
+
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+
+        final List<Integer> actualDocIds = new ArrayList<>();
+        final Map<Integer, Float> translatedScores = getTranslatedScores(SpaceType.L2::scoreTranslation);
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = translatedScores.get(docId) * boost;
+            assertEquals(score, knnScorer.score(), 0.01f);
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(
+                explanation,
+                score,
+                RADIAL_SEARCH,
+                ANN_SEARCH,
+                VectorDataType.FLOAT.name(),
+                SpaceType.L2.getValue(),
+                SpaceType.L2.explainScoreTranslation(DOC_ID_TO_SCORES.get(docId))
+            );
+            Explanation nestedDetail = explanation.getDetails()[0].getDetails()[0];
+            assertTrue(nestedDetail.getDescription().contains(KNNEngine.FAISS.name()));
+            assertEquals(DOC_ID_TO_SCORES.get(docId), nestedDetail.getValue().floatValue(), 0.01f);
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+    }
+
+    @SneakyThrows
+    public void testRadialExactSearch() {
+        ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
+        final SpaceType spaceType = randomFrom(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        KNNWeight.initialize(null, mockedExactSearcher);
+
+        final float[] queryVector = new float[] { 0.1f, 0.3f };
+        final float radius = 0.5f;
+        final int maxResults = 1000;
+        jniServiceMockedStatic.when(
+            () -> JNIService.radiusQueryIndex(
+                anyLong(),
+                eq(queryVector),
+                eq(radius),
+                eq(HNSW_METHOD_PARAMETERS),
+                any(),
+                eq(maxResults),
+                any(),
+                anyInt(),
+                any()
+            )
+        ).thenReturn(getKNNQueryResults());
+
+        Map<String, String> attributesMap = Map.of(
+            SPACE_TYPE,
+            spaceType.getValue(),
+            KNN_ENGINE,
+            KNNEngine.FAISS.getName(),
+            PARAMETERS,
+            String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+        );
+
+        setupTest(null, attributesMap, 0, spaceType, false, null, null, null);
+
+        KNNQuery.Context context = mock(KNNQuery.Context.class);
+        when(context.getMaxResultWindow()).thenReturn(maxResults);
+
+        final KNNQuery query = KNNQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(queryVector)
+            .radius(radius)
+            .indexName(INDEX_NAME)
+            .context(context)
+            .explain(true)
+            .vectorDataType(VectorDataType.FLOAT)
+            .methodParameters(HNSW_METHOD_PARAMETERS)
+            .build();
+        final float boost = 1;
+        final KNNWeight knnWeight = new KNNWeight(query, boost);
+        final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
+            .isParentHits(true)
+            // setting to true, so that if quantization details are present we want to do search on the quantized
+            // vectors as this flow is used in first pass of search.
+            .useQuantizedVectorsForSearch(true)
+            .knnQuery(query)
+            .build();
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+
+        final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
+        assertNotNull(knnScorer);
+        knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
+        final DocIdSetIterator docIdSetIterator = knnScorer.iterator();
+        final List<Integer> actualDocIds = new ArrayList<>();
+        for (int docId = docIdSetIterator.nextDoc(); docId != NO_MORE_DOCS; docId = docIdSetIterator.nextDoc()) {
+            actualDocIds.add(docId);
+            float score = DOC_ID_TO_SCORES.get(docId) * boost;
+            assertEquals(score, knnScorer.score(), 0.01f);
+            Explanation explanation = knnWeight.explain(leafReaderContext, docId, score);
+            assertExplanation(explanation, score, RADIAL_SEARCH, EXACT_SEARCH, VectorDataType.FLOAT.name(), spaceType.getValue());
+        }
+        assertEquals(docIdSetIterator.cost(), actualDocIds.size());
+        assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
+        // verify JNI Service is not called
+        jniServiceMockedStatic.verifyNoInteractions();
+        verify(mockedExactSearcher).searchLeaf(leafReaderContext, exactSearchContext);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTestCase.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockito.MockedStatic;
+import org.opensearch.common.io.PathUtils;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.codec.KNNCodecVersion;
+import org.opensearch.knn.index.memory.NativeMemoryAllocation;
+import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
+import org.opensearch.knn.jni.JNIService;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES;
+import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_SIZE_LIMIT;
+
+public class KNNWeightTestCase extends KNNTestCase {
+
+    protected static final String FIELD_NAME = "target_field";
+    protected static final float[] QUERY_VECTOR = new float[] { 1.8f, 2.4f };
+    protected static final byte[] BYTE_QUERY_VECTOR = new byte[] { 1, 2 };
+    protected static final String SEGMENT_NAME = "0";
+    protected static final int K = 5;
+    protected static final Set<String> SEGMENT_FILES_NMSLIB = Set.of("_0.cfe", "_0_2011_target_field.hnswc");
+    protected static final Set<String> SEGMENT_FILES_FAISS = Set.of("_0.cfe", "_0_2011_target_field.faissc");
+    protected static final Set<String> SEGMENT_FILES_DEFAULT = SEGMENT_FILES_FAISS;
+    protected static final Set<String> SEGMENT_MULTI_FIELD_FILES_FAISS = Set.of(
+        "_0.cfe",
+        "_0_2011_target_field.faissc",
+        "_0_2011_long_target_field.faissc"
+    );
+    protected static final String CIRCUIT_BREAKER_LIMIT_100KB = "100Kb";
+    protected static final Integer EF_SEARCH = 10;
+    protected static final Map<String, ?> HNSW_METHOD_PARAMETERS = Map.of(METHOD_PARAMETER_EF_SEARCH, EF_SEARCH);
+    protected static final Map<Integer, Float> DOC_ID_TO_SCORES = Map.of(10, 0.4f, 101, 0.05f, 100, 0.8f, 50, 0.52f);
+    protected static final Map<Integer, Float> FILTERED_DOC_ID_TO_SCORES = Map.of(101, 0.05f, 100, 0.8f, 50, 0.52f);
+    protected static final Map<Integer, Float> EXACT_SEARCH_DOC_ID_TO_SCORES = Map.of(0, 0.12048191f);
+    protected static final Map<Integer, Float> BINARY_EXACT_SEARCH_DOC_ID_TO_SCORES = Map.of(0, 0.5f);
+    protected static final Query FILTER_QUERY = new TermQuery(new Term("foo", "fooValue"));
+    protected static MockedStatic<NativeMemoryCacheManager> nativeMemoryCacheManagerMockedStatic;
+    protected static MockedStatic<JNIService> jniServiceMockedStatic;
+
+    protected static MockedStatic<KNNSettings> knnSettingsMockedStatic;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        final KNNSettings knnSettings = mock(KNNSettings.class);
+        knnSettingsMockedStatic = mockStatic(KNNSettings.class);
+        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED))).thenReturn(true);
+        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT))).thenReturn(CIRCUIT_BREAKER_LIMIT_100KB);
+        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED))).thenReturn(false);
+        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES))).thenReturn(TimeValue.timeValueMinutes(10));
+
+        final ByteSizeValue v = ByteSizeValue.parseBytesSizeValue(
+            CIRCUIT_BREAKER_LIMIT_100KB,
+            KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT
+        );
+        knnSettingsMockedStatic.when(KNNSettings::getClusterCbLimit).thenReturn(v);
+        knnSettingsMockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
+        ByteSizeValue cacheSize = ByteSizeValue.parseBytesSizeValue("1024kb", QUANTIZATION_STATE_CACHE_SIZE_LIMIT); // Setting 1MB as an
+        // example
+        when(knnSettings.getSettingValue(eq(QUANTIZATION_STATE_CACHE_SIZE_LIMIT))).thenReturn(cacheSize);
+        // Mock QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES setting
+        TimeValue mockTimeValue = TimeValue.timeValueMinutes(10);
+        when(knnSettings.getSettingValue(eq(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES))).thenReturn(mockTimeValue);
+
+        nativeMemoryCacheManagerMockedStatic = mockStatic(NativeMemoryCacheManager.class);
+
+        final NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
+        final NativeMemoryAllocation nativeMemoryAllocation = mock(NativeMemoryAllocation.class);
+        when(nativeMemoryCacheManager.get(any(), anyBoolean())).thenReturn(nativeMemoryAllocation);
+
+        nativeMemoryCacheManagerMockedStatic.when(NativeMemoryCacheManager::getInstance).thenReturn(nativeMemoryCacheManager);
+
+        final MockedStatic<PathUtils> pathUtilsMockedStatic = mockStatic(PathUtils.class);
+        final Path indexPath = mock(Path.class);
+        when(indexPath.toString()).thenReturn("/mydrive/myfolder");
+        pathUtilsMockedStatic.when(() -> PathUtils.get(anyString(), anyString())).thenReturn(indexPath);
+    }
+
+    @Before
+    public void setupBeforeTest() {
+        knnSettingsMockedStatic.when(() -> KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME)).thenReturn(0);
+        jniServiceMockedStatic = mockStatic(JNIService.class);
+    }
+
+    @After
+    public void tearDownAfterTest() {
+        jniServiceMockedStatic.close();
+    }
+
+    protected Map<Integer, Float> getTranslatedScores(Function<Float, Float> scoreTranslator) {
+        return DOC_ID_TO_SCORES.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> scoreTranslator.apply(entry.getValue())));
+    }
+
+    protected KNNQueryResult[] getKNNQueryResults() {
+        return DOC_ID_TO_SCORES.entrySet()
+            .stream()
+            .map(entry -> new KNNQueryResult(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList())
+            .toArray(new KNNQueryResult[0]);
+    }
+
+    protected KNNQueryResult[] getFilteredKNNQueryResults() {
+        return FILTERED_DOC_ID_TO_SCORES.entrySet()
+            .stream()
+            .map(entry -> new KNNQueryResult(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList())
+            .toArray(new KNNQueryResult[0]);
+    }
+
+    protected SegmentReader mockSegmentReader() {
+        return mockSegmentReader(true);
+    }
+
+    protected SegmentReader mockSegmentReader(boolean isCompoundFile) {
+        Path path = mock(Path.class);
+
+        FSDirectory directory = mock(FSDirectory.class);
+        when(directory.getDirectory()).thenReturn(path);
+
+        SegmentInfo segmentInfo = new SegmentInfo(
+            directory,
+            Version.LATEST,
+            Version.LATEST,
+            SEGMENT_NAME,
+            100,
+            isCompoundFile,
+            false,
+            KNNCodecVersion.CURRENT_DEFAULT,
+            Map.of(),
+            new byte[StringHelper.ID_LENGTH],
+            Map.of(),
+            Sort.RELEVANCE
+        );
+        segmentInfo.setFiles(SEGMENT_FILES_FAISS);
+        SegmentCommitInfo segmentCommitInfo = new SegmentCommitInfo(segmentInfo, 0, 0, 0, 0, 0, new byte[StringHelper.ID_LENGTH]);
+
+        SegmentReader reader = mock(SegmentReader.class);
+        when(reader.directory()).thenReturn(directory);
+        when(reader.getSegmentInfo()).thenReturn(segmentCommitInfo);
+        return reader;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -15,12 +15,9 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReader;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.store.FSDirectory;
@@ -29,16 +26,9 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.opensearch.common.io.PathUtils;
-import org.opensearch.common.unit.TimeValue;
-import org.opensearch.core.common.unit.ByteSizeValue;
-import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNN990Codec.QuantizationConfigKNNCollector;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
@@ -47,8 +37,6 @@ import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfFloatsSerializ
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.memory.NativeMemoryAllocation;
-import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
 import org.opensearch.knn.index.vectorvalues.KNNBinaryVectorValues;
@@ -80,7 +68,6 @@ import static java.util.Collections.emptyMap;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -95,90 +82,11 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
-import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
-import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES;
-import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_SIZE_LIMIT;
 
-public class KNNWeightTests extends KNNTestCase {
-    private static final String FIELD_NAME = "target_field";
-    private static final float[] QUERY_VECTOR = new float[] { 1.8f, 2.4f };
-    private static final byte[] BYTE_QUERY_VECTOR = new byte[] { 1, 2 };
-    private static final String SEGMENT_NAME = "0";
-    private static final int K = 5;
-    private static final Set<String> SEGMENT_FILES_NMSLIB = Set.of("_0.cfe", "_0_2011_target_field.hnswc");
-    private static final Set<String> SEGMENT_FILES_FAISS = Set.of("_0.cfe", "_0_2011_target_field.faissc");
-    private static final Set<String> SEGMENT_FILES_DEFAULT = SEGMENT_FILES_FAISS;
-    private static final Set<String> SEGMENT_MULTI_FIELD_FILES_FAISS = Set.of(
-        "_0.cfe",
-        "_0_2011_target_field.faissc",
-        "_0_2011_long_target_field.faissc"
-    );
-    private static final String CIRCUIT_BREAKER_LIMIT_100KB = "100Kb";
-    private static final Integer EF_SEARCH = 10;
-    private static final Map<String, ?> HNSW_METHOD_PARAMETERS = Map.of(METHOD_PARAMETER_EF_SEARCH, EF_SEARCH);
-
-    private static final Map<Integer, Float> DOC_ID_TO_SCORES = Map.of(10, 0.4f, 101, 0.05f, 100, 0.8f, 50, 0.52f);
-    private static final Map<Integer, Float> FILTERED_DOC_ID_TO_SCORES = Map.of(101, 0.05f, 100, 0.8f, 50, 0.52f);
-    private static final Map<Integer, Float> EXACT_SEARCH_DOC_ID_TO_SCORES = Map.of(0, 0.12048191f);
-    private static final Map<Integer, Float> BINARY_EXACT_SEARCH_DOC_ID_TO_SCORES = Map.of(0, 0.5f);
-
-    private static final Query FILTER_QUERY = new TermQuery(new Term("foo", "fooValue"));
-
-    private static MockedStatic<NativeMemoryCacheManager> nativeMemoryCacheManagerMockedStatic;
-    private static MockedStatic<JNIService> jniServiceMockedStatic;
-
-    private static MockedStatic<KNNSettings> knnSettingsMockedStatic;
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-        final KNNSettings knnSettings = mock(KNNSettings.class);
-        knnSettingsMockedStatic = mockStatic(KNNSettings.class);
-        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED))).thenReturn(true);
-        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT))).thenReturn(CIRCUIT_BREAKER_LIMIT_100KB);
-        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED))).thenReturn(false);
-        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES))).thenReturn(TimeValue.timeValueMinutes(10));
-
-        final ByteSizeValue v = ByteSizeValue.parseBytesSizeValue(
-            CIRCUIT_BREAKER_LIMIT_100KB,
-            KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT
-        );
-        knnSettingsMockedStatic.when(KNNSettings::getClusterCbLimit).thenReturn(v);
-        knnSettingsMockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
-        ByteSizeValue cacheSize = ByteSizeValue.parseBytesSizeValue("1024kb", QUANTIZATION_STATE_CACHE_SIZE_LIMIT); // Setting 1MB as an
-                                                                                                                    // example
-        when(knnSettings.getSettingValue(eq(QUANTIZATION_STATE_CACHE_SIZE_LIMIT))).thenReturn(cacheSize);
-        // Mock QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES setting
-        TimeValue mockTimeValue = TimeValue.timeValueMinutes(10);
-        when(knnSettings.getSettingValue(eq(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES))).thenReturn(mockTimeValue);
-
-        nativeMemoryCacheManagerMockedStatic = mockStatic(NativeMemoryCacheManager.class);
-
-        final NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
-        final NativeMemoryAllocation nativeMemoryAllocation = mock(NativeMemoryAllocation.class);
-        when(nativeMemoryCacheManager.get(any(), anyBoolean())).thenReturn(nativeMemoryAllocation);
-
-        nativeMemoryCacheManagerMockedStatic.when(NativeMemoryCacheManager::getInstance).thenReturn(nativeMemoryCacheManager);
-
-        final MockedStatic<PathUtils> pathUtilsMockedStatic = mockStatic(PathUtils.class);
-        final Path indexPath = mock(Path.class);
-        when(indexPath.toString()).thenReturn("/mydrive/myfolder");
-        pathUtilsMockedStatic.when(() -> PathUtils.get(anyString(), anyString())).thenReturn(indexPath);
-    }
-
-    @Before
-    public void setupBeforeTest() {
-        knnSettingsMockedStatic.when(() -> KNNSettings.getFilteredExactSearchThreshold(INDEX_NAME)).thenReturn(0);
-        jniServiceMockedStatic = mockStatic(JNIService.class);
-    }
-
-    @After
-    public void tearDownAfterTest() {
-        jniServiceMockedStatic.close();
-    }
-
+public class KNNWeightTests extends KNNWeightTestCase {
     @SneakyThrows
     public void testQueryResultScoreNmslib() {
         for (SpaceType space : List.of(SpaceType.L2, SpaceType.L1, SpaceType.COSINESIMIL, SpaceType.INNER_PRODUCT, SpaceType.LINF)) {
@@ -847,7 +755,7 @@ public class KNNWeightTests extends KNNTestCase {
         assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
     }
 
-    private SegmentReader mockSegmentReader() {
+    protected SegmentReader mockSegmentReader() {
         Path path = mock(Path.class);
 
         FSDirectory directory = mock(FSDirectory.class);
@@ -1617,28 +1525,6 @@ public class KNNWeightTests extends KNNTestCase {
         }
         assertEquals(docIdSetIterator.cost(), actualDocIds.size());
         assertTrue(Comparators.isInOrder(actualDocIds, Comparator.naturalOrder()));
-    }
-
-    private Map<Integer, Float> getTranslatedScores(Function<Float, Float> scoreTranslator) {
-        return DOC_ID_TO_SCORES.entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, entry -> scoreTranslator.apply(entry.getValue())));
-    }
-
-    private KNNQueryResult[] getKNNQueryResults() {
-        return DOC_ID_TO_SCORES.entrySet()
-            .stream()
-            .map(entry -> new KNNQueryResult(entry.getKey(), entry.getValue()))
-            .collect(Collectors.toList())
-            .toArray(new KNNQueryResult[0]);
-    }
-
-    private KNNQueryResult[] getFilteredKNNQueryResults() {
-        return FILTERED_DOC_ID_TO_SCORES.entrySet()
-            .stream()
-            .map(entry -> new KNNQueryResult(entry.getKey(), entry.getValue()))
-            .collect(Collectors.toList())
-            .toArray(new KNNQueryResult[0]);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/query/common/DocAndScoreQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/common/DocAndScoreQueryTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
@@ -23,10 +22,13 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.mockito.Mock;
+import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -56,7 +58,7 @@ public class DocAndScoreQueryTests extends OpenSearchTestCase {
         int[] expectedDocs = { 0, 1, 2, 3, 4 };
         float[] expectedScores = { 0.1f, 1.2f, 2.3f, 5.1f, 3.4f };
         int[] findSegments = { 0, 2, 5 };
-        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id());
+        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id(), null);
 
         // When
         Scorer scorer1 = objectUnderTest.createWeight(indexSearcher, ScoreMode.COMPLETE, 1).scorer(leaf1);
@@ -88,19 +90,18 @@ public class DocAndScoreQueryTests extends OpenSearchTestCase {
         int[] expectedDocs = { 0, 1, 2, 3, 4 };
         float[] expectedScores = { 0.1f, 1.2f, 2.3f, 5.1f, 3.4f };
         int[] findSegments = { 0, 2, 5 };
-        Explanation expectedExplanation = Explanation.match(1.2f, "within top 4");
 
         // When
-        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id());
+        KNNWeight knnWeight = mock(KNNWeight.class);
+        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id(), knnWeight);
         Weight weight = objectUnderTest.createWeight(indexSearcher, ScoreMode.COMPLETE, 1);
-        Explanation explanation = weight.explain(leaf1, 1);
+        weight.explain(leaf1, 1);
 
         // Then
         assertEquals(objectUnderTest, weight.getQuery());
         assertTrue(weight.isCacheable(leaf1));
         assertEquals(2, weight.count(leaf1));
-        assertEquals(expectedExplanation, explanation);
-        assertEquals(Explanation.noMatch("not in top 4"), weight.explain(leaf1, 9));
+        verify(knnWeight).explain(leaf1, 1, 1.2f);
     }
 
     private IndexReader createTestIndexReader() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -152,7 +152,6 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
 
         // Set the reader and searcher
         reader = directoryReader;
-        ;
         indexReaderContext = reader.getContext();
         // Extract LeafReaderContext
         List<LeafReaderContext> leaves = reader.leaves();
@@ -184,6 +183,44 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         // Then
         Query expected = QueryUtils.INSTANCE.createDocAndScoreQuery(reader, expectedTopDocs);
         assertEquals(expected, actual.getQuery());
+    }
+
+    @SneakyThrows
+    public void testExplain() {
+
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertEquals(1, leaves.size());
+        leaf1 = leaves.get(0);
+        leafReader1 = leaf1.reader();
+
+        PerLeafResult leafResult = new PerLeafResult(null, new HashMap<>(Map.of(4, 3.4f, 3, 5.1f)));
+
+        when(knnWeight.searchLeaf(leaf1, 4)).thenReturn(leafResult);
+
+        Bits liveDocs = mock(Bits.class);
+        when(liveDocs.get(anyInt())).thenReturn(true);
+        when(liveDocs.get(2)).thenReturn(false);
+        when(liveDocs.get(1)).thenReturn(false);
+
+        // k=4 to make sure we get topk results even if docs are deleted/less in one of the leaves
+        when(knnQuery.getK()).thenReturn(4);
+
+        TopDocs[] topDocs = { ResultUtil.resultMapToTopDocs(leafResult.getResult(), leaf1.docBase) };
+        TopDocs expectedTopDocs = TopDocs.merge(4, topDocs);
+
+        // When
+        Weight actual = objectUnderTest.createWeight(searcher, scoreMode, 1);
+
+        // Then
+        Query expected = QueryUtils.INSTANCE.createDocAndScoreQuery(reader, expectedTopDocs);
+        assertEquals(expected, actual.getQuery());
+        for (ScoreDoc scoreDoc : expectedTopDocs.scoreDocs) {
+            int docId = scoreDoc.doc;
+            if (docId == 0) continue;
+            float score = scoreDoc.score;
+            actual.explain(leaf1, docId);
+            verify(knnWeight).explain(leaf1, docId, score);
+        }
     }
 
     @SneakyThrows
@@ -220,7 +257,6 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
 
         // Set the reader and searcher
         reader = directoryReader;
-        ;
         indexReaderContext = reader.getContext();
         // Extract LeafReaderContext
         List<LeafReaderContext> leaves = reader.leaves();
@@ -471,7 +507,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
 
         QueryUtils queryUtils = mock(QueryUtils.class);
         when(queryUtils.getAllSiblings(any(), any(), any(), any())).thenReturn(allSiblings);
-        when(queryUtils.createDocAndScoreQuery(eq(reader), any())).thenReturn(finalQuery);
+        when(queryUtils.createDocAndScoreQuery(eq(reader), any(), eq(knnWeight))).thenReturn(finalQuery);
 
         // Run
         NativeEngineKnnVectorQuery query = new NativeEngineKnnVectorQuery(knnQuery, queryUtils, true);
@@ -482,7 +518,7 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         verify(queryUtils).getAllSiblings(leaf1, perLeafResults.get(0).keySet(), parentFilter, queryFilterBits);
         verify(queryUtils).getAllSiblings(leaf2, perLeafResults.get(1).keySet(), parentFilter, queryFilterBits);
         ArgumentCaptor<TopDocs> topDocsCaptor = ArgumentCaptor.forClass(TopDocs.class);
-        verify(queryUtils).createDocAndScoreQuery(eq(reader), topDocsCaptor.capture());
+        verify(queryUtils).createDocAndScoreQuery(eq(reader), topDocsCaptor.capture(), eq(knnWeight));
         TopDocs capturedTopDocs = topDocsCaptor.getValue();
         assertEquals(topK.totalHits, capturedTopDocs.totalHits);
         for (int i = 0; i < topK.scoreDocs.length; i++) {


### PR DESCRIPTION
### Description
Add support for explain for Exact/ANN/Radial/Disk/Filtering k-nn search. Score calculation explanation is currently added only for ANN search.
Proposal for explain is given here: https://github.com/opensearch-project/k-NN/issues/875#issuecomment-2611349466

### Related Issues
Resolves #875
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
