### PR TITLE
[LuceneOnFaiss Part-7] Enable memory optimized searching in VectorReader for FAISS engine.

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -110,7 +110,7 @@ public class KNNCodecUtil {
         if (knnEngine == null) {
             return null;
         }
-        final List<String> engineFiles = KNNCodecUtil.getEngineFiles(knnEngine.getExtension(), field.name, segmentInfo);
+        final List<String> engineFiles = KNNCodecUtil.getEngineFiles(knnEngine.getExtension(), field.getName(), segmentInfo);
         if (engineFiles.isEmpty()) {
             return null;
         } else {

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -47,7 +47,6 @@ public class JNIService {
             }
 
             return FaissService.initIndex(numDocs, dim, parameters);
-
         }
 
         throw new IllegalArgumentException(

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -19,7 +19,7 @@ public interface VectorSearcherFactory {
      *
      * @param directory Lucene's Directory.
      * @param fileName Logical file name to load.
-     * @return It must return a non-null {@link VectorSearcher}
+     * @return Null instance if it is not supported, otherwise return {@link VectorSearcher}
      * @throws IOException
      */
     VectorSearcher createVectorSearcher(Directory directory, String fileName) throws IOException;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
@@ -31,10 +31,10 @@ public class FaissHnswGraph extends HnswGraph {
     private int numNeighbors;
     private int nextNeighborIndex;
 
-    public FaissHnswGraph(final FaissHNSW faissHNSW, final int numVectors, final IndexInput indexInput) {
+    public FaissHnswGraph(final FaissHNSW faissHNSW, final IndexInput indexInput) {
         this.faissHnsw = faissHNSW;
         this.indexInput = indexInput;
-        this.numVectors = numVectors;
+        this.numVectors = Math.toIntExact(faissHNSW.getTotalNumberOfVectors());
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexScalarQuantizedFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexScalarQuantizedFlat.java
@@ -52,7 +52,7 @@ public class FaissIndexScalarQuantizedFlat extends FaissIndex {
         quantizerType = QuantizerType.values()[input.readInt()];
         if (quantizerType != QuantizerType.QT_8BIT_DIRECT_SIGNED) {
             // So far, we only support byte vector.
-            throw new IllegalArgumentException("Unsupported quantizer type: " + quantizerType);
+            throw new UnsupportedFaissIndexException("Unsupported quantizer type: " + quantizerType);
         }
 
         // Loading range statistics + arguments

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -5,9 +5,16 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss;
 
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IOSupplier;
+import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 
 import java.io.IOException;
@@ -16,32 +23,102 @@ import java.io.IOException;
  * This searcher directly reads FAISS index file via the provided {@link IndexInput} then perform vector search on it.
  */
 public class FaissMemoryOptimizedSearcher implements VectorSearcher {
+    private static final FlatVectorsScorer VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+
     private final IndexInput indexInput;
     private FaissIndex faissIndex;
+    private FaissHnswGraph faissHnswGraph;
 
     public FaissMemoryOptimizedSearcher(IndexInput indexInput) throws IOException {
         this.indexInput = indexInput;
-        try {
-            this.faissIndex = FaissIndex.load(indexInput);
-        } catch (UnsupportedFaissIndexException e) {
-            // TODO(KDY) : Remove this in part-7 (Complete Faiss Loading Part at Codec Level)
+        this.faissIndex = FaissIndex.load(indexInput);
+        final FaissHNSW hnsw = extractFaissHnsw(faissIndex);
+        this.faissHnswGraph = new FaissHnswGraph(hnsw, indexInput);
+    }
+
+    private static FaissHNSW extractFaissHnsw(final FaissIndex faissIndex) {
+        if (faissIndex instanceof FaissIdMapIndex idMapIndex) {
+            return idMapIndex.getNestedIndex().getHnsw();
         }
+
+        throw new IllegalArgumentException("Faiss index [" + faissIndex.getIndexType() + "] does not have HNSW as an index.");
     }
 
     @Override
     public void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
-        // TODO(KDY) : This will be covered in part-7 (Complete Faiss Loading Part at Codec Level)
-        throw new UnsupportedOperationException("Not implemented yet");
+        search(
+            VectorEncoding.FLOAT32,
+            () -> VECTOR_SCORER.getRandomVectorScorer(
+                faissIndex.getVectorSimilarityFunction().getVectorSimilarityFunction(),
+                faissIndex.getFloatValues(indexInput),
+                target
+            ),
+            knnCollector,
+            acceptDocs
+        );
     }
 
     @Override
     public void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
-        // TODO(KDY) : This will be covered in part-7 (Complete Faiss Loading Part at Codec Level)
-        throw new UnsupportedOperationException("Not implemented yet");
+        search(
+            VectorEncoding.BYTE,
+            () -> VECTOR_SCORER.getRandomVectorScorer(
+                faissIndex.getVectorSimilarityFunction().getVectorSimilarityFunction(),
+                faissIndex.getByteValues(indexInput),
+                target
+            ),
+            knnCollector,
+            acceptDocs
+        );
     }
 
     @Override
     public void close() throws IOException {
         indexInput.close();
+    }
+
+    private void search(
+        final VectorEncoding vectorEncoding,
+        final IOSupplier<RandomVectorScorer> scorerSupplier,
+        final KnnCollector knnCollector,
+        final Bits acceptDocs
+    ) throws IOException {
+        if (faissIndex.getTotalNumberOfVectors() == 0 || knnCollector.k() == 0) {
+            return;
+        }
+
+        if (faissIndex.getVectorEncoding() != vectorEncoding) {
+            throw new IllegalArgumentException(
+                "Search for vector encoding ["
+                    + vectorEncoding
+                    + "] is not supported in "
+                    + "an index vector whose encoding is ["
+                    + faissIndex.getVectorEncoding()
+                    + "]"
+            );
+        }
+
+        // Set up required components for vector search
+        final RandomVectorScorer scorer = scorerSupplier.get();
+        final KnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
+        final Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs);
+
+        if (knnCollector.k() < scorer.maxOrd()) {
+            // Do ANN search with Lucene's HNSW graph searcher.
+            HnswGraphSearcher.search(scorer, collector, faissHnswGraph, acceptedOrds);
+        } else {
+            // If k is larger than the number of vectors, we can just iterate over all vectors
+            // and collect them.
+            for (int i = 0; i < scorer.maxOrd(); i++) {
+                if (acceptedOrds == null || acceptedOrds.get(i)) {
+                    if (!knnCollector.earlyTerminated()) {
+                        knnCollector.incVisitedCount(1);
+                        knnCollector.collect(scorer.ordToDoc(i), scorer.score(i));
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }  // End if
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormatTests.java
@@ -48,7 +48,6 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.store.BaseDirectoryWrapper;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
 import org.junit.After;
@@ -259,15 +258,6 @@ public class NativeEngines990KnnVectorsFormatTests extends KNNTestCase {
         assertEquals(2, floatVectorValuesForBinaryQuantization.size());
         assertEquals(8, floatVectorValuesForBinaryQuantization.dimension());
 
-        Assert.assertThrows(
-            UnsupportedOperationException.class,
-            () -> leafReader.searchNearestVectors(FLOAT_VECTOR_FIELD, floatVector, 10, new Bits.MatchAllBits(1), 10)
-        );
-
-        Assert.assertThrows(
-            UnsupportedOperationException.class,
-            () -> leafReader.searchNearestVectors(BYTE_VECTOR_FIELD, byteVector, 10, new Bits.MatchAllBits(1), 10)
-        );
         // do it at the end so that all search is completed
         indexReader.close();
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -5,26 +5,31 @@
 
 package org.opensearch.knn.index.codec.KNN990Codec;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.SneakyThrows;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.mockito.MockedStatic;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
+import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.KNN_FIELD;
@@ -49,20 +54,44 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         // - field3: KNN field, FAISS
         // - field4: KNN field, FAISS
         // - field5: KNN field, FAISS, but it does not have file for some reason.
-        final FieldInfo[] fieldInfoArray = new FieldInfo[] {
-            createFieldInfo("field1", null, 0),
-            createFieldInfo("field2", KNNEngine.LUCENE, 1),
-            createFieldInfo("field3", KNNEngine.FAISS, 2),
-            createFieldInfo("field4", KNNEngine.FAISS, 3),
-            createFieldInfo("field5", KNNEngine.FAISS, 4) };
-        final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
-        final Set<String> filesInSegment = Set.of("_0_165_field3.faiss", "_0_165_field4.faiss");
 
-        // Load vector searchers
-        final Map<String, VectorSearcher> vectorSearchers = loadSearchers(fieldInfos, filesInSegment);
+        // Mocking FAISS engine to return a dummy vector searcher
+        KNNEngine mockFaiss = spy(KNNEngine.FAISS);
+        VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
+        when(mockFactory.createVectorSearcher(any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
 
-        // Validate #searchers
-        assertEquals(2, vectorSearchers.size());
+        try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {
+            // Prepare field infos
+            final FieldInfo[] fieldInfoArray = new FieldInfo[] {
+                createFieldInfo("field1", null, 0),
+                createFieldInfo("field2", KNNEngine.LUCENE, 1),
+                createFieldInfo("field3", mockFaiss, 2),
+                createFieldInfo("field4", mockFaiss, 3),
+                createFieldInfo("field5", mockFaiss, 4) };
+            final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
+            final Set<String> filesInSegment = Set.of("_0_165_field3.faiss", "_0_165_field4.faiss");
+
+            // Replace static 'getEngine' to return mockFaiss
+            mockedStatic.when(() -> KNNEngine.getEngine(any())).thenAnswer(invocation -> {
+                final String strArg = invocation.getArgument(0);
+                // Intercept FAISS engine to return mock
+                if (strArg.equals(KNNEngine.FAISS.getName())) {
+                    return mockFaiss;
+                }
+
+                // Otherwise return Lucene, as field2 is using Lucene.
+                return KNNEngine.LUCENE;
+            });
+
+            mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
+
+            // Load vector searchers
+            final Map<String, VectorSearcher> vectorSearchers = loadSearchers(fieldInfos, filesInSegment);
+
+            // Validate #searchers
+            assertEquals(2, vectorSearchers.size());
+        }
     }
 
     private static FieldInfo createFieldInfo(final String fieldName, final KNNEngine engine, final int fieldNo) {
@@ -84,16 +113,11 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         final SegmentInfo segmentInfo = mock(SegmentInfo.class);
         when(segmentInfo.files()).thenReturn(filesInSegment);
         when(segmentInfo.getId()).thenReturn((segmentInfo.hashCode() + "").getBytes());
-        final SegmentReadState readState = new SegmentReadState(mockDirectory, segmentInfo, fieldInfos, null);
+        final SegmentReadState readState = new SegmentReadState(mockDirectory, segmentInfo, fieldInfos, IOContext.DEFAULT);
 
         // Create reader
         final NativeEngines990KnnVectorsReader reader = new NativeEngines990KnnVectorsReader(readState, null);
         final Class clazz = NativeEngines990KnnVectorsReader.class;
-
-        // Call loadMemoryOptimizedSearcher()
-        final Method loadMethod = clazz.getDeclaredMethod("loadMemoryOptimizedSearcher");
-        loadMethod.setAccessible(true);
-        loadMethod.invoke(reader);
 
         // Get searcher table
         final Field tableField = clazz.getDeclaredField("vectorSearchers");

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemoryOptimizedSearchIndexingSupport.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemoryOptimizedSearchIndexingSupport.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.nativeindex;
+
+import lombok.experimental.UtilityClass;
+import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
+
+import java.io.IOException;
+
+@UtilityClass
+public class MemoryOptimizedSearchIndexingSupport {
+    public static void buildIndex(final BuildIndexParams indexParams) throws IOException {
+        MemOptimizedNativeIndexBuildStrategy.getInstance().buildAndWriteIndex(indexParams);
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissEngineTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissEngineTests.java
@@ -5,33 +5,10 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.engine.KNNEngine;
 
-import java.io.IOException;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class FaissEngineTests extends KNNTestCase {
-    public void testFaissEngineToReturnSearcher() throws IOException {
-        final VectorSearcherFactory factory = KNNEngine.FAISS.getVectorSearcherFactory();
-        assertNotNull(factory);
-
-        final IndexInput mockIndexInput = mock(IndexInput.class);
-        final Directory mockDirectory = mock(Directory.class);
-        when(mockDirectory.openInput(any(), any())).thenReturn(mockIndexInput);
-        final String fileName = "_0_165_target_field.faiss";
-        try (VectorSearcher searcher = factory.createVectorSearcher(mockDirectory, fileName)) {
-            assertNotNull(searcher);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public void testNonFaissEngineToReturnNullSearcher() {
         assertNull(KNNEngine.LUCENE.getVectorSearcherFactory());
         assertNull(KNNEngine.NMSLIB.getVectorSearcherFactory());

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHnswGraphTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHnswGraphTests.java
@@ -110,7 +110,7 @@ public class FaissHnswGraphTests extends KNNTestCase {
 
         // Create LuceneFaissHnswGraph
         indexInput = loadHnswBinary("data/memoryoptsearch/faiss_hnsw_100_vectors.bin");
-        final FaissHnswGraph graph = new FaissHnswGraph(faissHNSW, totalNumberOfVectors, indexInput);
+        final FaissHnswGraph graph = new FaissHnswGraph(faissHNSW, indexInput);
         return graph;
     }
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -1,0 +1,621 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.FixedBitSet;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsReader;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.knn.index.codec.nativeindex.MemoryOptimizedSearchIndexingSupport;
+import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.knn.index.query.FilterIdsSelector;
+import org.opensearch.knn.index.query.KNNQueryResult;
+import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
+import org.opensearch.knn.index.vectorvalues.KNNByteVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
+import org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy;
+import org.opensearch.knn.jni.JNIService;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.INDEX_THREAD_QTY;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
+public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
+    private static final String TARGET_FIELD = "target_field";
+    private static final String FLOAT_HNSW_INDEX_DESCRIPTION = "HNSW16,Flat";
+    private static final String BYTE_HNSW_INDEX_DESCRIPTION = "HNSW16,SQ8_direct_signed";
+    private static final int DIMENSIONS = 128;
+    private static final int MIN_VALUE = -1000000;
+    private static final int MAX_VALUE = 1000000;
+    private static final int TOTAL_NUM_DOCS_IN_SEGMENT = 1000;
+    private static final int NUM_CHILD_DOCS = 5;
+
+    public void testFloatIndexType() {
+        // Test a dense case where all docs have KNN field.
+        doSearchTest(VectorDataType.FLOAT, IndexingType.DENSE);
+
+        // Test a sparse case where some docs don't have KNN field
+        doSearchTest(VectorDataType.FLOAT, IndexingType.SPARSE);
+
+        // Test a sparse nested case where some parent docs don't have KNN field
+        doSearchTest(VectorDataType.FLOAT, IndexingType.SPARSE_NESTED);
+
+        // Test a dense nested case where ALL parent docs have KNN field.
+        doSearchTest(VectorDataType.FLOAT, IndexingType.DENSE_NESTED);
+    }
+
+    public void testByteIndexType() {
+        // TODO(KDY) : Will be covered in part-6 (FP16 support)
+        // doSearchTest(VectorDataType.BYTE, IndexingType.DENSE);
+        // doSearchTest(VectorDataType.BYTE, IndexingType.SPARSE);
+        // doSearchTest(VectorDataType.BYTE, IndexingType.SPARSE_NESTED);
+        // doSearchTest(VectorDataType.BYTE, IndexingType.DENSE_NESTED);
+    }
+
+    @SneakyThrows
+    private void doSearchTest(final VectorDataType dataType, final IndexingType indexingType) {
+        doSearchTest(dataType, indexingType, false, false);
+        doSearchTest(dataType, indexingType, false, true);
+        doSearchTest(dataType, indexingType, true, false);
+        doSearchTest(dataType, indexingType, true, false);
+    }
+
+    @SneakyThrows
+    private void doSearchTest(
+        final VectorDataType dataType,
+        final IndexingType indexingType,
+        final boolean doExhaustiveSearch,
+        final boolean applyFiltering
+    ) {
+        // Build FAISS index
+        final String indexDesc = dataType == VectorDataType.FLOAT ? FLOAT_HNSW_INDEX_DESCRIPTION : BYTE_HNSW_INDEX_DESCRIPTION;
+        final BuildInfo buildInfo = buildFaissIndex(dataType, indexDesc, TOTAL_NUM_DOCS_IN_SEGMENT, IndexingType.DENSE);
+
+        // Load FAISS index via JNI
+        long indexPointer = -1;
+        try (final Directory directory = newFSDirectory(buildInfo.tempDirPath)) {
+            try (final IndexInput input = directory.openInput(buildInfo.faissIndexFile, IOContext.READONCE)) {
+                final IndexInputWithBuffer indexInputWithBuffer = new IndexInputWithBuffer(input);
+                indexPointer = JNIService.loadIndex(indexInputWithBuffer, buildInfo.parameters, KNNEngine.FAISS);
+            }
+        }
+        assertNotEquals(-1, indexPointer);
+
+        // Make filtered ids
+        long[] filteredIds = null;
+        if (applyFiltering) {
+            // Take only 80%. e.g. filtering 20% out
+            final List<Integer> filteredDocIds = takePortions(buildInfo.documentIds, 0.8);
+            filteredIds = filteredDocIds.stream().mapToLong(Integer::longValue).toArray();
+        }
+
+        // Reconstruct parent ids if it's necessary
+        int[] parentIds = null;
+        if (indexingType.isNested()) {
+            parentIds = extractParentIds(buildInfo.documentIds);
+        }
+
+        // Take top-20 results
+        final int k = 20;
+
+        // Start search via JNI
+        final Object queryForVectorReader;
+        final float[] query;
+        final byte[] byteQuery;
+        if (dataType == VectorDataType.FLOAT) {
+            queryForVectorReader = query = generateOneSingleFloatVector();
+        } else if (dataType == VectorDataType.BYTE) {
+            queryForVectorReader = byteQuery = generateOneSingleByteVector();
+            query = new float[byteQuery.length];
+            for (int i = 0; i < byteQuery.length; i++) {
+                query[i] = byteQuery[i];
+            }
+        } else {
+            throw new AssertionError();
+        }
+
+        final KNNQueryResult[] resultsFromFaiss = JNIService.queryIndex(
+            indexPointer,
+            query,
+            k,
+            buildInfo.parameters,
+            KNNEngine.FAISS,
+            filteredIds,
+            FilterIdsSelector.FilterIdsSelectorType.BATCH.getValue(),
+            parentIds
+        );
+
+        // Search via VectorReader
+        final KNNQueryResult[] resultsFromVectorReader = doSearchViaVectorReader(
+            buildInfo,
+            queryForVectorReader,
+            dataType,
+            filteredIds,
+            k,
+            doExhaustiveSearch
+        );
+
+        // Validate results
+        validateResults(resultsFromFaiss, resultsFromVectorReader);
+    }
+
+    private void validateResults(KNNQueryResult[] resultsFromFaiss, KNNQueryResult[] resultsFromVectorReader) {
+        Set<Integer> expectedDocIds = new HashSet<>();
+        for (int i = 0; i < resultsFromFaiss.length; ++i) {
+            expectedDocIds.add(resultsFromFaiss[i].getId());
+        }
+        int matchCount = 0;
+        for (int i = 0; i < resultsFromFaiss.length; ++i) {
+            if (expectedDocIds.contains(resultsFromVectorReader[i].getId())) {
+                ++matchCount;
+            }
+        }
+
+        final float matchRatio = ((float) matchCount) / resultsFromFaiss.length;
+        // Should match at least 80% with the one obtained from FAISS
+        assertTrue(matchRatio >= 0.8);
+    }
+
+    @SneakyThrows
+    private static KNNQueryResult[] doSearchViaVectorReader(
+        BuildInfo buildInfo,
+        Object query,
+        VectorDataType vectorDataType,
+        long[] filteredIds,
+        int k,
+        final boolean exhaustiveSearch
+    ) {
+        // Make KNN vector field info
+        FieldInfo vectorField = KNNCodecTestUtil.FieldInfoBuilder.builder(TARGET_FIELD)
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .addAttribute(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .build();
+        final FieldInfo[] vectorFieldArr = new FieldInfo[] { vectorField };
+        final FieldInfos fieldInfos = new FieldInfos(vectorFieldArr);
+
+        // Make segment info
+        final SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        when(segmentInfo.getUseCompoundFile()).thenReturn(false);
+        when(segmentInfo.files()).thenReturn(Set.of(buildInfo.faissIndexFile));
+        when(segmentInfo.getId()).thenReturn("LuceneOnFaiss".getBytes());
+
+        // Prepare collector and bits
+        final int efSearch = exhaustiveSearch ? buildInfo.documentIds.size() + 1 : buildInfo.documentIds.size() - 1;
+        final KnnCollector knnCollector = new TopKnnCollector(efSearch, Integer.MAX_VALUE);
+        FixedBitSet acceptDocs = null;
+        if (filteredIds != null) {
+            acceptDocs = new FixedBitSet((int) filteredIds[filteredIds.length - 1] + 10);
+            for (long filteredId : filteredIds) {
+                acceptDocs.set((int) filteredId);
+            }
+        }
+
+        // Make SegmentReadState and do search
+        try (final Directory directory = newFSDirectory(buildInfo.tempDirPath)) {
+            final SegmentReadState readState = new SegmentReadState(directory, segmentInfo, fieldInfos, IOContext.DEFAULT);
+            try (
+                NativeEngines990KnnVectorsReader vectorsReader = new NativeEngines990KnnVectorsReader(
+                    readState,
+                    mock(FlatVectorsReader.class)
+                )
+            ) {
+                if (vectorDataType == VectorDataType.FLOAT) {
+                    vectorsReader.search(TARGET_FIELD, (float[]) query, knnCollector, acceptDocs);
+                } else if (vectorDataType == VectorDataType.BYTE) {
+                    vectorsReader.search(TARGET_FIELD, (byte[]) query, knnCollector, acceptDocs);
+                } else {
+                    throw new AssertionError();
+                }
+            }
+        }
+
+        // Make results
+        final TopDocs topDocs = knnCollector.topDocs();
+        final ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        assertTrue(scoreDocs.length >= k);
+        final List<KNNQueryResult> results = new ArrayList<>();
+        for (int i = 0; i < k; ++i) {
+            results.add(new KNNQueryResult(scoreDocs[i].doc, scoreDocs[i].score));
+        }
+        return results.toArray(new KNNQueryResult[0]);
+    }
+
+    @SneakyThrows
+    private BuildInfo buildFaissIndex(
+        final VectorDataType dataType,
+        final String indexDescription,
+        final int numberOfTotalDocsInSegment,
+        final IndexingType indexingType
+    ) {
+        final Path tempDir = createTempDir(UUID.randomUUID().toString());
+        final String fileName = UUID.randomUUID() + "_" + TARGET_FIELD + ".faiss";
+        BuildInfo buildInfo = null;
+        try (final Directory directory = newFSDirectory(tempDir)) {
+            // Set up basic parameters
+            try (final IndexOutput indexOutput = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                final BuildIndexParams.BuildIndexParamsBuilder builder = BuildIndexParams.builder();
+                builder.fieldName(TARGET_FIELD)
+                    .knnEngine(KNNEngine.FAISS)
+                    .vectorDataType(dataType)
+                    .indexOutputWithBuffer(new IndexOutputWithBuffer(indexOutput));
+
+                // Set up parameters
+                final Map<String, Object> parameters = new HashMap<>();
+                parameters.put(NAME, METHOD_HNSW);
+                parameters.put(VECTOR_DATA_TYPE_FIELD, dataType.getValue());
+                parameters.put(SPACE_TYPE, SpaceType.L2.getValue());
+                parameters.put(INDEX_THREAD_QTY, 1);
+                parameters.put(INDEX_DESCRIPTION_PARAMETER, indexDescription);
+
+                final Map<String, Object> methodParameters = new HashMap<>();
+                parameters.put(PARAMETERS, methodParameters);
+                methodParameters.put(METHOD_PARAMETER_EF_SEARCH, 100);
+                methodParameters.put(METHOD_PARAMETER_EF_CONSTRUCTION, 100);
+                methodParameters.put(METHOD_ENCODER_PARAMETER, Map.of(NAME, ENCODER_FLAT));
+                builder.parameters(parameters);
+
+                // Set up vectors
+                final List<Integer> documentIds = indexingType.generateDocumentIds(numberOfTotalDocsInSegment);
+                buildInfo = new BuildInfo(tempDir, fileName, parameters, documentIds);
+                builder.totalLiveDocs(documentIds.size());
+
+                if (dataType == VectorDataType.BYTE) {
+                    final KNNVectorValues<byte[]> byteVectorValues = createKNNByteVectorValues(documentIds);
+                    builder.knnVectorValuesSupplier(() -> byteVectorValues);
+                } else if (dataType == VectorDataType.FLOAT) {
+                    final KNNVectorValues<float[]> floatVectorValues = createKNNFloatVectorValues(documentIds);
+                    builder.knnVectorValuesSupplier(() -> floatVectorValues);
+                } else {
+                    throw new AssertionError();
+                }
+
+                // Now start indexing
+                final BuildIndexParams buildIndexParams = builder.build();
+                MemoryOptimizedSearchIndexingSupport.buildIndex(buildIndexParams);
+            }
+        }
+
+        return buildInfo;
+    }
+
+    @SneakyThrows
+    private KNNByteVectorValues createKNNByteVectorValues(final List<Integer> documentIds) {
+        final List<byte[]> vectors = generateRandomByteVectors(documentIds);
+
+        final KNNVectorValuesIterator iterator = new KNNVectorValuesIterator() {
+            private int index = -1;
+
+            @Override
+            public int docId() {
+                if (index == -1) {
+                    return -1;
+                } else if (index == DocIdSetIterator.NO_MORE_DOCS) {
+                    return DocIdSetIterator.NO_MORE_DOCS;
+                }
+                return documentIds.get(index);
+            }
+
+            @Override
+            public int advance(int docId) throws IOException {
+                throw new UnsupportedEncodingException();
+            }
+
+            @Override
+            public int nextDoc() {
+                if ((index + 1) >= documentIds.size()) {
+                    index = DocIdSetIterator.NO_MORE_DOCS;
+                    return DocIdSetIterator.NO_MORE_DOCS;
+                }
+
+                return documentIds.get(++index);
+            }
+
+            @Override
+            public DocIdSetIterator getDocIdSetIterator() {
+                return null;
+            }
+
+            @Override
+            public long liveDocs() {
+                return documentIds.size();
+            }
+
+            @Override
+            public VectorValueExtractorStrategy getVectorExtractorStrategy() {
+                return new VectorValueExtractorStrategy() {
+                    @Override
+                    public byte[] extract(VectorDataType vectorDataType, KNNVectorValuesIterator vectorValuesIterator) {
+                        return vectors.get(vectorValuesIterator.docId());
+                    }
+                };
+            }
+        };
+
+        // Instantiate KNNFloatVectorValues
+        Constructor<KNNByteVectorValues> constructor = KNNByteVectorValues.class.getDeclaredConstructor(KNNVectorValuesIterator.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(iterator);
+    }
+
+    @SneakyThrows
+    private static KNNFloatVectorValues createKNNFloatVectorValues(final List<Integer> documentIds) {
+        final List<float[]> vectors = generateRandomFloatVectors(documentIds);
+
+        final KNNVectorValuesIterator iterator = new KNNVectorValuesIterator() {
+            private int index = -1;
+
+            @Override
+            public int docId() {
+                if (index == -1) {
+                    return -1;
+                } else if (index == DocIdSetIterator.NO_MORE_DOCS) {
+                    return DocIdSetIterator.NO_MORE_DOCS;
+                }
+                return documentIds.get(index);
+            }
+
+            @Override
+            public int advance(int docId) throws IOException {
+                throw new UnsupportedEncodingException();
+            }
+
+            @Override
+            public int nextDoc() {
+                if ((index + 1) >= documentIds.size()) {
+                    index = DocIdSetIterator.NO_MORE_DOCS;
+                    return DocIdSetIterator.NO_MORE_DOCS;
+                }
+
+                return documentIds.get(++index);
+            }
+
+            @Override
+            public DocIdSetIterator getDocIdSetIterator() {
+                return null;
+            }
+
+            @Override
+            public long liveDocs() {
+                return documentIds.size();
+            }
+
+            @Override
+            public VectorValueExtractorStrategy getVectorExtractorStrategy() {
+                return new VectorValueExtractorStrategy() {
+                    @Override
+                    public float[] extract(VectorDataType vectorDataType, KNNVectorValuesIterator vectorValuesIterator) {
+                        return vectors.get(vectorValuesIterator.docId());
+                    }
+                };
+            }
+        };
+
+        // Instantiate KNNFloatVectorValues
+        Constructor<KNNFloatVectorValues> constructor = KNNFloatVectorValues.class.getDeclaredConstructor(KNNVectorValuesIterator.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(iterator);
+    }
+
+    private static float[] generateOneSingleFloatVector() {
+        final float[] vector = new float[DIMENSIONS];
+        for (int k = 0; k < DIMENSIONS; k++) {
+            vector[k] = MIN_VALUE + ThreadLocalRandom.current().nextFloat() * (MAX_VALUE - MIN_VALUE);
+        }
+        return vector;
+    }
+
+    private static byte[] generateOneSingleByteVector() {
+        final byte[] vector = new byte[DIMENSIONS];
+        for (int k = 0; k < DIMENSIONS; k++) {
+            vector[k] = (byte) (MIN_VALUE + ThreadLocalRandom.current().nextInt(MAX_VALUE - MIN_VALUE + 1));
+        }
+        return vector;
+    }
+
+    private static List<float[]> generateRandomFloatVectors(List<Integer> docIds) {
+        final List<float[]> vectors = new ArrayList<>();
+        for (int i = 0, j = 0; j < docIds.size(); j++) {
+            // Add null vectors.
+            // e.g. previous doc=15, current doc=18.
+            // then put two nulls for doc=16, 17. This indicates that doc=16 and 17 don't have vector field.
+            while (i < docIds.get(j)) {
+                vectors.add(null);
+                ++i;
+            }
+
+            vectors.add(generateOneSingleFloatVector());
+            ++i;
+        }
+
+        return vectors;
+    }
+
+    private List<byte[]> generateRandomByteVectors(List<Integer> docIds) {
+        final List<byte[]> vectors = new ArrayList<>();
+
+        for (int i = 0, j = 0; j < docIds.size(); j++) {
+            // Add null vectors.
+            // e.g. previous doc=15, current doc=18.
+            // then put two nulls for doc=16, 17. This indicates that doc=16 and 17 don't have vector field.
+            while (i < docIds.get(j)) {
+                vectors.add(null);
+                ++i;
+            }
+
+            vectors.add(generateOneSingleByteVector());
+            ++i;
+        }
+
+        return vectors;
+    }
+
+    private enum IndexingType {
+        DENSE {
+            @Override
+            public List<Integer> generateDocumentIds(int numberOfTotalDocsInSegment) {
+                return IntStream.rangeClosed(0, numberOfTotalDocsInSegment - 1).boxed().collect(Collectors.toList());
+            }
+        },
+        SPARSE {
+            @Override
+            public List<Integer> generateDocumentIds(int numberOfTotalDocsInSegment) {
+                List<Integer> docIds = new ArrayList<>(
+                    IntStream.rangeClosed(0, numberOfTotalDocsInSegment - 1).boxed().collect(Collectors.toList())
+                );
+
+                // Take only 80% docs. e.g. 20% docs won't have vector field.
+                return takePortions(docIds, 0.8);
+            }
+        },
+        DENSE_NESTED {
+            @Override
+            public List<Integer> generateDocumentIds(int numberOfParentDocs) {
+                final int numDocsHavingVector = NUM_CHILD_DOCS * numberOfParentDocs;
+                final List<Integer> docIds = new ArrayList<>(numDocsHavingVector);
+                for (int i = 0; i < numberOfParentDocs; i++) {
+                    for (int j = 0; j < NUM_CHILD_DOCS; ++j) {
+                        docIds.add(i * (NUM_CHILD_DOCS + 1) + j);
+                    }
+                }
+                // Ex: [[0, 1, 2, 3, 4],
+                // [6, 7, 8, 9, 10],
+                // [12, ...]
+                // Note that doc=5, doc=11 are parent document.
+                return docIds;
+            }
+
+            @Override
+            public boolean isNested() {
+                return true;
+            }
+        },
+        SPARSE_NESTED {
+            @Override
+            public List<Integer> generateDocumentIds(int numberOfTotalDocsInSegment) {
+                // Ex: [[0, 1, 2, 3, 4],
+                // [12, 13, 14, 15, 16],
+                // [18, ...]
+                // Note that docs in [6, 11] don't have vector fields.
+                List<Integer> docIds = new ArrayList<>();
+                int nextDocId = 0;
+                for (int i = 0; i < numberOfTotalDocsInSegment; i++) {
+                    // Only take 80%, or if it's last index
+                    // Why force it to add child docs at the last index?
+                    // -> So that we can always restore parent ids deterministically.
+                    if (i == (numberOfTotalDocsInSegment - 1) || ThreadLocalRandom.current().nextFloat(1f) >= 0.8f) {
+                        // This doc has vector
+                        for (int j = 0; j < NUM_CHILD_DOCS; j++) {
+                            docIds.add(nextDocId++);
+                        }
+
+                        // Visit a parent doc
+                        ++nextDocId;
+                    } else {
+                        // This doc don't have vector
+                        ++nextDocId;
+                    }
+                }
+
+                return docIds;
+            }
+
+            @Override
+            public boolean isNested() {
+                return true;
+            }
+        };
+
+        public abstract List<Integer> generateDocumentIds(int numberOfTotalDocsInSegment);
+
+        public boolean isNested() {
+            return false;
+        }
+    }
+
+    @AllArgsConstructor
+    static class BuildInfo {
+        Path tempDirPath;
+        String faissIndexFile;
+        Map<String, Object> parameters;
+        List<Integer> documentIds;
+    }
+
+    private static List<Integer> takePortions(final List<Integer> sequence, final double percentage) {
+        List<Integer> newSequence = new ArrayList<>(sequence);
+        Collections.shuffle(newSequence);
+        newSequence = newSequence.subList(0, (int) (newSequence.size() * percentage));
+        Collections.sort(newSequence);
+        return newSequence;
+    }
+
+    private static int[] extractParentIds(final List<Integer> childDocIds) {
+        // Reconstruct parent ids.
+        // e.g. with [0,1,2,3,4, 6,7,8, 9,10,11,12,13], parent ids=[5, 14] with 5 child docs
+        final List<Integer> parentIds = new ArrayList<>();
+        for (int i = 0, j = 0; i < childDocIds.size(); ++i, ++j) {
+            if (childDocIds.get(i) != j) {
+                parentIds.add(j);
+                j = i;
+            }
+        }
+
+        // We always add child docs at the end.
+        // So we can safely add parent id here.
+        // Ex: With [, ..., 100, 101, 102, 103, 104], parent id would be 105 (e.g. having 5 child docs)
+        parentIds.add(childDocIds.get(childDocIds.size() - 1) + 1);
+        return parentIds.stream().mapToInt(Integer::intValue).toArray();
+    }
+}


### PR DESCRIPTION
### Description
This PR enables memory optimized search in VectorReader for FAISS HNSW graph index.
Internally, it will delegate Lucene's HNSW graph searcher to perform vector search on FAISS index.

NOTE : Will add unit tests shortly.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
