### PR TITLE
Fixing bug where mapping accepts both dimension and model-id (#2410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixing the bug where setting rescore as false for on_disk knn_vector query is a no-op (#2399)[https://github.com/opensearch-project/k-NN/pull/2399]
 * Fixing the bug to prevent index.knn setting from being modified or removed on restore snapshot (#2445)[https://github.com/opensearch-project/k-NN/pull/2445]
 * Fix Faiss byte vector efficient filter bug (#2448)[https://github.com/opensearch-project/k-NN/pull/2448]
+* Fixing bug where mapping accepts both dimension and model-id (#2410)[https://github.com/opensearch-project/k-NN/pull/2410]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -386,6 +386,15 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 );
             }
 
+            // Ensure user-defined dimension and model are mutually exclusive for indicies created after 2.19
+            if (builder.dimension.getValue() != UNSET_MODEL_DIMENSION_IDENTIFIER
+                && builder.modelId.get() != null
+                && parserContext.indexVersionCreated().onOrAfter(Version.V_2_19_0)) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Cannot specify both a modelId and dimension in the mapping: %s", name)
+                );
+            }
+
             // Check for flat configuration and validate only if index is created after 2.17
             if (isKNNDisabled(parserContext.getSettings()) && parserContext.indexVersionCreated().onOrAfter(Version.V_2_17_0)) {
                 validateFromFlat(builder);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -682,7 +682,6 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         XContentBuilder xContentBuilder4 = XContentFactory.jsonBuilder()
             .startObject()
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION, 10)
             .field(VECTOR_DATA_TYPE_FIELD, VectorDataType.DEFAULT.getValue())
             .field(MODEL_ID, "test")
             .field(MODE_PARAMETER, Mode.ON_DISK.getName())
@@ -893,6 +892,27 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         );
 
         assertEquals(modelId, builder.modelId.get());
+
+        // Fails if both model_id and dimension are set after 2.19
+        XContentBuilder xContentBuilder2 = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, TEST_DIMENSION)
+            .field(MODEL_ID, modelId)
+            .endObject();
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> typeParser.parse(fieldName, xContentBuilderToMap(xContentBuilder2), buildParserContext(indexName, settings))
+        );
+
+        // Should not fail if both are set before 2.19
+        typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder2),
+            buildLegacyParserContext(indexName, settings, Version.V_2_18_1)
+        );
+
     }
 
     public void testTypeParser_parse_fromLegacy() throws IOException {


### PR DESCRIPTION
Manually raised PR to backport https://github.com/opensearch-project/k-NN/pull/2410 to 2.19 branch due to conflicts