### PR TITLE
3.0.0 Breaking Changes For KNN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Refactoring
 * Small Refactor Post Lucene 10.0.1 upgrade [#2541](https://github.com/opensearch-project/k-NN/pull/2541)
 * Refactor codec to leverage backwards_codecs [#2546](https://github.com/opensearch-project/k-NN/pull/2546)
+* 3.0.0 Breaking Changes For KNN [#2564] (https://github.com/opensearch-project/k-NN/pull/2564)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -68,10 +68,7 @@ public class KNNSettings {
     /**
      * Settings name
      */
-    public static final String KNN_SPACE_TYPE = "index.knn.space_type";
     public static final String INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD = "index.knn.advanced.approximate_threshold";
-    public static final String KNN_ALGO_PARAM_M = "index.knn.algo_param.m";
-    public static final String KNN_ALGO_PARAM_EF_CONSTRUCTION = "index.knn.algo_param.ef_construction";
     public static final String KNN_ALGO_PARAM_EF_SEARCH = "index.knn.algo_param.ef_search";
     public static final String KNN_ALGO_PARAM_INDEX_THREAD_QTY = "knn.algo_param.index_thread_qty";
     public static final String KNN_MEMORY_CIRCUIT_BREAKER_ENABLED = "knn.memory.circuit_breaker.enabled";
@@ -80,7 +77,6 @@ public class KNNSettings {
     public static final String KNN_CIRCUIT_BREAKER_TRIGGERED = "knn.circuit_breaker.triggered";
     public static final String KNN_CACHE_ITEM_EXPIRY_ENABLED = "knn.cache.item.expiry.enabled";
     public static final String KNN_CACHE_ITEM_EXPIRY_TIME_MINUTES = "knn.cache.item.expiry.minutes";
-    public static final String KNN_PLUGIN_ENABLED = "knn.plugin.enabled";
     public static final String KNN_CIRCUIT_BREAKER_UNSET_PERCENTAGE = "knn.circuit_breaker.unset.percentage";
     public static final String KNN_INDEX = "index.knn";
     public static final String MODEL_INDEX_NUMBER_OF_SHARDS = "knn.model.index.number_of_shards";
@@ -159,14 +155,6 @@ public class KNNSettings {
         Setting.Property.NodeScope
     );
 
-    public static final Setting<String> INDEX_KNN_SPACE_TYPE = Setting.simpleString(
-        KNN_SPACE_TYPE,
-        INDEX_KNN_DEFAULT_SPACE_TYPE,
-        new SpaceTypeValidator(),
-        IndexScope,
-        Setting.Property.Deprecated
-    );
-
     /**
      * build_vector_data_structure_threshold - This parameter determines when to build vector data structure for knn fields during indexing
      * and merging. Setting -1 (min) will skip building graph, whereas on any other values, the graph will be built if
@@ -183,20 +171,6 @@ public class KNNSettings {
     );
 
     /**
-     * M - the number of bi-directional links created for every new element during construction.
-     * Reasonable range for M is 2-100. Higher M work better on datasets with high intrinsic
-     * dimensionality and/or high recall, while low M work better for datasets with low intrinsic dimensionality and/or low recalls.
-     * The parameter also determines the algorithm's memory consumption, which is roughly M * 8-10 bytes per stored element.
-     */
-    public static final Setting<Integer> INDEX_KNN_ALGO_PARAM_M_SETTING = Setting.intSetting(
-        KNN_ALGO_PARAM_M,
-        INDEX_KNN_DEFAULT_ALGO_PARAM_M,
-        2,
-        IndexScope,
-        Setting.Property.Deprecated
-    );
-
-    /**
      *  ef or efSearch - the size of the dynamic list for the nearest neighbors (used during the search).
      *  Higher ef leads to more accurate but slower search. ef cannot be set lower than the number of queried nearest neighbors k.
      *  The value ef can be anything between k and the size of the dataset.
@@ -207,18 +181,6 @@ public class KNNSettings {
         2,
         IndexScope,
         Dynamic
-    );
-
-    /**
-     * ef_constrution - the parameter has the same meaning as ef, but controls the index_time/index_accuracy.
-     * Bigger ef_construction leads to longer construction(more indexing time), but better index quality.
-     */
-    public static final Setting<Integer> INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING = Setting.intSetting(
-        KNN_ALGO_PARAM_EF_CONSTRUCTION,
-        INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION,
-        2,
-        IndexScope,
-        Setting.Property.Deprecated
     );
 
     public static final Setting<Integer> MODEL_INDEX_NUMBER_OF_SHARDS_SETTING = Setting.intSetting(
@@ -394,11 +356,6 @@ public class KNNSettings {
     public static Map<String, Setting<?>> dynamicCacheSettings = new HashMap<String, Setting<?>>() {
         {
             /**
-             * KNN plugin enable/disable setting
-             */
-            put(KNN_PLUGIN_ENABLED, Setting.boolSetting(KNN_PLUGIN_ENABLED, true, NodeScope, Dynamic));
-
-            /**
              * Weight circuit breaker settings
              */
             put(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, Setting.boolSetting(KNN_MEMORY_CIRCUIT_BREAKER_ENABLED, true, NodeScope, Dynamic));
@@ -555,10 +512,7 @@ public class KNNSettings {
 
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
-            INDEX_KNN_SPACE_TYPE,
             INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING,
-            INDEX_KNN_ALGO_PARAM_M_SETTING,
-            INDEX_KNN_ALGO_PARAM_EF_CONSTRUCTION_SETTING,
             INDEX_KNN_ALGO_PARAM_EF_SEARCH_SETTING,
             KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING,
             KNN_CIRCUIT_BREAKER_TRIGGERED_SETTING,
@@ -581,10 +535,6 @@ public class KNNSettings {
         );
         return Stream.concat(settings.stream(), Stream.concat(getFeatureFlags().stream(), dynamicCacheSettings.values().stream()))
             .collect(Collectors.toList());
-    }
-
-    public static boolean isKNNPluginEnabled() {
-        return KNNSettings.state().getSettingValue(KNNSettings.KNN_PLUGIN_ENABLED);
     }
 
     public static boolean isCircuitBreakerTriggered() {

--- a/src/main/java/org/opensearch/knn/index/engine/SpaceTypeResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/SpaceTypeResolver.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.engine;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.index.mapper.MapperParsingException;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 
@@ -49,12 +48,6 @@ public final class SpaceTypeResolver {
         // 1. We try to get it from index setting, which is a relic of legacy.
         // 2. Otherwise, we return a default one.
         if (isSpaceTypeConfigured(methodSpaceType) == false && isSpaceTypeConfigured(topLevelSpaceType) == false) {
-            if (indexSettings != null) {
-                final String spaceType = indexSettings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey());
-                if (spaceType != null) {
-                    return SpaceType.getSpace(spaceType);
-                }
-            }
             return getDefaultSpaceType(vectorDataType);
         }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -60,7 +60,6 @@ import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createSto
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForFloatVector;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.useFullFieldNameValidation;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateIfCircuitBreakerIsNotTriggered;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.validateIfKNNPluginEnabled;
 import static org.opensearch.knn.index.mapper.ModelFieldMapper.UNSET_MODEL_DIMENSION_IDENTIFIER;
 
 /**
@@ -686,7 +685,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
      * Validation checks before parsing of doc begins
      */
     protected void validatePreparse() {
-        validateIfKNNPluginEnabled();
         validateIfCircuitBreakerIsNotTriggered();
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -21,7 +21,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.opensearch.common.StopWatch;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
@@ -171,9 +170,6 @@ public class KNNQuery extends Query {
      */
     @Override
     public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-        if (!KNNSettings.isKNNPluginEnabled()) {
-            throw new IllegalStateException("KNN plugin is disabled. To enable update knn.plugin.enabled to true");
-        }
         StopWatch stopWatch = null;
         if (log.isDebugEnabled()) {
             stopWatch = new StopWatch().start();

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -408,19 +408,6 @@ class FaissService {
     public static native byte[] trainByteIndex(Map<String, Object> indexParameters, int dimension, long trainVectorsPointer);
 
     /**
-     * <p>
-     * The function is deprecated. Use {@link JNICommons#storeVectorData(long, float[][], long)}
-     * </p>
-     * Transfer vectors from Java to native
-     *
-     * @param vectorsPointer pointer to vectors in native memory. Should be 0 to create vector as well
-     * @param trainingData data to be transferred
-     * @return pointer to native memory location of training data
-     */
-    @Deprecated(since = "2.14.0", forRemoval = true)
-    public static native long transferVectors(long vectorsPointer, float[][] trainingData);
-
-    /**
      * Range search index with filter
      *
      * @param indexPointer pointer to index in memory

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -420,21 +420,6 @@ public class JNIService {
     }
 
     /**
-     * <p>
-     * The function is deprecated. Use {@link JNICommons#storeVectorData(long, float[][], long, boolean)}
-     * </p>
-     * Transfer vectors from Java to native
-     *
-     * @param vectorsPointer pointer to vectors in native memory. Should be 0 to create vector as well
-     * @param trainingData   data to be transferred
-     * @return pointer to native memory location of training data
-     */
-    @Deprecated(since = "2.14.0", forRemoval = true)
-    public static long transferVectors(long vectorsPointer, float[][] trainingData) {
-        return FaissService.transferVectors(vectorsPointer, trainingData);
-    }
-
-    /**
      * Range search index for a given query vector
      *
      * @param indexPointer         pointer to index in memory

--- a/src/main/java/org/opensearch/knn/training/FloatTrainingDataConsumer.java
+++ b/src/main/java/org/opensearch/knn/training/FloatTrainingDataConsumer.java
@@ -15,7 +15,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.jni.JNICommons;
-import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
 import org.opensearch.knn.quantization.factory.QuantizerFactory;
 import org.opensearch.knn.quantization.models.quantizationOutput.BinaryQuantizationOutput;
@@ -59,9 +58,10 @@ public class FloatTrainingDataConsumer extends TrainingDataConsumer {
             }
         } else {
             trainingDataAllocation.setMemoryAddress(
-                JNIService.transferVectors(
+                JNICommons.storeVectorData(
                     trainingDataAllocation.getMemoryAddress(),
-                    floats.stream().map(v -> ArrayUtils.toPrimitive((Float[]) v)).toArray(float[][]::new)
+                    floats.stream().map(v -> ArrayUtils.toPrimitive((Float[]) v)).toArray(float[][]::new),
+                    floats.size()
                 )
             );
         }

--- a/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCreateIndexFromModelTests.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.KNNSingleNodeTestCase;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.jni.JNICommons;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.indices.Model;
@@ -49,7 +50,7 @@ public class KNNCreateIndexFromModelTests extends KNNSingleNodeTestCase {
         int dimension = 3;
 
         // "Train" a faiss flat index - this really just creates an empty index that does brute force k-NN
-        long vectorsPointer = JNIService.transferVectors(0, new float[0][0]);
+        long vectorsPointer = JNICommons.storeVectorData(0, new float[0][0], 0);
         byte[] modelBlob = JNIService.trainIndex(
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,

--- a/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
@@ -37,11 +37,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
 
     public void testKNNLegacySpaceTypeIndexingTest() throws IOException, ParseException {
         // Configure space_type at index level. This is deprecated and will be removed in the future.
-        final Settings indexSettings = Settings.builder()
-            .put("index.knn", true)
-            .put("knn.algo_param.ef_search", 100)
-            .put("knn.space_type", SpaceType.INNER_PRODUCT.getValue())
-            .build();
+        final Settings indexSettings = Settings.builder().put("index.knn", true).put("knn.algo_param.ef_search", 100).build();
 
         // This mapping does not have method.
         final String testField = "knn_field";
@@ -87,57 +83,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
         for (KNNResult result : results) {
             docIds.add(result.getDocId());
         }
-        assertEquals(new HashSet<>(Arrays.asList("1", "3")), docIds);
-    }
-
-    /**
-     * KNN Index writes should be blocked when the plugin disabled
-     * @throws Exception Exception from test
-     */
-    public void testIndexWritesPluginDisabled() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
-
-        Float[] vector = { 6.0f, 6.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
-
-        float[] qvector = { 1.0f, 2.0f };
-        Response response = searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 1), 1);
-        assertEquals("knn query failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        // disable plugin
-        updateClusterSettings(KNNSettings.KNN_PLUGIN_ENABLED, false);
-
-        // indexing should be blocked
-        Exception ex = expectThrows(ResponseException.class, () -> addKnnDoc(INDEX_NAME, "2", FIELD_NAME, vector));
-        assertThat(ex.getMessage(), containsString("KNN plugin is disabled"));
-
-        // enable plugin
-        updateClusterSettings(KNNSettings.KNN_PLUGIN_ENABLED, true);
-        addKnnDoc(INDEX_NAME, "3", FIELD_NAME, vector);
-    }
-
-    public void testQueriesPluginDisabled() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
-
-        Float[] vector = { 6.0f, 6.0f };
-        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
-
-        float[] qvector = { 1.0f, 2.0f };
-        Response response = searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 1), 1);
-        assertEquals("knn query failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
-
-        // update settings
-        updateClusterSettings(KNNSettings.KNN_PLUGIN_ENABLED, false);
-
-        // indexing should be blocked
-        Exception ex = expectThrows(
-            ResponseException.class,
-            () -> searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 1), 1)
-        );
-        assertThat(ex.getMessage(), containsString("KNN plugin is disabled"));
-        // enable plugin
-        updateClusterSettings(KNNSettings.KNN_PLUGIN_ENABLED, true);
-        searchKNNIndex(INDEX_NAME, new KNNQueryBuilder(FIELD_NAME, qvector, 1), 1);
+        assertEquals(new HashSet<>(Arrays.asList("2", "4")), docIds);
     }
 
     public void testItemRemovedFromCache_expiration() throws Exception {

--- a/src/test/java/org/opensearch/knn/index/NmslibIT.java
+++ b/src/test/java/org/opensearch/knn/index/NmslibIT.java
@@ -305,21 +305,6 @@ public class NmslibIT extends KNNRestTestCase {
         deleteKnnDoc(INDEX_NAME, "1");
     }
 
-    public void testCreateIndexWithValidAlgoParams_settings() {
-        try {
-            Settings settings = Settings.builder()
-                .put(getKNNDefaultIndexSettings())
-                .put("index.knn.algo_param.m", 32)
-                .put("index.knn.algo_param.ef_construction", 400)
-                .build();
-            createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
-            Float[] vector = { 6.0f, 6.0f };
-            addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
-        } catch (Exception ex) {
-            fail("Exception not expected as valid index arguements passed: " + ex);
-        }
-    }
-
     @SuppressWarnings("unchecked")
     public void testCreateIndexWithValidAlgoParams_mapping() {
         try {
@@ -368,86 +353,6 @@ public class NmslibIT extends KNNRestTestCase {
 
             Float[] vector = { 6.0f, 6.0f };
             addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
-        } catch (Exception ex) {
-            fail("Exception not expected as valid index arguments passed: " + ex);
-        }
-    }
-
-    public void testCreateIndexWithValidAlgoParams_mappingAndSettings() {
-        try {
-            String spaceType1 = SpaceType.L1.getValue();
-            int efConstruction1 = 14;
-            int m1 = 13;
-
-            Settings settings = Settings.builder()
-                .put(getKNNDefaultIndexSettings())
-                .put("index.knn.algo_param.m", m1)
-                .put("index.knn.algo_param.ef_construction", efConstruction1)
-                .build();
-
-            String mapping = XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("properties")
-                .startObject(FIELD_NAME)
-                .field("type", "knn_vector")
-                .field("dimension", 2)
-                .startObject(KNNConstants.KNN_METHOD)
-                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType1)
-                .field(KNN_ENGINE, KNNEngine.NMSLIB.getName())
-                .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-                .startObject(KNNConstants.PARAMETERS)
-                .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction1)
-                .field(KNNConstants.METHOD_PARAMETER_M, m1)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-                .toString();
-
-            createKnnIndex(INDEX_NAME + "1", settings, mapping);
-            Float[] vector = { 6.0f, 6.0f };
-            addKnnDoc(INDEX_NAME + "1", "1", FIELD_NAME, vector);
-
-            String spaceType2 = SpaceType.COSINESIMIL.getValue();
-            int efConstruction2 = 114;
-            int m2 = 113;
-
-            mapping = XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("properties")
-                .startObject(FIELD_NAME + "1")
-                .field("type", "knn_vector")
-                .field("dimension", 2)
-                .startObject(KNNConstants.KNN_METHOD)
-                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType1)
-                .field(KNN_ENGINE, KNNEngine.NMSLIB.getName())
-                .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-                .startObject(KNNConstants.PARAMETERS)
-                .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction1)
-                .field(KNNConstants.METHOD_PARAMETER_M, m1)
-                .endObject()
-                .endObject()
-                .endObject()
-                .startObject(FIELD_NAME + "2")
-                .field("type", "knn_vector")
-                .field("dimension", 2)
-                .startObject(KNNConstants.KNN_METHOD)
-                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType2)
-                .field(KNN_ENGINE, KNNEngine.NMSLIB.getName())
-                .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-                .startObject(KNNConstants.PARAMETERS)
-                .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction2)
-                .field(KNNConstants.METHOD_PARAMETER_M, m2)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-                .toString();
-
-            createKnnIndex(INDEX_NAME + "2", settings, mapping);
-            addKnnDoc(INDEX_NAME + "2", "1", FIELD_NAME, vector);
         } catch (Exception ex) {
             fail("Exception not expected as valid index arguments passed: " + ex);
         }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -453,7 +453,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         String modelId = "test-model-id";
 
         float[][] trainingData = TestVectorValues.getRandomVectors(200, dimension);
-        long trainingPtr = JNIService.transferVectors(0, trainingData);
+        long trainingPtr = JNICommons.storeVectorData(0, trainingData, trainingData.length * dimension);
 
         Map<String, Object> parameters = ImmutableMap.of(
             INDEX_DESCRIPTION_PARAMETER,

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -35,6 +35,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.index.query.BaseQueryFactory;
 import org.opensearch.knn.index.query.KNNQueryFactory;
+import org.opensearch.knn.jni.JNICommons;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
@@ -224,7 +225,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         int dimension = 3;
 
         // "Train" a faiss flat index - this really just creates an empty index that does brute force k-NN
-        long vectorsPointer = JNIService.transferVectors(0, new float[0][0]);
+        long vectorsPointer = JNICommons.storeVectorData(0, new float[0][0], 0);
         byte[] modelBlob = JNIService.trainIndex(
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,

--- a/src/test/java/org/opensearch/knn/index/engine/SpaceTypeResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/SpaceTypeResolverTests.java
@@ -15,7 +15,6 @@ import org.opensearch.knn.index.VectorDataType;
 
 import static org.opensearch.Version.CURRENT;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
-import static org.opensearch.knn.index.KNNSettings.KNN_SPACE_TYPE;
 
 public class SpaceTypeResolverTests extends KNNTestCase {
 
@@ -38,11 +37,7 @@ public class SpaceTypeResolverTests extends KNNTestCase {
 
     public void testResolveSpaceType_whenNoConfigProvided_thenFallbackToVectorDataType() {
         final Settings emptySettings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
-        final Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNN_SPACE_TYPE, SpaceType.L2.getValue())
-            .put(KNN_INDEX, true)
-            .build();
+        final Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
 
         final KNNMethodContext methodContext = new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.COSINESIMIL, MethodComponentContext.EMPTY);
         final KNNMethodContext emptyMethodContext = new KNNMethodContext(
@@ -135,22 +130,16 @@ public class SpaceTypeResolverTests extends KNNTestCase {
             "",
             settings,
             VectorDataType.BYTE,
-            SpaceType.getSpace(settings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey()))
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
         );
         assertResolveSpaceType(
             emptyMethodContext,
             "",
             settings,
             VectorDataType.FLOAT,
-            SpaceType.getSpace(settings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey()))
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
         );
-        assertResolveSpaceType(
-            emptyMethodContext,
-            "",
-            settings,
-            VectorDataType.BINARY,
-            SpaceType.getSpace(settings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey()))
-        );
+        assertResolveSpaceType(emptyMethodContext, "", settings, VectorDataType.BINARY, SpaceType.getSpace(SpaceType.HAMMING.name()));
         assertResolveSpaceType(emptyMethodContext, "", emptySettings, VectorDataType.BYTE, SpaceType.DEFAULT);
         assertResolveSpaceType(emptyMethodContext, "", emptySettings, VectorDataType.FLOAT, SpaceType.DEFAULT);
         assertResolveSpaceType(emptyMethodContext, "", emptySettings, VectorDataType.BINARY, SpaceType.DEFAULT_BINARY);
@@ -183,22 +172,16 @@ public class SpaceTypeResolverTests extends KNNTestCase {
             "",
             settings,
             VectorDataType.BYTE,
-            SpaceType.getSpace(settings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey()))
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
         );
         assertResolveSpaceType(
             nullMethodContext,
             "",
             settings,
             VectorDataType.FLOAT,
-            SpaceType.getSpace(settings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey()))
+            SpaceType.getSpace(KNNSettings.INDEX_KNN_DEFAULT_SPACE_TYPE)
         );
-        assertResolveSpaceType(
-            nullMethodContext,
-            "",
-            settings,
-            VectorDataType.BINARY,
-            SpaceType.getSpace(settings.get(KNNSettings.INDEX_KNN_SPACE_TYPE.getKey()))
-        );
+        assertResolveSpaceType(nullMethodContext, "", settings, VectorDataType.BINARY, SpaceType.getSpace(SpaceType.HAMMING.name()));
         assertResolveSpaceType(nullMethodContext, "", emptySettings, VectorDataType.BYTE, SpaceType.DEFAULT);
         assertResolveSpaceType(nullMethodContext, "", emptySettings, VectorDataType.FLOAT, SpaceType.DEFAULT);
         assertResolveSpaceType(nullMethodContext, "", emptySettings, VectorDataType.BINARY, SpaceType.DEFAULT_BINARY);

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -39,7 +39,6 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
@@ -168,11 +167,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             .endObject();
 
         // Setup settings
-        Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, mWrong)
-            .put(KNN_INDEX, true)
-            .build();
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
 
         KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
             "test-field-name-1",
@@ -203,11 +198,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         ModelDao modelDao = mock(ModelDao.class);
         int mForSetting = 71;
         // Setup settings
-        Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, mForSetting)
-            .put(KNN_INDEX, true)
-            .build();
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
         SpaceType methodSpaceType = SpaceType.COSINESIMIL;
         SpaceType topLevelSpaceType = SpaceType.INNER_PRODUCT;
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
@@ -312,7 +303,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             );
             // this check ensures that legacy mapping is hit, as in legacy mapping we pick M from index settings
             assertEquals(
-                mForSetting,
+                16,
                 knnVectorFieldMapper.fieldType()
                     .getKnnMappingConfig()
                     .getKnnMethodContext()
@@ -365,13 +356,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         int efConstruction = 17;
 
         // Setup settings
-        Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNNSettings.KNN_SPACE_TYPE, spaceType.getValue())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, m)
-            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, efConstruction)
-            .put(KNN_INDEX, true)
-            .build();
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
 
         String modelId = "Random modelId";
         ModelMetadata mockedModelMetadata = new ModelMetadata(
@@ -413,13 +398,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             .field(DIMENSION_FIELD_NAME, 12)
             .endObject();
 
-        Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, m)
-            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, efConstruction)
-            .put(KNNSettings.KNN_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
-            .put(KNN_INDEX, true)
-            .build();
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
 
         KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
             "test-field-name-1",
@@ -433,10 +412,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         assertTrue(knnVectorFieldMapper instanceof MethodFieldMapper);
         assertTrue(knnVectorFieldMapper.fieldType().getKnnMappingConfig().getKnnMethodContext().isPresent());
         assertTrue(knnVectorFieldMapper.fieldType().getKnnMappingConfig().getModelId().isEmpty());
-        assertEquals(
-            SpaceType.INNER_PRODUCT,
-            knnVectorFieldMapper.fieldType().getKnnMappingConfig().getKnnMethodContext().get().getSpaceType()
-        );
+        assertEquals(SpaceType.L2, knnVectorFieldMapper.fieldType().getKnnMappingConfig().getKnnMethodContext().get().getSpaceType());
     }
 
     public void testBuilder_build_fromLegacy() throws IOException {
@@ -452,12 +428,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             .field(DIMENSION_FIELD_NAME, 12)
             .endObject();
 
-        Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, m)
-            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, efConstruction)
-            .put(KNN_INDEX, true)
-            .build();
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
 
         KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
             "test-field-name-1",
