### PR TITLE
Fix race condition bug in NativeMemoryCacheManager

### DIFF
--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -375,8 +375,7 @@ public class NativeMemoryCacheManager implements Closeable {
                         }
                     }
                     result = cache.get(key, () -> {
-                        NativeMemoryAllocation.IndexAllocation allocation =
-                            (NativeMemoryAllocation.IndexAllocation) nativeMemoryEntryContext.load();
+                        NativeMemoryAllocation allocation = nativeMemoryEntryContext.load();
                         if (acquirePreemptiveReadLock) {
                             allocation.incRef();
                             lockAcquired.set(true);

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -346,7 +346,7 @@ public class NativeMemoryCacheManager implements Closeable {
                 return result;
             }
 
-            boolean lockAcquired = false;
+            AtomicBoolean lockAcquired = new AtomicBoolean(false);
             try {
                 synchronized (this) {
                     if (getCacheSizeInKilobytes() + nativeMemoryEntryContext.calculateSizeInKB() >= maxWeight) {
@@ -363,16 +363,20 @@ public class NativeMemoryCacheManager implements Closeable {
                             lruIterator.remove();
                         }
                     }
-                    result = cache.get(key, nativeMemoryEntryContext::load);
-                    if (acquirePreemptiveReadLock) {
-                        result.incRef();
-                        lockAcquired = true;
-                    }
+                    result = cache.get(key, () -> {
+                        NativeMemoryAllocation.IndexAllocation allocation =
+                            (NativeMemoryAllocation.IndexAllocation) nativeMemoryEntryContext.load();
+                        if (acquirePreemptiveReadLock) {
+                            allocation.incRef();
+                            lockAcquired.set(true);
+                        }
+                        return allocation;
+                    });
                     accessRecencyQueue.addLast(key);
                     return result;
                 }
             } catch (Exception e) {
-                if (result != null && lockAcquired) {
+                if (result != null && lockAcquired.get()) {
                     result.decRef();
                 }
                 throw e;

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -333,52 +333,48 @@ public class NativeMemoryCacheManager implements Closeable {
         }
 
         if (KNNFeatureFlags.isForceEvictCacheEnabled()) {
-            // Utilizes a force eviction mechanism to free up memory before the entry can be added to the cache
-            // In case of a cache hit, the operation just updates the locally maintained recency list
-            // In case of a cache miss, least recently accessed entries are evicted in a blocking manner
-            // before the new entry can be added to the cache.
             String key = nativeMemoryEntryContext.getKey();
             NativeMemoryAllocation result = cache.getIfPresent(key);
 
-            // Cache Hit
-            // In case of a cache hit, moving the item to the end of the recency queue adds
-            // some overhead to the get operation. This can be optimized further to make this operation
-            // as lightweight as possible. Multiple approaches and their outcomes were documented
-            // before moving forward with the current solution.
-            // The details are outlined here: https://github.com/opensearch-project/k-NN/pull/2015#issuecomment-2327064680
             if (result != null) {
                 accessRecencyQueue.remove(key);
                 accessRecencyQueue.addLast(key);
+                if (acquirePreemptiveReadLock) {
+                    result.incRef();
+                }
                 return result;
             }
 
-            // Cache Miss
-            // Evict before put
-            synchronized (this) {
-                if (getCacheSizeInKilobytes() + nativeMemoryEntryContext.calculateSizeInKB() >= maxWeight) {
-                    Iterator<String> lruIterator = accessRecencyQueue.iterator();
-                    while (lruIterator.hasNext()
+            boolean lockAcquired = false;
+            try {
+                synchronized (this) {
+                    if (getCacheSizeInKilobytes() + nativeMemoryEntryContext.calculateSizeInKB() >= maxWeight) {
+                        Iterator<String> lruIterator = accessRecencyQueue.iterator();
+                        while (lruIterator.hasNext()
                             && (getCacheSizeInKilobytes() + nativeMemoryEntryContext.calculateSizeInKB() >= maxWeight)) {
 
-                        String keyToRemove = lruIterator.next();
-                        NativeMemoryAllocation allocationToRemove = cache.getIfPresent(keyToRemove);
-                        if (allocationToRemove != null) {
-                            allocationToRemove.close();
-                            cache.invalidate(keyToRemove);
+                            String keyToRemove = lruIterator.next();
+                            NativeMemoryAllocation allocationToRemove = cache.getIfPresent(keyToRemove);
+                            if (allocationToRemove != null) {
+                                allocationToRemove.close();
+                                cache.invalidate(keyToRemove);
+                            }
+                            lruIterator.remove();
                         }
-                        lruIterator.remove();
                     }
                 }
-
-                result = cache.get(key, () -> {
-                    NativeMemoryAllocation allocation = nativeMemoryEntryContext.load();
-                    if (acquirePreemptiveReadLock) {
-                        allocation.readLock();
-                    }
-                    return allocation;
-                });
+                result = cache.get(key, nativeMemoryEntryContext::load);
+                if (acquirePreemptiveReadLock) {
+                    result.incRef();
+                    lockAcquired = true;
+                }
                 accessRecencyQueue.addLast(key);
                 return result;
+            } catch (Exception e) {
+                if (result != null && lockAcquired) {
+                    result.decRef();
+                }
+                throw e;
             }
         } else {
             return cache.get(nativeMemoryEntryContext.getKey(), nativeMemoryEntryContext::load);

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -307,7 +307,7 @@ public class NativeMemoryCacheManager implements Closeable {
      *
      * @param nativeMemoryEntryContext Context from which to get NativeMemoryAllocation
      * @param isAbleToTriggerEviction Determines if getting this allocation can evict other entries
-     * @param acquirePreemptiveReadLock Determines if a preemptive read lock is necessary to avoid race condition
+     * @param acquirePreemptiveReadLock Determines whether to increment ref count during cache loading to prevent eviction race condition
      * @return NativeMemoryAllocation associated with nativeMemoryEntryContext
      * @throws ExecutionException if there is an exception when loading from the cache
      */

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -314,7 +314,8 @@ public class KNNWeight extends Weight {
                     knnQuery.getIndexName(),
                     modelId
                 ),
-                true
+                true,
+                    true
             );
         } catch (ExecutionException e) {
             GRAPH_QUERY_ERRORS.increment();


### PR DESCRIPTION
### Description
Previously, the window between loading an item from its nativeMemoryContext and acquiring a read lock allowed for the item to be cleaned or evicted before being read for the query. The goal here is to synchronize the load and incRef() operations to avoid this race condition.

We were seeing the following exception when running an OSB vectorsearch workload with 5+ search clients:
`[ERROR] search_phase_execution_exception ({'error': {'root_cause': [{'type': 'illegal_state_exception', 'reason': "IndexAllocation-Reference is already closed can't increment refCount current count [0]"}`

With these changes, we are able to consistently execute the entire benchmark successfully with an error rate of 0%

### Related Issues
Resolves #2262 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
