### PR TITLE
[Bug fix LuceneOnFaiss] Having field info to have a corresponding Lucene vector similarity function.

### DIFF
--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Assert;
 import org.mockito.MockedStatic;
@@ -1278,6 +1279,89 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testMethodFieldMapper_saveBestMatchingVectorSimilarityFunction() {
+        final MethodComponentContext methodComponentContext = new MethodComponentContext(METHOD_HNSW, Collections.emptyMap());
+
+        doTestMethodFieldMapper_saveBestMatchingVectorSimilarityFunction(methodComponentContext, SpaceType.INNER_PRODUCT, Version.V_2_19_0);
+
+        doTestMethodFieldMapper_saveBestMatchingVectorSimilarityFunction(methodComponentContext, SpaceType.HAMMING, Version.V_2_19_0);
+
+        doTestMethodFieldMapper_saveBestMatchingVectorSimilarityFunction(methodComponentContext, SpaceType.INNER_PRODUCT, Version.V_3_0_0);
+
+        doTestMethodFieldMapper_saveBestMatchingVectorSimilarityFunction(methodComponentContext, SpaceType.HAMMING, Version.V_3_0_0);
+    }
+
+    @SneakyThrows
+    private void doTestMethodFieldMapper_saveBestMatchingVectorSimilarityFunction(
+        MethodComponentContext methodComponentContext,
+        SpaceType spaceType,
+        final Version version
+    ) {
+        try (MockedStatic<KNNVectorFieldMapperUtil> utilMockedStatic = Mockito.mockStatic(KNNVectorFieldMapperUtil.class)) {
+            final VectorDataType dataType = VectorDataType.FLOAT;
+            final int dimension = TEST_VECTOR.length;
+
+            final KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+                .vectorDataType(dataType)
+                .versionCreated(version)
+                .dimension(dimension)
+                .build();
+            final KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, spaceType, methodComponentContext);
+
+            final IndexSettings indexSettingsMock = mock(IndexSettings.class);
+            when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
+            final ParseContext.Document document = new ParseContext.Document();
+            final ContentPath contentPath = new ContentPath();
+            final ParseContext parseContext = mock(ParseContext.class);
+            when(parseContext.doc()).thenReturn(document);
+            when(parseContext.path()).thenReturn(contentPath);
+            when(parseContext.parser()).thenReturn(createXContentParser(dataType));
+            when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
+
+            utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(true);
+            utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(true);
+
+            final OriginalMappingParameters originalMappingParameters = new OriginalMappingParameters(
+                dataType,
+                dimension,
+                knnMethodContext,
+                Mode.NOT_CONFIGURED.getName(),
+                CompressionLevel.NOT_CONFIGURED.getName(),
+                null,
+                SpaceType.UNDEFINED.getValue()
+            );
+            originalMappingParameters.setResolvedKnnMethodContext(knnMethodContext);
+            EngineFieldMapper methodFieldMapper = EngineFieldMapper.createFieldMapper(
+                TEST_FIELD_NAME,
+                TEST_FIELD_NAME,
+                Collections.emptyMap(),
+                knnMethodConfigContext,
+                FieldMapper.MultiFields.empty(),
+                FieldMapper.CopyTo.empty(),
+                new Explicit<>(true, true),
+                false,
+                false,
+                originalMappingParameters
+            );
+            methodFieldMapper.parseCreateField(parseContext, dimension, dataType);
+            final IndexableField field1 = document.getFields().get(0);
+
+            VectorSimilarityFunction similarityFunction = SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+
+            if (version.onOrAfter(Version.V_3_0_0)) {
+                // If version >= 3.0, then it should find the best matching function.
+                try {
+                    similarityFunction = spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+                } catch (Exception e) {
+                    // Ignore
+                }
+            }
+
+            assertEquals(similarityFunction, field1.fieldType().vectorSimilarityFunction());
+        }
+    }
+
+    @SneakyThrows
     public void testMethodFieldMapperParseCreateField_validInput_thenDifferentFieldTypes() {
         try (MockedStatic<KNNVectorFieldMapperUtil> utilMockedStatic = Mockito.mockStatic(KNNVectorFieldMapperUtil.class)) {
             for (VectorDataType dataType : VectorDataType.values()) {
@@ -1342,10 +1426,10 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
 
                 assertEquals(field1.fieldType().vectorDimension(), adjustDimensionForSearch(dimension, dataType));
                 assertEquals(Integer.parseInt(field1.fieldType().getAttributes().get(DIMENSION_FIELD_NAME)), dimension);
-                assertEquals(
-                    field1.fieldType().vectorSimilarityFunction(),
-                    SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction()
-                );
+                final VectorSimilarityFunction similarityFunction = spaceType != SpaceType.HAMMING
+                    ? spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction()
+                    : SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+                assertEquals(field1.fieldType().vectorSimilarityFunction(), similarityFunction);
 
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(Mockito.any())).thenReturn(false);
                 utilMockedStatic.when(() -> KNNVectorFieldMapperUtil.useFullFieldNameValidation(Mockito.any())).thenReturn(false);


### PR DESCRIPTION
### Description
When memory optimized search is enabled, if a filtering is provided in a query, it will evaluate whether to fallback to exact search to preserve high recall.
During the exact search, Lucene will load FloatVectorValues and ByteVectorValues from configured VectorReader, which is NativeEngines990KnnVectorsReader at the moment - [Code](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java#L107)

Currently, regardless of the space type in mapping, the default space type will be saved in .vec file - [Code](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/mapper/MethodFieldMapper.java#L180)

We should change it to find the best matching similarity function with the best effort so that it will pick up the correct similarity function during exact search when memory optimized is enabled.
Hamming space type is the only FAISS exclusive one that does not support the corresponding Lucene similarity function. But this space type is not the scope of M1 milestone of LuceneOnFaiss project.

Also, this change will not bring side effect to the case where the mode is turned off, where delegating vector search to C++ layer, as [ExactSearcher](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java#L155) has a separate scoring phase, and it is relying on scorer extracted from Codec at the moment.

FYI : LuceneOnFaiss RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Related Issues
https://github.com/opensearch-project/k-NN/issues/2649

### Check List
- [ ] New functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
