### PR TITLE
Fix derived source for binary and byte vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
+*  Fix derived source for binary and byte vectors [#2533](https://github.com/opensearch-project/k-NN/pull/2533/)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/AbstractPerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/AbstractPerFieldDerivedVectorInjector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+
+import java.io.IOException;
+
+@Log4j2
+abstract class AbstractPerFieldDerivedVectorInjector implements PerFieldDerivedVectorInjector {
+    /**
+     * Utility method for formatting the vector values based on the vector data type. KNNVectorValues must be advanced
+     * to the correct position.
+     *
+     * @param fieldInfo fieldinfo for the vector field
+     * @param vectorValues vector values of the field. getVector or getConditionalVector should return expected vector.
+     * @return vector formatted based on the vector data type
+     * @throws IOException if unable to deserialize stored vector
+     */
+    protected Object formatVector(FieldInfo fieldInfo, KNNVectorValues<?> vectorValues) throws IOException {
+        Object vectorValue = vectorValues.getVector();
+        // If the vector value is a byte[], we must deserialize
+        if (vectorValue instanceof byte[]) {
+            BytesRef vectorBytesRef = new BytesRef((byte[]) vectorValue);
+            VectorDataType vectorDataType = FieldInfoExtractor.extractVectorDataType(fieldInfo);
+            return KNNVectorFieldMapperUtil.deserializeStoredVector(vectorBytesRef, vectorDataType);
+        }
+        return vectorValues.conditionalCloneVector();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorInjector.java
@@ -29,7 +29,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 @Log4j2
 @AllArgsConstructor
-public class NestedPerFieldDerivedVectorInjector implements PerFieldDerivedVectorInjector {
+public class NestedPerFieldDerivedVectorInjector extends AbstractPerFieldDerivedVectorInjector {
 
     private final FieldInfo childFieldInfo;
     private final DerivedSourceReaders derivedSourceReaders;
@@ -116,7 +116,7 @@ public class NestedPerFieldDerivedVectorInjector implements PerFieldDerivedVecto
                 reconstructedSource.add(position, new HashMap<>());
                 positions.add(position, docId);
             }
-            reconstructedSource.get(position).put(childFieldName, vectorValues.conditionalCloneVector());
+            reconstructedSource.get(position).put(childFieldName, formatVector(childFieldInfo, vectorValues));
             offsetPositionsIndex = position + 1;
         }
         sourceAsMap.put(parentFieldName, reconstructedSource);
@@ -137,7 +137,7 @@ public class NestedPerFieldDerivedVectorInjector implements PerFieldDerivedVecto
             String field = fields[i];
             currentMap = (Map<String, Object>) currentMap.computeIfAbsent(field, k -> new HashMap<>());
         }
-        currentMap.put(fields[fields.length - 1], vectorValues.getVector());
+        currentMap.put(fields[fields.length - 1], formatVector(childFieldInfo, vectorValues));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorInjector.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * {@link PerFieldDerivedVectorInjector} for root fields (i.e. non nested fields).
  */
-class RootPerFieldDerivedVectorInjector implements PerFieldDerivedVectorInjector {
+class RootPerFieldDerivedVectorInjector extends AbstractPerFieldDerivedVectorInjector {
 
     private final FieldInfo fieldInfo;
     private final CheckedSupplier<KNNVectorValues<?>, IOException> vectorValuesSupplier;
@@ -40,7 +40,7 @@ class RootPerFieldDerivedVectorInjector implements PerFieldDerivedVectorInjector
     public void inject(int docId, Map<String, Object> sourceAsMap) throws IOException {
         KNNVectorValues<?> vectorValues = vectorValuesSupplier.get();
         if (vectorValues.docId() == docId || vectorValues.advance(docId) == docId) {
-            sourceAsMap.put(fieldInfo.name, vectorValues.conditionalCloneVector());
+            sourceAsMap.put(fieldInfo.name, formatVector(fieldInfo, vectorValues));
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -86,10 +86,10 @@ public class KNNVectorFieldMapperUtil {
      * @return either int[] or float[] of corresponding vector
      */
     public static Object deserializeStoredVector(BytesRef storedVector, VectorDataType vectorDataType) {
-        if (VectorDataType.BYTE == vectorDataType) {
+        if (VectorDataType.BYTE == vectorDataType || VectorDataType.BINARY == vectorDataType) {
             byte[] bytes = storedVector.bytes;
-            int[] byteAsIntArray = new int[bytes.length];
-            Arrays.setAll(byteAsIntArray, i -> bytes[i]);
+            int[] byteAsIntArray = new int[storedVector.length];
+            Arrays.setAll(byteAsIntArray, i -> bytes[i + storedVector.offset]);
             return byteAsIntArray;
         }
 

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -41,6 +41,17 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
         assertArrayEquals(byteAsIntArray, (int[]) vector);
     }
 
+    public void testStoredFields_whenVectorIsBinaryType_thenSucceed() {
+        StoredField storedField = KNNVectorFieldMapperUtil.createStoredFieldForByteVector(TEST_FIELD_NAME, TEST_BYTE_VECTOR);
+        assertEquals(TEST_FIELD_NAME, storedField.name());
+        assertEquals(TEST_BYTE_VECTOR, storedField.binaryValue().bytes);
+        Object vector = KNNVectorFieldMapperUtil.deserializeStoredVector(storedField.binaryValue(), VectorDataType.BINARY);
+        assertTrue(vector instanceof int[]);
+        int[] byteAsIntArray = new int[TEST_BYTE_VECTOR.length];
+        Arrays.setAll(byteAsIntArray, i -> TEST_BYTE_VECTOR[i]);
+        assertArrayEquals(byteAsIntArray, (int[]) vector);
+    }
+
     public void testStoredFields_whenVectorIsFloatType_thenSucceed() {
         StoredField storedField = KNNVectorFieldMapperUtil.createStoredFieldForFloatVector(TEST_FIELD_NAME, TEST_FLOAT_VECTOR);
         assertEquals(TEST_FIELD_NAME, storedField.name());

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -791,7 +791,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     /**
      * Update a KNN Doc with a new vector for the given fieldName
      */
-    protected void updateKnnDoc(String index, String docId, String fieldName, Object[] vector) throws IOException {
+    protected <T> void updateKnnDoc(String index, String docId, String fieldName, T vector) throws IOException {
         Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         String parent = ParentChildHelper.getParentField(fieldName);
@@ -811,7 +811,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
     /**
      * Update a KNN Doc using the POST /\<index_name\>/_update/\<doc_id\>. Only the vector field will be updated.
      */
-    protected void updateKnnDocWithUpdateAPI(String index, String docId, String fieldName, Object[] vector) throws IOException {
+    protected <T> void updateKnnDocWithUpdateAPI(String index, String docId, String fieldName, T vector) throws IOException {
         Request request = new Request("POST", "/" + index + "/_update/" + docId + "?refresh=true");
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("doc");
         String parent = ParentChildHelper.getParentField(fieldName);
@@ -826,7 +826,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
 
-    protected void updateKnnDocByQuery(String index, String docId, String fieldName, Object[] vector) throws IOException {
+    protected <T> void updateKnnDocByQuery(String index, String docId, String fieldName, T vector) throws IOException {
         Request request = new Request("POST", "/" + index + "/_update_by_query?refresh=true");
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
@@ -1382,23 +1382,33 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     public void bulkIngestRandomVectors(String indexName, String fieldName, int numVectors, int dimension) throws IOException {
-        // TODO: Do better on this one
-        float[][] vectors = TestUtils.randomlyGenerateStandardVectors(numVectors, dimension, 1);
-        for (int i = 0; i < numVectors; i++) {
-            float[] vector = vectors[i];
-            addKnnDoc(indexName, String.valueOf(i + 1), fieldName, Floats.asList(vector).toArray());
-        }
+        bulkIngestRandomVectorsWithSkips(indexName, fieldName, numVectors, dimension, 32, 0.0f);
     }
 
-    public void bulkIngestRandomVectorsWithSkips(String indexName, String fieldName, int numVectors, int dimension, float skipProb)
-        throws IOException {
-        float[][] vectors = TestUtils.randomlyGenerateStandardVectors(numVectors, dimension, 1);
+    public void bulkIngestRandomVectorsWithSkips(
+        String indexName,
+        String fieldName,
+        int numVectors,
+        int dimension,
+        int bitsPerDimension,
+        float skipProb
+    ) throws IOException {
+        float[][] floatVectors = null;
+        int[][] intVectors = null;
+        if (bitsPerDimension == 32) {
+            floatVectors = TestUtils.randomlyGenerateStandardVectors(numVectors, dimension, 1);
+        } else if (bitsPerDimension == 8) {
+            intVectors = TestUtils.randomlyGenerateStandardVectors(numVectors, dimension, 1, 1);
+        } else {
+            intVectors = TestUtils.randomlyGenerateStandardVectors(numVectors, dimension, 8, 1);
+        }
+
         Random random = new Random();
         random.setSeed(2);
         for (int i = 0; i < numVectors; i++) {
-            float[] vector = vectors[i];
+            Object vector = floatVectors == null ? intVectors[i] : floatVectors[i];
             if (random.nextFloat() > skipProb) {
-                addKnnDoc(indexName, String.valueOf(i + 1), fieldName, Floats.asList(vector).toArray());
+                addKnnDoc(indexName, String.valueOf(i + 1), fieldName, vector);
             } else {
                 addDocWithNumericField(indexName, String.valueOf(i + 1), "numeric-field", 1);
             }
@@ -1633,6 +1643,17 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
             addKnnDocWithNestedField(indexName, String.valueOf(i + 1), nestedFieldPath, Floats.asList(vector).toArray());
         }
+    }
+
+    public int[] randomByteVector(int dimension, int dimPerByte) {
+        int numDims = dimension / dimPerByte;
+        byte[] byteVector = new byte[numDims];
+        random().nextBytes(byteVector);
+        int[] vector = new int[numDims];
+        for (int j = 0; j < numDims; j++) {
+            vector[j] = byteVector[j];
+        }
+        return vector;
     }
 
     // Method that adds multiple documents into the index using Bulk API

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -128,6 +128,24 @@ public class TestUtils {
         return standardVectors;
     }
 
+    // Generating vectors using random function with a seed which makes these vectors standard and generate same vectors for each run.
+    public static int[][] randomlyGenerateStandardVectors(int numVectors, int dimensions, int dimPerByte, int seed) {
+        int numDims = dimensions / dimPerByte;
+        int[][] standardVectors = new int[numVectors][numDims];
+        Random rand = new Random(seed);
+
+        for (int i = 0; i < numVectors; i++) {
+            byte[] byteVector = new byte[numDims];
+            rand.nextBytes(byteVector);
+            int[] vector = new int[numDims];
+            for (int j = 0; j < numDims; j++) {
+                vector[j] = byteVector[j];
+            }
+            standardVectors[i] = vector;
+        }
+        return standardVectors;
+    }
+
     public static float[][] generateRandomVectors(int numVectors, int dimensions) {
         float[][] randomVectors = new float[numVectors][dimensions];
 


### PR DESCRIPTION
### Description
For binary and byte vectors, for derived source, we were not formatting them before adding them back to the source. Thus, they were binary strings in the source. This change fixes this formatting to format them as ints before adding back.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
