### PR TITLE
Add checks to block derived source feature

### DIFF
--- a/src/main/java/org/opensearch/knn/index/DerivedKnnByteVectorField.java
+++ b/src/main/java/org/opensearch/knn/index/DerivedKnnByteVectorField.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import lombok.Getter;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+
+/**
+ * Wrapper around {@link KnnByteVectorField} so that {@link org.opensearch.knn.index.codec.derivedsource.DerivedSourceIndexOperationListener}
+ * can understand if it needs to modify the source in the translog
+ */
+
+public class DerivedKnnByteVectorField extends KnnByteVectorField {
+
+    @Getter
+    private final boolean isDerivedEnabled;
+
+    /**
+     *
+     * @param name Name of the field
+     * @param vector vector for the field
+     * @param isDerivedEnabled boolean to indicate if derived source is enabled
+     */
+    public DerivedKnnByteVectorField(String name, byte[] vector, FieldType fieldType, boolean isDerivedEnabled) {
+        super(name, vector, fieldType);
+        this.isDerivedEnabled = isDerivedEnabled;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/DerivedKnnFloatVectorField.java
+++ b/src/main/java/org/opensearch/knn/index/DerivedKnnFloatVectorField.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import lombok.Getter;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+
+/**
+ * Wrapper around {@link KnnByteVectorField} so that {@link org.opensearch.knn.index.codec.derivedsource.DerivedSourceIndexOperationListener}
+ * can understand if it needs to modify the source in the translog
+ */
+public class DerivedKnnFloatVectorField extends KnnFloatVectorField {
+
+    @Getter
+    private final boolean isDerivedEnabled;
+
+    /**
+     *
+     * @param name Name of the field
+     * @param vector vector for the field
+     * @param isDerivedEnabled boolean to indicate if derived source is enabled
+     */
+    public DerivedKnnFloatVectorField(String name, float[] vector, boolean isDerivedEnabled) {
+        super(name, vector);
+        this.isDerivedEnabled = isDerivedEnabled;
+    }
+
+    /**
+     *
+     * @param name Name of the field
+     * @param vector vector for the field
+     * @param fieldType FieldType of the field
+     * @param isDerivedEnabled boolean to indicate if derived source is enabled
+     */
+    public DerivedKnnFloatVectorField(String name, float[] vector, FieldType fieldType, boolean isDerivedEnabled) {
+        super(name, vector, fieldType);
+        this.isDerivedEnabled = isDerivedEnabled;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldMapper.java
@@ -15,10 +15,10 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.document.KnnByteVectorField;
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.opensearch.Version;
 import org.opensearch.common.Explicit;
+import org.opensearch.knn.index.DerivedKnnByteVectorField;
+import org.opensearch.knn.index.DerivedKnnFloatVectorField;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
@@ -124,9 +124,9 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
     }
 
     @Override
-    protected List<Field> getFieldsForFloatVector(final float[] array) {
+    protected List<Field> getFieldsForFloatVector(final float[] array, boolean isDerivedSourceEnabled) {
         final List<Field> fieldsToBeAdded = new ArrayList<>();
-        fieldsToBeAdded.add(new KnnFloatVectorField(name(), array, fieldType));
+        fieldsToBeAdded.add(new DerivedKnnFloatVectorField(name(), array, fieldType, isDerivedSourceEnabled));
 
         if (hasDocValues && vectorFieldType != null) {
             fieldsToBeAdded.add(new VectorField(name(), array, vectorFieldType));
@@ -139,9 +139,9 @@ public class LuceneFieldMapper extends KNNVectorFieldMapper {
     }
 
     @Override
-    protected List<Field> getFieldsForByteVector(final byte[] array) {
+    protected List<Field> getFieldsForByteVector(final byte[] array, boolean isDerivedSourceEnabled) {
         final List<Field> fieldsToBeAdded = new ArrayList<>();
-        fieldsToBeAdded.add(new KnnByteVectorField(name(), array, fieldType));
+        fieldsToBeAdded.add(new DerivedKnnByteVectorField(name(), array, fieldType, isDerivedSourceEnabled));
 
         if (hasDocValues && vectorFieldType != null) {
             fieldsToBeAdded.add(new VectorField(name(), array, vectorFieldType));

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -12,6 +12,8 @@ import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.common.ValidationException;
+import org.opensearch.index.mapper.FieldMapper;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.KNNSettings;
@@ -19,6 +21,7 @@ import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.query.request.MethodParameter;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.indices.ModelDao;
@@ -421,5 +424,34 @@ public class IndexUtil {
         return parameters.getOrDefault(VECTOR_DATA_TYPE_FIELD, VectorDataType.DEFAULT.getValue())
             .toString()
             .equals(VectorDataType.BYTE.getValue());
+    }
+
+    public static boolean isDerivedEnabledForIndex(MapperService mapperService) {
+        if (mapperService == null) {
+            return false;
+        }
+
+        if (mapperService.documentMapper().sourceMapper().enabled() == false) {
+            return false;
+        }
+
+        if (KNNSettings.isKNNDerivedSourceEnabled(mapperService.getIndexSettings().getSettings()) == false) {
+            return false;
+        }
+
+        // We do not support derived fields for seg rep with node to node replication enabled. This is because of
+        // special handling of source during indexing on segrep replicas with respect to the translog.
+        if (mapperService.getIndexSettings().isSegRepLocalEnabled()) {
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean isDerivedEnabledForField(KNNVectorFieldType knnVectorFieldType, MapperService mapperService) {
+        // Skip copy to fields
+        if (mapperService.documentMapper().mappers().getMapper(knnVectorFieldType.name()) instanceof FieldMapper mapper) {
+            return mapper.copyTo() == null || mapper.copyTo().copyToFields() == null || mapper.copyTo().copyToFields().isEmpty() != false;
+        }
+        return true;
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceIndexOperationListenerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceIndexOperationListenerTests.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.codec.derivedsource;
 
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.Term;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -19,6 +18,7 @@ import org.opensearch.index.engine.Engine;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.DerivedKnnFloatVectorField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,7 @@ public class DerivedSourceIndexOperationListenerTests extends KNNTestCase {
         BytesReference originalSource = bStream.bytes();
 
         ParseContext.Document document = new ParseContext.Document();
-        document.add(new KnnFloatVectorField(fieldName, backendVector));
+        document.add(new DerivedKnnFloatVectorField(fieldName, backendVector, true));
 
         Engine.Index operation = new Engine.Index(
             new Term("test-iud"),

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1203,12 +1203,15 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     .build();
                 final KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, spaceType, methodComponentContext);
 
+                IndexSettings indexSettingsMock = mock(IndexSettings.class);
+                when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
                 ParseContext.Document document = new ParseContext.Document();
                 ContentPath contentPath = new ContentPath();
                 ParseContext parseContext = mock(ParseContext.class);
                 when(parseContext.doc()).thenReturn(document);
                 when(parseContext.path()).thenReturn(contentPath);
                 when(parseContext.parser()).thenReturn(createXContentParser(dataType));
+                when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(true);
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(true);
@@ -1263,6 +1266,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 when(parseContext.doc()).thenReturn(document);
                 when(parseContext.path()).thenReturn(contentPath);
                 when(parseContext.parser()).thenReturn(createXContentParser(dataType));
+                when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
                 methodFieldMapper = MethodFieldMapper.createFieldMapper(
                     TEST_FIELD_NAME,
                     TEST_FIELD_NAME,
@@ -1315,10 +1319,14 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
                 ParseContext.Document document = new ParseContext.Document();
                 ContentPath contentPath = new ContentPath();
+                IndexSettings indexSettingsMock = mock(IndexSettings.class);
+                when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
+
                 ParseContext parseContext = mock(ParseContext.class);
                 when(parseContext.doc()).thenReturn(document);
                 when(parseContext.path()).thenReturn(contentPath);
                 when(parseContext.parser()).thenReturn(createXContentParser(dataType));
+                when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(true);
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(true);
@@ -1376,6 +1384,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 when(parseContext.doc()).thenReturn(document);
                 when(parseContext.path()).thenReturn(contentPath);
                 when(parseContext.parser()).thenReturn(createXContentParser(dataType));
+                when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
                 modelFieldMapper = ModelFieldMapper.createFieldMapper(
                     TEST_FIELD_NAME,
                     TEST_FIELD_NAME,
@@ -1406,13 +1415,15 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         // Create a lucene field mapper that creates a binary doc values field as well as KnnVectorField
         LuceneFieldMapper.CreateLuceneFieldMapperInput.CreateLuceneFieldMapperInputBuilder inputBuilder =
             createLuceneFieldMapperInputBuilder();
-
+        IndexSettings indexSettingsMock = mock(IndexSettings.class);
+        when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
         ParseContext.Document document = new ParseContext.Document();
         ContentPath contentPath = new ContentPath();
         ParseContext parseContext = mock(ParseContext.class);
         when(parseContext.doc()).thenReturn(document);
         when(parseContext.path()).thenReturn(contentPath);
         when(parseContext.parser()).thenReturn(createXContentParser(VectorDataType.FLOAT));
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
         KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
             .vectorDataType(VectorDataType.FLOAT)
             .versionCreated(CURRENT)
@@ -1469,6 +1480,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         when(parseContext.doc()).thenReturn(document);
         when(parseContext.path()).thenReturn(contentPath);
         when(parseContext.parser()).thenReturn(createXContentParser(VectorDataType.FLOAT));
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
 
         inputBuilder.hasDocValues(false);
 
@@ -1513,12 +1525,14 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
         LuceneFieldMapper.CreateLuceneFieldMapperInput.CreateLuceneFieldMapperInputBuilder inputBuilder =
             createLuceneFieldMapperInputBuilder();
-
+        IndexSettings indexSettingsMock = mock(IndexSettings.class);
+        when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
         ParseContext.Document document = new ParseContext.Document();
         ContentPath contentPath = new ContentPath();
         ParseContext parseContext = mock(ParseContext.class);
         when(parseContext.doc()).thenReturn(document);
         when(parseContext.path()).thenReturn(contentPath);
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
 
         OriginalMappingParameters originalMappingParameters = new OriginalMappingParameters(
             VectorDataType.BYTE,
@@ -1578,6 +1592,7 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         parseContext = mock(ParseContext.class);
         when(parseContext.doc()).thenReturn(document);
         when(parseContext.path()).thenReturn(contentPath);
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
 
         inputBuilder.hasDocValues(false);
 

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -394,7 +394,7 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
 
     @SneakyThrows
     protected void prepareOriginalIndices(List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts) {
-        assertEquals(6, indexConfigContexts.size());
+        assertTrue(1 < indexConfigContexts.size());
         DerivedSourceUtils.IndexConfigContext derivedSourceEnabledContext = indexConfigContexts.get(0);
         DerivedSourceUtils.IndexConfigContext derivedSourceDisabledContext = indexConfigContexts.get(1);
         createKnnIndex(


### PR DESCRIPTION
### Description
Adds checks to block derived fields under certain cases. This will prevent source derivation from happening. To accomplish this, I had to create a light wrapper around KnnFloatVectorField and KnnByteVectorField so that the index operation listener can get some of this information from the parsed document.

The checks that are being added are:
1. Is the source enabled
2. Is there a composite index present
3. Is derived source setting enabled
4. If a vector has the copyTo variable (this is broken right now in knn but added for safety in future - see #2636 )
5. Node to node segrep - there are some issues around translog where this will not work and so needs to be blocked.

### Related Issues
Resolves #2377 

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
