### PR TITLE
[LuceneOnFaiss Part-6] Adding byte index and FP16 index.

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/Faiss8BitsDirectSignedReconstructorFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/Faiss8BitsDirectSignedReconstructorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+/**
+ * This reconstructs a float from bytes encoded in a signed 8-bit, byte-compressed format.
+ *
+ * <a href="https://github.com/facebookresearch/faiss/blob/main/faiss/impl/ScalarQuantizer.cpp#L856">FAISS Decode</a>
+ */
+public class Faiss8BitsDirectSignedReconstructorFactory extends FaissQuantizedValueReconstructorFactory {
+    private Faiss8BitsDirectSignedReconstructor reconstructor;
+
+    public Faiss8BitsDirectSignedReconstructorFactory(int dimension, int numVectorBytes) {
+        super(dimension, numVectorBytes);
+        reconstructor = new Faiss8BitsDirectSignedReconstructor(dimension, numVectorBytes);
+    }
+
+    @Override
+    public FaissQuantizedValueReconstructor getOrCreate() {
+        return reconstructor;
+    }
+
+    private static class Faiss8BitsDirectSignedReconstructor extends FaissQuantizedValueReconstructor {
+        public Faiss8BitsDirectSignedReconstructor(int dimension, int numVectorBytes) {
+            super(dimension, numVectorBytes);
+        }
+
+        @Override
+        public void reconstruct(byte[] bytes, float[] floats) {
+            for (int i = 0; i < dimension; ++i) {
+                // bytes[i] should be interpreted as uint8_t.
+                // Hence, we can't just cast it to int.
+                // Ex: uint8_t x = 200 -> -56 as byte in Java.
+                //     With int casting, then it will become -56 rather than 200.
+                floats[i] = (bytes[i] & 0xFF) - 128;
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissFP16ReconstructorFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissFP16ReconstructorFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+import java.nio.ByteOrder;
+
+/**
+ * This reconstructs a float from FP16 encoded in short (e.g. uint16_t), two bytes compressed format.
+ *
+ * FYI : <a href="https://github.com/facebookresearch/faiss/blob/main/faiss/utils/fp16-inl.h#L89">FAISS Decoding</a>
+ */
+public class FaissFP16ReconstructorFactory extends FaissQuantizedValueReconstructorFactory {
+    private final FaissFP16Reconstructor reconstructor;
+
+    public FaissFP16ReconstructorFactory(int dimension, int numVectorBytes) {
+        super(dimension, numVectorBytes);
+        reconstructor = new FaissFP16Reconstructor(dimension, numVectorBytes);
+    }
+
+    @Override
+    public FaissQuantizedValueReconstructor getOrCreate() {
+        return reconstructor;
+    }
+
+    private static class FaissFP16Reconstructor extends FaissQuantizedValueReconstructor {
+        private final boolean isLittleEndian;
+
+        public FaissFP16Reconstructor(int dimension, int numVectorBytes) {
+            super(dimension, numVectorBytes);
+            // FAISS interprets float16 as uint16_t which ultimately interpreted again as uint8_t* then write into a file.
+            // That being said, when decoding we need to be careful with system endian, otherwise reconstruction results may have distorted
+            // value.
+            isLittleEndian = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+        }
+
+        @Override
+        public void reconstruct(final byte[] bytes, final float[] floats) {
+            if (isLittleEndian) {
+                for (int i = 0, j = 0; i < numVectorBytes; i += 2, ++j) {
+                    final short fp16 = (short) ((bytes[i] & 0xFF) | ((bytes[i + 1] & 0xFF) << 8));
+                    floats[j] = Float.float16ToFloat(fp16);
+                }
+            } else {
+                for (int i = 0, j = 0; i < numVectorBytes; i += 2, ++j) {
+                    final short fp16 = (short) (((bytes[i] & 0xFF) << 8) | (bytes[i + 1] & 0xFF));
+                    floats[j] = Float.float16ToFloat(fp16);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructor.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * This reconstructs quantized bytes to float array.
+ * For example, reconstructing encoded FP16 to FP32.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class FaissQuantizedValueReconstructor {
+    protected final int dimension;
+    protected final int numVectorBytes;
+
+    /**
+     * Reconstruct float32 array from quantized bytes.
+     * @param bytes Quantized byte stream.
+     * @param floats Destination float array buffer to reconstruct.
+     */
+    public abstract void reconstruct(byte[] bytes, float[] floats);
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructorFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructorFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * This factory class creates a reconstructor converting quantized byte values to float array.
+ * For example, reconstructing encoded FP16 to FP32.
+ */
+@RequiredArgsConstructor
+public abstract class FaissQuantizedValueReconstructorFactory {
+    protected final int dimension;
+    protected final int numVectorBytes;
+
+    /**
+     * Create reconstructor or return a singleton instance if possible.
+     *
+     * @return Reconstructor converting quantized bytes to float[]
+     */
+    public abstract FaissQuantizedValueReconstructor getOrCreate();
+}


### PR DESCRIPTION
### Description
In this PR, it added decoding algorithm to decode byte quantization and FP16.
Likewise currently how FAISS is doing at the moment, it will reads bytes then restore them into float[].
This logic for each quantizer type is encapsulated `FaissQuantizedValueReconstructor`.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
