### PR TITLE
Changes to publish jar to maven

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -32,4 +32,7 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
+          # For zip
           ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          # For jar
+          ./gradlew publishNebulaPublicationToSnapshotsRepository


### PR DESCRIPTION
### Description
Changes to publish the jar of knn plugin to maven.

### Related Issues
Resolves #1351 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Testing:

Since it is a call to an existing gradle task. I couldn't exactly test it.
But I'm to run the equivalent task `publishNebulaPublicationToMavenLocal` and use the locally published jar from my another project.