### PR TITLE
Fix bytes offset bug and duplicate readers and add uTs for derived source

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsFormat.java
@@ -19,6 +19,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaders;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
@@ -55,11 +56,14 @@ public class DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
         if (derivedVectorFields == null || derivedVectorFields.isEmpty()) {
             return delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
         }
+
+        SegmentReadState segmentReadState = new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext);
+        DerivedSourceReaders derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
         return new DerivedSourceStoredFieldsReader(
             delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext),
             derivedVectorFields,
-            derivedSourceReadersSupplier,
-            new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext)
+            derivedSourceReaders,
+            segmentReadState
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsReader.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.KNN9120Codec;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentReadState;
@@ -18,6 +19,7 @@ import org.opensearch.knn.index.codec.derivedsource.DerivedSourceVectorInjector;
 import java.io.IOException;
 import java.util.List;
 
+@Log4j2
 public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
     private final StoredFieldsReader delegate;
     private final List<FieldInfo> derivedVectorFields;
@@ -102,6 +104,7 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
 
     @Override
     public void close() throws IOException {
+        log.info("Closing derived source stored fields reader for segment: " + segmentReadState.segmentInfo.name);
         IOUtils.close(delegate, derivedSourceVectorInjector);
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsReader.java
@@ -12,7 +12,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.index.fieldvisitor.FieldsVisitor;
-import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaders;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceStoredFieldVisitor;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceVectorInjector;
 
@@ -23,7 +23,7 @@ import java.util.List;
 public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
     private final StoredFieldsReader delegate;
     private final List<FieldInfo> derivedVectorFields;
-    private final DerivedSourceReadersSupplier derivedSourceReadersSupplier;
+    private final DerivedSourceReaders derivedSourceReaders;
     private final SegmentReadState segmentReadState;
     private final boolean shouldInject;
 
@@ -33,36 +33,36 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
      *
      * @param delegate delegate StoredFieldsReader
      * @param derivedVectorFields List of fields that are derived source fields
-     * @param derivedSourceReadersSupplier Supplier for the derived source readers
+     * @param derivedSourceReaders Derived source readers
      * @param segmentReadState SegmentReadState for the segment
      * @throws IOException in case of I/O error
      */
     public DerivedSourceStoredFieldsReader(
         StoredFieldsReader delegate,
         List<FieldInfo> derivedVectorFields,
-        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState
     ) throws IOException {
-        this(delegate, derivedVectorFields, derivedSourceReadersSupplier, segmentReadState, true);
+        this(delegate, derivedVectorFields, derivedSourceReaders, segmentReadState, true);
     }
 
     private DerivedSourceStoredFieldsReader(
         StoredFieldsReader delegate,
         List<FieldInfo> derivedVectorFields,
-        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState,
         boolean shouldInject
     ) throws IOException {
         this.delegate = delegate;
         this.derivedVectorFields = derivedVectorFields;
-        this.derivedSourceReadersSupplier = derivedSourceReadersSupplier;
+        this.derivedSourceReaders = derivedSourceReaders;
         this.segmentReadState = segmentReadState;
         this.shouldInject = shouldInject;
         this.derivedSourceVectorInjector = createDerivedSourceVectorInjector();
     }
 
-    private DerivedSourceVectorInjector createDerivedSourceVectorInjector() throws IOException {
-        return new DerivedSourceVectorInjector(derivedSourceReadersSupplier, segmentReadState, derivedVectorFields);
+    private DerivedSourceVectorInjector createDerivedSourceVectorInjector() {
+        return new DerivedSourceVectorInjector(derivedSourceReaders, segmentReadState, derivedVectorFields);
     }
 
     @Override
@@ -88,7 +88,7 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
             return new DerivedSourceStoredFieldsReader(
                 delegate.clone(),
                 derivedVectorFields,
-                derivedSourceReadersSupplier,
+                derivedSourceReaders.clone(),
                 segmentReadState,
                 shouldInject
             );
@@ -104,7 +104,7 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
 
     @Override
     public void close() throws IOException {
-        log.info("Closing derived source stored fields reader for segment: " + segmentReadState.segmentInfo.name);
+        log.debug("Closing derived source stored fields reader for segment: " + segmentReadState.segmentInfo.name);
         IOUtils.close(delegate, derivedSourceVectorInjector);
     }
 
@@ -120,7 +120,7 @@ public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
             return new DerivedSourceStoredFieldsReader(
                 delegate.getMergeInstance(),
                 derivedVectorFields,
-                derivedSourceReadersSupplier,
+                derivedSourceReaders.clone(),
                 segmentReadState,
                 false
             );

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsWriter.java
@@ -79,7 +79,7 @@ public class DerivedSourceStoredFieldsWriter extends StoredFieldsWriter {
             // Reference:
             // https://github.com/opensearch-project/OpenSearch/blob/2.18.0/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java#L322
             Tuple<? extends MediaType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(
-                BytesReference.fromByteBuffer(ByteBuffer.wrap(bytesRef.bytes)),
+                BytesReference.fromByteBuffer(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length)),
                 true,
                 MediaTypeRegistry.JSON
             );

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120Codec.java
@@ -25,6 +25,7 @@ public class KNN9120Codec extends FilterCodec {
     private static final KNNCodecVersion VERSION = KNNCodecVersion.V_9_12_0;
     private final KNNFormatFacade knnFormatFacade;
     private final PerFieldKnnVectorsFormat perFieldKnnVectorsFormat;
+    private final StoredFieldsFormat storedFieldsFormat;
 
     private final MapperService mapperService;
 
@@ -48,6 +49,7 @@ public class KNN9120Codec extends FilterCodec {
         knnFormatFacade = VERSION.getKnnFormatFacadeSupplier().apply(delegate);
         perFieldKnnVectorsFormat = knnVectorsFormat;
         this.mapperService = mapperService;
+        this.storedFieldsFormat = getStoredFieldsFormat();
     }
 
     @Override
@@ -67,6 +69,10 @@ public class KNN9120Codec extends FilterCodec {
 
     @Override
     public StoredFieldsFormat storedFieldsFormat() {
+        return storedFieldsFormat;
+    }
+
+    private StoredFieldsFormat getStoredFieldsFormat() {
         DerivedSourceReadersSupplier derivedSourceReadersSupplier = new DerivedSourceReadersSupplier((segmentReadState) -> {
             if (segmentReadState.fieldInfos.hasVectorValues()) {
                 return knnVectorsFormat().fieldsReader(segmentReadState);

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Getter
 @Log4j2
-public class DerivedSourceReaders implements Closeable {
+public class DerivedSourceReaders implements Cloneable, Closeable {
     @Nullable
     private final KnnVectorsReader knnVectorsReader;
     @Nullable
@@ -35,9 +35,17 @@ public class DerivedSourceReaders implements Closeable {
     @Nullable
     private final NormsProducer normsProducer;
 
+    private final boolean isCloned;
+
     @Override
     public void close() throws IOException {
-        log.info("Closing derived source readers");
-        IOUtils.close(knnVectorsReader, docValuesProducer, fieldsProducer, normsProducer);
+        if (isCloned == false) {
+            IOUtils.close(knnVectorsReader, docValuesProducer, fieldsProducer, normsProducer);
+        }
+    }
+
+    @Override
+    public DerivedSourceReaders clone() {
+        return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, fieldsProducer, normsProducer, true);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.derivedsource;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -23,6 +24,7 @@ import java.io.IOException;
  */
 @RequiredArgsConstructor
 @Getter
+@Log4j2
 public class DerivedSourceReaders implements Closeable {
     @Nullable
     private final KnnVectorsReader knnVectorsReader;
@@ -35,6 +37,7 @@ public class DerivedSourceReaders implements Closeable {
 
     @Override
     public void close() throws IOException {
+        log.info("Closing derived source readers");
         IOUtils.close(knnVectorsReader, docValuesProducer, fieldsProducer, normsProducer);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersSupplier.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersSupplier.java
@@ -27,7 +27,7 @@ public class DerivedSourceReadersSupplier {
     private final DerivedSourceReaderSupplier<NormsProducer> normsProducer;
 
     /**
-     * Get the readers for the segment
+     * Get the readers for the segment.
      *
      * @param state SegmentReadState
      * @return DerivedSourceReaders
@@ -38,7 +38,8 @@ public class DerivedSourceReadersSupplier {
             knnVectorsReaderSupplier.apply(state),
             docValuesProducerSupplier.apply(state),
             fieldsProducerSupplier.apply(state),
-            normsProducer.apply(state)
+            normsProducer.apply(state),
+            false
         );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjector.java
@@ -39,6 +39,8 @@ public class DerivedSourceVectorInjector implements Closeable {
     private final List<PerFieldDerivedVectorInjector> perFieldDerivedVectorInjectors;
     private final Set<String> fieldNames;
 
+    private final String segmentName;
+
     /**
      * Constructor for DerivedSourceVectorInjector.
      *
@@ -60,6 +62,7 @@ public class DerivedSourceVectorInjector implements Closeable {
             );
             this.fieldNames.add(fieldInfo.name);
         }
+        this.segmentName = segmentReadState.segmentInfo.name;
     }
 
     /**
@@ -131,6 +134,7 @@ public class DerivedSourceVectorInjector implements Closeable {
 
     @Override
     public void close() throws IOException {
+        log.info("Closing derived source injector reader for segment" + segmentName);
         IOUtils.close(derivedSourceReaders);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjector.java
@@ -39,21 +39,19 @@ public class DerivedSourceVectorInjector implements Closeable {
     private final List<PerFieldDerivedVectorInjector> perFieldDerivedVectorInjectors;
     private final Set<String> fieldNames;
 
-    private final String segmentName;
-
     /**
      * Constructor for DerivedSourceVectorInjector.
      *
-     * @param derivedSourceReadersSupplier Supplier for the derived source readers.
+     * @param derivedSourceReaders Derived source readers.
      * @param segmentReadState Segment read state
      * @param fieldsToInjectVector List of fields to inject vectors into
      */
     public DerivedSourceVectorInjector(
-        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState,
         List<FieldInfo> fieldsToInjectVector
-    ) throws IOException {
-        this.derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
+    ) {
+        this.derivedSourceReaders = derivedSourceReaders;
         this.perFieldDerivedVectorInjectors = new ArrayList<>();
         this.fieldNames = new HashSet<>();
         for (FieldInfo fieldInfo : fieldsToInjectVector) {
@@ -62,7 +60,6 @@ public class DerivedSourceVectorInjector implements Closeable {
             );
             this.fieldNames.add(fieldInfo.name);
         }
-        this.segmentName = segmentReadState.segmentInfo.name;
     }
 
     /**
@@ -134,7 +131,6 @@ public class DerivedSourceVectorInjector implements Closeable {
 
     @Override
     public void close() throws IOException {
-        log.info("Closing derived source injector reader for segment" + segmentName);
         IOUtils.close(derivedSourceReaders);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/ParentChildHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/ParentChildHelper.java
@@ -15,9 +15,12 @@ public class ParentChildHelper {
      * this would return "parent.to".
      *
      * @param field nested field path
-     * @return parent field path without the child
+     * @return parent field path without the child. Null if no parent exists
      */
     public static String getParentField(String field) {
+        if (field == null) {
+            return null;
+        }
         int lastDot = field.lastIndexOf('.');
         if (lastDot == -1) {
             return null;
@@ -30,10 +33,16 @@ public class ParentChildHelper {
      * return "child".
      *
      * @param field nested field path
-     * @return child field path without the parent path
+     * @return child field path without the parent path. Null if no child exists
      */
     public static String getChildField(String field) {
+        if (field == null) {
+            return null;
+        }
         int lastDot = field.lastIndexOf('.');
+        if (lastDot == -1) {
+            return null;
+        }
         return field.substring(lastDot + 1);
     }
 
@@ -46,7 +55,11 @@ public class ParentChildHelper {
      * @return sibling field path
      */
     public static String constructSiblingField(String field, String sibling) {
-        return getParentField(field) + "." + sibling;
+        String parent = getParentField(field);
+        if (parent == null) {
+            return sibling;
+        }
+        return parent + "." + sibling;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/VectorValueExtractorStrategy.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 /**
  * Provides different strategies to extract the vectors from different {@link KNNVectorValuesIterator}
  */
-interface VectorValueExtractorStrategy {
+public interface VectorValueExtractorStrategy {
 
     /**
      * Extract a float vector from KNNVectorValuesIterator.

--- a/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testWriteField() {
+        StoredFieldsWriter delegate = mock(StoredFieldsWriter.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("_source").build();
+        List<String> fields = List.of("test");
+
+        DerivedSourceStoredFieldsWriter derivedSourceStoredFieldsWriter = new DerivedSourceStoredFieldsWriter(delegate, fields);
+
+        Map<String, Object> source = Map.of("test", new float[] { 1.0f, 2.0f, 3.0f }, "text_field", "text_value");
+        BytesStreamOutput bStream = new BytesStreamOutput();
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON, bStream).map(source);
+        builder.close();
+        byte[] originalBytes = bStream.bytes().toBytesRef().bytes;
+        byte[] shiftedBytes = new byte[originalBytes.length + 2];
+        System.arraycopy(originalBytes, 0, shiftedBytes, 1, originalBytes.length);
+        derivedSourceStoredFieldsWriter.writeField(fieldInfo, new BytesRef(shiftedBytes, 1, originalBytes.length));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitorTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DerivedSourceStoredFieldVisitorTests extends KNNTestCase {
+
+    public void testBinaryField() throws Exception {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        doAnswer(invocationOnMock -> null).when(delegate).binaryField(any(), any());
+        DerivedSourceVectorInjector derivedSourceVectorInjector = mock(DerivedSourceVectorInjector.class);
+        when(derivedSourceVectorInjector.injectVectors(anyInt(), any())).thenReturn(new byte[0]);
+        DerivedSourceStoredFieldVisitor derivedSourceStoredFieldVisitor = new DerivedSourceStoredFieldVisitor(
+            delegate,
+            0,
+            derivedSourceVectorInjector
+        );
+
+        // When field is not _source, then do not call the injector
+        derivedSourceStoredFieldVisitor.binaryField(KNNCodecTestUtil.FieldInfoBuilder.builder("test").build(), null);
+        verify(derivedSourceVectorInjector, times(0)).injectVectors(anyInt(), any());
+        verify(delegate, times(1)).binaryField(any(), any());
+
+        // When field is not _source, then do call the injector
+        derivedSourceStoredFieldVisitor.binaryField(KNNCodecTestUtil.FieldInfoBuilder.builder("_source").build(), null);
+        verify(derivedSourceVectorInjector, times(1)).injectVectors(anyInt(), any());
+        verify(delegate, times(2)).binaryField(any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjectorTests.java
@@ -59,7 +59,7 @@ public class DerivedSourceVectorInjectorTests extends KNNTestCase {
             });
 
             DerivedSourceVectorInjector derivedSourceVectorInjector = new DerivedSourceVectorInjector(
-                new DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                new DerivedSourceReaders(null, null, null, null, false),
                 null,
                 fields
             );
@@ -119,7 +119,7 @@ public class DerivedSourceVectorInjectorTests extends KNNTestCase {
 
         try (
             DerivedSourceVectorInjector vectorInjector = new DerivedSourceVectorInjector(
-                new DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                new DerivedSourceReaders(null, null, null, null, false),
                 null,
                 fields
             )

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorInjectorTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.FieldInfo;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+
+public class DerivedSourceVectorInjectorTests extends KNNTestCase {
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    public void testInjectVectors() {
+        List<FieldInfo> fields = List.of(
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test1").build(),
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test2").build(),
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test3").build()
+        );
+
+        Map<String, float[]> fieldToVector = Collections.unmodifiableMap(new HashMap<>() {
+            {
+                put("test1", new float[] { 1.0f, 2.0f, 3.0f });
+                put("test2", new float[] { 4.0f, 5.0f, 6.0f, 7.0f });
+                put("test3", new float[] { 7.0f, 8.0f, 9.0f, 1.0f, 3.0f, 4.0f });
+                put("test4", null);
+            }
+        });
+
+        try (MockedStatic<PerFieldDerivedVectorInjectorFactory> factory = Mockito.mockStatic(PerFieldDerivedVectorInjectorFactory.class)) {
+            factory.when(() -> PerFieldDerivedVectorInjectorFactory.create(any(), any(), any())).thenAnswer(invocation -> {
+                FieldInfo fieldInfo = invocation.getArgument(0);
+                return (PerFieldDerivedVectorInjector) (docId, sourceAsMap) -> {
+                    float[] vector = fieldToVector.get(fieldInfo.name);
+                    if (vector != null) {
+                        sourceAsMap.put(fieldInfo.name, vector);
+                    }
+                };
+            });
+
+            DerivedSourceVectorInjector derivedSourceVectorInjector = new DerivedSourceVectorInjector(
+                new DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                null,
+                fields
+            );
+
+            int docId = 2;
+            String existingFieldKey = "existingField";
+            String existingFieldValue = "existingField";
+            Map<String, Object> source = Map.of(existingFieldKey, existingFieldValue);
+            byte[] originalSourceBytes = mapToBytes(source);
+            byte[] modifiedSourceByttes = derivedSourceVectorInjector.injectVectors(docId, originalSourceBytes);
+            Map<String, Object> modifiedSource = bytesToMap(modifiedSourceByttes);
+
+            assertEquals(existingFieldValue, modifiedSource.get(existingFieldKey));
+
+            assertArrayEquals(fieldToVector.get("test1"), toFloatArray((List<Double>) modifiedSource.get("test1")), 0.000001f);
+            assertArrayEquals(fieldToVector.get("test2"), toFloatArray((List<Double>) modifiedSource.get("test2")), 0.000001f);
+            assertArrayEquals(fieldToVector.get("test3"), toFloatArray((List<Double>) modifiedSource.get("test3")), 0.000001f);
+            assertFalse(modifiedSource.containsKey("test4"));
+        }
+    }
+
+    @SneakyThrows
+    private byte[] mapToBytes(Map<String, Object> map) {
+
+        BytesStreamOutput bStream = new BytesStreamOutput(1024);
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON, bStream).map(map);
+        builder.close();
+        return BytesReference.toBytes(BytesReference.bytes(builder));
+    }
+
+    private float[] toFloatArray(List<Double> list) {
+        float[] array = new float[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            array[i] = list.get(i).floatValue();
+        }
+        return array;
+    }
+
+    private Map<String, Object> bytesToMap(byte[] bytes) {
+        Tuple<? extends MediaType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(
+            BytesReference.fromByteBuffer(ByteBuffer.wrap(bytes)),
+            true,
+            MediaTypeRegistry.getDefaultMediaType()
+        );
+
+        return mapTuple.v2();
+    }
+
+    @SneakyThrows
+    public void testShouldInject() {
+
+        List<FieldInfo> fields = List.of(
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test1").build(),
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test2").build(),
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test3").build()
+        );
+
+        try (
+            DerivedSourceVectorInjector vectorInjector = new DerivedSourceVectorInjector(
+                new DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                null,
+                fields
+            )
+        ) {
+            assertTrue(vectorInjector.shouldInject(null, null));
+            assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, null));
+            assertTrue(vectorInjector.shouldInject(new String[] { "test1", "test2", "test3" }, null));
+            assertTrue(vectorInjector.shouldInject(null, new String[] { "test2" }));
+            assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, new String[] { "test2" }));
+            assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, new String[] { "test2", "test3" }));
+            assertFalse(vectorInjector.shouldInject(null, new String[] { "test1", "test2", "test3" }));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/ParentChildHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/ParentChildHelperTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.opensearch.knn.KNNTestCase;
+
+public class ParentChildHelperTests extends KNNTestCase {
+
+    public void testGetParentField() {
+        assertEquals("parent.to", ParentChildHelper.getParentField("parent.to.child"));
+        assertEquals("parent", ParentChildHelper.getParentField("parent.to"));
+        assertNull(ParentChildHelper.getParentField("child"));
+        assertNull(ParentChildHelper.getParentField(""));
+        assertNull(ParentChildHelper.getParentField(null));
+    }
+
+    public void testGetChildField() {
+        assertEquals("child", ParentChildHelper.getChildField("parent.to.child"));
+        assertNull(ParentChildHelper.getChildField(null));
+        assertNull(ParentChildHelper.getChildField("child"));
+    }
+
+    public void testConstructSiblingField() {
+        assertEquals("parent.to.sibling", ParentChildHelper.constructSiblingField("parent.to.child", "sibling"));
+        assertEquals("sibling", ParentChildHelper.constructSiblingField("parent", "sibling"));
+    }
+
+    public void testSplitPath() {
+        String[] path = ParentChildHelper.splitPath("parent.to.child");
+        assertEquals(3, path.length);
+        assertEquals("parent", path[0]);
+        assertEquals("to", path[1]);
+        assertEquals("child", path[2]);
+
+        path = ParentChildHelper.splitPath("parent");
+        assertEquals(1, path.length);
+        assertEquals("parent", path[0]);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorInjectorFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorInjectorFactoryTests.java
@@ -13,7 +13,7 @@ public class PerFieldDerivedVectorInjectorFactoryTests extends KNNTestCase {
         // Non-nested case
         PerFieldDerivedVectorInjector perFieldDerivedVectorInjector = PerFieldDerivedVectorInjectorFactory.create(
             KNNCodecTestUtil.FieldInfoBuilder.builder("test").build(),
-            new DerivedSourceReaders(null, null, null, null),
+            new DerivedSourceReaders(null, null, null, null, false),
             null
         );
         assertTrue(perFieldDerivedVectorInjector instanceof RootPerFieldDerivedVectorInjector);
@@ -21,7 +21,7 @@ public class PerFieldDerivedVectorInjectorFactoryTests extends KNNTestCase {
         // Nested case
         perFieldDerivedVectorInjector = PerFieldDerivedVectorInjectorFactory.create(
             KNNCodecTestUtil.FieldInfoBuilder.builder("parent.test").build(),
-            new DerivedSourceReaders(null, null, null, null),
+            new DerivedSourceReaders(null, null, null, null, false),
             null
         );
         assertTrue(perFieldDerivedVectorInjector instanceof NestedPerFieldDerivedVectorInjector);

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorInjectorFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorInjectorFactoryTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+
+public class PerFieldDerivedVectorInjectorFactoryTests extends KNNTestCase {
+    public void testCreate() {
+        // Non-nested case
+        PerFieldDerivedVectorInjector perFieldDerivedVectorInjector = PerFieldDerivedVectorInjectorFactory.create(
+            KNNCodecTestUtil.FieldInfoBuilder.builder("test").build(),
+            new DerivedSourceReaders(null, null, null, null),
+            null
+        );
+        assertTrue(perFieldDerivedVectorInjector instanceof RootPerFieldDerivedVectorInjector);
+
+        // Nested case
+        perFieldDerivedVectorInjector = PerFieldDerivedVectorInjectorFactory.create(
+            KNNCodecTestUtil.FieldInfoBuilder.builder("parent.test").build(),
+            new DerivedSourceReaders(null, null, null, null),
+            null
+        );
+        assertTrue(perFieldDerivedVectorInjector instanceof NestedPerFieldDerivedVectorInjector);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorInjectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorInjectorTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
+import org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.knn.KNNRestTestCase.FIELD_NAME;
+
+public class RootPerFieldDerivedVectorInjectorTests extends KNNTestCase {
+    public static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
+
+    @SneakyThrows
+    public void testInject() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder(FIELD_NAME).build();
+        try (MockedStatic<KNNVectorValuesFactory> mockedKnnVectorValues = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            mockedKnnVectorValues.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, null, null))
+                .thenReturn(new KNNVectorValues<float[]>(new KNNVectorValuesIterator() {
+                    @Override
+                    public int docId() {
+                        return 0;
+                    }
+
+                    @Override
+                    public int advance(int docId) {
+                        return 0;
+                    }
+
+                    @Override
+                    public int nextDoc() {
+                        return 0;
+                    }
+
+                    @Override
+                    public DocIdSetIterator getDocIdSetIterator() {
+                        return null;
+                    }
+
+                    @Override
+                    public long liveDocs() {
+                        return 0;
+                    }
+
+                    @Override
+                    public VectorValueExtractorStrategy getVectorExtractorStrategy() {
+                        return null;
+                    }
+                }) {
+
+                    @Override
+                    public float[] getVector() {
+                        return TEST_VECTOR;
+                    }
+
+                    @Override
+                    public float[] conditionalCloneVector() {
+                        return TEST_VECTOR;
+                    }
+                });
+            PerFieldDerivedVectorInjector perFieldDerivedVectorInjector = new RootPerFieldDerivedVectorInjector(
+                fieldInfo,
+                new DerivedSourceReaders(null, null, null, null)
+            );
+
+            Map<String, Object> source = new HashMap<>();
+            perFieldDerivedVectorInjector.inject(0, source);
+            assertArrayEquals(TEST_VECTOR, (float[]) source.get(FIELD_NAME), 0.0001f);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fixes a bug in the derived source writer where we are reading the entire bytes array from the bytes ref instead of just the offset+length.

This was the error:
```
[2025-02-04T23:43:54,004][WARN ][o.o.i.e.Engine           ] [test] [target_index][0] failed engine [already closed by tragic event on the index writer]
org.opensearch.core.compress.NotXContentException: Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes
	at org.opensearch.core.compress.CompressorRegistry.compressor(CompressorRegistry.java:75) ~[opensearch-core-2.19.0.jar:2.19.0]
	at org.opensearch.common.xcontent.XContentHelper.convertToMap(XContentHelper.java:166) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.knn.index.codec.KNN9120Codec.DerivedSourceStoredFieldsWriter.writeField(DerivedSourceStoredFieldsWriter.java:81) ~[?:?]
	at org.apache.lucene.index.StoredFieldsConsumer.writeField(StoredFieldsConsumer.java:80) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.IndexingChain.processField(IndexingChain.java:754) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.IndexingChain.processDocument(IndexingChain.java:609) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.DocumentsWriterPerThread.updateDocuments(DocumentsWriterPerThread.java:263) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.DocumentsWriter.updateDocuments(DocumentsWriter.java:425) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.IndexWriter.updateDocuments(IndexWriter.java:1562) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.IndexWriter.updateDocument(IndexWriter.java:1847) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.apache.lucene.index.IndexWriter.addDocument(IndexWriter.java:1487) ~[lucene-core-9.12.1.jar:9.12.1 7a97a05a239d6fb9f1f347aa09bfa52e875be092 - 2024-12-09 16:47:48]
	at org.opensearch.index.engine.InternalEngine.addDocs(InternalEngine.java:1295) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.index.engine.InternalEngine.indexIntoLucene(InternalEngine.java:1231) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.index.engine.InternalEngine.index(InternalEngine.java:1012) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.index.shard.IndexShard.index(IndexShard.java:1216) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.index.shard.IndexShard.applyIndexOperation(IndexShard.java:1161) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.index.shard.IndexShard.applyIndexOperationOnPrimary(IndexShard.java:1052) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.action.bulk.TransportShardBulkAction.executeBulkItemRequest(TransportShardBulkAction.java:625) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.action.bulk.TransportShardBulkAction$2.doRun(TransportShardBulkAction.java:471) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.action.bulk.TransportShardBulkAction.performOnPrimary(TransportShardBulkAction.java:535) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.action.bulk.TransportShardBulkAction.dispatchedShardOperationOnPrimary(TransportShardBulkAction.java:416) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.action.bulk.TransportShardBulkAction.dispatchedShardOperationOnPrimary(TransportShardBulkAction.java:125) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.action.support.replication.TransportWriteAction$1.doRun(TransportWriteAction.java:275) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1014) ~[opensearch-2.19.0.jar:2.19.0]
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-2.19.0.jar:2.19.0]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

In order to hit this error, I was using OpenSearch Benchmarks. However, when I dont use OpenSearch benchmarks (i.e. curl or plugin iTs), it seems to work fine. But, with OpenSearch benchmarks locally, I verified the fix. 

Also, fixes readers to only open one (extra) per segment

Along with that, touches up the ParentChildHelper (no prod impact) and also adds some unit tests.

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
