### PR TITLE
Refactor Knn Search Results to use TopDocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Remote Vector Index Build] Add segment size upper bound setting and prepare other settings for GA [#2734](https://github.com/opensearch-project/k-NN/pull/2734)
 ### Bug Fixes
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
-* [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671) 
+* [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671)
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
 * [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
 * Block mode and compression for indices created before version 2.17.0 [#2722](https://github.com/opensearch-project/k-NN/pull/2722)
@@ -23,3 +23,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [BUGFIX] [Remote Vector Index Build] End remote build metrics before falling back to CPU, exception logging [#2693](https://github.com/opensearch-project/k-NN/pull/2693)
 * [BUGFIX] Fix RefCount and ClearCache in some race conditions [#2728](https://github.com/opensearch-project/k-NN/pull/2728)
 * [BUGFIX] FIX nested vector query at efficient filter scenarios [#2641](https://github.com/opensearch-project/k-NN/pull/2641)
+### Refactoring
+* Refactor Knn Search Results to use TopDocs [#2727](https://github.com/opensearch-project/k-NN/pull/2727)

--- a/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
+++ b/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
@@ -7,21 +7,20 @@ package org.opensearch.knn.index.query;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.util.Bits;
 import org.opensearch.common.Nullable;
 
-import java.util.Collections;
-import java.util.Map;
-
 @Getter
 public class PerLeafResult {
-    public static final PerLeafResult EMPTY_RESULT = new PerLeafResult(new Bits.MatchNoBits(0), Collections.emptyMap());
+    public static final PerLeafResult EMPTY_RESULT = new PerLeafResult(new Bits.MatchNoBits(0), TopDocsCollector.EMPTY_TOPDOCS);
     @Nullable
     private final Bits filterBits;
     @Setter
-    private Map<Integer, Float> result;
+    private TopDocs result;
 
-    public PerLeafResult(final Bits filterBits, final Map<Integer, Float> result) {
+    public PerLeafResult(final Bits filterBits, final TopDocs result) {
         this.filterBits = filterBits == null ? new Bits.MatchAllBits(0) : filterBits;
         this.result = result;
     }

--- a/src/main/java/org/opensearch/knn/index/query/TopApproxKnnCollector.java
+++ b/src/main/java/org/opensearch/knn/index/query/TopApproxKnnCollector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.TopKnnCollector;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+/**
+ * A specialized collector for approximate k-nearest neighbor search results.
+ * This collector extends Lucene's TopKnnCollector to handle approximate k-NN search
+ * with support for different space types and scoring mechanisms through the KNNEngine.
+ */
+public class TopApproxKnnCollector extends TopKnnCollector {
+
+    private final KNNEngine engine;
+    private final SpaceType spaceType;
+
+    public TopApproxKnnCollector(int k, KNNEngine engine, SpaceType spaceType) {
+        super(k, Integer.MAX_VALUE);
+        this.spaceType = spaceType;
+        this.engine = engine;
+    }
+
+    /**
+     * Collects a document with its similarity score, converting the raw similarity
+     * to a final score using the configured KNN engine and space type.
+     * @param docId of the vector to collect
+     * @param similarity its calculated similarity
+     * @return true if the document was competitive (i.e., collected), false otherwise
+     */
+    @Override
+    public boolean collect(int docId, float similarity) {
+        return super.collect(docId, engine.score(similarity, spaceType));
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/TopDocsDISI.java
+++ b/src/main/java/org/opensearch/knn/index/query/TopDocsDISI.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.TopDocs;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * A DocIdSetIterator implementation that iterates over documents from TopDocs in sorted order.
+ * This class maintains document IDs and their corresponding scores from the search results.
+ * The implementation is inspired from
+ * <a href="https://github.com/apache/lucene/blob/17a40bd1137837fee924a8ac4b2d4c9c1af16307/lucene/core/src/java/org/apache/lucene/search/SeededKnnVectorQuery.java#L228">SeededKnnVectorQuery.java</a>
+ */
+public class TopDocsDISI extends DocIdSetIterator {
+
+    private final int[] sortedDocIds;
+    private final float[] scores;
+    private int idx = -1;
+
+    public TopDocsDISI(TopDocs topDocs) {
+        // Sort documents by document ID
+        Arrays.sort(topDocs.scoreDocs, Comparator.comparingInt(a -> a.doc));
+        sortedDocIds = new int[topDocs.scoreDocs.length];
+        scores = new float[topDocs.scoreDocs.length];
+        for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+            sortedDocIds[i] = topDocs.scoreDocs[i].doc;
+            scores[i] = topDocs.scoreDocs[i].score;
+        }
+    }
+
+    @Override
+    public int docID() {
+        if (idx == -1) {
+            return idx;
+        }
+        if (idx >= sortedDocIds.length) {
+            return DocIdSetIterator.NO_MORE_DOCS;
+        }
+        return sortedDocIds[idx];
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        idx += 1;
+        return docID();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        return slowAdvance(target);
+    }
+
+    @Override
+    public long cost() {
+        return sortedDocIds.length;
+    }
+
+    public float score() {
+        if (idx == -1) {
+            return idx;
+        }
+        if (idx >= sortedDocIds.length) {
+            return Float.MAX_VALUE;
+        }
+        return scores[idx];
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/explain/KnnExplanation.java
+++ b/src/main/java/org/opensearch/knn/index/query/explain/KnnExplanation.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index.query.explain;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.opensearch.knn.index.query.KNNScorer;
+import org.apache.lucene.search.Scorer;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,7 +22,7 @@ public class KnnExplanation {
 
     private final Map<Integer, Float> rawScores;
 
-    private final Map<Object, KNNScorer> knnScorerPerLeaf;
+    private final Map<Object, Scorer> knnScorerPerLeaf;
 
     @Setter
     @Getter
@@ -43,7 +43,7 @@ public class KnnExplanation {
         this.rawScores.put(docId, rawScore);
     }
 
-    public void addKnnScorer(Object leafId, KNNScorer knnScorer) {
+    public void addKnnScorer(Object leafId, Scorer knnScorer) {
         this.knnScorerPerLeaf.put(leafId, knnScorer);
     }
 
@@ -55,7 +55,7 @@ public class KnnExplanation {
         return this.rawScores.get(docId);
     }
 
-    public KNNScorer getKnnScorer(Object leafId) {
+    public Scorer getKnnScorer(Object leafId) {
         return this.knnScorerPerLeaf.get(leafId);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -59,6 +59,7 @@ import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.RADIAL_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.utils.TopDocsTestUtils.*;
 
 public class ExplainTests extends KNNWeightTestCase {
 
@@ -274,7 +275,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .knnQuery(query)
             .build();
-        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
 
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
@@ -386,7 +387,7 @@ public class ExplainTests extends KNNWeightTestCase {
         ExactSearcher mockedExactSearcher = mock(ExactSearcher.class);
         KNNWeight.initialize(null, mockedExactSearcher);
         final Map<Integer, Float> translatedScores = getTranslatedScores(SpaceType.L2::scoreTranslation);
-        when(mockedExactSearcher.searchLeaf(any(), any())).thenReturn(translatedScores);
+        when(mockedExactSearcher.searchLeaf(any(), any())).thenReturn(buildTopDocs(translatedScores));
         // Given
         int k = 4;
         jniServiceMockedStatic.when(
@@ -487,7 +488,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .knnQuery(query)
             .build();
-        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
         knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
@@ -826,7 +827,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .knnQuery(query)
             .build();
-        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(DOC_ID_TO_SCORES);
+        when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
 
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);

--- a/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import static org.opensearch.knn.utils.TopDocsTestUtils.buildTopDocs;
+import static org.opensearch.knn.utils.TopDocsTestUtils.convertTopDocsToMap;
 
 public class ResultUtilTests extends KNNTestCase {
 
@@ -27,11 +29,11 @@ public class ResultUtilTests extends KNNTestCase {
 
         List<Map<Integer, Float>> initialLeafResults = getRandomListOfResults(firstPassK, segmentCount);
         List<PerLeafResult> perLeafLeafResults = initialLeafResults.stream()
-            .map(result -> new PerLeafResult(null, new HashMap<>(result)))
+            .map(result -> new PerLeafResult(null, buildTopDocs(result)))
             .collect(Collectors.toList());
         ResultUtil.reduceToTopK(perLeafLeafResults, finalK);
         List<Map<Integer, Float>> reducedLeafResults = perLeafLeafResults.stream()
-            .map(PerLeafResult::getResult)
+            .map(leaf -> convertTopDocsToMap(leaf.getResult()))
             .collect(Collectors.toList());
         assertTopK(initialLeafResults, reducedLeafResults, finalK);
 
@@ -41,10 +43,10 @@ public class ResultUtilTests extends KNNTestCase {
 
         initialLeafResults = getRandomListOfResults(firstPassK, segmentCount);
         perLeafLeafResults = initialLeafResults.stream()
-            .map(result -> new PerLeafResult(null, new HashMap<>(result)))
+            .map(result -> new PerLeafResult(null, buildTopDocs(result)))
             .collect(Collectors.toList());
         ResultUtil.reduceToTopK(perLeafLeafResults, finalK);
-        reducedLeafResults = perLeafLeafResults.stream().map(PerLeafResult::getResult).collect(Collectors.toList());
+        reducedLeafResults = perLeafLeafResults.stream().map(leaf -> convertTopDocsToMap(leaf.getResult())).collect(Collectors.toList());
         assertTopK(initialLeafResults, reducedLeafResults, firstPassK);
     }
 

--- a/src/test/java/org/opensearch/knn/index/query/TopApproxKnnCollectorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/TopApproxKnnCollectorTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.TopDocs;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class TopApproxKnnCollectorTests extends OpenSearchTestCase {
+
+    public void testCollect_thenSuccess() {
+        float similarity = randomFloat();
+        KNNEngine knnEngine = randomFrom(KNNEngine.FAISS, KNNEngine.LUCENE);
+        SpaceType spaceType = randomFrom(
+            Arrays.stream(SpaceType.values()).filter(space -> space != SpaceType.UNDEFINED).collect(Collectors.toList())
+        );
+        TopApproxKnnCollector collector = new TopApproxKnnCollector(1, knnEngine, spaceType);
+        assertTrue(collector.collect(1, similarity));
+        TopDocs topDocs = collector.topDocs();
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(knnEngine.score(similarity, spaceType), topDocs.scoreDocs[0].score, 0.01);
+    }
+
+    public void testCollect_MoreThanK_thenReturnTopKResults() {
+        TopApproxKnnCollector collector = new TopApproxKnnCollector(1, KNNEngine.FAISS, SpaceType.INNER_PRODUCT);
+        assertTrue(collector.collect(1, 0.5f));
+        assertTrue(collector.collect(2, 0.7f));
+        TopDocs topDocs = collector.topDocs();
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(KNNEngine.FAISS.score(0.7f, SpaceType.INNER_PRODUCT), topDocs.scoreDocs[0].score, 0.01);
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/query/TopDocsDISITests.java
+++ b/src/test/java/org/opensearch/knn/index/query/TopDocsDISITests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopDocsCollector;
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class TopDocsDISITests extends OpenSearchTestCase {
+
+    private TopDocsDISI topDocsDISI;
+    private ScoreDoc[] sampleScoreDocs;
+    private float maxScore;
+    private int totalHits;
+
+    @Before
+    public void setupBeforeTest() {
+        // Initialize test data
+        maxScore = 1.5f;
+        totalHits = 5;
+        sampleScoreDocs = new ScoreDoc[] {
+            new ScoreDoc(0, 1.5f),
+            new ScoreDoc(1, 1.2f),
+            new ScoreDoc(2, 0.9f),
+            new ScoreDoc(3, 0.6f),
+            new ScoreDoc(4, 0.3f) };
+
+        topDocsDISI = new TopDocsDISI(new TopDocs(new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), sampleScoreDocs));
+    }
+
+    public void testAdvance() throws Exception {
+        // Test advancing to specific positions
+        assertEquals(0, topDocsDISI.advance(0));  // First doc
+        assertEquals(2, topDocsDISI.advance(2));  // Middle doc
+        assertEquals(4, topDocsDISI.advance(4));  // Last doc
+        assertEquals(TopDocsDISI.NO_MORE_DOCS, topDocsDISI.advance(5));  // Beyond last doc
+    }
+
+    public void testDocID() throws IOException {
+        // Test initial state
+        assertEquals(-1, topDocsDISI.docID());
+
+        // Test after advancing
+        topDocsDISI.advance(2);
+        assertEquals(2, topDocsDISI.docID());
+    }
+
+    public void testNextDoc() throws Exception {
+        // Test sequential advancement
+        assertEquals(0, topDocsDISI.nextDoc());
+        assertEquals(1, topDocsDISI.nextDoc());
+        assertEquals(2, topDocsDISI.nextDoc());
+        assertEquals(3, topDocsDISI.nextDoc());
+        assertEquals(4, topDocsDISI.nextDoc());
+        assertEquals(TopDocsDISI.NO_MORE_DOCS, topDocsDISI.nextDoc());
+    }
+
+    public void testCost() {
+        // Test cost matches the number of documents
+        assertEquals(totalHits, topDocsDISI.cost());
+    }
+
+    public void testGetScore() throws IOException {
+        // Test score retrieval
+        topDocsDISI.advance(0);
+        assertEquals(1.5f, topDocsDISI.score(), 0.001f);
+
+        topDocsDISI.advance(2);
+        assertEquals(0.9f, topDocsDISI.score(), 0.001f);
+
+        topDocsDISI.advance(4);
+        assertEquals(0.3f, topDocsDISI.score(), 0.001f);
+    }
+
+    public void testEmptyTopDocs() {
+        // Test behavior with empty TopDocs
+        TopDocsDISI emptyDISI = new TopDocsDISI(TopDocsCollector.EMPTY_TOPDOCS);
+        assertEquals(-1, emptyDISI.docID());
+        assertEquals(0, emptyDISI.cost());
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/utils/TopDocsTestUtils.java
+++ b/src/test/java/org/opensearch/knn/utils/TopDocsTestUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.utils;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class TopDocsTestUtils {
+    public static TopDocs buildTopDocs(Map<Integer, Float> result) {
+        ScoreDoc[] allScoreDocs = result.entrySet()
+            .stream()
+            .map(entry -> new ScoreDoc(entry.getKey(), entry.getValue()))
+            .toArray(ScoreDoc[]::new);
+
+        return new TopDocs(new TotalHits(result.size(), TotalHits.Relation.EQUAL_TO), allScoreDocs);
+    }
+
+    public static Map<Integer, Float> convertTopDocsToMap(TopDocs topDocs) {
+
+        Map<Integer, Float> resultMap = new HashMap<>();
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            resultMap.put(scoreDoc.doc, scoreDoc.score);
+        }
+        return resultMap;
+    }
+
+}


### PR DESCRIPTION
### Description
With this change all search leaf will return TopDocs instead of map and later converted to TopDocs at last step. This will help us align with other search interfaces where results are always returned as TopDocs.

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
