### PR TITLE
Fix compatibility with Lucene 10.2.1

### DIFF
--- a/.github/workflows/remote_index_build.yml
+++ b/.github/workflows/remote_index_build.yml
@@ -113,18 +113,18 @@ jobs:
             if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq
             then
               echo "the system is an Intel(R) Sapphire Rapids or a newer-generation processor"
-              ./gradlew :integTestRemoteIndexBuild --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx512_spr.enabled=true -Dnproc.count=`nproc`
+              ./gradlew :integTestRemoteIndexBuild --refresh-dependencies --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx512_spr.enabled=true -Dnproc.count=`nproc`
             else
               echo "avx512 available on system"
-              ./gradlew :integTestRemoteIndexBuild --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx512_spr.enabled=false -Dnproc.count=`nproc`
+              ./gradlew :integTestRemoteIndexBuild --refresh-dependencies --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx512_spr.enabled=false -Dnproc.count=`nproc`
             fi
           elif lscpu  | grep -i avx2
           then
             echo "avx2 available on system"
-            ./gradlew :integTestRemoteIndexBuild --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`
+            ./gradlew :integTestRemoteIndexBuild --refresh-dependencies --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`
           else
             echo "avx512 and avx2 not available on system"
-            ./gradlew :integTestRemoteIndexBuild --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`
+            ./gradlew :integTestRemoteIndexBuild --refresh-dependencies --no-build-cache -Ds3.enabled=true -Dtest.remoteBuild=s3.localStack -Dtest.bucket=remote-index-build-bucket -Dtest.base_path=vectors -Daccess_key=${{ env.AWS_ACCESS_KEY_ID }} -Dsecret_key=${{ env.AWS_SECRET_ACCESS_KEY }} -Dsession_token=${{ env.AWS_SESSION_TOKEN}} -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`
           fi
 
       - name: Verify Remote Index Builder logs

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.KNN10010Codec;
 import org.apache.lucene.codecs.StoredFieldsWriter;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
-import org.apache.lucene.store.DataInput;
+import org.apache.lucene.index.StoredFieldDataInput;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -81,8 +81,8 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
     }
 
     @Override
