### PR TITLE
[Backport 2.x] Add support for search using the "fields" parameter with knn_vector field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use one formula to calculate cosine similarity (#2357)[https://github.com/opensearch-project/k-NN/pull/2357]
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
+* Fixing the bug where search fails with "fields" parameter for an index with a knn_vector field (#2314)[https://github.com/opensearch-project/k-NN/pull/2314]
 * Fix for NPE while merging segments after all the vector fields docs are deleted (#2365)[https://github.com/opensearch-project/k-NN/pull/2365]
 * Allow validation for non knn index only after 2.17.0 (#2315)[https://github.com/opensearch-project/k-NN/pull/2315]
 * Fixing the bug to prevent updating the index.knn setting after index creation(#2348)[https://github.com/opensearch-project/k-NN/pull/2348]

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -46,6 +46,7 @@ public class WarmupIT extends AbstractRestartUpgradeTestCase {
 
     // Custom Legacy Field Mapping
     // space_type : "innerproduct", engine : "nmslib", m : 2, ef_construction : 2
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2415")
     public void testKNNWarmupCustomLegacyFieldMapping() throws Exception {
 
         // When the cluster is in old version, create a KNN index with custom legacy field mapping settings

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -951,9 +951,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector2"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector3"));
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "vector3"));
 
         // Create match_all search body, some fields
         builder = XContentFactory.jsonBuilder()
@@ -965,9 +966,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response2 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector3"));
+        String entity2 = EntityUtils.toString(response2.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity2, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity2, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity2, "vector3"));
 
         // Create knn search body, all fields
         builder = XContentFactory.jsonBuilder()
@@ -983,9 +985,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response3 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector2"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector3"));
+        String entity3 = EntityUtils.toString(response3.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector3"));
 
         // Create knn search body, some fields
         builder = XContentFactory.jsonBuilder()
@@ -1001,9 +1004,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response4 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector3"));
+        String entity4 = EntityUtils.toString(response4.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity4, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity4, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity4, "vector3"));
     }
 
     public void testKNNIndexSearchFieldsParameterWithOtherFields() throws Exception {
@@ -1052,10 +1056,11 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector2"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "float1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "float2"));
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "float2"));
 
         // Create match_all search body, some fields
         builder = XContentFactory.jsonBuilder()
@@ -1067,10 +1072,11 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response2 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector1"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "float1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "float2"));
+        String entity2 = EntityUtils.toString(response2.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity2, "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity2, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity2, "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity2, "float2"));
 
         // Create knn search body, all fields
         builder = XContentFactory.jsonBuilder()
@@ -1086,10 +1092,11 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response3 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector2"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "float1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "float2"));
+        String entity3 = EntityUtils.toString(response3.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "float2"));
 
         // Create knn search body, some fields
         builder = XContentFactory.jsonBuilder()
@@ -1105,10 +1112,11 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response4 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector1"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "float1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "float2"));
+        String entity4 = EntityUtils.toString(response4.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity4, "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity4, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity4, "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity4, "float2"));
     }
 
     public void testKNNIndexSearchFieldsParameterDocsWithOnlyOtherFields() throws Exception {
@@ -1152,9 +1160,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector1"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector2"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "text1"));
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(0, parseSearchResponseFieldsCount(entity, "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity, "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity, "text1"));
 
         // Create match search body, all vector fields
         builder = XContentFactory.jsonBuilder()
@@ -1167,9 +1176,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response2 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector1"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "text1"));
+        String entity2 = EntityUtils.toString(response2.getEntity());
+        assertEquals(0, parseSearchResponseFieldsCount(entity2, "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity2, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity2, "text1"));
 
         // Create knn search body, all vector fields
         builder = XContentFactory.jsonBuilder()
@@ -1185,9 +1195,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response3 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector1"));
-        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "text1"));
+        String entity3 = EntityUtils.toString(response3.getEntity());
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(entity3, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity3, "text1"));
 
         // Create knn search body, all non vector fields
         builder = XContentFactory.jsonBuilder()
@@ -1203,9 +1214,10 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
         Response response4 = searchKNNIndex(INDEX_NAME, builder, k);
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector1"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector2"));
-        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "text1"));
+        String entity4 = EntityUtils.toString(response4.getEntity());
+        assertEquals(0, parseSearchResponseFieldsCount(entity4, "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity4, "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(entity4, "text1"));
     }
 
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -13,7 +13,7 @@ package org.opensearch.knn.index;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
-import java.util.Locale;
+
 import lombok.SneakyThrows;
 import org.apache.http.ParseException;
 import org.junit.BeforeClass;
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -922,6 +923,289 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         // Delete index
         deleteKNNIndex(indexName);
