### PR TITLE
Fix build due to phasing off SecurityManager usage in favor of Java Agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ buildscript {
 //****************************************************************************/
 
 plugins {
+    id 'eclipse'
     id 'java-library'
     id 'java-test-fixtures'
     id 'idea'
@@ -96,7 +97,7 @@ apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.rest-test'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.repositories'
-
+apply plugin: 'opensearch.java-agent'
 
 def opensearch_tmp_dir = rootProject.file('build/private/opensearch_tmp').absoluteFile
 opensearch_tmp_dir.mkdirs()

--- a/remote-index-build-client/build.gradle
+++ b/remote-index-build-client/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id "io.freefair.lombok"
     id 'com.diffplug.spotless' version '6.25.0'
     id 'opensearch.build'
+    id 'opensearch.java-agent'
 }
 
 repositories {

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -47,6 +47,7 @@ import org.opensearch.knn.index.util.KNNClusterUtil;
 import org.opensearch.knn.indices.ModelCache;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelGraveyard;
+import org.opensearch.knn.jni.PlatformUtils;
 import org.opensearch.knn.plugin.rest.RestClearCacheHandler;
 import org.opensearch.knn.plugin.rest.RestDeleteModelHandler;
 import org.opensearch.knn.plugin.rest.RestGetModelHandler;
@@ -117,6 +118,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
@@ -173,6 +175,14 @@ public class KNNPlugin extends Plugin
     private KNNStats knnStats;
     private ClusterService clusterService;
     private Supplier<RepositoriesService> repositoriesServiceSupplier;
+
+    static {
+        ForkJoinPool.commonPool().execute(() -> {
+            PlatformUtils.isAVX2SupportedBySystem();
+            PlatformUtils.isAVX512SupportedBySystem();
+            PlatformUtils.isAVX512SPRSupportedBySystem();
+        });
+    }
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {

--- a/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNSingleNodeTestCase.java
@@ -41,6 +41,9 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.test.OpenSearchSingleNodeTestCase;
 import org.opensearch.test.hamcrest.OpenSearchAssertions;
 
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Collection;
@@ -63,7 +66,18 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_STATE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_TIMESTAMP;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
+@ThreadLeakFilters(defaultFilters = true, filters = { KNNSingleNodeTestCase.ForkJoinFilter.class })
 public class KNNSingleNodeTestCase extends OpenSearchSingleNodeTestCase {
+    /**
+     * The the ForkJoinPool.commonPool() never terminates until program shutdown.
+     */
+    public static final class ForkJoinFilter implements ThreadFilter {
+        @Override
+        public boolean reject(Thread t) {
+            return t.getName().startsWith("ForkJoinPool.commonPool-worker");
+        }
+    }
+
     @Override
     public void setUp() throws Exception {
         super.setUp();

--- a/src/test/java/org/opensearch/knn/jni/PlatformUtilTests.java
+++ b/src/test/java/org/opensearch/knn/jni/PlatformUtilTests.java
@@ -12,8 +12,11 @@
 package org.opensearch.knn.jni;
 
 import com.sun.jna.Platform;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.opensearch.knn.KNNTestCase;
 import oshi.util.platform.mac.SysctlUtil;
 
 import java.nio.file.Files;
@@ -25,10 +28,16 @@ import static org.opensearch.knn.jni.PlatformUtils.isAVX2SupportedBySystem;
 import static org.opensearch.knn.jni.PlatformUtils.isAVX512SupportedBySystem;
 import static org.opensearch.knn.jni.PlatformUtils.isAVX512SPRSupportedBySystem;
 
-public class PlatformUtilTests extends KNNTestCase {
+public class PlatformUtilTests extends Assert {
     public static final String MAC_CPU_FEATURES = "machdep.cpu.leaf7_features";
     public static final String LINUX_PROC_CPU_INFO = "/proc/cpuinfo";
 
+    @Before
+    public void setUp() {
+        PlatformUtils.reset();
+    }
+
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsNotIntel_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(false);
@@ -36,6 +45,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsIntelWithOSAsWindows_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -44,6 +54,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsMac_returnsTrue() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -59,6 +70,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsMac_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -72,6 +84,7 @@ public class PlatformUtilTests extends KNNTestCase {
 
     }
 
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsMac_throwsExceptionReturnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -98,6 +111,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsLinux_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -112,6 +126,7 @@ public class PlatformUtilTests extends KNNTestCase {
 
     }
 
+    @Test
     public void testIsAVX2SupportedBySystem_platformIsLinux_throwsExceptionReturnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -127,7 +142,7 @@ public class PlatformUtilTests extends KNNTestCase {
     }
 
     // AVX512 tests
-
+    @Test
     public void testIsAVX512SupportedBySystem_platformIsNotIntel_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(false);
@@ -135,6 +150,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SupportedBySystem_platformIsMac_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isMac).thenReturn(false);
@@ -142,6 +158,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SupportedBySystem_platformIsIntelMac_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -150,6 +167,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SupportedBySystem_platformIsIntelWithOSAsWindows_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -158,6 +176,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SupportedBySystem_platformIsLinuxAllAVX512FlagsPresent_returnsTrue() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -171,6 +190,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SupportedBySystem_platformIsLinuxSomeAVX512FlagsPresent_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -185,7 +205,7 @@ public class PlatformUtilTests extends KNNTestCase {
     }
 
     // Tests AVX512 instructions available since Intel(R) Sapphire Rapids.
-
+    @Test
     public void testIsAVX512SPRSupportedBySystem_platformIsNotIntel_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(false);
@@ -193,6 +213,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SPRSupportedBySystem_platformIsMac_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isMac).thenReturn(false);
@@ -200,6 +221,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SPRSupportedBySystem_platformIsIntelMac_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -208,6 +230,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SPRSupportedBySystem_platformIsIntelWithOSAsWindows_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -216,6 +239,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SPRSupportedBySystem_platformIsLinuxAllAVX512SPRFlagsPresent_returnsTrue() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);
@@ -229,6 +253,7 @@ public class PlatformUtilTests extends KNNTestCase {
         }
     }
 
+    @Test
     public void testIsAVX512SPRSupportedBySystem_platformIsLinuxSomeAVX512SPRFlagsPresent_returnsFalse() {
         try (MockedStatic<Platform> mockedPlatform = mockStatic(Platform.class)) {
             mockedPlatform.when(Platform::isIntel).thenReturn(true);


### PR DESCRIPTION
### Description
Fix build due to phasing off SecurityManager usage in favor of Java Agent

### Related Issues
See please https://github.com/opensearch-project/k-NN/actions/runs/14364233941/job/40358433955?pr=2652
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
