### PR TITLE
Fixing bug to prevent NullPointerException while doing PUT mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Introduce node level circuit breakers for k-NN [#2509](https://github.com/opensearch-project/k-NN/pull/2509)
 ### Bug Fixes
+* Fixing bug to prevent NullPointerException while doing PUT mappings [#2556](https://github.com/opensearch-project/k-NN/issues/2556)
 ### Infrastructure
 * Removed JDK 11 and 17 version from CI runs [#1921](https://github.com/opensearch-project/k-NN/pull/1921)
 * Upgrade min JDK compatibility to JDK 21 [#2422](https://github.com/opensearch-project/k-NN/pull/2422)

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -161,7 +161,14 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             b.startObject(n);
             v.toXContent(b, ToXContent.EMPTY_PARAMS);
             b.endObject();
-        }), m -> m.getMethodComponentContext().getName());
+        }),
+                m -> {
+            if (m == null) {
+                throw new IllegalArgumentException("Mapping update for knn_vector fields is not supported. " +
+                        "Cannot update mapping without the original method configuration.");
+            }
+            return m.getMethodComponentContext().getName();
+        });
 
         protected final Parameter<String> mode = Parameter.restrictedStringParam(
             KNNConstants.MODE_PARAMETER,

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -164,8 +164,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         }), m -> {
             if (m == null) {
                 throw new IllegalArgumentException(
-                        "Cannot add or remove method key for existing KNN field [%s]. "
-                                + "KNN vector fields require consistent method configuration during updates."
+//                        "Cannot add or remove method key for existing KNN field: [%s]. "
+//                                + "KNN vector fields require consistent method configuration during updates."
+                        String.format("Cannot add or remove method key for existing KNN field [%s]. "
+                                + "KNN vector fields require consistent method configuration during updates.", this.name())
                 );
             }
             return m.getMethodComponentContext().getName();

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -164,8 +164,8 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         }), m -> {
             if (m == null) {
                 throw new IllegalArgumentException(
-                    "Mapping update for knn_vector fields is not supported. "
-                        + "Cannot update mapping without the original method configuration."
+                        "Cannot add or remove method key for existing KNN field [%s]. "
+                                + "KNN vector fields require consistent method configuration during updates."
                 );
             }
             return m.getMethodComponentContext().getName();

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -161,11 +161,12 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             b.startObject(n);
             v.toXContent(b, ToXContent.EMPTY_PARAMS);
             b.endObject();
-        }),
-                m -> {
+        }), m -> {
             if (m == null) {
-                throw new IllegalArgumentException("Mapping update for knn_vector fields is not supported. " +
-                        "Cannot update mapping without the original method configuration.");
+                throw new IllegalArgumentException(
+                    "Mapping update for knn_vector fields is not supported. "
+                        + "Cannot update mapping without the original method configuration."
+                );
             }
             return m.getMethodComponentContext().getName();
         });

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -169,7 +169,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             },
             // Conflict serializer - simple string representation for error messages
             v -> v == null ? null : v.getMethodComponentContext().getName()
-        ).acceptsNull();
+        );
 
         protected final Parameter<String> mode = Parameter.restrictedStringParam(
             KNNConstants.MODE_PARAMETER,

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -157,9 +157,11 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             (n, c, o) -> KNNMethodContext.parse(o),
             m -> toType(m).originalMappingParameters.getKnnMethodContext()
         ).setSerializer(
-            // Main serializer - handles null values properly
+            // Main serializer - handles null values with nullField
             (b, f, v) -> {
-                if (v != null) {
+                if (v == null) {
+                    b.nullField(f);
+                } else {
                     b.startObject(f);
                     v.toXContent(b, ToXContent.EMPTY_PARAMS);
                     b.endObject();

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1245,6 +1245,84 @@ public class OpenSearchIT extends KNNRestTestCase {
         );
     }
 
+    public void testKNNVectorMappingUpdate_whenDimensionChanged_thenSucceeds() throws Exception {
+        String indexName = "test-knn-index-partial";
+        String fieldName = "my_vector2";
+
+        XContentBuilder initialMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", 4)
+            .startObject("method")
+            .field("engine", "faiss")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), initialMapping.toString());
+
+        XContentBuilder updatedMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", 8)
+            .startObject("method")
+            .field("engine", "faiss")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        putMappingRequest(indexName, updatedMapping.toString());
+
+        Map<String, Object> mappingResponse = getIndexMappingAsMap(indexName);
+        assertEquals(8, ((Map<?, ?>) ((Map<?, ?>) mappingResponse.get("properties")).get(fieldName)).get("dimension"));
+    }
+
+    public void testKNNVectorMappingUpdate_whenMethodPartiallyRemoved_thenThrowsException() throws Exception {
+        String indexName = "test-knn-index-success";
+        String fieldName = "my_vector2";
+
+        XContentBuilder initialMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", 4)
+            .startObject("method")
+            .field("engine", "faiss")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), initialMapping.toString());
+
+        XContentBuilder updatedMapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", 8)
+            .startObject("method")
+            .field("engine", "faiss")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        ResponseException exception = expectThrows(ResponseException.class, () -> putMappingRequest(indexName, updatedMapping.toString()));
+
+        assertThat(EntityUtils.toString(exception.getResponse().getEntity()), containsString("name needs to be set"));
+
+    }
+
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)
         throws IOException, ParseException {
         final Response searchResponseField = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName, vector, k), k);

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1245,7 +1245,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         );
     }
 
