### PR TITLE
[BUGFIX] Block derived source enable if index.knn is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
 * [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671) 
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
+* [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
 import org.junit.Before;
+import org.opensearch.client.ResponseException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -191,5 +192,35 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         validateDerivedSetting(indexName, true);
         createIndex(indexNameDisabled, Settings.builder().build());
         validateDerivedSetting(indexNameDisabled, false);
+    }
+
+    @SneakyThrows
+    public void testBlockSettingIfKNNFalse() {
+        String indexName = getIndexName("setting-blocked", "test", false);
+        String fieldName = "test";
+        int dimension = 16;
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .endObject()
+            .endObject()
+            .endObject();
+        String mapping = builder.toString();
+        expectThrows(
+            ResponseException.class,
+            () -> createKnnIndex(
+                indexName,
+                Settings.builder().put("index.knn", false).put("index.knn.derived_source.enabled", true).build(),
+                mapping
+            )
+        );
+
+        expectThrows(
+            ResponseException.class,
+            () -> createKnnIndex(indexName, Settings.builder().put("index.knn.derived_source.enabled", true).build(), mapping)
+        );
     }
 }


### PR DESCRIPTION
### Description
This is a minor experience bug fix. Basically, for derived source, we need the knn codec to be used, so we need the index.knn setting to be set to true.

Adds setting dependency on derived source setting so that if index.knn is set to false, then index creation will be blocked.

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
