### PR TITLE
Migrate derived source from filter to mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Add filter function to KNNQueryBuilder with unit tests and integration tests [#2
 ### Maintenance
 ### Refactoring
 * Switch derived source from field attributes to segment attribute [#2606](https://github.com/opensearch-project/k-NN/pull/2606)
+* Migrate derived source from filter to mask [#2612](https://github.com/opensearch-project/k-NN/pull/2612)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ buildscript {
     ext {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
-        version_qualifier = System.getProperty("build.version_qualifier", "alpha1")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+        version_qualifier = System.getProperty("build.version_qualifier", "beta1")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         avx2_enabled = System.getProperty("avx2.enabled", "true")

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -52,7 +52,9 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
 
             // Delete
             testDelete(indexConfigContexts);
+            assertDocsMatch(indexConfigContexts);
         } else {
+            assertDocsMatch(indexConfigContexts);
             // Search
             testSearch(indexConfigContexts);
 
@@ -81,7 +83,9 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
         if (isRunningAgainstOldCluster()) {
             prepareOriginalIndices(indexConfigContexts);
         } else {
+            assertDocsMatch(indexConfigContexts);
             testMerging(indexConfigContexts);
+            assertDocsMatch(indexConfigContexts);
             // Update. Skipping update tests for nested docs for now. Will add in the future.
             if (indexConfigContexts.get(0).isNested() == false) {
                 testUpdate(indexConfigContexts);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010Codec.java
@@ -91,18 +91,7 @@ public class KNN10010Codec extends FilterCodec {
             }
             return null;
 
-        }, (segmentReadState) -> {
-            if (segmentReadState.fieldInfos.hasPostings()) {
-                return postingsFormat().fieldsProducer(segmentReadState);
-            }
-            return null;
-
-        }, (segmentReadState -> {
-            if (segmentReadState.fieldInfos.hasNorms()) {
-                return normsFormat().normsProducer(segmentReadState);
-            }
-            return null;
-        }));
+        });
         return new KNN10010DerivedSourceStoredFieldsFormat(delegate.storedFieldsFormat(), derivedSourceReadersSupplier, mapperService);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -9,7 +9,6 @@ import lombok.AllArgsConstructor;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
@@ -19,7 +18,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
-import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120DerivedSourceStoredFieldsReader;
+import org.opensearch.knn.index.codec.derivedsource.DerivedFieldInfo;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttributeParser;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
@@ -27,6 +26,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 @AllArgsConstructor
 public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
@@ -40,16 +40,22 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext ioContext)
         throws IOException {
-        List<FieldInfo> derivedVectorFields = DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo)
-            .stream()
-            .filter(field -> fieldInfos.fieldInfo(field) != null)
-            .map(fieldInfos::fieldInfo)
-            .toList();
+        List<DerivedFieldInfo> derivedVectorFields = Stream.concat(
+            DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false)
+                .stream()
+                .filter(field -> fieldInfos.fieldInfo(field) != null)
+                .map(field -> new DerivedFieldInfo(fieldInfos.fieldInfo(field), false)),
+            DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, true)
+                .stream()
+                .filter(field -> fieldInfos.fieldInfo(field) != null)
+                .map(field -> new DerivedFieldInfo(fieldInfos.fieldInfo(field), true))
+        ).toList();
+
         // If no fields have it enabled, we can just short-circuit and return the delegate's fieldReader
