### PR TITLE
Properly set gcc version lock on x64 and arm64 for avx512_spr support

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -111,8 +111,13 @@ fi
 # https://github.com/opensearch-project/k-NN/issues/975
 # https://github.com/opensearch-project/k-NN/issues/1138
 # https://github.com/opensearch-project/opensearch-build/issues/4386
+# 20250127: Require at least GCC 12 to support avx512_spr on x64, while keep GCC 10 on arm64
+# https://github.com/opensearch-project/opensearch-build/issues/5226
 GCC_VERSION=`gcc --version | head -n 1 | cut -d ' ' -f3`
-GCC_REQUIRED_VERSION=12.4
+GCC_REQUIRED_VERSION=10.0.0
+if [ `uname -m` = "x86_64" ]; then
+    GCC_REQUIRED_VERSION=12.4.0
+fi
 COMPARE_VERSION=`echo $GCC_REQUIRED_VERSION $GCC_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" != "$GCC_REQUIRED_VERSION" ]; then
     echo "gcc version on this env is older than $GCC_REQUIRED_VERSION, exit 1"


### PR DESCRIPTION
### Description
Properly set gcc version lock on x64 and arm64 for avx512_spr support

### Related Issues
https://github.com/opensearch-project/opensearch-build/issues/5152
Closes https://github.com/opensearch-project/opensearch-build/issues/5226

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
