### PR TITLE
[BUGFIX] Fix RefCount and ClearCache in some race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
 * [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
 * [BUGFIX] Avoid opening of graph file if graph is already loaded in memory [#2719](https://github.com/opensearch-project/k-NN/pull/2719)
+* [BUGFIX] Fix RefCount and ClearCache in some race conditions [#2728](https://github.com/opensearch-project/k-NN/pull/2728)
+
 
 ## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
 ### Features

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -21,7 +21,6 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
-import org.opensearch.OpenSearchException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.StopWatch;
 import org.opensearch.common.lucene.Lucene;
@@ -516,7 +515,8 @@ public class KNNWeight extends Weight {
             indexAllocation.incRef();
         } catch (IllegalStateException e) {
             indexAllocation.readUnlock();
-            throw new OpenSearchException("failed to create knn search when clear cache");
+            log.error("[KNN] Exception when allocation getting evicted: " + e);
+            throw new RuntimeException("Failed to do kNN search when vector data structures getting evicted ");
         }
         try {
             if (indexAllocation.isClosed()) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -44,6 +44,7 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.plugin.stats.KNNCounter;
+import org.opensearch.search.SearchException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -515,7 +516,7 @@ public class KNNWeight extends Weight {
             indexAllocation.incRef();
         } catch (IllegalStateException e) {
             indexAllocation.readUnlock();
-            throw new SearchException(shardTarget, "failed to create knn search when clear cache");
+            throw new OpenSearchParseException("failed to create knn search when clear cache");
         }
         try {
             if (indexAllocation.isClosed()) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -21,7 +21,7 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
-import org.opensearch.OpenSearchParseException;
+import org.opensearch.OpenSearchException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.StopWatch;
 import org.opensearch.common.lucene.Lucene;
@@ -516,7 +516,7 @@ public class KNNWeight extends Weight {
             indexAllocation.incRef();
         } catch (IllegalStateException e) {
             indexAllocation.readUnlock();
-            throw new OpenSearchParseException("failed to create knn search when clear cache");
+            throw new OpenSearchException("failed to create knn search when clear cache");
         }
         try {
             if (indexAllocation.isClosed()) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -511,7 +511,12 @@ public class KNNWeight extends Weight {
         FilterIdsSelector.FilterIdsSelectorType filterType = filterIdsSelector.getFilterType();
         // Now that we have the allocation, we need to readLock it
         indexAllocation.readLock();
-        indexAllocation.incRef();
+        try {
+            indexAllocation.incRef();
+        } catch (IllegalStateException e) {
+            indexAllocation.readUnlock();
+            throw new RuntimeException(e.getMessage() + " this is usually caused by clear cache");
+        }
         try {
             if (indexAllocation.isClosed()) {
                 throw new RuntimeException("Index has already been closed");

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -516,7 +516,7 @@ public class KNNWeight extends Weight {
         } catch (IllegalStateException e) {
             indexAllocation.readUnlock();
             log.error("[KNN] Exception when allocation getting evicted: ", e);
-            throw new RuntimeException("Failed to do kNN search when vector data structures getting evicted ");
+            throw new RuntimeException("Failed to do kNN search when vector data structures getting evicted ", e);
         }
         try {
             if (indexAllocation.isClosed()) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
+import org.opensearch.OpenSearchParseException;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.StopWatch;
 import org.opensearch.common.lucene.Lucene;
@@ -44,7 +45,6 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
 import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.plugin.stats.KNNCounter;
-import org.opensearch.search.SearchException;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -515,7 +515,7 @@ public class KNNWeight extends Weight {
             indexAllocation.incRef();
         } catch (IllegalStateException e) {
             indexAllocation.readUnlock();
-            throw new RuntimeException(e.getMessage() + " this is usually caused by clear cache");
+            throw new SearchException(shardTarget, "failed to create knn search when clear cache");
         }
         try {
             if (indexAllocation.isClosed()) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -515,7 +515,7 @@ public class KNNWeight extends Weight {
             indexAllocation.incRef();
         } catch (IllegalStateException e) {
             indexAllocation.readUnlock();
-            log.error("[KNN] Exception when allocation getting evicted: " + e);
+            log.error("[KNN] Exception when allocation getting evicted: ", e);
             throw new RuntimeException("Failed to do kNN search when vector data structures getting evicted ");
         }
         try {


### PR DESCRIPTION
Fix RefCount and ClearCache in some race conditions

### Description
in #2619 @owenhalpert describe a bugs: `IndexAllocation-Reference is already closed can't increment refCount current count [0]`,  i met the same case at scenarios:  at the time with hight throughput search, doing clear cache.

also it would also cause memory leak because it would waiting the writeLock.
![image](https://github.com/user-attachments/assets/cc5d44f2-2f19-419a-ac70-190baf839b09)

i analysis the race condition as following shows:

1. Time1: Search Thread, do `KNNWeight#doANNSearch` and get indexAllocation at https://github.com/opensearch-project/k-NN/blob/52dc64b6311a71e174a6ba7a6c6e904f2e2d378f/src/main/java/org/opensearch/knn/index/query/KNNWeight.java#L486-L501
2. Time2: Clear Thread, clear cache triggered, and google Cache do async clear cache, get into https://github.com/opensearch-project/k-NN/blob/52dc64b6311a71e174a6ba7a6c6e904f2e2d378f/src/main/java/org/opensearch/knn/index/memory/NativeMemoryCacheManager.java#L526-L529
3. Time3: Clear Thread, checked refCount to zero, and ready to do closeInternal in NativeMemory Allocation.
4. Time4: Search Thread, got readLock at https://github.com/opensearch-project/k-NN/blob/52dc64b6311a71e174a6ba7a6c6e904f2e2d378f/src/main/java/org/opensearch/knn/index/query/KNNWeight.java#L513-L514, and trying to do incRef but throw exception: `IndexAllocation-Reference is already closed can't increment refCount current count [0]`
5. Time5: Search Thread, throw exception without unlock readLock
6. Time6: Clear Thread, waiting for `writeLock()` which is a `dead lock`. like my pictures shows.

### Related Issues
#2619

### Proposal

i see #2435, but i think it can not fix the bugs. my proposal just catch the throw, and release the lock. it would cause one query throw exception, and also it is reasonable, after next query, it would be reload into memory.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
