### PR TITLE
Update rescore context for 4X Compression

### DIFF
--- a/release-notes/opensearch-knn.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-knn.release-notes-3.1.0.0.md
@@ -12,6 +12,7 @@ Compatible with OpenSearch 3.1.0.0
 * [Remote Vector Index Build] Add tuned repository upload/download configurations per benchmarking results [#2662](https://github.com/opensearch-project/k-NN/pull/2662)
 * [Remote Vector Index Build] Add segment size upper bound setting and prepare other settings for GA [#2734](https://github.com/opensearch-project/k-NN/pull/2734)
 * [Remote Vector Index Build] Make `index.knn.remote_index_build.enabled` default to true [#2743](https://github.com/opensearch-project/k-NN/pull/2743)
+* Update rescore context for 4X Compression [#2750](https://github.com/opensearch-project/k-NN/pull/2750)
 
 ### Bug Fixes
 * [BUGFIX] Fix KNN Quantization state cache have an invalid weight threshold [#2666](https://github.com/opensearch-project/k-NN/pull/2666)

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -108,14 +108,14 @@ public enum CompressionLevel {
      *                  is invalid.
      */
     public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version) {
-        //TODO move this to separate class called resolver to resolve rescore context
+        // TODO move this to separate class called resolver to resolve rescore context
         if (modesForRescore.contains(mode)) {
-            if( this == x4 && version.before(Version.V_3_1_0)){
+            if (this == x4 && version.before(Version.V_3_1_0)) {
                 // For index created before 3.1, context was always null and mode is empty
                 return null;
             }
-            // Adjust RescoreContext based on dimension
-            if (dimension <= RescoreContext.DIMENSION_THRESHOLD) {
+            // Adjust RescoreContext based on dimension except for 4x compression
+            if (this != x4 && dimension <= RescoreContext.DIMENSION_THRESHOLD) {
                 // For dimensions <= 1000, return a RescoreContext with 5.0f oversample factor
                 return RescoreContext.builder()
                     .oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD)
@@ -128,7 +128,7 @@ public enum CompressionLevel {
     }
 
     @VisibleForTesting
-    RescoreContext getDefaultRescoreContext(Mode mode, int dimension){
+    RescoreContext getDefaultRescoreContext(Mode mode, int dimension) {
         return getDefaultRescoreContext(mode, dimension, Version.CURRENT);
     }
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -125,7 +125,7 @@ public class KNNVectorFieldType extends MappedFieldType {
         int dimension = knnMappingConfig.getDimension();
         CompressionLevel compressionLevel = knnMappingConfig.getCompressionLevel();
         Mode mode = knnMappingConfig.getMode();
-        return compressionLevel.getDefaultRescoreContext(mode, dimension);
+        return compressionLevel.getDefaultRescoreContext(mode, dimension, knnMappingConfig.getIndexCreatedVersion());
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -93,7 +93,7 @@ public class CompressionLevelTests extends KNNTestCase {
         // x4 with dimension <= 1000 should have an oversample factor of 5.0f
         rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNotNull(rescoreContext);
-        assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
         // x4 with dimension > 1000 should have an oversample factor of 1.0f

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -90,12 +90,18 @@ public class CompressionLevelTests extends KNNTestCase {
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
-        // x4 with dimension <= 1000 should have an oversample factor of 5.0f (though it doesn't have its own RescoreContext)
+        // x4 with dimension <= 1000 should have an oversample factor of 5.0f
         rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, belowThresholdDimension);
-        assertNull(rescoreContext);
-        // x4 with dimension > 1000 should return null (no RescoreContext is configured for x4)
+        assertNotNull(rescoreContext);
+        assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
+        // x4 with dimension > 1000 should have an oversample factor of 1.0f
         rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, aboveThresholdDimension);
-        assertNull(rescoreContext);
+        assertNotNull(rescoreContext);
+        assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
+        assertTrue(rescoreContext.isRescoreEnabled());
+        assertFalse(rescoreContext.isUserProvided());
         // Other compression levels should behave similarly with respect to dimension
         rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, belowThresholdDimension);
         assertNull(rescoreContext);

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -650,8 +650,7 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
         String exactSearchResponseBody = EntityUtils.toString(exactSearchResponse.getEntity());
         List<Float> exactSearchKnnResults = parseSearchResponseScore(exactSearchResponseBody, FIELD_NAME);
         assertEquals(NUM_DOCS, exactSearchKnnResults.size());
-
-        if (CompressionLevel.x4.getName().equals(compressionLevelString) == false && Mode.ON_DISK.getName().equals(mode)) {
+        if(Mode.ON_DISK.getName().equals(mode)){
             Assert.assertEquals(exactSearchKnnResults, knnResults);
         }
 
@@ -681,7 +680,7 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
         responseBody = EntityUtils.toString(response.getEntity());
         knnResults = parseSearchResponseScore(responseBody, FIELD_NAME);
         assertEquals(K, knnResults.size());
-        if (CompressionLevel.x4.getName().equals(compressionLevelString) == false && Mode.ON_DISK.getName().equals(mode)) {
+        if (Mode.ON_DISK.getName().equals(mode)) {
             Assert.assertEquals(exactSearchKnnResults, knnResults);
         }
     }

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -650,7 +650,7 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
         String exactSearchResponseBody = EntityUtils.toString(exactSearchResponse.getEntity());
         List<Float> exactSearchKnnResults = parseSearchResponseScore(exactSearchResponseBody, FIELD_NAME);
         assertEquals(NUM_DOCS, exactSearchKnnResults.size());
-        if(Mode.ON_DISK.getName().equals(mode)){
+        if (Mode.ON_DISK.getName().equals(mode)) {
             Assert.assertEquals(exactSearchKnnResults, knnResults);
         }
 


### PR DESCRIPTION
### Description
Since rescore is supported for lucene engine,
update rescore context for 4x compression to
use 1x oversampling factor.

### Related Issues


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
