### PR TITLE
[LuceneOnFaiss M2, PR2] Added binary HNSW graph support in Faiss index for memory optimized search

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSWProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSWProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+/**
+ * Provider for returning an instance of {@link FaissHNSW}.
+ * <p>
+ * This provider should consistently return the same instance across multiple calls.
+ * It does not imply a singleton instance, but each provider instance should consistently return the same {@link FaissHNSW} instance across
+ * multiple calls.
+ */
+public interface FaissHNSWProvider {
+    /**
+     * Return internal {@link FaissHNSW}.
+     *
+     * @return {@link FaissHNSW} instance it internally keeps.
+     */
+    FaissHNSW getFaissHnsw();
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndex.java
@@ -50,7 +50,7 @@ public abstract class FaissIndex {
      * @throws IOException
      */
     public static FaissIndex load(IndexInput input) throws IOException {
-        final String indexType = readIndexType(input);
+        final String indexType = FaissIndexLoadUtils.readIndexType(input);
         final FaissIndex faissIndex = IndexTypeToFaissIndexMapping.getFaissIndex(indexType);
         faissIndex.doLoad(input);
         return faissIndex;
@@ -76,12 +76,6 @@ public abstract class FaissIndex {
         } else {
             throw new IllegalStateException("Partial loading does not support metric type index=" + metricTypeIndex + " from FAISS.");
         }
-    }
-
-    static private String readIndexType(final IndexInput input) throws IOException {
-        final byte[] fourBytes = new byte[4];
-        input.readBytes(fourBytes, 0, fourBytes.length);
-        return new String(fourBytes);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexLoadUtils.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexLoadUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.experimental.UtilityClass;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
+
+import java.io.IOException;
+
+/**
+ * Util class being used during partial load each section in Faiss index file.
+ * Refer to {@link FaissIndex#doLoad(IndexInput)} for more details regarding how it is being used.
+ */
+@UtilityClass
+public class FaissIndexLoadUtils {
+    /**
+     * Each section of Faiss index must start four leading characters indicating its index type.
+     * This is being used to read four bytes, then convert them to String.
+     *
+     * @param input IndexInput reading bytes from Faiss index.
+     * @return A string of index type.
+     * @throws IOException
+     */
+    public static String readIndexType(final IndexInput input) throws IOException {
+        final byte[] fourBytes = new byte[4];
+        input.readBytes(fourBytes, 0, fourBytes.length);
+        return new String(fourBytes);
+    }
+
+    /**
+     * Util function to convert {@link FaissIndex} to {@link FaissBinaryIndex}.
+     * If it fails to cast the given index instance, it will throw {@link IllegalArgumentException}.
+     *
+     * @param index Target index instance to be casted to {@link FaissBinaryIndex}.
+     * @return Casted {@link FaissBinaryIndex}.
+     */
+    public static FaissBinaryIndex toBinaryIndex(final FaissIndex index) {
+        if (index instanceof FaissBinaryIndex binaryIndex) {
+            return binaryIndex;
+        }
+
+        throw new IllegalArgumentException("Failed to convert [" + index.getIndexType() + "] to FaissBinaryIndex.");
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/IndexTypeToFaissIndexMapping.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/IndexTypeToFaissIndexMapping.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.experimental.UtilityClass;
+import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
 
@@ -37,6 +38,7 @@ public class IndexTypeToFaissIndexMapping {
 
         // Binary index
         mapping.put(FaissIndexBinaryFlat.IBXF, (indexType) -> new FaissIndexBinaryFlat());
+        mapping.put(FaissBinaryHnswIndex.IBHF, (indexType) -> new FaissBinaryHnswIndex());
 
         INDEX_TYPE_TO_FAISS_INDEX = Collections.unmodifiableMap(mapping);
     }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryHnswIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryHnswIndex.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.binary;
+
+import lombok.Getter;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSW;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSWProvider;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexLoadUtils;
+
+import java.io.IOException;
+
+/**
+ * HNSW graph having a binary storage internally in Faiss index file.
+ * <p>
+ * Faiss - <a href="https://github.com/facebookresearch/faiss/blob/main/faiss/IndexBinaryHNSW.h">...</a>
+ */
+public class FaissBinaryHnswIndex extends FaissBinaryIndex implements FaissHNSWProvider {
+    public static final String IBHF = "IBHf";
+
+    @Getter
+    private FaissHNSW faissHnsw;
+    private FaissBinaryIndex storage;
+
+    public FaissBinaryHnswIndex() {
+        super(IBHF);
+        this.faissHnsw = new FaissHNSW();
+    }
+
+    /**
+     * Partial load binary HNSW index via the provided {@link IndexInput}.
+     * <p>
+     * Faiss - <a href="https://github.com/facebookresearch/faiss/blob/main/faiss/impl/index_read.cpp#L1381">...</a>
+     *
+     * @param input
+     * @throws IOException
+     */
+    @Override
+    protected void doLoad(IndexInput input) throws IOException {
+        // Read common binary index header
+        readCommonHeader(input);
+
+        // Partial load HNSW graph
+        faissHnsw.load(input, getTotalNumberOfVectors());
+
+        // Partial load storage
+        storage = FaissIndexLoadUtils.toBinaryIndex(FaissIndex.load(input));
+    }
+
+    @Override
+    public VectorEncoding getVectorEncoding() {
+        return storage.getVectorEncoding();
+    }
+
+    @Override
+    public FloatVectorValues getFloatValues(IndexInput indexInput) throws IOException {
+        throw new UnsupportedOperationException(FaissBinaryHnswIndex.class.getSimpleName() + " doees not support FloatVectorValues.");
+    }
+
+    @Override
+    public ByteVectorValues getByteValues(IndexInput indexInput) throws IOException {
+        return storage.getByteValues(indexInput);
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryIndex.java
@@ -33,7 +33,7 @@ public abstract class FaissBinaryIndex extends FaissIndex {
      * @param inputStream Input stream reading bytes from Faiss index file.
      * @throws IOException
      */
-    public void readCommonBinaryHeader(final IndexInput inputStream) throws IOException {
+    protected void readCommonHeader(final IndexInput inputStream) throws IOException {
         dimension = inputStream.readInt();
         codeSize = inputStream.readInt();
         totalNumberOfVectors = Math.toIntExact(inputStream.readLong());

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
@@ -19,13 +19,8 @@ import java.io.IOException;
  * <p>
  * The format consists of two parts:
  * 1. A binary header
- * 2. A quantized flat vector section
- * <p>
- * The quantized vector section contains a list of vectors, each of size `codeSize`.
- * For example, applying 8x compression to a 100-dimensional float vector results in
- * a `codeSize` of 50 bytes per vector, calculated as (4 * 100) / 8.
- * <p>
- * Note: Quantized vectors should be compared using Hamming distance only.
+ * 2. A flat binary vector section
+ * Note: Binary vectors stored within this format should be compared using Hamming distance only.
  * See <a href="https://github.com/facebookresearch/faiss/blob/main/faiss/IndexBinaryFlat.h">...</a> for more details.
  */
 public class FaissIndexBinaryFlat extends FaissBinaryIndex {
@@ -46,7 +41,7 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
      */
     @Override
     protected void doLoad(IndexInput input) throws IOException {
-        readCommonBinaryHeader(input);
+        readCommonHeader(input);
         binaryFlatVectorSection = new FaissSection(input, 1);
     }
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissBinaryHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissBinaryHnswIndexTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.opensearch.knn.memoryoptsearch.FaissIndexFloatFlatTests.NUM_VECTORS;
+
+public class FaissBinaryHnswIndexTests extends KNNTestCase {
+    public static final int CODE_SIZE = 64;
+    // 512 binary Dimension
+    public static final int BINARY_DIMENSION = (int) (Math.ceil((4 * 128) / 8) * 8);
+    private static final int IBHF_START_OFFSET = 25;
+
+    @SneakyThrows
+    public void testLoad() {
+        // Load binary
+        final IndexInput indexInput = loadBinaryHnswIndex();
+
+        // Trigger load
+        final FaissIndex faissIndex = FaissIndex.load(indexInput);
+        assertTrue(faissIndex instanceof FaissBinaryHnswIndex);
+        final FaissBinaryHnswIndex faissBinaryHnswIndex = (FaissBinaryHnswIndex) faissIndex;
+
+        // Validate index
+        assertEquals(FaissBinaryHnswIndex.IBHF, faissBinaryHnswIndex.getIndexType());
+
+        // Validate header
+        assertEquals(VectorEncoding.BYTE, faissBinaryHnswIndex.getVectorEncoding());
+        assertEquals(NUM_VECTORS, faissBinaryHnswIndex.getTotalNumberOfVectors());
+        assertEquals(KNNVectorSimilarityFunction.HAMMING, faissBinaryHnswIndex.getVectorSimilarityFunction());
+        assertEquals(CODE_SIZE, faissBinaryHnswIndex.getCodeSize());
+        assertEquals(BINARY_DIMENSION, faissBinaryHnswIndex.getDimension());
+    }
+
+    @SneakyThrows
+    private IndexInput loadBinaryHnswIndex() {
+        final String relativePath = "data/memoryoptsearch/faiss_binary_50_vectors_512_dim.bin";
+        final URL floatFloatVectors = FaissHNSWTests.class.getClassLoader().getResource(relativePath);
+        byte[] bytes = Files.readAllBytes(Path.of(floatFloatVectors.toURI()));
+        bytes = Arrays.copyOfRange(bytes, IBHF_START_OFFSET, bytes.length);
+        final IndexInput indexInput = new ByteArrayIndexInput("FaissIndexFloatFlatTests", bytes);
+        return indexInput;
+    }
+}


### PR DESCRIPTION
### Description
This PR is to support binary HNSW in memory optimized search.
The binary HNSW consists of two parts:
1. HNSW
2. Binary flat vectors

In the change, added `FaissBinaryHnswIndex` along with an util class having a common loading functions that being used when loading both binary index and non-binary index.

RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
