### PR TITLE
[Bug Fix] Fix Cagra HNSW graph populates random entry points at the beginning of search.

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -8,7 +8,9 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOSupplier;
@@ -17,8 +19,10 @@ import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
+import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * This searcher directly reads FAISS index file via the provided {@link IndexInput} then perform vector search on it.
@@ -109,7 +113,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
         // Set up required components for vector search
         final RandomVectorScorer scorer = scorerSupplier.get();
-        final KnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
+        final KnnCollector collector = createKnnCollector(knnCollector, scorer);
         final Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs);
 
         if (knnCollector.k() < scorer.maxOrd()) {
@@ -133,5 +137,75 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
     private IndexInput getSlicedIndexInput() throws IOException {
         return indexInput.slice("FaissMemoryOptimizedSearcher", 0, fileSize);
+    }
+
+    private KnnCollector createKnnCollector(final KnnCollector knnCollector, final RandomVectorScorer scorer) {
+        final KnnCollector ordinalTranslatedKnnCollector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
+
+        if (hnsw instanceof FaissCagraHNSW cagraHNSW) {
+            return new KnnCollector.Decorator(ordinalTranslatedKnnCollector) {
+                @Override
+                public KnnSearchStrategy getSearchStrategy() {
+                    return new RandomEntryPointsKnnSearchStrategy(
+                        cagraHNSW.getNumBaseLevelSearchEntryPoints(),
+                        cagraHNSW.getTotalNumberOfVectors(),
+                        knnCollector.getSearchStrategy()
+                    );
+                }
+            };
+        } else {
+            return ordinalTranslatedKnnCollector;
+        }
+    }
+
+    /**
+     * Knn search strategy having a doc-id-iterator returning random document ids.
+     * This is not designed for general purpose, it is particularly designed for populating random document ids for Cagra index.
+     * Note that doc-id-iterator returns a random ids in `nextDoc` method without sorting, and might return duplicated ids.
+     */
+    static class RandomEntryPointsKnnSearchStrategy extends KnnSearchStrategy.Seeded {
+        public RandomEntryPointsKnnSearchStrategy(
+            final int numberOfEntryPoints,
+            final long totalNumberOfVectors,
+            final KnnSearchStrategy originalStrategy
+        ) {
+            super(
+                generateRandomEntryPoints(numberOfEntryPoints, Math.toIntExact(totalNumberOfVectors)),
+                numberOfEntryPoints,
+                originalStrategy
+            );
+        }
+
+        private static DocIdSetIterator generateRandomEntryPoints(final int numberOfEntryPoints, int totalNumberOfVectors) {
+            return new DocIdSetIterator() {
+                int numPopulatedVectors = 0;
+
+                @Override
+                public int docID() {
+                    throw new UnsupportedOperationException("DISI in RandomEntryPointsKnnSearchStrategy does not support docID()");
+                }
+
+                @Override
+                public int nextDoc() {
+                    if (numPopulatedVectors < numberOfEntryPoints) {
+                        ++numPopulatedVectors;
+                        // It is fine to populate the same doc ids here, the same vectors will not be visited more than once with bitset.
+                        return ThreadLocalRandom.current().nextInt(totalNumberOfVectors);
+                    }
+
+                    return NO_MORE_DOCS;
+                }
+
+                @Override
+                public int advance(int targetDoc) {
+                    throw new UnsupportedOperationException("DISI in RandomEntryPointsKnnSearchStrategy does not support advance(int)");
+                }
+
+                @Override
+                public long cost() {
+                    throw new UnsupportedOperationException("DISI in RandomEntryPointsKnnSearchStrategy does not support cost()");
+                }
+            };
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissCagraHNSW.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissCagraHNSW.java
@@ -5,11 +5,12 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss.cagra;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSW;
 
 import java.io.IOException;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * This represents CAGRA HNSW.
@@ -17,6 +18,10 @@ import java.util.concurrent.ThreadLocalRandom;
  * The only difference are entry point and the number of layers, as searches in CAGRA HNSW are always conducted on the bottom layer.
  */
 public class FaissCagraHNSW extends FaissHNSW {
+    @Setter
+    @Getter
+    private int numBaseLevelSearchEntryPoints;
+
     /**
      * Partial load the CAGRA HNSW graph.
      * During a search on CAGRA HNSW, the entry point is randomly selected, and the search runs on the bottom graph.
@@ -25,16 +30,15 @@ public class FaissCagraHNSW extends FaissHNSW {
      *
      * @param input An input stream for a FAISS HNSW graph file, allowing access to the neighbor list and vector locations.
      * @param totalNumberOfVectors The total number of vectors stored in the graph.
-     *
+     * <p>
      * See : <a href="https://github.com/facebookresearch/faiss/blob/main/faiss/IndexHNSW.cpp#L956">...</a>
      * @throws IOException
      */
     public void load(IndexInput input, long totalNumberOfVectors) throws IOException {
         super.load(input, totalNumberOfVectors);
 
-        // We pick a random entry point
-        // See : https://github.com/facebookresearch/faiss/blob/main/faiss/IndexHNSW.cpp#L945
-        entryPoint = ThreadLocalRandom.current().nextInt((int) totalNumberOfVectors);
+        // Entry points will be provided via `RandomEntryPointsKnnSearchStrategy`, assigning -1 here.
+        entryPoint = -1;
 
         // Result graph has 1-layer, but this info is not saved in file (having -1), so we override it in here.
         maxLevel = 1;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissHNSWCagraIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissHNSWCagraIndex.java
@@ -67,6 +67,7 @@ public class FaissHNSWCagraIndex extends AbstractFaissHNSWIndex {
 
         // Partial load HNSW graph
         faissHnsw.load(input, getTotalNumberOfVectors());
+        ((FaissCagraHNSW) faissHnsw).setNumBaseLevelSearchEntryPoints(numBaseLevelSearchEntryPoint);
 
         // Partial load flat vector storage
         flatVectors = FaissIndex.load(input);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/RandomEntryPointsKnnSearchStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/RandomEntryPointsKnnSearchStrategyTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class RandomEntryPointsKnnSearchStrategyTests {
+    @Test
+    @SneakyThrows
+    public void randomEntryPointsGenerationTests() {
+        final int numEntries = 100;
+        final long numVectors = 10000;
+
+        // Create strategy
+        final FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy strategy =
+            new FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy(numEntries, numVectors, mock(KnnSearchStrategy.class));
+
+        // Validate #entry points
+        assertEquals(numEntries, strategy.numberOfEntryPoints());
+
+        // We should get exactly `numEntries` vector ids.
+        final DocIdSetIterator iterator = strategy.entryPoints();
+        for (int i = 0; i < numEntries; ++i) {
+            final int internalVectorId = iterator.nextDoc();
+            assertTrue(internalVectorId >= 0);
+            assertTrue(internalVectorId < numVectors);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Cagra HNSW graph first populates randomly selected entry points then do the search.
Which is not included in LuceneOnFaiss. This PR has added fix to populate random entry points at the beginning of search.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
