### PR TITLE
skip/ignore RestoreSnapshotIT to unblock 2.19 release

### DIFF
--- a/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
+++ b/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index;
 
+import org.junit.Ignore;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -16,6 +17,7 @@ import org.junit.Test;
 import lombok.SneakyThrows;
 import static org.hamcrest.Matchers.containsString;
 
+@Ignore
 public class RestoreSnapshotIT extends KNNRestTestCase {
 
     private String index = "test-index";;
@@ -29,6 +31,7 @@ public class RestoreSnapshotIT extends KNNRestTestCase {
         setupSnapshotRestore(index, snapshot, repository);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2458")
     @Test
     @SneakyThrows
     public void testKnnSettingIsModifiable_whenRestore_thenSuccess() {
@@ -51,6 +54,7 @@ public class RestoreSnapshotIT extends KNNRestTestCase {
         assertEquals(200, restoreResponse.getStatusLine().getStatusCode());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2458")
     @Test
     @SneakyThrows
     public void testKnnSettingIsUnmodifiable_whenRestore_thenFailure() {
@@ -72,6 +76,7 @@ public class RestoreSnapshotIT extends KNNRestTestCase {
         assertThat(error.getMessage(), containsString("cannot modify UnmodifiableOnRestore setting [index.knn]" + " on restore"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2458")
     @Test
     @SneakyThrows
     public void testKnnSettingCanBeIgnored_whenRestore_thenSuccess() {
@@ -89,6 +94,7 @@ public class RestoreSnapshotIT extends KNNRestTestCase {
         assertEquals(200, restoreResponse.getStatusLine().getStatusCode());
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2458")
     @Test
     @SneakyThrows
     public void testKnnSettingCannotBeIgnored_whenRestore_thenFailure() {


### PR DESCRIPTION
### Description
- Mute `RestoreSnapshotIT` test to unblock 2.19 release after confirmation with engineers on KNN team
- Will need some time to root cause issue and fix, so muting to unblock release

### Related Issues
Resolves #2458

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