-    public void writeField(FieldInfo info, DataInput value, int length) throws IOException {
-        delegate.writeField(info, value, length);
+    public void writeField(FieldInfo info, StoredFieldDataInput value) throws IOException {
+        delegate.writeField(info, value);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/QuantizationConfigKNNCollector.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/QuantizationConfigKNNCollector.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 
 /**
@@ -59,6 +60,11 @@ public class QuantizationConfigKNNCollector implements KnnCollector {
 
     @Override
     public TopDocs topDocs() {
+        throw new UnsupportedOperationException(NATIVE_ENGINE_SEARCH_ERROR_MESSAGE);
+    }
+
+    @Override
+    public KnnSearchStrategy getSearchStrategy() {
         throw new UnsupportedOperationException(NATIVE_ENGINE_SEARCH_ERROR_MESSAGE);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNScorer.java
@@ -67,7 +67,33 @@ public class KNNScorer extends Scorer {
     }
 
     private static final Scorer EMPTY_SCORER_INSTANCE = new Scorer() {
-        private final DocIdSetIterator docIdsIter = DocIdSetIterator.empty();
+        /**
+         * stateless empty DocIdSetIterator. Used in testing as opposed to DocIdSetIterator.empty() since
+         * DocIdSetIterator.empty() contains a stateful exhausted variable. If we associate a particular
+         * DocIdSetIterator.empty() instance with our static EMPTY_SCORER_INSTANCE then we hit an assertion error
+         * when multiple threads race to call advance() as it is not thread-safe.
+         */
+        public static DocIdSetIterator statelessEmptyDocIdSetIterator() {
+            return new DocIdSetIterator() {
+                public int advance(int target) {
+                    return Integer.MAX_VALUE;
+                }
+
+                public int docID() {
+                    return DocIdSetIterator.NO_MORE_DOCS;
+                }
+
+                public int nextDoc() {
+                    return Integer.MAX_VALUE;
+                }
+
+                public long cost() {
+                    return 0L;
+                }
+            };
+        }
+
+        private static final DocIdSetIterator docIdsIter = statelessEmptyDocIdSetIterator();
 
         @Override
         public DocIdSetIterator iterator() {

--- a/src/main/java/org/opensearch/knn/index/query/KNNScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNScorer.java
@@ -7,9 +7,8 @@ package org.opensearch.knn.index.query;
 
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.Weight;
 
-import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -27,7 +26,7 @@ public class KNNScorer extends Scorer {
     private final Map<Integer, Float> scores;
     private final float boost;
 
-    public KNNScorer(Weight weight, DocIdSetIterator docIdsIter, Map<Integer, Float> scores, float boost) {
+    public KNNScorer(DocIdSetIterator docIdsIter, Map<Integer, Float> scores, float boost) {
         super();
         this.docIdsIter = docIdsIter;
         this.scores = scores;
@@ -40,7 +39,7 @@ public class KNNScorer extends Scorer {
     }
 
     @Override
-    public float getMaxScore(int upTo) throws IOException {
+    public float getMaxScore(int upTo) {
         return Float.MAX_VALUE;
     }
 
@@ -58,72 +57,12 @@ public class KNNScorer extends Scorer {
     }
 
     /**
-     * Returns the Empty Scorer implementation. We use this scorer to short circuit the actual search when it is not
-     * required.
+     * Returns an Empty Scorer. We use this scorer to short circuit the actual search when it is not
+     * required. Since the underlying DocIdSetIterator.empty() is stateful and not thread-safe we must create a new
+     * scorer instance each time to avoid race conditions.
      * @return {@link KNNScorer}
      */
-    public static Scorer emptyScorer() {
-        return EMPTY_SCORER_INSTANCE;
+    public static KNNScorer emptyScorer() {
+        return new KNNScorer(DocIdSetIterator.empty(), Collections.emptyMap(), 0);
     }
-
-    private static final Scorer EMPTY_SCORER_INSTANCE = new Scorer() {
-        /**
-         * stateless empty DocIdSetIterator. Used in testing as opposed to DocIdSetIterator.empty() since
-         * DocIdSetIterator.empty() contains a stateful exhausted variable. If we associate a particular
-         * DocIdSetIterator.empty() instance with our static EMPTY_SCORER_INSTANCE then we hit an assertion error
-         * when multiple threads race to call advance() as it is not thread-safe.
-         */
-        public static DocIdSetIterator statelessEmptyDocIdSetIterator() {
-            return new DocIdSetIterator() {
-                public int advance(int target) {
-                    return Integer.MAX_VALUE;
-                }
-
-                public int docID() {
-                    return DocIdSetIterator.NO_MORE_DOCS;
-                }
-
-                public int nextDoc() {
-                    return Integer.MAX_VALUE;
-                }
-
-                public long cost() {
-                    return 0L;
-                }
-            };
-        }
-
-        private static final DocIdSetIterator docIdsIter = statelessEmptyDocIdSetIterator();
-
-        @Override
-        public DocIdSetIterator iterator() {
-            return docIdsIter;
-        }
-
-        @Override
-        public float getMaxScore(int upTo) throws IOException {
-            return 0;
-        }
-
-        @Override
-        public float score() throws IOException {
-            assert docID() != DocIdSetIterator.NO_MORE_DOCS;
-            return 0;
-        }
-
-        @Override
-        public int docID() {
-            return docIdsIter.docID();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return this == obj; // Singleton ensures only one instance exists
-        }
-
-        @Override
-        public int hashCode() {
-            return System.identityHashCode(this); // Consistent hash for singleton
-        }
-    };
 }

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -136,9 +136,6 @@ public class KNNWeight extends Weight {
         } catch (IOException e) {
             throw new RuntimeException(String.format("Error while explaining KNN score for doc [%d], score [%f]", doc, score), e);
         }
-        // catch (Exception e) {
-        // throw new RuntimeException(String.format("Error while explaining KNN score for doc [%d], score [%f]", doc, score), e);
-        // }
         final String highLevelExplanation = getHighLevelExplanation();
         final StringBuilder leafLevelExplanation = getLeafLevelExplanation(context);
 
@@ -245,10 +242,6 @@ public class KNNWeight extends Weight {
     }
 
     private KNNScorer getOrCreateKnnScorer(LeafReaderContext context) throws IOException {
-        // Disabling the cache mechanism due to interface updates for RandomVectorScorer
-        // Issue: https://github.com/opensearch-project/k-NN/issues/2717
-
-        /*
         // First try to get the cached scorer
         KNNScorer scorer = knnExplanation.getKnnScorer(context);
 
@@ -257,9 +250,8 @@ public class KNNWeight extends Weight {
             scorer = (KNNScorer) scorer(context);
             knnExplanation.addKnnScorer(context, scorer);
         }
-        */
 
-        return (KNNScorer) scorer(context);
+        return scorer;
     }
 
     private float getKnnScore(KNNScorer knnScorer, int doc) throws IOException {
@@ -267,7 +259,7 @@ public class KNNWeight extends Weight {
     }
 
     @Override
-    public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+    public ScorerSupplier scorerSupplier(LeafReaderContext context) {
         return new ScorerSupplier() {
             long cost = -1L;
 
@@ -279,7 +271,7 @@ public class KNNWeight extends Weight {
                     return KNNScorer.emptyScorer();
                 }
                 final int maxDoc = Collections.max(docIdToScoreMap.keySet()) + 1;
-                return new KNNScorer(KNNWeight.this, ResultUtil.resultMapToDocIds(docIdToScoreMap, maxDoc), docIdToScoreMap, boost);
+                return new KNNScorer(ResultUtil.resultMapToDocIds(docIdToScoreMap, maxDoc), docIdToScoreMap, boost);
             }
 
             @Override

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -136,6 +136,9 @@ public class KNNWeight extends Weight {
         } catch (IOException e) {
             throw new RuntimeException(String.format("Error while explaining KNN score for doc [%d], score [%f]", doc, score), e);
         }
+        // catch (Exception e) {
+        // throw new RuntimeException(String.format("Error while explaining KNN score for doc [%d], score [%f]", doc, score), e);
+        // }
         final String highLevelExplanation = getHighLevelExplanation();
         final StringBuilder leafLevelExplanation = getLeafLevelExplanation(context);
 
@@ -242,6 +245,10 @@ public class KNNWeight extends Weight {
     }
 
     private KNNScorer getOrCreateKnnScorer(LeafReaderContext context) throws IOException {
+        // Disabling the cache mechanism due to interface updates for RandomVectorScorer
+        // Issue: https://github.com/opensearch-project/k-NN/issues/2717
+
+        /*
         // First try to get the cached scorer
         KNNScorer scorer = knnExplanation.getKnnScorer(context);
 
@@ -250,8 +257,9 @@ public class KNNWeight extends Weight {
             scorer = (KNNScorer) scorer(context);
             knnExplanation.addKnnScorer(context, scorer);
         }
+        */
 
-        return scorer;
+        return (KNNScorer) scorer(context);
     }
 
     private float getKnnScore(KNNScorer knnScorer, int doc) throws IOException {

--- a/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/ResultUtil.java
@@ -85,7 +85,9 @@ public final class ResultUtil {
         }
         final DocIdSetBuilder docIdSetBuilder = new DocIdSetBuilder(maxDoc);
         final DocIdSetBuilder.BulkAdder setAdder = docIdSetBuilder.grow(resultMap.size());
-        resultMap.keySet().forEach(setAdder::add);
+        for (int doc : resultMap.keySet()) {
+            setAdder.add(doc);
+        }
         return docIdSetBuilder.build().iterator();
     }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
@@ -187,4 +187,14 @@ public class FaissHnswGraph extends HnswGraph {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public int neighborCount() {
+        return numNeighbors;
+    }
+
+    @Override
+    public int maxConn() {
+        return UNKNOWN_MAX_CONN;
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldVisitorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120DerivedSourceStoredFieldVisitorTests.java
@@ -21,7 +21,7 @@ public class KNN9120DerivedSourceStoredFieldVisitorTests extends KNNTestCase {
 
     public void testBinaryField() throws Exception {
         StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
-        doAnswer(invocationOnMock -> null).when(delegate).binaryField(any(), any());
+        doAnswer(invocationOnMock -> null).when(delegate).binaryField(any(), (byte[]) any());
         DerivedSourceVectorInjector derivedSourceVectorInjector = mock(DerivedSourceVectorInjector.class);
         when(derivedSourceVectorInjector.injectVectors(anyInt(), any())).thenReturn(new byte[0]);
         KNN9120DerivedSourceStoredFieldVisitor derivedSourceStoredFieldVisitor = new KNN9120DerivedSourceStoredFieldVisitor(
@@ -31,13 +31,13 @@ public class KNN9120DerivedSourceStoredFieldVisitorTests extends KNNTestCase {
         );
 
         // When field is not _source, then do not call the injector
-        derivedSourceStoredFieldVisitor.binaryField(KNNCodecTestUtil.FieldInfoBuilder.builder("test").build(), null);
+        derivedSourceStoredFieldVisitor.binaryField(KNNCodecTestUtil.FieldInfoBuilder.builder("test").build(), (byte[]) null);
         verify(derivedSourceVectorInjector, times(0)).injectVectors(anyInt(), any());
-        verify(delegate, times(1)).binaryField(any(), any());
+        verify(delegate, times(1)).binaryField(any(), (byte[]) any());
 
         // When field is not _source, then do call the injector
-        derivedSourceStoredFieldVisitor.binaryField(KNNCodecTestUtil.FieldInfoBuilder.builder("_source").build(), null);
+        derivedSourceStoredFieldVisitor.binaryField(KNNCodecTestUtil.FieldInfoBuilder.builder("_source").build(), (byte[]) null);
         verify(derivedSourceVectorInjector, times(1)).injectVectors(anyInt(), any());
-        verify(delegate, times(2)).binaryField(any(), any());
+        verify(delegate, times(2)).binaryField(any(), (byte[]) any());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
@@ -61,7 +60,6 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.RADIAL_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2717")
 public class ExplainTests extends KNNWeightTestCase {
 
     @Mock

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
@@ -60,6 +61,7 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.RADIAL_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2717")
 public class ExplainTests extends KNNWeightTestCase {
 
     @Mock

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -286,7 +286,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         // When no knn fields are available , field info for vector field will be null
         when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(null);
         final Scorer knnScorer = knnWeight.scorer(leafReaderContext);
-        assertEquals(KNNScorer.emptyScorer(), knnScorer);
+        assertEmptyScorer(knnScorer);
     }
 
     @SneakyThrows
@@ -330,7 +330,14 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(fieldInfos.fieldInfo(any())).thenReturn(fieldInfo);
 
         final Scorer knnScorer = knnWeight.scorer(leafReaderContext);
-        assertEquals(KNNScorer.emptyScorer(), knnScorer);
+        assertEmptyScorer(knnScorer);
+    }
+
+    @SneakyThrows
+    public static void assertEmptyScorer(Scorer knnScorer) {
+        final DocIdSetIterator iterator = knnScorer.iterator();
+        assertEquals(-1, iterator.docID());
+        assertEquals(NO_MORE_DOCS, iterator.nextDoc());
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
- Build fixes for Lucene 10.2.1 and OpenSearch 3.1

### Changes/Adaptations
1. RandomVectorScorer
    - Adapts BinaryScorer to match the BitScorer implementation in Lucene 10.2.1
    - BitScorer_10_0: https://github.com/apache/lucene/blob/branch_10_0/lucene/codecs/src/java/org/apache/lucene/codecs/bitvectors/FlatBitVectorsScorer.java#L61-L121
    - BitScorer_10_2: https://github.com/apache/lucene/blob/main/lucene/codecs/src/java/org/apache/lucene/codecs/bitvectors/FlatBitVectorsScorer.java#L60-L123
3. HnswGraph
    - Implements `maxConn()` and `neighborCount`
5. DerivedSourceFieldWriter
    - Changes signature to include `StoredFieldDataInput` instead of `DataInput, length` explicitly
7. QuantizationKNNCollector
   - Implements `getSearchStrategy` with `UnsupportedOperationException`
8. Bug fix to make it return an empty scorer every time it was requested. We are returning a mutable singleton scorer.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
