### PR TITLE
Update build.gradle and build.sh to separate x64 linux nmslib build with different gcc versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,11 @@ jobs:
       matrix:
         java: [11, 17, 21]
 
+    env:
+       CC: gcc10-gcc
+       CXX: gcc10-g++
+       FC: gcc10-gfortran
+
     name: Build and Test k-NN Plugin on Linux
     runs-on: ubuntu-latest
     needs: Get-CI-Image-Tag

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -39,6 +39,10 @@ jobs:
     strategy:
       matrix:
         java: [21]
+    env:
+       CC: gcc10-gcc
+       CXX: gcc10-g++
+       FC: gcc10-gfortran
 
     name: Run Integration Tests on Linux
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -347,13 +347,25 @@ task cmakeJniLib(type:Exec) {
     commandLine args
 }
 
+task buildNmslib(type:Exec) {
+    workingDir 'jni'
+    environment('CC', 'gcc')
+    environment('CXX', 'g++')
+    environment('FC', 'gfortran')
+    commandLine 'make', 'opensearchknn_nmslib', '-j', "${nproc_count}"
+}
+
 task buildJniLib(type:Exec) {
     dependsOn cmakeJniLib
     workingDir 'jni'
-    commandLine 'make', 'opensearchknn_nmslib', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
+    environment('CC', 'gcc10-gcc')
+    environment('CXX', 'gcc10-gcc')
+    environment('FC', 'gcc10-gcc')
+    commandLine 'make', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
 }
 
 test {
+    dependsOn buildNmslib
     dependsOn buildJniLib
     systemProperty 'tests.security.manager', 'false'
     systemProperty "java.library.path", "$rootDir/jni/release"
@@ -368,6 +380,7 @@ test {
 def _numNodes = findProperty('numNodes') as Integer ?: 1
 integTest {
     if (integTestDependOnJniLib) {
+        dependsOn buildNmslib
         dependsOn buildJniLib
     }
     systemProperty 'tests.security.manager', 'false'
@@ -468,6 +481,7 @@ task integTestRemote(type: RestIntegTestTask) {
 
 run {
     useCluster project.testClusters.integTest
+    dependsOn buildNmslib
     dependsOn buildJniLib
     doFirst {
         // There seems to be an issue when running multi node run or integ tasks with unicast_hosts

--- a/build.gradle
+++ b/build.gradle
@@ -343,24 +343,24 @@ task cmakeJniLib(type:Exec) {
         args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
         args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
     }
+    //if (System.getenv("LIBNAME") == "nmslib_linux_x64") {
+    //    environment('CC', 'gcc10-gcc')
+    //    environment('CXX', 'gcc10-g++')
+    //    environment('FC', 'gcc10-gfortran')
+    //}
 
     commandLine args
 }
 
 task buildNmslib(type:Exec) {
+    dependsOn cmakeJniLib
     workingDir 'jni'
-    environment('CC', 'gcc')
-    environment('CXX', 'g++')
-    environment('FC', 'gfortran')
-    commandLine 'make', 'opensearchknn_nmslib', '-j', "${nproc_count}"
+    commandLine 'make', '-B', 'opensearchknn_nmslib', '-j', "${nproc_count}"
 }
 
 task buildJniLib(type:Exec) {
     dependsOn cmakeJniLib
     workingDir 'jni'
-    environment('CC', 'gcc10-gcc')
-    environment('CXX', 'gcc10-gcc')
-    environment('FC', 'gcc10-gcc')
     commandLine 'make', 'opensearchknn_faiss', 'opensearchknn_common', '-j', "${nproc_count}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -343,11 +343,6 @@ task cmakeJniLib(type:Exec) {
         args.add("-DBLAS_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
         args.add("-DLAPACK_LIBRARIES=$rootDir\\src\\main\\resources\\windowsDependencies\\libopenblas.dll")
     }
-    //if (System.getenv("LIBNAME") == "nmslib_linux_x64") {
-    //    environment('CC', 'gcc10-gcc')
-    //    environment('CXX', 'gcc10-g++')
-    //    environment('FC', 'gcc10-gfortran')
-    //}
 
     commandLine args
 }

--- a/build.gradle
+++ b/build.gradle
@@ -350,7 +350,7 @@ task cmakeJniLib(type:Exec) {
 task buildNmslib(type:Exec) {
     dependsOn cmakeJniLib
     workingDir 'jni'
-    commandLine 'make', '-B', 'opensearchknn_nmslib', '-j', "${nproc_count}"
+    commandLine 'make', 'opensearchknn_nmslib', '-j', "${nproc_count}"
 }
 
 task buildJniLib(type:Exec) {

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -134,6 +134,7 @@ testClusters {
 // All nodes are upgraded to latest version and run the tests
     task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
         dependsOn "testAgainstOldCluster"
+        dependsOn rootProject.tasks.buildNmslib
         dependsOn rootProject.tasks.buildJniLib
         dependsOn rootProject.tasks.assemble
         useCluster testClusters."${baseName}"

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -52,6 +52,7 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
 // This results in a mixed cluster with 2 nodes on the old version and 1 upgraded node.
 task testAgainstOneThirdUpgradedCluster(type: StandaloneRestIntegTestTask) {
     useCluster testClusters."${baseName}"
+    dependsOn rootProject.tasks.buildNmslib
     dependsOn rootProject.tasks.buildJniLib
     dependsOn rootProject.tasks.assemble
     dependsOn "testAgainstOldCluster"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -133,7 +133,7 @@ cd $work_dir
 if [ "$PLATFORM" != "windows" ] && [ "$ARCHITECTURE" = "x64" ]; then
   echo "Building k-NN library nmslib with gcc 10 on non-windows x64"
   rm -rf jni/CMakeCache.txt jni/CMakeFiles
-  env CC=gcc10-gcc CXX=gcc10-g++ FC=gcc10-gfortran ./gradlew :buildNmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false --info
+  env CC=gcc10-gcc CXX=gcc10-g++ FC=gcc10-gfortran ./gradlew :buildNmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false
 
   echo "Building k-NN library after enabling AVX2"
   # Skip applying patches as patches were applied already from previous :buildJniLib task
@@ -148,7 +148,7 @@ if [ "$PLATFORM" != "windows" ] && [ "$ARCHITECTURE" = "x64" ]; then
   ./gradlew :buildJniLib -Davx512_spr.enabled=true -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false
 
 else
-  ./gradlew :buildNmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false --info
+  ./gradlew :buildNmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false
 fi
 
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER


### PR DESCRIPTION
### Description
Update build.gradle and build.sh to separate x64 linux nmslib build with different gcc versions

### Related Issues
Closes https://github.com/opensearch-project/k-NN/issues/2484

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
