### PR TITLE
[LuceneOnFaiss M2, PR4] Support hamming distance in memory optimized search.

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -112,6 +112,7 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_NPROBES = "nprobes";
     public static final String ENCODER_FLAT = "flat";
     public static final String ENCODER_PQ = "pq";
+    public static final String ENCODER_BINARY = "binary";
     public static final String ENCODER_PARAMETER_PQ_M = "m";
     public static final String ENCODER_PARAMETER_PQ_CODE_SIZE = "code_size";
     public static final String FAISS_HNSW_DESCRIPTION = "HNSW";

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -61,8 +61,7 @@ public class KNNVectorFieldType extends MappedFieldType {
         this.knnMappingConfig = annConfig;
         this.memoryOptimizedSearchSupported = MemoryOptimizedSearchSupportSpec.supported(
             knnMappingConfig.getKnnMethodContext(),
-            knnMappingConfig.getQuantizationConfig(),
-            vectorDataType
+            annConfig.getModelId()
         );
     }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.experimental.UtilityClass;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+
+import java.io.IOException;
+
+@UtilityClass
+public class FlatVectorsScorerProvider {
+    private static final FlatVectorsScorer DELEGATE_VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+    private static final FlatVectorsScorer HAMMING_VECTOR_SCORER = new HammingFlatVectorsScorer();
+
+    public static FlatVectorsScorer getFlatVectorsScorer(final KNNVectorSimilarityFunction similarityFunction) {
+        if (similarityFunction == KNNVectorSimilarityFunction.HAMMING) {
+            return HAMMING_VECTOR_SCORER;
+        }
+
+        return DELEGATE_VECTOR_SCORER;
+    }
+
+    private static class HammingFlatVectorsScorer implements FlatVectorsScorer {
+
+        @Override
+        public RandomVectorScorer getRandomVectorScorer(
+            VectorSimilarityFunction vectorSimilarityFunction,
+            KnnVectorValues knnVectorValues,
+            byte[] target
+        ) {
+            if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
+                return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                    @Override
+                    public float score(int internalVectorId) throws IOException {
+                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                        return KNNVectorSimilarityFunction.HAMMING.compare(target, quantizedByteVector);
+                    }
+                };
+            }
+
+            throw new IllegalArgumentException(
+                "Expected "
+                    + ByteVectorValues.class.getSimpleName()
+                    + " for hamming vector scorer, got "
+                    + knnVectorValues.getClass().getSimpleName()
+            );
+        }
+
+        @Override
+        public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+            VectorSimilarityFunction vectorSimilarityFunction,
+            KnnVectorValues knnVectorValues
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RandomVectorScorer getRandomVectorScorer(
+            VectorSimilarityFunction vectorSimilarityFunction,
+            KnnVectorValues knnVectorValues,
+            float[] target
+        ) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlatVectorsScorerProviderTests extends KNNTestCase {
+    private static final float[] FLOAT_QUERY = new float[] { 1.3f, 2.2f, -0.7f, 11.f };
+    private static final float[] FLOAT_VECTOR = new float[] { 8.f, 3.7f, 4.12f, -0.3f };
+    private static final byte[] BYTE_QUERY = new byte[] { 12, 77, 100, 4 };
+    private static final byte[] BYTE_VECTOR = new byte[] { 1, 3, 0, 90 };
+
+    @SneakyThrows
+    public void testHammingScoring() {
+        // Get hamming scorer
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(KNNVectorSimilarityFunction.HAMMING);
+
+        // Test byte[] vector and query
+        final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+        when(byteVectorValues.vectorValue(anyInt())).thenReturn(BYTE_VECTOR);
+        final RandomVectorScorer vectorScorer = scorer.getRandomVectorScorer(null, byteVectorValues, BYTE_QUERY);
+
+        // Validate score
+        final float score = vectorScorer.score(0);
+        final float expectedScore = KNNVectorSimilarityFunction.HAMMING.compare(BYTE_VECTOR, BYTE_QUERY);
+        assertEquals(expectedScore, score, 1e-6);
+
+        // Test float[] vector and query, it is not supported
+        try {
+            scorer.getRandomVectorScorer(null, byteVectorValues, new float[] {});
+            fail();
+        } catch (UnsupportedOperationException e) {
+            // Expected
+        }
+
+        // Test non-ByteVectorValues is not supported
+        final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+        try {
+            scorer.getRandomVectorScorer(null, floatVectorValues, BYTE_QUERY);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    public void testNonHammingScoring() {
+        // Test L2
+        doTest(KNNVectorSimilarityFunction.EUCLIDEAN, true);
+        doTest(KNNVectorSimilarityFunction.EUCLIDEAN, false);
+
+        // Test DotProduct
+        doTest(KNNVectorSimilarityFunction.DOT_PRODUCT, true);
+        doTest(KNNVectorSimilarityFunction.DOT_PRODUCT, false);
+
+        // Test Cosine
+        doTest(KNNVectorSimilarityFunction.COSINE, true);
+        doTest(KNNVectorSimilarityFunction.COSINE, false);
+
+        // Test Maximum Inner Product
+        doTest(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, true);
+        doTest(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, false);
+    }
+
+    @SneakyThrows
+    private void doTest(final KNNVectorSimilarityFunction knnVectorSimilarityFunction, final boolean isFloat) {
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(knnVectorSimilarityFunction);
+
+        if (isFloat) {
+            final FloatVectorValues vectorValues = mock(FloatVectorValues.class);
+            when(vectorValues.vectorValue(anyInt())).thenReturn(FLOAT_VECTOR);
+            when(vectorValues.dimension()).thenReturn(FLOAT_VECTOR.length);
+            final RandomVectorScorer vectorScorer = scorer.getRandomVectorScorer(
+                knnVectorSimilarityFunction.getVectorSimilarityFunction(),
+                vectorValues,
+                FLOAT_QUERY
+            );
+            final float score = vectorScorer.score(0);
+            final float expected = knnVectorSimilarityFunction.compare(FLOAT_VECTOR, FLOAT_QUERY);
+            assertEquals(expected, score, 1e-6);
+        } else {
+            final ByteVectorValues vectorValues = mock(ByteVectorValues.class);
+            when(vectorValues.vectorValue(anyInt())).thenReturn(BYTE_VECTOR);
+            when(vectorValues.dimension()).thenReturn(BYTE_VECTOR.length);
+            final RandomVectorScorer vectorScorer = scorer.getRandomVectorScorer(
+                knnVectorSimilarityFunction.getVectorSimilarityFunction(),
+                vectorValues,
+                BYTE_QUERY
+            );
+            final float score = vectorScorer.score(0);
+            final float expected = knnVectorSimilarityFunction.compare(BYTE_VECTOR, BYTE_QUERY);
+            assertEquals(expected, score, 1e-6);
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR is to add a hamming distance calculation for memory optimized search.
Also it looses constraints in `MemoryOptimizedSearchSupportSpec` to allow memory optimized search for disk mode. 
But note that PQ is still not in the scope, so it will reject PQ based field type having model id.

RFC : https://github.com/opensearch-project/k-NN/issues/2401

### Related Issues
N/A


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
