### PR TITLE
Bump cmake version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Infrastructure
 ### Documentation
 ### Maintenance
+* Update minimum required CMAKE version in NMSLIB [#2635](https://github.com/opensearch-project/k-NN/pull/2635)
 ### Refactoring
 * Switch derived source from field attributes to segment attribute [#2606](https://github.com/opensearch-project/k-NN/pull/2606)
 * Migrate derived source from filter to mask [#2612](https://github.com/opensearch-project/k-NN/pull/2612)

--- a/jni/cmake/init-nmslib.cmake
+++ b/jni/cmake/init-nmslib.cmake
@@ -21,6 +21,7 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0003-Added-streaming-apis-for-vector-index-loading-in-Hnsw.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0004-Added-a-new-save-apis-in-Hnsw-with-streaming-interfa.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0005-Add-util-include-to-fix-pragma-error.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0006-Bump-cmake-version-nmslib.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib)

--- a/jni/patches/nmslib/0006-Bump-cmake-version-nmslib.patch
+++ b/jni/patches/nmslib/0006-Bump-cmake-version-nmslib.patch
@@ -1,0 +1,54 @@
+From 38d32faf4183ad400831624a3d6874af6128f9a8 Mon Sep 17 00:00:00 2001
+From: Owen Halpert <ohalpert@amazon.com>
+Date: Mon, 31 Mar 2025 17:00:48 -0700
+Subject: [PATCH] Bump cmake version nmslib
+
+---
+ similarity_search/CMakeLists.txt | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/similarity_search/CMakeLists.txt b/similarity_search/CMakeLists.txt
+index bc6ef3c..c555115 100644
+--- a/similarity_search/CMakeLists.txt
++++ b/similarity_search/CMakeLists.txt
+@@ -8,7 +8,11 @@
+ #
+ #
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 3.5...4.0)
++
++if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
++    cmake_policy(SET CMP0153 OLD)
++endif()
+ 
+ project (NonMetricSpaceLib)
+ 
+@@ -20,12 +24,10 @@ project (NonMetricSpaceLib)
+ #
+ function(CXX_COMPILER_DUMPVERSION _OUTPUT_VERSION)
+ 
+-  exec_program(${CMAKE_CXX_COMPILER}
+-    ARGS ${CMAKE_CXX_COMPILER_ARG1} -dumpversion
+-    OUTPUT_VARIABLE COMPILER_VERSION
++  execute_process(
++      COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} -dumpversion
++      OUTPUT_VARIABLE COMPILER_VERSION
+   )
+-  #string(REGEX REPLACE "([0-9])\\.([0-9])(\\.[0-9])?" "\\1\\2"
+-  #   COMPILER_VERSION ${COMPILER_VERSION})
+ 
+   set(${_OUTPUT_VERSION} ${COMPILER_VERSION} PARENT_SCOPE)
+ endfunction()
+@@ -55,7 +57,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+     endif()
+     set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wunreachable-code -Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -fpic")
+     set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wunreachable-code -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -fpic")
+-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
++elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+     if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+         # MACOSX
+         set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread -fpic ${SIMD_FLAGS}")
+-- 
+2.47.1
+


### PR DESCRIPTION
### Description
Upgrade minimum required CMake version in NMSLib to 3.5 due to Ubuntu runner getting bumped to Cmake 4: https://github.com/actions/runner-images/commit/83ff3a65f622b420db5f9fa3643db34b327cdf5f which does not support versions before 3.5. 

### Related Issues
N/A

### Check List
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [X] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
