### PR TITLE
Block mode and compression for indices created before version 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671) 
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
 * [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
+* Block mode and compression for indices created before version 2.17.0 [#2722](https://github.com/opensearch-project/k-NN/pull/2722)
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -36,6 +36,7 @@ testClusters {
 }
 
    def versionsBelow2_3 = ["1.", "2.0.", "2.1.", "2.2."]
+   def versionOnOrAfter2_17 = ["2.17", "2.18", "2.19", "2.20", "3."]
 // Task to run BWC tests against the old cluster
     task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
         dependsOn "zipBwcPlugin"
@@ -150,6 +151,12 @@ testClusters {
                 knn_bwc_version.startsWith("2.19.")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
+            }
+        }
+
+        if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
             }
         }
 
@@ -279,6 +286,12 @@ testClusters {
                 knn_bwc_version.startsWith("2.19.")) {
             filter {
                 excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
+            }
+        }
+
+        if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
+            filter {
+                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
             }
         }
 


### PR DESCRIPTION
### Description
Block from using mode and compression on indices that were created before version 2.17.0, even when the customer tries to create a new knn vector field with mode and compression after upgrading the cluster to version 2.17.0 or later.  

### Related Issues
Resolves #2708 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
