### PR TITLE
Add engine as a top level mapping parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Refactored the KNN Stat files for better readability.
 
 ### Enhancements
-* Add engine as a top-level optional parameter while creating vector field [#2736](https://github.com/opensearch-project/k-NN/pull/2736)
+* Added engine as a top-level optional parameter while creating vector field [#2736](https://github.com/opensearch-project/k-NN/pull/2736)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.3](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Refactoring
 * Refactored the KNN Stat files for better readability.
+
+### Enhancements
+* Add engine as a top-level optional parameter while creating vector field [#2736](https://github.com/opensearch-project/k-NN/pull/2736)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -39,6 +39,7 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_SPACE_TYPE = "space_type"; // used for mapping parameter
     // used for defining toplevel parameter
     public static final String TOP_LEVEL_PARAMETER_SPACE_TYPE = METHOD_PARAMETER_SPACE_TYPE;
+    public static final String TOP_LEVEL_PARAMETER_ENGINE = KNN_ENGINE;
     public static final String COMPOUND_EXTENSION = "c";
     public static final String MODEL = "model";
     public static final String MODELS = "models";
@@ -80,6 +81,7 @@ public class KNNConstants {
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
     public static final String MINIMAL_MODE_AND_COMPRESSION_FEATURE = "mode_and_compression_feature";
     public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
+    public static final String TOP_LEVEL_ENGINE_FEATURE = "top_level_engine_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
     public static final String MODEL_VERSION = "model_version";

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -81,7 +81,6 @@ public class KNNConstants {
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
     public static final String MINIMAL_MODE_AND_COMPRESSION_FEATURE = "mode_and_compression_feature";
     public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
-    public static final String TOP_LEVEL_ENGINE_FEATURE = "top_level_engine_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
     public static final String MODEL_VERSION = "model_version";

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -81,6 +81,7 @@ public class KNNConstants {
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
     public static final String MINIMAL_MODE_AND_COMPRESSION_FEATURE = "mode_and_compression_feature";
     public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
+    public static final String TOP_LEVEL_ENGINE_FEATURE = "top_level_engine_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
     public static final String MODEL_VERSION = "model_version";

--- a/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
@@ -8,9 +8,14 @@ package org.opensearch.knn.index.engine;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 import org.opensearch.Version;
+import org.opensearch.index.mapper.MapperParsingException;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
+
+import java.util.Locale;
 
 import static org.opensearch.knn.index.engine.KNNEngine.DEPRECATED_ENGINES;
 
@@ -45,6 +50,25 @@ public final class EngineResolver {
         Version version
     ) {
         return logAndReturnEngine(resolveKNNEngine(knnMethodConfigContext, knnMethodContext, requiresTraining, version));
+    }
+
+    /**
+     * Resolves engine from configuration details. It is guaranteed not to return null.
+     * When engine is not in either method and top level, DEFAULT will be returned.
+     *
+     * @param knnMethodConfigContext configuration context
+     * @param knnMethodContext KNNMethodContext
+     * @param toplevelEngineString Alternative top-level engine
+     * @return {@link SpaceType} for the method
+     */
+    public KNNEngine resolveEngine(
+            KNNMethodConfigContext knnMethodConfigContext,
+            KNNMethodContext knnMethodContext,
+            String toplevelEngineString,
+            boolean requiresTraining,
+            Version version
+    ) {
+        return logAndReturnEngine(resolveKNNEngine(knnMethodConfigContext, knnMethodContext, toplevelEngineString, requiresTraining, version));
     }
 
     /**
@@ -92,6 +116,76 @@ public final class EngineResolver {
         return KNNEngine.FAISS;
     }
 
+    /**
+     * Based on the provided {@link Mode} and {@link CompressionLevel}, resolve to a {@link KNNEngine}.
+     *
+     * @param knnMethodConfigContext configuration context
+     * @param knnMethodContext KNNMethodContext
+     * @param topLevelEngineString Alternative top-level engine
+     * @param requiresTraining whether config requires training
+     * @param version opensearch index version
+     * @return {@link KNNEngine}
+     */
+    private KNNEngine resolveKNNEngine(
+            KNNMethodConfigContext knnMethodConfigContext,
+            KNNMethodContext knnMethodContext,
+            String topLevelEngineString,
+            boolean requiresTraining,
+            Version version
+    ) {
+        KNNEngine methodEngine = getEngineTypeFromMethodContext(knnMethodContext);
+        KNNEngine topLevelEngine = getEngineFromString(topLevelEngineString);
+
+        // user configured method engine
+        if (isEngineConfigured(topLevelEngine) == false && isEngineConfigured(methodEngine) != false) {
+            return knnMethodContext.getKnnEngine();
+        }
+
+        // user configured top level engine
+        if (isEngineConfigured(methodEngine) == false && isEngineConfigured(topLevelEngine) != false) {
+            return KNNEngine.getEngine(topLevelEngineString);
+        }
+
+        if (topLevelEngine != KNNEngine.UNDEFINED && topLevelEngine == methodEngine && methodEngine != KNNEngine.UNDEFINED) {
+            // both engines are same
+            return topLevelEngine;
+        } else if (topLevelEngine != methodEngine) {
+            // engines are different
+            throw new MapperParsingException(
+                    String.format(
+                            Locale.ROOT,
+                            "Cannot specify conflicting engines: \"[%s]\" \"[%s]\"",
+                            methodEngine.getName(),
+                            topLevelEngine.getName()
+                    )
+            );
+        }
+
+        // Handle training case
+        if (requiresTraining) {
+            // Faiss is the only engine that supports training, so we default to faiss here for now
+            return KNNEngine.FAISS;
+        }
+
+        Mode mode = knnMethodConfigContext.getMode();
+        CompressionLevel compressionLevel = knnMethodConfigContext.getCompressionLevel();
+
+        // If both mode and compression are not specified, we can just default
+        if (Mode.isConfigured(mode) == false && CompressionLevel.isConfigured(compressionLevel) == false) {
+            return KNNEngine.DEFAULT;
+        }
+
+        if (compressionLevel == CompressionLevel.x4) {
+            // Lucene is only engine that supports 4x - so we have to default to it here.
+            return KNNEngine.LUCENE;
+        }
+        if (CompressionLevel.isConfigured(compressionLevel) == false || compressionLevel == CompressionLevel.x1) {
+            // For 1x or no compression, we need to default to faiss if mode is provided and use nmslib otherwise based on version check
+            return resolveEngineForX1OrNoCompression(mode, version);
+        }
+        return KNNEngine.FAISS;
+    }
+
     private boolean hasUserConfiguredEngine(KNNMethodContext knnMethodContext) {
         return knnMethodContext != null && knnMethodContext.isEngineConfigured();
     }
@@ -108,5 +202,25 @@ public final class EngineResolver {
             logger.warn("[Deprecation] {} engine is deprecated and will be removed in a future release.", knnEngine);
         }
         return knnEngine;
+    }
+
+    private boolean isEngineConfigured(final KNNEngine knnEngine) {
+        return knnEngine != null && knnEngine != KNNEngine.UNDEFINED;
+    }
+
+    private KNNEngine getEngineTypeFromMethodContext(final KNNMethodContext knnMethodContext) {
+        if (knnMethodContext == null) {
+            return KNNEngine.UNDEFINED;
+        }
+
+        return knnMethodContext.getKnnEngine();
+    }
+
+    private KNNEngine getEngineFromString(final String knnEngineString) {
+        if (Strings.isEmpty(knnEngineString)) {
+            return KNNEngine.UNDEFINED;
+        }
+
+        return KNNEngine.getEngine(knnEngineString);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -31,7 +31,8 @@ public enum KNNEngine implements KNNLibrary {
     @Deprecated(since = "2.19.0", forRemoval = true)
     NMSLIB(NMSLIB_NAME, Nmslib.INSTANCE, Version.V_3_0_0),
     FAISS(FAISS_NAME, Faiss.INSTANCE),
-    LUCENE(LUCENE_NAME, Lucene.INSTANCE);
+    LUCENE(LUCENE_NAME, Lucene.INSTANCE),
+    UNDEFINED("undefined");
 
     public static final KNNEngine DEFAULT = FAISS;
     private final Version restrictedFromVersion; // Nullable field
@@ -72,6 +73,15 @@ public enum KNNEngine implements KNNLibrary {
         this.restrictedFromVersion = restrictedVersion;
     }
 
+    /**
+     * Constructor for undefined engines.
+     */
+    KNNEngine(String name) {
+        this.name = name;
+        this.knnLibrary = null;
+        this.restrictedFromVersion = null;
+    }
+
     private final String name;
     private final KNNLibrary knnLibrary;
 
@@ -92,6 +102,10 @@ public enum KNNEngine implements KNNLibrary {
 
         if (LUCENE.getName().equalsIgnoreCase(name)) {
             return LUCENE;
+        }
+
+        if (UNDEFINED.getName().equalsIgnoreCase(name)) {
+            return UNDEFINED;
         }
 
         throw new IllegalArgumentException(String.format("Invalid engine type: %s", name));

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -149,7 +149,7 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         Map<String, Object> methodMap = (Map<String, Object>) in;
 
         boolean isEngineConfigured = false;
-        KNNEngine engine = KNNEngine.DEFAULT; // Get or default
+        KNNEngine engine = KNNEngine.UNDEFINED; // Get or default
         SpaceType spaceType = SpaceType.UNDEFINED; // Get or default
         String name = "";
         Map<String, Object> parameters = new HashMap<>();

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -199,7 +199,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             false,
             m -> toType(m).originalMappingParameters.getTopLevelEngine(),
             KNNEngine.UNDEFINED.getName()
-        ).setValidator(KNNEngine::getEngine).alwaysSerialize();
+        ).setValidator(KNNEngine::getEngine);
 
         protected final Parameter<Map<String, String>> meta = Parameter.metaParam();
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -199,8 +199,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             false,
             m -> toType(m).originalMappingParameters.getTopLevelEngine(),
             KNNEngine.UNDEFINED.getName()
-        ).setValidator(KNNEngine::getEngine)
-        .alwaysSerialize();
+        ).setValidator(KNNEngine::getEngine).alwaysSerialize();
 
         protected final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
@@ -433,6 +432,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 // we must wrap it and pick up the default when it is UNDEFINED.
                 setSpaceType(builder.originalParameters.getKnnMethodContext(), resolvedSpaceType);
                 validateSpaceType(builder);
+                validateEngine(builder);
 
                 // Resolve method component. For the legacy case where space type can be configured at index level,
                 // it first tries to use the given one then tries to get it from index setting when the space type is UNDEFINED.
@@ -468,10 +468,10 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 KNNEngine knnMethodContextEngine = knnMethodContext.getKnnEngine();
                 KNNEngine topLevelEngine = KNNEngine.getEngine(builder.originalParameters.getTopLevelEngine());
                 if (topLevelEngine != KNNEngine.UNDEFINED
-                        && knnMethodContextEngine != KNNEngine.UNDEFINED
-                        && topLevelEngine != knnMethodContextEngine) {
+                    && knnMethodContextEngine != KNNEngine.UNDEFINED
+                    && topLevelEngine != knnMethodContextEngine) {
                     throw new MapperParsingException(
-                            "Engine in \"method\" and top level engine should be same or one of them should be defined."
+                        "Engine in method and top level engine should be same or one of them should be defined."
                     );
                 }
             }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -432,7 +432,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 // we must wrap it and pick up the default when it is UNDEFINED.
                 setSpaceType(builder.originalParameters.getKnnMethodContext(), resolvedSpaceType);
                 validateSpaceType(builder);
-                validateEngine(builder);
 
                 // Resolve method component. For the legacy case where space type can be configured at index level,
                 // it first tries to use the given one then tries to get it from index setting when the space type is UNDEFINED.
@@ -457,21 +456,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                     && knnMethodContextSpaceType != SpaceType.UNDEFINED) {
                     throw new MapperParsingException(
                         "Space type in \"method\" and top level space type should be same or one of them should be defined"
-                    );
-                }
-            }
-        }
-
-        private void validateEngine(KNNVectorFieldMapper.Builder builder) {
-            final KNNMethodContext knnMethodContext = builder.knnMethodContext.get();
-            if (knnMethodContext != null) {
-                KNNEngine knnMethodContextEngine = knnMethodContext.getKnnEngine();
-                KNNEngine topLevelEngine = KNNEngine.getEngine(builder.originalParameters.getTopLevelEngine());
-                if (topLevelEngine != KNNEngine.UNDEFINED
-                    && knnMethodContextEngine != KNNEngine.UNDEFINED
-                    && topLevelEngine != knnMethodContextEngine) {
-                    throw new MapperParsingException(
-                        "Engine in method and top level engine should be same or one of them should be defined."
                     );
                 }
             }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -602,7 +602,6 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 builder.indexCreatedVersion
             );
             setEngine(builder.originalParameters.getResolvedKnnMethodContext(), resolvedKNNEngine);
