### PR TITLE
Prevent derived source from open reader per transform

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -18,6 +18,7 @@ import org.opensearch.common.Nullable;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.derivedsource.DerivedFieldInfo;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaders;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttributeParser;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
@@ -55,11 +56,13 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         if (derivedVectorFields.isEmpty()) {
             return delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
         }
+        SegmentReadState segmentReadState = new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext);
+        DerivedSourceReaders derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
         return new KNN10010DerivedSourceStoredFieldsReader(
             delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext),
             derivedVectorFields,
-            derivedSourceReadersSupplier,
-            new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext)
+            derivedSourceReaders,
+            segmentReadState
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjector.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -18,7 +17,6 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -33,7 +31,7 @@ import java.util.Set;
  *  format readers and information about the fields to inject vectors into the source.
  */
 @Log4j2
-public class DerivedSourceVectorInjector implements Closeable {
+public class DerivedSourceVectorInjector {
 
     private final KNN9120DerivedSourceReaders derivedSourceReaders;
     private final List<PerFieldDerivedVectorInjector> perFieldDerivedVectorInjectors;
@@ -42,16 +40,16 @@ public class DerivedSourceVectorInjector implements Closeable {
     /**
      * Constructor for DerivedSourceVectorInjector.
      *
-     * @param derivedSourceReadersSupplier Supplier for the derived source readers.
+     * @param derivedSourceReaders Derived source readers.
      * @param segmentReadState Segment read state
      * @param fieldsToInjectVector List of fields to inject vectors into
      */
     public DerivedSourceVectorInjector(
-        KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        KNN9120DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState,
         List<FieldInfo> fieldsToInjectVector
-    ) throws IOException {
-        this.derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
+    ) {
+        this.derivedSourceReaders = derivedSourceReaders;
         this.perFieldDerivedVectorInjectors = new ArrayList<>();
         this.fieldNames = new HashSet<>();
         for (FieldInfo fieldInfo : fieldsToInjectVector) {
@@ -127,10 +125,5 @@ public class DerivedSourceVectorInjector implements Closeable {
             return excludedVectorFieldCount < fieldNames.size();
         }
         return true;
-    }
-
-    @Override
-    public void close() throws IOException {
-        IOUtils.close(derivedSourceReaders);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldsFormat.java
@@ -51,10 +51,12 @@ public class KNN9120DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
         if (derivedVectorFields == null || derivedVectorFields.isEmpty()) {
             return delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext);
         }
+        SegmentReadState segmentReadState = new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext);
+        KNN9120DerivedSourceReaders derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
         return new KNN9120DerivedSourceStoredFieldsReader(
             delegate.fieldsReader(directory, segmentInfo, fieldInfos, ioContext),
             derivedVectorFields,
-            derivedSourceReadersSupplier,
+            derivedSourceReaders,
             new SegmentReadState(directory, segmentInfo, fieldInfos, ioContext)
         );
     }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldsReader.java
@@ -23,7 +23,7 @@ import static org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec.KNN912
 public class KNN9120DerivedSourceStoredFieldsReader extends StoredFieldsReader {
     private final StoredFieldsReader delegate;
     private final List<FieldInfo> derivedVectorFields;
-    private final KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier;
+    private final KNN9120DerivedSourceReaders derivedSourceReaders;
     private final SegmentReadState segmentReadState;
     private final boolean shouldInject;
 
@@ -33,36 +33,36 @@ public class KNN9120DerivedSourceStoredFieldsReader extends StoredFieldsReader {
      *
      * @param delegate delegate StoredFieldsReader
      * @param derivedVectorFields List of fields that are derived source fields
-     * @param derivedSourceReadersSupplier Supplier for the derived source readers
+     * @param derivedSourceReaders Derived source readers
      * @param segmentReadState SegmentReadState for the segment
      * @throws IOException in case of I/O error
      */
     public KNN9120DerivedSourceStoredFieldsReader(
         StoredFieldsReader delegate,
         List<FieldInfo> derivedVectorFields,
-        KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        KNN9120DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState
     ) throws IOException {
-        this(delegate, derivedVectorFields, derivedSourceReadersSupplier, segmentReadState, true);
+        this(delegate, derivedVectorFields, derivedSourceReaders, segmentReadState, true);
     }
 
     private KNN9120DerivedSourceStoredFieldsReader(
         StoredFieldsReader delegate,
         List<FieldInfo> derivedVectorFields,
-        KNN9120DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        KNN9120DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState,
         boolean shouldInject
     ) throws IOException {
         this.delegate = delegate;
         this.derivedVectorFields = derivedVectorFields;
-        this.derivedSourceReadersSupplier = derivedSourceReadersSupplier;
+        this.derivedSourceReaders = derivedSourceReaders;
         this.segmentReadState = segmentReadState;
         this.shouldInject = shouldInject;
         this.derivedSourceVectorInjector = createDerivedSourceVectorInjector();
     }
 
     private DerivedSourceVectorInjector createDerivedSourceVectorInjector() throws IOException {
-        return new DerivedSourceVectorInjector(derivedSourceReadersSupplier, segmentReadState, derivedVectorFields);
+        return new DerivedSourceVectorInjector(derivedSourceReaders, segmentReadState, derivedVectorFields);
     }
 
     @Override
@@ -88,7 +88,7 @@ public class KNN9120DerivedSourceStoredFieldsReader extends StoredFieldsReader {
             return new KNN9120DerivedSourceStoredFieldsReader(
                 delegate.clone(),
                 derivedVectorFields,
-                derivedSourceReadersSupplier,
+                derivedSourceReaders.cloneWithMerge(),
                 segmentReadState,
                 shouldInject
             );
@@ -104,7 +104,7 @@ public class KNN9120DerivedSourceStoredFieldsReader extends StoredFieldsReader {
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(delegate, derivedSourceVectorInjector);
+        IOUtils.close(delegate, derivedSourceReaders);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -9,11 +9,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Class holds the readers necessary to implement derived source. Important to note that if a segment does not have
@@ -21,14 +23,53 @@ import java.io.IOException;
  */
 @RequiredArgsConstructor
 @Getter
-public class DerivedSourceReaders implements Closeable {
+public final class DerivedSourceReaders implements Closeable {
     @Nullable
     private final KnnVectorsReader knnVectorsReader;
     @Nullable
     private final DocValuesProducer docValuesProducer;
 
+    // Copied from lucene (https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java):
+    // We need to reference count these readers because they may be shared amongst different instances.
+    // "Counts how many other readers share the core objects
+    // (freqStream, proxStream, tis, etc.) of this reader;
+    // when coreRef drops to 0, these core objects may be
+    // closed. A given instance of SegmentReader may be
+    // closed, even though it shares core objects with other
+    // SegmentReaders":
+    private final AtomicInteger ref = new AtomicInteger(1);
+
+    /**
+     * Returns this DerivedSourceReaders object with incremented reference count
+     *
+     * @return DerivedSourceReaders object with incremented reference count
+     */
+    public DerivedSourceReaders cloneWithMerge() {
+        // For cloning, we dont need to reference count. In Lucene, the merging will actually not close any of the
+        // readers, so it should only be handled by the original code. See
+        // https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L3372
+        // for more details
+        return this;
+    }
+
     @Override
     public void close() throws IOException {
-        IOUtils.close(knnVectorsReader, docValuesProducer);
+        decRef();
+    }
+
+    private void incRef() {
+        int count;
+        while ((count = ref.get()) > 0) {
+            if (ref.compareAndSet(count, count + 1)) {
+                return;
+            }
+        }
+        throw new AlreadyClosedException("DerivedSourceReaders is already closed");
+    }
+
+    private void decRef() throws IOException {
+        if (ref.decrementAndGet() == 0) {
+            IOUtils.close(knnVectorsReader, docValuesProducer);
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.codec.derivedsource;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
@@ -18,7 +17,6 @@ import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -27,7 +25,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 @Log4j2
-public class DerivedSourceVectorTransformer implements Closeable {
+public class DerivedSourceVectorTransformer {
 
     private final DerivedSourceReaders derivedSourceReaders;
     Function<Map<String, Object>, Map<String, Object>> derivedSourceVectorTransformer;
@@ -37,16 +35,16 @@ public class DerivedSourceVectorTransformer implements Closeable {
 
     /**
      *
-     * @param derivedSourceReadersSupplier Supplier for the derived source readers.
+     * @param derivedSourceReaders derived source readers.
      * @param segmentReadState Segment read state
      * @param fieldsToInjectVector List of fields to inject vectors into
      */
     public DerivedSourceVectorTransformer(
-        DerivedSourceReadersSupplier derivedSourceReadersSupplier,
+        DerivedSourceReaders derivedSourceReaders,
         SegmentReadState segmentReadState,
         List<DerivedFieldInfo> fieldsToInjectVector
-    ) throws IOException {
-        this.derivedSourceReaders = derivedSourceReadersSupplier.getReaders(segmentReadState);
+    ) {
+        this.derivedSourceReaders = derivedSourceReaders;
         perFieldDerivedVectorTransformers = new HashMap<>();
         Map<String, Function<Object, Object>> perFieldDerivedVectorTransformersFunctionValues = new HashMap<>();
         for (DerivedFieldInfo derivedFieldInfo : fieldsToInjectVector) {
@@ -136,10 +134,5 @@ public class DerivedSourceVectorTransformer implements Closeable {
             return excludedVectorFieldCount < perFieldDerivedVectorTransformers.size();
         }
         return true;
-    }
-
-    @Override
-    public void close() throws IOException {
-        IOUtils.close(derivedSourceReaders);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/DerivedSourceVectorInjectorTests.java
@@ -59,7 +59,7 @@ public class DerivedSourceVectorInjectorTests extends KNNTestCase {
             });
 
             DerivedSourceVectorInjector derivedSourceVectorInjector = new DerivedSourceVectorInjector(
-                new KNN9120DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
+                new KNN9120DerivedSourceReaders(null, null, null, null),
                 null,
                 fields
             );
@@ -117,20 +117,18 @@ public class DerivedSourceVectorInjectorTests extends KNNTestCase {
             KNNCodecTestUtil.FieldInfoBuilder.builder("test3").build()
         );
 
-        try (
-            DerivedSourceVectorInjector vectorInjector = new DerivedSourceVectorInjector(
-                new KNN9120DerivedSourceReadersSupplier(s -> null, s -> null, s -> null, s -> null),
-                null,
-                fields
-            )
-        ) {
-            assertTrue(vectorInjector.shouldInject(null, null));
-            assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, null));
-            assertTrue(vectorInjector.shouldInject(new String[] { "test1", "test2", "test3" }, null));
-            assertTrue(vectorInjector.shouldInject(null, new String[] { "test2" }));
-            assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, new String[] { "test2" }));
-            assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, new String[] { "test2", "test3" }));
-            assertFalse(vectorInjector.shouldInject(null, new String[] { "test1", "test2", "test3" }));
-        }
+        DerivedSourceVectorInjector vectorInjector = new DerivedSourceVectorInjector(
+            new KNN9120DerivedSourceReaders(null, null, null, null),
+            null,
+            fields
+        );
+        assertTrue(vectorInjector.shouldInject(null, null));
+        assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, null));
+        assertTrue(vectorInjector.shouldInject(new String[] { "test1", "test2", "test3" }, null));
+        assertTrue(vectorInjector.shouldInject(null, new String[] { "test2" }));
+        assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, new String[] { "test2" }));
+        assertTrue(vectorInjector.shouldInject(new String[] { "test1" }, new String[] { "test2", "test3" }));
+        assertFalse(vectorInjector.shouldInject(null, new String[] { "test1", "test2", "test3" }));
+
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.mockito.Mock;
+import org.opensearch.knn.KNNTestCase;
+
+import static org.mockito.Mockito.verify;
+
+public class DerivedSourceReadersTests extends KNNTestCase {
+
+    @Mock
+    private KnnVectorsReader mockKnnVectorsReader;
+    @Mock
+    private DocValuesProducer mockDocValuesProducer;
+
+    private DerivedSourceReaders readers;
+
+    @SneakyThrows
+    public void testInitialReferenceCount() {
+        readers = new DerivedSourceReaders(mockKnnVectorsReader, mockDocValuesProducer);
+
+        // Initial reference count is 1, so closing once should trigger actual close
+        readers.close();
+
+        verify(mockKnnVectorsReader).close();
+        verify(mockDocValuesProducer).close();
+    }
+
+    @SneakyThrows
+    public void testNullReaders() {
+        // Test with null readers to ensure no NPE
+        DerivedSourceReaders nullReaders = new DerivedSourceReaders(null, null);
+        nullReaders.close(); // Should not throw any exception
+    }
+}


### PR DESCRIPTION
### Description
Fixes a bug that was already fixed in #2494 but was then reverted by accident in a refactor. It makes it so that instead of opening up readers for each transform request, it opens up once per reader.

This was caught in a 100M perf test I was running. Im thinking we should maybe upgrade our nightlies to use this to prevent in future.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
