### PR TITLE
[Bug Fix] Fix the exact searcher to use the given radius value as it is when memory optimized search is enabled.

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -401,7 +401,9 @@ public abstract class KNNWeight extends Weight {
             .matchedDocsIterator(acceptedDocs)
             .numberOfMatchedDocs(numberOfAcceptedDocs)
             .floatQueryVector(knnQuery.getQueryVector())
-            .byteQueryVector(knnQuery.getByteQueryVector());
+            .byteQueryVector(knnQuery.getByteQueryVector())
+            .isMemoryOptimizedSearchEnabled(knnQuery.isMemoryOptimizedSearch());
+
         if (knnQuery.getContext() != null) {
             exactSearcherContextBuilder.maxResultWindow(knnQuery.getContext().getMaxResultWindow());
         }

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -169,6 +169,7 @@ public class NativeEngineKnnVectorQuery extends Query {
                     .radius(knnQuery.getRadius())
                     .floatQueryVector(knnQuery.getQueryVector())
                     .byteQueryVector(knnQuery.getByteQueryVector())
+                    .isMemoryOptimizedSearchEnabled(knnQuery.isMemoryOptimizedSearch())
                     .build();
                 TopDocs rescoreResult = knnWeight.exactSearch(leafReaderContext, exactSearcherContext);
                 return new PerLeafResult(perLeafResult.getFilterBits(), rescoreResult);
@@ -217,6 +218,7 @@ public class NativeEngineKnnVectorQuery extends Query {
                     .field(knnQuery.getField())
                     .floatQueryVector(knnQuery.getQueryVector())
                     .byteQueryVector(knnQuery.getByteQueryVector())
+                    .isMemoryOptimizedSearchEnabled(knnQuery.isMemoryOptimizedSearch())
                     .build();
                 TopDocs rescoreResult = knnWeight.exactSearch(leafReaderContext, exactSearcherContext);
                 return new PerLeafResult(perLeafeResult.getFilterBits(), rescoreResult);

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -271,6 +271,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .floatQueryVector(queryVector)
             .field(FIELD_NAME)
+            .isMemoryOptimizedSearchEnabled(false)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
 
@@ -484,6 +485,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .field(FIELD_NAME)
             .floatQueryVector(queryVector)
+            .isMemoryOptimizedSearchEnabled(false)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
@@ -824,6 +826,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .floatQueryVector(queryVector)
             .field(FIELD_NAME)
             .radius(radius)
+            .isMemoryOptimizedSearchEnabled(false)
             .maxResultWindow(maxResults)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -941,6 +941,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .floatQueryVector(queryVector)
             .field(FIELD_NAME)
+            .isMemoryOptimizedSearchEnabled(false)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFP16IndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFP16IndexIT.java
@@ -38,8 +38,7 @@ public class MOSFaissFP16IndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     }
 
     public void testWhenNoIndexBuilt() {
-        // TODO : Fix
-        // doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, true, SpaceType.L2, NO_BUILD_HNSW);
-        // doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, false, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, true, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, false, SpaceType.L2, NO_BUILD_HNSW);
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
@@ -34,8 +34,7 @@ public class MOSFaissFloatIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     }
 
     public void testWhenNoIndexBuilt() {
-        // TODO : Fix this
-        // doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
-        // doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
     }
 }


### PR DESCRIPTION
### Description
When memory optimized search (MOS) is enabled, it internally relies on Lucene’s scoring framework. While Faiss uses the concept of distance, Lucene uses score to evaluate vectors. Conceptually, they represent the same idea: a smaller distance corresponds to a higher score, and vice versa.

For radius search queries, when a user specifies either min_score or max_distance ([doc](https://docs.opensearch.org/docs/latest/vector-search/specialized-operations/radial-search-knn/)), the threshold is converted to either a distance or a score, depending on the associated field type and index settings. Specifically, when MOS is enabled, the threshold is converted to a score; otherwise, it’s converted to a distance. This conversion logic applies regardless of whether the Faiss engine is being used — [code reference](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java#L493-L518).

The issue arises in the exact searcher, which assumes that `radius` always originates from a distance-based threshold. This assumption was valid before MOS existed, since Faiss was the only engine type that supported exact radius search. In that case, the `radius` needed to be converted via the `SpaceType::scoreTranslation` method — [code reference](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java#L102).

However, when MOS is enabled, this conversion is unnecessary because radius already is a minimum score. This PR fixes the issue by skipping the conversion when MOS is turned on.




### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
