### PR TITLE
[Backport 2.x] Fix setting rescore as false in on_disk knn_vector query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix shard level rescoring disabled setting flag (#2352)[https://github.com/opensearch-project/k-NN/pull/2352]
 * Fix filter rewrite logic which was resulting in getting inconsistent / incorrect results for cases where filter was getting rewritten for shards (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
 * Fixing it to retrieve space_type from index setting when both method and top level don't have the value. [#2374](https://github.com/opensearch-project/k-NN/pull/2374)
+* Fixing the bug where setting rescore as false for on_disk knn_vector query is a no-op (#2399)[https://github.com/opensearch-project/k-NN/pull/2399]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -25,10 +25,10 @@ public enum CompressionLevel {
     x1(1, "1x", null, Collections.emptySet()),
     x2(2, "2x", null, Collections.emptySet()),
     x4(4, "4x", null, Collections.emptySet()),
-    x8(8, "8x", new RescoreContext(2.0f, false), Set.of(Mode.ON_DISK)),
-    x16(16, "16x", new RescoreContext(3.0f, false), Set.of(Mode.ON_DISK)),
-    x32(32, "32x", new RescoreContext(3.0f, false), Set.of(Mode.ON_DISK)),
-    x64(64, "64x", new RescoreContext(5.0f, false), Set.of(Mode.ON_DISK));
+    x8(8, "8x", new RescoreContext(2.0f, false, false), Set.of(Mode.ON_DISK)),
+    x16(16, "16x", new RescoreContext(3.0f, false, false), Set.of(Mode.ON_DISK)),
+    x32(32, "32x", new RescoreContext(3.0f, false, false), Set.of(Mode.ON_DISK)),
+    x64(64, "64x", new RescoreContext(5.0f, false, false), Set.of(Mode.ON_DISK));
 
     public static final CompressionLevel MAX_COMPRESSION_LEVEL = CompressionLevel.x64;
 

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -60,7 +60,7 @@ public class NativeEngineKnnVectorQuery extends Query {
         List<PerLeafResult> perLeafResults;
         RescoreContext rescoreContext = knnQuery.getRescoreContext();
         final int finalK = knnQuery.getK();
-        if (rescoreContext == null) {
+        if (rescoreContext == null || !rescoreContext.isRescoreEnabled()) {
             perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, finalK);
         } else {
             boolean isShardLevelRescoringDisabled = KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(knnQuery.getIndexName());

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -24,7 +24,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
@@ -34,6 +37,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.EXPAND_NESTED_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.RESCORE_FIELD;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_PARAMETER;
+import static org.opensearch.knn.index.query.rescore.RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT;
 import static org.opensearch.knn.index.util.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.FILTER_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.IGNORE_UNMAPPED_FIELD;
@@ -84,12 +88,22 @@ public final class KNNQueryBuilderParser {
         );
         internalParser.declareObject(KNNQueryBuilder.Builder::filter, (p, v) -> parseInnerQueryBuilder(p), FILTER_FIELD);
 
-        internalParser.declareObjectOrDefault(
-            KNNQueryBuilder.Builder::rescoreContext,
-            (p, v) -> RescoreParser.fromXContent(p),
-            RescoreContext::getDefault,
-            RESCORE_FIELD
-        );
+        internalParser.declareField((p, v, c) -> {
+            BiConsumer<KNNQueryBuilder.Builder, RescoreContext> consumer = KNNQueryBuilder.Builder::rescoreContext;
+            BiFunction<XContentParser, Void, RescoreContext> objectParser = (_p, _v) -> RescoreParser.fromXContent(_p);
+            Supplier<RescoreContext> defaultValue = RescoreContext::getDefault;
+            if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
+                if (p.booleanValue()) {
+                    consumer.accept(v, defaultValue.get());
+                } else {
+                    // If the user specifies false, we explicitly set to null so we don't
+                    // accidentally resolve.
+                    consumer.accept(v, EXPLICITLY_DISABLED_RESCORE_CONTEXT);
+                }
+            } else {
+                consumer.accept(v, objectParser.apply(p, c));
+            }
+        }, RESCORE_FIELD, ObjectParser.ValueType.OBJECT_OR_BOOLEAN);
 
         internalParser.declareBoolean(KNNQueryBuilder.Builder::expandNested, EXPAND_NESTED_FIELD);
 

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -48,6 +48,17 @@ public final class RescoreContext {
     private boolean userProvided = true;
 
     /**
+     * Flag to track whether rescoring has been disabled by the query parameters.
+     */
+    @Builder.Default
+    private boolean rescoreEnabled = true;
+
+    public static final RescoreContext EXPLICITLY_DISABLED_RESCORE_CONTEXT = RescoreContext.builder()
+        .oversampleFactor(DEFAULT_OVERSAMPLE_FACTOR)
+        .rescoreEnabled(false)
+        .build();
+
+    /**
      *
      * @return default RescoreContext
      */

--- a/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
@@ -334,6 +334,78 @@ public class KNNQueryBuilderParserTests extends KNNTestCase {
         assertTrue(exception.getMessage(), exception.getMessage().contains("[knn] failed to parse field [vector]"));
     }
 
+    public void testFromXContent_rescoreEnabled() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        RescoreContext explicitRescoreContext = RescoreContext.builder().oversampleFactor(1.5f).build();
+        // Test with default rescore
+        KNNQueryBuilder knnQueryBuilderDefaultRescore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .rescoreContext(RescoreContext.getDefault())
+            .build();
+        XContentBuilder builderDefaultRescore = XContentFactory.jsonBuilder();
+        builderDefaultRescore.startObject();
+        builderDefaultRescore.startObject(knnQueryBuilderDefaultRescore.fieldName());
+        builderDefaultRescore.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilderDefaultRescore.vector());
+        builderDefaultRescore.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilderDefaultRescore.getK());
+        builderDefaultRescore.field(KNNQueryBuilder.RESCORE_FIELD.getPreferredName(), true);
+        builderDefaultRescore.endObject();
+        builderDefaultRescore.endObject();
+        XContentParser contentParserDefaultRescore = createParser(builderDefaultRescore);
+        contentParserDefaultRescore.nextToken();
+        KNNQueryBuilder actualBuilderDefaultRescore = KNNQueryBuilderParser.fromXContent(contentParserDefaultRescore);
+        assertEquals(knnQueryBuilderDefaultRescore, actualBuilderDefaultRescore);
+
+        // Test with explicit rescore
+        KNNQueryBuilder knnQueryBuilderExplicitRescore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .rescoreContext(explicitRescoreContext)
+            .build();
+        XContentBuilder builderExplicitRescore = XContentFactory.jsonBuilder();
+        builderExplicitRescore.startObject();
+        builderExplicitRescore.startObject(knnQueryBuilderExplicitRescore.fieldName());
+        builderExplicitRescore.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilderExplicitRescore.vector());
+        builderExplicitRescore.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilderExplicitRescore.getK());
+        builderExplicitRescore.startObject(KNNQueryBuilder.RESCORE_FIELD.getPreferredName());
+        builderExplicitRescore.field(
+            KNNQueryBuilder.RESCORE_OVERSAMPLE_FIELD.getPreferredName(),
+            explicitRescoreContext.getOversampleFactor()
+        );
+        builderExplicitRescore.endObject();
+        builderExplicitRescore.endObject();
+        builderExplicitRescore.endObject();
+        XContentParser contentParserExplicitRescore = createParser(builderExplicitRescore);
+        contentParserExplicitRescore.nextToken();
+        KNNQueryBuilder actualBuilderExplicitRescore = KNNQueryBuilderParser.fromXContent(contentParserExplicitRescore);
+        assertEquals(knnQueryBuilderExplicitRescore, actualBuilderExplicitRescore);
+    }
+
+    public void testFromXContent_rescoreDisabled() throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+        // Test with rescore disabled
+        KNNQueryBuilder knnQueryBuilderRescoreDisabled = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(K)
+            .rescoreContext(RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT)
+            .build();
+        XContentBuilder builderRescoreDisabled = XContentFactory.jsonBuilder();
+        builderRescoreDisabled.startObject();
+        builderRescoreDisabled.startObject(knnQueryBuilderRescoreDisabled.fieldName());
+        builderRescoreDisabled.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), knnQueryBuilderRescoreDisabled.vector());
+        builderRescoreDisabled.field(KNNQueryBuilder.K_FIELD.getPreferredName(), knnQueryBuilderRescoreDisabled.getK());
+        builderRescoreDisabled.field(KNNQueryBuilder.RESCORE_FIELD.getPreferredName(), false);
+        builderRescoreDisabled.endObject();
+        builderRescoreDisabled.endObject();
+        XContentParser contentParserRescoreDisabled = createParser(builderRescoreDisabled);
+        contentParserRescoreDisabled.nextToken();
+        KNNQueryBuilder actualBuilderRescoreDisabled = KNNQueryBuilderParser.fromXContent(contentParserRescoreDisabled);
+        assertEquals(knnQueryBuilderRescoreDisabled, actualBuilderRescoreDisabled);
+    }
+
     public void testFromXContent_whenFlat_thenException() throws Exception {
         float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
         XContentBuilder builder = XContentFactory.jsonBuilder();


### PR DESCRIPTION
### Description
Backport of #2399 
Skip Flaky BWC in #2417 

This change adds a flag to RescoreContext for tracking if rescore has been disabled by the KNN query parameters. This flag is set to not skip rescore by default, and is only set to skip rescore if `"rescore": false` is in the KNN query. UTs were added for the KNNQueryBuilderParser that covers the different cases for rescore. The below steps were also run with a debugging cluster to verify that the rescore was being run/skipped correctly based on the query parameters.

### Related Issues
Resolves #2360 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
