### PR TITLE
Switch away from getMergeInstance for derived source

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsReader.java
@@ -107,12 +107,12 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
 
     /**
      * For merging, we need to tell the derived source stored fields reader to skip injecting the source. Otherwise,
-     * on merge we will end up just writing the source to disk
+     * on merge we will end up just writing the source to disk. We cant override
+     * {@link StoredFieldsReader#getMergeInstance()} because it is used elsewhere than just merging.
      *
      * @return Merged instance that wont inject by default
      */
-    @Override
-    public StoredFieldsReader getMergeInstance() {
+    private StoredFieldsReader cloneForMerge() {
         try {
             return new DerivedSourceStoredFieldsReader(
                 delegate.getMergeInstance(),
@@ -124,5 +124,19 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * For merging, we need to tell the derived source stored fields reader to skip injecting the source. Otherwise,
+     * on merge we will end up just writing the source to disk
+     *
+     * @param storedFieldsReader stored fields reader to wrap
+     * @return wrapped stored fields reader
+     */
+    public static StoredFieldsReader wrapForMerge(StoredFieldsReader storedFieldsReader) {
+        if (storedFieldsReader instanceof DerivedSourceStoredFieldsReader) {
+            return ((DerivedSourceStoredFieldsReader) storedFieldsReader).cloneForMerge();
+        }
+        return storedFieldsReader;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsWriter.java
@@ -65,6 +65,10 @@ public class DerivedSourceStoredFieldsWriter extends StoredFieldsWriter {
 
     @Override
     public int merge(MergeState mergeState) throws IOException {
+        // We have to wrap these here to avoid storing the vectors during merge
+        for (int i = 0; i < mergeState.storedFieldsReaders.length; i++) {
+            mergeState.storedFieldsReaders[i] = DerivedSourceStoredFieldsReader.wrapForMerge(mergeState.storedFieldsReaders[i]);
+        }
         return delegate.merge(mergeState);
     }
 


### PR DESCRIPTION
### Description
I was running the DerivedSourceIts for the derived source feature in a multi-node setting with replicas and was noticing that getMergeInstance was being called outside of merge when reindex was happening. I couldnt figure out the stack trace, but decided to revert back to wrapping the readers during merge. This fixed it.

It might be getting called in the SequentialStoredFieldsReader in this hack: 
* https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/fetch/FetchPhase.java#L154-L157
* https://github.com/opensearch-project/OpenSearch/blob/2847695ad1fcc04c88b96c8bab0bfdf694fa05dc/server/src/main/java/org/opensearch/common/lucene/index/SequentialStoredFieldsLeafReader.java#L71

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
