### PR TITLE
Add version check for full field name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixing the bug to prevent index.knn setting from being modified or removed on restore snapshot (#2445)[https://github.com/opensearch-project/k-NN/pull/2445]
 * Fix Faiss byte vector efficient filter bug (#2448)[https://github.com/opensearch-project/k-NN/pull/2448]
 * Fixing bug where mapping accepts both dimension and model-id (#2410)[https://github.com/opensearch-project/k-NN/pull/2410]
+* Add version check for full field name validation (#2477)[https://github.com/opensearch-project/k-NN/pull/2477]
 ### Infrastructure
 * Updated C++ version in JNI from c++11 to c++17 [#2259](https://github.com/opensearch-project/k-NN/pull/2259)
 * Upgrade bytebuddy and objenesis version to match OpenSearch core and, update github ci runner for macos [#2279](https://github.com/opensearch-project/k-NN/pull/2279)

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -58,6 +58,7 @@ import static org.opensearch.knn.common.KNNValidationUtil.validateVectorDimensio
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createKNNMethodContextFromLegacy;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForByteVector;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForFloatVector;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.useFullFieldNameValidation;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateIfCircuitBreakerIsNotTriggered;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateIfKNNPluginEnabled;
 import static org.opensearch.knn.index.mapper.ModelFieldMapper.UNSET_MODEL_DIMENSION_IDENTIFIER;
@@ -240,7 +241,9 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
         @Override
         public KNNVectorFieldMapper build(BuilderContext context) {
-            validateFullFieldName(context);
+            if (useFullFieldNameValidation(indexCreatedVersion)) {
+                validateFullFieldName(context);
+            }
 
             final MultiFields multiFieldsBuilder = this.multiFieldsBuilder.build(this, context);
             final CopyTo copyToBuilder = copyTo.build();

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -146,6 +146,16 @@ public class KNNVectorFieldMapperUtil {
         return indexCreatedVersion.onOrAfter(Version.V_2_17_0);
     }
 
+    /**
+     * Determines if full field name validation should be applied based on the index creation version.
+     *
+     * @param indexCreatedVersion The version when the index was created
+     * @return true if the index version is 2.17.0 or later, false otherwise
+     */
+    static boolean useFullFieldNameValidation(final Version indexCreatedVersion) {
+        return indexCreatedVersion != null && indexCreatedVersion.onOrAfter(Version.V_2_17_0);
+    }
+
     public static SpaceType getSpaceType(final Settings indexSettings) {
         String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
         if (spaceType == null) {

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1177,6 +1177,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 when(parseContext.parser()).thenReturn(createXContentParser(dataType));
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(true);
+                utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(true);
 
                 OriginalMappingParameters originalMappingParameters = new OriginalMappingParameters(
                     dataType,
@@ -1222,6 +1223,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 );
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(false);
+                utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(false);
 
                 document = new ParseContext.Document();
                 contentPath = new ContentPath();
@@ -1287,6 +1289,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 when(parseContext.parser()).thenReturn(createXContentParser(dataType));
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(true);
+                utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(true);
 
                 OriginalMappingParameters originalMappingParameters = new OriginalMappingParameters(
                     VectorDataType.DEFAULT,
@@ -1335,6 +1338,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 );
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(false);
+                utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(true);
 
                 document = new ParseContext.Document();
                 contentPath = new ContentPath();

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -76,4 +76,13 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
         Assert.assertFalse(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_16_0));
         Assert.assertTrue(KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Version.V_2_17_0));
     }
+
+    /**
+     * Test useFullFieldNameValidation method for different OpenSearch versions
+     */
+    public void testUseFullFieldNameValidation() {
+        Assert.assertFalse(KNNVectorFieldMapperUtil.useFullFieldNameValidation(Version.V_2_16_0));
+        Assert.assertTrue(KNNVectorFieldMapperUtil.useFullFieldNameValidation(Version.V_2_17_0));
+        Assert.assertTrue(KNNVectorFieldMapperUtil.useFullFieldNameValidation(Version.V_2_18_0));
+    }
 }


### PR DESCRIPTION
### Description
- Adds a version check for field name validation 
- This is to prevent issues during version upgrades for users moving from versions <2.17.0 to a higher version - essentially preventing upgrade failures and rendering the check for indexes created on or after 2.17.0

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
