### PR TITLE
Use latest json-smart lib to fix  CVE-2024-57699

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,10 @@ dependencies {
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
     testFixturesImplementation('com.jayway.jsonpath:json-path:2.9.0') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
+        exclude group: 'net.minidev', module: 'json-smart'
     }
+    // Explicitly include a safe version of json-smart for test fixtures
+    testFixturesImplementation group: 'net.minidev', name: 'json-smart', version: "${versions.json_smart}"
     testFixturesImplementation "org.opensearch:common-utils:${version}"
     implementation 'com.github.oshi:oshi-core:6.4.13'
     api "net.java.dev.jna:jna:5.13.0"


### PR DESCRIPTION
### Description
json-path 2.9.0 has been flagged in https://github.com/advisories/GHSA-pq2g-wx69-c263. They do not have fix yet, and their devs suggest to switch to json-smart https://github.com/json-path/JsonPath/issues/1031.

We need to have this library for ml-commons, follow their strategy: keep json-path, but excluding json-smart part of it, and include json-mart of the proper version separately.

Picking up version of json-smart from the OS core, they added in the recent PR https://github.com/opensearch-project/OpenSearch/pull/17569

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
