### PR TITLE
Mute testKNNWarmupCustomLegacyFieldMapping

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -46,6 +46,7 @@ public class WarmupIT extends AbstractRestartUpgradeTestCase {
 
     // Custom Legacy Field Mapping
     // space_type : "innerproduct", engine : "nmslib", m : 2, ef_construction : 2
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2415")
     public void testKNNWarmupCustomLegacyFieldMapping() throws Exception {
 
         // When the cluster is in old version, create a KNN index with custom legacy field mapping settings


### PR DESCRIPTION
### Description
- Mutes `testKNNWarmupCustomLegacyFieldMapping` after confirmation with the test author on the impact
- Re-running the test with the same seed is unable to reproduce the issue
- RCA is taking longer - unblocking the CI/merges for 2.19 in the meanwhile

### Related Issues
Mutes #2415 
<!-- List any other related issues here -->

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
