### PR TITLE
Avoid opening of graph file if graph is already loaded in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671) 
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
 * [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
+* [BUGFIX] Avoid opening of graph file if graph is already loaded in memory [#2719](https://github.com/opensearch-project/k-NN/pull/2719)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
+++ b/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java
@@ -433,11 +433,16 @@ public class NativeMemoryCacheManager implements Closeable {
                 return result;
             }
         } else {
-            // open graphFile before load
             try (nativeMemoryEntryContext) {
                 String key = nativeMemoryEntryContext.getKey();
-                open(key, nativeMemoryEntryContext);
-                return cache.get(key, nativeMemoryEntryContext::load);
+                // if we already have the allocation we should not open file again as this will cause slowdown in
+                // heavy throughput cases, since open() function do locking while opening and mapping the graph file to
+                // memory.
+                return cache.get(key, () -> {
+                    // open graphFile before load
+                    open(key, nativeMemoryEntryContext);
+                    return nativeMemoryEntryContext.load();
+                });
             }
         }
     }

--- a/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
+++ b/src/test/java/org/opensearch/knn/index/memory/NativeMemoryCacheManagerTests.java
@@ -12,9 +12,11 @@
 package org.opensearch.knn.index.memory;
 
 import com.google.common.cache.CacheStats;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexInput;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import lombok.SneakyThrows;
 import org.junit.Test;
@@ -599,8 +601,8 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         assertFalse(indexEntryContext1.isIndexGraphFileOpened());
         assertEquals(indexAllocation1, nativeMemoryCacheManager.get(indexEntryContext1, false));
 
-        verify(mockDirectory, times(2)).openInput(any(), any());
-        verify(mockReadStream, times(2)).seek(0);
+        verify(mockDirectory, times(1)).openInput(any(), any());
+        verify(mockReadStream, times(1)).seek(0);
         verify(mockReadStream, times(2)).close();
 
     }
@@ -621,7 +623,6 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
     }
 
     @SneakyThrows
-    @Test(expected = IllegalStateException.class)
     public void testGetWithInvalidFile_IllegalStateException() {
         NativeMemoryCacheManager nativeMemoryCacheManager = new NativeMemoryCacheManager();
 
@@ -633,7 +634,11 @@ public class NativeMemoryCacheManagerTests extends OpenSearchSingleNodeTestCase 
         doReturn(0).when(indexEntryContext).calculateSizeInKB();
         Directory mockDirectory = mock(Directory.class);
         // This should throw the exception
-        nativeMemoryCacheManager.get(indexEntryContext, false);
+        Exception exception = Assert.assertThrows(
+            UncheckedExecutionException.class,
+            () -> nativeMemoryCacheManager.get(indexEntryContext, false)
+        );
+        assertTrue(exception.getCause() instanceof IllegalStateException);
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Avoid opening of graph file if graph is already loaded in memory.

While doing some high performance query tests I saw that performance I was getting is not similar to what I was getting with same dataset on 2.15 version of OpenSearch. On doing some deep-dive and looking at flame graph I saw a weird trace of opening of a file with locks which should not be there as everything is loaded in the memory. This could be one of the reason why I am not seeing high performance for my tests(CPU was only 50% even when I tried putting 100 search clients), since most of the threads are blocked while previous one is opening the file. 

Will do a patch on my distribution to see if this fixes. Otherwise next step will be to find if there are other bottlenecks in the code. 


Pasting the reference of profiler for more details.

![Screenshot 2025-05-25 at 11 30 46 PM](https://github.com/user-attachments/assets/95e682cd-357c-427b-9ca7-65443466958d)





Raising PR for now since main branch is broken. Will add test once main branch is fixed.


### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