-            builder.originalParameters.setTopLevelEngine(resolvedKNNEngine.getName());
             // Create a copy of the KNNMethodContext and fill in the parameters left blank by configuration context context
             ResolvedMethodContext resolvedMethodContext = resolvedKNNEngine.resolveMethod(
                 builder.originalParameters.getResolvedKnnMethodContext(),

--- a/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
@@ -45,6 +45,8 @@ public final class OriginalMappingParameters {
     private final String compressionLevel;
     private final String modelId;
     private final String topLevelSpaceType;
+    @Setter
+    private String topLevelEngine;
 
     /**
      * Initialize the parameters from the builder
@@ -60,6 +62,7 @@ public final class OriginalMappingParameters {
         this.compressionLevel = builder.compressionLevel.get();
         this.modelId = builder.modelId.get();
         this.topLevelSpaceType = builder.topLevelSpaceType.get();
+        this.topLevelEngine = builder.topLevelEngine.get();
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
@@ -45,8 +45,7 @@ public final class OriginalMappingParameters {
     private final String compressionLevel;
     private final String modelId;
     private final String topLevelSpaceType;
-    @Setter
-    private String topLevelEngine;
+    private final String topLevelEngine;
 
     /**
      * Initialize the parameters from the builder

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -66,7 +66,7 @@ public class IndexUtil {
     private static final Version MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE = Version.V_2_17_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION = Version.V_2_17_0;
     private static final Version MINIMAL_EXPAND_NESTED_FEATURE = Version.V_2_19_0;
-    private static final Version MINIMAL_TOP_LEVEL_ENGINE_FEATURE = Version.V_3_0_0;
+    private static final Version MINIMAL_TOP_LEVEL_ENGINE_FEATURE = Version.V_3_2_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -66,6 +66,7 @@ public class IndexUtil {
     private static final Version MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE = Version.V_2_17_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION = Version.V_2_17_0;
     private static final Version MINIMAL_EXPAND_NESTED_FEATURE = Version.V_2_19_0;
+    private static final Version MINIMAL_TOP_LEVEL_ENGINE_FEATURE = Version.V_3_0_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -431,6 +432,7 @@ public class IndexUtil {
                 put(KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE, MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE);
                 put(KNNConstants.MODEL_VERSION, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION);
                 put(EXPAND_NESTED, MINIMAL_EXPAND_NESTED_FEATURE);
+                put(KNNConstants.TOP_LEVEL_ENGINE_FEATURE, MINIMAL_TOP_LEVEL_ENGINE_FEATURE);
             }
         };
 

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -14,12 +14,16 @@ package org.opensearch.knn.plugin.rest;
 import com.google.common.collect.ImmutableList;
 import org.opensearch.transport.client.node.NodeClient;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.Version;
 import org.opensearch.index.mapper.NumberFieldMapper;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.SpaceTypeResolver;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.EngineResolver;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.indices.ModelUtil;
@@ -97,6 +101,7 @@ public class RestTrainModelHandler extends BaseRestHandler {
         int maximumVectorCount = DEFAULT_NOT_SET_INT_VALUE;
         int searchSize = DEFAULT_NOT_SET_INT_VALUE;
         SpaceType topLevelSpaceType = SpaceType.UNDEFINED;
+        KNNEngine topLevelEngine = KNNEngine.UNDEFINED;
 
         String compressionLevel = null;
         String mode = null;
@@ -129,6 +134,8 @@ public class RestTrainModelHandler extends BaseRestHandler {
             } else if ((KNNConstants.SPACE_TYPE.equals(fieldName) || KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE.equals(fieldName))
                 && ensureSpaceTypeNotSet(topLevelSpaceType)) {
                     topLevelSpaceType = SpaceType.getSpace(parser.text());
+                } else if ((KNNConstants.KNN_ENGINE.equals(fieldName)) && ensureEngineNotSet(topLevelEngine)) {
+                    topLevelEngine = KNNEngine.getEngine(parser.text());
                 } else {
                     throw new IllegalArgumentException("Unable to parse token. \"" + fieldName + "\" is not a valid " + "parameter.");
                 }
@@ -153,6 +160,9 @@ public class RestTrainModelHandler extends BaseRestHandler {
             && topLevelSpaceType == SpaceType.UNDEFINED) {
             topLevelSpaceType = SpaceTypeResolver.getDefaultSpaceType(vectorDataType);
         }
+        if ((knnMethodContext == null || knnMethodContext.getKnnEngine() == KNNEngine.UNDEFINED) && topLevelEngine == KNNEngine.UNDEFINED) {
+            topLevelEngine = KNNEngine.FAISS;
+        }
 
         ensureIfSetThenEquals(
             MODE_PARAMETER,
@@ -171,6 +181,20 @@ public class RestTrainModelHandler extends BaseRestHandler {
             vectorDataType
         );
         setSpaceType(knnMethodContext, resolvedSpaceType);
+        KNNEngine resolvedEngine = EngineResolver.INSTANCE.resolveEngine(
+            KNNMethodConfigContext.builder()
+                .vectorDataType(vectorDataType)
+                .dimension(dimension)
+                .versionCreated(Version.CURRENT)
+                .compressionLevel(CompressionLevel.fromName(compressionLevel))
+                .mode(Mode.fromName(mode))
+                .build(),
+            knnMethodContext,
+            topLevelEngine.getName(),
+            true,
+            Version.CURRENT
+        );
+        setEngine(knnMethodContext, resolvedEngine);
         TrainingModelRequest trainingModelRequest = new TrainingModelRequest(
             modelId,
             knnMethodContext,
@@ -182,7 +206,8 @@ public class RestTrainModelHandler extends BaseRestHandler {
             vectorDataType,
             Mode.fromName(mode),
             CompressionLevel.fromName(compressionLevel),
-            resolvedSpaceType
+            resolvedSpaceType,
+            resolvedEngine
         );
 
         if (maximumVectorCount != DEFAULT_NOT_SET_INT_VALUE) {
@@ -228,6 +253,20 @@ public class RestTrainModelHandler extends BaseRestHandler {
             return;
         }
         knnMethodContext.setSpaceType(resolvedSpaceType);
+    }
+
+    private boolean ensureEngineNotSet(KNNEngine knnEngine) {
+        if (knnEngine != KNNEngine.UNDEFINED) {
+            throw new IllegalArgumentException("Unable to parse KNNEngine as it is duplicated.");
+        }
+        return true;
+    }
+
+    private void setEngine(KNNMethodContext knnMethodContext, KNNEngine resolvedEngine) {
+        if (knnMethodContext == null | knnMethodContext.isEngineConfigured()) {
+            return;
+        }
+        knnMethodContext.setKnnEngine(resolvedEngine);
     }
 
     private void ensureIfSetThenEquals(

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestTrainModelHandler.java
@@ -263,7 +263,7 @@ public class RestTrainModelHandler extends BaseRestHandler {
     }
 
     private void setEngine(KNNMethodContext knnMethodContext, KNNEngine resolvedEngine) {
-        if (knnMethodContext == null | knnMethodContext.isEngineConfigured()) {
+        if (knnMethodContext == null || knnMethodContext.isEngineConfigured()) {
             return;
         }
         knnMethodContext.setKnnEngine(resolvedEngine);

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -27,7 +27,6 @@ import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.ResolvedMethodContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
-import org.opensearch.knn.index.engine.EngineResolver;
 import org.opensearch.knn.index.util.IndexUtil;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.VectorDataType;
@@ -82,7 +81,8 @@ public class TrainingModelRequest extends ActionRequest {
             vectorDataType,
             mode,
             compressionLevel,
-            SpaceType.DEFAULT
+            SpaceType.DEFAULT,
+            knnMethodContext == null ? KNNEngine.DEFAULT : knnMethodContext.getKnnEngine()
         );
     }
 
@@ -108,7 +108,8 @@ public class TrainingModelRequest extends ActionRequest {
         VectorDataType vectorDataType,
         Mode mode,
         CompressionLevel compressionLevel,
-        SpaceType spaceType
+        SpaceType spaceType,
+        KNNEngine knnEngine
     ) {
         super();
         this.modelId = modelId;
@@ -134,7 +135,6 @@ public class TrainingModelRequest extends ActionRequest {
             .mode(mode)
             .build();
 
-        KNNEngine knnEngine = EngineResolver.INSTANCE.resolveEngine(knnMethodConfigContext, knnMethodContext, true, Version.CURRENT);
         ResolvedMethodContext resolvedMethodContext = knnEngine.resolveMethod(knnMethodContext, knnMethodConfigContext, true, spaceType);
         this.knnMethodContext = resolvedMethodContext.getKnnMethodContext();
         this.compressionLevel = resolvedMethodContext.getCompressionLevel();

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -283,4 +283,30 @@ public class EngineResolverTests extends KNNTestCase {
             )
         );
     }
+
+    public void testValidateTopLevelEngine() throws IOException {
+        // only top-level defined; set to faiss with compression 4x
+        expectThrows(
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x4).build(),
+                null,
+                "faiss",
+                false,
+                Version.CURRENT
+            )
+        );
+
+        // top-level and method defined to lucene; requires training
+        expectThrows(
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x4).build(),
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                "lucene",
+                true,
+                Version.CURRENT
+            )
+        );
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -17,7 +17,8 @@ import org.opensearch.knn.index.mapper.Mode;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
 public class EngineResolverTests extends KNNTestCase {
 

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -17,8 +17,7 @@ import org.opensearch.knn.index.mapper.Mode;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.opensearch.knn.common.KNNConstants.NAME;
-import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.*;
 
 public class EngineResolverTests extends KNNTestCase {
 
@@ -30,34 +29,37 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().build(),
                 new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                null,
                 false
             )
         );
     }
 
     public void testResolveEngine_whenRequiresTraining_thenFaiss() {
-        assertEquals(KNNEngine.FAISS, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, true));
+        assertEquals(KNNEngine.FAISS, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, null, true));
     }
 
     public void testResolveEngine_whenModeAndCompressionAreFalse_thenDefault() {
-        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, false));
+        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, null, false));
         assertEquals(
             KNNEngine.DEFAULT,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().build(),
                 new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                null,
                 false
             )
         );
     }
 
     public void testResolveEngine_whenModeSpecifiedAndCompressionIsNotSpecified_whenVersionBefore2_19_thenNMSLIB() {
-        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, false));
+        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, null, false));
         assertEquals(
             KNNEngine.NMSLIB,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).build(),
                 new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                null,
                 false,
                 Version.V_2_18_0
             )
@@ -65,12 +67,13 @@ public class EngineResolverTests extends KNNTestCase {
     }
 
     public void testResolveEngine_whenModeSpecifiedAndCompressionIsNotSpecified_thenFAISS() {
-        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, false));
+        assertEquals(KNNEngine.DEFAULT, ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, null, false));
         assertEquals(
             KNNEngine.FAISS,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).build(),
                 new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                null,
                 false
             )
         );
@@ -82,17 +85,19 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x1).build(),
                 null,
+                null,
                 false
             )
         );
         assertEquals(
             KNNEngine.FAISS,
-            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x1).build(), null, false)
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x1).build(), null, null, false)
         );
         assertEquals(
             KNNEngine.NMSLIB,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x1).build(),
+                null,
                 null,
                 false,
                 Version.V_2_18_0
@@ -106,12 +111,13 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x4).build(),
                 null,
+                null,
                 false
             )
         );
         assertEquals(
             KNNEngine.LUCENE,
-            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x4).build(), null, false)
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x4).build(), null, null, false)
         );
     }
 
@@ -121,6 +127,7 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x2).build(),
                 null,
+                null,
                 false
             )
         );
@@ -128,6 +135,7 @@ public class EngineResolverTests extends KNNTestCase {
             KNNEngine.FAISS,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x2).build(),
+                null,
                 null,
                 false
             )
@@ -137,6 +145,7 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x8).build(),
                 null,
+                null,
                 false
             )
         );
@@ -144,6 +153,7 @@ public class EngineResolverTests extends KNNTestCase {
             KNNEngine.FAISS,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x8).build(),
+                null,
                 null,
                 false
             )
@@ -153,6 +163,7 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x16).build(),
                 null,
+                null,
                 false
             )
         );
@@ -160,6 +171,7 @@ public class EngineResolverTests extends KNNTestCase {
             KNNEngine.FAISS,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x16).build(),
+                null,
                 null,
                 false
             )
@@ -169,6 +181,7 @@ public class EngineResolverTests extends KNNTestCase {
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x32).build(),
                 null,
+                null,
                 false
             )
         );
@@ -176,6 +189,7 @@ public class EngineResolverTests extends KNNTestCase {
             KNNEngine.FAISS,
             ENGINE_RESOLVER.resolveEngine(
                 KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x32).build(),
+                null,
                 null,
                 false
             )
@@ -185,104 +199,88 @@ public class EngineResolverTests extends KNNTestCase {
     public void testResolveEngine_whenMethodAndTopLevelEngineSpecified() throws IOException {
         // only method defined; set to faiss (default)
         assertEquals(
-                KNNEngine.FAISS,
-                ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        new KNNMethodContext(KNNEngine.FAISS, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                        false,
-                        Version.CURRENT
-                )
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.FAISS, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                null,
+                false,
+                Version.CURRENT
+            )
         );
 
         // only method defined; set to lucene (non-default)
         assertEquals(
-                KNNEngine.LUCENE,
-                ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                        false,
-                        Version.CURRENT
-                )
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                null,
+                false,
+                Version.CURRENT
+            )
         );
 
         // method set to lucene, top level set to faiss; should throw exception
         expectThrows(
-                MapperParsingException.class,
-                () -> ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                        "faiss",
-                        false,
-                        Version.CURRENT
-                )
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                "faiss",
+                false,
+                Version.CURRENT
+            )
         );
 
         // method set to faiss, top level set to lucene; should throw exception
         expectThrows(
-                MapperParsingException.class,
-                () -> ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        new KNNMethodContext(KNNEngine.FAISS, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                        "lucene",
-                        false,
-                        Version.CURRENT
-                )
+            MapperParsingException.class,
+            () -> ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.FAISS, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                "lucene",
+                false,
+                Version.CURRENT
+            )
         );
 
         // only top-level defined; set to faiss (default)
         assertEquals(
-                KNNEngine.FAISS,
-                ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        null,
-                        "faiss",
-                        false,
-                        Version.CURRENT
-                )
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, "faiss", false, Version.CURRENT)
         );
 
         // only top-level defined; set to lucene (non-default)
         assertEquals(
-                KNNEngine.LUCENE,
-                ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        null,
-                        "lucene",
-                        false,
-                        Version.CURRENT
-                )
+            KNNEngine.LUCENE,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, "lucene", false, Version.CURRENT)
         );
 
         // no engine defined; method not defined
         assertEquals(
-                KNNEngine.FAISS,
-                ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        null,
-                        "",
-                        false,
-                        Version.CURRENT
-                )
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, "", false, Version.CURRENT)
         );
 
         // no engine defined; method defined
         String methodName = "test-method";
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(NAME, methodName)
-                .field(PARAMETERS, (String) null)
-                .endObject();
+            .startObject()
+            .field(NAME, methodName)
+            .field(PARAMETERS, (String) null)
+            .endObject();
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         assertEquals(
-                KNNEngine.FAISS,
-                ENGINE_RESOLVER.resolveEngine(
-                        KNNMethodConfigContext.builder().build(),
-                        new KNNMethodContext(KNNEngine.UNDEFINED, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
-                        "",
-                        false,
-                        Version.CURRENT
-                )
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.UNDEFINED, SpaceType.DEFAULT, MethodComponentContext.EMPTY, false),
+                "",
+                false,
+                Version.CURRENT
+            )
         );
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
@@ -107,6 +107,7 @@ public class KNNEngineTests extends KNNTestCase {
 
     public void testMmapFileExtensions() {
         final List<String> mmapExtensions = Arrays.stream(KNNEngine.values())
+            .filter(engine -> engine != KNNEngine.UNDEFINED)
             .flatMap(engine -> engine.mmapFileExtensions().stream())
             .collect(Collectors.toList());
         assertNotNull(mmapExtensions);

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -158,7 +158,7 @@ public class KNNMethodContextTests extends KNNTestCase {
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
 
-        assertEquals(KNNEngine.DEFAULT, knnMethodContext.getKnnEngine());
+        assertEquals(null, knnMethodContext.getKnnEngine());
         assertEquals(SpaceType.UNDEFINED, knnMethodContext.getSpaceType());
         assertEquals(methodName, knnMethodContext.getMethodComponentContext().getName());
         assertTrue(knnMethodContext.getMethodComponentContext().getParameters().isEmpty());

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -158,7 +158,7 @@ public class KNNMethodContextTests extends KNNTestCase {
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
 
-        assertEquals(null, knnMethodContext.getKnnEngine());
+        assertEquals(KNNEngine.UNDEFINED, knnMethodContext.getKnnEngine());
         assertEquals(SpaceType.UNDEFINED, knnMethodContext.getSpaceType());
         assertEquals(methodName, knnMethodContext.getMethodComponentContext().getName());
         assertTrue(knnMethodContext.getMethodComponentContext().getParameters().isEmpty());

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -124,7 +124,16 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             modelDao,
             CURRENT,
             null,
-            new OriginalMappingParameters(VectorDataType.DEFAULT, TEST_DIMENSION, null, null, null, null, SpaceType.UNDEFINED.getValue())
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                TEST_DIMENSION,
+                null,
+                null,
+                null,
+                null,
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
+            )
         );
 
         assertEquals(11, builder.getParameters().size());
@@ -1412,7 +1421,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 Mode.NOT_CONFIGURED.getName(),
                 CompressionLevel.NOT_CONFIGURED.getName(),
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
             );
             originalMappingParameters.setResolvedKnnMethodContext(knnMethodContext);
             EngineFieldMapper methodFieldMapper = EngineFieldMapper.createFieldMapper(
@@ -1480,7 +1490,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     Mode.NOT_CONFIGURED.getName(),
                     CompressionLevel.NOT_CONFIGURED.getName(),
                     null,
-                    SpaceType.UNDEFINED.getValue()
+                    SpaceType.UNDEFINED.getValue(),
+                    KNNEngine.UNDEFINED.getName()
                 );
                 originalMappingParameters.setResolvedKnnMethodContext(knnMethodContext);
                 EngineFieldMapper methodFieldMapper = EngineFieldMapper.createFieldMapper(
@@ -1595,7 +1606,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     Mode.NOT_CONFIGURED.getName(),
                     CompressionLevel.NOT_CONFIGURED.getName(),
                     MODEL_ID,
-                    SpaceType.UNDEFINED.getValue()
+                    SpaceType.UNDEFINED.getValue(),
+                    KNNEngine.UNDEFINED.getName()
                 );
 
                 ModelFieldMapper modelFieldMapper = ModelFieldMapper.createFieldMapper(
@@ -1697,7 +1709,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
             null,
-            SpaceType.UNDEFINED.getValue()
+            SpaceType.UNDEFINED.getValue(),
+            KNNEngine.UNDEFINED.getName()
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
 
@@ -1759,7 +1772,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
             null,
-            SpaceType.UNDEFINED.getValue()
+            SpaceType.UNDEFINED.getValue(),
+            KNNEngine.UNDEFINED.getName()
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
         luceneFieldMapper = EngineFieldMapper.createFieldMapper(
@@ -1806,7 +1820,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
             null,
-            SpaceType.UNDEFINED.getValue()
+            SpaceType.UNDEFINED.getValue(),
+            KNNEngine.UNDEFINED.getName()
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
 

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -71,7 +71,25 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.Version.CURRENT;
-import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_NAME;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNConstants.TOP_LEVEL_PARAMETER_ENGINE;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
@@ -468,9 +486,9 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         XContentBuilder xContentBuilder = createXContentForFieldMapping_Engine(KNNEngine.LUCENE, null, null, null, TEST_DIMENSION);
 
         KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
-                "test-field-name-1",
-                xContentBuilderToMap(xContentBuilder),
-                buildParserContext("test", settings)
+            "test-field-name-1",
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext("test", settings)
         );
 
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
@@ -484,9 +502,9 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         xContentBuilder = createXContentForFieldMapping_Engine(null, KNNEngine.LUCENE, null, null, TEST_DIMENSION);
 
         builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
-                "test-field-name-1",
-                xContentBuilderToMap(xContentBuilder),
-                buildParserContext("test", settings)
+            "test-field-name-1",
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext("test", settings)
         );
 
         builderContext = new Mapper.BuilderContext(settings, new ContentPath());
@@ -496,14 +514,13 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         assertEquals(KNNEngine.LUCENE, knnVectorFieldMapper.fieldType().getKnnMappingConfig().getKnnMethodContext().get().getKnnEngine());
         assertTrue(knnVectorFieldMapper.fieldType().getKnnMappingConfig().getModelId().isEmpty());
 
-
         // not setting any engine
         xContentBuilder = createXContentForFieldMapping_Engine(null, null, SpaceType.DEFAULT, null, TEST_DIMENSION);
 
         builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
-                "test-field-name-1",
-                xContentBuilderToMap(xContentBuilder),
-                buildParserContext("test", settings)
+            "test-field-name-1",
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext("test", settings)
         );
 
         builderContext = new Mapper.BuilderContext(settings, new ContentPath());
@@ -516,9 +533,9 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         // if engines are same
         xContentBuilder = createXContentForFieldMapping_Engine(KNNEngine.LUCENE, KNNEngine.LUCENE, null, null, TEST_DIMENSION);
         builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
-                "test-field-name-1",
-                xContentBuilderToMap(xContentBuilder),
-                buildParserContext("test", settings)
+            "test-field-name-1",
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext("test", settings)
         );
 
         builderContext = new Mapper.BuilderContext(settings, new ContentPath());
@@ -532,8 +549,12 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         xContentBuilder = createXContentForFieldMapping_Engine(KNNEngine.LUCENE, KNNEngine.FAISS, null, null, TEST_DIMENSION);
         XContentBuilder finalXContentBuilder_diff = xContentBuilder;
         Assert.assertThrows(
-                MapperParsingException.class,
-                () -> typeParser.parse("test-field-name-1", xContentBuilderToMap(finalXContentBuilder_diff), buildParserContext("test", settings))
+            MapperParsingException.class,
+            () -> typeParser.parse(
+                "test-field-name-1",
+                xContentBuilderToMap(finalXContentBuilder_diff),
+                buildParserContext("test", settings)
+            )
         );
     }
 
@@ -2495,31 +2516,32 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
     }
 
     private XContentBuilder createXContentForFieldMapping_Engine(
-            KNNEngine methodKNNEngine,
-            KNNEngine topLevelKNNEngine,
-            SpaceType spaceType,
-            VectorDataType vectorDataType,
-            int dimension
+        KNNEngine methodKNNEngine,
+        KNNEngine topLevelKNNEngine,
+        SpaceType spaceType,
+        VectorDataType vectorDataType,
+        int dimension
     ) throws IOException {
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
-                .startObject()
-                .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-                .field(DIMENSION_FIELD_NAME, dimension);
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension);
 
-        if (topLevelKNNEngine != null && topLevelKNNEngine != KNNEngine.UNDEFINED) {
+        if (topLevelKNNEngine != null) {
             xContentBuilder.field(TOP_LEVEL_PARAMETER_ENGINE, topLevelKNNEngine.getName());
         }
         if (vectorDataType != null) {
             xContentBuilder.field(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
         }
-        xContentBuilder.startObject(KNN_METHOD).field(NAME, METHOD_HNSW);
-        if (spaceType != null && spaceType != SpaceType.UNDEFINED) {
-            xContentBuilder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
-        }
-        if (methodKNNEngine != null && methodKNNEngine != KNNEngine.UNDEFINED) {
+        if (methodKNNEngine != null) {
+            xContentBuilder.startObject(KNN_METHOD).field(NAME, METHOD_HNSW);
+            if (spaceType != null && spaceType != SpaceType.UNDEFINED) {
+                xContentBuilder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue());
+            }
             xContentBuilder.field(KNN_ENGINE, methodKNNEngine.getName());
+            xContentBuilder.endObject();
         }
-        xContentBuilder.endObject().endObject();
+        xContentBuilder.endObject();
         return xContentBuilder;
     }
 

--- a/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
@@ -18,12 +18,28 @@ public class OriginalMappingParametersTests extends KNNTestCase {
 
     public void testIsLegacy() {
         assertTrue(
-            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, null, SpaceType.UNDEFINED.getValue())
-                .isLegacyMapping()
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                123,
+                null,
+                null,
+                null,
+                null,
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
+            ).isLegacyMapping()
         );
         assertFalse(
-            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, "model-id", SpaceType.UNDEFINED.getValue())
-                .isLegacyMapping()
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                123,
+                null,
+                null,
+                null,
+                "model-id",
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
+            ).isLegacyMapping()
         );
         assertFalse(
             new OriginalMappingParameters(
@@ -33,7 +49,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 Mode.ON_DISK.getName(),
                 null,
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
             ).isLegacyMapping()
         );
         assertFalse(
@@ -44,7 +61,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 null,
                 CompressionLevel.x2.getName(),
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
             ).isLegacyMapping()
         );
         assertFalse(
@@ -55,7 +73,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 null,
                 null,
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                KNNEngine.UNDEFINED.getName()
             ).isLegacyMapping()
         );
     }

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -1041,6 +1041,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
     public void testRadialSearch_whenUnsupportedEngine_thenThrowException() {
         List<KNNEngine> unsupportedEngines = Arrays.stream(KNNEngine.values())
             .filter(knnEngine -> !ENGINES_SUPPORTING_RADIAL_SEARCH.contains(knnEngine))
+            .filter(knnEngine -> knnEngine != KNNEngine.UNDEFINED)
             .collect(Collectors.toList());
         for (KNNEngine knnEngine : unsupportedEngines) {
             KNNMethodContext knnMethodContext = new KNNMethodContext(

--- a/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
@@ -6,12 +6,24 @@
 package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.TOP_LEVEL_PARAMETER_ENGINE;
@@ -68,6 +80,7 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
 
         String mapping = builder.toString();
         createKnnIndex(INDEX_NAME, mapping);
+
     }
 
     private void createTestIndexWithMethodEngineOnly() throws IOException {
@@ -142,5 +155,50 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
 
         String mapping = builder.toString();
         createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    @Override
+    public void validateKNNSearch(String testIndex, String testField, int dimension, int numDocs, int k) throws Exception {
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, (float) numDocs);
+
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().k(k).fieldName(testField).vector(queryVector).build();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        knnQueryBuilder.doXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject().endObject();
+
+        Response searchResponse = searchKNNIndex(testIndex, builder, k);
+        assertOK(searchResponse);
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), testField);
+
+        assertEquals(k, results.size());
+        for (int i = 0; i < k; i++) {
+            assertEquals(numDocs - i - 1, Integer.parseInt(results.get(i).getDocId()));
+        }
+    }
+
+    @Override
+    protected void createKnnIndex(String index, String mapping) throws IOException {
+        createIndex(index, getKNNDefaultIndexSettings(), null, null);
+        putMappingRequest(index, mapping);
+    }
+
+    protected static void createIndex(String name, Settings settings, String mapping, String aliases) throws IOException {
+        Request request = new Request("PUT", "/" + name);
+        String entity = "{\"settings\": " + Strings.toString(MediaTypeRegistry.JSON, settings);
+        if (mapping != null) {
+            entity += ",\"mappings\" : {" + mapping + "}";
+        }
+        if (aliases != null) {
+            entity += ",\"aliases\": {" + aliases + "}";
+        }
+        entity += "}";
+        if (settings.getAsBoolean(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true) == false) {
+            expectSoftDeletesWarning(request, name);
+        }
+        request.setJsonEntity(entity);
+        Response response = client().performRequest(request);
+        assertOK(response);
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.TOP_LEVEL_PARAMETER_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+
+public class TopLevelEngineParameterIT extends KNNRestTestCase {
+    private final static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f };
+    private final static int DIMENSION = 2;
+    private final static int K = 1;
+    private static final String INDEX_NAME = "top-level-engine-index";
+
+    @SneakyThrows
+    public void testBaseCase() {
+        createTestIndexWithTopLevelEngineOnly();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+
+        createTestIndexWithMethodEngineOnly();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+
+        createTestIndexWithTopLevelEngineAndMethodEngine();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+
+        createTestIndexWithNoEngine();
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testDifferentEnginesDefined_ThenException() {
+        Exception e = expectThrows(Exception.class, () -> createTestIndexWithDifferentEngines());
+        assertTrue(
+            e.getMessage(),
+            e.getMessage().contains("Engine in method and top level engine should be same or one of them should be defined.")
+        );
+    }
+
+    private void createTestIndexWithTopLevelEngineOnly() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(TOP_LEVEL_PARAMETER_ENGINE, KNNEngine.LUCENE.getName())
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createTestIndexWithMethodEngineOnly() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createTestIndexWithTopLevelEngineAndMethodEngine() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(TOP_LEVEL_PARAMETER_ENGINE, KNNEngine.LUCENE.getName())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createTestIndexWithNoEngine() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private void createTestIndexWithDifferentEngines() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(TOP_LEVEL_PARAMETER_ENGINE, KNNEngine.LUCENE.getName())
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
@@ -51,10 +51,7 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
     @SneakyThrows
     public void testDifferentEnginesDefined_ThenException() {
         Exception e = expectThrows(Exception.class, () -> createTestIndexWithDifferentEngines());
-        assertTrue(
-            e.getMessage(),
-            e.getMessage().contains("Engine in method and top level engine should be same or one of them should be defined.")
-        );
+        assertTrue(e.getMessage(), e.getMessage().contains("Cannot specify conflicting engines: [faiss] and [lucene]"));
     }
 
     private void createTestIndexWithTopLevelEngineOnly() throws IOException {


### PR DESCRIPTION
### Description
The engine parameter is currently located in the method section of the knn_vector mapping. Moving it up to be a top-level mapping field parameter would make the method subsection simpler for the user, as it would now only contain the algorithm and its parameters. The user can also then set the engine without defining the method section when creating a vector field.

This PR introduces engine as a top-level field parameter, similar to how space_type was moved in a previous release. It is an optional parameter, and the user can set engine in either the method or at the top-level. 

### Changes Made

* “engine” added as a top-level mapping parameter
* new KNNEngine type “UNDEFINED” (similar to in SpaceType) that is used when user does not set an engine

### Testing

Both integration testing and unit testing were performed to test the new field. Unit tests were added for EngineResolver and KNNVectorFieldMapper. IT was added for the new top level engine parameter. An example of one of the integration tests is below:

```
{
    "settings": {
        "index": {
            "knn": "true"
        }
    },
    "mappings": {
        "properties": {
            "vector1": {
                "type": "knn_vector",
                "dimension": 4,
                "space_type": "l2",
                "engine": "lucene"
            }
        }
    }
}
```
This resulted in the index successfully being created with the “lucene” engine set.

### Related Issues
Resolves #2534
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
