### PR TITLE
Add path.repo for registering snapshot repository in integ tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,6 +373,7 @@ integTest {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
     systemProperty "java.library.path", "$rootDir/jni/release"
+    systemProperty "tests.path.repo", "${buildDir}/testSnapshotFolder"
     // allows integration test classes to access test resource from project root path
     systemProperty('project.root', project.rootDir.absolutePath)
 
@@ -438,6 +439,9 @@ testClusters.integTest {
         }
     }
     systemProperty("java.library.path", "$rootDir/jni/release")
+    final testSnapshotFolder = file("${buildDir}/testSnapshotFolder")
+    testSnapshotFolder.mkdirs()
+    setting 'path.repo', "${buildDir}/testSnapshotFolder"
 }
 
 task integTestRemote(type: RestIntegTestTask) {

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 import org.opensearch.Version;
-import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.xcontent.DeprecationHandler;
@@ -74,8 +73,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
@@ -1986,17 +1983,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
     @SneakyThrows
     protected void setupSnapshotRestore(String index, String snapshot, String repository) {
-        Request clusterSettingsRequest = new Request("GET", "/_cluster/settings");
-        clusterSettingsRequest.addParameter("include_defaults", "true");
-        Response clusterSettingsResponse = client().performRequest(clusterSettingsRequest);
-        Map<String, Object> clusterSettings = entityAsMap(clusterSettingsResponse);
-
-        @SuppressWarnings("unchecked")
-        List<String> pathRepos = (List<String>) XContentMapValues.extractValue("defaults.path.repo", clusterSettings);
-        assertThat(pathRepos, notNullValue());
-        assertThat(pathRepos, hasSize(1));
-
-        final String pathRepo = pathRepos.get(0);
+        final String pathRepo = System.getProperty("tests.path.repo");
 
         // create index
         createIndex(index, getDefaultIndexSettings());


### PR DESCRIPTION
### Description
A prior PR https://github.com/opensearch-project/k-NN/pull/2445 was breaking the release build of 2.19 due to https://github.com/opensearch-project/k-NN/issues/2458. This PR fixes the issue by updating the `path.repo` used to register snapshot repositories in integ tests

### Related Issues
Resolves #2458 


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
