### PR TITLE
Enhance derived source integ tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -513,7 +513,7 @@ def commonIntegTestClusters(OpenSearchCluster cluster, _numNodes){
 
 
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
-    if (_numNodes > 1) numberOfNodes = _numNodes
+    if (_numNodes > 1) cluster.numberOfNodes = _numNodes
     // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore
     // i.e. we have to use a custom property to flag when we want to debug opensearch JVM
     // since we also support multi node integration tests we increase debugPort per node
@@ -559,6 +559,7 @@ task integTestRemote(type: RestIntegTestTask) {
 
     systemProperty 'tests.security.manager', 'false'
     systemProperty("test.exhaustive", System.getProperty("test.exhaustive"))
+    systemProperty "tests.path.repo", "${layout.buildDirectory.toString()}/testSnapshotFolder"
 
     // Run tests with remote cluster only if rest case is defined
     if (System.getProperty("tests.rest.cluster") != null) {

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
+import org.junit.Before;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.DerivedSourceTestCase;
 import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.knn.Pair;
@@ -13,6 +15,7 @@ import org.opensearch.knn.index.VectorDataType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 import static org.opensearch.knn.DerivedSourceUtils.DERIVED_ENABLED_WITH_SEGREP_SETTINGS;
@@ -24,6 +27,18 @@ import static org.opensearch.knn.DerivedSourceUtils.randomVectorSupplier;
  * a few gaps in functionality. Ignoring tests for now as feature is experimental.
  */
 public class DerivedSourceIT extends DerivedSourceTestCase {
+
+    private final String snapshot = "snapshot-test";
+    private final String repository = "repo";
+
+    @Before
+    @SneakyThrows
+    public void setUp() {
+        super.setUp();
+        final String pathRepo = System.getProperty("tests.path.repo");
+        Settings repoSettings = Settings.builder().put("compress", randomBoolean()).put("location", pathRepo).build();
+        registerRepository(repository, "fs", true, repoSettings);
+    }
 
     @SneakyThrows
     public void testFlatFields() {
@@ -144,6 +159,8 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
         // Reindex
         testReindex(indexConfigContexts);
-    }
 
+        // Snapshot restore
+        testSnapshotRestore(repository, snapshot + getTestName().toLowerCase(Locale.ROOT), indexConfigContexts);
+    }
 }

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -35,9 +35,9 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
     );
 
     private static final int MIN_DIMENSION = 4;
-    private static final int MAX_DIMENSION = 64;
-    private static final int MIN_DOCS = 100;
-    private static final int MAX_DOCS = 500;
+    private static final int MAX_DIMENSION = 32;
+    private static final int MIN_DOCS = 50;
+    private static final int MAX_DOCS = 200;
 
     /**
      * Testing flat, single field base case with index configuration. The test will automatically skip adding fields for
@@ -164,11 +164,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *           "properties" : {
      *             "test_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 63
      *             },
      *             "update_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 34
      *             }
      *           }
      *         },
@@ -181,11 +181,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *                 },
      *                 "test_vector" : {
      *                   "type" : "knn_vector",
-     *                   "dimension" : 16
+     *                   "dimension" : 41
      *                 },
      *                 "update_vector" : {
      *                   "type" : "knn_vector",
-     *                   "dimension" : 16
+     *                   "dimension" : 8
      *                 }
      *               }
      *             },
@@ -194,11 +194,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *             },
      *             "test_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 45
      *             },
      *             "update_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 7
      *             }
      *           }
      *         },
@@ -210,11 +210,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *         },
      *         "test_vector" : {
      *           "type" : "knn_vector",
-     *           "dimension" : 16
+     *           "dimension" : 10
      *         },
      *         "update_vector" : {
      *           "type" : "knn_vector",
-     *           "dimension" : 16
+     *           "dimension" : 51
      *         }
      *       }
      *     }
@@ -318,13 +318,24 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *         "nested_1" : {
      *           "type" : "nested",
      *           "properties" : {
+     *             "object_1" : {
+     *               "properties" : {
+     *                 "test-int" : {
+     *                   "type" : "integer"
+     *                 },
+     *                 "test_vector" : {
+     *                   "type" : "knn_vector",
+     *                   "dimension" : 64
+     *                 }
+     *               }
+     *             },
      *             "test_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 9
      *             },
      *             "update_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 4
      *             }
      *           }
      *         },
@@ -339,11 +350,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *                 },
      *                 "test_vector" : {
      *                   "type" : "knn_vector",
-     *                   "dimension" : 16
+     *                   "dimension" : 27
      *                 },
      *                 "update_vector" : {
      *                   "type" : "knn_vector",
-     *                   "dimension" : 16
+     *                   "dimension" : 14
      *                 }
      *               }
      *             },
@@ -352,11 +363,28 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *             },
      *             "test_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 57
      *             },
      *             "update_vector" : {
      *               "type" : "knn_vector",
-     *               "dimension" : 16
+     *               "dimension" : 10
+     *             }
+     *           }
+     *         },
+     *         "object_1" : {
+     *           "properties" : {
+     *             "nested_1" : {
+     *               "type" : "nested",
+     *               "properties" : {
+     *                 "test_vector" : {
+     *                   "type" : "knn_vector",
+     *                   "dimension" : 30
+     *                 }
+     *               }
+     *             },
+     *             "test_vector" : {
+     *               "type" : "knn_vector",
+     *               "dimension" : 51
      *             }
      *           }
      *         },
@@ -368,11 +396,11 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *         },
      *         "test_vector" : {
      *           "type" : "knn_vector",
-     *           "dimension" : 16
+     *           "dimension" : 63
      *         },
      *         "update_vector" : {
      *           "type" : "knn_vector",
-     *           "dimension" : 16
+     *           "dimension" : 4
      *         }
      *       }
      *     }
@@ -391,6 +419,28 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                 .random(new Random(consistentRandomSeed))
                 .fields(
                     List.of(
+                        DerivedSourceUtils.ObjectFieldContext.builder()
+                            .fieldPath("object_1")
+                            .children(
+                                List.of(
+                                    DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
+                                        .dimension(dimensionSupplier.get())
+                                        .fieldPath("object_1.test_vector")
+                                        .build(),
+                                    DerivedSourceUtils.NestedFieldContext.builder()
+                                        .fieldPath("object_1.nested_1")
+                                        .children(
+                                            List.of(
+                                                DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
+                                                    .dimension(dimensionSupplier.get())
+                                                    .fieldPath("object_1.nested_1.test_vector")
+                                                    .build()
+                                            )
+                                        )
+                                        .build()
+                                )
+                            )
+                            .build(),
                         DerivedSourceUtils.NestedFieldContext.builder()
                             .fieldPath("nested_1")
                             .children(
@@ -403,6 +453,18 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                                         .dimension(dimensionSupplier.get())
                                         .fieldPath("nested_1.update_vector")
                                         .isUpdate(true)
+                                        .build(),
+                                    DerivedSourceUtils.ObjectFieldContext.builder()
+                                        .fieldPath("nested_1.object_1")
+                                        .children(
+                                            List.of(
+                                                DerivedSourceUtils.KNNVectorFieldTypeContext.builder()
+                                                    .dimension(dimensionSupplier.get())
+                                                    .fieldPath("nested_1.object_1.test_vector")
+                                                    .build(),
+                                                DerivedSourceUtils.IntFieldType.builder().fieldPath("nested_1.object_1.test-int").build()
+                                            )
+                                        )
                                         .build()
                                 )
                             )
@@ -729,6 +791,85 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
         refreshAllIndices();
         assertIndexBigger(originalIndexNameDerivedSourceDisabled, originalIndexNameDerivedSourceEnabled);
 
+        assertIndexBigger(originalIndexNameDerivedSourceDisabled, reindexFromEnabledToEnabledIndexName);
+        assertIndexBigger(originalIndexNameDerivedSourceDisabled, reindexFromDisabledToEnabledIndexName);
+        assertIndexBigger(reindexFromEnabledToDisabledIndexName, originalIndexNameDerivedSourceEnabled);
+        assertIndexBigger(reindexFromDisabledToDisabledIndexName, originalIndexNameDerivedSourceEnabled);
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            originalIndexNameDerivedSourceDisabled,
+            reindexFromEnabledToEnabledIndexName
+        );
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            originalIndexNameDerivedSourceDisabled,
+            reindexFromDisabledToEnabledIndexName
+        );
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            originalIndexNameDerivedSourceDisabled,
+            reindexFromEnabledToDisabledIndexName
+        );
+        assertDocsMatch(
+            derivedSourceDisabledContext.docCount,
+            originalIndexNameDerivedSourceDisabled,
+            reindexFromDisabledToDisabledIndexName
+        );
+    }
+
+    @SneakyThrows
+    protected void testSnapshotRestore(
+        String repository,
+        String snapshot,
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts
+    ) {
+        DerivedSourceUtils.IndexConfigContext derivedSourceEnabledContext = indexConfigContexts.get(0);
+        DerivedSourceUtils.IndexConfigContext derivedSourceDisabledContext = indexConfigContexts.get(1);
+        DerivedSourceUtils.IndexConfigContext reindexFromEnabledToEnabledContext = indexConfigContexts.get(2);
+        DerivedSourceUtils.IndexConfigContext reindexFromEnabledToDisabledContext = indexConfigContexts.get(3);
+        DerivedSourceUtils.IndexConfigContext reindexFromDisabledToEnabledContext = indexConfigContexts.get(4);
+        DerivedSourceUtils.IndexConfigContext reindexFromDisabledToDisabledContext = indexConfigContexts.get(5);
+
+        String originalIndexNameDerivedSourceEnabled = derivedSourceEnabledContext.indexName;
+        String originalIndexNameDerivedSourceDisabled = derivedSourceDisabledContext.indexName;
+        String reindexFromEnabledToEnabledIndexName = reindexFromEnabledToEnabledContext.indexName;
+        String reindexFromEnabledToDisabledIndexName = reindexFromEnabledToDisabledContext.indexName;
+        String reindexFromDisabledToEnabledIndexName = reindexFromDisabledToEnabledContext.indexName;
+        String reindexFromDisabledToDisabledIndexName = reindexFromDisabledToDisabledContext.indexName;
+
+        createSnapshot(repository, snapshot, true);
+
+        deleteIndex(originalIndexNameDerivedSourceEnabled);
+        deleteIndex(originalIndexNameDerivedSourceDisabled);
+        deleteIndex(reindexFromEnabledToEnabledIndexName);
+        deleteIndex(reindexFromEnabledToDisabledIndexName);
+        deleteIndex(reindexFromDisabledToEnabledIndexName);
+        deleteIndex(reindexFromDisabledToDisabledIndexName);
+
+        String restoreSuffix = "-restored";
+        restoreSnapshot(
+            restoreSuffix,
+            List.of(
+                originalIndexNameDerivedSourceEnabled,
+                originalIndexNameDerivedSourceDisabled,
+                reindexFromEnabledToEnabledIndexName,
+                reindexFromEnabledToDisabledIndexName,
+                reindexFromDisabledToEnabledIndexName,
+                reindexFromDisabledToDisabledIndexName
+            ),
+            repository,
+            snapshot,
+            true
+        );
+
+        originalIndexNameDerivedSourceEnabled += restoreSuffix;
+        originalIndexNameDerivedSourceDisabled += restoreSuffix;
+        reindexFromEnabledToEnabledIndexName += restoreSuffix;
+        reindexFromEnabledToDisabledIndexName += restoreSuffix;
+        reindexFromDisabledToEnabledIndexName += restoreSuffix;
+        reindexFromDisabledToDisabledIndexName += restoreSuffix;
+
+        assertIndexBigger(originalIndexNameDerivedSourceDisabled, originalIndexNameDerivedSourceEnabled);
         assertIndexBigger(originalIndexNameDerivedSourceDisabled, reindexFromEnabledToEnabledIndexName);
         assertIndexBigger(originalIndexNameDerivedSourceDisabled, reindexFromDisabledToEnabledIndexName);
         assertIndexBigger(reindexFromEnabledToDisabledIndexName, originalIndexNameDerivedSourceEnabled);


### PR DESCRIPTION
### Description
Enhances derived source integ tests to have a bit more complex mappings. This is probably overkill, but good to be sure. With this, it also reduces the number of docs/max dimension to prevent tests from running too long. 

Also, it adds a snapshot/restore test to ensure after snapshot, everything works as expected.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
