### PR TITLE
Optimize first child lookup for nested docs

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -22,12 +22,12 @@ import static org.opensearch.knn.TestUtils.RESTART_UPGRADE_OLD_CLUSTER;
 public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
 
     public void testFlat_indexAndForceMergeOnOld_injectOnNew() throws IOException {
-        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("knn-bwc", false);
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("knn-bwc", false, false);
         testIndexAndForceMergeOnOld_injectOnNew(indexConfigContexts);
     }
 
     public void testFlat_indexOnOld_forceMergeAndInjectOnNew() throws IOException {
-        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("knn-bwc", false);
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("knn-bwc", false, false);
         testIndexOnOld_forceMergeAndInjectOnNew(indexConfigContexts);
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelper.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.derivedsource;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.NumericDocValues;
@@ -21,13 +22,26 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 @RequiredArgsConstructor
 public class DerivedSourceLuceneHelper {
 
+    // Offsets from the parent docId to start from in order to determine where to start the search from for first child.
+    // In other words, we're guessing the upperbound on the number of nested documents a single parent will have.
+    // This is an optimization to avoid starting from the first doc to find the previous parent to the parent docid.
+    // The values are just back of the napkin calculations, but heres how I got these numbers: Assuming there are
+    // ~12 bytes an entry for NumericDocValues (8 for long value, 4 for int id). On a single
+    // 4kb page, it should be possible to fit 340 values. If first offset is 150, we can be confident it will be only 1
+    // page fetched typically. Then 10 pages and then 40 pages.
+    private static final int[] NESTED_OFFSET_STARTING_POINTS = new int[] { 150, 1500, 6000 };
+
     private final DerivedSourceReaders derivedSourceReaders;
     private final SegmentReadState segmentReadState;
+
+    @VisibleForTesting
+    static final int NO_CHILDREN_INDICATOR = -1;
 
     /**
      * Get the first child of the given parentDoc. This can be used to determine if the document contains any nested
      * fields.
      *
+     * @param parentDocId Parent doc id to find children for
      * @return doc id of last matching doc. {@link DocIdSetIterator#NO_MORE_DOCS} if no children exist.
      * @throws IOException
      */
@@ -36,16 +50,38 @@ public class DerivedSourceLuceneHelper {
         if (parentDocId == 0) {
             return NO_MORE_DOCS;
         }
+        int lastStartingPoint = -1;
+        for (int offset : NESTED_OFFSET_STARTING_POINTS) {
+            int currentStartingPoint = Math.max(0, parentDocId - offset);
+            // If we've already checked this starting point, no need to continue
+            if (currentStartingPoint <= lastStartingPoint) {
+                break;
+            }
+            int firstChild = getFirstChild(parentDocId, currentStartingPoint);
+            // If the returned value is NO_CHILDREN_INDICATOR, we know for sure that there are no children. No need to
+            // keep checking
+            if (firstChild == NO_CHILDREN_INDICATOR) {
+                return NO_MORE_DOCS;
+            }
+            // If the first child is in between currentStartingPoint and parentDocId, we can return
+            if (firstChild != NO_MORE_DOCS) {
+                return firstChild;
+            }
+            lastStartingPoint = currentStartingPoint;
+        }
+        // If none of the shortcuts worked, we'll try from the start
+        return getFirstChild(parentDocId, 0);
+    }
 
+    @VisibleForTesting
+    int getFirstChild(int parentDocId, int startingPoint) throws IOException {
         // Only root level documents have the "_primary_term" field. So, we iterate through all of the documents in
         // order to find out if any have this term.
-        // TODO: This is expensive and should be optimized. We should start at doc parentDocId - 10000 and work back
-        // (can we fetch the setting? Maybe)
         FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo("_primary_term");
         assert derivedSourceReaders.getDocValuesProducer() != null;
         NumericDocValues numericDocValues = derivedSourceReaders.getDocValuesProducer().getNumeric(fieldInfo);
         int previousParentDocId = NO_MORE_DOCS;
-        numericDocValues.advance(0);
+        numericDocValues.advance(startingPoint);
         while (numericDocValues.docID() != NO_MORE_DOCS) {
             if (numericDocValues.docID() >= parentDocId) {
                 break;
@@ -59,9 +95,9 @@ public class DerivedSourceLuceneHelper {
         if (previousParentDocId == NO_MORE_DOCS) {
             return 0;
         }
-        // If the document right before is the previous parent, then there are no children.
+        // If the document right before is the previous parent, then there are no children. Return
         if (parentDocId - previousParentDocId <= 1) {
-            return NO_MORE_DOCS;
+            return NO_CHILDREN_INDICATOR;
         }
         return previousParentDocId + 1;
     }

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelperTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.IOException;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.codec.derivedsource.DerivedSourceLuceneHelper.NO_CHILDREN_INDICATOR;
+
+public class DerivedSourceLuceneHelperTests extends KNNTestCase {
+    @Mock
+    private FieldInfos fieldInfos;
+
+    @Mock
+    private FieldInfo fieldInfo;
+
+    @Mock
+    private DerivedSourceReaders derivedSourceReaders;
+
+    @Mock
+    private DocValuesProducer docValuesProducer;
+
+    @Mock
+    private NumericDocValues numericDocValues;
+
+    private SegmentReadState segmentReadState;
+    private DerivedSourceLuceneHelper helper;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        segmentReadState = new SegmentReadState(null, null, fieldInfos, null, null);
+
+        when(fieldInfos.fieldInfo("_primary_term")).thenReturn(fieldInfo);
+        when(derivedSourceReaders.getDocValuesProducer()).thenReturn(docValuesProducer);
+        when(docValuesProducer.getNumeric(fieldInfo)).thenReturn(numericDocValues);
+        helper = new DerivedSourceLuceneHelper(derivedSourceReaders, segmentReadState);
+    }
+
+    @SneakyThrows
+    public void testGetFirstChild_WhenNoDocumentsBeforeParent() throws IOException {
+        int parentDocId = 5;
+        int startingPoint = 0;
+        when(numericDocValues.advance(startingPoint)).thenReturn(10); // First doc is after parent
+        when(numericDocValues.docID()).thenReturn(10, NO_MORE_DOCS);
+
+        int result = helper.getFirstChild(parentDocId, startingPoint);
+
+        assertEquals(0, result);
+    }
+
+    @SneakyThrows
+    public void testGetFirstChild_WhenNoChildren() {
+        int parentDocId = 5;
+        int startingPoint = 0;
+        when(numericDocValues.advance(startingPoint)).thenReturn(4);
+        when(numericDocValues.docID()).thenReturn(4, 4, 4, 5, 5);
+        when(numericDocValues.nextDoc()).thenReturn(5);
+
+        int result = helper.getFirstChild(parentDocId, startingPoint);
+
+        assertEquals(NO_CHILDREN_INDICATOR, result);
+    }
+
+    @SneakyThrows
+    public void testGetFirstChild_WhenChildrenExist() {
+        int parentDocId = 10;
+        int startingPoint = 0;
+        when(numericDocValues.advance(startingPoint)).thenReturn(5);
+        when(numericDocValues.docID()).thenReturn(5, 5, 5, 10, 10);
+        when(numericDocValues.nextDoc()).thenReturn(10);
+
+        int result = helper.getFirstChild(parentDocId, startingPoint);
+
+        assertEquals(6, result); // Should return previousParentDocId + 1
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -27,7 +27,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
     @SneakyThrows
     public void testFlatFields() {
-        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("derivedit", true);
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("derivedit", true, true);
         testDerivedSourceE2E(indexConfigContexts);
     }
 
@@ -52,11 +52,13 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             new Pair<>("original-disable-", false)
         );
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = new ArrayList<>();
+        long consistentRandomSeed = random().nextLong();
         for (Pair<String, Boolean> index : indexPrefixToEnabled) {
+            Random random = new Random(consistentRandomSeed);
             DerivedSourceUtils.IndexConfigContext indexConfigContext = DerivedSourceUtils.IndexConfigContext.builder()
                 .indexName(getIndexName("deriveit", index.getFirst(), false))
                 .derivedEnabled(index.getSecond())
-                .random(new Random(1))
+                .random(random)
                 .settings(index.getSecond() ? DERIVED_ENABLED_WITH_SEGREP_SETTINGS : null)
                 .fields(
                     List.of(
@@ -67,7 +69,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .fieldPath("nested_1.test_vector")
                                         .dimension(TEST_DIMENSION)
-                                        .valueSupplier(randomVectorSupplier(new Random(0), TEST_DIMENSION, VectorDataType.BYTE))
+                                        .valueSupplier(randomVectorSupplier(random, TEST_DIMENSION, VectorDataType.BYTE))
                                         .build()
                                 )
                             )
@@ -80,7 +82,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
                                     DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                         .fieldPath("nested_2.test_vector")
                                         .dimension(TEST_DIMENSION)
-                                        .valueSupplier(randomVectorSupplier(new Random(0), TEST_DIMENSION, VectorDataType.BYTE))
+                                        .valueSupplier(randomVectorSupplier(random, TEST_DIMENSION, VectorDataType.BYTE))
                                         .build(),
                                     DerivedSourceUtils.NestedFieldContext.builder()
                                         .fieldPath("nested_2.nested_3")
@@ -89,7 +91,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
                                                 DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                                                     .fieldPath("nested_2.nested_3.test_vector")
                                                     .dimension(TEST_DIMENSION)
-                                                    .valueSupplier(randomVectorSupplier(new Random(0), TEST_DIMENSION, VectorDataType.BYTE))
+                                                    .valueSupplier(randomVectorSupplier(random, TEST_DIMENSION, VectorDataType.BYTE))
                                                     .build(),
                                                 DerivedSourceUtils.IntFieldType.builder().fieldPath("nested_2.nested_3.test-int").build()
                                             )
@@ -100,7 +102,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
                             .build(),
                         DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
                             .dimension(TEST_DIMENSION)
-                            .valueSupplier(randomVectorSupplier(new Random(0), TEST_DIMENSION, VectorDataType.BYTE))
+                            .valueSupplier(randomVectorSupplier(random, TEST_DIMENSION, VectorDataType.BYTE))
                             .fieldPath("test_vector")
                             .build(),
                         DerivedSourceUtils.TextFieldType.builder().fieldPath("test-text").build(),


### PR DESCRIPTION
### Description
Optimization for derived source. The only changed source file is `src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceLuceneHelper.java`. The rest are tests. 

For nested documents, in order to initialize the iterators properly, we need to find the first child document of the parent document. To do this, we can scan the numeric doc values for the _primary_term field, which is only present for parent documents. In the code now, we start this scan at 0. This requires reading all of the numeric doc values. This code introduces an optimization where instead of starting at 0, it first tries 150 documents before the parentdoc, then 1500, then 6000, then tries from 0.

Along with this, I updated some testing logic.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
