### PR TITLE
[Backport 2.19] [Bug-fix] Enables rescoring by default when dimensions > 1024. (#2671)

### DIFF
--- a/release-notes/opensearch-knn.release-notes-2.19.2.0.md
+++ b/release-notes/opensearch-knn.release-notes-2.19.2.0.md
@@ -1,0 +1,11 @@
+## Version 2.19.2.0 Release Notes
+
+Compatible with OpenSearch 2.19.2
+
+### Features
+### Enhancements
+### Bug Fixes
+* Enables rescoring by default when dimensions > 1024. [#2671](https://github.com/opensearch-project/k-NN/pull/2671)
+### Infrastructure
+### Documentation
+### Maintenance

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -25,10 +25,10 @@ public enum CompressionLevel {
     x1(1, "1x", null, Collections.emptySet()),
     x2(2, "2x", null, Collections.emptySet()),
     x4(4, "4x", null, Collections.emptySet()),
-    x8(8, "8x", new RescoreContext(2.0f, false, false), Set.of(Mode.ON_DISK)),
-    x16(16, "16x", new RescoreContext(3.0f, false, false), Set.of(Mode.ON_DISK)),
-    x32(32, "32x", new RescoreContext(3.0f, false, false), Set.of(Mode.ON_DISK)),
-    x64(64, "64x", new RescoreContext(5.0f, false, false), Set.of(Mode.ON_DISK));
+    x8(8, "8x", new RescoreContext(2.0f, false, true), Set.of(Mode.ON_DISK)),
+    x16(16, "16x", new RescoreContext(3.0f, false, true), Set.of(Mode.ON_DISK)),
+    x32(32, "32x", new RescoreContext(3.0f, false, true), Set.of(Mode.ON_DISK)),
+    x64(64, "64x", new RescoreContext(5.0f, false, true), Set.of(Mode.ON_DISK));
 
     public static final CompressionLevel MAX_COMPRESSION_LEVEL = CompressionLevel.x64;
 

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -52,30 +52,43 @@ public class CompressionLevelTests extends KNNTestCase {
         RescoreContext rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
 
         // x32 with dimension > 1000 should have an oversample factor of 3.0f
         rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, aboveThresholdDimension);
         assertNotNull(rescoreContext);
         assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
 
         // x16 with dimension <= 1000 should have an oversample factor of 5.0f
         rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
 
         // x16 with dimension > 1000 should have an oversample factor of 3.0f
         rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, aboveThresholdDimension);
         assertNotNull(rescoreContext);
         assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
 
         // x8 with dimension <= 1000 should have an oversample factor of 5.0f
         rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
+
         // x8 with dimension > 1000 should have an oversample factor of 2.0f
         rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, aboveThresholdDimension);
         assertNotNull(rescoreContext);
         assertEquals(2.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
 
         // x4 with dimension <= 1000 should have an oversample factor of 5.0f (though it doesn't have its own RescoreContext)
         rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, belowThresholdDimension);

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -30,6 +30,7 @@ import org.opensearch.knn.index.codec.derivedsource.ParentChildHelper;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.knn.plugin.script.KNNScoringScriptEngine;
@@ -185,6 +186,26 @@ public class KNNRestTestCase extends ODFERestTestCase {
     protected void createKnnIndex(String index, String mapping) throws IOException {
         createIndex(index, getKNNDefaultIndexSettings());
         putMappingRequest(index, mapping);
+    }
+
+    /**
+     * Builds a KNN Index for dimension and index, with on_disk mode
+     */
+    protected void createOnDiskIndex(String index, Integer dimensions, SpaceType spaceType) throws IOException {
+        createIndex(index, getKNNDefaultIndexSettings());
+        String mappings = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimensions.toString())
+            .field("space_type", spaceType.getValue())
+            .field("mode", Mode.ON_DISK.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        putMappingRequest(index, mappings);
     }
 
     /**
@@ -1145,6 +1166,16 @@ public class KNNRestTestCase extends ODFERestTestCase {
         ).map().get("hits")).get("hits");
 
         return hits.stream().map(hit -> (String) ((Map<String, Object>) hit).get("_id")).collect(Collectors.toList());
+    }
+
+    protected List<Double> parseScores(String searchResponseBody) throws IOException {
+        @SuppressWarnings("unchecked")
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            searchResponseBody
+        ).map().get("hits")).get("hits");
+
+        return hits.stream().map(hit -> (Double) ((Map<String, Object>) hit).get("_score")).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
### Description
Backport of PR: https://github.com/opensearch-project/k-NN/pull/2671

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