+    }
+
+    public void testKNNIndexSearchFieldsParameter() throws Exception {
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2", "vector3"), Arrays.asList(2, 3, 5)));
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector1 = { (float) i, (float) (i + 1) };
+            Float[] vector2 = { (float) i, (float) (i + 1), (float) (i + 2) };
+            Float[] vector3 = { (float) i, (float) (i + 1), (float) (i + 2), (float) (i + 3), (float) (i + 4) };
+            addKnnDoc(
+                INDEX_NAME,
+                Integer.toString(i),
+                Arrays.asList("vector1", "vector2", "vector3"),
+                Arrays.asList(vector1, vector2, vector3)
+            );
+        }
+        int k = 10; // nearest 10 neighbors
+
+        // Create match_all search body, all fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "*" })
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector3"));
+
+        // Create match_all search body, some fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "vector2" })
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response2 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector3"));
+
+        // Create knn search body, all fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "*" })
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response3 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector3"));
+
+        // Create knn search body, some fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "vector2" })
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response4 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector3"));
+    }
+
+    public void testKNNIndexSearchFieldsParameterWithOtherFields() throws Exception {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("vector1")
+            .field("type", "knn_vector")
+            .field("dimension", "2")
+            .endObject()
+            .startObject("vector2")
+            .field("type", "knn_vector")
+            .field("dimension", "3")
+            .endObject()
+            .startObject("float1")
+            .field("type", "float")
+            .endObject()
+            .startObject("float2")
+            .field("type", "float")
+            .endObject()
+            .endObject()
+            .endObject();
+        createKnnIndex(INDEX_NAME, xContentBuilder.toString());
+        // Add docs with knn_vector and other fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector1 = { (float) i, (float) (i + 1) };
+            Float[] vector2 = { (float) i, (float) (i + 1), (float) (i + 2) };
+            Float[] float1 = { (float) i };
+            Float[] float2 = { (float) (i + 1) };
+            addKnnDoc(
+                INDEX_NAME,
+                Integer.toString(i),
+                Arrays.asList("vector1", "vector2", "float1", "float2"),
+                Arrays.asList(vector1, vector2, float1, float2)
+            );
+        }
+        int k = 10; // nearest 10 neighbors
+
+        // Create match_all search body, all fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "*" })
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "float2"));
+
+        // Create match_all search body, some fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "float2" })
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response2 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "float2"));
+
+        // Create knn search body, all fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "*" })
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response3 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "float2"));
+
+        // Create knn search body, some fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "float2" })
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response4 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "float1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "float2"));
+    }
+
+    public void testKNNIndexSearchFieldsParameterDocsWithOnlyOtherFields() throws Exception {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("vector1")
+            .field("type", "knn_vector")
+            .field("dimension", "2")
+            .endObject()
+            .startObject("vector2")
+            .field("type", "knn_vector")
+            .field("dimension", "3")
+            .endObject()
+            .startObject("text1")
+            .field("type", "text")
+            .endObject()
+            .endObject()
+            .endObject();
+        createKnnIndex(INDEX_NAME, xContentBuilder.toString());
+        // Add knn_vector docs
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector1 = { (float) i, (float) (i + 1) };
+            Float[] vector2 = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDoc(INDEX_NAME, Integer.toString(i), Arrays.asList("vector1", "vector2"), Arrays.asList(vector1, vector2));
+        }
+        // Add non knn_vector docs
+        for (int i = 21; i <= 40; i++) {
+            addNonKNNDoc(INDEX_NAME, Integer.toString(i), "text1", "text " + i);
+        }
+        int k = 10; // nearest 10 neighbors
+
+        // Create match search body, all non vector fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "text1" })
+            .startObject("query")
+            .startObject("match")
+            .field("text1", "text")
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "vector2"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response.getEntity()), "text1"));
+
+        // Create match search body, all vector fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "vector2" })
+            .startObject("query")
+            .startObject("match")
+            .field("text1", "text")
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response2 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response2.getEntity()), "text1"));
+
+        // Create knn search body, all vector fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "vector2" })
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response3 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response3.getEntity()), "text1"));
+
+        // Create knn search body, all non vector fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "text1" })
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response4 = searchKNNIndex(INDEX_NAME, builder, k);
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector1"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "vector2"));
+        assertEquals(0, parseSearchResponseFieldsCount(EntityUtils.toString(response4.getEntity()), "text1"));
     }
 
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.opensearch.index.mapper.ArraySourceValueFetcher;
+import org.opensearch.index.mapper.ValueFetcher;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+public class KNNVectorFieldTypeTests extends KNNTestCase {
+    private static final String FIELD_NAME = "test-field";
+
+    public void testValueFetcher() {
+        KNNMethodContext knnMethodContext = getDefaultKNNMethodContext();
+        KNNVectorFieldType knnVectorFieldType = new KNNVectorFieldType(
+            FIELD_NAME,
+            Collections.emptyMap(),
+            VectorDataType.FLOAT,
+            getMappingConfigForMethodMapping(knnMethodContext, 3)
+        );
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        ValueFetcher valueFetcher = knnVectorFieldType.valueFetcher(mockQueryShardContext, null, null);
+        assertTrue(valueFetcher instanceof ArraySourceValueFetcher);
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -337,6 +337,27 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return knnSearchResponses;
     }
 
+    protected int parseSearchResponseFieldsCount(String responseBody, String fieldName) throws IOException {
+        @SuppressWarnings("unchecked")
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("hits")).get("hits");
+
+        @SuppressWarnings("unchecked")
+        List<Integer> fieldFound = hits.stream().map(hit -> {
+            if (((Map<String, Object>) hit).get("fields") == null) {
+                return 0;
+            }
+            if (((Map<String, Object>) ((Map<String, Object>) hit).get("fields")).get(fieldName) != null) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }).collect(Collectors.toList());
+        return fieldFound.stream().mapToInt(Integer::intValue).sum();
+    }
+
     /**
      * Parse the response of Aggregation to extract the value
      */


### PR DESCRIPTION
### Description
Backport of #2314 
Fix Sign-Off Issues/Test Failures in #2394 

This change implements valueFetcher in KNNVectorFieldType so search can support using the "fields" parameter when used with the knn_vector field type.  ITs for this change were added to OpenSearchIT after the change was tested manually.  

### Related Issues
Resolves #1633

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
