### PR TITLE
[Backport main] [Remote Vector Index Build] fix: end remote build metrics before falling back to CPU, log exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Block mode and compression for indices created before version 2.17.0 [#2722](https://github.com/opensearch-project/k-NN/pull/2722)
 * [BUGFIX] Avoid opening of graph file if graph is already loaded in memory [#2719](https://github.com/opensearch-project/k-NN/pull/2719)
 * [BUGFIX] FIX nested vector query at efficient filter scenarios [#2641](https://github.com/opensearch-project/k-NN/pull/2641)
+* [BUGFIX] [Remote Vector Index Build] End remote build metrics before falling back to CPU, exception logging [#2693](https://github.com/opensearch-project/k-NN/pull/2693)

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildMetrics.java
@@ -141,7 +141,7 @@ public class RemoteIndexBuildMetrics {
             log.debug("Remote index build succeeded after {} ms for vector field [{}]", time_in_millis, fieldName);
         } else {
             INDEX_BUILD_FAILURE_COUNT.increment();
-            log.warn("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
+            log.debug("Remote index build failed after {} ms for vector field [{}]", time_in_millis, fieldName);
         }
         if (isFlush) {
             REMOTE_INDEX_BUILD_CURRENT_FLUSH_OPERATIONS.decrement();


### PR DESCRIPTION
### Description
Manual backport of #2693 because there were merge conflicts on the autobackport #2699.
