### PR TITLE
Fix quantization cache bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
 ### Enhancements
 * Removing redundant type conversions for script scoring for hamming space with binary vectors [#2351](https://github.com/opensearch-project/k-NN/pull/2351)
+### Bug Fixes
+* [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
@@ -54,7 +54,7 @@ public final class KNN990QuantizationStateReader {
         String quantizationStateFileName = getQuantizationStateFileName(segmentReadState);
         int fieldNumber = segmentReadState.fieldInfos.fieldInfo(field).getFieldNumber();
 
-        try (IndexInput input = segmentReadState.directory.openInput(quantizationStateFileName, IOContext.DEFAULT)) {
+        try (IndexInput input = segmentReadState.directory.openInput(quantizationStateFileName, IOContext.READONCE)) {
 
             CodecUtil.retrieveChecksum(input);
             int numFields = getNumFields(input);

--- a/src/main/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCache.java
+++ b/src/main/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCache.java
@@ -22,6 +22,8 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES;
@@ -66,7 +68,8 @@ public class QuantizationStateCache implements Closeable {
     }
 
     private void buildCache() {
-        this.cache = CacheBuilder.newBuilder().concurrencyLevel(1).maximumWeight(maxCacheSizeInKB).weigher((k, v) -> {
+        final long maxCacheSizeInBytes = maxCacheSizeInKB * 1024;
+        this.cache = CacheBuilder.newBuilder().concurrencyLevel(1).maximumWeight(maxCacheSizeInBytes).weigher((k, v) -> {
             try {
                 return ((QuantizationState) v).toByteArray().length;
             } catch (IOException e) {
@@ -122,17 +125,12 @@ public class QuantizationStateCache implements Closeable {
      * @param fieldName The name of the field.
      * @return The associated QuantizationState, or null if not present.
      */
-    QuantizationState getQuantizationState(String fieldName) {
-        return cache.getIfPresent(fieldName);
-    }
-
-    /**
-     * Adds or updates a quantization state in the cache.
-     * @param fieldName The name of the field.
-     * @param quantizationState The quantization state to store.
-     */
-    void addQuantizationState(String fieldName, QuantizationState quantizationState) {
-        cache.put(fieldName, quantizationState);
+    QuantizationState getQuantizationState(final String fieldName, final Callable<QuantizationState> valueLoader) {
+        try {
+            return cache.get(fieldName, valueLoader);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManager.java
+++ b/src/main/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManager.java
@@ -42,24 +42,12 @@ public final class QuantizationStateCacheManager implements Closeable {
      * @return The associated QuantizationState
      */
     public QuantizationState getQuantizationState(QuantizationStateReadConfig quantizationStateReadConfig) throws IOException {
-        QuantizationState quantizationState = QuantizationStateCache.getInstance()
-            .getQuantizationState(quantizationStateReadConfig.getCacheKey());
-        if (quantizationState == null) {
-            quantizationState = KNN990QuantizationStateReader.read(quantizationStateReadConfig);
-            if (quantizationState != null) {
-                addQuantizationState(quantizationStateReadConfig.getCacheKey(), quantizationState);
-            }
-        }
+        final QuantizationState quantizationState = QuantizationStateCache.getInstance()
+            .getQuantizationState(
+                quantizationStateReadConfig.getCacheKey(),
+                () -> KNN990QuantizationStateReader.read(quantizationStateReadConfig)
+            );
         return quantizationState;
-    }
-
-    /**
-     * Adds or updates a quantization state in the cache.
-     * @param fieldName The name of the field.
-     * @param quantizationState The quantization state to store.
-     */
-    public void addQuantizationState(String fieldName, QuantizationState quantizationState) {
-        QuantizationStateCache.getInstance().addQuantizationState(fieldName, quantizationState);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheManagerTests.java
@@ -6,22 +6,103 @@
 package org.opensearch.knn.quantization.models.quantizationState;
 
 import lombok.SneakyThrows;
+import org.junit.After;
+import org.junit.Before;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNN990Codec.KNN990QuantizationStateReader;
+import org.opensearch.threadpool.ThreadPool;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 public class QuantizationStateCacheManagerTests extends KNNTestCase {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void setThreadPool() {
+        threadPool = new ThreadPool(Settings.builder().put("node.name", "QuantizationStateCacheTests").build());
+        QuantizationStateCache.setThreadPool(threadPool);
+        QuantizationStateCache.getInstance().rebuildCache();
+    }
+
+    @After
+    public void terminateThreadPool() {
+        terminate(threadPool);
+    }
+
+    @SneakyThrows
+    public void testConcurrentLoad() {
+        // Get manager and clean it.
+        final QuantizationStateCacheManager manager = QuantizationStateCacheManager.getInstance();
+        manager.rebuildCache();
+
+        // Mock read config
+        final QuantizationStateReadConfig readConfig = mock(QuantizationStateReadConfig.class);
+        when(readConfig.getCacheKey()).thenReturn("cache_key");
+
+        // Add state first.
+        final QuantizationState quantizationState = mock(QuantizationState.class);
+        when(quantizationState.toByteArray()).thenReturn(new byte[32]);
+        try (MockedStatic<KNN990QuantizationStateReader> mockedStaticReader = Mockito.mockStatic(KNN990QuantizationStateReader.class)) {
+            // Mock static
+            mockedStaticReader.when(() -> KNN990QuantizationStateReader.read(readConfig)).thenReturn(quantizationState);
+
+            // Add state
+            manager.getQuantizationState(readConfig);
+        }
+
+        // Set up thread executors
+        final int threadCount = 10;
+        final int tries = 100;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Try to get in parallel
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    for (int k = 0; k < tries; k++) {
+                        // Since we already added state at the beginning, even multiple threads try to load,
+                        // the retrieved one should be the one that we added.
+                        final QuantizationState acquired = manager.getQuantizationState(readConfig);
+                        assertEquals(quantizationState, acquired);
+                    }
+                } catch (Exception e) {
+                    fail(e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+    }
 
     @SneakyThrows
     public void testRebuildCache() {
         try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
-            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            // Mocking state cache singleton
+            QuantizationStateCache quantizationStateCache = mock(QuantizationStateCache.class);
             mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
+
+            // Mocking it to do nothing when `rebuildCache`
             Mockito.doNothing().when(quantizationStateCache).rebuildCache();
             QuantizationStateCacheManager.getInstance().rebuildCache();
+
+            // Verify rebuildCache is called exactly once
             Mockito.verify(quantizationStateCache, times(1)).rebuildCache();
         }
     }
@@ -29,22 +110,30 @@ public class QuantizationStateCacheManagerTests extends KNNTestCase {
     @SneakyThrows
     public void testGetQuantizationState() {
         try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
-            QuantizationStateReadConfig quantizationStateReadConfig = Mockito.mock(QuantizationStateReadConfig.class);
+            // Mocking read config with cache key
+            QuantizationStateReadConfig quantizationStateReadConfig = mock(QuantizationStateReadConfig.class);
             String cacheKey = "test-key";
-            Mockito.when(quantizationStateReadConfig.getCacheKey()).thenReturn(cacheKey);
-            QuantizationState quantizationState = Mockito.mock(QuantizationState.class);
-            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            when(quantizationStateReadConfig.getCacheKey()).thenReturn(cacheKey);
+
+            // Mocking quantization state
+            QuantizationState quantizationState = mock(QuantizationState.class);
+            QuantizationStateCache quantizationStateCache = mock(QuantizationStateCache.class);
             mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
-            Mockito.doNothing().when(quantizationStateCache).addQuantizationState(cacheKey, quantizationState);
+            when(quantizationStateCache.getQuantizationState(any(), any())).thenReturn(quantizationState);
+
+            // Validate `getQuantizationState` of `quantizationStateCache` was called.
             try (MockedStatic<KNN990QuantizationStateReader> mockedStaticReader = Mockito.mockStatic(KNN990QuantizationStateReader.class)) {
                 mockedStaticReader.when(() -> KNN990QuantizationStateReader.read(quantizationStateReadConfig))
                     .thenReturn(quantizationState);
                 QuantizationStateCacheManager.getInstance().getQuantizationState(quantizationStateReadConfig);
-                Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(cacheKey, quantizationState);
+                Mockito.verify(quantizationStateCache, times(1)).getQuantizationState(eq(cacheKey), any());
             }
-            Mockito.when(quantizationStateCache.getQuantizationState(cacheKey)).thenReturn(quantizationState);
+
+            // Validate `getQuantizationState` was called AGAIN.
+            // But this time, we don't need to invoke `read` as we have a value loaded already.
+            when(quantizationStateCache.getQuantizationState(any(), any())).thenReturn(quantizationState);
             QuantizationStateCacheManager.getInstance().getQuantizationState(quantizationStateReadConfig);
-            Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(cacheKey, quantizationState);
+            Mockito.verify(quantizationStateCache, times(2)).getQuantizationState(eq(cacheKey), any());
         }
     }
 
@@ -52,7 +141,7 @@ public class QuantizationStateCacheManagerTests extends KNNTestCase {
     public void testEvict() {
         try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
             String field = "test-field";
-            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            QuantizationStateCache quantizationStateCache = mock(QuantizationStateCache.class);
             mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
             Mockito.doNothing().when(quantizationStateCache).evict(field);
             QuantizationStateCacheManager.getInstance().evict(field);
@@ -61,23 +150,10 @@ public class QuantizationStateCacheManagerTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testAddQuantizationState() {
-        try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
-            String field = "test-field";
-            QuantizationState quantizationState = Mockito.mock(QuantizationState.class);
-            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
-            mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
-            Mockito.doNothing().when(quantizationStateCache).addQuantizationState(field, quantizationState);
-            QuantizationStateCacheManager.getInstance().addQuantizationState(field, quantizationState);
-            Mockito.verify(quantizationStateCache, times(1)).addQuantizationState(field, quantizationState);
-        }
-    }
-
-    @SneakyThrows
     public void testSetMaxCacheSizeInKB() {
         try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
             long maxCacheSizeInKB = 1024;
-            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            QuantizationStateCache quantizationStateCache = mock(QuantizationStateCache.class);
             mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
             Mockito.doNothing().when(quantizationStateCache).setMaxCacheSizeInKB(maxCacheSizeInKB);
             QuantizationStateCacheManager.getInstance().setMaxCacheSizeInKB(1024);
@@ -88,7 +164,7 @@ public class QuantizationStateCacheManagerTests extends KNNTestCase {
     @SneakyThrows
     public void testClear() {
         try (MockedStatic<QuantizationStateCache> mockedStaticCache = Mockito.mockStatic(QuantizationStateCache.class)) {
-            QuantizationStateCache quantizationStateCache = Mockito.mock(QuantizationStateCache.class);
+            QuantizationStateCache quantizationStateCache = mock(QuantizationStateCache.class);
             mockedStaticCache.when(QuantizationStateCache::getInstance).thenReturn(quantizationStateCache);
             Mockito.doNothing().when(quantizationStateCache).clear();
             QuantizationStateCacheManager.getInstance().clear();

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.SneakyThrows;
 import org.junit.After;
 import org.junit.Before;
-import org.opensearch.transport.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -19,6 +18,7 @@ import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
@@ -39,6 +39,7 @@ public class QuantizationStateCacheTests extends KNNTestCase {
     public void setThreadPool() {
         threadPool = new ThreadPool(Settings.builder().put("node.name", "QuantizationStateCacheTests").build());
         QuantizationStateCache.setThreadPool(threadPool);
+        QuantizationStateCache.getInstance().rebuildCache();
     }
 
     @After
@@ -47,13 +48,76 @@ public class QuantizationStateCacheTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testConcurrentLoadWhenValueExists() {
+        // Set up thread executors
+        final int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Prepare quantization state
+        final String fieldName = "multiThreadField";
+        final QuantizationState state = new OneBitScalarQuantizationState(
+            new ScalarQuantizationParams(ONE_BIT),
+            new float[] { 1.2f, 2.3f, 3.4f }
+        );
+
+        // Configure settings
+        final String cacheSize = "10%";
+        final TimeValue expiry = TimeValue.timeValueMinutes(30);
+        final Settings settings = Settings.builder()
+            .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
+            .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+
+        // Mocking ClusterService
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        // Apply settings
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        clusterService.getClusterSettings().applySettings(settings);
+
+        // Add the state first
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> state);
+        assertEquals(state, retrievedState);
+
+        // Add state from multiple threads
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    // Since we already added state at the beginning, even multiple threads try to load,
+                    // the retrieved one should be the one that we added.
+                    final QuantizationState acquired = cache.getQuantizationState(
+                        fieldName,
+                        () -> new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), new float[] { 1.2f, 2.3f, 3.4f })
+                    );
+                    assertEquals(state, acquired);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all threads to finish
+        latch.await();
+        executorService.shutdown();
+    }
+
+    @SneakyThrows
     public void testSingleThreadedAddAndRetrieve() {
+        // Prepare state
         String fieldName = "singleThreadField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
 
+        // Configure settings with 10%
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
@@ -65,35 +129,40 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        // Apply the configured setting
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
         clusterService.getClusterSettings().applySettings(settings);
 
-        // Add state
-        cache.addQuantizationState(fieldName, state);
-
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        // Try to get a state and validate
+        final QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> state);
         assertNotNull("State should be retrieved successfully", retrievedState);
         assertSame("Retrieved state should be the same instance as the one added", state, retrievedState);
     }
 
     @SneakyThrows
     public void testMultiThreadedAddAndRetrieve() {
-        int threadCount = 10;
+        // Set up thread executors
+        final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch latch = new CountDownLatch(threadCount);
-        String fieldName = "multiThreadField";
-        QuantizationState state = new OneBitScalarQuantizationState(
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Prepare quantization state
+        final String fieldName = "multiThreadField";
+        final QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
-        String cacheSize = "10%";
-        TimeValue expiry = TimeValue.timeValueMinutes(30);
 
-        Settings settings = Settings.builder()
+        // Configure settings
+        final String cacheSize = "10%";
+        final TimeValue expiry = TimeValue.timeValueMinutes(30);
+        final Settings settings = Settings.builder()
             .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
             .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
             .build();
@@ -101,18 +170,24 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        // Apply settings
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
         clusterService.getClusterSettings().applySettings(settings);
 
         // Add state from multiple threads
+        final int tries = 100;
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    cache.addQuantizationState(fieldName, state);
+                    for (int k = 0; k < tries; k++) {
+                        cache.getQuantizationState(fieldName, () -> state);
+                    }
                 } finally {
                     latch.countDown();
                 }
@@ -123,16 +198,20 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         latch.await();
         executorService.shutdown();
 
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
+        // Validate retrieved state
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> state);
         assertNotNull("State should be retrieved successfully", retrievedState);
         assertSame("Retrieved state should be the same instance as the one added", state, retrievedState);
     }
 
     @SneakyThrows
     public void testMultiThreadedEvict() {
-        int threadCount = 10;
+        // Set up threads
+        final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Prepare quantization state
         String fieldName = "multiThreadEvictField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
@@ -141,10 +220,13 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
 
+        // Configure settings
         Settings settings = Settings.builder()
             .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
             .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
             .build();
+
+        // Mocking ClusterService
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
@@ -153,11 +235,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
-
+        // Apply settings to ClusterService
         clusterService.getClusterSettings().applySettings(settings);
 
-        cache.addQuantizationState(fieldName, state);
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.getQuantizationState(fieldName, () -> state);
 
         // Evict state from multiple threads
         for (int i = 0; i < threadCount; i++) {
@@ -174,27 +256,34 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         latch.await();
         executorService.shutdown();
 
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
-        assertNull("State should be null", retrievedState);
+        final QuantizationState mockedState = getMockedState();
+        final QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> mockedState);
+        assertEquals(mockedState, retrievedState);
     }
 
     @SneakyThrows
     public void testConcurrentAddAndEvict() {
+        // Set up thread executors
         int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
-        String fieldName = "concurrentAddEvictField";
+
+        // Prepare quantization state
+        final String fieldName = "concurrentAddEvictField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
+
+        // Configure settings
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
-
         Settings settings = Settings.builder()
             .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
             .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
             .build();
+
+        // Mocking ClusterService
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
@@ -203,15 +292,16 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        // Apply settings
         clusterService.getClusterSettings().applySettings(settings);
 
         // Concurrently add and evict state from multiple threads
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
         for (int i = 0; i < threadCount; i++) {
             if (i % 2 == 0) {
                 executorService.submit(() -> {
                     try {
-                        cache.addQuantizationState(fieldName, state);
+                        cache.getQuantizationState(fieldName, () -> state);
                     } finally {
                         latch.countDown();
                     }
@@ -225,7 +315,6 @@ public class QuantizationStateCacheTests extends KNNTestCase {
                     }
                 });
             }
-
         }
 
         // Wait for all threads to finish
@@ -233,23 +322,28 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         executorService.shutdown();
 
         // Since operations are concurrent, we can't be sure of the final state, but we can assert that the cache handles it gracefully
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
-        assertTrue("Final state should be either null or the added state", retrievedState == null || retrievedState == state);
+        QuantizationState mockedState = getMockedState();
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> mockedState);
+        assertTrue("Final state should be either new one or the added state", retrievedState == mockedState || retrievedState == state);
     }
 
     @SneakyThrows
     public void testMultipleThreadedCacheClear() {
-        int threadCount = 10;
+        // Set up thread executors
+        final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
-        String fieldName = "multiThreadField";
+
+        // Prepare quantization state
+        final String fieldName = "multiThreadField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
+
+        // Configure settings
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
-
         Settings settings = Settings.builder()
             .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
             .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
@@ -258,13 +352,16 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        // Apply settings
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
         clusterService.getClusterSettings().applySettings(settings);
-        cache.addQuantizationState(fieldName, state);
+        cache.getQuantizationState(fieldName, () -> state);
 
         // Clear cache from multiple threads
         for (int i = 0; i < threadCount; i++) {
@@ -281,23 +378,29 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         latch.await();
         executorService.shutdown();
 
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
-        assertNull("State should be null", retrievedState);
+        // Validate there's no state, and it should be the one we just added.
+        QuantizationState mockedState = getMockedState();
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> mockedState);
+        assertEquals(mockedState, retrievedState);
     }
 
     @SneakyThrows
     public void testRebuild() {
-        int threadCount = 10;
+        // Set up thread executors
+        final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Prepare quantization state
         String fieldName = "rebuildField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
+
+        // Configure settings
         String cacheSize = "10%";
         TimeValue expiry = TimeValue.timeValueMinutes(30);
-
         Settings settings = Settings.builder()
             .put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), cacheSize)
             .put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), expiry)
@@ -306,12 +409,15 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
-        cache.addQuantizationState(fieldName, state);
+        // Apply settings
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.getQuantizationState(fieldName, () -> state);
 
         // Rebuild cache from multiple threads
         for (int i = 0; i < threadCount; i++) {
@@ -328,41 +434,49 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         latch.await();
         executorService.shutdown();
 
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
-        assertNull("State should be null", retrievedState);
+        // Validate there's no state, and it should be the one we just added.
+        QuantizationState mockedState = getMockedState();
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> mockedState);
+        assertEquals(mockedState, retrievedState);
     }
 
     @SneakyThrows
     public void testRebuildOnCacheSizeSettingsChange() {
+        // Set up thread executors
         int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Prepare quantization state
         String fieldName = "rebuildField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
 
+        // Configure settings
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
+        // Initialize KNNSettings
         Client client = mock(Client.class);
-
         KNNSettings.state().initialize(client, clusterService);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
-        cache.rebuildCache();
+        // Rebuild and add the state
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
         long maxCacheSizeInKB = cache.getMaxCacheSizeInKB();
-        cache.addQuantizationState(fieldName, state);
+        cache.getQuantizationState(fieldName, () -> state);
 
+        // Prepare a new setting
         String newCacheSize = "10%";
-
         Settings newSettings = Settings.builder().put(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING.getKey(), newCacheSize).build();
 
         // Rebuild cache from multiple threads
@@ -380,40 +494,49 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         latch.await();
         executorService.shutdown();
 
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
-        assertNull("State should be null", retrievedState);
+        // Validate there's no state and KB threshold value.
+        QuantizationState mockedState = getMockedState();
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> mockedState);
+        assertEquals(mockedState, retrievedState);
         assertNotEquals(maxCacheSizeInKB, cache.getMaxCacheSizeInKB());
     }
 
     @SneakyThrows
     public void testRebuildOnTimeExpirySettingsChange() {
-        int threadCount = 10;
+        // Set up thread executors
+        final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // Prepare quantization state
         String fieldName = "rebuildField";
         QuantizationState state = new OneBitScalarQuantizationState(
             new ScalarQuantizationParams(ONE_BIT),
             new float[] { 1.2f, 2.3f, 3.4f }
         );
 
+        // Configure settings
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
+        // Initialize KNNSettings
         Client client = mock(Client.class);
-
         KNNSettings.state().initialize(client, clusterService);
 
-        QuantizationStateCache cache = QuantizationStateCache.getInstance();
-        cache.addQuantizationState(fieldName, state);
+        // Add a new state
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.getQuantizationState(fieldName, () -> state);
 
+        // Prepare a new settings
         TimeValue newExpiry = TimeValue.timeValueMinutes(30);
-
         Settings newSettings = Settings.builder().put(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING.getKey(), newExpiry).build();
 
         // Rebuild cache from multiple threads
@@ -431,44 +554,118 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         latch.await();
         executorService.shutdown();
 
-        QuantizationState retrievedState = cache.getQuantizationState(fieldName);
-        assertNull("State should be null", retrievedState);
+        // Validate there was no state in it.
+        QuantizationState mockedState = getMockedState();
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> mockedState);
+        assertEquals(mockedState, retrievedState);
     }
 
-    public void testCacheEvictionDueToSize() throws IOException {
-        String fieldName = "evictionField";
-        // States have size of slightly over 500 bytes so that adding two will reach the max size of 1 kb for the cache
-        int arrayLength = 112;
-        float[] arr = new float[arrayLength];
-        float[] arr2 = new float[arrayLength];
+    public void testCacheEvictionToSize() throws IOException {
+        // Adding 4K + 100 bytes as meta info (e.g. length vint encoding etc)
+        final int arrayLength = 1024;
+
+        // Prepare state1 ~ roughly 4,100 bytes
+        float[] meanThresholds1 = new float[arrayLength];
         for (int i = 0; i < arrayLength; i++) {
-            arr[i] = i;
-            arr[i] = i + 1;
+            meanThresholds1[i] = i;
         }
-        QuantizationState state = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), arr);
-        QuantizationState state2 = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), arr2);
-        long cacheSize = 1;
+
+        // Configure settings
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
             ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
         );
+
+        // Mocking ClusterService
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.getSettings()).thenReturn(settings);
 
-        QuantizationStateCache cache = new QuantizationStateCache();
-        cache.setMaxCacheSizeInKB(cacheSize);
-        cache.rebuildCache();
-        cache.addQuantizationState(fieldName, state);
-        cache.addQuantizationState(fieldName, state2);
+        // Build cache
+        final String fieldName = "evictionField";
+        // Setting 1KB as a threshold. As a result, expected the first one added will be evicted right away.
+        final long cacheSizeKB = 1;
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.setMaxCacheSizeInKB(cacheSizeKB);
+        cache.rebuildCache();  // Need to rebuild to update size threshold.
+
+        // Try to add the first state
+        final QuantizationState state = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), meanThresholds1);
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> state);
+        assertEquals(state, retrievedState);
+
+        // Try again
+        final QuantizationState state2 = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), meanThresholds1);
+        retrievedState = cache.getQuantizationState(fieldName, () -> state2);
+        assertEquals(state2, retrievedState);
+
+        // Close cache
         cache.clear();
         cache.close();
+
+        // Validate whether states were evicted due to size.
+        assertNotNull(cache.getEvictedDueToSizeAt());
+    }
+
+    public void testCacheEvictionDueToSize() throws IOException {
+        // Adding 4K + 100 bytes as meta info (e.g. length vint encoding etc)
+        final int arrayLength = 1024;
+
+        // Prepare state1 ~ roughly 4,100 bytes
+        float[] meanThresholds1 = new float[arrayLength];
+        for (int i = 0; i < arrayLength; i++) {
+            meanThresholds1[i] = i;
+        }
+        QuantizationState state1 = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), meanThresholds1);
+
+        // Prepare state2 ~ roughly 4,100 bytes
+        float[] meanThresholds2 = new float[arrayLength];
+        for (int i = 0; i < arrayLength; i++) {
+            meanThresholds2[i] = i + 1;
+        }
+        QuantizationState state2 = new OneBitScalarQuantizationState(new ScalarQuantizationParams(ONE_BIT), meanThresholds2);
+
+        // Configure settings
+        Settings settings = Settings.builder().build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+        );
+
+        // Mocking ClusterService
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        // Build cache
+        final String fieldName = "evictionField";
+        final String fieldName2 = "evictionField2";
+        // Setting 7KB as a threshold. As the weight of each one si roughly 4,100 bytes
+        // Thus, setting 7KB so that it can evict the first one added when the second state is added.
+        final long cacheSizeKB = 7;
+        final QuantizationStateCache cache = QuantizationStateCache.getInstance();
+        cache.setMaxCacheSizeInKB(cacheSizeKB);
+        cache.rebuildCache();  // Need to rebuild to update size threshold.
+
+        // Try to add the first state
+        QuantizationState retrievedState = cache.getQuantizationState(fieldName, () -> state1);
+        assertEquals(state1, retrievedState);
+
+        // Try to add the second state
+        retrievedState = cache.getQuantizationState(fieldName2, () -> state2);
+        assertEquals(state2, retrievedState);
+
+        // Close cache
+        cache.clear();
+        cache.close();
+
+        // Validate whether states were evicted due to size.
         assertNotNull(cache.getEvictedDueToSizeAt());
     }
 
     public void testMaintenanceScheduled() throws Exception {
-        QuantizationStateCache quantizationStateCache = new QuantizationStateCache();
+        final QuantizationStateCache quantizationStateCache = QuantizationStateCache.getInstance();
         Scheduler.Cancellable maintenanceTask = quantizationStateCache.getMaintenanceTask();
 
         assertNotNull(maintenanceTask);
@@ -478,7 +675,7 @@ public class QuantizationStateCacheTests extends KNNTestCase {
     }
 
     public void testMaintenanceWithRebuild() throws Exception {
-        QuantizationStateCache quantizationStateCache = new QuantizationStateCache();
+        final QuantizationStateCache quantizationStateCache = QuantizationStateCache.getInstance();
         Scheduler.Cancellable task1 = quantizationStateCache.getMaintenanceTask();
         assertNotNull(task1);
 
@@ -488,5 +685,12 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         assertTrue(task1.isCancelled());
         assertNotNull(task2);
         quantizationStateCache.close();
+    }
+
+    @SneakyThrows
+    private static QuantizationState getMockedState() {
+        QuantizationState mockedState = mock(QuantizationState.class);
+        when(mockedState.toByteArray()).thenReturn(new byte[32]);
+        return mockedState;
     }
 }


### PR DESCRIPTION
### Description
This PR fixes two bugs:
1. Scale issue : We are using KB as the limit as oppose to use bytes. As a result, even the value occupies few bytes, it is interpreted as KB leading to frequent cache eviction.
2. Non thread safe : Since Check-then-update logic is not properly guarded, leading to multiple threads are loading the meta info from the disk and update the value, which is unnecessary though.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/k-NN/issues/2665

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
