### PR TITLE
Support custom codecs via stored fields.

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010Codec.java
@@ -104,6 +104,11 @@ public class KNN10010Codec extends FilterCodec {
             }
             return null;
         }));
-        return new DerivedSourceStoredFieldsFormat(delegate.storedFieldsFormat(), derivedSourceReadersSupplier, mapperService);
+        return new DerivedSourceStoredFieldsFormat(
+            delegate.storedFieldsFormat(),
+            derivedSourceReadersSupplier,
+            mapperService,
+            delegate.getName()
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/DerivedSourceStoredFieldsFormat.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.codec.KNN9120Codec;
 
 import lombok.AllArgsConstructor;
+import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
@@ -32,15 +33,26 @@ import static org.opensearch.knn.common.KNNConstants.DERIVED_VECTOR_FIELD_ATTRIB
 @AllArgsConstructor
 public class DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
 
+    private static final String DELEGATE_CODEC_KEY = "knn_delegate_codec";
+
     private final StoredFieldsFormat delegate;
     private final DerivedSourceReadersSupplier derivedSourceReadersSupplier;
     // IMPORTANT Do not rely on this for the reader, it will be null if SPI is used
     @Nullable
     private final MapperService mapperService;
+    // IMPORTANT Do not rely on this for the reader, it will be null if SPI is used
+    @Nullable
+    private final String delegateCodecName;
 
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext ioContext)
         throws IOException {
+        StoredFieldsFormat delegateFromWriting = delegate;
+        if (segmentInfo.getAttribute(DELEGATE_CODEC_KEY) != null) {
+            String delegateCodecName = segmentInfo.getAttribute(DELEGATE_CODEC_KEY);
+            delegateFromWriting = Codec.forName(delegateCodecName).storedFieldsFormat();
+        }
+
         List<FieldInfo> derivedVectorFields = null;
         for (FieldInfo fieldInfo : fieldInfos) {
             if (DERIVED_VECTOR_FIELD_ATTRIBUTE_TRUE_VALUE.equals(fieldInfo.attributes().get(DERIVED_VECTOR_FIELD_ATTRIBUTE_KEY))) {
@@ -53,10 +65,10 @@ public class DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
         }
         // If no fields have it enabled, we can just short-circuit and return the delegate's fieldReader
         if (derivedVectorFields == null || derivedVectorFields.isEmpty()) {
-            return delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
+            return delegateFromWriting.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
         }
         return new DerivedSourceStoredFieldsReader(
-            delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext),
+            delegateFromWriting.fieldsReader(directory, segmentInfo, fieldInfos, ioContext),
             derivedVectorFields,
             derivedSourceReadersSupplier,
             new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext)
@@ -65,6 +77,24 @@ public class DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
 
     @Override
     public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo segmentInfo, IOContext ioContext) throws IOException {
+        // We write the delegate codec name into the segmentInfo attributes so that we can read it when loading the
+        // codec from SPI.
+        // This is similar to whats done in
+        // https://github.com/opensearch-project/custom-codecs/blob/2.19.0.0/src/main/java/org/opensearch/index/codec/customcodecs/Lucene912CustomStoredFieldsFormat.java#L95-L100
+        String previous = segmentInfo.putAttribute(DELEGATE_CODEC_KEY, delegateCodecName);
+        if (previous != null && previous.equals(delegateCodecName) == false) {
+            throw new IllegalStateException(
+                "found existing value for "
+                    + DELEGATE_CODEC_KEY
+                    + " for segment: "
+                    + segmentInfo.name
+                    + " old = "
+                    + previous
+                    + ", new = "
+                    + delegateCodecName
+            );
+        }
+
         StoredFieldsWriter delegateWriter = delegate.fieldsWriter(directory, segmentInfo, ioContext);
         if (mapperService != null && KNNSettings.isKNNDerivedSourceEnabled(mapperService.getIndexSettings().getSettings())) {
             List<String> vectorFieldTypes = new ArrayList<>();

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120Codec.java
@@ -100,6 +100,11 @@ public class KNN9120Codec extends FilterCodec {
             }
             return null;
         }));
-        return new DerivedSourceStoredFieldsFormat(delegate.storedFieldsFormat(), derivedSourceReadersSupplier, mapperService);
+        return new DerivedSourceStoredFieldsFormat(
+            delegate.storedFieldsFormat(),
+            derivedSourceReadersSupplier,
+            mapperService,
+            delegate.getName()
+        );
     }
 }


### PR DESCRIPTION
### Description
Following up on discussion in #2414. @bugmakerrrrrr had idea to serialize info about delegate as segment attribute. Something similar is done in https://github.com/opensearch-project/custom-codecs/blob/2.19.0.0/src/main/java/org/opensearch/index/codec/customcodecs/Lucene912CustomStoredFieldsFormat.java#L95-L100.

One short coming with this approach is that it only works for stored fields formats. We could generalize to write in segmentinfoformat. However, with that, I think we would need to create a custom format for all formats, which seems a bit heavy. So, just focusing on segmentinfoformat for now.

Still need to write some tests, but wanted to see what people thought early.

### Related Issues
Resolves #2414 

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
