### PR TITLE
Add upper bound setting for remote vector index build + GA settings changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
+## [Unreleased 3.x](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Infrastructure
 * Add testing support to run all ITs with remote index builder [#2659](https://github.com/opensearch-project/k-NN/pull/2659)
 * Fix KNNSettingsTests after change in MockNode constructor [#2700](https://github.com/opensearch-project/k-NN/pull/2700)
@@ -12,19 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Removing redundant type conversions for script scoring for hamming space with binary vectors [#2351](https://github.com/opensearch-project/k-NN/pull/2351)
 * [Remote Vector Index Build] Add tuned repository upload/download configurations per benchmarking results [#2662](https://github.com/opensearch-project/k-NN/pull/2662)
 * Apply mask operation in preindex to optimize derived source [#2704](https://github.com/opensearch-project/k-NN/pull/2704)
+* [Remote Vector Index Build] Add segment size upper bound setting and prepare other settings for GA [#2734](https://github.com/opensearch-project/k-NN/pull/2734)
 ### Bug Fixes
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
 * [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671) 
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
 * [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
 * [BUGFIX] Avoid opening of graph file if graph is already loaded in memory [#2719](https://github.com/opensearch-project/k-NN/pull/2719)
-
-## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
-### Features
-### Enhancements
-### Bug Fixes
 * [BUGFIX] FIX nested vector query at efficient filter scenarios [#2641](https://github.com/opensearch-project/k-NN/pull/2641)
-### Infrastructure
-### Documentation
-### Maintenance
-### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -493,6 +493,10 @@ integTest {
 
 task integTestRemoteIndexBuild(type: RestIntegTestTask) {
     commonIntegTest(it, project, integTestDependOnJniLib, opensearch_tmp_dir, _numNodes)
+    filter {
+        // Temporarily skipping this test class, see: https://github.com/opensearch-project/k-NN/issues/2726
+        excludeTestsMatching "org.opensearch.knn.index.SegmentReplicationIT"
+    }
     systemProperty("test.remoteBuild", System.getProperty("test.remoteBuild"))
     systemProperty("test.bucket", System.getProperty("test.bucket"))
     systemProperty("test.base_path", System.getProperty("test.base_path"))

--- a/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
+++ b/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
@@ -26,7 +26,6 @@ public class KNNFeatureFlags {
 
     // Feature flags
     private static final String KNN_FORCE_EVICT_CACHE_ENABLED = "knn.feature.cache.force_evict.enabled";
-    private static final String KNN_REMOTE_VECTOR_BUILD = "knn.feature.remote_index_build.enabled";
 
     @VisibleForTesting
     public static final Setting<Boolean> KNN_FORCE_EVICT_CACHE_ENABLED_SETTING = Setting.boolSetting(
@@ -36,18 +35,8 @@ public class KNNFeatureFlags {
         Dynamic
     );
 
-    /**
-     * Feature flag to control remote index build at the cluster level
-     */
-    public static final Setting<Boolean> KNN_REMOTE_VECTOR_BUILD_SETTING = Setting.boolSetting(
-        KNN_REMOTE_VECTOR_BUILD,
-        false,
-        NodeScope,
-        Dynamic
-    );
-
     public static List<Setting<?>> getFeatureFlags() {
-        return ImmutableList.of(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING, KNN_REMOTE_VECTOR_BUILD_SETTING);
+        return ImmutableList.of(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING);
     }
 
     /**
@@ -56,12 +45,5 @@ public class KNNFeatureFlags {
      */
     public static boolean isForceEvictCacheEnabled() {
         return Booleans.parseBoolean(KNNSettings.state().getSettingValue(KNN_FORCE_EVICT_CACHE_ENABLED).toString(), false);
-    }
-
-    /**
-     * @return true if remote vector index build feature flag is enabled
-     */
-    public static boolean isKNNRemoteVectorBuildEnabled() {
-        return Booleans.parseBooleanStrict(KNNSettings.state().getSettingValue(KNN_REMOTE_VECTOR_BUILD).toString(), false);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.codec.nativeindex;
 import lombok.Setter;
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.index.IndexSettings;
-import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -21,6 +20,7 @@ import java.util.function.Supplier;
 
 import static org.opensearch.knn.common.FieldInfoExtractor.extractKNNEngine;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.index.KNNSettings.isKNNRemoteVectorBuildEnabled;
 import static org.opensearch.knn.index.codec.util.KNNCodecUtil.initializeVectorValues;
 
 /**
@@ -68,7 +68,7 @@ public final class NativeIndexBuildStrategyFactory {
         initializeVectorValues(knnVectorValues);
         long vectorBlobLength = ((long) knnVectorValues.bytesPerVector()) * totalLiveDocs;
 
-        if (KNNFeatureFlags.isKNNRemoteVectorBuildEnabled()
+        if (isKNNRemoteVectorBuildEnabled()
             && repositoriesServiceSupplier != null
             && indexSettings != null
             && knnEngine.supportsRemoteIndexBuild(knnLibraryIndexingContext)

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -32,7 +32,6 @@ import org.opensearch.index.engine.EngineFactory;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.shard.IndexSettingProvider;
 import org.opensearch.indices.SystemIndexDescriptor;
-import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.KNNCircuitBreaker;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNNCodecService;
@@ -423,10 +422,8 @@ public class KNNPlugin extends Plugin
      */
     @Override
     public void reload(Settings settings) {
-        if (KNNFeatureFlags.isKNNRemoteVectorBuildEnabled()) {
-            SecureString username = KNNSettings.KNN_REMOTE_BUILD_CLIENT_USERNAME_SETTING.get(settings);
-            SecureString password = KNNSettings.KNN_REMOTE_BUILD_CLIENT_PASSWORD_SETTING.get(settings);
-            RemoteIndexHTTPClient.reloadAuthHeader(username, password);
-        }
+        SecureString username = KNNSettings.KNN_REMOTE_BUILD_SERVER_USERNAME_SETTING.get(settings);
+        SecureString password = KNNSettings.KNN_REMOTE_BUILD_SERVER_PASSWORD_SETTING.get(settings);
+        RemoteIndexHTTPClient.reloadAuthHeader(username, password);
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/transport/KNNStatsRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/KNNStatsRequest.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.plugin.transport;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.plugin.stats.StatNames;
 
 import java.io.IOException;
@@ -101,9 +100,6 @@ public class KNNStatsRequest extends BaseNodesRequest<KNNStatsRequest> {
      */
     private Set<String> getValidStats() {
         Set<String> stats = StatNames.getNames();
-        if (!KNNFeatureFlags.isKNNRemoteVectorBuildEnabled()) {
-            stats.remove(StatNames.REMOTE_VECTOR_INDEX_BUILD_STATS.getName());
-        }
         return stats;
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildTests.java
@@ -50,7 +50,7 @@ import java.util.function.Supplier;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.knn.index.KNNSettings.KNN_REMOTE_VECTOR_REPO_SETTING;
+import static org.opensearch.knn.index.KNNSettings.KNN_REMOTE_VECTOR_REPOSITORY_SETTING;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.BUCKET;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.S3;
 
@@ -161,7 +161,7 @@ abstract class RemoteIndexBuildTests extends KNNTestCase {
     public void setUp() throws Exception {
         super.setUp();
         ClusterSettings clusterSettings = mock(ClusterSettings.class);
-        when(clusterSettings.get(KNN_REMOTE_VECTOR_REPO_SETTING)).thenReturn("test-repo-name");
+        when(clusterSettings.get(KNN_REMOTE_VECTOR_REPOSITORY_SETTING)).thenReturn("test-repo-name");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         KNNSettings.state().setClusterService(clusterService);
     }

--- a/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestKNNStatsHandlerIT.java
@@ -25,7 +25,6 @@ import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.KNNRestTestCase;
-import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -55,7 +54,6 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
-import static org.opensearch.knn.plugin.stats.StatNames.REMOTE_VECTOR_INDEX_BUILD_STATS;
 
 /**
  * Integration tests to check the correctness of RestKNNStatsHandler
@@ -93,23 +91,12 @@ public class RestKNNStatsHandlerIT extends KNNRestTestCase {
      */
     public void testCorrectStatsReturned() throws Exception {
         // Enable flag to get all stats in KNNStats returned
-        updateClusterSettings(KNNFeatureFlags.KNN_REMOTE_VECTOR_BUILD_SETTING.getKey(), true);
         Response response = getKnnStats(Collections.emptyList(), Collections.emptyList());
         String responseBody = EntityUtils.toString(response.getEntity());
         Map<String, Object> clusterStats = parseClusterStatsResponse(responseBody);
         assertEquals(knnStats.getClusterStats().keySet(), clusterStats.keySet());
         List<Map<String, Object>> nodeStats = parseNodeStatsResponse(responseBody);
         assertEquals(knnStats.getNodeStats().keySet(), nodeStats.get(0).keySet());
-    }
-
-    /**
-     * Test checks that handler correctly omits stats based on feature flag
-     */
-    public void testFeatureFlagOmittingStats() throws Exception {
-        updateClusterSettings(KNNFeatureFlags.KNN_REMOTE_VECTOR_BUILD_SETTING.getKey(), false);
-        Response response = getKnnStats(Collections.emptyList(), Collections.emptyList());
-        String responseBody = EntityUtils.toString(response.getEntity());
-        assertFalse(responseBody.contains(REMOTE_VECTOR_INDEX_BUILD_STATS.getName()));
     }
 
     /**


### PR DESCRIPTION
### Description
Depending on the implementation of the remote vector index build service being used, there may be an upper limit on the segment size that the GPU instances being used can handle. For segments about this size, the GPU instances will run OOM, so we should fail fast before uploading the vector to S3. This PR introduces a new cluster setting which specifies the upper bound of the vector size.

This PR also makes an attempt at updating the CHANGELOG the be more in line with core/other plugins. Ref:
- https://github.com/opensearch-project/OpenSearch/blob/main/CHANGELOG.md
- https://github.com/opensearch-project/neural-search/blob/main/CHANGELOG.md

Docs issue for settings name change + GA: https://github.com/opensearch-project/documentation-website/issues/10053

Also, muting the flakey test from https://github.com/opensearch-project/k-NN/issues/2726 in this PR

### Related Issues
Resolves #2732

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
