### PR TITLE
[Remote Vector Index Build] fix: end remote build metrics before falling back to CPU, log exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Removing redundant type conversions for script scoring for hamming space with binary vectors [#2351](https://github.com/opensearch-project/k-NN/pull/2351)
 ### Bug Fixes 
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
+* [Remote Vector Index Build] End  remote build metrics before falling back to CPU, exception logging
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
@@ -141,7 +141,7 @@ public class RemoteIndexBuildMetrics {
             log.debug("Remote index build succeeded after {} ms for vector field [{}]", time_in_millis, fieldName);
         } else {
             INDEX_BUILD_FAILURE_COUNT.increment();
-            log.warn("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
+            log.debug("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
         }
         if (isFlush) {
             REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS.decrement();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -146,20 +146,20 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
 
             // 4. Download index file and write to indexOutput
             readFromRepository(indexInfo, repositoryContext, remoteBuildStatusResponse);
-
             success = true;
+            return;
         } catch (Exception e) {
-            fallbackStrategy.buildAndWriteIndex(indexInfo);
+            log.error("Failed to build index remotely: " + indexInfo, e);
         } finally {
             metrics.endRemoteIndexBuildMetrics(success);
         }
+        fallbackStrategy.buildAndWriteIndex(indexInfo);
     }
 
     /**
      * Writes the required vector and doc ID data to the repository
      */
-    private void writeToRepository(RepositoryContext repositoryContext, BuildIndexParams indexInfo) throws IOException,
-        InterruptedException {
+    private void writeToRepository(RepositoryContext repositoryContext, BuildIndexParams indexInfo) {
         VectorRepositoryAccessor vectorRepositoryAccessor = repositoryContext.vectorRepositoryAccessor;
         boolean success = false;
         metrics.startRepositoryWriteMetrics();
@@ -172,8 +172,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             );
             success = true;
         } catch (InterruptedException | IOException e) {
-            log.debug("Repository write failed for vector field [{}]", indexInfo.getFieldName());
-            throw e;
+            throw new RuntimeException(String.format("Repository write failed for vector field [%s]", indexInfo.getFieldName()), e);
         } finally {
             metrics.endRepositoryWriteMetrics(success);
         }
@@ -183,8 +182,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
      * Submits a remote build request to the remote index build service
      * @return RemoteBuildResponse containing the response from the remote service
      */
-    private RemoteBuildResponse submitBuild(RepositoryContext repositoryContext, BuildIndexParams indexInfo, RemoteIndexClient client)
-        throws IOException {
+    private RemoteBuildResponse submitBuild(RepositoryContext repositoryContext, BuildIndexParams indexInfo, RemoteIndexClient client) {
         final RemoteBuildResponse remoteBuildResponse;
         boolean success = false;
         metrics.startBuildRequestMetrics();
@@ -200,8 +198,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             success = true;
             return remoteBuildResponse;
         } catch (IOException e) {
-            log.debug("Submit vector build failed for vector field [{}]", indexInfo.getFieldName());
-            throw e;
+            throw new RuntimeException(String.format("Submit vector build failed for vector field [%s]", indexInfo.getFieldName()), e);
         } finally {
             metrics.endBuildRequestMetrics(success);
         }
@@ -216,7 +213,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         RemoteBuildResponse remoteBuildResponse,
         BuildIndexParams indexInfo,
         RemoteIndexClient client
-    ) throws IOException, InterruptedException {
+    ) {
         RemoteBuildStatusResponse remoteBuildStatusResponse;
         metrics.startWaitingMetrics();
         try {
@@ -225,11 +222,11 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
                 .build();
             RemoteIndexWaiter waiter = RemoteIndexWaiterFactory.getRemoteIndexWaiter(client);
             remoteBuildStatusResponse = waiter.awaitVectorBuild(remoteBuildStatusRequest);
-            metrics.endWaitingMetrics();
             return remoteBuildStatusResponse;
         } catch (InterruptedException | IOException e) {
-            log.debug("Await vector build failed for vector field [{}]", indexInfo.getFieldName(), e);
-            throw e;
+            throw new RuntimeException(String.format("Await index build failed for vector field [%s]", indexInfo.getFieldName()), e);
+        } finally {
+            metrics.endWaitingMetrics();
         }
     }
 
@@ -240,7 +237,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         BuildIndexParams indexInfo,
         RepositoryContext repositoryContext,
         RemoteBuildStatusResponse remoteBuildStatusResponse
-    ) throws IOException {
+    ) {
         metrics.startRepositoryReadMetrics();
         boolean success = false;
         try {
@@ -250,8 +247,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             );
             success = true;
         } catch (Exception e) {
-            log.debug("Repository read failed for vector field [{}]", indexInfo.getFieldName());
-            throw e;
+            throw new RuntimeException(String.format("Repository read failed for vector field [%s]", indexInfo.getFieldName()), e);
         } finally {
             metrics.endRepositoryReadMetrics(success);
         }


### PR DESCRIPTION
### Description
Because it is in the `finally` block, the call to `endRemoteBuildMetrics` is happening after the fallback strategy so the failure time is inaccurate. 

Additionally, Exceptions in the remote build process are caught and rethrown to let each step give a failure message:
https://github.com/opensearch-project/k-NN/blob/76d6662a5e80c44a924c23491cc7e99715cb5c43/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java#L251-L253

We should add the exception itself to these debug logs to add more insight into why the failure occurred (for example, adding this to the `submitBuild` step will give the HTTP status code instead of just saying "Submit vector build failed". This is already the case for `awaitVectorBuild`.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
