### PR TITLE
Remove integrity checking TODO and leave up to the vendor implementation

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/DefaultVectorRepositoryAccessorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/DefaultVectorRepositoryAccessorTests.java
@@ -35,9 +35,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 import static org.opensearch.knn.index.remote.KNNRemoteConstants.DOC_ID_FILE_EXTENSION;
 import static org.opensearch.knn.index.remote.KNNRemoteConstants.VECTOR_BLOB_FILE_EXTENSION;
-import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 
 public class DefaultVectorRepositoryAccessorTests extends RemoteIndexBuildTests {
 
@@ -109,7 +109,7 @@ public class DefaultVectorRepositoryAccessorTests extends RemoteIndexBuildTests 
     /**
      * Test that when an exception is thrown during asyncBlobUpload, the exception is rethrown.
      */
-    public void testAsyncUploadThrowsException() throws InterruptedException, IOException {
+    public void testAsyncUploadThrowsException() throws IOException {
         RepositoriesService repositoriesService = mock(RepositoriesService.class);
         BlobStoreRepository mockRepository = mock(BlobStoreRepository.class);
         BlobPath testBasePath = new BlobPath().add("testBasePath");

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildTests.java
@@ -127,7 +127,7 @@ abstract class RemoteIndexBuildTests extends KNNTestCase {
 
         @Override
         public boolean remoteIntegrityCheckSupported() {
-            return false;
+            return true;
         }
 
         @Override


### PR DESCRIPTION
### Description

In this PR we are making the decision to leave integrity checking up to the individual vendor SDK and repository implementations. For example, in https://github.com/opensearch-project/OpenSearch/pull/17396 the aws s3 SDK was bumped to automatically support integrity checking.

### Integrity Checking Overview
We are making the decision to leave integrity checking to the vendor implementation in all cases. This section will give a brief overview of how this is done for S3. 

When using the aws java sdk and repository-s3, during object upload a CRC32 checksum is automatically computed by the SDK, and validated + persisted to the object store. During object download, if a checksum is present in the object store, the SDK will automatically validate the downloaded object against the checksum found in the object store.

As a future improvement, we can also manually do this integrity checking if the vendor implementation indicates that integrity checking is not supported. For example, remote store does this like so: https://github.com/opensearch-project/OpenSearch/blob/3ea0a31f6f613ddd5b7bde0053195d5b212c813d/server/src/main/java/org/opensearch/common/blobstore/transfer/RemoteTransferContainer.java#L213-L222.

Tracking the future improvement here: https://github.com/opensearch-project/k-NN/issues/2579

### Other

We have separate testing in `KnnVectorValuesInputStreamTests` that provides coverage on if the InputStream is correctly reading the `KNNVectorValues`, and we do not need to separately compute a checksum on this.


### Related Issues
Relates https://github.com/opensearch-project/k-NN/issues/2465
Relates https://github.com/opensearch-project/k-NN/issues/2392
Relates https://github.com/opensearch-project/k-NN/issues/2391

### Check List
- [x] New functionality includes testing.
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
