### PR TITLE
[LuceneOnFaiss Part-6] Adding byte index, FP16 index decoding.

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSWIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSWIndex.java
@@ -25,18 +25,11 @@ public class FaissHNSWIndex extends AbstractFaissHNSWIndex {
     // https://github.com/facebookresearch/faiss/blob/15491a1e4f5a513a8684e5b7262ef4ec22eda19d/faiss/IndexHNSW.h#L144C8-L144C19
     public static final String IHNS = "IHNs";
 
-    private VectorEncoding vectorEncoding;
-
     public FaissHNSWIndex(final String indexType) {
         super(indexType, new FaissHNSW());
 
-        // Set encoding
-        if (indexType.equals(IHNF)) {
-            vectorEncoding = VectorEncoding.FLOAT32;
-        } else if (indexType.equals(IHNS)) {
-            vectorEncoding = VectorEncoding.BYTE;
-        } else {
-            throw new IllegalStateException("Unsupported index type: " + indexType + " in " + FaissHNSWIndex.class.getSimpleName());
+        if (indexType.equals(IHNF) == false && indexType.equals(IHNS) == false) {
+            throw new IllegalStateException("Unsupported index type: [" + indexType + "] in " + FaissHNSWIndex.class.getSimpleName());
         }
     }
 
@@ -61,7 +54,7 @@ public class FaissHNSWIndex extends AbstractFaissHNSWIndex {
 
     @Override
     public VectorEncoding getVectorEncoding() {
-        return vectorEncoding;
+        return flatVectors.getVectorEncoding();
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/Faiss8BitsDirectSignedReconstructor.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/Faiss8BitsDirectSignedReconstructor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+public class Faiss8BitsDirectSignedReconstructor extends FaissQuantizedValueReconstructor {
+    public Faiss8BitsDirectSignedReconstructor(int dimension, int oneVectorElementBits) {
+        super(dimension, oneVectorElementBits);
+    }
+
+    @Override
+    public void reconstruct(byte[] quantizedBytes, byte[] bytes) {
+        for (int i = 0; i < dimension; ++i) {
+            // bytes[i] should be interpreted as uint8_t.
+            // Hence, we can't just cast it to int.
+            // Ex: uint8_t x = 200 -> -56 as byte in Java.
+            // With int casting, then it will become -56 rather than 200, which is incorrect conversion.
+            bytes[i] = (byte) ((quantizedBytes[i] & 0xFF) - 128);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissFP16Reconstructor.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissFP16Reconstructor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+import java.nio.ByteOrder;
+
+public class FaissFP16Reconstructor extends FaissQuantizedValueReconstructor {
+    private final boolean isLittleEndian;
+
+    public FaissFP16Reconstructor(int dimension, int oneVectorElementBits) {
+        super(dimension, oneVectorElementBits);
+        // FAISS interprets float16 as uint16_t which ultimately interpreted again as uint8_t* then write into a file.
+        // That being said, when decoding we need to be careful with system endian, otherwise reconstruction results may have distorted
+        // value.
+        isLittleEndian = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+    }
+
+    @Override
+    public void reconstruct(final byte[] quantizedBytes, final float[] floats) {
+        if (isLittleEndian) {
+            for (int i = 0, j = 0; j < dimension; i += 2, ++j) {
+                final short fp16 = (short) ((quantizedBytes[i] & 0xFF) | ((quantizedBytes[i + 1] & 0xFF) << 8));
+                floats[j] = Float.float16ToFloat(fp16);
+            }
+        } else {
+            for (int i = 0, j = 0; j < dimension; i += 2, ++j) {
+                final short fp16 = (short) (((quantizedBytes[i] & 0xFF) << 8) | (quantizedBytes[i + 1] & 0xFF));
+                floats[j] = Float.float16ToFloat(fp16);
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructor.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * This reconstructs quantized bytes to float array.
+ * For example, reconstructing encoded FP16 to FP32.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class FaissQuantizedValueReconstructor {
+    protected final int dimension;
+    protected final int oneVectorElementBits;
+
+    /**
+     * Reconstruct float32 array from quantized bytes.
+     * @param quantizedBytes Quantized byte stream.
+     * @param floats Destination float array buffer to reconstruct.
+     */
+    public void reconstruct(byte[] quantizedBytes, float[] floats) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Reconstruct quantized bytes to byte[].
+     * This reconstruct method may not be applied for all quantization type.
+     * For example, FP16, which encode Flat32 into two bytes, cannot use this method but must use
+     * 'void reconstruct(byte[] quantizedBytes, float[] floats)'
+     * <p>
+     * Length of `bytes` must be greater than or equal to the length of `quantizedBytes`, must not be null.
+     * It is allowed to pass the identical byte[] as parameters.
+     * <p>
+     * Ex:
+     * byte[] quantizedBytes = read(...);
+     * reconstruct(quantizedBytes, quantizedBytes);  -> this decode quantized byte then put it back to the passed byte array.
+     *
+     * @param quantizedBytes Quantized byte stream.
+     * @param bytes Destination float array buffer to reconstruct.
+     */
+    public void reconstruct(byte[] quantizedBytes, byte[] bytes) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructorFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizedValueReconstructorFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+import lombok.experimental.UtilityClass;
+import org.opensearch.knn.memoryoptsearch.faiss.UnsupportedFaissIndexException;
+
+@UtilityClass
+public class FaissQuantizedValueReconstructorFactory {
+    public static FaissQuantizedValueReconstructor create(
+        final FaissQuantizerType quantizerType,
+        final int dimension,
+        final int numOneVectorBits
+    ) {
+
+        if (quantizerType == FaissQuantizerType.QT_8BIT_DIRECT_SIGNED) {
+            return new Faiss8BitsDirectSignedReconstructor(dimension, numOneVectorBits);
+        }
+        if (quantizerType == FaissQuantizerType.QT_FP16) {
+            return new FaissFP16Reconstructor(dimension, numOneVectorBits);
+        }
+
+        throw new UnsupportedFaissIndexException("Unsupported quantizer type: " + quantizerType);
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizerType.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/reconstruct/FaissQuantizerType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.reconstruct;
+
+// Refer to https://github.com/facebookresearch/faiss/blob/main/faiss/impl/ScalarQuantizer.h#L27
+public enum FaissQuantizerType {
+    QT_8BIT,
+    QT_4BIT,
+    QT_8BIT_UNIFORM,
+    QT_4BIT_UNIFORM,
+    QT_FP16,
+    QT_8BIT_DIRECT,
+    QT_6BIT,
+    QT_BF16,
+    QT_8BIT_DIRECT_SIGNED
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -6,12 +6,14 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
@@ -21,6 +23,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.FixedBitSet;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
@@ -48,6 +51,7 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,6 +62,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -77,52 +82,105 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     private static final String TARGET_FIELD = "target_field";
     private static final String FLOAT_HNSW_INDEX_DESCRIPTION = "HNSW16,Flat";
     private static final String BYTE_HNSW_INDEX_DESCRIPTION = "HNSW16,SQ8_direct_signed";
+    private static final String FLOAT16_HNSW_INDEX_DESCRIPTION = "HNSW8,SQfp16";
     private static final int DIMENSIONS = 128;
-    private static final int MIN_VALUE = -1000000;
-    private static final int MAX_VALUE = 1000000;
-    private static final int TOTAL_NUM_DOCS_IN_SEGMENT = 1000;
+    private static final int TOTAL_NUM_DOCS_IN_SEGMENT = 300;
     private static final int NUM_CHILD_DOCS = 5;
+    private static final int TOP_K = 30;
+    private static final float NO_FILTERING = Float.NaN;
 
     public void testFloatIndexType() {
+        final TestingSpec testingSpec = new TestingSpec(
+            VectorDataType.FLOAT,
+            VectorDataType.FLOAT,
+            FLOAT_HNSW_INDEX_DESCRIPTION,
+            -1000000,
+            1000000
+        );
+
         // Test a dense case where all docs have KNN field.
-        doSearchTest(VectorDataType.FLOAT, IndexingType.DENSE);
+        doSearchTest(testingSpec, IndexingType.DENSE);
 
         // Test a sparse case where some docs don't have KNN field
-        doSearchTest(VectorDataType.FLOAT, IndexingType.SPARSE);
+        doSearchTest(testingSpec, IndexingType.SPARSE);
 
         // Test a sparse nested case where some parent docs don't have KNN field
-        doSearchTest(VectorDataType.FLOAT, IndexingType.SPARSE_NESTED);
+        doSearchTest(testingSpec, IndexingType.SPARSE_NESTED);
 
         // Test a dense nested case where ALL parent docs have KNN field.
-        doSearchTest(VectorDataType.FLOAT, IndexingType.DENSE_NESTED);
+        doSearchTest(testingSpec, IndexingType.DENSE_NESTED);
     }
 
     public void testByteIndexType() {
-        // TODO(KDY) : Will be covered in part-6 (FP16 support)
-        // doSearchTest(VectorDataType.BYTE, IndexingType.DENSE);
-        // doSearchTest(VectorDataType.BYTE, IndexingType.SPARSE);
-        // doSearchTest(VectorDataType.BYTE, IndexingType.SPARSE_NESTED);
-        // doSearchTest(VectorDataType.BYTE, IndexingType.DENSE_NESTED);
+        final TestingSpec testingSpec = new TestingSpec(VectorDataType.FLOAT, VectorDataType.BYTE, BYTE_HNSW_INDEX_DESCRIPTION, -128, 127) {
+            @Override
+            public float trimValue(float value) {
+                return (byte) value;
+            }
+        };
+
+        // Test a dense case where all docs have KNN field.
+        doSearchTest(testingSpec, IndexingType.DENSE);
+
+        // Test a sparse case where some docs don't have KNN field
+        doSearchTest(testingSpec, IndexingType.SPARSE);
+
+        // Test a sparse nested case where some parent docs don't have KNN field
+        doSearchTest(testingSpec, IndexingType.SPARSE_NESTED);
+
+        // Test a dense nested case where ALL parent docs have KNN field.
+        doSearchTest(testingSpec, IndexingType.DENSE_NESTED);
+    }
+
+    public void testFloat16IndexType() {
+        final TestingSpec testingSpec = new TestingSpec(
+            VectorDataType.FLOAT,
+            VectorDataType.FLOAT,
+            FLOAT16_HNSW_INDEX_DESCRIPTION,
+            -65504,
+            65504
+        );
+
+        // Test a dense case where all docs have KNN field.
+        doSearchTest(testingSpec, IndexingType.DENSE);
+
+        // Test a sparse case where some docs don't have KNN field
+        doSearchTest(testingSpec, IndexingType.SPARSE);
+
+        // Test a sparse nested case where some parent docs don't have KNN field
+        doSearchTest(testingSpec, IndexingType.SPARSE_NESTED);
+
+        // Test a dense nested case where ALL parent docs have KNN field.
+        doSearchTest(testingSpec, IndexingType.DENSE_NESTED);
     }
 
     @SneakyThrows
-    private void doSearchTest(final VectorDataType dataType, final IndexingType indexingType) {
-        doSearchTest(dataType, indexingType, false, false);
-        doSearchTest(dataType, indexingType, false, true);
-        doSearchTest(dataType, indexingType, true, false);
-        doSearchTest(dataType, indexingType, true, false);
+    private void doSearchTest(final TestingSpec testingSpec, final IndexingType indexingType) {
+        for (final SpaceType spaceType : Arrays.asList(SpaceType.L2, SpaceType.INNER_PRODUCT)) {
+            doSearchTest(testingSpec, indexingType, spaceType, false, NO_FILTERING);
+            doSearchTest(testingSpec, indexingType, spaceType, false, 0.8f);
+
+            doSearchTest(testingSpec, indexingType, spaceType, false, NO_FILTERING);
+            doSearchTest(testingSpec, indexingType, spaceType, false, 0.8f);
+
+            doSearchTest(testingSpec, indexingType, spaceType, true, NO_FILTERING);
+            doSearchTest(testingSpec, indexingType, spaceType, true, 0.8f);
+
+            doSearchTest(testingSpec, indexingType, spaceType, true, NO_FILTERING);
+            doSearchTest(testingSpec, indexingType, spaceType, true, 0.8f);
+        }
     }
 
     @SneakyThrows
     private void doSearchTest(
-        final VectorDataType dataType,
+        final TestingSpec testingSpec,
         final IndexingType indexingType,
+        final SpaceType spaceType,
         final boolean doExhaustiveSearch,
-        final boolean applyFiltering
+        final float filteringRatio
     ) {
         // Build FAISS index
-        final String indexDesc = dataType == VectorDataType.FLOAT ? FLOAT_HNSW_INDEX_DESCRIPTION : BYTE_HNSW_INDEX_DESCRIPTION;
-        final BuildInfo buildInfo = buildFaissIndex(dataType, indexDesc, TOTAL_NUM_DOCS_IN_SEGMENT, IndexingType.DENSE);
+        final BuildInfo buildInfo = buildFaissIndex(testingSpec, TOTAL_NUM_DOCS_IN_SEGMENT, indexingType, spaceType);
 
         // Load FAISS index via JNI
         long indexPointer = -1;
@@ -136,9 +194,9 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
 
         // Make filtered ids
         long[] filteredIds = null;
-        if (applyFiltering) {
-            // Take only 80%. e.g. filtering 20% out
-            final List<Integer> filteredDocIds = takePortions(buildInfo.documentIds, 0.8);
+        if (Float.compare(filteringRatio, NO_FILTERING) != 0) {
+            // Take only X%. Ex: Keep 80% of docs = cut off 20% of docs.
+            final List<Integer> filteredDocIds = takePortions(buildInfo.documentIds, filteringRatio);
             filteredIds = filteredDocIds.stream().mapToLong(Integer::longValue).toArray();
         }
 
@@ -148,17 +206,17 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
             parentIds = extractParentIds(buildInfo.documentIds);
         }
 
-        // Take top-20 results
-        final int k = 20;
+        // Take top-k results
+        final int k = TOP_K;
 
         // Start search via JNI
         final Object queryForVectorReader;
         final float[] query;
         final byte[] byteQuery;
-        if (dataType == VectorDataType.FLOAT) {
-            queryForVectorReader = query = generateOneSingleFloatVector();
-        } else if (dataType == VectorDataType.BYTE) {
-            queryForVectorReader = byteQuery = generateOneSingleByteVector();
+        if (testingSpec.searchDataType == VectorDataType.FLOAT) {
+            queryForVectorReader = query = generateOneSingleFloatVector(testingSpec);
+        } else if (testingSpec.searchDataType == VectorDataType.BYTE) {
+            queryForVectorReader = byteQuery = generateOneSingleByteVector(testingSpec);
             query = new float[byteQuery.length];
             for (int i = 0; i < byteQuery.length; i++) {
                 query[i] = byteQuery[i];
@@ -178,35 +236,107 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
             parentIds
         );
 
+        JNIService.free(indexPointer, KNNEngine.FAISS);
+
         // Search via VectorReader
         final KNNQueryResult[] resultsFromVectorReader = doSearchViaVectorReader(
             buildInfo,
             queryForVectorReader,
-            dataType,
+            testingSpec.searchDataType,
             filteredIds,
             k,
             doExhaustiveSearch
         );
 
         // Validate results
-        validateResults(resultsFromFaiss, resultsFromVectorReader);
+        validateResults(
+            buildInfo,
+            query,
+            filteredIds,
+            testingSpec,
+            resultsFromFaiss,
+            resultsFromVectorReader,
+            spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction()
+        );
     }
 
-    private void validateResults(KNNQueryResult[] resultsFromFaiss, KNNQueryResult[] resultsFromVectorReader) {
-        Set<Integer> expectedDocIds = new HashSet<>();
+    private Set<Integer> getAnswerSet(
+        List<Integer> documentIds,
+        final List<float[]> vectors,
+        final float[] query,
+        long[] filteredIds,
+        final VectorSimilarityFunction similarityFunction
+    ) {
+
+        final Set<Integer> filteredIdSet;
+        if (filteredIds != null) {
+            filteredIdSet = LongStream.of(filteredIds).mapToInt(l -> (int) l).boxed().collect(Collectors.toSet());
+        } else {
+            filteredIdSet = null;
+        }
+
+        // Create a new one
+        documentIds = new ArrayList<>(documentIds);
+
+        // Sort indices by similarity
+        documentIds.sort(
+            (docId1, docId2) -> -Float.compare(
+                similarityFunction.compare(vectors.get(docId1), query),
+                similarityFunction.compare(vectors.get(docId2), query)
+            )
+        );
+
+        // Apply filtering and collect top K
+        final Set<Integer> answerSet = new HashSet<>();
+        int i = 0;
+        while (answerSet.size() < TOP_K && i < documentIds.size()) {
+            if (filteredIdSet == null || filteredIdSet.contains(documentIds.get(i))) {
+                answerSet.add(documentIds.get(i));
+            }
+            ++i;
+        }
+
+        return answerSet;
+    }
+
+    private void validateResults(
+        BuildInfo buildInfo,
+        Object query,
+        long[] filteredIds,
+        TestingSpec testingSpec,
+        KNNQueryResult[] resultsFromFaiss,
+        KNNQueryResult[] resultsFromVectorReader,
+        VectorSimilarityFunction similarityFunction
+    ) {
+        final Set<Integer> answerDocIds = getAnswerSet(
+            buildInfo.documentIds,
+            buildInfo.floatVectors,
+            (float[]) query,
+            filteredIds,
+            similarityFunction
+        );
+
+        final Set<Integer> expectedDocIds = new HashSet<>();
         for (int i = 0; i < resultsFromFaiss.length; ++i) {
             expectedDocIds.add(resultsFromFaiss[i].getId());
         }
+        int answerMatchCount = 0;
         int matchCount = 0;
         for (int i = 0; i < resultsFromFaiss.length; ++i) {
             if (expectedDocIds.contains(resultsFromVectorReader[i].getId())) {
                 ++matchCount;
             }
+            if (answerDocIds.contains(resultsFromVectorReader[i].getId())) {
+                ++answerMatchCount;
+            }
         }
 
         final float matchRatio = ((float) matchCount) / resultsFromFaiss.length;
-        // Should match at least 80% with the one obtained from FAISS
-        assertTrue(matchRatio >= 0.8);
+        final float recall = ((float) answerMatchCount) / TOP_K;
+
+        // It can happen that match ratio between FAISS and MemOptimizedSearch is lower than 80%, but if it happens with a recall lower than
+        // 0.8 indicates something's off.
+        assertFalse(matchRatio < 0.8 && recall < 0.8);
     }
 
     @SneakyThrows
@@ -233,18 +363,20 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         when(segmentInfo.getId()).thenReturn("LuceneOnFaiss".getBytes());
 
         // Prepare collector and bits
+        // buildInfo.documentIds.size() + 1 -> Will force it to do exhaustive search.
+        // buildInfo.documentIds.size() - 1 -> Will maximize search space, this is equivalent to set efSearch = len(N) - 1
         final int efSearch = exhaustiveSearch ? buildInfo.documentIds.size() + 1 : buildInfo.documentIds.size() - 1;
         final KnnCollector knnCollector = new TopKnnCollector(efSearch, Integer.MAX_VALUE);
         FixedBitSet acceptDocs = null;
         if (filteredIds != null) {
-            acceptDocs = new FixedBitSet((int) filteredIds[filteredIds.length - 1] + 10);
+            acceptDocs = new FixedBitSet(buildInfo.documentIds.getLast() + 10);
             for (long filteredId : filteredIds) {
                 acceptDocs.set((int) filteredId);
             }
         }
 
         // Make SegmentReadState and do search
-        try (final Directory directory = newFSDirectory(buildInfo.tempDirPath)) {
+        try (final Directory directory = new MMapDirectory(buildInfo.tempDirPath)) {
             final SegmentReadState readState = new SegmentReadState(directory, segmentInfo, fieldInfos, IOContext.DEFAULT);
             try (
                 NativeEngines990KnnVectorsReader vectorsReader = new NativeEngines990KnnVectorsReader(
@@ -275,10 +407,10 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
 
     @SneakyThrows
     private BuildInfo buildFaissIndex(
-        final VectorDataType dataType,
-        final String indexDescription,
+        final TestingSpec testingSpec,
         final int numberOfTotalDocsInSegment,
-        final IndexingType indexingType
+        final IndexingType indexingType,
+        final SpaceType spaceType
     ) {
         final Path tempDir = createTempDir(UUID.randomUUID().toString());
         final String fileName = UUID.randomUUID() + "_" + TARGET_FIELD + ".faiss";
@@ -289,21 +421,21 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
                 final BuildIndexParams.BuildIndexParamsBuilder builder = BuildIndexParams.builder();
                 builder.fieldName(TARGET_FIELD)
                     .knnEngine(KNNEngine.FAISS)
-                    .vectorDataType(dataType)
+                    .vectorDataType(testingSpec.indexingDataType)
                     .indexOutputWithBuffer(new IndexOutputWithBuffer(indexOutput));
 
                 // Set up parameters
                 final Map<String, Object> parameters = new HashMap<>();
                 parameters.put(NAME, METHOD_HNSW);
-                parameters.put(VECTOR_DATA_TYPE_FIELD, dataType.getValue());
-                parameters.put(SPACE_TYPE, SpaceType.L2.getValue());
+                parameters.put(VECTOR_DATA_TYPE_FIELD, testingSpec.indexingDataType.getValue());
+                parameters.put(SPACE_TYPE, spaceType.getValue());
                 parameters.put(INDEX_THREAD_QTY, 1);
-                parameters.put(INDEX_DESCRIPTION_PARAMETER, indexDescription);
+                parameters.put(INDEX_DESCRIPTION_PARAMETER, testingSpec.indexDescription);
 
                 final Map<String, Object> methodParameters = new HashMap<>();
                 parameters.put(PARAMETERS, methodParameters);
-                methodParameters.put(METHOD_PARAMETER_EF_SEARCH, 100);
-                methodParameters.put(METHOD_PARAMETER_EF_CONSTRUCTION, 100);
+                methodParameters.put(METHOD_PARAMETER_EF_SEARCH, numberOfTotalDocsInSegment - 1);
+                methodParameters.put(METHOD_PARAMETER_EF_CONSTRUCTION, numberOfTotalDocsInSegment);
                 methodParameters.put(METHOD_ENCODER_PARAMETER, Map.of(NAME, ENCODER_FLAT));
                 builder.parameters(parameters);
 
@@ -312,11 +444,11 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
                 buildInfo = new BuildInfo(tempDir, fileName, parameters, documentIds);
                 builder.totalLiveDocs(documentIds.size());
 
-                if (dataType == VectorDataType.BYTE) {
-                    final KNNVectorValues<byte[]> byteVectorValues = createKNNByteVectorValues(documentIds);
+                if (testingSpec.indexingDataType == VectorDataType.BYTE) {
+                    final KNNVectorValues<byte[]> byteVectorValues = createKNNByteVectorValues(buildInfo, testingSpec);
                     builder.knnVectorValuesSupplier(() -> byteVectorValues);
-                } else if (dataType == VectorDataType.FLOAT) {
-                    final KNNVectorValues<float[]> floatVectorValues = createKNNFloatVectorValues(documentIds);
+                } else if (testingSpec.indexingDataType == VectorDataType.FLOAT) {
+                    final KNNVectorValues<float[]> floatVectorValues = createKNNFloatVectorValues(buildInfo, testingSpec);
                     builder.knnVectorValuesSupplier(() -> floatVectorValues);
                 } else {
                     throw new AssertionError();
@@ -332,8 +464,10 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    private KNNByteVectorValues createKNNByteVectorValues(final List<Integer> documentIds) {
-        final List<byte[]> vectors = generateRandomByteVectors(documentIds);
+    private KNNByteVectorValues createKNNByteVectorValues(final BuildInfo buildInfo, final TestingSpec testingSpec) {
+        final List<Integer> documentIds = buildInfo.documentIds;
+        final List<byte[]> vectors = generateRandomByteVectors(documentIds, testingSpec);
+        buildInfo.byteVectors = vectors;
 
         final KNNVectorValuesIterator iterator = new KNNVectorValuesIterator() {
             private int index = -1;
@@ -391,8 +525,10 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    private static KNNFloatVectorValues createKNNFloatVectorValues(final List<Integer> documentIds) {
-        final List<float[]> vectors = generateRandomFloatVectors(documentIds);
+    private static KNNFloatVectorValues createKNNFloatVectorValues(final BuildInfo buildInfo, final TestingSpec testingSpec) {
+        final List<Integer> documentIds = buildInfo.documentIds;
+        final List<float[]> vectors = generateRandomFloatVectors(documentIds, testingSpec);
+        buildInfo.floatVectors = vectors;
 
         final KNNVectorValuesIterator iterator = new KNNVectorValuesIterator() {
             private int index = -1;
@@ -449,23 +585,26 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         return constructor.newInstance(iterator);
     }
 
-    private static float[] generateOneSingleFloatVector() {
+    private static float[] generateOneSingleFloatVector(final TestingSpec testingSpec) {
         final float[] vector = new float[DIMENSIONS];
         for (int k = 0; k < DIMENSIONS; k++) {
-            vector[k] = MIN_VALUE + ThreadLocalRandom.current().nextFloat() * (MAX_VALUE - MIN_VALUE);
+            final float value = testingSpec.minValue + ThreadLocalRandom.current().nextFloat() * (testingSpec.maxValue
+                - testingSpec.minValue);
+            vector[k] = testingSpec.trimValue(value);
         }
         return vector;
     }
 
-    private static byte[] generateOneSingleByteVector() {
+    private static byte[] generateOneSingleByteVector(final TestingSpec testingSpec) {
         final byte[] vector = new byte[DIMENSIONS];
         for (int k = 0; k < DIMENSIONS; k++) {
-            vector[k] = (byte) (MIN_VALUE + ThreadLocalRandom.current().nextInt(MAX_VALUE - MIN_VALUE + 1));
+            vector[k] = (byte) (testingSpec.minValue + ThreadLocalRandom.current()
+                .nextInt((int) (testingSpec.maxValue - testingSpec.minValue + 1)));
         }
         return vector;
     }
 
-    private static List<float[]> generateRandomFloatVectors(List<Integer> docIds) {
+    private static List<float[]> generateRandomFloatVectors(final List<Integer> docIds, final TestingSpec testingSpec) {
         final List<float[]> vectors = new ArrayList<>();
         for (int i = 0, j = 0; j < docIds.size(); j++) {
             // Add null vectors.
@@ -476,14 +615,14 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
                 ++i;
             }
 
-            vectors.add(generateOneSingleFloatVector());
+            vectors.add(generateOneSingleFloatVector(testingSpec));
             ++i;
         }
 
         return vectors;
     }
 
-    private List<byte[]> generateRandomByteVectors(List<Integer> docIds) {
+    private List<byte[]> generateRandomByteVectors(final List<Integer> docIds, final TestingSpec testingSpec) {
         final List<byte[]> vectors = new ArrayList<>();
 
         for (int i = 0, j = 0; j < docIds.size(); j++) {
@@ -495,7 +634,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
                 ++i;
             }
 
-            vectors.add(generateOneSingleByteVector());
+            vectors.add(generateOneSingleByteVector(testingSpec));
             ++i;
         }
 
@@ -585,14 +724,6 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         }
     }
 
-    @AllArgsConstructor
-    static class BuildInfo {
-        Path tempDirPath;
-        String faissIndexFile;
-        Map<String, Object> parameters;
-        List<Integer> documentIds;
-    }
-
     private static List<Integer> takePortions(final List<Integer> sequence, final double percentage) {
         List<Integer> newSequence = new ArrayList<>(sequence);
         Collections.shuffle(newSequence);
@@ -603,12 +734,15 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
 
     private static int[] extractParentIds(final List<Integer> childDocIds) {
         // Reconstruct parent ids.
-        // e.g. with [0,1,2,3,4, 6,7,8, 9,10,11,12,13], parent ids=[5, 14] with 5 child docs
+        // e.g. with [0,1,2,3,4, 6,7,8,9,10 22,23,24,25,26], parent ids=[5, 14, 27] with 5 child docs
         final List<Integer> parentIds = new ArrayList<>();
-        for (int i = 0, j = 0; i < childDocIds.size(); ++i, ++j) {
+        for (int i = 0, j = childDocIds.get(0); i < childDocIds.size();) {
             if (childDocIds.get(i) != j) {
                 parentIds.add(j);
-                j = i;
+                j = childDocIds.get(i);
+            } else {
+                ++i;
+                ++j;
             }
         }
 
@@ -617,5 +751,29 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         // Ex: With [, ..., 100, 101, 102, 103, 104], parent id would be 105 (e.g. having 5 child docs)
         parentIds.add(childDocIds.get(childDocIds.size() - 1) + 1);
         return parentIds.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    @RequiredArgsConstructor
+    static class BuildInfo {
+        final Path tempDirPath;
+        final String faissIndexFile;
+        final Map<String, Object> parameters;
+        final List<Integer> documentIds;
+        List<float[]> floatVectors = null;
+        List<byte[]> byteVectors = null;
+    }
+
+    @RequiredArgsConstructor
+    @AllArgsConstructor
+    private static class TestingSpec {
+        public final VectorDataType indexingDataType;
+        public final VectorDataType searchDataType;
+        public final String indexDescription;
+        public float minValue;
+        public float maxValue;
+
+        public float trimValue(final float value) {
+            return value;
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/QuantizedValueReconstructorTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/QuantizedValueReconstructorTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueReconstructor;
+import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueReconstructorFactory;
+import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizerType;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class QuantizedValueReconstructorTests extends KNNTestCase {
+    public void testReconstruct8BitDirectSigned() {
+        // Index config
+        final int dimension = 128;
+        byte[] encodedBytes = new byte[dimension];
+        float[] answerValues = new float[dimension];
+        for (int i = 0; i < dimension; ++i) {
+            final int value = ThreadLocalRandom.current().nextInt(-127, 128);
+            answerValues[i] = value;
+            // See : https://github.com/facebookresearch/faiss/blob/main/faiss/impl/ScalarQuantizer.cpp#L844
+            final byte encodedByte = (byte) (value + 128);
+            encodedBytes[i] = encodedByte;
+        }
+
+        // Decoding bytes
+        final FaissQuantizedValueReconstructor reconstructor = FaissQuantizedValueReconstructorFactory.create(
+            FaissQuantizerType.QT_8BIT_DIRECT_SIGNED,
+            dimension,
+            Byte.SIZE
+        );
+        final byte[] buffer = new byte[dimension];
+        reconstructor.reconstruct(encodedBytes, buffer);
+        final float[] floatBuffer = new float[dimension];
+        for (int i = 0; i < floatBuffer.length; i++) {
+            floatBuffer[i] = buffer[i]; // Direct cast
+        }
+
+        // Validate results
+        assertArrayEquals(answerValues, floatBuffer, 1e-6f);
+    }
+
+    public void testReconstructFP16() {
+        // Index config
+        final int dimension = 128;
+        final int numVectorBytes = 2 * dimension;
+
+        // Encode a vector
+        final ByteBuffer buffer = ByteBuffer.allocate(dimension * Short.BYTES);
+        buffer.order(ByteOrder.nativeOrder());
+
+        // FP16 encode a vector
+        final float[] vector = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            final float value = ThreadLocalRandom.current().nextFloat();
+            final short fp16Value = Float.floatToFloat16(value);
+            buffer.putShort(fp16Value);
+            vector[i] = Float.float16ToFloat(fp16Value);
+        }
+        final byte[] fp16EncodedBytes = buffer.array();
+
+        // Restore encoded bytes
+        final FaissQuantizedValueReconstructor reconstructor = FaissQuantizedValueReconstructorFactory.create(
+            FaissQuantizerType.QT_FP16,
+            dimension,
+            Float.SIZE / 2
+        );
+        float[] restoredVector = new float[dimension];
+        reconstructor.reconstruct(fp16EncodedBytes, restoredVector);
+
+        // Validate results
+        assertArrayEquals(vector, restoredVector, 1e-6f);
+    }
+}


### PR DESCRIPTION
### Description
In this PR, it added decoding algorithm to decode byte quantization and FP16.
Likewise currently how FAISS is doing at the moment, it will reads bytes then restore them into float[].
This logic for each quantizer type is encapsulated `FaissQuantizedValueReconstructor`.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
