### PR TITLE
[LuceneOnFaiss] Apply monotonic increasing integer encoding to FAISS HNSW and IdMapIndex.

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MonotonicIntegerSequenceEncoder.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MonotonicIntegerSequenceEncoder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.experimental.UtilityClass;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.apache.lucene.util.packed.DirectMonotonicWriter;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+
+import java.io.IOException;
+
+@UtilityClass
+public class MonotonicIntegerSequenceEncoder {
+    // Use 64KB (=2^16) block size for monotonic encoding.
+    private static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+
+    /**
+     * Encodes a monotonically increasing sequence of integers and returns a decoder. During encoding, it reads long values from the
+     * provided {@link IndexInput} and converts them to integers. If a value exceeds {@link Integer#MAX_VALUE},
+     * an {@link ArithmeticException} is thrown. If the sequence is not strictly monotonically increasing,
+     * an {@link IllegalArgumentException} is thrown.
+     *
+     * @param numElements Number of elements in sequence for encoding.
+     * @param input Input stream for integer sequence.
+     * @return A decoder to return a mapped integer with given index i.
+     * @throws IOException
+     */
+    public static DirectMonotonicReader encode(final int numElements, final IndexInput input) throws IOException {
+        // Prepare a buffer for meta
+        ByteBuffersDataOutput dataOutput = new ByteBuffersDataOutput();
+        ByteBuffersIndexOutput dataIndexOutput = new ByteBuffersIndexOutput(
+            dataOutput,
+            "MonotonicSequenceEncoder",
+            "MonotonicSequenceEncoderData"
+        );
+
+        // Prepare a buffer for data
+        ByteBuffersDataOutput metaOutput = new ByteBuffersDataOutput();
+        ByteBuffersIndexOutput metaIndexOutput = new ByteBuffersIndexOutput(
+            metaOutput,
+            "MonotonicSequenceEncoder",
+            "MonotonicSequenceEncoderMeta"
+        );
+
+        // Prepare an encoder with a 64KB(=2^16) chunk.
+        DirectMonotonicWriter encoder = DirectMonotonicWriter.getInstance(
+            metaIndexOutput,
+            dataIndexOutput,
+            numElements,
+            DIRECT_MONOTONIC_BLOCK_SHIFT
+        );
+
+        // Encode integer sequence.
+        boolean isIdenticalMapping = true;
+        for (long i = 0; i < numElements; i++) {
+            final long value = Math.toIntExact(input.readLong());
+            if (value != i) {
+                isIdenticalMapping = false;
+            }
+            encoder.add(value);
+        }
+
+        encoder.finish();
+
+        // Close outputs
+        IOUtils.close(dataIndexOutput, metaIndexOutput);
+
+        if (isIdenticalMapping) {
+            // It's an identical mapping (e.g. i -> i), no need to continue encoding.
+            return null;
+        }
+
+        // Create input streams for both meta, data
+        final byte[] metaBytes = metaOutput.toArrayCopy();
+        final IndexInput metaInput = new ByteArrayIndexInput("MonotonicSequenceEncoder", metaBytes);
+
+        final byte[] dataBytes = dataOutput.toArrayCopy();
+        final ByteArrayIndexInput dataInput = new ByteArrayIndexInput("MonotonicSequenceEncoder", dataBytes);
+
+        // Create decoder
+        final DirectMonotonicReader.Meta encodingMeta = DirectMonotonicReader.loadMeta(
+            metaInput,
+            numElements,
+            DIRECT_MONOTONIC_BLOCK_SHIFT
+        );
+        return DirectMonotonicReader.getInstance(encodingMeta, dataInput);
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHNSWTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHNSWTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
 import org.opensearch.common.lucene.store.ByteArrayIndexInput;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSW;
@@ -55,7 +56,10 @@ public class FaissHNSWTests extends KNNTestCase {
         assertArrayEquals(cumulativeNumNeighbors, faissHNSW.getCumNumberNeighborPerLevel());
 
         // offsets
-        assertArrayEquals(offsets, faissHNSW.getOffsets());
+        final DirectMonotonicReader offsetsReader = faissHNSW.getOffsetsReader();
+        for (int i = 0; i < offsets.length; i++) {
+            assertEquals(offsets[i], offsetsReader.get(i));
+        }
 
         // neighbors
         assertEquals(neighborsBaseOffset, faissHNSW.getNeighbors().getBaseOffset());

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MonotonicIntegerSequenceEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MonotonicIntegerSequenceEncoderTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.memoryoptsearch.faiss.MonotonicIntegerSequenceEncoder;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+public class MonotonicIntegerSequenceEncoderTests extends KNNTestCase {
+    @SneakyThrows
+    public void testEncodeIdentityCase() {
+        // Create a sequence
+        final int size = 100000;
+        final IndexInput input = createSequence((i) -> i, size);
+
+        // Call encode
+        DirectMonotonicReader reader = MonotonicIntegerSequenceEncoder.encode(size, input);
+
+        // It should be null, as it's identical mapping
+        assertNull(reader);
+    }
+
+    @SneakyThrows
+    public void testEncodeIdentityCaseSmallVolume() {
+        // Create a sequence
+        final int size = 10;
+        final IndexInput input = createSequence((i) -> i, size);
+
+        // Call encode
+        DirectMonotonicReader reader = MonotonicIntegerSequenceEncoder.encode(size, input);
+
+        // It should be null, as it's identical mapping
+        assertNull(reader);
+    }
+
+    @SneakyThrows
+    public void testEmptyCase() {
+        DirectMonotonicReader reader = MonotonicIntegerSequenceEncoder.encode(0, null);
+        assertNull(reader);
+    }
+
+    @SneakyThrows
+    public void testTooBigNumber() {
+        final int size = 100;
+
+        final IndexInput input = createSequence((i) -> Integer.MAX_VALUE + i, size);
+
+        try {
+            // Call encode
+            MonotonicIntegerSequenceEncoder.encode(size, input);
+            fail();
+        } catch (ArithmeticException e) {}
+    }
+
+    @SneakyThrows
+    public void testWhenNegativeNumbers() {
+        final int size = 100;
+
+        final IndexInput input = createSequence((i) -> -i, size);
+
+        try {
+            // Call encode
+            MonotonicIntegerSequenceEncoder.encode(size, input);
+            fail();
+        } catch (IllegalArgumentException e) {}
+    }
+
+    @SneakyThrows
+    public void testIncreasingSequence() {
+        // Create a sequence
+        final int size = 100000;
+        final IndexInput input = createSequence((i) -> i / 5, size);
+
+        // Call encode
+        DirectMonotonicReader reader = MonotonicIntegerSequenceEncoder.encode(size, input);
+
+        // It should not be null
+        assertNotNull(reader);
+
+        // Validate values
+        for (int i = 0; i < size; ++i) {
+            assertEquals(i / 5, reader.get(i));
+        }
+    }
+
+    @SneakyThrows
+    public void testIncreasingSequenceWithSmallVolume() {
+        // Create a sequence
+        final int size = 100;
+        final IndexInput input = createSequence((i) -> i / 5, size);
+
+        // Call encode
+        DirectMonotonicReader reader = MonotonicIntegerSequenceEncoder.encode(size, input);
+
+        // It should not be null
+        assertNotNull(reader);
+
+        // Validate values
+        for (int i = 0; i < size; ++i) {
+            assertEquals(i / 5, reader.get(i));
+        }
+    }
+
+    private static IndexInput createSequence(Function<Long, Long> mapping, int length) throws IOException {
+        ByteBuffersDataOutput dataOutput = new ByteBuffersDataOutput();
+        ByteBuffersIndexOutput dataIndexOutput = new ByteBuffersIndexOutput(
+            dataOutput,
+            "MonotonicIntegerSequenceEncoderTests",
+            "MonotonicIntegerSequenceEncoderTests"
+        );
+
+        for (int i = 0; i < length; i++) {
+            dataIndexOutput.writeLong(mapping.apply((long) i));
+        }
+
+        dataIndexOutput.close();
+        byte[] bytes = dataOutput.toArrayCopy();
+        return new ByteArrayIndexInput("MonotonicIntegerSequenceEncoderTests", bytes);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a monotonic integer sequence encoding scheme for doc IDs in IdMapIndex and offsets in FAISS HNSW.
Previously, both were stored as long[], consuming O(N) memory where N is the total number of vectors. For example, with a 10M dataset, they occupied 228MB (76MB + 152MB). Using monotonic encoding, this can be reduced to a few hundred KB. Lucene already uses this encoding scheme [Link](https://github.com/apache/lucene/blob/9472dcad0ebfadf2ae6460793682635880ac48eb/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java#L402C13-L402C17)

The key difference is that Lucene applies encoding during segment creation, whereas we do it at load time. However, encoding is extremely fast, on my local setup it takes about 3.2 seconds for 100M integers.
A warm-up API could further optimize this by preloading data before search, though this hasn't been raised yet, but it is part of future PR.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
