### PR TITLE
Introduce node level circuit breaker settings for k-NN

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -470,7 +470,7 @@ task integTestRemote(type: RestIntegTestTask) {
     // Run tests with remote cluster only if rest case is defined
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {
-            includeTestsMatching "org.opensearch.knn.index.KNNCircuitBreakerIT"
+            includeTestsMatching "org.opensearch.knn.*IT"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -424,6 +424,9 @@ integTest {
 testClusters.integTest {
     testDistribution = "ARCHIVE"
 
+    //Used for circuit breaker integration tests
+    setting 'node.attr.knn_cb_tier', 'integ'
+
     // Optionally install security
     if (System.getProperty("security.enabled") != null) {
         configureSecurityPlugin(testClusters.integTest)
@@ -434,6 +437,7 @@ testClusters.integTest {
         // Add the paths of built JNI libraries and its dependent libraries to PATH variable in System variables
         environment('PATH', System.getenv('PATH') + ";$rootDir/jni/release" + ";$rootDir/src/main/resources/windowsDependencies")
     }
+
 
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
@@ -466,7 +470,7 @@ task integTestRemote(type: RestIntegTestTask) {
     // Run tests with remote cluster only if rest case is defined
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {
-            includeTestsMatching "org.opensearch.knn.*IT"
+            includeTestsMatching "org.opensearch.knn.index.KNNCircuitBreakerIT"
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/KNNCircuitBreaker.java
+++ b/src/main/java/org/opensearch/knn/index/KNNCircuitBreaker.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class KNNCircuitBreaker {
     private static Logger logger = LogManager.getLogger(KNNCircuitBreaker.class);
-    public static int CB_TIME_INTERVAL = 10; // seconds
+    public static int CB_TIME_INTERVAL = 2 * 60; // seconds
 
     private static KNNCircuitBreaker INSTANCE;
     private ThreadPool threadPool;
@@ -57,7 +57,6 @@ public class KNNCircuitBreaker {
         this.clusterService = clusterService;
         this.client = client;
         NativeMemoryCacheManager nativeMemoryCacheManager = NativeMemoryCacheManager.getInstance();
-
         Runnable runnable = () -> {
             if (nativeMemoryCacheManager.isCacheCapacityReached() && clusterService.localNode().isDataNode()) {
                 long currentSizeKiloBytes = nativeMemoryCacheManager.getCacheSizeInKilobytes();

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -74,7 +74,8 @@ public class KNNSettings {
     public static final String KNN_ALGO_PARAM_EF_SEARCH = "index.knn.algo_param.ef_search";
     public static final String KNN_ALGO_PARAM_INDEX_THREAD_QTY = "knn.algo_param.index_thread_qty";
     public static final String KNN_MEMORY_CIRCUIT_BREAKER_ENABLED = "knn.memory.circuit_breaker.enabled";
-    public static final String KNN_MEMORY_CIRCUIT_BREAKER_LIMIT = "knn.memory.circuit_breaker.limit";
+    public static final String KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT = "knn.memory.circuit_breaker.limit";
+    public static final String KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX = "knn.memory.circuit_breaker.limit.";
     public static final String KNN_VECTOR_STREAMING_MEMORY_LIMIT_IN_MB = "knn.vector_streaming_memory.limit";
     public static final String KNN_CIRCUIT_BREAKER_TRIGGERED = "knn.circuit_breaker.triggered";
     public static final String KNN_CACHE_ITEM_EXPIRY_ENABLED = "knn.cache.item.expiry.enabled";
@@ -114,6 +115,7 @@ public class KNNSettings {
     public static final Integer KNN_MAX_MODEL_CACHE_SIZE_LIMIT_PERCENTAGE = 25; // Model cache limit cannot exceed 25% of the JVM heap
     public static final String KNN_DEFAULT_MEMORY_CIRCUIT_BREAKER_LIMIT = "50%";
     public static final String KNN_DEFAULT_VECTOR_STREAMING_MEMORY_LIMIT_PCT = "1%";
+    public static final String KNN_CIRCUIT_BREAKER_TIER = "knn_cb_tier";
 
     public static final Integer ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD_DEFAULT_VALUE = -1;
     public static final Integer KNN_DEFAULT_QUANTIZATION_STATE_CACHE_SIZE_LIMIT_PERCENTAGE = 5; // By default, set aside 5% of the JVM for
@@ -375,17 +377,33 @@ public class KNNSettings {
              * Weight circuit breaker settings
              */
             put(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, Setting.boolSetting(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, true, NodeScope, Dynamic));
+
+            /**
+             * Group setting that manages node-level circuit breaker configurations based on node tiers.
+             * Settings under this group define memory limits for different node classifications.
+             */
             put(
-                KNN_MEMORY_CIRCUIT_BREAKER_LIMIT,
+                KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX,
+                Setting.groupSetting(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX, NodeScope, Dynamic)
+            );
+
+            /**
+             * Cluster-wide circuit breaker limit that serves as the default configuration.
+             * This setting is used when a node either:
+             * - Has no circuit breaker tier attribute defined
+             * - Has a tier that doesn't match any node-level configuration
+             * Default value: {@value KNN_DEFAULT_MEMORY_CIRCUIT_BREAKER_LIMIT}
+             */
+            put(
+                KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT,
                 new Setting<>(
-                    KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT,
+                    KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT,
                     KNNSettings.KNN_DEFAULT_MEMORY_CIRCUIT_BREAKER_LIMIT,
-                    (s) -> parseknnMemoryCircuitBreakerValue(s, KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT),
+                    (s) -> parseknnMemoryCircuitBreakerValue(s, null, KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT),
                     NodeScope,
                     Dynamic
                 )
             );
-
             /**
              * Cache expiry time settings
              */
@@ -422,10 +440,9 @@ public class KNNSettings {
                 updatedSettings.getAsBoolean(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, getSettingValue(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED))
             );
 
-            builder.maxWeight(((ByteSizeValue) getSettingValue(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb());
-            if (updatedSettings.hasValue(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)) {
-                builder.maxWeight(((ByteSizeValue) getSetting(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT).get(updatedSettings)).getKb());
-            }
+            // If any cb related limits have changed at the cluster or node level, we need to check if the max weight of the cache needs to
+            // be updated as well.
+            builder.maxWeight(getUpdatedCircuitBreakerLimit(updatedSettings).getKb());
 
             builder.isExpirationLimited(
                 updatedSettings.getAsBoolean(KNN_CACHE_ITEM_EXPIRY_ENABLED, getSettingValue(KNN_CACHE_ITEM_EXPIRY_ENABLED))
@@ -550,8 +567,114 @@ public class KNNSettings {
         return KNNSettings.state().getSettingValue(KNNSettings.KNN_CIRCUIT_BREAKER_TRIGGERED);
     }
 
-    public static ByteSizeValue getCircuitBreakerLimit() {
-        return KNNSettings.state().getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT);
+    public static Settings getAllAvailableCbLimits() {
+        return KNNSettings.state().getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX);
+    }
+
+    /**
+     * Returns the cluster-level circuit breaker limit. Needed for initialization
+     * during startup when node attributes are not yet available through ClusterService.
+     * This limit serves two purposes:
+     * 1. As a temporary value during node startup before node-specific limits can be determined
+     * 2. As a fallback value for nodes that don't have a circuit_breaker_tier attribute or
+     *    whose tier doesn't match any configured node-level limit
+     *
+     * @return ByteSizeValue representing the cluster-wide circuit breaker limit
+     */
+    public static ByteSizeValue getClusterLevelCircuitBreakerLimit() {
+        return KNNSettings.state().getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT);
+    }
+
+    /**
+     * Returns the circuit breaker limit for this node. The limit is determined by:
+     * 1. Node-specific limit based on the node's circuit breaker tier attribute, if configured
+     * 2. Cluster-level default limit if no node-specific configuration exists
+     *
+     * @return ByteSizeValue representing the circuit breaker limit, either as a percentage
+     *         of available memory or as an absolute value
+     */
+    public ByteSizeValue getCircuitBreakerLimit() {
+
+        // Attempt to fetch node-level limits if present - otherwise fall back to the cluster-level value
+        return parseknnMemoryCircuitBreakerValue(
+            getKnnCircuitBreakerLimitForTier(getAllAvailableCbLimits()),
+            getClusterLevelCircuitBreakerLimit(),
+            KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX
+        );
+    }
+
+    /**
+     * Retrieves the circuit breaker limit configuration for this node's tier.
+     * The method:
+     * 1. Gets the node's circuit_breaker_tier attribute (if it exists)
+     * 2. Looks up the corresponding limit configuration
+     *
+     * For example, if a node has attribute circuit_breaker_tier: "high",
+     * this will return the limit configured for the "high" tier.
+     *
+     * @return String representing the circuit breaker limit for this node's tier,
+     *         null if either:
+     *         - Node has no circuit_breaker_tier attribute
+     *         - No configuration exists for the node's tier
+     */
+    private String getKnnCircuitBreakerLimitForTier(Settings settings) {
+        // Get this node's circuit breaker tier attribute
+        String tierAttribute = clusterService.localNode().getAttributes().get(KNN_CIRCUIT_BREAKER_TIER);
+
+        if (tierAttribute == null) {
+            return null;
+        }
+
+        return settings.get(tierAttribute);
+    }
+
+    /**
+     * Determines if and how the circuit breaker limit should be updated for this node.
+     * Evaluates both node-specific and cluster-level updates in the updated settings,
+     * maintaining proper precedence:
+     * 1. Node-tier specific limit from updates (if available)
+     * 2. Appropriate fallback value based on node's current configuration
+     *
+     * @param updatedCbLimits Settings object containing pending circuit breaker updates
+     * @return ByteSizeValue representing the new circuit breaker limit to apply,
+     *         or null if no applicable updates found
+     */
+    private ByteSizeValue getUpdatedCircuitBreakerLimit(Settings updatedCbLimits) {
+        // Parse any updates, using appropriate fallback if no direct tier update exists
+        return parseknnMemoryCircuitBreakerValue(
+            getKnnCircuitBreakerLimitForTier(updatedCbLimits.getByPrefix(KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX)),
+            getFallbackCbLimitValue(updatedCbLimits),
+            KNN_MEMORY_CIRCUIT_BREAKER_LIMIT_PREFIX
+        );
+    }
+
+    /**
+     * Determines the appropriate fallback circuit breaker limit value.
+     * The fallback logic follows this hierarchy:
+     * 1. If node currently uses cluster-level limit:
+     *    - Use updated cluster-level limit if available
+     *    - Otherwise maintain current limit
+     * 2. If node uses tier-specific limit:
+     *    - Maintain current limit (ignore cluster-level updates)
+     *
+     * This ensures nodes maintain their configuration hierarchy and don't
+     * inadvertently fall back to cluster-level limits when they should use
+     * tier-specific values.
+     *
+     * @param updatedCbLimits Settings object containing pending updates
+     * @return ByteSizeValue representing the appropriate fallback limit
+     */
+    private ByteSizeValue getFallbackCbLimitValue(Settings updatedCbLimits) {
+        // Check if node is currently using cluster-level limit
+        if (getKnnCircuitBreakerLimitForTier(getAllAvailableCbLimits()) == null) {
+            // If there's an updated cluster-level limit, use it
+            if (updatedCbLimits.hasValue(KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT)) {
+                return (ByteSizeValue) getSetting(KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT).get(updatedCbLimits);
+            }
+        }
+
+        // Otherwise maintain current limit (either tier-specific or cluster-level)
+        return getCircuitBreakerLimit();
     }
 
     public static double getCircuitBreakerUnsetPercentage() {
@@ -614,7 +737,7 @@ public class KNNSettings {
         setSettingsUpdateConsumers();
     }
 
-    public static ByteSizeValue parseknnMemoryCircuitBreakerValue(String sValue, String settingName) {
+    public static ByteSizeValue parseknnMemoryCircuitBreakerValue(String sValue, ByteSizeValue defaultValue, String settingName) {
         settingName = Objects.requireNonNull(settingName);
         if (sValue != null && sValue.endsWith("%")) {
             final String percentAsString = sValue.substring(0, sValue.length() - 1);
@@ -634,7 +757,7 @@ public class KNNSettings {
                 throw new OpenSearchParseException("failed to parse [{}] as a double", e, percentAsString);
             }
         } else {
-            return parseBytesSizeValue(sValue, settingName);
+            return parseBytesSizeValue(sValue, defaultValue, settingName);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -81,11 +81,20 @@ public class NativeMemoryCacheManager implements Closeable {
         return INSTANCE;
     }
 
+    /**
+     * Initialize NativeMemoryCacheManager with configurations.
+     * Note: maxWeight is initially set to the cluster-level circuit breaker limit
+     * because node attributes are not yet available during startup. Once the
+     * ClusterService is fully bootstrapped, the circuit breaker will update this
+     * value to use any node-specific limits based on the node's circuit_breaker_tier
+     * attribute if configured.
+     */
     private void initialize() {
         initialize(
             NativeMemoryCacheManagerDto.builder()
                 .isWeightLimited(KNNSettings.state().getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED))
-                .maxWeight(KNNSettings.getCircuitBreakerLimit().getKb())
+                // Initially use cluster-level limit; will be updated later during cache refresh if node-specific limit exists
+                .maxWeight(KNNSettings.getClusterLevelCircuitBreakerLimit().getKb())
                 .isExpirationLimited(KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED))
                 .expiryTimeInMin(
                     ((TimeValue) KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES)).getMinutes()
@@ -127,7 +136,7 @@ public class NativeMemoryCacheManager implements Closeable {
         rebuildCache(
             NativeMemoryCacheManagerDto.builder()
                 .isWeightLimited(KNNSettings.state().getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED))
-                .maxWeight(KNNSettings.getCircuitBreakerLimit().getKb())
+                .maxWeight(KNNSettings.state().getCircuitBreakerLimit().getKb())
                 .isExpirationLimited(KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED))
                 .expiryTimeInMin(
                     ((TimeValue) KNNSettings.state().getSettingValue(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES)).getMinutes()
@@ -460,7 +469,7 @@ public class NativeMemoryCacheManager implements Closeable {
     }
 
     private Float getSizeAsPercentage(long size) {
-        long cbLimit = KNNSettings.getCircuitBreakerLimit().getKb();
+        long cbLimit = KNNSettings.state().getCircuitBreakerLimit().getKb();
         if (cbLimit == 0) {
             return 0.0F;
         }

--- a/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
@@ -5,13 +5,17 @@
 
 package org.opensearch.knn.index;
 
+import org.junit.Assert;
 import org.opensearch.knn.KNNRestTestCase;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.plugin.stats.StatNames;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.knn.index.KNNCircuitBreaker.CB_TIME_INTERVAL;
@@ -21,20 +25,79 @@ import static org.opensearch.knn.index.KNNCircuitBreaker.CB_TIME_INTERVAL;
  */
 public class KNNCircuitBreakerIT extends KNNRestTestCase {
     private static final Integer ALWAYS_BUILD_GRAPH = 0;
+    private static final String INDEX_1 = INDEX_NAME + "1";
+    private static final String INDEX_2 = INDEX_NAME + "2";
 
     /**
-     * To trip the circuit breaker, we will create two indices and index documents. Each index will be small enough so
-     * that individually they fit into the cache, but together they do not. To prevent Lucene conditions where
-     * multiple segments may or may not be created, we will force merge each index into a single segment before
-     * searching.
+     * Base setup for all circuit breaker tests.
+     * Creates two indices with enough documents to consume ~2kb of memory when loaded.
      */
-    private void tripCb() throws Exception {
-        // Make sure that Cb is intially not tripped
-        assertFalse(isCbTripped());
+    private void setupIndices() throws Exception {
+        generateCbLoad(INDEX_1, INDEX_2);
 
-        // Set circuit breaker limit to 1 KB
+        // Verify initial state
+        assertFalse(isCbTripped());
+    }
+
+    /**
+     * Tests circuit breaker behavior with only cluster-level limit configured.
+     * Expected behavior:
+     * 1. Set cluster limit to 1kb
+     * 2. Load indices consuming 2kb
+     * 3. Circuit breaker should trip
+     */
+    private void testClusterLevelCircuitBreaker() throws Exception {
+        // Set cluster-level limit to 1kb (half of what indices require)
         updateClusterSettings("knn.memory.circuit_breaker.limit", "1kb");
 
+        // Load indices into cache
+        search(INDEX_1, INDEX_2);
+
+        // Verify circuit breaker tripped
+        Thread.sleep(5 * 1000);
+        assertTrue(isCbTripped());
+    }
+
+    /**
+    * Tests circuit breaker behavior with only node-level limit configured.
+    * Expected behavior:
+    * 1. Set cluster limit high (10kb) to ensure it doesn't interfere
+    * 2. Set node limit to 1kb
+    * 3. Load indices consuming 2kb
+    * 4. Circuit breaker should trip because node limit (1kb) < memory needed (2kb)
+    */
+    private void testNodeLevelCircuitBreaker() throws Exception {
+
+        // Set cluster-level limit high to ensure it doesn't interfere
+        updateClusterSettings("knn.memory.circuit_breaker.limit", "10kb");
+
+        // Set node-level limit to 1kb (half of what indices require)
+        updateClusterSettings("knn.memory.circuit_breaker.limit.integ", "1kb");
+
+        // Load indices into cache
+        search(INDEX_1, INDEX_2);
+
+        // Verify circuit breaker tripped with 1kb node limit
+        Thread.sleep(5 * 1000);
+        assertTrue(isCbTripped());
+
+        // Increase node limit to 4kb - should untrip CB and show 50% usage
+        updateClusterSettings("knn.memory.circuit_breaker.limit.integ", "4kb");
+
+        // Load indices again
+        search(INDEX_1, INDEX_2);
+
+        // Verify CB untripped and correct memory usage
+        Thread.sleep(5 * 1000);
+        verifyCbUntrips();
+
+        // The contents of the cache should take about 2kb with the current test.
+        // This could change in the future depending on the cache library and other factors
+        // Verify value is greater than what the percentage would be if the cluster level circuit breaker was in play with 2kb
+        Assert.assertTrue(getGraphMemoryPercentage() > 20.0);
+    }
+
+    private void generateCbLoad(String indexName1, String indexName2) throws Exception {
         // Create index with 1 primary and numNodes-1 replicas so that the data will be on every node in the cluster
         int numNodes = Integer.parseInt(System.getProperty("cluster.number_of_nodes", "1"));
         Settings settings = Settings.builder()
@@ -43,9 +106,6 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
             .put("index.knn", true)
             .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, ALWAYS_BUILD_GRAPH)
             .build();
-
-        String indexName1 = INDEX_NAME + "1";
-        String indexName2 = INDEX_NAME + "2";
 
         createKnnIndex(indexName1, settings, createKnnIndexMapping(FIELD_NAME, 2));
         createKnnIndex(indexName2, settings, createKnnIndexMapping(FIELD_NAME, 2));
@@ -60,7 +120,9 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
 
         forceMergeKnnIndex(indexName1);
         forceMergeKnnIndex(indexName2);
+    }
 
+    private void search(String indexName1, String indexName2) throws IOException {
         // Execute search on both indices - will cause eviction
         float[] qvector = { 1.9f, 2.4f };
         int k = 10;
@@ -70,10 +132,16 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
             searchKNNIndex(indexName1, new KNNQueryBuilder(FIELD_NAME, qvector, k), k);
             searchKNNIndex(indexName2, new KNNQueryBuilder(FIELD_NAME, qvector, k), k);
         }
+    }
 
-        // Give cluster 5 seconds to update settings and then assert that Cb get triggered
-        Thread.sleep(5 * 1000); // seconds
-        assertTrue(isCbTripped());
+    private double getGraphMemoryPercentage() throws Exception {
+        Response response = getKnnStats(
+            Collections.emptyList(),
+            Collections.singletonList(StatNames.GRAPH_MEMORY_USAGE_PERCENTAGE.getName())
+        );
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<Map<String, Object>> nodeStatsResponse = parseNodeStatsResponse(responseBody);
+        return Double.parseDouble(nodeStatsResponse.getFirst().get(StatNames.GRAPH_MEMORY_USAGE_PERCENTAGE.getName()).toString());
     }
 
     public boolean isCbTripped() throws Exception {
@@ -84,12 +152,17 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
     }
 
     public void testCbTripped() throws Exception {
-        tripCb();
+        setupIndices();
+        testClusterLevelCircuitBreaker();
+        testNodeLevelCircuitBreaker();
     }
 
-    public void testCbUntrips() throws Exception {
-        updateClusterSettings("knn.circuit_breaker.triggered", "true");
-        assertTrue(isCbTripped());
+    public void verifyCbUntrips() throws Exception {
+
+        if (!isCbTripped()) {
+            updateClusterSettings("knn.circuit_breaker.triggered", "true");
+
+        }
 
         int backOffInterval = 5; // seconds
         for (int i = 0; i < CB_TIME_INTERVAL; i += backOffInterval) {

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -42,13 +42,13 @@ public class KNNSettingsTests extends KNNTestCase {
     public void testGetSettingValueFromConfig() {
         long expectedKNNCircuitBreakerLimit = 13;
         Node mockNode = createMockNode(
-            Map.of(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT, "\"" + expectedKNNCircuitBreakerLimit + "kb\"")
+            Map.of(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT, "\"" + expectedKNNCircuitBreakerLimit + "kb\"")
         );
         mockNode.start();
         ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
         KNNSettings.state().setClusterService(clusterService);
         long actualKNNCircuitBreakerLimit = ((ByteSizeValue) KNNSettings.state()
-            .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
+            .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT)).getKb();
         mockNode.close();
         assertEquals(expectedKNNCircuitBreakerLimit, actualKNNCircuitBreakerLimit);
     }
@@ -60,11 +60,11 @@ public class KNNSettingsTests extends KNNTestCase {
         ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
         KNNSettings.state().setClusterService(clusterService);
         long actualKNNCircuitBreakerLimit = ((ByteSizeValue) KNNSettings.state()
-            .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT)).getKb();
+            .getSettingValue(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT)).getKb();
         mockNode.close();
         assertEquals(
-            ((ByteSizeValue) KNNSettings.dynamicCacheSettings.get(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT).getDefault(Settings.EMPTY))
-                .getKb(),
+            ((ByteSizeValue) KNNSettings.dynamicCacheSettings.get(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT)
+                .getDefault(Settings.EMPTY)).getKb(),
             actualKNNCircuitBreakerLimit
 
         );

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
@@ -294,7 +294,7 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
 
     public void testGetMaxCacheSizeInKB() {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
-        assertEquals(KNNSettings.getCircuitBreakerLimit().getKb(), nativeMemoryCacheManager.getMaxCacheSizeInKilobytes());
+        assertEquals(KNNSettings.getClusterLevelCircuitBreakerLimit().getKb(), nativeMemoryCacheManager.getMaxCacheSizeInKilobytes());
         nativeMemoryCacheManager.close();
     }
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -137,15 +137,15 @@ public class KNNWeightTests extends KNNTestCase {
         final KNNSettings knnSettings = mock(KNNSettings.class);
         knnSettingsMockedStatic = mockStatic(KNNSettings.class);
         when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_ENABLED))).thenReturn(true);
-        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT))).thenReturn(CIRCUIT_BREAKER_LIMIT_100KB);
+        when(knnSettings.getSettingValue(eq(KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT))).thenReturn(CIRCUIT_BREAKER_LIMIT_100KB);
         when(knnSettings.getSettingValue(eq(KNNSettings.KNN_CACHE_ITEM_EXPIRY_ENABLED))).thenReturn(false);
         when(knnSettings.getSettingValue(eq(KNNSettings.KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES))).thenReturn(TimeValue.timeValueMinutes(10));
 
         final ByteSizeValue v = ByteSizeValue.parseBytesSizeValue(
             CIRCUIT_BREAKER_LIMIT_100KB,
-            KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_LIMIT
+            KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_CLUSTER_LIMIT
         );
-        knnSettingsMockedStatic.when(KNNSettings::getCircuitBreakerLimit).thenReturn(v);
+        knnSettingsMockedStatic.when(KNNSettings::getClusterLevelCircuitBreakerLimit).thenReturn(v);
         knnSettingsMockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
         knnSettingsMockedStatic.when(KNNSettings::isKNNPluginEnabled).thenReturn(true);
         ByteSizeValue cacheSize = ByteSizeValue.parseBytesSizeValue("1024kb", QUANTIZATION_STATE_CACHE_SIZE_LIMIT); // Setting 1MB as an


### PR DESCRIPTION
### Description

KNN plugin currently uses a cluster-wide circuit breaker. This doesn't work as well as it could when nodes have different memory capacities.

### Solution
Added node-specific circuit breaker limits using node attributes. This opens up flexibility for heterogenous circuit breaker limits.

### Usage

1. Set node attribute in `opensearch.yml`:
```yaml
node.attr.knn_cb_tier: "high"  # Examples: "high", "low", "standard"
```

2. Configure limit for that tier:
```json
PUT /_cluster/settings
{
  "persistent": {
    "knn.memory.circuit_breaker.limit.high": "75%"
  }
}
```

### Implementation
- Uses OpenSearch's `groupSetting` for dynamic limit configurations
- Cache initially uses cluster-level default
- Updates to node-specific limit when node attributes are available
- Falls back to cluster default if no node-specific limit exists

### Testing

Modified KNNCircuitBreakerIT integration tests to include node-level CB.

Used OSB benchmarking to run a modified low load test with/without the node level circuit breaker. 

- Added `node.attr.knn_cb_tier = 'integ'` to build.gradle
- Ran 5-query search-only vector benchmark after indexing 
- Verified memory usage and circuit breaker behavior

Initial state (no limits set):
```json
{
  "graph_memory_usage_percentage": 1.35,
  "graph_memory_usage": 110056
}
```

After setting node limit to 500000kb:
```json

curl -XPUT "http://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
  "persistent" : {
    "knn.memory.circuit_breaker.limit" : "500000kb"
  }
}
'

Results:

{
  "graph_memory_usage_percentage": 22.01,
  "graph_memory_usage": 110056,
  "circuit_breaker_triggered": false
}
```

Setting cluster limit to 5kb didn't affect node with specific limit which confirms proper override behavior.

### Related Issues
Resolves #2263 
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
