### PR TITLE
Bug fix that fixes AVX512SPR build 

### DIFF
--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -111,7 +111,7 @@ endif()
 if(NOT DEFINED AVX512_SPR_ENABLED)
     # Check if the system is Intel(R) Sapphire Rapids or a newer-generation processor
     execute_process(COMMAND bash -c "lscpu | grep -q 'GenuineIntel' && lscpu | grep -i 'avx512_fp16' | grep -i 'avx512_bf16' | grep -i 'avx512_vpopcntdq'" OUTPUT_VARIABLE SPR_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if (AND NOT "${SPR_FLAGS}" STREQUAL "")
+    if (NOT "${SPR_FLAGS}" STREQUAL "")
 	set(AVX512_SPR_ENABLED true)
     else()
 	set(AVX512_SPR_ENABLED false)


### PR DESCRIPTION
Remove an AND from avx512spr check, which causes the k-nn build to fail when running on an Intel Sapphire Rapids machine.

### Description
[Describe what this change achieves]
Fix a bug that was failing AVX512SPR builds. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