@@ -923,12 +894,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         int m = 144;
         int efConstruction = 123;
         SpaceType spaceType = SpaceType.L2;
-        Settings settings = Settings.builder()
-            .put(settings(CURRENT).build())
-            .put(KNNSettings.KNN_SPACE_TYPE, spaceType.getValue())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, m)
-            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, efConstruction)
-            .build();
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).build();
 
         ModelDao modelDao = mock(ModelDao.class);
         KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryAllocationTests.java
@@ -392,7 +392,7 @@ public class NativeMemoryAllocationTests extends KNNTestCase {
         for (int i = 0; i < numVectors; i++) {
             Arrays.fill(vectors[i], 1f);
         }
-        long memoryAddress = JNIService.transferVectors(0, vectors);
+        long memoryAddress = JNICommons.storeVectorData(0, vectors, vectors.length * dimension);
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         NativeMemoryAllocation.TrainingDataAllocation trainingDataAllocation = new NativeMemoryAllocation.TrainingDataAllocation(

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -147,7 +147,6 @@ public class KNNWeightTests extends KNNTestCase {
         );
         knnSettingsMockedStatic.when(KNNSettings::getCircuitBreakerLimit).thenReturn(v);
         knnSettingsMockedStatic.when(KNNSettings::state).thenReturn(knnSettings);
-        knnSettingsMockedStatic.when(KNNSettings::isKNNPluginEnabled).thenReturn(true);
         ByteSizeValue cacheSize = ByteSizeValue.parseBytesSizeValue("1024kb", QUANTIZATION_STATE_CACHE_SIZE_LIMIT); // Setting 1MB as an
                                                                                                                     // example
         when(knnSettings.getSettingValue(eq(QUANTIZATION_STATE_CACHE_SIZE_LIMIT))).thenReturn(cacheSize);

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -1609,12 +1609,20 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     public void testTransferVectors() {
-        long trainPointer1 = JNIService.transferVectors(0, testData.indexData.vectors);
+        long trainPointer1 = JNICommons.storeVectorData(
+            0,
+            testData.indexData.vectors,
+            testData.indexData.vectors.length * testData.indexData.vectors[0].length
+        );
         assertNotEquals(0, trainPointer1);
 
         long trainPointer2;
         for (int i = 0; i < 10; i++) {
-            trainPointer2 = JNIService.transferVectors(trainPointer1, testData.indexData.vectors);
+            trainPointer2 = JNICommons.storeVectorData(
+                trainPointer1,
+                testData.indexData.vectors,
+                testData.indexData.vectors.length * testData.indexData.vectors[0].length
+            );
             assertEquals(trainPointer1, trainPointer2);
         }
 
@@ -1720,12 +1728,20 @@ public class JNIServiceTests extends KNNTestCase {
     }
 
     private long transferVectors(int numDuplicates) {
-        long trainPointer1 = JNIService.transferVectors(0, testData.indexData.vectors);
+        long trainPointer1 = JNICommons.storeVectorData(
+            0,
+            testData.indexData.vectors,
+            testData.indexData.vectors.length * testData.indexData.vectors[0].length
+        );
         assertNotEquals(0, trainPointer1);
 
         long trainPointer2;
         for (int i = 0; i < numDuplicates; i++) {
-            trainPointer2 = JNIService.transferVectors(trainPointer1, testData.indexData.vectors);
+            trainPointer2 = JNICommons.storeVectorData(
+                trainPointer1,
+                testData.indexData.vectors,
+                testData.indexData.vectors.length * testData.indexData.vectors[0].length
+            );
             assertEquals(trainPointer1, trainPointer2);
         }
 
@@ -1734,12 +1750,20 @@ public class JNIServiceTests extends KNNTestCase {
 
     public void createIndexFromTemplate() throws IOException {
 
-        long trainPointer1 = JNIService.transferVectors(0, testData.indexData.vectors);
+        long trainPointer1 = JNICommons.storeVectorData(
+            0,
+            testData.indexData.vectors,
+            testData.indexData.vectors.length * testData.indexData.vectors[0].length
+        );
         assertNotEquals(0, trainPointer1);
 
         long trainPointer2;
         for (int i = 0; i < 10; i++) {
-            trainPointer2 = JNIService.transferVectors(trainPointer1, testData.indexData.vectors);
+            trainPointer2 = JNICommons.storeVectorData(
+                trainPointer1,
+                testData.indexData.vectors,
+                testData.indexData.vectors.length * testData.indexData.vectors[0].length
+            );
             assertEquals(trainPointer1, trainPointer2);
         }
 
@@ -1818,7 +1842,11 @@ public class JNIServiceTests extends KNNTestCase {
             ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, faissMethod, KNNConstants.SPACE_TYPE, SpaceType.L2.getValue())
         );
 
-        long trainPointer = JNIService.transferVectors(0, testData.indexData.vectors);
+        long trainPointer = JNICommons.storeVectorData(
+            0,
+            testData.indexData.vectors,
+            testData.indexData.vectors.length * testData.indexData.vectors[0].length
+        );
         assertNotEquals(0, trainPointer);
         KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
             .versionCreated(Version.CURRENT)
@@ -1972,7 +2000,11 @@ public class JNIServiceTests extends KNNTestCase {
 
     private String createFaissIVFPQIndex(Directory directory, int ivfNlist, int pqM, int pqCodeSize, SpaceType spaceType)
         throws IOException {
-        long trainPointer = JNIService.transferVectors(0, testData.indexData.vectors);
+        long trainPointer = JNICommons.storeVectorData(
+            0,
+            testData.indexData.vectors,
+            testData.indexData.vectors.length * testData.indexData.vectors[0].length
+        );
         assertNotEquals(0, trainPointer);
         KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
             .versionCreated(Version.CURRENT)

--- a/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
+++ b/src/test/java/org/opensearch/knn/training/TrainingJobTests.java
@@ -161,7 +161,7 @@ public class TrainingJobTests extends KNNTestCase {
         int tdataPoints = 100;
         float[][] trainingData = new float[tdataPoints][dimension];
         fillFloatArrayRandomly(trainingData);
-        long memoryAddress = JNIService.transferVectors(0, trainingData);
+        long memoryAddress = JNICommons.storeVectorData(0, trainingData, trainingData.length * dimension);
 
         // Setup model manager
         NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);
@@ -481,7 +481,7 @@ public class TrainingJobTests extends KNNTestCase {
         int tdataPoints = 2;
         float[][] trainingData = new float[tdataPoints][dimension];
         fillFloatArrayRandomly(trainingData);
-        long memoryAddress = JNIService.transferVectors(0, trainingData);
+        long memoryAddress = JNICommons.storeVectorData(0, trainingData, trainingData.length * dimension);
 
         // Setup model manager
         NativeMemoryCacheManager nativeMemoryCacheManager = mock(NativeMemoryCacheManager.class);

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1808,13 +1808,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         Integer m,
         Integer ef_construction
     ) {
-        return Settings.builder()
-            .put(NUMBER_OF_SHARDS, 1)
-            .put(NUMBER_OF_REPLICAS, 0)
-            .put(INDEX_KNN, true)
-            .put(KNNSettings.KNN_SPACE_TYPE, spaceType.getValue())
-            .put(KNNSettings.KNN_ALGO_PARAM_M, m)
-            .put(KNNSettings.KNN_ALGO_PARAM_EF_CONSTRUCTION, ef_construction);
+        return Settings.builder().put(NUMBER_OF_SHARDS, 1).put(NUMBER_OF_REPLICAS, 0).put(INDEX_KNN, true);
     }
 
     protected Settings createKNNIndexCustomLegacyFieldMappingIndexSettings(SpaceType spaceType, Integer m, Integer ef_construction) {


### PR DESCRIPTION
### Description
As part of OpenSearch 3.0.0 release , we are removing some of the already deprecated feature from KNN Plugin , this will be breaking change from KNN. Here is the list of changes.

1. Remove Knn Plugin enabled setting 
2. Remove ef construction from Index Seeting.
3. Remove m from Index Setting.
4. Remove space type from index setting
5. Remove deprecated apis from JNI Layer.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
