### PR TITLE
Only evaluate GPU index setting if cluster setting is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Remote Vector Index Build] Add tuned repository upload/download configurations per benchmarking results [#2662](https://github.com/opensearch-project/k-NN/pull/2662)
 * Apply mask operation in preindex to optimize derived source [#2704](https://github.com/opensearch-project/k-NN/pull/2704)
 * [Remote Vector Index Build] Add segment size upper bound setting and prepare other settings for GA [#2734](https://github.com/opensearch-project/k-NN/pull/2734)
+* [Remote Vector Index Build] Make remote vector index build index setting only override cluster setting when cluster setting is enabled [#2742](https://github.com/opensearch-project/k-NN/pull/2742)
 ### Bug Fixes
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)
 * [BUGFIX] Fix enable rescoring when dimensions > 1000. [#2671](https://github.com/opensearch-project/k-NN/pull/2671)

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -92,8 +92,8 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             return false;
         }
 
-        // If setting is not enabled, return false
-        if (!indexSettings.getValue(KNN_INDEX_REMOTE_VECTOR_BUILD_SETTING)) {
+        // Only evaluate index setting if explicitly set
+        if (!indexSettings.getSettings().getAsBoolean(KNN_INDEX_REMOTE_VECTOR_BUILD_SETTING.getKey(), true)) {
             log.debug("Remote index build is disabled for index: [{}]", indexSettings.getIndex().getName());
             return false;
         }


### PR DESCRIPTION
### Description
Make GPU index setting override cluster setting only if not set. This means the cluster setting can be used to force turn off the feature, while the index setting can still be used to disable for specific indices.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
