### PR TITLE
[LuceneOnFaiss Part-8] Added `index.knn.memory_optimized_search` index setting.

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -155,11 +155,12 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
     private NativeEngines990KnnVectorsFormat nativeEngineVectorsFormat() {
         // mapperService is already checked for null or valid instance type at caller, hence we don't need
         // addition isPresent check here.
-        int approximateThreshold = getApproximateThresholdValue();
+        final int approximateThreshold = getApproximateThresholdValue();
         return new NativeEngines990KnnVectorsFormat(
             new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()),
             approximateThreshold,
-            nativeIndexBuildStrategyFactory
+            nativeIndexBuildStrategyFactory,
+            mapperService
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.index.codec.KNN990Codec;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
@@ -19,22 +20,31 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
+import java.util.Optional;
+
+import static org.opensearch.knn.index.KNNSettings.DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
+import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
 
 /**
  * This is a Vector format that will be used for Native engines like Faiss and Nmslib for reading and writing vector
  * related data structures.
  */
+@Log4j2
 public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     /** The format for storing, reading, merging vectors on disk */
     private static FlatVectorsFormat flatVectorsFormat;
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
     private static int approximateThreshold;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final boolean memoryOptimizedSearchEnabled;
 
     public NativeEngines990KnnVectorsFormat() {
         this(new Lucene99FlatVectorsFormat(new DefaultFlatVectorScorer()));
@@ -49,18 +59,20 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     }
 
     public NativeEngines990KnnVectorsFormat(final FlatVectorsFormat flatVectorsFormat, int approximateThreshold) {
-        this(flatVectorsFormat, approximateThreshold, new NativeIndexBuildStrategyFactory());
+        this(flatVectorsFormat, approximateThreshold, new NativeIndexBuildStrategyFactory(), Optional.empty());
     }
 
     public NativeEngines990KnnVectorsFormat(
         final FlatVectorsFormat flatVectorsFormat,
         int approximateThreshold,
-        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        final Optional<MapperService> mapperService
     ) {
         super(FORMAT_NAME);
         NativeEngines990KnnVectorsFormat.flatVectorsFormat = flatVectorsFormat;
         NativeEngines990KnnVectorsFormat.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.memoryOptimizedSearchEnabled = isMemoryOptimizedSearchSupported(mapperService);
     }
 
     /**
@@ -85,7 +97,7 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
      */
     @Override
     public KnnVectorsReader fieldsReader(final SegmentReadState state) throws IOException {
-        return new NativeEngines990KnnVectorsReader(state, flatVectorsFormat.fieldsReader(state));
+        return new NativeEngines990KnnVectorsReader(state, flatVectorsFormat.fieldsReader(state), memoryOptimizedSearchEnabled);
     }
 
     /**
@@ -106,5 +118,22 @@ public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
             + ", approximateThreshold="
             + approximateThreshold
             + ")";
+    }
+
+    private static boolean isMemoryOptimizedSearchSupported(final Optional<MapperService> mapperService) {
+        if (mapperService.isPresent()) {
+            final IndexSettings indexSettings = mapperService.get().getIndexSettings();
+            if (indexSettings != null) {
+                final Settings settings = indexSettings.getSettings();
+                if (settings != null) {
+                    try {
+                        return settings.getAsBoolean(MEMORY_OPTIMIZED_KNN_SEARCH_MODE, DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE);
+                    } catch (Throwable th) {
+                        log.error("Failed to get a bool flag of [{}] from settings.", MEMORY_OPTIMIZED_KNN_SEARCH_MODE);
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.memoryoptsearch.VectorSearcher;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+/**
+ * This class encapsulates a determination logic for memory optimized search.
+ * Memory-optimized-search may not be applied to a certain type of index even {@link KNNEngine} returns a non-null
+ * {@link org.opensearch.knn.memoryoptsearch.VectorSearcherFactory}.
+ * The overall logic will be made based on the given method context and quantization configuration.
+ */
+public class MemoryOptimizedSearchSupportSpec {
+    private static final Set<String> SUPPORTED_HNSW_ENCODING = Set.of(ENCODER_FLAT, ENCODER_SQ);
+
+    /**
+     * Determine whether if a KNN field supports memory-optimized-search.
+     * If it is supported, then the field can perform memory-optimized search via {@link VectorSearcher}.
+     * Which can be obtained from a factory acquired from {@link KNNEngine#getVectorSearcherFactory()}.
+     *
+     * @param methodContextOpt   Optional method context.
+     * @param quantizationConfig Quantization configuration.
+     * @param vectorDataType Vector data type.
+     * @return True if memory-optimized-search is supported, otherwise false.
+     */
+    public static boolean supported(
+        final Optional<KNNMethodContext> methodContextOpt,
+        final QuantizationConfig quantizationConfig,
+        final VectorDataType vectorDataType
+    ) {
+        if (methodContextOpt.isPresent()) {
+            final KNNMethodContext methodContext = methodContextOpt.get();
+            final KNNEngine engine = methodContext.getKnnEngine();
+
+            // We support Lucene engine
+            if (engine == KNNEngine.LUCENE) {
+                return true;
+            }
+
+            // We don't support non-FAISS engine
+            if (engine != KNNEngine.FAISS) {
+                return false;
+            }
+
+            // We only support HNSW method.
+            final MethodComponentContext methodComponentContext = methodContext.getMethodComponentContext();
+            if (methodComponentContext.getName().equals(METHOD_HNSW) == false) {
+                return false;
+            }
+
+            // We don't support quantization yet.
+            if (quantizationConfig != null && quantizationConfig.getQuantizationType() != null) {
+                return false;
+            }
+
+            // Only support FLOAT/BYTE index.
+            if (vectorDataType != VectorDataType.FLOAT && vectorDataType != VectorDataType.BYTE) {
+                return false;
+            }
+
+            // L2 or Inner product are supported.
+            if (methodContext.getSpaceType() != SpaceType.L2 && methodContext.getSpaceType() != SpaceType.INNER_PRODUCT) {
+                return false;
+            }
+
+            // We only support Flat and SQ encoder for HNSW.
+            final Map<String, Object> parameters = methodComponentContext.getParameters();
+            final Object methodComponentContextObj = parameters.get(METHOD_ENCODER_PARAMETER);
+            if ((methodComponentContextObj instanceof MethodComponentContext) == false) {
+                return false;
+            }
+
+            if (SUPPORTED_HNSW_ENCODING.contains(((MethodComponentContext) methodComponentContextObj).getName()) == false) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -24,6 +24,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
+import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
 import org.opensearch.search.aggregations.support.CoreValuesSourceType;
 import org.opensearch.search.lookup.SearchLookup;
 
@@ -44,6 +45,7 @@ public class KNNVectorFieldType extends MappedFieldType {
     private static final Logger logger = LogManager.getLogger(KNNVectorFieldType.class);
     KNNMappingConfig knnMappingConfig;
     VectorDataType vectorDataType;
+    boolean memoryOptimizedSearchSupported;
 
     /**
      * Constructor for KNNVectorFieldType.
@@ -57,6 +59,11 @@ public class KNNVectorFieldType extends MappedFieldType {
         super(name, false, false, true, TextSearchInfo.NONE, metadata);
         this.vectorDataType = vectorDataType;
         this.knnMappingConfig = annConfig;
+        this.memoryOptimizedSearchSupported = MemoryOptimizedSearchSupportSpec.supported(
+            knnMappingConfig.getKnnMethodContext(),
+            knnMappingConfig.getQuantizationConfig(),
+            vectorDataType
+        );
     }
 
     @Override
@@ -151,6 +158,5 @@ public class KNNVectorFieldType extends MappedFieldType {
             return;
         }
         throw new IllegalStateException("Either KNN method context or Model Id should be configured");
-
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
@@ -51,6 +51,7 @@ public abstract class BaseQueryFactory {
         private QueryShardContext context;
         private RescoreContext rescoreContext;
         private Boolean expandNested;
+        private boolean memoryOptimizedSearchSupported;
 
         public Optional<QueryBuilder> getFilter() {
             return Optional.ofNullable(filter);

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -23,22 +23,23 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.WithFieldName;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.VectorQueryType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNLibrarySearchContext;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.model.QueryContext;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.query.parser.KNNQueryBuilderParser;
 import org.opensearch.knn.index.query.parser.RescoreParser;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.knn.index.util.IndexUtil;
-import org.opensearch.knn.index.engine.MethodComponentContext;
-import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.VectorQueryType;
-import org.opensearch.knn.index.query.parser.KNNQueryBuilderParser;
-import org.opensearch.knn.index.engine.KNNLibrarySearchContext;
-import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
@@ -56,9 +57,9 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
-import static org.opensearch.knn.index.query.parser.MethodParametersParser.validateMethodParameters;
 import static org.opensearch.knn.index.engine.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
 import static org.opensearch.knn.index.engine.validation.ParameterValidator.validateParameters;
+import static org.opensearch.knn.index.query.parser.MethodParametersParser.validateMethodParameters;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_OVERSAMPLE_PARAMETER;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_PARAMETER;
 
@@ -404,6 +405,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         knnVectorFieldType.transformQueryVector(vector);
 
         VectorQueryType vectorQueryType = getVectorQueryType(k, maxDistance, minScore);
+        final String indexName = context.index().getName();
+        final boolean memoryOptimizedSearchSupported = knnVectorFieldType.isMemoryOptimizedSearchSupported()
+            && KNNSettings.isMemoryOptimizedKnnSearchModeEnabled(indexName);
         updateQueryStats(vectorQueryType);
 
         // This could be null in the case of when a model did not have serialized methodComponent information
@@ -488,7 +492,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                 spaceType.validateVector(byteVector);
                 break;
             case BYTE:
-                if (KNNEngine.LUCENE == knnEngine) {
+                if (isUsingLuceneQuery(knnEngine, memoryOptimizedSearchSupported)) {
                     byteVector = new byte[vector.length];
                     for (int i = 0; i < vector.length; i++) {
                         validateByteVectorValue(vector[i], knnVectorFieldType.getVectorDataType());
@@ -512,15 +516,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support filters", knnEngine));
         }
 
-        String indexName = context.index().getName();
-
         if (k != 0) {
             KNNQueryFactory.CreateQueryRequest createQueryRequest = KNNQueryFactory.CreateQueryRequest.builder()
                 .knnEngine(knnEngine)
                 .indexName(indexName)
                 .fieldName(this.fieldName)
                 .vector(getVectorForCreatingQueryRequest(vectorDataType, knnEngine))
-                .byteVector(getVectorForCreatingQueryRequest(vectorDataType, knnEngine, byteVector))
+                .byteVector(getVectorForCreatingQueryRequest(vectorDataType, knnEngine, byteVector, memoryOptimizedSearchSupported))
                 .vectorDataType(vectorDataType)
                 .k(this.k)
                 .methodParameters(this.methodParameters)
@@ -528,6 +530,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                 .context(context)
                 .rescoreContext(processedRescoreContext)
                 .expandNested(expandNested)
+                .memoryOptimizedSearchSupported(memoryOptimizedSearchSupported)
                 .build();
             return KNNQueryFactory.create(createQueryRequest);
         }
@@ -543,6 +546,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                 .methodParameters(this.methodParameters)
                 .filter(this.filter)
                 .context(context)
+                .memoryOptimizedSearchSupported(memoryOptimizedSearchSupported)
                 .build();
             return RNNQueryFactory.create(createQueryRequest);
         }
@@ -572,6 +576,19 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         }
 
         throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not built for ANN search.", this.fieldName));
+    }
+
+    /**
+     * Determine whether the query will be using Lucene query to perform vector search.
+     * Currently, if memory optimized search is enabled, it fallbacks to Lucene and delegate its HNSW graph searcher to perform ANN search
+     * on FAISS index. Hence, if it is true, then we need to use Lucene query.
+     *
+     * @param engine Engine type
+     * @param memoryOptimizedSearchSupported A bool flag whether memory optimized search is enabled.
+     * @return True when it should use Lucene query False otherwise.
+     */
+    private static boolean isUsingLuceneQuery(final KNNEngine engine, final boolean memoryOptimizedSearchSupported) {
+        return memoryOptimizedSearchSupported || engine == KNNEngine.LUCENE;
     }
 
     private ModelMetadata getModelMetadataForField(String modelId) {
@@ -621,8 +638,15 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         return null;
     }
 
-    private byte[] getVectorForCreatingQueryRequest(VectorDataType vectorDataType, KNNEngine knnEngine, byte[] byteVector) {
-        if (VectorDataType.BINARY == vectorDataType || (VectorDataType.BYTE == vectorDataType && KNNEngine.LUCENE == knnEngine)) {
+    private byte[] getVectorForCreatingQueryRequest(
+        VectorDataType vectorDataType,
+        KNNEngine knnEngine,
+        byte[] byteVector,
+        boolean memoryOptimizedSearchSupported
+    ) {
+
+        if (VectorDataType.BINARY == vectorDataType
+            || (VectorDataType.BYTE == vectorDataType && isUsingLuceneQuery(knnEngine, memoryOptimizedSearchSupported))) {
             return byteVector;
         }
         return null;

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -49,8 +49,9 @@ public class KNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery = getFilterQuery(createQueryRequest);
         final Map<String, ?> methodParameters = createQueryRequest.getMethodParameters();
         final RescoreContext rescoreContext = createQueryRequest.getRescoreContext().orElse(null);
-        final KNNEngine knnEngine = createQueryRequest.getKnnEngine();
         final boolean expandNested = createQueryRequest.getExpandNested().orElse(false);
+        final boolean memoryOptimizedSearchSupported = createQueryRequest.isMemoryOptimizedSearchSupported();
+
         BitSetProducer parentFilter = null;
         int shardId = -1;
         if (createQueryRequest.getContext().isPresent()) {
@@ -70,7 +71,8 @@ public class KNNQueryFactory extends BaseQueryFactory {
             );
         }
 
-        if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
+        if (memoryOptimizedSearchSupported == false
+            && KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
             final Query validatedFilterQuery = validateFilterQuerySupport(filterQuery, createQueryRequest.getKnnEngine());
 
             log.debug(

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemoryOptimizedSearchFlagInFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemoryOptimizedSearchFlagInFormatTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.nativeindex;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.KNNSettings.DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
+import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
+
+public class MemoryOptimizedSearchFlagInFormatTests extends KNNTestCase {
+    private static final int DONT_CARE = -1;
+
+    @SneakyThrows
+    public void testWhenNullSettings() {
+        // Create format with null index settings
+        final IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getSettings()).thenReturn(null);
+
+        // Mock MapperService
+        final MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        final NativeEngines990KnnVectorsFormat format = new NativeEngines990KnnVectorsFormat(
+            null,  // Don't care
+            -1,  // Don't care
+            null,  // Don't care
+            Optional.of(mapperService)
+        );
+
+        doTest(format, false);
+    }
+
+    @SneakyThrows
+    public void testWhenSettingsDontHaveTheFlag() {
+        // Mock settings
+        final Settings settings = mock(Settings.class);
+        when(settings.getAsBoolean(any(), any())).thenReturn(false);
+
+        // Mock index settings
+        final IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getSettings()).thenReturn(settings);
+
+        // Create format with null index settings
+        final NativeEngines990KnnVectorsFormat format = new NativeEngines990KnnVectorsFormat(
+            null,  // Don't care
+            -1,  // Don't care
+            null,  // Don't care
+            Optional.empty()
+        );
+
+        doTest(format, false);
+    }
+
+    @SneakyThrows
+    public void testWhenSettingsHaveTheFlag() {
+        // Mock settings
+        final Settings settings = mock(Settings.class);
+        when(settings.getAsBoolean(MEMORY_OPTIMIZED_KNN_SEARCH_MODE, DEFAULT_MEMORY_OPTIMIZED_KNN_SEARCH_MODE)).thenReturn(true);
+
+        // Mock index settings
+        final IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getSettings()).thenReturn(settings);
+
+        // Mock MapperService
+        final MapperService mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        // Create format with null index settings
+        final NativeEngines990KnnVectorsFormat format = new NativeEngines990KnnVectorsFormat(
+            null,  // Don't care
+            -1,  // Don't care
+            null,  // Don't care
+            Optional.of(mapperService)
+        );
+
+        doTest(format, true);
+    }
+
+    @SneakyThrows
+    private void doTest(final NativeEngines990KnnVectorsFormat format, final boolean expected) {
+        // Get field
+        final Field field = NativeEngines990KnnVectorsFormat.class.getDeclaredField("memoryOptimizedSearchEnabled");
+        field.setAccessible(true); // Bypass private access
+
+        // Test whether it is supported
+        final boolean result = (boolean) field.get(format);
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -8,9 +8,12 @@ package org.opensearch.knn.index.query;
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
 import org.apache.lucene.search.FloatVectorSimilarityQuery;
+import org.apache.lucene.search.KnnByteVectorQuery;
+import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.junit.Before;
+import org.mockito.MockedStatic;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterModule;
 import org.opensearch.cluster.service.ClusterService;
@@ -57,8 +60,10 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
 import static org.opensearch.knn.index.engine.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
@@ -609,6 +614,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        when(mockQueryShardContext.index()).thenReturn(new Index("dummy", "dummy"));
         KNNMethodContext knnMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
             SpaceType.COSINESIMIL,
@@ -643,6 +649,78 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(knnMethodContext, 4));
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         expectThrows(IllegalArgumentException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testDoToQuery_whenMemoryOptimizedSearchIsEnabled() {
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(true, true, VectorDataType.FLOAT);
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(true, true, VectorDataType.BYTE);
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(true, false, VectorDataType.FLOAT);
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(true, false, VectorDataType.BYTE);
+
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(false, true, VectorDataType.FLOAT);
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(false, true, VectorDataType.BYTE);
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(false, false, VectorDataType.FLOAT);
+        do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(false, false, VectorDataType.BYTE);
+    }
+
+    private void do_testDoToQuery_whenMemoryOptimizedSearchIsEnabled(
+        boolean memoryOptimizedSearchEnabled,
+        boolean memoryOptimizedSearchSupportedInField,
+        VectorDataType vectorDataType
+    ) {
+
+        try (MockedStatic<KNNSettings> knnSettingsMockedStatic = mockStatic(KNNSettings.class)) {
+            // Index setting mocking
+            knnSettingsMockedStatic.when(() -> KNNSettings.isMemoryOptimizedKnnSearchModeEnabled(any()))
+                .thenReturn(memoryOptimizedSearchEnabled);
+
+            // Query vector
+            float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f };
+            KNNQueryBuilder knnQueryBuilder = new KNNQueryBuilder(FIELD_NAME, queryVector, K, TERM_QUERY);
+
+            // Query shard context
+            Index dummyIndex = new Index("dummy", "dummy");
+            QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+            when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+
+            // Field type
+            KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+            when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+            when(mockKNNVectorField.isMemoryOptimizedSearchSupported()).thenReturn(memoryOptimizedSearchSupportedInField);
+            when(mockKNNVectorField.getVectorDataType()).thenReturn(vectorDataType);
+
+            // Method context
+            MethodComponentContext methodComponentContext = new MethodComponentContext(
+                org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
+                ImmutableMap.of()
+            );
+            final KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, methodComponentContext);
+
+            // KNN mapping config
+            when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(knnMethodContext, 4));
+
+            // Execute `doToQuery`
+            final Query query = knnQueryBuilder.doToQuery(mockQueryShardContext);
+            final boolean isEnabled = memoryOptimizedSearchEnabled && memoryOptimizedSearchSupportedInField;
+            if (isEnabled) {
+                // If memory optimized search is on then, use Lucene query
+                assertFalse(query instanceof NativeEngineKnnVectorQuery);
+                assertTrue(query instanceof LuceneEngineKnnVectorQuery);
+                final LuceneEngineKnnVectorQuery luceneQuery = (LuceneEngineKnnVectorQuery) query;
+
+                if (vectorDataType == VectorDataType.FLOAT) {
+                    assert (luceneQuery.getLuceneQuery() instanceof KnnFloatVectorQuery);
+                    assertEquals(queryVector.length, ((KnnFloatVectorQuery) luceneQuery.getLuceneQuery()).getTargetCopy().length);
+                } else if (vectorDataType == VectorDataType.BYTE) {
+                    assert (luceneQuery.getLuceneQuery() instanceof KnnByteVectorQuery);
+                    assertEquals(queryVector.length, ((KnnByteVectorQuery) luceneQuery.getLuceneQuery()).getTargetCopy().length);
+                }
+            } else {
+                // If memory optimized search is turned off then, use Native query
+                assertTrue(query instanceof NativeEngineKnnVectorQuery);
+                assertFalse(query instanceof LuceneEngineKnnVectorQuery);
+            }
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchSupportSpecTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchSupportSpecTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+public class MemoryOptimizedSearchSupportSpecTests extends KNNTestCase {
+    public void testLuceneEngineIsSupported() {
+        // Lucene + any configurations must be supported.
+        final TestingSpec testingSpec = new TestingSpec(
+            KNNEngine.LUCENE,
+            Arrays.asList(SpaceType.values()),
+            Arrays.asList(VectorDataType.values()),
+            // Don't care MethodComponentContext for Lucene
+            Collections.emptyList()
+        );
+
+        mustSupported(testingSpec);
+    }
+
+    public void testFaissSupportedCases() {
+        // HNSW,float, L2|IP, Flat
+        // HNSW,float, L2|IP, SQ
+        // Note that we do support byte index. And it is VectorDataType.FLOAT for the byte index, not VectorDataType.BYTE.
+        final TestingSpec testingSpec = new TestingSpec(
+            KNNEngine.FAISS,
+            Arrays.asList(SpaceType.L2, SpaceType.INNER_PRODUCT),
+            Arrays.asList(VectorDataType.FLOAT),
+            Arrays.asList(
+                new MethodComponentContext(
+                    METHOD_HNSW,
+                    Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_FLAT, Collections.emptyMap()))
+                ),
+                new MethodComponentContext(
+                    METHOD_HNSW,
+                    Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Collections.emptyMap()))
+                )
+            )
+        );
+
+        mustSupported(testingSpec);
+    }
+
+    public void testFaissUnsupportedCases() {
+        // HNSW,float, L2|IP, Flat
+        // HNSW,float, L2|IP, SQ
+        // Note that we do support byte index. And it is VectorDataType.FLOAT for the byte index, not VectorDataType.BYTE.
+        final TestingSpec testingSpec = new TestingSpec(
+            KNNEngine.FAISS,
+            Arrays.asList(SpaceType.values()),
+            Arrays.asList(VectorDataType.values()),
+            Arrays.asList(
+                new MethodComponentContext(
+                    METHOD_HNSW,
+                    Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext("DUMMY_KEY", Collections.emptyMap()))
+                ),
+                new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, new Object()))
+            )
+        );
+
+        mustNotSupported(testingSpec);
+    }
+
+    public void testBinaryFiassNotSupportedCases() {
+        // HNSW,binary, L2|IP, Flat
+        // HNSW,binary, L2|IP, SQ
+        // Note that we do support byte index. And it is VectorDataType.FLOAT for the byte index, not VectorDataType.BYTE.
+        final TestingSpec testingSpec = new TestingSpec(
+            KNNEngine.FAISS,
+            Arrays.asList(SpaceType.values()),
+            Arrays.asList(VectorDataType.BINARY),
+            Arrays.asList(
+                new MethodComponentContext(
+                    METHOD_HNSW,
+                    Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext("DUMMY_KEY", Collections.emptyMap()))
+                ),
+                new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, new Object()))
+            )
+        );
+
+        mustNotSupported(testingSpec);
+    }
+
+    private void mustSupported(final TestingSpec testingSpec) {
+        doTest(testingSpec, true);
+    }
+
+    private void mustNotSupported(final TestingSpec testingSpec) {
+        doTest(testingSpec, false);
+    }
+
+    private void doTest(final TestingSpec testingSpec, final boolean expected) {
+        for (final SpaceType spaceType : testingSpec.spaceTypes) {
+            for (final VectorDataType vectorDataType : testingSpec.vectorDataTypes) {
+                for (final MethodComponentContext methodComponentContext : testingSpec.methodComponentContexts) {
+                    final Params params = buildParameters(testingSpec.knnEngine, spaceType, vectorDataType, methodComponentContext);
+
+                    final boolean isSupported = MemoryOptimizedSearchSupportSpec.supported(
+                        params.methodContextOpt,
+                        params.quantizationConfig,
+                        params.vectorDataType
+                    );
+
+                    assertEquals(expected, isSupported);
+                }
+            }
+        }
+    }
+
+    private Params buildParameters(
+        final KNNEngine knnEngine,
+        final SpaceType spaceType,
+        final VectorDataType vectorDataType,
+        final MethodComponentContext methodComponentContext
+    ) {
+
+        final Params.ParamsBuilder builder = Params.builder();
+        builder.vectorDataType(vectorDataType);
+
+        final KNNMethodContext methodContext = new KNNMethodContext(knnEngine, spaceType, methodComponentContext);
+        builder.methodContextOpt = Optional.of(methodContext);
+
+        return builder.build();
+    }
+
+    @Builder
+    private static class Params {
+        Optional<KNNMethodContext> methodContextOpt;
+        QuantizationConfig quantizationConfig;
+        VectorDataType vectorDataType;
+    }
+
+    @RequiredArgsConstructor
+    private static class TestingSpec {
+        final KNNEngine knnEngine;
+        final List<SpaceType> spaceTypes;
+        final List<VectorDataType> vectorDataTypes;
+        final List<MethodComponentContext> methodComponentContexts;
+    }
+}


### PR DESCRIPTION
### Description
This PR adds `index.knn.memory_optimized_search` index settings.
Overall, this brings two major changes listed below along with the new setting definition:

1. In codec level, it relies on MapperService to retrieve `index.knn.memory_optimized_search` bool flag. Which then be used to determine whether to initialize partial loading on KNN fields. 
But this is not always working, during recovery MapperService can be null, therefore adding lazy-loading logic in both constructor and search method. For 99%, it will be loaded in the constructor, so it won't affect search p99 latency as by the time the search method is called, MemoryOptimizedSearch should be loaded already.

2. Branching in KNNQueryBuilder
This PR will make each knn field type decide whether memory-optimized-search is supported or not.
Currently only Float HNSW is supported, therefore any binary HNSW graphs will return `false` to indicate the feature is not supported.
If target field in search is supported for memory-optimized-search, control will fallback to Lucene query to proceed vector search. In which, Lucene's HNSW graph searcher will perform KNN search + Radius search on FAISS index.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

RFC: https://github.com/opensearch-project/k-NN/issues/2401

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
