### PR TITLE
Adds debug logs for KNNQuery and KNNWeight

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -171,10 +171,17 @@ public class KNNQuery extends Query {
         if (!KNNSettings.isKNNPluginEnabled()) {
             throw new IllegalStateException("KNN plugin is disabled. To enable update knn.plugin.enabled to true");
         }
-        StopWatch stopWatch = new StopWatch().start();
+        StopWatch stopWatch = null;
+        if (log.isDebugEnabled()) {
+            stopWatch = new StopWatch().start();
+        }
+
         final Weight filterWeight = getFilterWeight(searcher);
-        stopWatch.stop();
-        log.debug("Creating filter weight for field [{}] took [{}] nanos", field, stopWatch.totalTime().nanos());
+        if (log.isDebugEnabled() && stopWatch != null) {
+            stopWatch.stop();
+            log.debug("Creating filter weight for field [{}] took [{}] nanos", field, stopWatch.totalTime().nanos());
+        }
+
         if (filterWeight != null) {
             return new KNNWeight(this, boost, filterWeight);
         }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.FieldExistsQuery;
@@ -19,6 +20,7 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
+import org.opensearch.common.StopWatch;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
@@ -32,6 +34,7 @@ import java.util.Objects;
  * Custom KNN query. Query is used for KNNEngine's that create their own custom segment files. These files need to be
  * loaded and queried in a custom manner throughout the query path.
  */
+@Log4j2
 @Getter
 @Builder
 @AllArgsConstructor
@@ -168,7 +171,10 @@ public class KNNQuery extends Query {
         if (!KNNSettings.isKNNPluginEnabled()) {
             throw new IllegalStateException("KNN plugin is disabled. To enable update knn.plugin.enabled to true");
         }
+        StopWatch stopWatch = new StopWatch().start();
         final Weight filterWeight = getFilterWeight(searcher);
+        stopWatch.stop();
+        log.debug("Creating filter weight for field [{}] took [{}] nanos", field, stopWatch.totalTime().nanos());
         if (filterWeight != null) {
             return new KNNWeight(this, boost, filterWeight);
         }

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -48,13 +48,16 @@ public class KNNQuery extends Query {
     private final String indexName;
     private final VectorDataType vectorDataType;
     private final RescoreContext rescoreContext;
-
     @Setter
     private Query filterQuery;
     @Getter
     private BitSetProducer parentsFilter;
     private Float radius;
     private Context context;
+
+    // Note: ideally query should not have to deal with shard level information. Adding it for logging purposes only
+    // TODO: ThreadContext does not work with logger, remove this from here once its figured out
+    private int shardId;
 
     public KNNQuery(
         final String field,
@@ -179,7 +182,12 @@ public class KNNQuery extends Query {
         final Weight filterWeight = getFilterWeight(searcher);
         if (log.isDebugEnabled() && stopWatch != null) {
             stopWatch.stop();
-            log.debug("Creating filter weight for field [{}] took [{}] nanos", field, stopWatch.totalTime().nanos());
+            log.debug(
+                "Creating filter weight, Shard: [{}], field: [{}] took in nanos: [{}]",
+                shardId,
+                field,
+                stopWatch.totalTime().nanos()
+            );
         }
 
         if (filterWeight != null) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -52,9 +52,11 @@ public class KNNQueryFactory extends BaseQueryFactory {
         final KNNEngine knnEngine = createQueryRequest.getKnnEngine();
         final boolean expandNested = createQueryRequest.getExpandNested().orElse(false);
         BitSetProducer parentFilter = null;
+        int shardId = -1;
         if (createQueryRequest.getContext().isPresent()) {
             QueryShardContext context = createQueryRequest.getContext().get();
             parentFilter = context.getParentFilter();
+            shardId = context.getShardId();
         }
 
         if (parentFilter == null && expandNested) {
@@ -93,6 +95,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
                         .filterQuery(validatedFilterQuery)
                         .vectorDataType(vectorDataType)
                         .rescoreContext(rescoreContext)
+                        .shardId(shardId)
                         .build();
                     break;
                 default:
@@ -106,6 +109,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
                         .filterQuery(validatedFilterQuery)
                         .vectorDataType(vectorDataType)
                         .rescoreContext(rescoreContext)
+                        .shardId(shardId)
                         .build();
             }
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -152,7 +152,7 @@ public class KNNWeight extends Weight {
          * This improves the recall.
          */
         if (isFilteredExactSearchPreferred(cardinality)) {
-            Map<Integer, Float> result = doExactSearch(context, new BitSetIterator(filterBitSet, cardinality), cardinality, k, segmentName);
+            Map<Integer, Float> result = doExactSearch(context, new BitSetIterator(filterBitSet, cardinality), cardinality, k);
             return new PerLeafResult(filterWeight == null ? null : filterBitSet, result);
         }
 
@@ -241,8 +241,7 @@ public class KNNWeight extends Weight {
         final LeafReaderContext context,
         final DocIdSetIterator acceptedDocs,
         final long numberOfAcceptedDocs,
-        final int k,
-        final String segmentName
+        final int k
     ) throws IOException {
         final ExactSearcherContextBuilder exactSearcherContextBuilder = ExactSearcher.ExactSearcherContext.builder()
             .isParentHits(true)

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -171,7 +171,7 @@ public class KNNWeight extends Weight {
         // results less than K, though we have more than k filtered docs
         if (isExactSearchRequire(context, cardinality, docIdsToScoreMap.size())) {
             final BitSetIterator docs = filterWeight != null ? new BitSetIterator(filterBitSet, cardinality) : null;
-            Map<Integer, Float> result = doExactSearch(context, docs, cardinality, k, segmentName);
+            Map<Integer, Float> result = doExactSearch(context, docs, cardinality, k);
             return new PerLeafResult(filterWeight == null ? null : filterBitSet, result);
         }
         return new PerLeafResult(filterWeight == null ? null : filterBitSet, docIdsToScoreMap);

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -133,7 +133,7 @@ public class KNNWeight extends Weight {
     public PerLeafResult searchLeaf(LeafReaderContext context, int k) throws IOException {
         StopWatch stopWatch = startStopWatch();
         final BitSet filterBitSet = getFilteredDocsBitSet(context);
-        stopStopWatchAndLog(stopWatch, "Creating filter bitset for field [{}] took [{}] nanos");
+        stopStopWatchAndLog(stopWatch, "FilterBitSet creation");
 
         final int maxDoc = context.reader().maxDoc();
         int cardinality = filterBitSet.cardinality();
@@ -158,10 +158,10 @@ public class KNNWeight extends Weight {
          * so that it will not do a bitset look up in bottom search layer.
          */
         final BitSet annFilter = (filterWeight != null && cardinality == maxDoc) ? null : filterBitSet;
+
         StopWatch annStopWatch = startStopWatch();
-        ;
         final Map<Integer, Float> docIdsToScoreMap = doANNSearch(context, annFilter, cardinality, k);
-        stopStopWatchAndLog(annStopWatch, "ANN search for field [{}] took [{}] nanos");
+        stopStopWatchAndLog(annStopWatch, "ANN search");
 
         // See whether we have to perform exact search based on approx search results
         // This is required if there are no native engine files or if approximate search returned
@@ -174,10 +174,11 @@ public class KNNWeight extends Weight {
         return new PerLeafResult(filterWeight == null ? null : filterBitSet, docIdsToScoreMap);
     }
 
-    private void stopStopWatchAndLog(@Nullable StopWatch stopWatch, String message) {
+    private void stopStopWatchAndLog(@Nullable final StopWatch stopWatch, final String prefixMessage) {
         if (log.isDebugEnabled() && stopWatch != null) {
             stopWatch.stop();
-            log.debug(message, knnQuery.getField(), stopWatch.totalTime().nanos());
+            final String logMessage = prefixMessage + ", field: [{}], time in nanos:[{}] ";
+            log.debug(logMessage, knnQuery.getField(), stopWatch.totalTime().nanos());
         }
     }
 
@@ -419,7 +420,7 @@ public class KNNWeight extends Weight {
     ) throws IOException {
         StopWatch stopWatch = startStopWatch();
         Map<Integer, Float> exactSearchResults = exactSearcher.searchLeaf(leafReaderContext, exactSearcherContext);
-        stopStopWatchAndLog(stopWatch, "Exact search for field [{}] took [{}] nanos");
+        stopStopWatchAndLog(stopWatch, "Exact search");
         return exactSearchResults;
     }
 


### PR DESCRIPTION
### Description
Adds debug logs with timing information for various knn query components

### Testing

Cluster setting changed in local
```
curl --request PUT \
  --url http://localhost:9200/_cluster/settings \
  --header 'Content-Type: application/json' \
  --data '{
  "persistent" : {
		"logger.org.opensearch.knn.index.query" : "DEBUG"
  }
}'
```

Output
```
q.KNNQueryFactory] [integTest-0] Creating custom k-NN query for index:target_index_faiss, field:location, k:3, filterQuery:+IndexOrDocValuesQuery(indexQuery=rating:[8 TO 10], dvQuery=rating:[8 TO 10]), efSearch:null
[2025-01-29T11:20:21,929][DEBUG][o.o.k.i.q.KNNQuery       ] [integTest-0] Creating filter weight for field [location] took [603583] nanos
[2025-01-29T11:20:21,930][DEBUG][o.o.k.i.q.KNNWeight      ] [integTest-0] Creating filter bitset for field [location] took [462500] nanos
[2025-01-29T11:20:21,930][DEBUG][o.o.k.i.q.KNNWeight      ] [integTest-0] Info for doing exact search filterIdsLength : 10, Threshold value: -1
[2025-01-29T11:20:21,930][DEBUG][o.o.k.i.q.KNNWeight      ] [integTest-0] Exact search for field [location] took [232083] nanos

```

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
