### PR TITLE
Fix build.gradle AVX settings to not to use default value.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,10 @@ buildscript {
         version_qualifier = System.getProperty("build.version_qualifier", "beta1")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        avx2_enabled = System.getProperty("avx2.enabled", "true")
+        avx2_enabled = System.getProperty("avx2.enabled")
         nproc_count = System.getProperty("nproc.count", "1")
-        avx512_enabled = System.getProperty("avx512.enabled", "true")
-        avx512_spr_enabled = System.getProperty("avx512_spr.enabled", "true")
+        avx512_enabled = System.getProperty("avx512.enabled")
+        avx512_spr_enabled = System.getProperty("avx512_spr.enabled")
         // This flag determines whether the CMake build system should apply a custom patch. It prevents build failures
         // when the cmakeJniLib task is run multiple times. If the build.lib.commit_patches is true, the CMake build
         // system skips applying the patch if the patches have been applied already. If build.lib.commit_patches is
@@ -373,9 +373,15 @@ tasks.register('cmakeJniLib', Exec) {
     args.add("-S jni") // CMakelists.txt directory
     args.add("-B jni/build") // Build directory
     args.add("-DKNN_PLUGIN_VERSION=${opensearch_version}")
-    args.add("-DAVX2_ENABLED=${avx2_enabled}")
-    args.add("-DAVX512_ENABLED=${avx512_enabled}")
-    args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
+    if (avx2_enabled != null) {
+        args.add("-DAVX2_ENABLED=${avx2_enabled}")
+    }
+    if (avx512_enabled != null) {
+        args.add("-DAVX512_ENABLED=${avx512_enabled}")
+    }
+    if (avx512_spr_enabled != null) {
+        args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
+    }
     args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
     args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
     args.add("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")


### PR DESCRIPTION
### Description
Fix `build.gradle` script not to use `true` as a default AVX settings.
Currently, we have three AVX settings as listed below:
 - AVX2
 - AVX512
 - AVX512-SPR

The issue is, regardless of whether if Linux environment supports the settings, since we are assigning the variable with `System.getProperty("...", "true")` which return "true" when it is not set, `gradle` always passes `-DAVX512_SPR_ENABLED=true` even for an instance not having the Intel SPR process installed.

This always force `make` to link `avx512-spr` shared library due to the `if-else` evaluation order in cmake file - [Code](https://github.com/opensearch-project/k-NN/blob/main/jni/cmake/init-faiss.cmake#L125)
It first evaluates whether OS is Windows, then check whether AVX512_SPR_ENABLED is set which is always true.

This is only issue in Linux environment, and due to this, KNN operations always fails as it could not find avx2 so file or avx512 so file for non-SPR processor. 

Hence, fixing `build.gradle` to pass AVX related parameters to `cmake` only if when user configured manually. 


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