-        if (derivedVectorFields == null || derivedVectorFields.isEmpty()) {
+        if (derivedVectorFields.isEmpty()) {
             return delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
         }
-        return new KNN9120DerivedSourceStoredFieldsReader(
+        return new KNN10010DerivedSourceStoredFieldsReader(
             delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext),
             derivedVectorFields,
             derivedSourceReadersSupplier,
@@ -60,18 +66,34 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
     @Override
     public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo segmentInfo, IOContext ioContext) throws IOException {
         StoredFieldsWriter delegateWriter = delegate.fieldsWriter(directory, segmentInfo, ioContext);
-        if (mapperService != null && KNNSettings.isKNNDerivedSourceEnabled(mapperService.getIndexSettings().getSettings())) {
-            List<String> vectorFieldTypes = new ArrayList<>();
-            for (MappedFieldType fieldType : mapperService.fieldTypes()) {
-                if (fieldType instanceof KNNVectorFieldType) {
+        if (mapperService == null || KNNSettings.isKNNDerivedSourceEnabled(mapperService.getIndexSettings().getSettings()) == false) {
+            return delegateWriter;
+        }
+
+        List<String> vectorFieldTypes = new ArrayList<>();
+        List<String> nestedVectorFieldTypes = new ArrayList<>();
+        for (MappedFieldType fieldType : mapperService.fieldTypes()) {
+            if (fieldType instanceof KNNVectorFieldType) {
+                boolean isNested = mapperService.documentMapper().mappers().getNestedScope(fieldType.name()) != null;
+                if (isNested) {
+                    nestedVectorFieldTypes.add(fieldType.name());
+                } else {
                     vectorFieldTypes.add(fieldType.name());
                 }
             }
-            if (vectorFieldTypes.isEmpty() == false) {
-                DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(segmentInfo, vectorFieldTypes);
-                return new KNN10010DerivedSourceStoredFieldsWriter(delegateWriter, vectorFieldTypes);
-            }
         }
-        return delegateWriter;
+        if (vectorFieldTypes.isEmpty() && nestedVectorFieldTypes.isEmpty()) {
+            return delegateWriter;
+        }
+
+        // Store nested fields separately from non-nested for easy handling on read
+        if (vectorFieldTypes.isEmpty() == false) {
+            DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(segmentInfo, vectorFieldTypes, false);
+        }
+        if (nestedVectorFieldTypes.isEmpty() == false) {
+            vectorFieldTypes.addAll(nestedVectorFieldTypes);
+            DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(segmentInfo, nestedVectorFieldTypes, true);
+        }
+        return new KNN10010DerivedSourceStoredFieldsWriter(delegateWriter, vectorFieldTypes);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN10010Codec;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.util.IOUtils;
+import org.opensearch.index.fieldvisitor.FieldsVisitor;
+import org.opensearch.knn.index.codec.derivedsource.DerivedFieldInfo;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceStoredFieldVisitor;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceVectorTransformer;
+
+import java.io.IOException;
+import java.util.List;
+
+public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader {
+    private final StoredFieldsReader delegate;
+    private final List<DerivedFieldInfo> derivedVectorFields;
+    private final DerivedSourceReadersSupplier derivedSourceReadersSupplier;
+    private final SegmentReadState segmentReadState;
+    private final boolean shouldInject;
+
+    private final DerivedSourceVectorTransformer derivedSourceVectorTransformer;
+
+    /**
+     *
+     * @param delegate delegate StoredFieldsReader
+     * @param derivedVectorFields List of fields that are derived source fields
+     * @param derivedSourceReadersSupplier Supplier for the derived source readers
+     * @param segmentReadState SegmentReadState for the segment
+     * @throws IOException in case of I/O error
+     */
+    public KNN10010DerivedSourceStoredFieldsReader(
+        StoredFieldsReader delegate,
+        List<DerivedFieldInfo> derivedVectorFields,
+        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        SegmentReadState segmentReadState
+    ) throws IOException {
+        this(delegate, derivedVectorFields, derivedSourceReadersSupplier, segmentReadState, true);
+    }
+
+    private KNN10010DerivedSourceStoredFieldsReader(
+        StoredFieldsReader delegate,
+        List<DerivedFieldInfo> derivedVectorFields,
+        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        SegmentReadState segmentReadState,
+        boolean shouldInject
+    ) throws IOException {
+        this.delegate = delegate;
+        this.derivedVectorFields = derivedVectorFields;
+        this.derivedSourceReadersSupplier = derivedSourceReadersSupplier;
+        this.segmentReadState = segmentReadState;
+        this.shouldInject = shouldInject;
+        this.derivedSourceVectorTransformer = createDerivedSourceVectorTransformer();
+    }
+
+    private DerivedSourceVectorTransformer createDerivedSourceVectorTransformer() throws IOException {
+        return new DerivedSourceVectorTransformer(derivedSourceReadersSupplier, segmentReadState, derivedVectorFields);
+    }
+
+    @Override
+    public void document(int docId, StoredFieldVisitor storedFieldVisitor) throws IOException {
+        // If the visitor has explicitly indicated it does not need the fields, we should not inject them
+        if (shouldInject && doesVisitorNeedVectors(storedFieldVisitor)) {
+            delegate.document(docId, new DerivedSourceStoredFieldVisitor(storedFieldVisitor, docId, derivedSourceVectorTransformer));
+            return;
+        }
+        delegate.document(docId, storedFieldVisitor);
+    }
+
+    private boolean doesVisitorNeedVectors(StoredFieldVisitor delegate) {
+        if (delegate instanceof FieldsVisitor) {
+            return derivedSourceVectorTransformer.shouldInject(
+                ((FieldsVisitor) delegate).includes(),
+                ((FieldsVisitor) delegate).excludes()
+            );
+        }
+        return true;
+    }
+
+    @Override
+    public StoredFieldsReader clone() {
+        try {
+            return new KNN10010DerivedSourceStoredFieldsReader(
+                delegate.clone(),
+                derivedVectorFields,
+                derivedSourceReadersSupplier,
+                segmentReadState,
+                shouldInject
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        delegate.checkIntegrity();
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(delegate, derivedSourceVectorTransformer);
+    }
+
+    /**
+     * For merging, we need to tell the derived source stored fields reader to skip injecting the source. Otherwise,
+     * on merge we will end up just writing the source to disk. We cant override
+     * {@link StoredFieldsReader#getMergeInstance()} because it is used elsewhere than just merging.
+     *
+     * @return Merged instance that wont inject by default
+     */
+    private StoredFieldsReader cloneForMerge() {
+        try {
+            return new KNN10010DerivedSourceStoredFieldsReader(
+                delegate.getMergeInstance(),
+                derivedVectorFields,
+                derivedSourceReadersSupplier,
+                segmentReadState,
+                false
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * For merging, we need to tell the derived source stored fields reader to skip injecting the source. Otherwise,
+     * on merge we will end up just writing the source to disk
+     *
+     * @param storedFieldsReader stored fields reader to wrap
+     * @return wrapped stored fields reader
+     */
+    public static StoredFieldsReader wrapForMerge(StoredFieldsReader storedFieldsReader) {
+        if (storedFieldsReader instanceof KNN10010DerivedSourceStoredFieldsReader) {
+            return ((KNN10010DerivedSourceStoredFieldsReader) storedFieldsReader).cloneForMerge();
+        }
+        return storedFieldsReader;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.codec.KNN10010Codec;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
@@ -20,19 +19,41 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.SourceFieldMapper;
-import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120DerivedSourceStoredFieldsReader;
+import org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec.KNN9120DerivedSourceStoredFieldsReader;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter {
 
     private final StoredFieldsWriter delegate;
-    private final List<String> vectorFieldTypes;
+    private final Function<Map<String, Object>, Map<String, Object>> vectorMask;
+
+    // Keeping the mask as small as possible.
+    private final static Byte MASK = 0x1;
+
+    /**
+     *
+     * @param delegate StoredFieldsWriter to wrap
+     * @param vectorFieldTypesArg List of vector field types to mask. If empty, no masking will be done
+     */
+    public KNN10010DerivedSourceStoredFieldsWriter(StoredFieldsWriter delegate, List<String> vectorFieldTypesArg) {
+        this.delegate = delegate;
+        List<String> vectorFieldTypes = vectorFieldTypesArg.stream().map(String::toLowerCase).toList();
+        if (vectorFieldTypes.isEmpty() == false) {
+            this.vectorMask = XContentMapValues.transform(
+                vectorFieldTypes.stream().collect(Collectors.toMap(k -> k, k -> (Object o) -> o == null ? o : MASK)),
+                false
+            );
+        } else {
+            this.vectorMask = null;
+        }
+    }
 
     @Override
     public void startDocument() throws IOException {
@@ -66,9 +87,17 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
 
     @Override
     public int merge(MergeState mergeState) throws IOException {
-        // We have to wrap these here to avoid storing the vectors during merge
+        // In case of backwards compatibility, with old segments, we need to perform a non-optimal merge. Basically, it
+        // will repopulate each source and then inject the vector and then remove it. This allows us to migrate
+        // segments from filter approach to mask approach
+        if (KNN9120DerivedSourceStoredFieldsReader.doesMergeContainLegacySegments(mergeState)) {
+            return super.merge(mergeState);
+        }
+
+        // We wrap the segments to avoid injecting back vectors and then removing. If this is not done, then we will
+        // inject and then just write to disk potentially.
         for (int i = 0; i < mergeState.storedFieldsReaders.length; i++) {
-            mergeState.storedFieldsReaders[i] = KNN9120DerivedSourceStoredFieldsReader.wrapForMerge(mergeState.storedFieldsReaders[i]);
+            mergeState.storedFieldsReaders[i] = KNN10010DerivedSourceStoredFieldsReader.wrapForMerge(mergeState.storedFieldsReaders[i]);
         }
         return delegate.merge(mergeState);
     }
@@ -76,7 +105,7 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
     @Override
     public void writeField(FieldInfo fieldInfo, BytesRef bytesRef) throws IOException {
         // Parse out the vectors from the source
-        if (Objects.equals(fieldInfo.name, SourceFieldMapper.NAME) && !vectorFieldTypes.isEmpty()) {
+        if (vectorMask != null && Objects.equals(fieldInfo.name, SourceFieldMapper.NAME)) {
             // Reference:
             // https://github.com/opensearch-project/OpenSearch/blob/2.18.0/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java#L322
             Tuple<? extends MediaType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(
@@ -84,8 +113,7 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
                 true,
                 MediaTypeRegistry.JSON
             );
-            Map<String, Object> filteredSource = XContentMapValues.filter(null, vectorFieldTypes.toArray(new String[0]))
-                .apply(mapTuple.v2());
+            Map<String, Object> filteredSource = vectorMask.apply(mapTuple.v2());
             BytesStreamOutput bStream = new BytesStreamOutput();
             MediaType actualContentType = mapTuple.v1();
             XContentBuilder builder = MediaTypeRegistry.contentBuilder(actualContentType, bStream).map(filteredSource);

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/AbstractPerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/AbstractPerFieldDerivedVectorInjector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+
+import java.io.IOException;
+
+@Log4j2
+abstract class AbstractPerFieldDerivedVectorInjector implements PerFieldDerivedVectorInjector {
+    /**
+     * Utility method for formatting the vector values based on the vector data type. KNNVectorValues must be advanced
+     * to the correct position.
+     *
+     * @param fieldInfo fieldinfo for the vector field
+     * @param vectorValues vector values of the field. getVector or getConditionalVector should return expected vector.
+     * @return vector formatted based on the vector data type
+     * @throws IOException if unable to deserialize stored vector
+     */
+    protected Object formatVector(FieldInfo fieldInfo, KNNVectorValues<?> vectorValues) throws IOException {
+        Object vectorValue = vectorValues.getVector();
+        // If the vector value is a byte[], we must deserialize
+        if (vectorValue instanceof byte[]) {
+            BytesRef vectorBytesRef = new BytesRef((byte[]) vectorValue);
+            VectorDataType vectorDataType = FieldInfoExtractor.extractVectorDataType(fieldInfo);
+            return KNNVectorFieldMapperUtil.deserializeStoredVector(vectorBytesRef, vectorDataType);
+        }
+        return vectorValues.conditionalCloneVector();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjector.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
@@ -35,7 +35,7 @@ import java.util.Set;
 @Log4j2
 public class DerivedSourceVectorInjector implements Closeable {
 
-    private final DerivedSourceReaders derivedSourceReaders;
+    private final KNN9120DerivedSourceReaders derivedSourceReaders;
     private final List<PerFieldDerivedVectorInjector> perFieldDerivedVectorInjectors;
     private final Set<String> fieldNames;
 
@@ -47,7 +47,7 @@ public class DerivedSourceVectorInjector implements Closeable {
      * @param fieldsToInjectVector List of fields to inject vectors into
      */
     public DerivedSourceVectorInjector(
-        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier,
         SegmentReadState segmentReadState,
         List<FieldInfo> fieldsToInjectVector
     ) throws IOException {

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120Codec.java
@@ -17,7 +17,6 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80DocValuesFormat;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
-import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
 
 import java.util.Optional;
 
@@ -76,7 +75,7 @@ public class KNN9120Codec extends FilterCodec {
     }
 
     private StoredFieldsFormat getStoredFieldsFormat() {
-        DerivedSourceReadersSupplier derivedSourceReadersSupplier = new DerivedSourceReadersSupplier((segmentReadState) -> {
+        KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier = new KNN9120DerivedSourceReadersSupplier((segmentReadState) -> {
             if (segmentReadState.fieldInfos.hasVectorValues()) {
                 return knnVectorsFormat().fieldsReader(segmentReadState);
             }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceReaders.java
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.Nullable;
 
@@ -21,14 +23,18 @@ import java.io.IOException;
  */
 @RequiredArgsConstructor
 @Getter
-public class DerivedSourceReaders implements Closeable {
+public class KNN9120DerivedSourceReaders implements Closeable {
     @Nullable
     private final KnnVectorsReader knnVectorsReader;
     @Nullable
     private final DocValuesProducer docValuesProducer;
+    @Nullable
+    private final FieldsProducer fieldsProducer;
+    @Nullable
+    private final NormsProducer normsProducer;
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(knnVectorsReader, docValuesProducer);
+        IOUtils.close(knnVectorsReader, docValuesProducer, fieldsProducer, normsProducer);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceReadersSupplier.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceReadersSupplier.java
@@ -3,12 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.index.SegmentReadState;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaderSupplier;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaders;
 
 import java.io.IOException;
 
@@ -18,9 +23,15 @@ import java.io.IOException;
  * the correct format reader for that segment.
  */
 @RequiredArgsConstructor
-public class DerivedSourceReadersSupplier {
+public class KNN9120DerivedSourceReadersSupplier {
+    @NonNull
     private final DerivedSourceReaderSupplier<KnnVectorsReader> knnVectorsReaderSupplier;
+    @NonNull
     private final DerivedSourceReaderSupplier<DocValuesProducer> docValuesProducerSupplier;
+    @NonNull
+    private final DerivedSourceReaderSupplier<FieldsProducer> fieldsProducerSupplier;
+    @NonNull
+    private final DerivedSourceReaderSupplier<NormsProducer> normsProducer;
 
     /**
      * Get the readers for the segment
@@ -29,7 +40,12 @@ public class DerivedSourceReadersSupplier {
      * @return DerivedSourceReaders
      * @throws IOException in case of I/O error
      */
-    public DerivedSourceReaders getReaders(SegmentReadState state) throws IOException {
-        return new DerivedSourceReaders(knnVectorsReaderSupplier.apply(state), docValuesProducerSupplier.apply(state));
+    public KNN9120DerivedSourceReaders getReaders(SegmentReadState state) throws IOException {
+        return new KNN9120DerivedSourceReaders(
+            knnVectorsReaderSupplier.apply(state),
+            docValuesProducerSupplier.apply(state),
+            fieldsProducerSupplier.apply(state),
+            normsProducer.apply(state)
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldVisitor.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldVisitor.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import lombok.AllArgsConstructor;
 import org.apache.lucene.index.FieldInfo;
@@ -17,16 +17,16 @@ import java.io.IOException;
  * source vector fields into the document. After the source is modified, it is forwarded to the delegate.
  */
 @AllArgsConstructor
-public class DerivedSourceStoredFieldVisitor extends StoredFieldVisitor {
+public class KNN9120DerivedSourceStoredFieldVisitor extends StoredFieldVisitor {
 
     private final StoredFieldVisitor delegate;
     private final Integer documentId;
-    private final DerivedSourceVectorTransformer derivedSourceVectorTransformer;
+    private final DerivedSourceVectorInjector derivedSourceVectorInjector;
 
     @Override
     public void binaryField(FieldInfo fieldInfo, byte[] value) throws IOException {
         if (fieldInfo.name.equals(SourceFieldMapper.NAME)) {
-            delegate.binaryField(fieldInfo, derivedSourceVectorTransformer.injectVectors(documentId, value));
+            delegate.binaryField(fieldInfo, derivedSourceVectorInjector.injectVectors(documentId, value));
             return;
         }
         delegate.binaryField(fieldInfo, value);

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldsFormat.java
@@ -17,8 +17,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.opensearch.common.Nullable;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120DerivedSourceStoredFieldsReader;
-import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,13 +26,13 @@ import java.util.List;
 public class KNN9120DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
 
     private final StoredFieldsFormat delegate;
-    private final DerivedSourceReadersSupplier derivedSourceReadersSupplier;
+    private final KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier;
     // IMPORTANT Do not rely on this for the reader, it will be null if SPI is used
     @Nullable
     private final MapperService mapperService;
 
-    private static final String DERIVED_VECTOR_FIELD_ATTRIBUTE_KEY = "knn-derived-source-enabled";
-    private static final String DERIVED_VECTOR_FIELD_ATTRIBUTE_TRUE_VALUE = "true";
+    static final String DERIVED_VECTOR_FIELD_ATTRIBUTE_KEY = "knn-derived-source-enabled";
+    static final String DERIVED_VECTOR_FIELD_ATTRIBUTE_TRUE_VALUE = "true";
 
     @Override
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo segmentInfo, FieldInfos fieldInfos, IOContext ioContext)

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/NestedPerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/NestedPerFieldDerivedVectorInjector.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -32,7 +32,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 public class NestedPerFieldDerivedVectorInjector extends AbstractPerFieldDerivedVectorInjector {
 
     private final FieldInfo childFieldInfo;
-    private final DerivedSourceReaders derivedSourceReaders;
+    private final KNN9120DerivedSourceReaders derivedSourceReaders;
     private final SegmentReadState segmentReadState;
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/NestedPerFieldParentToDocIdIterator.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/NestedPerFieldParentToDocIdIterator.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.NumericDocValues;
@@ -27,7 +27,7 @@ public class NestedPerFieldParentToDocIdIterator {
 
     private final FieldInfo childFieldInfo;
     private final SegmentReadState segmentReadState;
-    private final DerivedSourceReaders derivedSourceReaders;
+    private final KNN9120DerivedSourceReaders derivedSourceReaders;
     private final int parentDocId;
     private final int previousParentDocId;
     private final List<Integer> children;
@@ -37,14 +37,14 @@ public class NestedPerFieldParentToDocIdIterator {
      *
      * @param childFieldInfo FieldInfo for the child field
      * @param segmentReadState SegmentReadState for the segment
-     * @param derivedSourceReaders {@link DerivedSourceReaders} instance
+     * @param derivedSourceReaders {@link KNN9120DerivedSourceReaders} instance
      * @param parentDocId Parent docId of the parent
      * @throws IOException if there is an error reading the parent docId
      */
     public NestedPerFieldParentToDocIdIterator(
         FieldInfo childFieldInfo,
         SegmentReadState segmentReadState,
-        DerivedSourceReaders derivedSourceReaders,
+        KNN9120DerivedSourceReaders derivedSourceReaders,
         int parentDocId
     ) throws IOException {
         this.childFieldInfo = childFieldInfo;

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/ParentChildHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/ParentChildHelper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 /**
  * Helper class for working with nested fields.

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/PerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/PerFieldDerivedVectorInjector.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/PerFieldDerivedVectorInjectorFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/PerFieldDerivedVectorInjectorFactory.java
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentReadState;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaders;
 
 /**
  * Factory for creating {@link PerFieldDerivedVectorInjector} instances.
@@ -22,7 +23,7 @@ class PerFieldDerivedVectorInjectorFactory {
      */
     public static PerFieldDerivedVectorInjector create(
         FieldInfo fieldInfo,
-        DerivedSourceReaders derivedSourceReaders,
+        KNN9120DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState
     ) {
         // Nested case

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/RootPerFieldDerivedVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/RootPerFieldDerivedVectorInjector.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.common.CheckedSupplier;
@@ -25,9 +25,9 @@ class RootPerFieldDerivedVectorInjector extends AbstractPerFieldDerivedVectorInj
      * Constructor for RootPerFieldDerivedVectorInjector.
      *
      * @param fieldInfo FieldInfo for the field to create the injector for
-     * @param derivedSourceReaders {@link DerivedSourceReaders} instance
+     * @param derivedSourceReaders {@link KNN9120DerivedSourceReaders} instance
      */
-    public RootPerFieldDerivedVectorInjector(FieldInfo fieldInfo, DerivedSourceReaders derivedSourceReaders) {
+    public RootPerFieldDerivedVectorInjector(FieldInfo fieldInfo, KNN9120DerivedSourceReaders derivedSourceReaders) {
         this.fieldInfo = fieldInfo;
         this.vectorValuesSupplier = () -> KNNVectorValuesFactory.getVectorValues(
             fieldInfo,

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/AbstractPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/AbstractPerFieldDerivedVectorTransformer.java
@@ -5,35 +5,37 @@
 
 package org.opensearch.knn.index.codec.derivedsource;
 
-import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.CheckedSupplier;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
-import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
 import java.io.IOException;
 
-@Log4j2
-abstract class AbstractPerFieldDerivedVectorInjector implements PerFieldDerivedVectorInjector {
+public abstract class AbstractPerFieldDerivedVectorTransformer implements PerFieldDerivedVectorTransformer {
     /**
-     * Utility method for formatting the vector values based on the vector data type. KNNVectorValues must be advanced
-     * to the correct position.
+     * Utility method for formatting the vector values based on the vector data type.
      *
      * @param fieldInfo fieldinfo for the vector field
-     * @param vectorValues vector values of the field. getVector or getConditionalVector should return expected vector.
-     * @return vector formatted based on the vector data type
+     * @param vectorSupplier supplies vector (without clone)
+     * @param vectorCloneSupplier supplies clone of vector.
+     * @return vector formatted based on the vector data type. Typically, this will be a float[] or int[].
      * @throws IOException if unable to deserialize stored vector
      */
-    protected Object formatVector(FieldInfo fieldInfo, KNNVectorValues<?> vectorValues) throws IOException {
-        Object vectorValue = vectorValues.getVector();
+    protected Object formatVector(
+        FieldInfo fieldInfo,
+        CheckedSupplier<Object, IOException> vectorSupplier,
+        CheckedSupplier<Object, IOException> vectorCloneSupplier
+    ) throws IOException {
+        Object vectorValue = vectorSupplier.get();
         // If the vector value is a byte[], we must deserialize
         if (vectorValue instanceof byte[]) {
             BytesRef vectorBytesRef = new BytesRef((byte[]) vectorValue);
             VectorDataType vectorDataType = FieldInfoExtractor.extractVectorDataType(fieldInfo);
             return KNNVectorFieldMapperUtil.deserializeStoredVector(vectorBytesRef, vectorDataType);
         }
-        return vectorValues.conditionalCloneVector();
+        return vectorCloneSupplier.get();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedFieldInfo.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedFieldInfo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.Builder;
+import org.apache.lucene.index.FieldInfo;
+
+/**
+ * Light wrapper around {@link FieldInfo} that indicates whether the field is nested or not.
+ */
+@Builder
+public record DerivedFieldInfo(FieldInfo fieldInfo, boolean isNested) {
+    /**
+     * @return name of the field
+     */
+    public String name() {
+        return fieldInfo.name;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.search.DocIdSetIterator;
+
+import java.io.IOException;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+/**
+ * Utility class used to implement Lucene functionality that can be used to interact with Lucene
+ */
+@RequiredArgsConstructor
+public class DerivedSourceLuceneHelper {
+
+    private final DerivedSourceReaders derivedSourceReaders;
+    private final SegmentReadState segmentReadState;
+
+    /**
+     * Get the first child of the given parentDoc. This can be used to determine if the document contains any nested
+     * fields.
+     *
+     * @return doc id of last matching doc. {@link DocIdSetIterator#NO_MORE_DOCS} if no children exist.
+     * @throws IOException
+     */
+    public int getFirstChild(int parentDocId) throws IOException {
+        // If its the first document id, then there is no change there are parents
+        if (parentDocId == 0) {
+            return NO_MORE_DOCS;
+        }
+
+        // Only root level documents have the "_primary_term" field. So, we iterate through all of the documents in
+        // order to find out if any have this term.
+        // TODO: This is expensive and should be optimized. We should start at doc parentDocId - 10000 and work back
+        // (can we fetch the setting? Maybe)
+        FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo("_primary_term");
+        assert derivedSourceReaders.getDocValuesProducer() != null;
+        NumericDocValues numericDocValues = derivedSourceReaders.getDocValuesProducer().getNumeric(fieldInfo);
+        int previousParentDocId = NO_MORE_DOCS;
+        numericDocValues.advance(0);
+        while (numericDocValues.docID() != NO_MORE_DOCS) {
+            if (numericDocValues.docID() >= parentDocId) {
+                break;
+            }
+            previousParentDocId = numericDocValues.docID();
+            numericDocValues.nextDoc();
+        }
+
+        // If there are no numeric docvalues before the current parent doc, then the parent doc is the first parent. So
+        // its first child must be 0
+        if (previousParentDocId == NO_MORE_DOCS) {
+            return 0;
+        }
+        // If the document right before is the previous parent, then there are no children.
+        if (parentDocId - previousParentDocId <= 1) {
+            return NO_MORE_DOCS;
+        }
+        return previousParentDocId + 1;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceSegmentAttributeParser.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceSegmentAttributeParser.java
@@ -20,19 +20,22 @@ import java.util.stream.Collectors;
 public class DerivedSourceSegmentAttributeParser {
 
     static final String DERIVED_SOURCE_FIELD = "derived_vector_fields";
+    static final String NESTED_DERIVED_SOURCE_FIELD = "nested_derived_vector_fields";
     static final String DELIMETER = ",";
 
     /**
      * From segmentInfo, parse the derived_vector_fields
      *
      * @param segmentInfo {@link SegmentInfo}
+     * @param isNested Whether the vector field is nested or not
      * @return List of fields that derived source is enabled for. Potentially null if no fields
      */
-    public static List<String> parseDerivedVectorFields(SegmentInfo segmentInfo) {
+    public static List<String> parseDerivedVectorFields(SegmentInfo segmentInfo, boolean isNested) {
         if (segmentInfo == null) {
             return Collections.emptyList();
         }
-        String derivedVectorFields = segmentInfo.getAttribute(DERIVED_SOURCE_FIELD);
+        String fieldName = isNested ? NESTED_DERIVED_SOURCE_FIELD : DERIVED_SOURCE_FIELD;
+        String derivedVectorFields = segmentInfo.getAttribute(fieldName);
         if (StringUtils.isEmpty(derivedVectorFields)) {
             return Collections.emptyList();
         }
@@ -44,14 +47,20 @@ public class DerivedSourceSegmentAttributeParser {
      *
      * @param segmentInfo {@link SegmentInfo}
      * @param vectorFieldTypes List of vector field names
+     * @param isNested Whether the vector field is nested or not
      */
-    public static void addDerivedVectorFieldsSegmentInfoAttribute(SegmentInfo segmentInfo, List<String> vectorFieldTypes) {
+    public static void addDerivedVectorFieldsSegmentInfoAttribute(
+        SegmentInfo segmentInfo,
+        List<String> vectorFieldTypes,
+        boolean isNested
+    ) {
         if (segmentInfo == null) {
             throw new IllegalArgumentException("SegmentInfo cannot be null");
         }
         if (vectorFieldTypes == null || vectorFieldTypes.isEmpty()) {
             throw new IllegalArgumentException("VectorFieldTypes cannot be null or empty");
         }
-        segmentInfo.putAttribute(DERIVED_SOURCE_FIELD, String.join(DELIMETER, vectorFieldTypes));
+        String fieldName = isNested ? NESTED_DERIVED_SOURCE_FIELD : DERIVED_SOURCE_FIELD;
+        segmentInfo.putAttribute(fieldName, String.join(DELIMETER, vectorFieldTypes));
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.util.IOUtils;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@Log4j2
+public class DerivedSourceVectorTransformer implements Closeable {
+
+    private final DerivedSourceReaders derivedSourceReaders;
+    Function<Map<String, Object>, Map<String, Object>> derivedSourceVectorTransformer;
+    Map<String, PerFieldDerivedVectorTransformer> perFieldDerivedVectorTransformers;
+    private boolean isNested;
+    private final DerivedSourceLuceneHelper derivedSourceLuceneHelper;
+
+    /**
+     *
+     * @param derivedSourceReadersSupplier Supplier for the derived source readers.
+     * @param segmentReadState Segment read state
+     * @param fieldsToInjectVector List of fields to inject vectors into
+     */
+    public DerivedSourceVectorTransformer(
+        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        SegmentReadState segmentReadState,
+        List<DerivedFieldInfo> fieldsToInjectVector
+    ) throws IOException {
+        this.derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
+        perFieldDerivedVectorTransformers = new HashMap<>();
+        Map<String, Function<Object, Object>> perFieldDerivedVectorTransformersFunctionValues = new HashMap<>();
+        for (DerivedFieldInfo derivedFieldInfo : fieldsToInjectVector) {
+            isNested = derivedFieldInfo.isNested() || isNested;
+            PerFieldDerivedVectorTransformer perFieldDerivedVectorTransformer = PerFieldDerivedVectorTransformerFactory.create(
+                derivedFieldInfo.fieldInfo(),
+                derivedFieldInfo.isNested(),
+                derivedSourceReaders
+            );
+            perFieldDerivedVectorTransformers.put(derivedFieldInfo.name(), perFieldDerivedVectorTransformer);
+            perFieldDerivedVectorTransformersFunctionValues.put(derivedFieldInfo.name(), perFieldDerivedVectorTransformer);
+        }
+        derivedSourceVectorTransformer = XContentMapValues.transform(perFieldDerivedVectorTransformersFunctionValues, false);
+        derivedSourceLuceneHelper = new DerivedSourceLuceneHelper(derivedSourceReaders, segmentReadState);
+    }
+
+    /**
+     * Given a docId and the source of that doc as bytes, add all the necessary vector fields into the source.
+     *
+     * @param docId doc id of the document
+     * @param sourceAsBytes source of document as bytes
+     * @return byte array of the source with the vector fields added
+     * @throws IOException if there is an issue reading from the formats
+     */
+    public byte[] injectVectors(int docId, byte[] sourceAsBytes) throws IOException {
+        // Reference:
+        // https://github.com/opensearch-project/OpenSearch/blob/2.18.0/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java#L322
+        // Deserialize the source into a modifiable map
+        Tuple<? extends MediaType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(
+            BytesReference.fromByteBuffer(ByteBuffer.wrap(sourceAsBytes)),
+            true,
+            MediaTypeRegistry.getDefaultMediaType()
+        );
+        // Have to create a copy of the map here to ensure that is mutable
+        Map<String, Object> sourceAsMap = new HashMap<>(mapTuple.v2());
+
+        // We only need the offset for the nested fields. If there arent any, we can skip
+        int offset = 0;
+        if (isNested) {
+            offset = derivedSourceLuceneHelper.getFirstChild(docId);
+        }
+
+        // For each vector field, add in the source. The per field injectors are responsible for skipping if
+        // the field is not present.
+        for (PerFieldDerivedVectorTransformer vectorTransformer : perFieldDerivedVectorTransformers.values()) {
+            vectorTransformer.setCurrentDoc(offset, docId);
+        }
+
+        Map<String, Object> copy = derivedSourceVectorTransformer.apply(sourceAsMap);
+
+        // At this point, we can serialize the modified source map
+        // Setting to 1024 based on
+        // https://github.com/opensearch-project/OpenSearch/blob/2.18.0/server/src/main/java/org/opensearch/search/fetch/subphase/FetchSourcePhase.java#L106
+        BytesStreamOutput bStream = new BytesStreamOutput(1024);
+        MediaType actualContentType = mapTuple.v1();
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(actualContentType, bStream).map(copy);
+        builder.close();
+        return BytesReference.toBytes(BytesReference.bytes(builder));
+    }
+
+    /**
+     * Whether or not to inject vectors based on what fields are explicitly required
+     *
+     * @param includes List of fields that are required to be injected
+     * @param excludes List of fields that are not required to be injected
+     * @return true if vectors should be injected, false otherwise
+     */
+    public boolean shouldInject(String[] includes, String[] excludes) {
+        // If any of the vector fields are explicitly required we should inject
+        if (includes != null && includes != Strings.EMPTY_ARRAY) {
+            for (String includedField : includes) {
+                if (perFieldDerivedVectorTransformers.containsKey(includedField)) {
+                    return true;
+                }
+            }
+        }
+
+        // If all of the vector fields are explicitly excluded we should not inject
+        if (excludes != null && excludes != Strings.EMPTY_ARRAY) {
+            int excludedVectorFieldCount = 0;
+            for (String excludedField : excludes) {
+                if (perFieldDerivedVectorTransformers.containsKey(excludedField)) {
+                    excludedVectorFieldCount++;
+                }
+            }
+            // Inject if we havent excluded all of the fields
+            return excludedVectorFieldCount < perFieldDerivedVectorTransformers.size();
+        }
+        return true;
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(derivedSourceReaders);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/NestedPerFieldDerivedVectorTransformer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.apache.lucene.index.FieldInfo;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+
+import java.io.IOException;
+
+public class NestedPerFieldDerivedVectorTransformer extends AbstractPerFieldDerivedVectorTransformer {
+
+    private final FieldInfo childFieldInfo;
+    private final DerivedSourceReaders derivedSourceReaders;
+    private KNNVectorValues<?> vectorValues;
+
+    /**
+     *
+     * @param childFieldInfo FieldInfo of the child field
+     * @param derivedSourceReaders Readers for access segment info
+     */
+    public NestedPerFieldDerivedVectorTransformer(FieldInfo childFieldInfo, DerivedSourceReaders derivedSourceReaders) {
+        this.childFieldInfo = childFieldInfo;
+        this.derivedSourceReaders = derivedSourceReaders;
+    }
+
+    @Override
+    public Object apply(Object object) {
+        if (object == null) {
+            return object;
+        }
+
+        try {
+            Object vector = formatVector(childFieldInfo, vectorValues::getVector, vectorValues::conditionalCloneVector);
+            vectorValues.nextDoc();
+            return vector;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void setCurrentDoc(int offset, int docId) throws IOException {
+        vectorValues = KNNVectorValuesFactory.getVectorValues(
+            childFieldInfo,
+            derivedSourceReaders.getDocValuesProducer(),
+            derivedSourceReaders.getKnnVectorsReader()
+        );
+        vectorValues.advance(offset);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorTransformer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+public interface PerFieldDerivedVectorTransformer extends Function<Object, Object> {
+
+    /**
+     * Update the current doc to the given doc id
+     *
+     * @param offset Offset to advance iterators to
+     * @param docId Parent doc id
+     * @throws IOException thrown on invalid read
+     */
+    void setCurrentDoc(int offset, int docId) throws IOException;
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorTransformerFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/PerFieldDerivedVectorTransformerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.apache.lucene.index.FieldInfo;
+
+public class PerFieldDerivedVectorTransformerFactory {
+
+    /**
+     * Create a {@link PerFieldDerivedVectorTransformer} instance based on information in field info.
+     *
+     * @param fieldInfo FieldInfo for the field to create the injector for
+     * @param derivedSourceReaders {@link DerivedSourceReaders} instance
+     * @return PerFieldDerivedVectorInjector instance
+     */
+    public static PerFieldDerivedVectorTransformer create(
+        FieldInfo fieldInfo,
+        boolean isNested,
+        DerivedSourceReaders derivedSourceReaders
+    ) {
+        // Nested case
+        if (isNested) {
+            return new NestedPerFieldDerivedVectorTransformer(fieldInfo, derivedSourceReaders);
+        }
+
+        // Non-nested case
+        return new RootPerFieldDerivedVectorTransformer(fieldInfo, derivedSourceReaders);
+    }
+
+}

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/RootPerFieldDerivedVectorTransformer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.apache.lucene.index.FieldInfo;
+import org.opensearch.common.CheckedSupplier;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+
+import java.io.IOException;
+
+public class RootPerFieldDerivedVectorTransformer extends AbstractPerFieldDerivedVectorTransformer {
+
+    private final FieldInfo fieldInfo;
+    private final CheckedSupplier<KNNVectorValues<?>, IOException> vectorValuesSupplier;
+    private KNNVectorValues<?> vectorValues;
+
+    /**
+     * Constructor for RootPerFieldDerivedVectorTransformer.
+     *
+     * @param fieldInfo FieldInfo for the field to create the injector for
+     * @param derivedSourceReaders {@link DerivedSourceReaders} instance
+     */
+    public RootPerFieldDerivedVectorTransformer(FieldInfo fieldInfo, DerivedSourceReaders derivedSourceReaders) {
+        this.fieldInfo = fieldInfo;
+        this.vectorValuesSupplier = () -> KNNVectorValuesFactory.getVectorValues(
+            fieldInfo,
+            derivedSourceReaders.getDocValuesProducer(),
+            derivedSourceReaders.getKnnVectorsReader()
+        );
+    }
+
+    @Override
+    public void setCurrentDoc(int offset, int docId) throws IOException {
+        vectorValues = vectorValuesSupplier.get();
+        vectorValues.advance(docId);
+    }
+
+    @Override
+    public Object apply(Object object) {
+        if (object == null) {
+            return object;
+        }
+
+        try {
+            return formatVector(fieldInfo, vectorValues::getVector, vectorValues::conditionalCloneVector);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.KNN9120Codec;
+package org.opensearch.knn.index.codec.KNN10010Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.StoredFieldsWriter;
@@ -13,7 +13,6 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010DerivedSourceStoredFieldsWriter;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 
 import java.util.List;

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjectorTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.index.FieldInfo;
@@ -59,7 +59,7 @@ public class DerivedSourceVectorInjectorTests extends KNNTestCase {
             });
 
             DerivedSourceVectorInjector derivedSourceVectorInjector = new DerivedSourceVectorInjector(
-                new DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                new KNN9120DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
                 null,
                 fields
             );
@@ -119,7 +119,7 @@ public class DerivedSourceVectorInjectorTests extends KNNTestCase {
 
         try (
             DerivedSourceVectorInjector vectorInjector = new DerivedSourceVectorInjector(
-                new DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                new KNN9120DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
                 null,
                 fields
             )

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldVisitorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldVisitorTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.opensearch.knn.KNNTestCase;
@@ -17,14 +17,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DerivedSourceStoredFieldVisitorTests extends KNNTestCase {
+public class KNN9120DerivedSourceStoredFieldVisitorTests extends KNNTestCase {
 
     public void testBinaryField() throws Exception {
         StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
         doAnswer(invocationOnMock -> null).when(delegate).binaryField(any(), any());
         DerivedSourceVectorInjector derivedSourceVectorInjector = mock(DerivedSourceVectorInjector.class);
         when(derivedSourceVectorInjector.injectVectors(anyInt(), any())).thenReturn(new byte[0]);
-        DerivedSourceStoredFieldVisitor derivedSourceStoredFieldVisitor = new DerivedSourceStoredFieldVisitor(
+        KNN9120DerivedSourceStoredFieldVisitor derivedSourceStoredFieldVisitor = new KNN9120DerivedSourceStoredFieldVisitor(
             delegate,
             0,
             derivedSourceVectorInjector

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/ParentChildHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/ParentChildHelperTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.opensearch.knn.KNNTestCase;
 

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/PerFieldDerivedVectorInjectorFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/PerFieldDerivedVectorInjectorFactoryTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
@@ -13,7 +13,7 @@ public class PerFieldDerivedVectorInjectorFactoryTests extends KNNTestCase {
         // Non-nested case
         PerFieldDerivedVectorInjector perFieldDerivedVectorInjector = PerFieldDerivedVectorInjectorFactory.create(
             KNNCodecTestUtil.FieldInfoBuilder.builder("test").build(),
-            new DerivedSourceReaders(null, null, null, null),
+            new KNN9120DerivedSourceReaders(null, null, null, null),
             null
         );
         assertTrue(perFieldDerivedVectorInjector instanceof RootPerFieldDerivedVectorInjector);
@@ -21,7 +21,7 @@ public class PerFieldDerivedVectorInjectorFactoryTests extends KNNTestCase {
         // Nested case
         perFieldDerivedVectorInjector = PerFieldDerivedVectorInjectorFactory.create(
             KNNCodecTestUtil.FieldInfoBuilder.builder("parent.test").build(),
-            new DerivedSourceReaders(null, null, null, null),
+            new KNN9120DerivedSourceReaders(null, null, null, null),
             null
         );
         assertTrue(perFieldDerivedVectorInjector instanceof NestedPerFieldDerivedVectorInjector);

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/RootPerFieldDerivedVectorInjectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/RootPerFieldDerivedVectorInjectorTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.derivedsource;
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.index.FieldInfo;
@@ -74,7 +74,7 @@ public class RootPerFieldDerivedVectorInjectorTests extends KNNTestCase {
                 });
             PerFieldDerivedVectorInjector perFieldDerivedVectorInjector = new RootPerFieldDerivedVectorInjector(
                 fieldInfo,
-                new DerivedSourceReaders(null, null, null, null)
+                new KNN9120DerivedSourceReaders(null, null, null, null)
             );
 
             Map<String, Object> source = new HashMap<>();

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceSegmentAttributeParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceSegmentAttributeParserTests.java
@@ -30,15 +30,16 @@ public class DerivedSourceSegmentAttributeParserTests extends KNNTestCase {
 
         DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(
             mockSegmentInfo,
-            List.of("test", "test2.nested", "vector")
+            List.of("test", "test2.nested", "vector"),
+            false
         );
         assertEquals("test,test2.nested,vector", fakeAttributes.get(DERIVED_SOURCE_FIELD));
         fakeAttributes.remove(DERIVED_SOURCE_FIELD);
 
-        DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(mockSegmentInfo, List.of("test"));
+        DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(mockSegmentInfo, List.of("test"), false);
         assertEquals("test", fakeAttributes.get(DERIVED_SOURCE_FIELD));
 
-        DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(mockSegmentInfo, List.of("", "", "", "", ""));
+        DerivedSourceSegmentAttributeParser.addDerivedVectorFieldsSegmentInfoAttribute(mockSegmentInfo, List.of("", "", "", "", ""), false);
         assertEquals(",,,,", fakeAttributes.get(DERIVED_SOURCE_FIELD));
     }
 
@@ -46,15 +47,15 @@ public class DerivedSourceSegmentAttributeParserTests extends KNNTestCase {
         Map<String, String> fakeAttributes = new HashMap<>();
         when(mockSegmentInfo.getAttribute(any())).thenAnswer(t -> fakeAttributes.get(t.getArgument(0)));
 
-        assertEquals(Collections.emptyList(), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(null));
-        assertEquals(Collections.emptyList(), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(mockSegmentInfo));
+        assertEquals(Collections.emptyList(), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(null, false));
+        assertEquals(Collections.emptyList(), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(mockSegmentInfo, false));
 
         fakeAttributes.put(DERIVED_SOURCE_FIELD, "test,test2.nested,vector");
         List<String> expectedFieldInfos = Arrays.asList("test", "test2.nested", "vector");
-        assertEquals(expectedFieldInfos, DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(mockSegmentInfo));
+        assertEquals(expectedFieldInfos, DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(mockSegmentInfo, false));
 
         fakeAttributes.put(DERIVED_SOURCE_FIELD, ",,,,");
         expectedFieldInfos = Arrays.asList("", "", "", "", "");
-        assertEquals(expectedFieldInfos, DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(mockSegmentInfo));
+        assertEquals(expectedFieldInfos, DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(mockSegmentInfo, false));
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -31,8 +31,8 @@ import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 public class DerivedSourceTestCase extends KNNRestTestCase {
-    protected final int TEST_DIMENSION = 128;
-    protected final int DOCS = 50;
+    protected final int TEST_DIMENSION = 16;
+    protected final int DOCS = 500;
     protected final static String NESTED_NAME = "test_nested";
     protected final static String FIELD_NAME = "test_vector";
 
@@ -78,6 +78,8 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
             derivedSourceDisabledContext.indexName,
             derivedSourceEnabledContext.indexName
         );
+        flush(derivedSourceEnabledContext.indexName, true);
+        flush(derivedSourceDisabledContext.indexName, true);
     }
 
     @SneakyThrows
@@ -86,8 +88,9 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
         IndexConfigContext derivedSourceDisabledContext = indexConfigContexts.get(1);
         String originalIndexNameDerivedSourceEnabled = derivedSourceEnabledContext.indexName;
         String originalIndexNameDerivedSourceDisabled = derivedSourceDisabledContext.indexName;
-        forceMergeKnnIndex(originalIndexNameDerivedSourceEnabled, 10);
-        forceMergeKnnIndex(originalIndexNameDerivedSourceDisabled, 10);
+        forceMergeKnnIndex(originalIndexNameDerivedSourceEnabled, 1);
+        forceMergeKnnIndex(originalIndexNameDerivedSourceDisabled, 1);
+
         refreshAllIndices();
         assertIndexBigger(originalIndexNameDerivedSourceDisabled, originalIndexNameDerivedSourceEnabled);
         assertDocsMatch(
@@ -100,6 +103,20 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
         forceMergeKnnIndex(originalIndexNameDerivedSourceDisabled, 1);
         refreshAllIndices();
         assertIndexBigger(originalIndexNameDerivedSourceDisabled, originalIndexNameDerivedSourceEnabled);
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            originalIndexNameDerivedSourceDisabled,
+            originalIndexNameDerivedSourceEnabled
+        );
+        flush(derivedSourceEnabledContext.indexName, true);
+        flush(derivedSourceDisabledContext.indexName, true);
+    }
+
+    public void assertDocsMatch(List<IndexConfigContext> indexConfigContexts) {
+        IndexConfigContext derivedSourceEnabledContext = indexConfigContexts.get(0);
+        IndexConfigContext derivedSourceDisabledContext = indexConfigContexts.get(1);
+        String originalIndexNameDerivedSourceEnabled = derivedSourceEnabledContext.indexName;
+        String originalIndexNameDerivedSourceDisabled = derivedSourceDisabledContext.indexName;
         assertDocsMatch(
             derivedSourceDisabledContext.docCount,
             originalIndexNameDerivedSourceDisabled,

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -42,7 +42,7 @@ import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.codec.derivedsource.ParentChildHelper;
+import org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec.ParentChildHelper;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.knn.plugin.KNNPlugin;
@@ -772,7 +772,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
      * Adds a doc where document is represented as a string.
      */
     protected void addKnnDoc(final String index, final String docId, final String document) throws IOException {
-        Request request = new Request("POST", "/" + index + "/_doc/" + docId);
+        Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
         request.setJsonEntity(document);
         client().performRequest(request);
     }


### PR DESCRIPTION
### Description
Migrates derived source functionality from filter to mask based approach in a bwc way. The change can be summed up as instead of remove vector fields from source, it replaces them with a smaller representation (mask). When we need to add them back, we transform the source map to replace the masks with the actual vectors. This makes handling nested docs much easier.

For backwards compatibility, this PR moves old read functionality and related classes to backwardscodecs/KNN9120Codec package and removes old write as no longer necessary. On merge, we add custom functionality in the stored fields writer merge logic to fall back to base, non-optimized merge if it detects older readers in the merge state. For this, we will reconstruct the source document with the reader and then apply the mask again on top of it to remove the vectors. This ensures that segments are migrated to the mask approach. To verify this, I added several backwards compatibility tests.

There are 40+ file changes, but most of them are just moving files to backwards codec. 

Adding a few more test cases today.

### Related Issues
Resolves #2377 

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
