### PR TITLE
Add UnmodifiableOnRestore property to index.knn setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix filter rewrite logic which was resulting in getting inconsistent / incorrect results for cases where filter was getting rewritten for shards (#2359)[https://github.com/opensearch-project/k-NN/pull/2359]
 * Fixing it to retrieve space_type from index setting when both method and top level don't have the value. [#2374](https://github.com/opensearch-project/k-NN/pull/2374)
 * Fixing the bug where setting rescore as false for on_disk knn_vector query is a no-op (#2399)[https://github.com/opensearch-project/k-NN/pull/2399]
+* Fixing the bug to prevent index.knn setting from being modified or removed on restore snapshot (#2445)[https://github.com/opensearch-project/k-NN/pull/2445]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -44,6 +44,7 @@ import static org.opensearch.common.settings.Setting.Property.Dynamic;
 import static org.opensearch.common.settings.Setting.Property.IndexScope;
 import static org.opensearch.common.settings.Setting.Property.NodeScope;
 import static org.opensearch.common.settings.Setting.Property.Final;
+import static org.opensearch.common.settings.Setting.Property.UnmodifiableOnRestore;
 import static org.opensearch.common.unit.MemorySizeValue.parseBytesSizeValueOrHeapRatio;
 import static org.opensearch.core.common.unit.ByteSizeValue.parseBytesSizeValue;
 import static org.opensearch.knn.common.featureflags.KNNFeatureFlags.getFeatureFlags;
@@ -269,7 +270,13 @@ public class KNNSettings {
     /**
      * This setting identifies KNN index.
      */
-    public static final Setting<Boolean> IS_KNN_INDEX_SETTING = Setting.boolSetting(KNN_INDEX, false, IndexScope, Final);
+    public static final Setting<Boolean> IS_KNN_INDEX_SETTING = Setting.boolSetting(
+        KNN_INDEX,
+        false,
+        IndexScope,
+        Final,
+        UnmodifiableOnRestore
+    );
 
     /**
      * index_thread_quantity - the parameter specifies how many threads the nms library should use to create the graph.

--- a/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
+++ b/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
@@ -8,57 +8,52 @@ package org.opensearch.knn.index;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
-import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.test.rest.OpenSearchRestTestCase;
-
-import java.util.List;
-import java.util.Map;
-
+import org.opensearch.knn.KNNRestTestCase;
+import org.junit.Before;
+import org.junit.Test;
+import lombok.SneakyThrows;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.hasSize;
 
-public class RestoreSnapshotIT extends OpenSearchRestTestCase {
+public class RestoreSnapshotIT extends KNNRestTestCase {
 
-    private String index;
-    private String snapshot;
-    private String repository;
+    private String index = "test-index";;
+    private String snapshot = "snapshot-" + index;
+    private String repository = "repo";
 
-    private void setupSnapshotRestore() throws Exception {
-        Request clusterSettingsRequest = new Request("GET", "/_cluster/settings");
-        clusterSettingsRequest.addParameter("include_defaults", "true");
-        Response clusterSettingsResponse = client().performRequest(clusterSettingsRequest);
-        Map<String, Object> clusterSettings = entityAsMap(clusterSettingsResponse);
-
-        @SuppressWarnings("unchecked")
-        List<String> pathRepos = (List<String>) XContentMapValues.extractValue("defaults.path.repo", clusterSettings);
-        assertThat(pathRepos, notNullValue());
-        assertThat(pathRepos, hasSize(1));
-
-        final String pathRepo = pathRepos.get(0);
-
-        index = "test-index";
-        snapshot = "snapshot-" + index;
-        repository = "repo";
-
-        // create index
-        Settings indexSettings = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 1).put("index.knn", true).build();
-        createIndex(index, indexSettings);
-
-        // create repo
-        Settings repoSettings = Settings.builder().put("compress", randomBoolean()).put("location", pathRepo).build();
-        registerRepository(repository, "fs", true, repoSettings);
-
-        // create snapshot
-        createSnapshot(repository, snapshot, true);
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        setupSnapshotRestore(index, snapshot, repository);
     }
 
-    public void testKnnSettingIsUnmodifiableOnRestore() throws Exception {
-        setupSnapshotRestore();
+    @Test
+    @SneakyThrows
+    public void testKnnSettingIsModifiable_whenRestore_thenSuccess() {
+        // valid restore
+        XContentBuilder restoreCommand = JsonXContent.contentBuilder().startObject();
+        restoreCommand.field("indices", index);
+        restoreCommand.field("rename_pattern", index);
+        restoreCommand.field("rename_replacement", "restored-" + index);
+        restoreCommand.startObject("index_settings");
+        {
+            restoreCommand.field("knn.model.index.number_of_shards", 1);
+        }
+        restoreCommand.endObject();
+        restoreCommand.endObject();
+        Request restoreRequest = new Request("POST", "/_snapshot/" + repository + "/" + snapshot + "/_restore");
+        restoreRequest.addParameter("wait_for_completion", "true");
+        restoreRequest.setJsonEntity(restoreCommand.toString());
 
+        final Response restoreResponse = client().performRequest(restoreRequest);
+        assertEquals(200, restoreResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testKnnSettingIsUnmodifiable_whenRestore_thenFailure() {
         // invalid restore
         XContentBuilder restoreCommand = JsonXContent.contentBuilder().startObject();
         restoreCommand.field("indices", index);
@@ -77,9 +72,26 @@ public class RestoreSnapshotIT extends OpenSearchRestTestCase {
         assertThat(error.getMessage(), containsString("cannot modify UnmodifiableOnRestore setting [index.knn]" + " on restore"));
     }
 
-    public void testKnnSettingCannotBeIgnoredDuringRestore() throws Exception {
-        setupSnapshotRestore();
+    @Test
+    @SneakyThrows
+    public void testKnnSettingCanBeIgnored_whenRestore_thenSuccess() {
+        // valid restore
+        XContentBuilder restoreCommand = JsonXContent.contentBuilder().startObject();
+        restoreCommand.field("indices", index);
+        restoreCommand.field("rename_pattern", index);
+        restoreCommand.field("rename_replacement", "restored-" + index);
+        restoreCommand.field("ignore_index_settings", "knn.model.index.number_of_shards");
+        restoreCommand.endObject();
+        Request restoreRequest = new Request("POST", "/_snapshot/" + repository + "/" + snapshot + "/_restore");
+        restoreRequest.addParameter("wait_for_completion", "true");
+        restoreRequest.setJsonEntity(restoreCommand.toString());
+        final Response restoreResponse = client().performRequest(restoreRequest);
+        assertEquals(200, restoreResponse.getStatusLine().getStatusCode());
+    }
 
+    @Test
+    @SneakyThrows
+    public void testKnnSettingCannotBeIgnored_whenRestore_thenFailure() {
         // invalid restore
         XContentBuilder restoreCommand = JsonXContent.contentBuilder().startObject();
         restoreCommand.field("indices", index);

--- a/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
+++ b/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
@@ -56,7 +56,7 @@ public class RestoreSnapshotIT extends OpenSearchRestTestCase {
         createSnapshot(repository, snapshot, true);
     }
 
-    public void testUnmodifiableOnRestoreSettingModifiedOnRestore() throws Exception {
+    public void testKnnSettingIsUnmodifiableOnRestore() throws Exception {
         setupSnapshotRestore();
 
         // invalid restore
@@ -77,7 +77,7 @@ public class RestoreSnapshotIT extends OpenSearchRestTestCase {
         assertThat(error.getMessage(), containsString("cannot modify UnmodifiableOnRestore setting [index.knn]" + " on restore"));
     }
 
-    public void testUnmodifiableOnRestoreSettingIgnoredOnRestore() throws Exception {
+    public void testKnnSettingCannotBeIgnoredDuringRestore() throws Exception {
         setupSnapshotRestore();
 
         // invalid restore

--- a/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
+++ b/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+
+public class RestoreSnapshotIT extends OpenSearchRestTestCase {
+
+    private String index;
+    private String snapshot;
+
+    public void setupSnapshotRestore() throws Exception {
+        Request clusterSettingsRequest = new Request("GET", "/_cluster/settings");
+        clusterSettingsRequest.addParameter("include_defaults", "true");
+        Response clusterSettingsResponse = client().performRequest(clusterSettingsRequest);
+        Map<String, Object> clusterSettings = entityAsMap(clusterSettingsResponse);
+
+        @SuppressWarnings("unchecked")
+        List<String> pathRepos = (List<String>) XContentMapValues.extractValue("defaults.path.repo", clusterSettings);
+        assertThat(pathRepos, notNullValue());
+        assertThat(pathRepos, hasSize(1));
+
+        final String pathRepo = pathRepos.get(0);
+
+        index = "test-index";
+        snapshot = "snapshot-" + index;
+
+        // create index
+        XContentBuilder settings = jsonBuilder();
+        settings.startObject();
+        {
+            settings.startObject("settings");
+            settings.field(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
+            settings.field(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1);
+            settings.field(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true);
+            settings.endObject();
+        }
+        settings.endObject();
+
+        Request createIndex = new Request("PUT", "/" + index);
+        createIndex.setJsonEntity(settings.toString());
+        createIndex.setOptions(allowTypesRemovalWarnings());
+        client().performRequest(createIndex);
+
+        // create repo
+        XContentBuilder repoConfig = JsonXContent.contentBuilder().startObject();
+        {
+            repoConfig.field("type", "fs");
+            repoConfig.startObject("settings");
+            {
+                repoConfig.field("compress", randomBoolean());
+                repoConfig.field("location", pathRepo);
+            }
+            repoConfig.endObject();
+        }
+        repoConfig.endObject();
+        Request createRepoRequest = new Request("PUT", "/_snapshot/repo");
+        createRepoRequest.setJsonEntity(repoConfig.toString());
+        client().performRequest(createRepoRequest);
+
+        // create snapshot
+        Request createSnapshot = new Request("PUT", "/_snapshot/repo/" + snapshot);
+        createSnapshot.addParameter("wait_for_completion", "true");
+        createSnapshot.setJsonEntity("{\"indices\": \"" + index + "\"}");
+        client().performRequest(createSnapshot);
+    }
+
+    public void testUnmodifiableOnRestoreSettingModifiedOnRestore() throws Exception {
+        setupSnapshotRestore();
+
+        // invalid restore
+        XContentBuilder restoreCommand = JsonXContent.contentBuilder().startObject();
+        restoreCommand.field("indices", index);
+        restoreCommand.field("rename_pattern", index);
+        restoreCommand.field("rename_replacement", "restored-" + index);
+        restoreCommand.startObject("index_settings");
+        {
+            restoreCommand.field("index.knn", false);
+        }
+        restoreCommand.endObject();
+        restoreCommand.endObject();
+        Request restoreRequest = new Request("POST", "/_snapshot/repo/" + snapshot + "/_restore");
+        restoreRequest.addParameter("wait_for_completion", "true");
+        restoreRequest.setJsonEntity(restoreCommand.toString());
+        final ResponseException error = expectThrows(ResponseException.class, () -> client().performRequest(restoreRequest));
+        assertThat(error.getMessage(), containsString("cannot modify UnmodifiableOnRestore setting [index.knn]" + " on restore"));
+    }
+
+    public void testUnmodifiableOnRestoreSettingIgnoredOnRestore() throws Exception {
+        setupSnapshotRestore();
+
+        // invalid restore
+        XContentBuilder restoreCommand = JsonXContent.contentBuilder().startObject();
+        restoreCommand.field("indices", index);
+        restoreCommand.field("rename_pattern", index);
+        restoreCommand.field("rename_replacement", "restored-" + index);
+        restoreCommand.field("ignore_index_settings", "index.knn");
+        restoreCommand.endObject();
+        Request restoreRequest = new Request("POST", "/_snapshot/repo/" + snapshot + "/_restore");
+        restoreRequest.addParameter("wait_for_completion", "true");
+        restoreRequest.setJsonEntity(restoreCommand.toString());
+        final ResponseException error = expectThrows(ResponseException.class, () -> client().performRequest(restoreRequest));
+        assertThat(error.getMessage(), containsString("cannot remove UnmodifiableOnRestore setting [index.knn] on restore"));
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.opensearch.Version;
+import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -73,6 +74,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
@@ -1979,5 +1982,30 @@ public class KNNRestTestCase extends ODFERestTestCase {
      */
     protected static String randomLowerCaseString() {
         return randomAlphaOfLengthBetween(MIN_CODE_UNITS, MAX_CODE_UNITS).toLowerCase(Locale.ROOT);
+    }
+
+    @SneakyThrows
+    protected void setupSnapshotRestore(String index, String snapshot, String repository) {
+        Request clusterSettingsRequest = new Request("GET", "/_cluster/settings");
+        clusterSettingsRequest.addParameter("include_defaults", "true");
+        Response clusterSettingsResponse = client().performRequest(clusterSettingsRequest);
+        Map<String, Object> clusterSettings = entityAsMap(clusterSettingsResponse);
+
+        @SuppressWarnings("unchecked")
+        List<String> pathRepos = (List<String>) XContentMapValues.extractValue("defaults.path.repo", clusterSettings);
+        assertThat(pathRepos, notNullValue());
+        assertThat(pathRepos, hasSize(1));
+
+        final String pathRepo = pathRepos.get(0);
+
+        // create index
+        createIndex(index, getDefaultIndexSettings());
+
+        // create repo
+        Settings repoSettings = Settings.builder().put("compress", randomBoolean()).put("location", pathRepo).build();
+        registerRepository(repository, "fs", true, repoSettings);
+
+        // create snapshot
+        createSnapshot(repository, snapshot, true);
     }
 }


### PR DESCRIPTION
### Description
This PR builds on another [PR](https://github.com/opensearch-project/OpenSearch/pull/16957). In the other PR we added a new Setting property `UnmodifiableOnRestore` to prevent settings from being modified on restore. So in this PR we're adding that new `UnmodifiableOnRestore` property to the `index.knn` setting to prevent it from being modified or removed on restore snapshot.

### Related Issues
Resolves Issue #2334 
Also resolves Issue 17019 in Core Opensearch repository https://github.com/opensearch-project/OpenSearch/issues/17019

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
