### PR TITLE
Fixing bug where mapping accepts both dimension and model-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix filter rewrite logic which was resulting in getting inconsistent / incorrect results for cases where filter was getting rewritten for shards (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
 * Fixing it to retrieve space_type from index setting when both method and top level don't have the value. [#2374](https://github.com/opensearch-project/k-NN/pull/2374)
 * Fixing the bug where setting rescore as false for on_disk knn_vector query is a no-op (#2399)[https://github.com/opensearch-project/k-NN/pull/2399]
-* Fixing bug where mapping accepts both dimension and model-id (#XXXX)[]
+* Fixing bug where mapping accepts both dimension and model-id (#2410)[https://github.com/opensearch-project/k-NN/pull/2410]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix filter rewrite logic which was resulting in getting inconsistent / incorrect results for cases where filter was getting rewritten for shards (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
 * Fixing it to retrieve space_type from index setting when both method and top level don't have the value. [#2374](https://github.com/opensearch-project/k-NN/pull/2374)
 * Fixing the bug where setting rescore as false for on_disk knn_vector query is a no-op (#2399)[https://github.com/opensearch-project/k-NN/pull/2399]
+* Fixing bug where mapping accepts both dimension and model-id (#XXXX)[]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -383,7 +383,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 && builder.modelId.get() != null
                 && parserContext.indexVersionCreated().onOrAfter(Version.V_2_19_0)) {
                 throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "Dimension and model can not be both specified in the mapping: %s", name)
+                    String.format(Locale.ROOT, "Cannot specify both a modelId and dimension in the mapping: %s", name)
                 );
             }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -378,6 +378,15 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 );
             }
 
+            // Ensure user-defined dimension and model are mutually exclusive for indicies created after 2.19
+            if (builder.dimension.getValue() != UNSET_MODEL_DIMENSION_IDENTIFIER
+                && builder.modelId.get() != null
+                && parserContext.indexVersionCreated().onOrAfter(Version.V_2_19_0)) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Dimension and model can not be both specified in the mapping: %s", name)
+                );
+            }
+
             // Check for flat configuration and validate only if index is created after 2.17
             if (isKNNDisabled(parserContext.getSettings()) && parserContext.indexVersionCreated().onOrAfter(Version.V_2_17_0)) {
                 validateFromFlat(builder);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -892,6 +892,27 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         );
 
         assertEquals(modelId, builder.modelId.get());
+
+        // Fails if both model_id and dimension are set after 2.19
+        XContentBuilder xContentBuilder2 = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, TEST_DIMENSION)
+            .field(MODEL_ID, modelId)
+            .endObject();
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> typeParser.parse(fieldName, xContentBuilderToMap(xContentBuilder2), buildParserContext(indexName, settings))
+        );
+
+        // Should not fail if both are set before 2.19
+        typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder2),
+            buildLegacyParserContext(indexName, settings, Version.V_2_18_1)
+        );
+
     }
 
     public void testTypeParser_parse_fromLegacy() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -681,7 +681,6 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         XContentBuilder xContentBuilder4 = XContentFactory.jsonBuilder()
             .startObject()
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION, 10)
             .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.DEFAULT.getValue())
             .field(MODEL_ID, "test")
             .field(MODE_PARAMETER, Mode.ON_DISK.getName())


### PR DESCRIPTION
### Description

## Current Problem
- KNN indices can be created with both `model_id` and `dimension` parameters simultaneously
- This is incorrect as dimensions should come from either:
  - The training index (when using `model_id`)
  - OR user-defined dimensions (when using `dimension` parameter)

## Implemented Solution
- Raise an exception when both `model_id` and `dimension` parameters are present in the index creation request

## Version Scope
- Applies to all indices created on or after version 2.19

## Testing

```
wumr@88665a07f65b ~ %  curl -XPUT "http://localhost:9200/my-knn-index-1" -H 'Content-Type: application/json' -d'                                                                                                                                                           
{
  "settings": {
    "index": {
      "knn":true
    }
  },
  "mappings": {
    "properties": {
      "my_vector1": {
        "type": "knn_vector", "model_id": "1234",
        "dimension": 2
      }}}}'
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"Failed to parse mapping [_doc]: Dimension and model can not be both specified in the mapping: my_vector1"}],"type":"mapper_parsing_exception","reason":"Failed to parse mapping [_doc]: Dimension and model can not be both specified in the mapping: my_vector1","caused_by":{"type":"illegal_argument_exception","reason":"Dimension and model can not be both specified in the mapping: my_vector1"}},"status":400}%  
```

Normal input:

```
wumr@88665a07f65b ~ % curl -XPUT "http://localhost:9200/target-index" -H 'Content-Type: application/json' -d'
{
  "settings": {
    "number_of_shards": 3,
    "number_of_replicas": 1,
    "index.knn": true
  },
  "mappings": {
    "properties": {
      "target-field": {
        "type": "knn_vector",
        "model_id": "my-model"
      }
    }
  }
}
'
{"acknowledged":true,"shards_acknowledged":true,"index":"target-index"}% 
```

On 3.0:

```
wumr@88665a07f65b ~ % curl localhost:9200
{
  "name" : "integTest-0",
  "cluster_name" : "integTest",
  "cluster_uuid" : "pMFCf1AqRpak3k_OTJD12Q",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.0.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "a609e634a348b76386fb11936bbe8c4b38ea72d0",
    "build_date" : "2025-01-14T04:33:30.338382Z",
    "build_snapshot" : true,
    "lucene_version" : "9.12.1",
    "minimum_wire_compatibility_version" : "2.19.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```

### Related Issues
Resolves #2318 

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