-    public void testKNNVectorMappingUpdate_whenDimensionChanged_thenSucceeds() throws Exception {
+    public void testCreateKNNIndexWithDifferentDimension() throws Exception {
         String indexName = "test-knn-index-partial";
         String fieldName = "my_vector2";
 

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1249,22 +1249,6 @@ public class OpenSearchIT extends KNNRestTestCase {
         String indexName = "test-knn-index-partial";
         String fieldName = "my_vector2";
 
-        XContentBuilder initialMapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(fieldName)
-            .field("type", "knn_vector")
-            .field("dimension", 4)
-            .startObject("method")
-            .field("engine", "faiss")
-            .field("name", "hnsw")
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
-
-        createKnnIndex(indexName, getKNNDefaultIndexSettings(), initialMapping.toString());
-
         XContentBuilder updatedMapping = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -1279,8 +1263,7 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .endObject();
 
-        putMappingRequest(indexName, updatedMapping.toString());
-
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), updatedMapping.toString());
         Map<String, Object> mappingResponse = getIndexMappingAsMap(indexName);
         assertEquals(8, ((Map<?, ?>) ((Map<?, ?>) mappingResponse.get("properties")).get(fieldName)).get("dimension"));
     }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1984,6 +1984,38 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         );
     }
 
+    public void testKnnMethodContextParameter_defaultValue() {
+        // Use the same builder pattern as in your existing tests
+        KNNVectorFieldMapper.Builder builder = new KNNVectorFieldMapper.Builder(
+            "test-field",
+            mock(ModelDao.class),
+            CURRENT,
+            null,
+            null,
+            false
+        );
+        // Test that the default value is null
+        assertNull(builder.knnMethodContext.get());
+    }
+
+    public void testBuild_whenNullMethodContext_thenThrowException() {
+        // Prepare context
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
+        String validFieldName = "validFieldName";
+
+        // When we try to build with null method context
+        Exception e = assertThrows(IllegalArgumentException.class, () -> {
+            new KNNVectorFieldMapper.Builder(validFieldName, null, CURRENT, null, null, false).build(builderContext);
+        });
+
+        // Then verify the exception message matches what we expect from the knnMethodContext parameter
+        assertEquals(
+            "Mapping update for knn_vector fields is not supported. " + "Cannot update mapping without the original method configuration.",
+            e.getMessage()
+        );
+    }
+
     private void validateBuilderAfterParsing(
         KNNVectorFieldMapper.Builder builder,
         KNNEngine expectedEngine,

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -2004,12 +2004,12 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
         String validFieldName = "validFieldName";
 
-        // When we try to build with null method context
+        // IllegalArgumentException thrown when building with null method context
         Exception e = assertThrows(IllegalArgumentException.class, () -> {
             new KNNVectorFieldMapper.Builder(validFieldName, null, CURRENT, null, null, false).build(builderContext);
         });
 
-        // Then verify the exception message matches what we expect from the knnMethodContext parameter
+        // Verify the exception message matches the knnMethodContext parameter
         assertEquals(
             "Mapping update for knn_vector fields is not supported. " + "Cannot update mapping without the original method configuration.",
             e.getMessage()


### PR DESCRIPTION
### Description
Following code prevents the state of a NullPointerException from occurring while doing PUT mappings. The expected behavior is to block the update by telling the user that we cannot update the mapping.

### Related Issues
Resolves #2556
<!-- List any other related issues here -->

### Check List
- [ ✔️ ] New functionality includes testing.
- [ ✔️ ] New functionality has been documented.
- [ ✔️ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ✔️ ] Commits are signed per the DCO using `--signoff`.
- [ ✔️ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Input:

Create index with below mappings:
```
curl --request PUT \
  --url http://localhost:9200/my-knn-index-1/ \
  --header 'Content-Type: application/json' \
  --data '{
	"settings": {
		"index": {
			"number_of_shards": 1,
			"number_of_replicas": 0,
			"refresh_interval": "1s",
			"knn": true
		}
	},
	"mappings": {
		"properties": {
			"my_vector2": {
				"type": "knn_vector",
				"dimension": 4,
				"method": {
					"engine": "faiss",
					"name": "hnsw"
				}
			}
		}
	}
}'
```

Try doing put mappings like this:
```
curl --request PUT \
  --url http://localhost:9200/my-knn-index-1/_mappings \
  --header 'Content-Type: application/json' \
  --data '{
	"properties": {
		"my_vector2": {
			"type": "knn_vector",
			"dimension": 4
		}
	}
}'
```
### Changes

Previous Error Output:
```
{
	"error": {
		"root_cause": [
			{
				"type": "null_pointer_exception",
				"reason": "Cannot invoke \"org.opensearch.knn.index.engine.KNNMethodContext.getMethodComponentContext()\" because \"m\" is null"
			}
		],
		"type": "null_pointer_exception",
		"reason": "Cannot invoke \"org.opensearch.knn.index.engine.KNNMethodContext.getMethodComponentContext()\" because \"m\" is null"
	},
	"status": 500
}
```
New Error Output:
```
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "Mapping update for knn_vector fields is not supported. Cannot update mapping without the original method configuration."
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "Mapping update for knn_vector fields is not supported. Cannot update mapping without the original method configuration."
    },
    "status": 400
}
```
