### PR TITLE
Switch derived to default and fix bug in byte derived

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.bwc;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.DerivedSourceTestCase;
 import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
@@ -64,6 +66,29 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
 
             // Reindex
             testReindex(indexConfigContexts);
+        }
+    }
+
+    public void testOldSettingPreservedOnUpgrade() throws IOException {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        String indexName = getIndexName("knn-bwc", "defaults-", false);
+        if (isRunningAgainstOldCluster()) {
+            String fieldName = "test";
+            int dimension = 16;
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(fieldName)
+                .field("type", "knn_vector")
+                .field("dimension", dimension)
+                .endObject()
+                .endObject()
+                .endObject();
+            String mapping = builder.toString();
+            createKnnIndex(indexName, mapping);
+            validateDerivedSetting(indexName, false);
+        } else {
+            validateDerivedSetting(indexName, false);
         }
     }
 

--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -9,6 +9,7 @@ import lombok.experimental.UtilityClass;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.VectorEncoding;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -60,6 +61,10 @@ public class FieldInfoExtractor {
             if (modelMetadata != null) {
                 VectorDataType vectorDataType = modelMetadata.getVectorDataType();
                 vectorDataTypeString = vectorDataType == null ? null : vectorDataType.getValue();
+            } else if (fieldInfo.hasVectorValues()) {
+                vectorDataTypeString = fieldInfo.getVectorEncoding() == VectorEncoding.FLOAT32
+                    ? VectorDataType.FLOAT.toString()
+                    : VectorDataType.BYTE.toString();
             }
         }
         return StringUtils.isNotEmpty(vectorDataTypeString) ? VectorDataType.get(vectorDataTypeString) : VectorDataType.DEFAULT;

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -259,19 +259,19 @@ public class KNNSettings {
         Setting.Property.Dynamic
     );
 
-    public static final Setting<Boolean> KNN_DERIVED_SOURCE_ENABLED_SETTING = Setting.boolSetting(
-        KNN_DERIVED_SOURCE_ENABLED,
+    /**
+     * This setting identifies KNN index.
+     */
+    public static final Setting<Boolean> IS_KNN_INDEX_SETTING = Setting.boolSetting(
+        KNN_INDEX,
         false,
         IndexScope,
         Final,
         UnmodifiableOnRestore
     );
 
-    /**
-     * This setting identifies KNN index.
-     */
-    public static final Setting<Boolean> IS_KNN_INDEX_SETTING = Setting.boolSetting(
-        KNN_INDEX,
+    public static final Setting<Boolean> KNN_DERIVED_SOURCE_ENABLED_SETTING = Setting.boolSetting(
+        KNN_DERIVED_SOURCE_ENABLED,
         false,
         IndexScope,
         Final,

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -8,6 +8,8 @@ package org.opensearch.knn.integ;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.DerivedSourceTestCase;
 import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.knn.Pair;
@@ -162,5 +164,27 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
         // Snapshot restore
         testSnapshotRestore(repository, snapshot + getTestName().toLowerCase(Locale.ROOT), indexConfigContexts);
+    }
+
+    @SneakyThrows
+    public void testDefaultSetting() {
+        String indexName = getIndexName("defaults", "test", false);
+        String fieldName = "test";
+        String indexNameDisabled = "disabled";
+        int dimension = 16;
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .endObject()
+            .endObject()
+            .endObject();
+        String mapping = builder.toString();
+        createKnnIndex(indexName, mapping);
+        validateDerivedSetting(indexName, true);
+        createIndex(indexNameDisabled, Settings.builder().build());
+        validateDerivedSetting(indexNameDisabled, false);
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -16,6 +16,7 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.VectorDataType;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -948,5 +949,9 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
 
             return randomMultiple;
         };
+    }
+
+    protected void validateDerivedSetting(String indexName, boolean expectedValue) throws IOException {
+        assertEquals(expectedValue, Boolean.parseBoolean(getIndexSettingByName(indexName, "index.knn.derived_source.enabled", true)));
     }
 }


### PR DESCRIPTION
### Description
Enables derived source by default. Benchmarks in https://benchmarks.opensearch.org show significant improvements, so we should turn on by default. 

Lucene latencies:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/13a85cd9-1602-406a-8740-47267d2da86b" />
Faiss store size:
<img width="848" alt="image" src="https://github.com/user-attachments/assets/88c39ed9-494e-4e62-9347-6c10ba0fe64e" />


In particular, this change will help configurations that leverage disk in some component.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
