### PR TITLE
[Backport 2.x] Deprecate nmslib engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Added Lucene BWC tests (#2313)[https://github.com/opensearch-project/k-NN/pull/2313]
 * Upgrade jsonpath from 2.8.0 to 2.9.0[2325](https://github.com/opensearch-project/k-NN/pull/2325)
 * Bump Faiss commit from 1f42e81 to 0cbc2a8 to accelerate hamming distance calculation using _mm512_popcnt_epi64  intrinsic and also add avx512-fp16 instructions to boost performance [#2381](https://github.com/opensearch-project/k-NN/pull/2381)
+* Deprecate nmslib engine (#2427)[https://github.com/opensearch-project/k-NN/pull/2427]
 ### Refactoring

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -91,6 +91,7 @@ public class KNNConstants {
     public static final int LUCENE_SQ_DEFAULT_BITS = 7;
 
     // nmslib specific constants
+    @Deprecated(since = "2.19.0", forRemoval = true)
     public static final String NMSLIB_NAME = "nmslib";
     public static final String COMMONS_NAME = "common";
     public static final String SPACE_TYPE = "spaceType"; // used as field info key

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.index.engine;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.faiss.Faiss;
@@ -25,6 +27,7 @@ import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
  * passed to the respective k-NN library's JNI layer.
  */
 public enum KNNEngine implements KNNLibrary {
+    @Deprecated(since = "2.19.0", forRemoval = true)
     NMSLIB(NMSLIB_NAME, Nmslib.INSTANCE),
     FAISS(FAISS_NAME, Faiss.INSTANCE),
     LUCENE(LUCENE_NAME, Lucene.INSTANCE);
@@ -34,6 +37,7 @@ public enum KNNEngine implements KNNLibrary {
     private static final Set<KNNEngine> CUSTOM_SEGMENT_FILE_ENGINES = ImmutableSet.of(KNNEngine.NMSLIB, KNNEngine.FAISS);
     private static final Set<KNNEngine> ENGINES_SUPPORTING_FILTERS = ImmutableSet.of(KNNEngine.LUCENE, KNNEngine.FAISS);
     public static final Set<KNNEngine> ENGINES_SUPPORTING_RADIAL_SEARCH = ImmutableSet.of(KNNEngine.LUCENE, KNNEngine.FAISS);
+    private static Logger logger = LogManager.getLogger(KNNEngine.class);
 
     private static Map<KNNEngine, Integer> MAX_DIMENSIONS_BY_ENGINE = Map.of(
         KNNEngine.NMSLIB,
@@ -66,6 +70,9 @@ public enum KNNEngine implements KNNLibrary {
      */
     public static KNNEngine getEngine(String name) {
         if (NMSLIB.getName().equalsIgnoreCase(name)) {
+            logger.warn(
+                "[Deprecation] nmslib engine is deprecated and will be removed in a future release. Please use Faiss or Lucene engine instead."
+            );
             return NMSLIB;
         }
 
@@ -88,6 +95,9 @@ public enum KNNEngine implements KNNLibrary {
      */
     public static KNNEngine getEngineNameFromPath(String path) {
         if (path.endsWith(KNNEngine.NMSLIB.getExtension()) || path.endsWith(KNNEngine.NMSLIB.getCompoundExtension())) {
+            logger.warn(
+                "[Deprecation] nmslib engine is deprecated and will be removed in a future release. Please use Faiss or Lucene engine instead."
+            );
             return KNNEngine.NMSLIB;
         }
 

--- a/src/main/java/org/opensearch/knn/index/engine/nmslib/Nmslib.java
+++ b/src/main/java/org/opensearch/knn/index/engine/nmslib/Nmslib.java
@@ -22,7 +22,11 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 /**
  * Implements NativeLibrary for the nmslib native library
+ *
+ * @deprecated As of 2.19.0, please use {@link org.opensearch.knn.index.engine.faiss.Faiss} or Lucene's native k-NN.
+ * This engine will be removed in a future release.
  */
+@Deprecated(since = "2.19.0", forRemoval = true)
 public class Nmslib extends NativeLibrary {
     // Extension to be used for Nmslib files. It is ".hnsw" and not ".nmslib" for legacy purposes.
     public final static String EXTENSION = ".hnsw";

--- a/src/main/java/org/opensearch/knn/index/engine/nmslib/NmslibHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/nmslib/NmslibHNSWMethod.java
@@ -24,7 +24,11 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 
 /**
  * Nmslib's HNSW implementation
+ *
+ * @deprecated As of 2.19.0, please use {@link org.opensearch.knn.index.engine.faiss.Faiss} or Lucene engine.
+ * This engine will be removed in a future release.
  */
+@Deprecated(since = "2.19.0", forRemoval = true)
 public class NmslibHNSWMethod extends AbstractKNNMethod {
 
     private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT);

--- a/src/main/java/org/opensearch/knn/index/engine/nmslib/NmslibMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/nmslib/NmslibMethodResolver.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.index.engine.nmslib;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.AbstractMethodResolver;
@@ -23,10 +25,15 @@ import static org.opensearch.knn.index.engine.nmslib.NmslibHNSWMethod.HNSW_METHO
 /**
  * Method resolution logic for nmslib. Because nmslib does not support quantization, it is in general a validation
  * before returning the original request
+ *
+ * @deprecated As of 2.19.0, please use {@link org.opensearch.knn.index.engine.faiss.Faiss} or Lucene engine.
+ * This engine will be removed in a future release.
  */
+@Deprecated(since = "2.19.0", forRemoval = true)
 public class NmslibMethodResolver extends AbstractMethodResolver {
 
     private static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS = Set.of(CompressionLevel.x1);
+    private static Logger logger = LogManager.getLogger(NmslibMethodResolver.class);
 
     @Override
     public ResolvedMethodContext resolveMethod(
@@ -35,6 +42,9 @@ public class NmslibMethodResolver extends AbstractMethodResolver {
         boolean shouldRequireTraining,
         final SpaceType spaceType
     ) {
+        logger.warn(
+            "[Deprecation] nmslib engine is deprecated and will be removed in a future release. Please use Faiss or Lucene engine instead."
+        );
         validateConfig(knnMethodConfigContext, shouldRequireTraining);
         KNNMethodContext resolvedKNNMethodContext = initResolvedKNNMethodContext(
             knnMethodContext,

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -12,6 +12,8 @@
 package org.opensearch.knn.jni;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -27,6 +29,9 @@ import java.util.Map;
  * Service to distribute requests to the proper engine jni service
  */
 public class JNIService {
+
+    private static Logger logger = LogManager.getLogger(JNIService.class);
+
     /**
      * Initialize an index for the native library. Takes in numDocs to
      * allocate the correct amount of memory.
@@ -137,6 +142,9 @@ public class JNIService {
         KNNEngine knnEngine
     ) {
         if (KNNEngine.NMSLIB == knnEngine) {
+            logger.warn(
+                "[Deprecation] nmslib engine is deprecated and will be removed in a future release. Please use Faiss or Lucene engine instead."
+            );
             NmslibService.createIndex(ids, vectorsAddress, dim, output, parameters);
             return;
         }
@@ -201,6 +209,9 @@ public class JNIService {
                 return FaissService.loadIndexWithStream(readStream);
             }
         } else if (KNNEngine.NMSLIB == knnEngine) {
+            logger.warn(
+                "[Deprecation] nmslib engine is deprecated and will be removed in a future release. Please use Faiss or Lucene engine instead."
+            );
             return NmslibService.loadIndexWithStream(readStream, parameters);
         }
 

--- a/src/main/java/org/opensearch/knn/jni/NmslibService.java
+++ b/src/main/java/org/opensearch/knn/jni/NmslibService.java
@@ -28,7 +28,11 @@ import java.util.Map;
  * javac -h jni/include src/main/java/org/opensearch/knn/jni/NmslibService.java
  *      src/main/java/org/opensearch/knn/index/KNNQueryResult.java
  *      src/main/java/org/opensearch/knn/common/KNNConstants.java
+ *
+ *  @deprecated As of 2.19.0, please use {@link FaissService} or Lucene.
+ *  This engine will be removed in a future release.
  */
+@Deprecated(since = "2.19.0", forRemoval = true)
 class NmslibService {
 
     static {

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -38,6 +38,7 @@ import java.util.TreeMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 
+@Deprecated(since = "2.19.0", forRemoval = true)
 public class NmslibIT extends KNNRestTestCase {
 
     static TestUtils.TestData testData;

--- a/src/test/java/org/opensearch/knn/index/engine/nmslib/NmslibMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/nmslib/NmslibMethodResolverTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
+@Deprecated(since = "2.19.0", forRemoval = true)
 public class NmslibMethodResolverTests extends KNNTestCase {
 
     MethodResolver TEST_RESOLVER = new NmslibMethodResolver();


### PR DESCRIPTION
### Description
- Backports #2427 to `2.x`

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
