### PR TITLE
[Enhancement] Make Merge in nativeEngine can Abort

### DIFF
--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -268,6 +268,20 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex
   (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jobject, jint, jintArray);
 
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    setMergeInterruptCallback
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterruptCallback(JNIEnv * env, jclass cls);
+
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    setMergeInterruptCallback
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_unsetMergeInterruptCallback(JNIEnv * env, jclass cls);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/src/jni_util.cpp
+++ b/jni/src/jni_util.cpp
@@ -65,6 +65,11 @@ void knn_jni::JNIUtil::Initialize(JNIEnv *env) {
     this->cachedClasses["org/opensearch/knn/index/query/KNNQueryResult"] = (jclass) env->NewGlobalRef(tempLocalClassRef);
     this->cachedMethods["org/opensearch/knn/index/query/KNNQueryResult:<init>"] = env->GetMethodID(tempLocalClassRef, "<init>", "(IF)V");
     env->DeleteLocalRef(tempLocalClassRef);
+
+    tempLocalClassRef = env->FindClass("org/apache/lucene/index/KNNMergeHelper");
+    this->cachedClasses["org/apache/lucene/index/KNNMergeHelper"] = (jclass) env->NewGlobalRef(tempLocalClassRef);
+    this->cachedMethods["org/apache/lucene/index/KNNMergeHelper:isMergeAborted"] = env->GetStaticMethodID(tempLocalClassRef, "isMergeAborted", "()Z");
+    env->DeleteLocalRef(tempLocalClassRef);
 }
 
 void knn_jni::JNIUtil::Uninitialize(JNIEnv* env) {

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -481,3 +481,23 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
     }
     return nullptr;
 }
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterruptCallback(JNIEnv * env, jclass cls)
+{
+    try {
+        faiss::InterruptCallback::instance.reset(
+            new knn_jni::faiss_wrapper::OpenSearchMergeInterruptCallback(&jniUtil, env)
+        );
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_unsetMergeInterruptCallback(JNIEnv * env, jclass cls)
+{
+    try {
+        faiss::InterruptCallback::instance.get()->clear_instance();
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}

--- a/src/main/java/org/apache/lucene/index/KNNMergeHelper.java
+++ b/src/main/java/org/apache/lucene/index/KNNMergeHelper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.lucene.index;
+
+public class KNNMergeHelper {
+
+    private KNNMergeHelper() {}
+    public static boolean isMergeAborted() {
+        Thread mergeThread = Thread.currentThread();
+        if (mergeThread instanceof ConcurrentMergeScheduler.MergeThread) {
+            return ((ConcurrentMergeScheduler.MergeThread) mergeThread).merge.isAborted();
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.index.codec.KNN80Codec;
 
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.KNNMergeHelper;
 import org.opensearch.common.StopWatch;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.KNNMergeHelper;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.Nullable;
@@ -46,6 +47,8 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.buildEngineFileName;
 import static org.opensearch.knn.index.engine.faiss.Faiss.FAISS_BINARY_INDEX_DESCRIPTION_PREFIX;
+import static org.opensearch.knn.jni.JNIService.setMergeInterruptCallback;
+import static org.opensearch.knn.jni.JNIService.unsetMergeInterruptCallback;
 
 /**
  * Writes KNN Index for a field in a segment. This is intended to be used for native engines
@@ -119,9 +122,18 @@ public class NativeIndexWriter {
         }
 
         long bytesPerVector = knnVectorValues.bytesPerVector();
-        startMergeStats(totalLiveDocs, bytesPerVector);
-        buildAndWriteIndex(knnVectorValues, totalLiveDocs);
-        endMergeStats(totalLiveDocs, bytesPerVector);
+        final KNNEngine knnEngine = extractKNNEngine(fieldInfo);
+        setMergeInterruptCallback(knnEngine);
+        try {
+            startMergeStats(totalLiveDocs, bytesPerVector);
+            buildAndWriteIndex(knnVectorValues, totalLiveDocs);
+            endMergeStats(totalLiveDocs, bytesPerVector);
+        } catch (Exception ex) {
+            //TODO handle
+            log.debug("Merge may abort {}",KNNMergeHelper.isMergeAborted());
+        } finally {
+            unsetMergeInterruptCallback(knnEngine);
+        }
     }
 
     private void buildAndWriteIndex(final KNNVectorValues<?> knnVectorValues, int totalLiveDocs) throws IOException {

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -463,4 +463,8 @@ class FaissService {
         int indexMaxResultWindow,
         int[] parentIds
     );
+
+    public static native void setMergeInterruptCallback();
+
+    public static native void unsetMergeInterruptCallback();
 }

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -476,4 +476,17 @@ public class JNIService {
         }
         throw new IllegalArgumentException(String.format(Locale.ROOT, "RadiusQueryIndex not supported for provided engine"));
     }
+
+    public static void setMergeInterruptCallback(KNNEngine knnEngine) {
+
+        if (KNNEngine.FAISS == knnEngine) {
+            FaissService.setMergeInterruptCallback();
+        }
+    }
+
+    public static void unsetMergeInterruptCallback(KNNEngine knnEngine) {
+        if (KNNEngine.FAISS == knnEngine) {
+            FaissService.unsetMergeInterruptCallback();
+        }
+    }
 }


### PR DESCRIPTION
### Description
When there is a scenarios: 
1. There is A Merge Task On `Node1#Index1#Shard1`(long time running)
2. After merge task started, begin relocating from `Node1#Index1#Shard1` TO `Node2#Index1#Shard1`
3. At the finalize step, source need do closeShard, but the merge task would take a long time, stack as following shows.
4. The clusterApplierService would wait for about N minutes(long time running), and mark the node stale, and master let node1 left because of this.
 
```
opensearch[datanode1][clusterApplierService#updateTask][T#1]" #41 daemon prio=5 os_prio=0 cpu=5183.70ms elapsed=93132.85s tid=0x00007f3f392509d0 nid=0x101 in Object.wait()  [0x00007f3f6ddfb000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17.0.2/Native Method)
	- waiting on <no object reference available>
	at org.apache.lucene.index.IndexWriter.doWait(IndexWriter.java:5410)
	- locked <0x0000001022b0abe8> (a org.apache.lucene.index.IndexWriter)
	at org.apache.lucene.index.IndexWriter.abortMerges(IndexWriter.java:2721)
	- locked <0x0000001022b0abe8> (a org.apache.lucene.index.IndexWriter)
	at org.apache.lucene.index.IndexWriter.rollbackInternalNoCommit(IndexWriter.java:2469)
	- locked <0x0000001022b0abe8> (a org.apache.lucene.index.IndexWriter)
	at org.apache.lucene.index.IndexWriter.rollbackInternal(IndexWriter.java:2449)
	- locked <0x0000001022bae6d0> (a java.lang.Object)
	at org.apache.lucene.index.IndexWriter.rollback(IndexWriter.java:2441)
	at org.opensearch.index.engine.InternalEngine.closeNoLock(InternalEngine.java:2370)
	at org.opensearch.index.engine.Engine.close(Engine.java:2000)
	at org.opensearch.index.engine.Engine.flushAndClose(Engine.java:1987)
	at org.opensearch.index.shard.IndexShard.close(IndexShard.java:1907)
	- locked <0x0000001022b07ea0> (a java.lang.Object)
	at org.opensearch.index.IndexService.closeShard(IndexService.java:623)
	at org.opensearch.index.IndexService.removeShard(IndexService.java:599)
	- locked <0x0000001022a976a8> (a org.opensearch.index.IndexService)
	at org.opensearch.index.IndexService.close(IndexService.java:374)
	- locked <0x0000001022a976a8> (a org.opensearch.index.IndexService)
	at org.opensearch.indices.IndicesService.removeIndex(IndicesService.java:993)
	at org.opensearch.indices.cluster.IndicesClusterStateService.removeIndices(IndicesClusterStateService.java:446)
	at org.opensearch.indices.cluster.IndicesClusterStateService.applyClusterState(IndicesClusterStateService.java:287)
	- locked <0x000000100b7da520> (a org.opensearch.indices.cluster.IndicesClusterStateService)
	at org.opensearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:606)
	at org.opensearch.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:593)
``` 
### Proposal

i think we can introduce abort mechanism for long time merge task meanwhile close shard called.

i think we can introduce `KNNMergeHelper` class to check if merge aborted. and when build the graph, we can reuse faiss::InterruptCallback which is interrupt callback mechanism to check whether aborted or not

BUT `ConcurrentMergeScheduler#MergeThread` is a internal class, we can not call this directly. it throws `org.apache.lucene.index.ConcurrentMergeScheduler$MergeThread is in unnamed module of loader 'app'`

we can added this static method into OpenSearch Core like `OneMergeHelper`


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
