### PR TITLE
[Remote Vector Index Build] Add tuned upload/download values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Enhancements
 * Removing redundant type conversions for script scoring for hamming space with binary vectors [#2351](https://github.com/opensearch-project/k-NN/pull/2351)
+* [Remote Vector Index Build] Add tuned repository upload/download configurations per benchmarking results [#2662](https://github.com/opensearch-project/k-NN/pull/2662)
 ### Bug Fixes
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
 


### PR DESCRIPTION
### Description
Adds tuned upload and download buffer sizes from the benchmarking done in #2595, pasted below for convenience:

# Repository Upload and Download Results

The following are the results of benchmarking the repository upload and download buffer size settings. The benchmarking was carried out on an `r6g.4xlarge` instance with 3 data nodes, using OpenSearch Benchmark's `vectorsearch` workload and its included `cohere-100k` and `cohere-1m` datasets. Time-based metrics were collected using OpenSearch's Stopwatch class and memory deltas were collected using Java's Runtime methods, which sometimes returned negative values.

## Repository Upload - Force Merge Results

The benchmarks were run a total of 3 times each. The values shown below are averages taken over all 3 iterations. 

### Vector Upload

`cohere-100k` dataset, uploaded file size was 293 MB.

| | 8kb (default) | 50mb | 100mb | 200mb |
|--------|--------------|------|-------|-------|
| Vector Write Time (ms) | 2964.33 | 2924.67 | 2877.33 | 3086 |
| Vector Throughput (MiB/s) | 99.05 | 100.26 | 101.82 | 94.95 |
| Memory Delta (MB) | 365.37 | 416.2 | 464.72 | 557.94 |

`cohere-1m` dataset, uploaded file size was 2.9 GB. The memory delta data were all negative for these runs, so it has been excluded.

| | 8kb (default) | 50mb | 100mb | 200mb |
|--------|--------------|------|-------|-------|
| Vector Write Time (ms) | 29428 | 29278.33 | 29908 | 30879.33 |
| Vector Throughput (MiB/s) | 99.58 | 100.08 | 98.02 | 95.17 |

### Doc ID Upload

`cohere-100k` dataset, uploaded file size was 390.6 KB. Memory delta was insignificant and showed 0 for each run, so it has been excluded.

| | 8kb (default) | 50kb | 100kb | 200kb |
|--------|--------------|------|-------|-------|
| Doc ID Write Time (ms) | 79.33 | 94 | 78.33 | 139 |
| Doc ID Throughput (MiB/s) | 5.98 | 4.11 | 5.17 | 3.43 |

`cohere-1m` dataset, uploaded file size was 3.8 MB.

| | 8kb (default) | 50kb | 100kb | 200kb |
|--------|--------------|------|-------|-------|
| Doc ID Write Time (ms) | 202.67 | 217.67 | 186.67 | 209.67 |
| Doc ID Throughput (MiB/s) | 21.26 | 18.12 | 20.5 | 18.24 |
| Memory Delta (KB) | 35498.67 | 40945.33 | 35520.67 | 40941.09 |

## Repository Upload - Flush Results

Among other factors, the overhead associated with the uploads may be skewed in flushes with low doc counts when looking at a pure average. For this reason, the averages here were weighted by the file sizes in each operation.

Run 1
| | 8kb (default) | 50mb | 100mb | 200mb |
|--------|--------------|------|-------|-------|
| Doc ID Throughput (MiB/s) | 0.90 | 0.65 | 0.63 | 0.59 |
| Vector Throughput (MiB/s) | 56.24 | 56.76 | 54.55 | 53.86 |

Run 2
| | 8kb (default) | 50mb | 100mb | 200mb |
|--------|--------------|------|-------|-------|
| Doc ID Throughput (MiB/s) | 0.57 | 0.72 | 0.35 | 0.52 |
| Vector Throughput (MiB/s) | 54.73 | 53.94 | 51.71 | 52.03 |

## Repository Download - Force Merge Results

Averaged over 3 iterations. Only one set of results per dataset, since there is only one object (the completed index) being transferred. Before, it was the vectors and doc IDs separately.

`cohere-100k` dataset, downloaded file size of 307.5 MB

| | 64kb (default) | 50mb | 100mb | 200mb |
|--------|--------------|------|-------|-------|
| Read Time (ms) | 6402 | 5928.67 | 5393.67 | 5142 |
| Throughput (MiB/s) | 48.17 | 52.22 | 57.26 | 60.03 |
| Memory Delta (MB) | 61.49 | 64 | 58.8 | 56.16 |

`cohere-1m` dataset, downloaded file size was 3.0 GB

| | 64kb (default) | 50mb | 100mb | 200mb |
|--------|--------------|------|-------|-------|
| Read Time (ms) | 65455.67 | 61220 | 59838.67 | 51937 |
| Throughput (MiB/s) | 47.27 | 50.61 | 51.58 | 59.3 |
| Memory Delta (MB) | -6135.77 | 491.16 | 470.11 | 438.35 |

--- 

### Repository Upload and Download Conclusions 
Drawing from the above results, it seems as if the buffer size did not have much of an impact on the upload phase. It seems clear in the download phase, though, that increasing the buffer size is associated with an increased throughput. However, since the threshold to build an index remotely is only `50mb`, higher buffer sizes could often be allocating more memory than needed and hence "wasting" memory.

To be conservative, we should go with `50mb` for now, and in the future if we raise the minimum size threshold above `50mb` we can adjust these buffer sizes accordingly.

Because each doc ID is only 4 bytes, a conservative choice along the same reasoning would be to stick with the default buffer size of `8kb`, which would be 2000 docs worth.

### Check List
~- [ ] New functionality includes testing.~
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [X] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
