### PR TITLE
Binary hamming fix 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make the build work for M series MacOS without manual code changes and local JAVA_HOME config (#2397)[https://github.com/opensearch-project/k-NN/pull/2397]
 - Remove DocsWithFieldSet reference from NativeEngineFieldVectorsWriter (#2408)[https://github.com/opensearch-project/k-NN/pull/2408]
 - Remove skip building graph check for quantization use case (#2430)[https://github.com/opensearch-project/k-NN/2430]
+- Removing redundant type conversions for script scoring for hamming space with binary vectors (#2351)[https://github.com/opensearch-project/k-NN/pull/2351]
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]
 * Fixing the bug where search fails with "fields" parameter for an index with a knn_vector field (#2314)[https://github.com/opensearch-project/k-NN/pull/2314]

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
@@ -39,7 +39,7 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
     }
 
     @Override
-    public ScriptDocValues<float[]> getScriptValues() {
+    public ScriptDocValues<?> getScriptValues() {
         try {
             FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, fieldName);
             if (fieldInfo == null) {

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -60,6 +60,28 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
         }
     }
 
+    public byte[] getByteValue() {
+        if (!docExists) {
+            String errorMessage = String.format(
+                "One of the document doesn't have a value for field '%s'. "
+                    + "This can be avoided by checking if a document has a value for the field or not "
+                    + "by doc['%s'].size() == 0 ? 0 : {your script}",
+                fieldName,
+                fieldName
+            );
+            throw new IllegalStateException(errorMessage);
+        }
+        try {
+            return doGetByteValue();
+        } catch (IOException e) {
+            throw ExceptionsHelper.convertToOpenSearchException(e);
+        }
+    }
+
+    protected byte[] doGetByteValue() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
     protected abstract float[] doGetValue() throws IOException;
 
     @Override
@@ -111,6 +133,15 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
             }
             return value;
         }
+
+        @Override
+        public byte[] doGetByteValue() {
+            try {
+                return values.vectorValue();
+            } catch (IOException e) {
+                throw ExceptionsHelper.convertToOpenSearchException(e);
+            }
+        }
     }
 
     private static final class KNNFloatVectorScriptDocValues extends KNNVectorScriptDocValues {
@@ -138,6 +169,15 @@ public abstract class KNNVectorScriptDocValues extends ScriptDocValues<float[]> 
         @Override
         protected float[] doGetValue() throws IOException {
             return getVectorDataType().getVectorFromBytesRef(values.binaryValue());
+        }
+
+        @Override
+        public byte[] doGetByteValue() {
+            try {
+                return values.binaryValue().bytes;
+            } catch (IOException e) {
+                throw ExceptionsHelper.convertToOpenSearchException(e);
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/VectorDataType.java
+++ b/src/main/java/org/opensearch/knn/index/VectorDataType.java
@@ -46,15 +46,8 @@ public enum VectorDataType {
         }
 
         @Override
-        public float[] getVectorFromBytesRef(BytesRef binaryValue) {
-            float[] vector = new float[binaryValue.length];
-            int i = 0;
-            int j = binaryValue.offset;
-
-            while (i < binaryValue.length) {
-                vector[i++] = binaryValue.bytes[j++];
-            }
-            return vector;
+        public byte[] getVectorFromBytesRef(BytesRef binaryValue) {
+            return binaryValue.bytes;
         }
 
         @Override
@@ -75,15 +68,8 @@ public enum VectorDataType {
         }
 
         @Override
-        public float[] getVectorFromBytesRef(BytesRef binaryValue) {
-            float[] vector = new float[binaryValue.length];
-            int i = 0;
-            int j = binaryValue.offset;
-
-            while (i < binaryValue.length) {
-                vector[i++] = binaryValue.bytes[j++];
-            }
-            return vector;
+        public byte[] getVectorFromBytesRef(BytesRef binaryValue) {
+            return binaryValue.bytes;
         }
 
         @Override
@@ -143,7 +129,7 @@ public enum VectorDataType {
      * @param binaryValue Binary Value
      * @return float vector deserialized from binary value
      */
-    public abstract float[] getVectorFromBytesRef(BytesRef binaryValue);
+    public abstract <T> T getVectorFromBytesRef(BytesRef binaryValue);
 
     /**
      * @param trainingDataAllocation training data that has been allocated in native memory

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
@@ -144,4 +144,39 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
             return this.scoringMethod.apply(this.queryValue, scriptDocValues.getValue());
         }
     }
+
+    /**
+     * KNNVectors with byte[] type. The query value passed in is expected to be byte[]. The fieldType of the docs
+     * being searched over are expected to be KNNVector type.
+     */
+    public static class KNNByteVectorType extends KNNScoreScript<byte[]> {
+
+        public KNNByteVectorType(
+            Map<String, Object> params,
+            byte[] queryValue,
+            String field,
+            BiFunction<byte[], byte[], Float> scoringMethod,
+            SearchLookup lookup,
+            LeafReaderContext leafContext,
+            IndexSearcher searcher
+        ) throws IOException {
+            super(params, queryValue, field, scoringMethod, lookup, leafContext, searcher);
+        }
+
+        /**
+         * This function called for each doc in the segment. We evaluate the score of the vector in the doc
+         *
+         * @param explanationHolder A helper to take in an explanation from a script and turn
+         *                          it into an {@link org.apache.lucene.search.Explanation}
+         * @return score of the vector to the query vector
+         */
+        @Override
+        public double execute(ScoreScript.ExplanationHolder explanationHolder) {
+            KNNVectorScriptDocValues scriptDocValues = (KNNVectorScriptDocValues) getDoc().get(this.field);
+            if (scriptDocValues.isEmpty()) {
+                return 0.0;
+            }
+            return this.scoringMethod.apply(this.queryValue, scriptDocValues.getByteValue());
+        }
+    }
 }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoreScript.java
@@ -114,9 +114,9 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
      * KNNVectors with float[] type. The query value passed in is expected to be float[]. The fieldType of the docs
      * being searched over are expected to be KNNVector type.
      */
-    public static class KNNVectorType extends KNNScoreScript<float[]> {
+    public static class KNNFloatVectorType extends KNNScoreScript<float[]> {
 
-        public KNNVectorType(
+        public KNNFloatVectorType(
             Map<String, Object> params,
             float[] queryValue,
             String field,
@@ -136,8 +136,9 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
          * @return score of the vector to the query vector
          */
         @Override
+        @SuppressWarnings("unchecked")
         public double execute(ScoreScript.ExplanationHolder explanationHolder) {
-            KNNVectorScriptDocValues scriptDocValues = (KNNVectorScriptDocValues) getDoc().get(this.field);
+            KNNVectorScriptDocValues<float[]> scriptDocValues = (KNNVectorScriptDocValues<float[]>) getDoc().get(this.field);
             if (scriptDocValues.isEmpty()) {
                 return 0.0;
             }
@@ -171,12 +172,13 @@ public abstract class KNNScoreScript<T> extends ScoreScript {
          * @return score of the vector to the query vector
          */
         @Override
+        @SuppressWarnings("unchecked")
         public double execute(ScoreScript.ExplanationHolder explanationHolder) {
-            KNNVectorScriptDocValues scriptDocValues = (KNNVectorScriptDocValues) getDoc().get(this.field);
+            KNNVectorScriptDocValues<byte[]> scriptDocValues = (KNNVectorScriptDocValues<byte[]>) getDoc().get(this.field);
             if (scriptDocValues.isEmpty()) {
                 return 0.0;
             }
-            return this.scoringMethod.apply(this.queryValue, scriptDocValues.getByteValue());
+            return this.scoringMethod.apply(this.queryValue, scriptDocValues.getValue());
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -92,7 +92,7 @@ public interface KNNScoringSpace {
                     ctx,
                     searcher
                 );
-            } else {
+            } else if (processedQuery instanceof byte[]) {
                 return new KNNScoreScript.KNNByteVectorType(
                     params,
                     (byte[]) this.processedQuery,
@@ -101,6 +101,10 @@ public interface KNNScoringSpace {
                     lookup,
                     ctx,
                     searcher
+                );
+            } else {
+                throw new IllegalStateException(
+                    "Unexpected type for processedQuery. Expected float[] or byte[], but got: " + processedQuery.getClass().getName()
                 );
             }
         }
@@ -139,7 +143,7 @@ public interface KNNScoringSpace {
             VectorDataType vectorDataType = knnVectorFieldType.getVectorDataType() == null
                 ? VectorDataType.FLOAT
                 : knnVectorFieldType.getVectorDataType();
-            if (vectorDataType.equals(VectorDataType.FLOAT)) {
+            if (vectorDataType == VectorDataType.FLOAT) {
                 return parseToFloatArray(
                     query,
                     KNNVectorFieldMapperUtil.getExpectedVectorLength(knnVectorFieldType),

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -200,11 +200,11 @@ public interface KNNScoringSpace {
                     // https://github.com/apache/lucene/blob/0494c824e0ac8049b757582f60d085932a890800/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java#L73
                     // for indices that are created on or after 2.19.0
                     //
-                    // OS Score = ( 2 − cosineSimil) / 2
-                    // However cosineSimil = 1 - cos θ, after applying this to above formula,
-                    // OS Score = ( 2 − ( 1 − cos θ ) ) / 2
+                    // OS Score = ( 2 - cosineSimil) / 2
+                    // However cosineSimil = 1 - cos x, after applying this to above formula,
+                    // OS Score = ( 2 - ( 1 - cos x ) ) / 2
                     // which simplifies to
-                    // OS Score = ( 1 + cos θ ) / 2
+                    // OS Score = ( 1 + cos x ) / 2
                     return (float[] q, float[] v) -> Math.max(
                         ((1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude)) / 2.0F),
                         0

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpace.java
@@ -27,16 +27,14 @@ import java.util.function.BiFunction;
 
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.getVectorMagnitudeSquared;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryFieldType;
-import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isBinaryVectorDataType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isKNNVectorFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.isLongFieldType;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToBigInteger;
-import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToByteArray;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToFloatArray;
+import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToByteArray;
 import static org.opensearch.knn.plugin.script.KNNScoringSpaceUtil.parseToLong;
 
 public interface KNNScoringSpace {
-
     /**
      * Return the correct scoring script for a given query. The scoring script
      *
@@ -57,9 +55,9 @@ public interface KNNScoringSpace {
     abstract class KNNFieldSpace implements KNNScoringSpace {
         public static final Set<VectorDataType> DATA_TYPES_DEFAULT = Set.of(VectorDataType.FLOAT, VectorDataType.BYTE);
 
-        private float[] processedQuery;
+        private Object processedQuery;
         @Getter
-        private BiFunction<float[], float[], Float> scoringMethod;
+        private BiFunction<?, ?, Float> scoringMethod;
 
         public KNNFieldSpace(final Object query, final MappedFieldType fieldType, final String spaceName) {
             this(query, fieldType, spaceName, DATA_TYPES_DEFAULT);
@@ -76,6 +74,7 @@ public interface KNNScoringSpace {
             this.scoringMethod = getScoringMethod(this.processedQuery, knnVectorFieldType.getKnnMappingConfig().getIndexCreatedVersion());
         }
 
+        @SuppressWarnings("unchecked")
         public ScoreScript getScoreScript(
             Map<String, Object> params,
             String field,
@@ -83,7 +82,27 @@ public interface KNNScoringSpace {
             LeafReaderContext ctx,
             IndexSearcher searcher
         ) throws IOException {
-            return new KNNScoreScript.KNNVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
+            if (processedQuery instanceof float[]) {
+                return new KNNScoreScript.KNNFloatVectorType(
+                    params,
+                    (float[]) this.processedQuery,
+                    field,
+                    (BiFunction<float[], float[], Float>) this.scoringMethod,
+                    lookup,
+                    ctx,
+                    searcher
+                );
+            } else {
+                return new KNNScoreScript.KNNByteVectorType(
+                    params,
+                    (byte[]) this.processedQuery,
+                    field,
+                    (BiFunction<byte[], byte[], Float>) this.scoringMethod,
+                    lookup,
+                    ctx,
+                    searcher
+                );
+            }
         }
 
         private KNNVectorFieldType toKNNVectorFieldType(
@@ -116,17 +135,27 @@ public interface KNNScoringSpace {
             return knnVectorFieldType;
         }
 
-        protected float[] getProcessedQuery(final Object query, final KNNVectorFieldType knnVectorFieldType) {
-            return parseToFloatArray(
+        protected Object getProcessedQuery(final Object query, final KNNVectorFieldType knnVectorFieldType) {
+            VectorDataType vectorDataType = knnVectorFieldType.getVectorDataType() == null
+                ? VectorDataType.FLOAT
+                : knnVectorFieldType.getVectorDataType();
+            if (vectorDataType.equals(VectorDataType.FLOAT)) {
+                return parseToFloatArray(
+                    query,
+                    KNNVectorFieldMapperUtil.getExpectedVectorLength(knnVectorFieldType),
+                    knnVectorFieldType.getVectorDataType()
+                );
+            }
+            return parseToByteArray(
                 query,
                 KNNVectorFieldMapperUtil.getExpectedVectorLength(knnVectorFieldType),
                 knnVectorFieldType.getVectorDataType()
             );
         }
 
-        protected abstract BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery);
+        public abstract BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery);
 
-        protected BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery, Version indexCreatedVersion) {
+        protected BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery, Version indexCreatedVersion) {
             return getScoringMethod(processedQuery);
         }
 
@@ -138,8 +167,12 @@ public interface KNNScoringSpace {
         }
 
         @Override
-        public BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery) {
-            return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
+        public BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery) {
+            if (processedQuery instanceof float[]) {
+                return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
+            } else {
+                return (byte[] q, byte[] v) -> 1 / (1 + KNNScoringUtil.l2Squared(q, v));
+            }
         }
     }
 
@@ -149,30 +182,35 @@ public interface KNNScoringSpace {
         }
 
         @Override
-        protected BiFunction<float[], float[], Float> getScoringMethod(float[] processedQuery) {
+        public BiFunction<?, ?, Float> getScoringMethod(Object processedQuery) {
             return getScoringMethod(processedQuery, Version.CURRENT);
         }
 
         @Override
-        protected BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery, Version indexCreatedVersion) {
-            SpaceType.COSINESIMIL.validateVector(processedQuery);
-            float qVectorSquaredMagnitude = getVectorMagnitudeSquared(processedQuery);
-            if (indexCreatedVersion.onOrAfter(Version.V_2_19_0)) {
-                // To be consistent, we will be using same formula used by lucene as mentioned below
-                // https://github.com/apache/lucene/blob/0494c824e0ac8049b757582f60d085932a890800/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java#L73
-                // for indices that are created on or after 2.19.0
-                //
-                // OS Score = ( 2 - cosineSimil) / 2
-                // However cosineSimil = 1 - cos x, after applying this to above formula,
-                // OS Score = ( 2 - ( 1 - cos x ) ) / 2
-                // which simplifies to
-                // OS Score = ( 1 + cos x ) / 2
-                return (float[] q, float[] v) -> Math.max(
-                    ((1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude)) / 2.0F),
-                    0
-                );
+        protected BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery, Version indexCreatedVersion) {
+            if (processedQuery instanceof float[]) {
+                SpaceType.COSINESIMIL.validateVector((float[]) processedQuery);
+                float qVectorSquaredMagnitude = getVectorMagnitudeSquared((float[]) processedQuery);
+                if (indexCreatedVersion.onOrAfter(Version.V_2_19_0)) {
+                    // To be consistent, we will be using same formula used by lucene as mentioned below
+                    // https://github.com/apache/lucene/blob/0494c824e0ac8049b757582f60d085932a890800/lucene/core/src/java/org/apache/lucene/index/VectorSimilarityFunction.java#L73
+                    // for indices that are created on or after 2.19.0
+                    //
+                    // OS Score = ( 2 − cosineSimil) / 2
+                    // However cosineSimil = 1 - cos θ, after applying this to above formula,
+                    // OS Score = ( 2 − ( 1 − cos θ ) ) / 2
+                    // which simplifies to
+                    // OS Score = ( 1 + cos θ ) / 2
+                    return (float[] q, float[] v) -> Math.max(
+                        ((1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude)) / 2.0F),
+                        0
+                    );
+                }
+                return (float[] q, float[] v) -> 1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude);
+            } else {
+                SpaceType.COSINESIMIL.validateVector((byte[]) processedQuery);
+                return (byte[] q, byte[] v) -> 1 + KNNScoringUtil.cosinesimil(q, v);
             }
-            return (float[] q, float[] v) -> 1 + KNNScoringUtil.cosinesimilOptimized(q, v, qVectorSquaredMagnitude);
         }
     }
 
@@ -182,8 +220,12 @@ public interface KNNScoringSpace {
         }
 
         @Override
-        protected BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery) {
-            return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
+        public BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery) {
+            if (processedQuery instanceof float[]) {
+                return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
+            } else {
+                return (byte[] q, byte[] v) -> 1 / (1 + KNNScoringUtil.l1Norm(q, v));
+            }
         }
     }
 
@@ -193,8 +235,12 @@ public interface KNNScoringSpace {
         }
 
         @Override
-        protected BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery) {
-            return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
+        public BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery) {
+            if (processedQuery instanceof float[]) {
+                return (float[] q, float[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
+            } else {
+                return (byte[] q, byte[] v) -> 1 / (1 + KNNScoringUtil.lInfNorm(q, v));
+            }
         }
     }
 
@@ -204,51 +250,25 @@ public interface KNNScoringSpace {
         }
 
         @Override
-        protected BiFunction<float[], float[], Float> getScoringMethod(final float[] processedQuery) {
-            return (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));
+        public BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery) {
+            if (processedQuery instanceof float[]) {
+                return (float[] q, float[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));
+            } else {
+                return (byte[] q, byte[] v) -> KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(q, v));
+            }
         }
     }
 
-    class Hamming implements KNNScoringSpace {
-        private byte[] processedQuery;
-        BiFunction<byte[], byte[], Float> scoringMethod;
+    class Hamming extends KNNFieldSpace {
+        private static final Set<VectorDataType> DATA_TYPES_HAMMING = Set.of(VectorDataType.BINARY);
 
         public Hamming(Object query, MappedFieldType fieldType) {
-            if (!isKNNVectorFieldType(fieldType)) {
-                throw new IllegalArgumentException("Incompatible field_type for hamming space. The field type must be knn_vector.");
-            }
-            KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldType) fieldType;
-            if (!isBinaryVectorDataType(knnVectorFieldType)) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        Locale.ROOT,
-                        "Incompatible field_type for hamming space. The data type should be [BINARY] but got %s",
-                        knnVectorFieldType.getVectorDataType()
-                    )
-                );
-            }
-
-            this.processedQuery = parseToByteArray(
-                query,
-                KNNVectorFieldMapperUtil.getExpectedVectorLength(knnVectorFieldType),
-                knnVectorFieldType.getVectorDataType()
-            );
-            this.scoringMethod = getHammingScoringMethod();
-        }
-
-        public BiFunction<byte[], byte[], Float> getHammingScoringMethod() {
-            return (byte[] q, byte[] v) -> 1 / (1 + KNNScoringUtil.calculateHammingBit(q, v));
+            super(query, fieldType, "hamming", DATA_TYPES_HAMMING);
         }
 
         @Override
-        public ScoreScript getScoreScript(
-            Map<String, Object> params,
-            String field,
-            SearchLookup lookup,
-            LeafReaderContext ctx,
-            IndexSearcher searcher
-        ) throws IOException {
-            return new KNNScoreScript.KNNByteVectorType(params, this.processedQuery, field, this.scoringMethod, lookup, ctx, searcher);
+        public BiFunction<?, ?, Float> getScoringMethod(final Object processedQuery) {
+            return (byte[] q, byte[] v) -> 1 / (1 + KNNScoringUtil.calculateHammingBit(q, v));
         }
     }
 

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -155,6 +155,7 @@ public class KNNScoringSpaceUtil {
     /**
      * Converts Object vector to byte[]
      *
+     * Expects all numbers in the Object vector to be in the byte range of [-128 to 127]
      * @param vector input vector
      * @return Byte array representing the vector
      */

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -112,24 +112,6 @@ public class KNNScoringSpaceUtil {
     }
 
     /**
-     * Convert an Object to a byte array.
-     *
-     * @param object Object to be converted to a byte array
-     * @param expectedVectorLength int representing the expected vector length of this array.
-     * @return byte[] of the object
-     */
-    public static byte[] parseToByteArray(Object object, int expectedVectorLength, VectorDataType vectorDataType) {
-        byte[] byteArray = convertVectorToByteArray(object, vectorDataType);
-        if (expectedVectorLength != byteArray.length) {
-            KNNCounter.SCRIPT_QUERY_ERRORS.increment();
-            throw new IllegalStateException(
-                "Object's length=" + byteArray.length + " does not match the " + "expected length=" + expectedVectorLength + "."
-            );
-        }
-        return byteArray;
-    }
-
-    /**
      * Converts Object vector to primitive float[]
      *
      * @param vector input vector
@@ -150,6 +132,24 @@ public class KNNScoringSpaceUtil {
             }
         }
         return primitiveVector;
+    }
+
+    /**
+     * Convert an Object to a byte array.
+     *
+     * @param object Object to be converted to a byte array
+     * @param expectedVectorLength int representing the expected vector length of this array.
+     * @return byte[] of the object
+     */
+    public static byte[] parseToByteArray(Object object, int expectedVectorLength, VectorDataType vectorDataType) {
+        byte[] byteArray = convertVectorToByteArray(object, vectorDataType);
+        if (expectedVectorLength != byteArray.length) {
+            KNNCounter.SCRIPT_QUERY_ERRORS.increment();
+            throw new IllegalStateException(
+                "Object's length=" + byteArray.length + " does not match the " + "expected length=" + expectedVectorLength + "."
+            );
+        }
+        return byteArray;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtil.java
@@ -112,6 +112,24 @@ public class KNNScoringSpaceUtil {
     }
 
     /**
+     * Convert an Object to a byte array.
+     *
+     * @param object Object to be converted to a byte array
+     * @param expectedVectorLength int representing the expected vector length of this array.
+     * @return byte[] of the object
+     */
+    public static byte[] parseToByteArray(Object object, int expectedVectorLength, VectorDataType vectorDataType) {
+        byte[] byteArray = convertVectorToByteArray(object, vectorDataType);
+        if (expectedVectorLength != byteArray.length) {
+            KNNCounter.SCRIPT_QUERY_ERRORS.increment();
+            throw new IllegalStateException(
+                "Object's length=" + byteArray.length + " does not match the " + "expected length=" + expectedVectorLength + "."
+            );
+        }
+        return byteArray;
+    }
+
+    /**
      * Converts Object vector to primitive float[]
      *
      * @param vector input vector
@@ -132,6 +150,29 @@ public class KNNScoringSpaceUtil {
             }
         }
         return primitiveVector;
+    }
+
+    /**
+     * Converts Object vector to byte[]
+     *
+     * @param vector input vector
+     * @return Byte array representing the vector
+     */
+    @SuppressWarnings("unchecked")
+    public static byte[] convertVectorToByteArray(Object vector, VectorDataType vectorDataType) {
+        byte[] byteVector = null;
+        if (vector != null) {
+            final List<Number> tmp = (List<Number>) vector;
+            byteVector = new byte[tmp.size()];
+            for (int i = 0; i < byteVector.length; i++) {
+                float value = tmp.get(i).floatValue();
+                if (VectorDataType.BYTE == vectorDataType || VectorDataType.BINARY == vectorDataType) {
+                    validateByteVectorValue(value, vectorDataType);
+                }
+                byteVector[i] = tmp.get(i).byteValue();
+            }
+        }
+        return byteVector;
     }
 
     /**

--- a/src/main/resources/org/opensearch/knn/plugin/script/knn_allowlist.txt
+++ b/src/main/resources/org/opensearch/knn/plugin/script/knn_allowlist.txt
@@ -4,7 +4,7 @@
 # Painless definition of classes used by knn plugin
 
 class org.opensearch.knn.index.KNNVectorScriptDocValues {
-  float[] getValue()
+  Object getValue()
 }
 static_import {
   float l2Squared(List, org.opensearch.knn.index.KNNVectorScriptDocValues) from_class org.opensearch.knn.plugin.script.KNNScoringUtil

--- a/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
@@ -61,20 +61,22 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
         directory.close();
     }
 
+    @SuppressWarnings("unchecked")
     public void testGetScriptValues() {
         KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
             leafReaderContext.reader(),
             MOCK_INDEX_FIELD_NAME,
             VectorDataType.FLOAT
         );
-        ScriptDocValues<float[]> scriptValues = leafFieldData.getScriptValues();
+        ScriptDocValues<float[]> scriptValues = (ScriptDocValues<float[]>) leafFieldData.getScriptValues();
         assertNotNull(scriptValues);
         assertTrue(scriptValues instanceof KNNVectorScriptDocValues);
     }
 
+    @SuppressWarnings("unchecked")
     public void testGetScriptValuesWrongFieldName() {
         KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(leafReaderContext.reader(), "invalid", VectorDataType.FLOAT);
-        ScriptDocValues<float[]> scriptValues = leafFieldData.getScriptValues();
+        ScriptDocValues<float[]> scriptValues = (ScriptDocValues<float[]>) leafFieldData.getScriptValues();
         assertNotNull(scriptValues);
     }
 

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeTests.java
@@ -32,7 +32,7 @@ public class VectorDataTypeTests extends KNNTestCase {
 
     @SneakyThrows
     public void testGetDocValuesWithFloatVectorDataType() {
-        KNNVectorScriptDocValues scriptDocValues = getKNNFloatVectorScriptDocValues();
+        KNNVectorScriptDocValues<float[]> scriptDocValues = getKNNFloatVectorScriptDocValues();
 
         scriptDocValues.setNextDocId(0);
         Assert.assertArrayEquals(SAMPLE_FLOAT_VECTOR_DATA, scriptDocValues.getValue(), 0.1f);
@@ -43,35 +43,37 @@ public class VectorDataTypeTests extends KNNTestCase {
 
     @SneakyThrows
     public void testGetDocValuesWithByteVectorDataType() {
-        KNNVectorScriptDocValues scriptDocValues = getKNNByteVectorScriptDocValues();
+        KNNVectorScriptDocValues<byte[]> scriptDocValues = getKNNByteVectorScriptDocValues();
 
         scriptDocValues.setNextDocId(0);
-        Assert.assertArrayEquals(SAMPLE_FLOAT_VECTOR_DATA, scriptDocValues.getValue(), 0.1f);
+        Assert.assertArrayEquals(SAMPLE_BYTE_VECTOR_DATA, scriptDocValues.getValue());
 
         reader.close();
         directory.close();
     }
 
+    @SuppressWarnings("unchecked")
     @SneakyThrows
-    private KNNVectorScriptDocValues getKNNFloatVectorScriptDocValues() {
+    private KNNVectorScriptDocValues<float[]> getKNNFloatVectorScriptDocValues() {
         directory = newDirectory();
         createKNNFloatVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        return KNNVectorScriptDocValues.create(
+        return (KNNVectorScriptDocValues<float[]>) KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME),
             VectorDataTypeTests.MOCK_FLOAT_INDEX_FIELD_NAME,
             VectorDataType.FLOAT
         );
     }
 
+    @SuppressWarnings("unchecked")
     @SneakyThrows
-    private KNNVectorScriptDocValues getKNNByteVectorScriptDocValues() {
+    private KNNVectorScriptDocValues<byte[]> getKNNByteVectorScriptDocValues() {
         directory = newDirectory();
         createKNNByteVectorDocument(directory);
         reader = DirectoryReader.open(directory);
         LeafReaderContext leafReaderContext = reader.getContext().leaves().get(0);
-        return KNNVectorScriptDocValues.create(
+        return (KNNVectorScriptDocValues<byte[]>) KNNVectorScriptDocValues.create(
             leafReaderContext.reader().getBinaryDocValues(VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME),
             VectorDataTypeTests.MOCK_BYTE_INDEX_FIELD_NAME,
             VectorDataType.BYTE
@@ -110,8 +112,7 @@ public class VectorDataTypeTests extends KNNTestCase {
 
     public void testGetVectorFromBytesRef_whenBinary_thenException() {
         byte[] vector = { 1, 2, 3 };
-        float[] expected = { 1, 2, 3 };
         BytesRef bytesRef = new BytesRef(vector);
-        assertArrayEquals(expected, VectorDataType.BINARY.getVectorFromBytesRef(bytesRef), 0.01f);
+        assertArrayEquals(vector, VectorDataType.BINARY.getVectorFromBytesRef(bytesRef));
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
@@ -770,15 +770,6 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         return vector;
     }
 
-    private byte[] randomByteVector(final int dimensions, final VectorDataType vectorDataType) {
-        int size = VectorDataType.BINARY == vectorDataType ? dimensions / 8 : dimensions;
-        final byte[] vector = new byte[size];
-        for (int i = 0; i < size; i++) {
-            vector[i] = randomByte();
-        }
-        return vector;
-    }
-
     private Map<String, KNNResult> createDataset(
         Function<float[], Float> scoreFunction,
         int dimensions,
@@ -812,7 +803,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
                 FIELD_NAME,
                 Collections.emptyMap(),
                 vectorDataType,
-                getMappingConfigForFlatMapping(vectorDataType.equals(VectorDataType.BINARY) ? queryVector.length * 8 : queryVector.length)
+                getMappingConfigForFlatMapping(vectorDataType == VectorDataType.BINARY ? queryVector.length * 8 : queryVector.length)
             )
         );
         switch (spaceType) {
@@ -822,7 +813,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             case COSINESIMIL:
             case INNER_PRODUCT:
             case HAMMING:
-                if (vectorDataType.equals(VectorDataType.FLOAT)) {
+                if (vectorDataType == VectorDataType.FLOAT) {
                     return ((KNNScoringSpace.KNNFieldSpace) knnScoringSpace).getScoringMethod(queryVector);
                 }
                 return ((KNNScoringSpace.KNNFieldSpace) knnScoringSpace).getScoringMethod(toByte(queryVector));

--- a/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
@@ -70,16 +70,32 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         testKNNScriptScore(SpaceType.L2);
     }
 
+    public void testKNNL2ByteScriptScore() throws Exception {
+        testKNNByteScriptScore(SpaceType.L2);
+    }
+
     public void testKNNL1ScriptScore() throws Exception {
         testKNNScriptScore(SpaceType.L1);
+    }
+
+    public void testKNNL1ByteScriptScore() throws Exception {
+        testKNNByteScriptScore(SpaceType.L1);
     }
 
     public void testKNNLInfScriptScore() throws Exception {
         testKNNScriptScore(SpaceType.LINF);
     }
 
+    public void testKNNLInfByteScriptScore() throws Exception {
+        testKNNByteScriptScore(SpaceType.LINF);
+    }
+
     public void testKNNCosineScriptScore() throws Exception {
         testKNNScriptScore(SpaceType.COSINESIMIL);
+    }
+
+    public void testKNNByteCosineScriptScore() throws Exception {
+        testKNNByteScriptScore(SpaceType.COSINESIMIL);
     }
 
     @SneakyThrows
@@ -87,16 +103,21 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         testKNNScriptScoreOnBinaryIndex(SpaceType.HAMMING);
     }
 
+    @SuppressWarnings("unchecked")
     @SneakyThrows
     public void testKNNHammingScriptScore_whenNonBinary_thenException() {
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BYTE);
-        final BiFunction<byte[], byte[], Float> scoreFunction = getHammingScoreFunction();
+        final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
+            SpaceType.HAMMING,
+            queryVector,
+            VectorDataType.BINARY
+        );
         List<VectorDataType> nonBinary = List.of(VectorDataType.FLOAT, VectorDataType.BYTE);
         for (VectorDataType vectorDataType : nonBinary) {
             Exception e = expectThrows(
                 Exception.class,
-                () -> createIndexAndAssertHammingScriptScore(
+                () -> createIndexAndAssertByteScriptScore(
                     createKnnIndexMapping(FIELD_NAME, dims, vectorDataType),
                     SpaceType.HAMMING,
                     scoreFunction,
@@ -111,18 +132,23 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void testKNNNonHammingScriptScore_whenBinary_thenException() {
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BINARY);
+        final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
+            SpaceType.HAMMING,
+            queryVector,
+            VectorDataType.BINARY
+        );
         Set<SpaceType> spaceTypeToExclude = Set.of(SpaceType.UNDEFINED, SpaceType.HAMMING);
         Arrays.stream(SpaceType.values()).filter(s -> spaceTypeToExclude.contains(s) == false).forEach(s -> {
-            final BiFunction<float[], float[], Float> scoreFunction = getScoreFunction(s, queryVector);
             Exception e = expectThrows(
                 Exception.class,
-                () -> createIndexAndAssertScriptScore(
+                () -> createIndexAndAssertByteScriptScore(
                     createKnnIndexMapping(FIELD_NAME, dims, VectorDataType.BINARY),
                     s,
-                    v -> scoreFunction.apply(queryVector, v),
+                    scoreFunction,
                     dims,
                     queryVector,
                     true,
@@ -616,6 +642,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         assertEquals(1, secondQueryCacheMap.get("hit_count"));
     }
 
+    @SuppressWarnings("unchecked")
     public void testKNNScriptScoreOnModelBasedIndex() throws Exception {
         int dimensions = randomIntBetween(2, 10);
         String trainMapping = createKnnIndexMapping(TRAIN_FIELD_PARAMETER, dimensions);
@@ -652,7 +679,11 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
                 continue;
             }
             final float[] queryVector = randomVector(dimensions);
-            final BiFunction<float[], float[], Float> scoreFunction = getScoreFunction(spaceType, queryVector);
+            final BiFunction<float[], float[], Float> scoreFunction = (BiFunction<float[], float[], Float>) getScoreFunction(
+                spaceType,
+                queryVector,
+                VectorDataType.FLOAT
+            );
             createIndexAndAssertScriptScore(testMapping, spaceType, scoreFunction, dimensions, queryVector, true);
         }
     }
@@ -675,6 +706,30 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
                 KNNEngine.LUCENE.getName(),
                 SpaceType.DEFAULT.getValue(),
                 false
+            )
+        );
+    }
+
+    private List<String> createByteMappers(int dimensions) throws Exception {
+        return List.of(
+            createKnnIndexMapping(FIELD_NAME, dimensions, VectorDataType.BYTE),
+            createKnnIndexMapping(
+                FIELD_NAME,
+                dimensions,
+                KNNConstants.METHOD_HNSW,
+                KNNEngine.LUCENE.getName(),
+                SpaceType.DEFAULT.getValue(),
+                true,
+                VectorDataType.BYTE
+            ),
+            createKnnIndexMapping(
+                FIELD_NAME,
+                dimensions,
+                KNNConstants.METHOD_HNSW,
+                KNNEngine.LUCENE.getName(),
+                SpaceType.DEFAULT.getValue(),
+                false,
+                VectorDataType.BYTE
             )
         );
     }
@@ -715,6 +770,15 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         return vector;
     }
 
+    private byte[] randomByteVector(final int dimensions, final VectorDataType vectorDataType) {
+        int size = VectorDataType.BINARY == vectorDataType ? dimensions / 8 : dimensions;
+        final byte[] vector = new byte[size];
+        for (int i = 0; i < size; i++) {
+            vector[i] = randomByte();
+        }
+        return vector;
+    }
+
     private Map<String, KNNResult> createDataset(
         Function<float[], Float> scoreFunction,
         int dimensions,
@@ -736,10 +800,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         return dataset;
     }
 
-    private BiFunction<byte[], byte[], Float> getHammingScoreFunction() {
-        final int dims = randomIntBetween(2, 10);
-        final float[] queryVector = randomVector(dims, VectorDataType.BINARY);
-        final SpaceType spaceType = SpaceType.HAMMING;
+    private BiFunction<?, ?, Float> getScoreFunction(SpaceType spaceType, float[] queryVector, VectorDataType vectorDataType) {
         List<Float> target = new ArrayList<>(queryVector.length);
         for (float f : queryVector) {
             target.add(f);
@@ -750,27 +811,8 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             new KNNVectorFieldType(
                 FIELD_NAME,
                 Collections.emptyMap(),
-                VectorDataType.BINARY,
-                getMappingConfigForFlatMapping(queryVector.length * 8)
-            )
-        );
-
-        return ((KNNScoringSpace.Hamming) knnScoringSpace).getHammingScoringMethod();
-    }
-
-    private BiFunction<float[], float[], Float> getScoreFunction(SpaceType spaceType, float[] queryVector) {
-        List<Float> target = new ArrayList<>(queryVector.length);
-        for (float f : queryVector) {
-            target.add(f);
-        }
-        KNNScoringSpace knnScoringSpace = KNNScoringSpaceFactory.create(
-            spaceType.getValue(),
-            target,
-            new KNNVectorFieldType(
-                FIELD_NAME,
-                Collections.emptyMap(),
-                SpaceType.HAMMING == spaceType ? VectorDataType.BINARY : VectorDataType.FLOAT,
-                getMappingConfigForFlatMapping(SpaceType.HAMMING == spaceType ? queryVector.length * 8 : queryVector.length)
+                vectorDataType,
+                getMappingConfigForFlatMapping(vectorDataType.equals(VectorDataType.BINARY) ? queryVector.length * 8 : queryVector.length)
             )
         );
         switch (spaceType) {
@@ -779,35 +821,64 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             case LINF:
             case COSINESIMIL:
             case INNER_PRODUCT:
-                return ((KNNScoringSpace.KNNFieldSpace) knnScoringSpace).getScoringMethod();
+            case HAMMING:
+                if (vectorDataType.equals(VectorDataType.FLOAT)) {
+                    return ((KNNScoringSpace.KNNFieldSpace) knnScoringSpace).getScoringMethod(queryVector);
+                }
+                return ((KNNScoringSpace.KNNFieldSpace) knnScoringSpace).getScoringMethod(toByte(queryVector));
             default:
                 throw new IllegalArgumentException();
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void testKNNScriptScore(SpaceType spaceType) throws Exception {
         final int dims = randomIntBetween(2, 10);
         final float[] queryVector = randomVector(dims);
-        final BiFunction<float[], float[], Float> scoreFunction = getScoreFunction(spaceType, queryVector);
+        final BiFunction<float[], float[], Float> scoreFunction = (BiFunction<float[], float[], Float>) getScoreFunction(
+            spaceType,
+            queryVector,
+            VectorDataType.FLOAT
+        );
         for (String mapper : createMappers(dims)) {
             createIndexAndAssertScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, true);
             createIndexAndAssertScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, false);
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private void testKNNByteScriptScore(SpaceType spaceType) throws Exception {
+        final int dims = randomIntBetween(2, 10);
+        final float[] queryVector = randomVector(dims, VectorDataType.BYTE);
+        final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
+            spaceType,
+            queryVector,
+            VectorDataType.BYTE
+        );
+        for (String mapper : createByteMappers(dims)) {
+            createIndexAndAssertByteScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, true, true, VectorDataType.BYTE);
+            createIndexAndAssertByteScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, false, true, VectorDataType.BYTE);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
     private void testKNNScriptScoreOnBinaryIndex(SpaceType spaceType) throws Exception {
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BINARY);
-        final BiFunction<byte[], byte[], Float> scoreFunction = getHammingScoreFunction();
+        final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
+            spaceType,
+            queryVector,
+            VectorDataType.BINARY
+        );
 
         // Test when knn is enabled and engine is Faiss
         for (String mapper : createBinaryIndexMappers(dims)) {
-            createIndexAndAssertHammingScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, true, true, VectorDataType.BINARY);
-            createIndexAndAssertHammingScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, false, true, VectorDataType.BINARY);
+            createIndexAndAssertByteScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, true, true, VectorDataType.BINARY);
+            createIndexAndAssertByteScriptScore(mapper, spaceType, scoreFunction, dims, queryVector, false, true, VectorDataType.BINARY);
         }
 
         // Test when knn is disabled and engine is default(Nmslib)
-        createIndexAndAssertHammingScriptScore(
+        createIndexAndAssertByteScriptScore(
             createKnnIndexMapping(FIELD_NAME, dims, VectorDataType.BINARY),
             spaceType,
             scoreFunction,
@@ -817,7 +888,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
             false,
             VectorDataType.BINARY
         );
-        createIndexAndAssertHammingScriptScore(
+        createIndexAndAssertByteScriptScore(
             createKnnIndexMapping(FIELD_NAME, dims, VectorDataType.BINARY),
             spaceType,
             scoreFunction,
@@ -902,7 +973,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
         }
     }
 
-    private void createIndexAndAssertHammingScriptScore(
+    private void createIndexAndAssertByteScriptScore(
         String mapper,
         SpaceType spaceType,
         BiFunction<byte[], byte[], Float> scoreFunction,

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -217,8 +217,8 @@ public class KNNScoringSpaceTests extends KNNTestCase {
 
         KNNScoringSpace.Hamming hamming = new KNNScoringSpace.Hamming(arrayListQueryObject, fieldType);
 
-        float[] arrayFloat = new float[] { 1.0f, 2.0f, 3.0f };
-        assertEquals(1F, hamming.getScoringMethod().apply(arrayFloat, arrayFloat), 0.1F);
+        byte[] arrayByte = new byte[] { 1, 2, 3 };
+        assertEquals(1F, ((BiFunction<byte[], byte[], Float>) hamming.scoringMethod).apply(arrayByte, arrayByte), 0.1F);
     }
 
     public void testHamming_whenNonBinaryVectorDataType_thenException() {

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -55,6 +55,7 @@ public class KNNScoringSpaceTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    @SuppressWarnings("unchecked")
     public void testL2_whenValid_thenSucceed() {
         float[] arrayFloat = new float[] { 1.0f, 2.0f, 3.0f };
         List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
@@ -66,7 +67,12 @@ public class KNNScoringSpaceTests extends KNNTestCase {
             getMappingConfigForMethodMapping(knnMethodContext, 3)
         );
         KNNScoringSpace.L2 l2 = new KNNScoringSpace.L2(arrayListQueryObject, fieldType);
-        assertEquals(1F, l2.getScoringMethod().apply(arrayFloat, arrayFloat), 0.1F);
+        float[] processedFloatQuery = (float[]) l2.getProcessedQuery(arrayListQueryObject, fieldType);
+        assertEquals(
+            1F,
+            ((BiFunction<float[], float[], Float>) l2.getScoringMethod(processedFloatQuery)).apply(arrayFloat, arrayFloat),
+            0.1F
+        );
     }
 
     @SneakyThrows
@@ -75,6 +81,7 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         expectThrowsExceptionWithKNNFieldWithBinaryDataType(KNNScoringSpace.L2.class);
     }
 
+    @SuppressWarnings("unchecked")
     public void testCosineSimilarity_whenValid_thenSucceed() {
         float[] arrayFloat = new float[] { 1.0f, 2.0f, 3.0f };
         List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(2.0, 4.0, 6.0));
@@ -87,9 +94,10 @@ public class KNNScoringSpaceTests extends KNNTestCase {
             getMappingConfigForMethodMapping(knnMethodContext, 3)
         );
         KNNScoringSpace.CosineSimilarity cosineSimilarity = new KNNScoringSpace.CosineSimilarity(arrayListQueryObject, fieldType);
+        float[] processedFloatQuery = (float[]) cosineSimilarity.getProcessedQuery(arrayListQueryObject, fieldType);
         assertEquals(
             VectorSimilarityFunction.COSINE.compare(arrayFloat2, arrayFloat),
-            cosineSimilarity.getScoringMethod().apply(arrayFloat2, arrayFloat),
+            ((BiFunction<float[], float[], Float>) cosineSimilarity.getScoringMethod(processedFloatQuery)).apply(arrayFloat2, arrayFloat),
             0.1F
         );
 
@@ -131,6 +139,7 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         expectThrowsExceptionWithKNNFieldWithBinaryDataType(KNNScoringSpace.CosineSimilarity.class);
     }
 
+    @SuppressWarnings("unchecked")
     public void testInnerProd_whenValid_thenSucceed() {
         float[] arrayFloat_case1 = new float[] { 1.0f, 2.0f, 3.0f };
         List<Double> arrayListQueryObject_case1 = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
@@ -145,23 +154,45 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         );
         KNNScoringSpace.InnerProd innerProd = new KNNScoringSpace.InnerProd(arrayListQueryObject_case1, fieldType);
 
-        assertEquals(7.0F, innerProd.getScoringMethod().apply(arrayFloat_case1, arrayFloat2_case1), 0.001F);
+        float[] processedFloatQuery_case1 = (float[]) innerProd.getProcessedQuery(arrayListQueryObject_case1, fieldType);
+        assertEquals(
+            7.0F,
+            ((BiFunction<float[], float[], Float>) innerProd.getScoringMethod(processedFloatQuery_case1)).apply(
+                arrayFloat_case1,
+                arrayFloat2_case1
+            ),
+            0.001F
+        );
 
         float[] arrayFloat_case2 = new float[] { 100_000.0f, 200_000.0f, 300_000.0f };
         List<Double> arrayListQueryObject_case2 = new ArrayList<>(Arrays.asList(100_000.0, 200_000.0, 300_000.0));
         float[] arrayFloat2_case2 = new float[] { -100_000.0f, -200_000.0f, -300_000.0f };
 
         innerProd = new KNNScoringSpace.InnerProd(arrayListQueryObject_case2, fieldType);
-
-        assertEquals(7.142857143E-12F, innerProd.getScoringMethod().apply(arrayFloat_case2, arrayFloat2_case2), 1.0E-11F);
+        float[] processedFloatQuery_case2 = (float[]) innerProd.getProcessedQuery(arrayListQueryObject_case2, fieldType);
+        assertEquals(
+            7.142857143E-12F,
+            ((BiFunction<float[], float[], Float>) innerProd.getScoringMethod(processedFloatQuery_case2)).apply(
+                arrayFloat_case2,
+                arrayFloat2_case2
+            ),
+            1.0E-11F
+        );
 
         float[] arrayFloat_case3 = new float[] { 100_000.0f, 200_000.0f, 300_000.0f };
         List<Double> arrayListQueryObject_case3 = new ArrayList<>(Arrays.asList(100_000.0, 200_000.0, 300_000.0));
         float[] arrayFloat2_case3 = new float[] { 100_000.0f, 200_000.0f, 300_000.0f };
 
         innerProd = new KNNScoringSpace.InnerProd(arrayListQueryObject_case3, fieldType);
-
-        assertEquals(140_000_000_001F, innerProd.getScoringMethod().apply(arrayFloat_case3, arrayFloat2_case3), 0.01F);
+        float[] processedFloatQuery_case3 = (float[]) innerProd.getProcessedQuery(arrayListQueryObject_case3, fieldType);
+        assertEquals(
+            140_000_000_001F,
+            ((BiFunction<float[], float[], Float>) innerProd.getScoringMethod(processedFloatQuery_case3)).apply(
+                arrayFloat_case3,
+                arrayFloat2_case3
+            ),
+            0.01F
+        );
     }
 
     @SneakyThrows
@@ -205,6 +236,7 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         );
     }
 
+    @SuppressWarnings("unchecked")
     public void testHamming_whenKNNFieldType_thenSucceed() {
         List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
         KNNMethodContext knnMethodContext = getDefaultKNNMethodContext();
@@ -216,9 +248,13 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         );
 
         KNNScoringSpace.Hamming hamming = new KNNScoringSpace.Hamming(arrayListQueryObject, fieldType);
-
+        byte[] processedByteQuery = (byte[]) hamming.getProcessedQuery(arrayListQueryObject, fieldType);
         byte[] arrayByte = new byte[] { 1, 2, 3 };
-        assertEquals(1F, ((BiFunction<byte[], byte[], Float>) hamming.scoringMethod).apply(arrayByte, arrayByte), 0.1F);
+        assertEquals(
+            1F,
+            ((BiFunction<byte[], byte[], Float>) hamming.getScoringMethod(processedByteQuery)).apply(arrayByte, arrayByte),
+            0.1F
+        );
     }
 
     public void testHamming_whenNonBinaryVectorDataType_thenException() {

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceUtilTests.java
@@ -76,6 +76,12 @@ public class KNNScoringSpaceUtilTests extends KNNTestCase {
         expectThrows(ClassCastException.class, () -> KNNScoringSpaceUtil.parseToFloatArray(invalidObject, 3, VectorDataType.FLOAT));
     }
 
+    public void testConvertVectorToByteArray() {
+        byte[] arrayByte = new byte[] { 1, 2, 3 };
+        List<Double> arrayListQueryObject = new ArrayList<>(Arrays.asList(1.0, 2.0, 3.0));
+        assertArrayEquals(arrayByte, KNNScoringSpaceUtil.parseToByteArray(arrayListQueryObject, 3, VectorDataType.BINARY));
+    }
+
     public void testIsBinaryVectorDataType_whenBinary_thenReturnTrue() {
         KNNVectorFieldType fieldType = mock(KNNVectorFieldType.class);
         when(fieldType.getVectorDataType()).thenReturn(VectorDataType.BINARY);

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringUtilTests.java
@@ -314,11 +314,10 @@ public class KNNScoringUtilTests extends KNNTestCase {
         byte[] b1 = { 1, 16, -128 };  // 0000 0001, 0001 0000, 1000 0000
         byte[] b2 = { 2, 17, -1 };    // 0000 0010, 0001 0001, 1111 1111
         float[] f1 = { 1, 16, -128 };  // 0000 0001, 0001 0000, 1000 0000
-        float[] f2 = { 2, 17, -1 };    // 0000 0010, 0001 0001, 1111 1111
         List<Number> queryVector = Arrays.asList(f1[0], f1[1], f1[2]);
-        KNNVectorScriptDocValues docValues = mock(KNNVectorScriptDocValues.class);
+        KNNVectorScriptDocValues<?> docValues = mock(KNNVectorScriptDocValues.class);
         when(docValues.getVectorDataType()).thenReturn(VectorDataType.BINARY);
-        when(docValues.getValue()).thenReturn(f2);
+        when(docValues.getValue()).thenReturn(b2);
         assertEquals(KNNScoringUtil.calculateHammingBit(b1, b2), KNNScoringUtil.hamming(queryVector, docValues), 0.01f);
     }
 


### PR DESCRIPTION
### Description

Removes the unnecessary type conversion from byte[] to float[] and again float[] to byte for script score on KNN Binary vector using hamming space. This would help bring down the overall query latency.

For details, check https://github.com/opensearch-project/k-NN/issues/1827#issuecomment-2555581909

### Related Issues
Resolves #1827 

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- N/A API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- N/A Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
