### PR TITLE
fix broken build flag, move build to one directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixing it to retrieve space_type from index setting when both method and top level don't have the value. [#2374](https://github.com/opensearch-project/k-NN/pull/2374)
 * Fixing the bug where setting rescore as false for on_disk knn_vector query is a no-op (#2399)[https://github.com/opensearch-project/k-NN/pull/2399]
 * Fixing bug where mapping accepts both dimension and model-id (#2410)[https://github.com/opensearch-project/k-NN/pull/2410]
-* Add version check for full field name validation (#2477)[https://github.com/opensearch-project/k-NN/pull/2477]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)
@@ -58,5 +57,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade jsonpath from 2.8.0 to 2.9.0[2325](https://github.com/opensearch-project/k-NN/pull/2325)
 * Bump Faiss commit from 1f42e81 to 0cbc2a8 to accelerate hamming distance calculation using _mm512_popcnt_epi64  intrinsic and also add avx512-fp16 instructions to boost performance [#2381](https://github.com/opensearch-project/k-NN/pull/2381)
 * Enabled indices.breaker.total.use_real_memory setting via build.gradle for integTest Cluster to catch heap CB in local ITs and github CI actions [#2395](https://github.com/opensearch-project/k-NN/pull/2395/) 
-* Fixing Lucene912Codec Issue with BWC for Lucene 10.0.1 upgrade[#2429](https://github.com/opensearch-project/k-NN/pull/2429)
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,7 @@ task cmakeJniLib(type:Exec) {
     workingDir 'jni'
     def args = []
     args.add("cmake")
-    args.add(".")
+    args.add("-B build")
     args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
     args.add("-DAVX2_ENABLED=${avx2_enabled}")
     args.add("-DAVX512_ENABLED=${avx512_enabled}")

--- a/build.gradle
+++ b/build.gradle
@@ -329,48 +329,6 @@ task windowsPatches(type:Exec) {
     commandLine 'cmd', '/c', "Powershell -File $rootDir\\scripts\\windowsScript.ps1"
 }
 
-tasks.register('checkCmakePath', Exec) {
-    def outputStream = new ByteArrayOutputStream()
-    def findCmakePathArgs = []
-    findCmakePathArgs.add("which")
-    findCmakePathArgs.add("cmake")
-    commandLine findCmakePathArgs
-    standardOutput = outputStream
-    doLast {
-        def cmakePath = outputStream.toString().trim()
-        println "CMake path: ${cmakePath}"
-        // Ensure cmakePath is treated as a String. If parsing to an int is required,
-        // handle it explicitly, though a path typically should not be parsed as an int.
-        if (cmakePath.isEmpty()) {
-            throw new GradleException("CMake not found in PATH. Please install CMake.")
-        }
-        workingDir 'jni'
-        def args = []
-        args.add("cmake")
-        args.add("-B build")
-        args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
-        args.add("-DAVX2_ENABLED=${avx2_enabled}")
-        args.add("-DAVX512_ENABLED=${avx512_enabled}")
-        args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
-        args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
-        args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
-        def javaHome = Jvm.current().getJavaHome()
-        logger.lifecycle("Java home directory used by gradle: $javaHome")
-        if (Os.isFamily(Os.FAMILY_MAC)) {
-            environment('JAVA_HOME', javaHome)
-        }
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            dependsOn windowsPatches
-            args.add("-G")
-            args.add("Unix Makefiles")
-            args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
-            args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
-        }
-
-        commandLine args
-    }
-}
-
 tasks.register('cmakeJniLib', Exec) {
     def outputStream = new ByteArrayOutputStream()
     def findCmakePathArgs = []
@@ -388,7 +346,7 @@ tasks.register('cmakeJniLib', Exec) {
         }
         workingDir 'jni'
         def args = []
-        args.add("cmake")
+        args.add(cmakePath)
         args.add("-B build")
         args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
         args.add("-DAVX2_ENABLED=${avx2_enabled}")
@@ -415,8 +373,25 @@ tasks.register('cmakeJniLib', Exec) {
 
 task buildJniLib(type:Exec) {
     dependsOn cmakeJniLib
-    workingDir 'jni/build'
-    commandLine 'make', 'opensearchknn_nmslib', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
+    def outputStream = new ByteArrayOutputStream()
+    def findMakePathArgs = []
+    findMakePathArgs.add("which")
+    findMakePathArgs.add("make")
+    commandLine findMakePathArgs
+    standardOutput = outputStream
+    doLast {
+        def makePath = outputStream.toString().trim()
+        println "Make path: ${makePath}"
+        // Ensure makePath is treated as a String. If parsing to an int is required,
+        // handle it explicitly, though a path typically should not be parsed as an int.
+        if (makePath.isEmpty()) {
+            throw new GradleException("Make not found in PATH. Please install Make.")
+        }
+
+        workingDir 'jni/build'
+        commandLine makePath, 'opensearchknn_nmslib', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
+    }
+
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ task cmakeJniLib(type:Exec) {
 
 task buildJniLib(type:Exec) {
     dependsOn cmakeJniLib
-    workingDir 'jni'
+    workingDir 'jni/build'
     commandLine 'make', 'opensearchknn_nmslib', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -329,69 +329,95 @@ task windowsPatches(type:Exec) {
     commandLine 'cmd', '/c', "Powershell -File $rootDir\\scripts\\windowsScript.ps1"
 }
 
-tasks.register('cmakeJniLib', Exec) {
-    def outputStream = new ByteArrayOutputStream()
-    def findCmakePathArgs = []
-    findCmakePathArgs.add("which")
-    findCmakePathArgs.add("cmake")
-    commandLine findCmakePathArgs
-    standardOutput = outputStream
-    doLast {
-        def cmakePath = outputStream.toString().trim()
-        println "CMake path: ${cmakePath}"
-        // Ensure cmakePath is treated as a String. If parsing to an int is required,
-        // handle it explicitly, though a path typically should not be parsed as an int.
-        if (cmakePath.isEmpty()) {
-            throw new GradleException("CMake not found in PATH. Please install CMake.")
-        }
-        workingDir 'jni'
-        def args = []
-        args.add(cmakePath)
-        args.add("-B build")
-        args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
-        args.add("-DAVX2_ENABLED=${avx2_enabled}")
-        args.add("-DAVX512_ENABLED=${avx512_enabled}")
-        args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
-        args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
-        args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
-        def javaHome = Jvm.current().getJavaHome()
-        logger.lifecycle("Java home directory used by gradle: $javaHome")
-        if (Os.isFamily(Os.FAMILY_MAC)) {
-            environment('JAVA_HOME', javaHome)
-        }
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            dependsOn windowsPatches
-            args.add("-G")
-            args.add("Unix Makefiles")
-            args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
-            args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
-        }
+def findExecutable(String executableName, List<String> additionalPaths = []) {
+    // Print the task's environment before setting it
+    // Print PATH specifically
+    logger.lifecycle("\nSystem PATH:")
+    logger.lifecycle(System.getenv("PATH"))
 
-        commandLine args
+    def commonBasePaths = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin"
+    ]
+
+    // Start with just the executable name (will use system PATH)
+    def execPath = executableName
+
+    if (Os.isFamily(Os.FAMILY_MAC)) {
+        def searchPaths = []
+        // Add common paths
+        commonBasePaths.each { basePath ->
+            searchPaths.add("${basePath}/${executableName}")
+        }
+        // Add any additional specific paths
+        searchPaths.addAll(additionalPaths)
+
+        for (path in searchPaths) {
+            if (new File(path).exists()) {
+                logger.lifecycle("Found ${executableName} at: ${path}")
+                execPath = path
+                break
+            }
+        }
     }
+
+    return execPath
+}
+
+tasks.register('cmakeJniLib', Exec) {
+    def cmakePath = findExecutable("cmake")
+    logger.lifecycle("Using cmake at: ${cmakePath}")
+    // Inherit the current environment
+    environment System.getenv()
+
+    def args = []
+    args.add(cmakePath)
+    args.add("-S jni")
+    args.add("-B jni/build")
+    args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
+    args.add("-DAVX2_ENABLED=${avx2_enabled}")
+    args.add("-DAVX512_ENABLED=${avx512_enabled}")
+    args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
+    args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
+    args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
+    def javaHome = Jvm.current().getJavaHome()
+    logger.lifecycle("Java home directory used by gradle: $javaHome")
+    if (Os.isFamily(Os.FAMILY_MAC)) {
+        environment('JAVA_HOME', javaHome)
+    }
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        dependsOn windowsPatches
+        args.add("-G")
+        args.add("Unix Makefiles")
+        args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
+        args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
+    }
+
+    // Print the task's environment after setting it
+    logger.lifecycle("\nTask Environment PATH:")
+    logger.lifecycle(environment.get('PATH'))
+
+    // Print the command that will be executed
+    logger.lifecycle("CMake command: ${args.join(' ')}")
+    def outputStream = new ByteArrayOutputStream()
+    commandLine args
+    standardOutput = outputStream
 }
 
 task buildJniLib(type:Exec) {
     dependsOn cmakeJniLib
-    def outputStream = new ByteArrayOutputStream()
-    def findMakePathArgs = []
-    findMakePathArgs.add("which")
-    findMakePathArgs.add("make")
-    commandLine findMakePathArgs
-    standardOutput = outputStream
-    doLast {
-        def makePath = outputStream.toString().trim()
-        println "Make path: ${makePath}"
-        // Ensure makePath is treated as a String. If parsing to an int is required,
-        // handle it explicitly, though a path typically should not be parsed as an int.
-        if (makePath.isEmpty()) {
-            throw new GradleException("Make not found in PATH. Please install Make.")
-        }
-
-        workingDir 'jni/build'
-        commandLine makePath, 'opensearchknn_nmslib', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
+    def makePath = findExecutable("make")
+    logger.lifecycle("Using make at: ${makePath}")
+    println "Make path: ${makePath}"
+    // Ensure makePath is treated as a String. If parsing to an int is required,
+    // handle it explicitly, though a path typically should not be parsed as an int.
+    if (makePath.isEmpty()) {
+        throw new GradleException("Make not found in PATH. Please install Make.")
     }
-
+    def outputStream = new ByteArrayOutputStream()
+    commandLine makePath, '-Cjni/build','opensearchknn_nmslib', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
+    standardOutput = outputStream
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -329,31 +329,88 @@ task windowsPatches(type:Exec) {
     commandLine 'cmd', '/c', "Powershell -File $rootDir\\scripts\\windowsScript.ps1"
 }
 
-task cmakeJniLib(type:Exec) {
-    workingDir 'jni'
-    def args = []
-    args.add("cmake")
-    args.add("-B build")
-    args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
-    args.add("-DAVX2_ENABLED=${avx2_enabled}")
-    args.add("-DAVX512_ENABLED=${avx512_enabled}")
-    args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
-    args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
-    args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
-    def javaHome = Jvm.current().getJavaHome()
-    logger.lifecycle("Java home directory used by gradle: $javaHome")
-    if (Os.isFamily(Os.FAMILY_MAC)) {
-        environment('JAVA_HOME',javaHome)
-    }
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        dependsOn windowsPatches
-        args.add("-G")
-        args.add("Unix Makefiles")
-        args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
-        args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
-    }
+tasks.register('checkCmakePath', Exec) {
+    def outputStream = new ByteArrayOutputStream()
+    def findCmakePathArgs = []
+    findCmakePathArgs.add("which")
+    findCmakePathArgs.add("cmake")
+    commandLine findCmakePathArgs
+    standardOutput = outputStream
+    doLast {
+        def cmakePath = outputStream.toString().trim()
+        println "CMake path: ${cmakePath}"
+        // Ensure cmakePath is treated as a String. If parsing to an int is required,
+        // handle it explicitly, though a path typically should not be parsed as an int.
+        if (cmakePath.isEmpty()) {
+            throw new GradleException("CMake not found in PATH. Please install CMake.")
+        }
+        workingDir 'jni'
+        def args = []
+        args.add("cmake")
+        args.add("-B build")
+        args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
+        args.add("-DAVX2_ENABLED=${avx2_enabled}")
+        args.add("-DAVX512_ENABLED=${avx512_enabled}")
+        args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
+        args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
+        args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
+        def javaHome = Jvm.current().getJavaHome()
+        logger.lifecycle("Java home directory used by gradle: $javaHome")
+        if (Os.isFamily(Os.FAMILY_MAC)) {
+            environment('JAVA_HOME', javaHome)
+        }
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            dependsOn windowsPatches
+            args.add("-G")
+            args.add("Unix Makefiles")
+            args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
+            args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
+        }
 
-    commandLine args
+        commandLine args
+    }
+}
+
+tasks.register('cmakeJniLib', Exec) {
+    def outputStream = new ByteArrayOutputStream()
+    def findCmakePathArgs = []
+    findCmakePathArgs.add("which")
+    findCmakePathArgs.add("cmake")
+    commandLine findCmakePathArgs
+    standardOutput = outputStream
+    doLast {
+        def cmakePath = outputStream.toString().trim()
+        println "CMake path: ${cmakePath}"
+        // Ensure cmakePath is treated as a String. If parsing to an int is required,
+        // handle it explicitly, though a path typically should not be parsed as an int.
+        if (cmakePath.isEmpty()) {
+            throw new GradleException("CMake not found in PATH. Please install CMake.")
+        }
+        workingDir 'jni'
+        def args = []
+        args.add("cmake")
+        args.add("-B build")
+        args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
+        args.add("-DAVX2_ENABLED=${avx2_enabled}")
+        args.add("-DAVX512_ENABLED=${avx512_enabled}")
+        args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
+        args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
+        args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
+        def javaHome = Jvm.current().getJavaHome()
+        logger.lifecycle("Java home directory used by gradle: $javaHome")
+        if (Os.isFamily(Os.FAMILY_MAC)) {
+            environment('JAVA_HOME', javaHome)
+        }
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            dependsOn windowsPatches
+            args.add("-G")
+            args.add("Unix Makefiles")
+            args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
+            args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
+        }
+
+        commandLine args
+    }
 }
 
 task buildJniLib(type:Exec) {

--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -111,10 +111,10 @@ endif()
 if(NOT DEFINED AVX512_SPR_ENABLED)
     # Check if the system is Intel(R) Sapphire Rapids or a newer-generation processor
     execute_process(COMMAND bash -c "lscpu | grep -q 'GenuineIntel' && lscpu | grep -i 'avx512_fp16' | grep -i 'avx512_bf16' | grep -i 'avx512_vpopcntdq'" OUTPUT_VARIABLE SPR_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if (AND NOT "${SPR_FLAGS}" STREQUAL "")
-	set(AVX512_SPR_ENABLED true)
+    if (NOT "${SPR_FLAGS}" STREQUAL "")
+	      set(AVX512_SPR_ENABLED true)
     else()
-	set(AVX512_SPR_ENABLED false)
+	      set(AVX512_SPR_ENABLED false)
     endif()
 endif()
 

--- a/src/main/java/org/opensearch/knn/index/KNNCircuitBreaker.java
+++ b/src/main/java/org/opensearch/knn/index/KNNCircuitBreaker.java
@@ -13,7 +13,7 @@ import org.opensearch.knn.plugin.transport.KNNStatsRequest;
 import org.opensearch.knn.plugin.transport.KNNStatsResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.threadpool.ThreadPool;

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Booleans;

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -36,7 +36,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.health.ClusterIndexHealth;
 import org.opensearch.cluster.metadata.IndexMetadata;

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -49,7 +49,7 @@ import org.opensearch.knn.plugin.transport.ClearCacheTransportAction;
 import com.google.common.collect.ImmutableList;
 
 import org.opensearch.action.ActionRequest;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestClearCacheHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestClearCacheHandler.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.plugin.rest;
 import com.google.common.collect.ImmutableList;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.common.Strings;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestDeleteModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestDeleteModelHandler.java
@@ -12,7 +12,7 @@
 package org.opensearch.knn.plugin.rest;
 
 import com.google.common.collect.ImmutableList;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.core.common.Strings;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.DeleteModelAction;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestGetModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestGetModelHandler.java
@@ -13,7 +13,7 @@ package org.opensearch.knn.plugin.rest;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.StringUtils;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.GetModelAction;
 import org.opensearch.knn.plugin.transport.GetModelRequest;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestKNNStatsHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestKNNStatsHandler.java
@@ -11,7 +11,7 @@ import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.KNNStatsAction;
 import org.opensearch.knn.plugin.transport.KNNStatsRequest;
 import com.google.common.collect.ImmutableList;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.action.RestActions;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestKNNWarmupHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestKNNWarmupHandler.java
@@ -13,7 +13,7 @@ import org.opensearch.knn.plugin.transport.KNNWarmupRequest;
 import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestSearchModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestSearchModelHandler.java
@@ -13,7 +13,7 @@ package org.opensearch.knn.plugin.rest;
 
 import com.google.common.collect.ImmutableList;
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.transport.SearchModelAction;
 import org.opensearch.rest.BaseRestHandler;

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -12,7 +12,7 @@
 package org.opensearch.knn.plugin.rest;
 
 import com.google.common.collect.ImmutableList;
-import org.opensearch.client.node.NodeClient;
+import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.knn.common.KNNConstants;

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportAction.java
@@ -17,7 +17,7 @@ import org.opensearch.action.ActionListenerResponseHandler;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ValidationException;

--- a/src/main/java/org/opensearch/knn/training/VectorReader.java
+++ b/src/main/java/org/opensearch/knn/training/VectorReader.java
@@ -17,7 +17,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequestBuilder;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.ValidationException;

--- a/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/TrainingJobRouterTransportActionTests.java
@@ -16,7 +16,7 @@ import org.apache.lucene.search.TotalHits;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
@@ -9,7 +9,7 @@ import com.google.common.collect.ImmutableSet;
 import lombok.SneakyThrows;
 import org.junit.After;
 import org.junit.Before;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;


### PR DESCRIPTION
### Description
Addresses a bug and house cleaning during build.
1. Cmake has invalid syntax in if condition causing this message:
```
CMake Error at cmake/init-faiss.cmake:114 (if):
  if given arguments:

    "AND" "NOT" "" "STREQUAL" ""

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:107 (include)
```
2. Move all build artifacts created into a build directory following conventional build standards. Currently there are multiple temporary artifacts generated by cmake which are scattered under `jni` directory.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ x] New functionality includes testing.
- [x ] New functionality has been documented.
- [x ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ x] Commits are signed per the DCO using `--signoff`.
- [ x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
