### PR TITLE
Fix flaky test in RemoteIndexBuildStrategyTests.java 

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -77,6 +77,6 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
         when(clusterSettings.get(KNN_REMOTE_VECTOR_REPO_SETTING)).thenReturn("test-vector-repo");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         KNNSettings.state().setClusterService(clusterService);
-        assertTrue(RemoteIndexBuildStrategy.shouldBuildIndexRemotely(indexSettings, randomIntBetween(BYTE_SIZE - 1, BYTE_SIZE * 2)));
+        assertTrue(RemoteIndexBuildStrategy.shouldBuildIndexRemotely(indexSettings, randomIntBetween(BYTE_SIZE, BYTE_SIZE * 2)));
     }
 }


### PR DESCRIPTION
### Description
`RemoteIndexBuildStrategy.shouldBuildIndexRemotely` [makes a check](https://github.com/opensearch-project/k-NN/blob/b77b6b6d1ccab63f0b01f4891cf30d7e45b4acf0/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java#L86) comparing the size of the vector blob to the minimum remote build threshold. If the size threshold is not met, the remote build will not be triggered.

Before this PR's change, a random `BYTE_SIZE` was being generated in the range `BYTE_SIZE - 1, BYTE_SIZE * 2` to trigger the happy path. But, since the lower bound is inclusive, it was possible the random `BYTE_SIZE` was actually below the threshold (at exactly `BYTE_SIZE - 1`). With this change, the minimum random size will be exactly `BYTE_SIZE` as to always meet the threshold.

I verified this fix by reproducing the bug using the seed and ensuring the test runs successfully at the new minimum `BYTE_SIZE`.

### Related Issues
Addresses https://github.com/opensearch-project/k-NN/actions/runs/13798419172/job/38595557504?pr=2582 — thanks @oaganesh for flagging

### Check List
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [✅] Commits are signed per the DCO using `--signoff`.

~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
