### PR TITLE
fix: end remote build metrics before falling back to CPU, log excepti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 3.0](https://github.com/opensearch-project/k-NN/compare/2.x...HEAD)
+## [Unreleased 3.x](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Infrastructure
 * Add testing support to run all ITs with remote index builder [#2659](https://github.com/opensearch-project/k-NN/pull/2659)
 * Fix KNNSettingsTests after change in MockNode constructor [#2700](https://github.com/opensearch-project/k-NN/pull/2700)
@@ -12,19 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Removing redundant type conversions for script scoring for hamming space with binary vectors [#2351](https://github.com/opensearch-project/k-NN/pull/2351)
 * [Remote Vector Index Build] Add tuned repository upload/download configurations per benchmarking results [#2662](https://github.com/opensearch-project/k-NN/pull/2662)
 * Apply mask operation in preindex to optimize derived source [#2704](https://github.com/opensearch-project/k-NN/pull/2704)
+* [Remote Vector Index Build] Add segment size upper bound setting and prepare other settings for GA [#2734](https://github.com/opensearch-project/k-NN/pull/2734)
 ### Bug Fixes
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
-* [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671) 
+* [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671)
 * [BUGFIX] Honors slice counts for non-quantization cases [#2692](https://github.com/opensearch-project/k-NN/pull/2692)
 * [BUGFIX] Block derived source enable if index.knn is false [#2702](https://github.com/opensearch-project/k-NN/pull/2702)
 * [BUGFIX] Avoid opening of graph file if graph is already loaded in memory [#2719](https://github.com/opensearch-project/k-NN/pull/2719)
-
-## [Unreleased 2.x](https://github.com/opensearch-project/k-NN/compare/2.19...2.x)
-### Features
-### Enhancements
-### Bug Fixes
 * [BUGFIX] FIX nested vector query at efficient filter scenarios [#2641](https://github.com/opensearch-project/k-NN/pull/2641)
-### Infrastructure
-### Documentation
-### Maintenance
-### Refactoring
+* [BUGFIX] [Remote Vector Index Build] End remote build metrics before falling back to CPU, exception logging [#2693](https://github.com/opensearch-project/k-NN/pull/2693)

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
@@ -141,7 +141,7 @@ public class RemoteIndexBuildMetrics {
             log.debug("Remote index build succeeded after {} ms for vector field [{}]", time_in_millis, fieldName);
         } else {
             INDEX_BUILD_FAILURE_COUNT.increment();
-            log.warn("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
+            log.debug("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
         }
         if (isFlush) {
             REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS.decrement();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -146,20 +146,20 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
 
             // 4. Download index file and write to indexOutput
             readFromRepository(indexInfo, repositoryContext, remoteBuildStatusResponse);
-
             success = true;
+            return;
         } catch (Exception e) {
-            fallbackStrategy.buildAndWriteIndex(indexInfo);
+            log.error("Failed to build index remotely: " + indexInfo, e);
         } finally {
             metrics.endRemoteIndexBuildMetrics(success);
         }
+        fallbackStrategy.buildAndWriteIndex(indexInfo);
     }
 
     /**
      * Writes the required vector and doc ID data to the repository
      */
-    private void writeToRepository(RepositoryContext repositoryContext, BuildIndexParams indexInfo) throws IOException,
-        InterruptedException {
+    private void writeToRepository(RepositoryContext repositoryContext, BuildIndexParams indexInfo) {
         VectorRepositoryAccessor vectorRepositoryAccessor = repositoryContext.vectorRepositoryAccessor;
         boolean success = false;
         metrics.startRepositoryWriteMetrics();
@@ -172,8 +172,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             );
             success = true;
         } catch (InterruptedException | IOException e) {
-            log.debug("Repository write failed for vector field [{}]", indexInfo.getFieldName());
-            throw e;
+            throw new RuntimeException(String.format("Repository write failed for vector field [%s]", indexInfo.getFieldName()), e);
         } finally {
             metrics.endRepositoryWriteMetrics(success);
         }
@@ -183,8 +182,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
      * Submits a remote build request to the remote index build service
      * @return RemoteBuildResponse containing the response from the remote service
      */
-    private RemoteBuildResponse submitBuild(RepositoryContext repositoryContext, BuildIndexParams indexInfo, RemoteIndexClient client)
-        throws IOException {
+    private RemoteBuildResponse submitBuild(RepositoryContext repositoryContext, BuildIndexParams indexInfo, RemoteIndexClient client) {
         final RemoteBuildResponse remoteBuildResponse;
         boolean success = false;
         metrics.startBuildRequestMetrics();
@@ -200,8 +198,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             success = true;
             return remoteBuildResponse;
         } catch (IOException e) {
-            log.debug("Submit vector build failed for vector field [{}]", indexInfo.getFieldName());
-            throw e;
+            throw new RuntimeException(String.format("Submit vector build failed for vector field [%s]", indexInfo.getFieldName()), e);
         } finally {
             metrics.endBuildRequestMetrics(success);
         }
@@ -216,7 +213,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         RemoteBuildResponse remoteBuildResponse,
         BuildIndexParams indexInfo,
         RemoteIndexClient client
-    ) throws IOException, InterruptedException {
+    ) {
         RemoteBuildStatusResponse remoteBuildStatusResponse;
         metrics.startWaitingMetrics();
         try {
@@ -225,11 +222,11 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
                 .build();
             RemoteIndexWaiter waiter = RemoteIndexWaiterFactory.getRemoteIndexWaiter(client);
             remoteBuildStatusResponse = waiter.awaitVectorBuild(remoteBuildStatusRequest);
-            metrics.endWaitingMetrics();
             return remoteBuildStatusResponse;
         } catch (InterruptedException | IOException e) {
-            log.debug("Await vector build failed for vector field [{}]", indexInfo.getFieldName(), e);
-            throw e;
+            throw new RuntimeException(String.format("Await index build failed for vector field [%s]", indexInfo.getFieldName()), e);
+        } finally {
+            metrics.endWaitingMetrics();
         }
     }
 
@@ -240,7 +237,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         BuildIndexParams indexInfo,
         RepositoryContext repositoryContext,
         RemoteBuildStatusResponse remoteBuildStatusResponse
-    ) throws IOException {
+    ) {
         metrics.startRepositoryReadMetrics();
         boolean success = false;
         try {
@@ -250,8 +247,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             );
             success = true;
         } catch (Exception e) {
-            log.debug("Repository read failed for vector field [{}]", indexInfo.getFieldName());
-            throw e;
+            throw new RuntimeException(String.format("Repository read failed for vector field [%s]", indexInfo.getFieldName()), e);
         } finally {
             metrics.endRepositoryReadMetrics(success);
         }


### PR DESCRIPTION
…on (#2693)

(cherry picked from commit df0e5ce61db11eab9d2a399b32dfa7c04497212b)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
