### PR TITLE
Fix main knnlib dir in build script based on #2442

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -174,7 +174,7 @@ else
    ompPath=$(ldconfig -p | grep libgomp | cut -d ' ' -f 4)
    cp -v $ompPath $distributions/lib
 fi
-cp -v ./jni/release/${libPrefix}* $distributions/lib
+cp -v ./jni/build/release/${libPrefix}* $distributions/lib
 ls -l $distributions/lib
 
 # Add lib directory to the k-NN plugin zip


### PR DESCRIPTION
### Description
Fix main knnlib dir in build script based on #2442

### Related Issues
```
+ cp -v './jni/release/libopensearchknn*' /home/ci-runner/k-NN2/build/distributions/lib
cp: cannot stat './jni/release/libopensearchknn*': No such file or directory
```
https://build.ci.opensearch.org/job/distribution-build-opensearch/10808/

### Check List
- ~~[ ] New functionality includes testing.~~
- ~~[ ] New functionality has been documented.~~
- ~~[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~~
- [x] Commits are signed per the DCO using `--signoff`.
- ~~[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
