### PR TITLE
Fix the put mapping issue for already created index with flat mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 ### Enhancements
 ### Bug Fixes
-*  Fix derived source for binary and byte vectors [#2533](https://github.com/opensearch-project/k-NN/pull/2533/)
+* Fix derived source for binary and byte vectors [#2533](https://github.com/opensearch-project/k-NN/pull/2533/)
+* Fix the put mapping issue for already created index with flat mapper [#2542](https://github.com/opensearch-project/k-NN/pull/2542)
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -272,7 +272,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             // return FlatVectorFieldMapper only for indices that are created on or after 2.17.0, for others, use either LuceneFieldMapper
             // or
             // MethodFieldMapper to maintain backwards compatibility
-            if (originalParameters.getResolvedKnnMethodContext() == null && context.indexCreatedVersion().onOrAfter(Version.V_2_17_0)) {
+            if (originalParameters.getResolvedKnnMethodContext() == null && indexCreatedVersion.onOrAfter(Version.V_2_17_0)) {
                 return FlatVectorFieldMapper.createFieldMapper(
                     buildFullName(context),
                     name,

--- a/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
@@ -377,6 +377,24 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testPutMappings_whenIndexAlreadyCreated_thenSuccess() {
+        List<KNNEngine> enginesToTest = List.of(KNNEngine.NMSLIB, KNNEngine.FAISS, KNNEngine.LUCENE);
+        float[] testVector = new float[] { -100.0f, 100.0f, 0f, 1f };
+        for (KNNEngine knnEngine : enginesToTest) {
+            String indexName = INDEX_NAME + "_" + knnEngine.getName();
+            createKnnIndex(indexName, createVectorMapping(testVector.length, knnEngine.getName(), VectorDataType.FLOAT.getValue(), false));
+            putMappingRequest(
+                indexName,
+                createVectorMapping(testVector.length, knnEngine.getName(), VectorDataType.FLOAT.getValue(), false)
+            );
+        }
+        // Check with FlatMapper
+        String indexName = INDEX_NAME + "_flat_index";
+        createBasicKnnIndex(indexName, FIELD_NAME, testVector.length);
+        putMappingRequest(indexName, createKnnIndexMapping(FIELD_NAME, testVector.length));
+    }
+
     /**
      * Mapping
      * {


### PR DESCRIPTION
### Description
Fix the put mapping issue for already created index with flat mapper

### Root Cause:
When put mappings is called for an already created index, the mappings are merged from the old index. During that merge the buildContext https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java#L243 doesn't have the index version. 

The failure happens only when index.knn is false because checking of the index version is in `&&` hence when `index.knn` is true buildContext is not getting hit.

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/2540
### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
