### PR TITLE
[Backport main] Enabled concurrent graph creation for Lucene engine with index thread qty settings (#2480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use one formula to calculate cosine similarity (#2357)[https://github.com/opensearch-project/k-NN/pull/2357]
 - Add WithFieldName implementation to KNNQueryBuilder (#2398)[https://github.com/opensearch-project/k-NN/pull/2398]
 - Make the build work for M series MacOS without manual code changes and local JAVA_HOME config (#2397)[https://github.com/opensearch-project/k-NN/pull/2397]
+- Enabled concurrent graph creation for Lucene engine with index thread qty settings(#2480)[https://github.com/opensearch-project/k-NN/pull/2480]
 - Remove DocsWithFieldSet reference from NativeEngineFieldVectorsWriter (#2408)[https://github.com/opensearch-project/k-NN/pull/2408]
 ### Bug Fixes
 * Fixing the bug when a segment has no vector field present for disk based vector search (#2282)[https://github.com/opensearch-project/k-NN/pull/2282]

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -709,6 +709,14 @@ public class KNNSettings {
         });
     }
 
+    /**
+     * Get the index thread quantity setting value from cluster setting.
+     * @return int
+     */
+    public static int getIndexThreadQty() {
+        return KNNSettings.state().getSettingValue(KNN_ALGO_PARAM_INDEX_THREAD_QTY);
+    }
+
     private static String percentageAsString(Integer percentage) {
         return percentage + "%";
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -7,18 +7,22 @@ package org.opensearch.knn.index.codec.KNN9120Codec;
 
 import org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.BasePerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Class provides per field format implementation for Lucene Knn vector type
  */
 public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat {
-    private static final int NUM_MERGE_WORKERS = 1;
+    private static final Tuple<Integer, ExecutorService> DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE = Tuple.tuple(1, null);
 
     public KNN9120PerFieldKnnVectorsFormat(final Optional<MapperService> mapperService) {
         super(
@@ -27,37 +31,67 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
             Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH,
             Lucene99HnswVectorsFormat::new,
             knnVectorsFormatParams -> {
+                final Tuple<Integer, ExecutorService> mergeThreadCountAndExecutorService = getMergeThreadCountAndExecutorService();
                 // There is an assumption here that hamming space will only be used for binary vectors. This will need to be fixed if that
                 // changes in the future.
                 if (knnVectorsFormatParams.getSpaceType() == SpaceType.HAMMING) {
                     return new KNN9120HnswBinaryVectorsFormat(
                         knnVectorsFormatParams.getMaxConnections(),
-                        knnVectorsFormatParams.getBeamWidth()
+                        knnVectorsFormatParams.getBeamWidth(),
+                        // number of merge threads
+                        mergeThreadCountAndExecutorService.v1(),
+                        // executor service
+                        mergeThreadCountAndExecutorService.v2()
                     );
                 } else {
-                    return new Lucene99HnswVectorsFormat(knnVectorsFormatParams.getMaxConnections(), knnVectorsFormatParams.getBeamWidth());
+                    return new Lucene99HnswVectorsFormat(
+                        knnVectorsFormatParams.getMaxConnections(),
+                        knnVectorsFormatParams.getBeamWidth(),
+                        // number of merge threads
+                        mergeThreadCountAndExecutorService.v1(),
+                        // executor service
+                        mergeThreadCountAndExecutorService.v2()
+                    );
                 }
             },
-            knnScalarQuantizedVectorsFormatParams -> new Lucene99HnswScalarQuantizedVectorsFormat(
-                knnScalarQuantizedVectorsFormatParams.getMaxConnections(),
-                knnScalarQuantizedVectorsFormatParams.getBeamWidth(),
-                NUM_MERGE_WORKERS,
-                knnScalarQuantizedVectorsFormatParams.getBits(),
-                knnScalarQuantizedVectorsFormatParams.isCompressFlag(),
-                knnScalarQuantizedVectorsFormatParams.getConfidenceInterval(),
-                null
-            )
+            knnScalarQuantizedVectorsFormatParams -> {
+                final Tuple<Integer, ExecutorService> mergeThreadCountAndExecutorService = getMergeThreadCountAndExecutorService();
+                return new Lucene99HnswScalarQuantizedVectorsFormat(
+                    knnScalarQuantizedVectorsFormatParams.getMaxConnections(),
+                    knnScalarQuantizedVectorsFormatParams.getBeamWidth(),
+                    // Number of merge threads
+                    mergeThreadCountAndExecutorService.v1(),
+                    knnScalarQuantizedVectorsFormatParams.getBits(),
+                    knnScalarQuantizedVectorsFormatParams.isCompressFlag(),
+                    knnScalarQuantizedVectorsFormatParams.getConfidenceInterval(),
+                    // Executor service
+                    mergeThreadCountAndExecutorService.v2()
+                );
+            }
         );
     }
 
-    @Override
     /**
      * This method returns the maximum dimension allowed from KNNEngine for Lucene codec
      *
      * @param fieldName Name of the field, ignored
      * @return Maximum constant dimension set by KNNEngine
      */
+    @Override
     public int getMaxDimensions(String fieldName) {
         return KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    private static Tuple<Integer, ExecutorService> getMergeThreadCountAndExecutorService() {
+        // To ensure that only once we are fetching the settings per segment, we are fetching the num threads once while
+        // creating the executors
+        int mergeThreadCount = KNNSettings.getIndexThreadQty();
+        // We need to return null whenever the merge threads are <=1, as lucene assumes that if number of threads are 1
+        // then we should be giving a null value of the executor
+        if (mergeThreadCount <= 1) {
+            return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
+        } else {
+            return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -226,7 +226,7 @@ public class NativeIndexWriter {
         maybeAddBinaryPrefixForFaissBWC(knnEngine, parameters, fieldAttributes);
 
         // Used to determine how many threads to use when indexing
-        parameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
+        parameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.getIndexThreadQty());
 
         return parameters;
     }
@@ -258,7 +258,7 @@ public class NativeIndexWriter {
 
     private Map<String, Object> getTemplateParameters(FieldInfo fieldInfo, Model model) throws IOException {
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.state().getSettingValue(KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY));
+        parameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.getIndexThreadQty());
         parameters.put(KNNConstants.MODEL_ID, fieldInfo.attributes().get(MODEL_ID));
         parameters.put(KNNConstants.MODEL_BLOB_PARAMETER, model.getModelBlob());
         if (FieldInfoExtractor.extractQuantizationConfig(fieldInfo) != QuantizationConfig.EMPTY) {

--- a/src/main/java/org/opensearch/knn/training/TrainingJob.java
+++ b/src/main/java/org/opensearch/knn/training/TrainingJob.java
@@ -179,10 +179,7 @@ public class TrainingJob implements Runnable {
                 .getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext);
 
             Map<String, Object> trainParameters = libraryIndexingContext.getLibraryParameters();
-            trainParameters.put(
-                KNNConstants.INDEX_THREAD_QTY,
-                KNNSettings.state().getSettingValue(KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY)
-            );
+            trainParameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.getIndexThreadQty());
 
             if (libraryIndexingContext.getQuantizationConfig() != QuantizationConfig.EMPTY) {
                 trainParameters.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.BINARY.getValue());

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -205,6 +205,17 @@ public class KNNSettingsTests extends KNNTestCase {
         assertEquals(expectedKNNFaissAVX2Disabled, actualKNNFaissAVX2Disabled);
     }
 
+    @SneakyThrows
+    public void testGetIndexThreadQty_WithDifferentValues_thenSuccess() {
+        Node mockNode = createMockNode(Map.of(KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY, 3));
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        int threadQty = KNNSettings.getIndexThreadQty();
+        mockNode.close();
+        assertEquals(3, threadQty);
+    }
+
     private Node createMockNode(Map<String, Object> configSettings) throws IOException {
         Path configDir = createTempDir();
         File configFile = configDir.resolve("opensearch.yml").toFile();


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/k-NN/pull/2480

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).