### PR TITLE
[LuceneOnFaiss M2, PR3] Make FaissIdMapIndex support binary format in Faiss index.

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/AbstractFaissHNSWIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/AbstractFaissHNSWIndex.java
@@ -7,13 +7,13 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.Getter;
 
-public abstract class AbstractFaissHNSWIndex extends FaissIndex {
+public abstract class AbstractFaissHNSWIndex extends FaissIndex implements FaissHNSWProvider {
     @Getter
-    protected FaissHNSW hnsw = new FaissHNSW();
+    protected FaissHNSW faissHnsw;
     protected FaissIndex flatVectors;
 
-    public AbstractFaissHNSWIndex(final String indexType, final FaissHNSW hnsw) {
+    public AbstractFaissHNSWIndex(final String indexType, final FaissHNSW faissHnsw) {
         super(indexType);
-        this.hnsw = hnsw;
+        this.faissHnsw = faissHnsw;
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSW.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSW.java
@@ -93,4 +93,23 @@ public class FaissHNSW {
         // dummy read a deprecated field.
         input.readInt();
     }
+
+    public int getMaxNumNeighbors() {
+        if (cumNumberNeighborPerLevel != null && cumNumberNeighborPerLevel.length >= 1) {
+            // Faiss uses a prefix-sum table to track the number of neighbors per level (commonly referred to as "connections" in Lucene
+            // terminology).
+            // For example, if level 0 has 32 neighbors, level 1 has 16, and level 2 has 16, the prefix-sum table would be: [0, 32 + 0,
+            // 16 + 32 + 0, 16 + 16 + 32 + 0]. The number of neighbors at a given level `i` can be computed as table[i + 1] - table[i].
+            //
+            // In HNSW terminology, the number of neighbors per level is referred to as M, which is user-configurable.
+            // All levels above the bottom have up to M neighbors per node. The bottom level (level 0) can have up to 2 * M neighbors,
+            // which is also known as M₀.
+            //
+            // This method returns M₀. Note that the prefix-sum table always starts with 0 as its first element.
+            return cumNumberNeighborPerLevel[1];
+        }
+
+        // Two cases are possible: Either this was not initialized yet, or we don't have any vectors inside.
+        return 0;
+    }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSWIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSWIndex.java
@@ -46,7 +46,7 @@ public class FaissHNSWIndex extends AbstractFaissHNSWIndex {
         readCommonHeader(input);
 
         // Partial load HNSW graph
-        hnsw.load(input, getTotalNumberOfVectors());
+        faissHnsw.load(input, getTotalNumberOfVectors());
 
         // Partial load flat vector storage
         flatVectors = FaissIndex.load(input);

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
@@ -195,6 +195,6 @@ public class FaissHnswGraph extends HnswGraph {
 
     @Override
     public int maxConn() {
-        return UNKNOWN_MAX_CONN;
+        return faissHnsw.getMaxNumNeighbors();
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -45,7 +45,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
     private static FaissHNSW extractFaissHnsw(final FaissIndex faissIndex) {
         if (faissIndex instanceof FaissIdMapIndex idMapIndex) {
-            return idMapIndex.getNestedIndex().getHnsw();
+            return idMapIndex.getFaissHnsw();
         }
 
         throw new IllegalArgumentException("Faiss index [" + faissIndex.getIndexType() + "] does not have HNSW as an index.");

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/IndexTypeToFaissIndexMapping.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/IndexTypeToFaissIndexMapping.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import lombok.experimental.UtilityClass;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
+import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
 
 import java.util.Collections;
@@ -28,7 +29,7 @@ public class IndexTypeToFaissIndexMapping {
     static {
         final Map<String, Function<String, FaissIndex>> mapping = new HashMap<>();
 
-        mapping.put(FaissIdMapIndex.IXMP, (indexType) -> new FaissIdMapIndex());
+        mapping.put(FaissIdMapIndex.IXMP, FaissIdMapIndex::new);
         mapping.put(FaissHNSWIndex.IHNF, FaissHNSWIndex::new);
         mapping.put(FaissHNSWIndex.IHNS, FaissHNSWIndex::new);
         mapping.put(FaissIndexFloatFlat.IXF2, FaissIndexFloatFlat::new);
@@ -39,6 +40,7 @@ public class IndexTypeToFaissIndexMapping {
         // Binary index
         mapping.put(FaissIndexBinaryFlat.IBXF, (indexType) -> new FaissIndexBinaryFlat());
         mapping.put(FaissBinaryHnswIndex.IBHF, (indexType) -> new FaissBinaryHnswIndex());
+        mapping.put(FaissIdMapIndex.IBMP, FaissIdMapIndex::new);
 
         INDEX_TYPE_TO_FAISS_INDEX = Collections.unmodifiableMap(mapping);
     }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryHnswIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryHnswIndex.java
@@ -45,7 +45,7 @@ public class FaissBinaryHnswIndex extends FaissBinaryIndex implements FaissHNSWP
     @Override
     protected void doLoad(IndexInput input) throws IOException {
         // Read common binary index header
-        readCommonHeader(input);
+        readBinaryCommonHeader(input);
 
         // Partial load HNSW graph
         faissHnsw.load(input, getTotalNumberOfVectors());

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryIndex.java
@@ -33,7 +33,7 @@ public abstract class FaissBinaryIndex extends FaissIndex {
      * @param inputStream Input stream reading bytes from Faiss index file.
      * @throws IOException
      */
-    protected void readCommonHeader(final IndexInput inputStream) throws IOException {
+    protected void readBinaryCommonHeader(final IndexInput inputStream) throws IOException {
         dimension = inputStream.readInt();
         codeSize = inputStream.readInt();
         totalNumberOfVectors = Math.toIntExact(inputStream.readLong());

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
@@ -41,7 +41,7 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
      */
     @Override
     protected void doLoad(IndexInput input) throws IOException {
-        readCommonHeader(input);
+        readBinaryCommonHeader(input);
         binaryFlatVectorSection = new FaissSection(input, 1);
     }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissHNSWCagraIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissHNSWCagraIndex.java
@@ -66,7 +66,7 @@ public class FaissHNSWCagraIndex extends AbstractFaissHNSWIndex {
         numBaseLevelSearchEntryPoint = input.readInt();
 
         // Partial load HNSW graph
-        hnsw.load(input, getTotalNumberOfVectors());
+        faissHnsw.load(input, getTotalNumberOfVectors());
 
         // Partial load flat vector storage
         flatVectors = FaissIndex.load(input);

--- a/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
+++ b/src/test/java/org/opensearch/knn/jni/JNIServiceTests.java
@@ -1922,9 +1922,7 @@ public class JNIServiceTests extends KNNTestCase {
                 KNNEngine.FAISS
             );
             fail("Exception thrown was expected");
-        } catch (Throwable t) {
-            System.out.println("!!!!!!!!!!!!!!!!!!!!! " + t.getMessage());
-        }
+        } catch (Throwable expectedToBeThrown) {}
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHNSWTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHNSWTests.java
@@ -55,6 +55,9 @@ public class FaissHNSWTests extends KNNTestCase {
         // Cumulative number of neighbor per level
         assertArrayEquals(cumulativeNumNeighbors, faissHNSW.getCumNumberNeighborPerLevel());
 
+        // Max conn test
+        assertEquals(cumulativeNumNeighbors[1], faissHNSW.getMaxNumNeighbors());
+
         // offsets
         final DirectMonotonicReader offsetsReader = faissHNSW.getOffsetsReader();
         for (int i = 0; i < offsets.length; i++) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHnswGraphTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissHnswGraphTests.java
@@ -105,7 +105,7 @@ public class FaissHnswGraphTests extends KNNTestCase {
         final int totalNumberOfVectors = 100;
         final FaissHNSW faissHNSW = new FaissHNSW();
         faissHNSW.load(indexInput, totalNumberOfVectors);
-        when(parentIndex.getHnsw()).thenReturn(faissHNSW);
+        when(parentIndex.getFaissHnsw()).thenReturn(faissHNSW);
         when(parentIndex.getTotalNumberOfVectors()).thenReturn(totalNumberOfVectors);
 
         // Create LuceneFaissHnswGraph

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexTestUtils.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexTestUtils.java
@@ -5,12 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
-import lombok.SneakyThrows;
 import org.apache.lucene.store.ByteBuffersDataOutput;
-import org.apache.lucene.store.IndexInput;
-import org.opensearch.knn.memoryoptsearch.faiss.FaissIdMapIndex;
-
-import java.lang.reflect.Method;
 
 public class FaissIndexTestUtils {
     public static byte[] makeCommonHeader(final int dimension, final long totalNumberOfVectors, final boolean l2MetricType) {
@@ -33,11 +28,19 @@ public class FaissIndexTestUtils {
         return output.toArrayCopy();
     }
 
-    @SneakyThrows
-    public static <T> T triggerDoLoad(final IndexInput input, T index) {
-        final Method doLoadMethod = FaissIdMapIndex.class.getDeclaredMethod("doLoad", IndexInput.class);
-        doLoadMethod.setAccessible(true);
-        doLoadMethod.invoke(index, input);
-        return index;
+    public static byte[] makeBinaryCommonHeader(final int dimension, final int codeSize, final long totalNumberOfVectors) {
+        final ByteBuffersDataOutput output = new ByteBuffersDataOutput();
+        // Dimension
+        output.writeInt(dimension);
+        // Code size
+        output.writeInt(codeSize);
+        // #vectors
+        output.writeLong(totalNumberOfVectors);
+
+        // Two dummy fields: is_trained, metric_type
+        output.writeByte((byte) 0);
+        output.writeInt((byte) 0);
+
+        return output.toArrayCopy();
     }
 }


### PR DESCRIPTION
### Description
In this PR, it made FaissIdMapIndex support both binary index and non-binary index.
The only difference is in the parsing header, where a binary index has one more column `codeSize` than non-binary index. 
And in the class, it branches on its index type to choose parsing function. 

Note that base classes are pasted from [PR1](https://github.com/opensearch-project/k-NN/pull/2675) and [PR2](https://github.com/opensearch-project/k-NN/pull/2676). 

RFC : https://github.com/opensearch-project/k-NN/issues/2401


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
