### PR TITLE
[Fix] Log error responseBody on submitVectorBuild failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.2](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+### Bug Fixes 
+* [Remote Vector Index Build] Add exception logging on submitVectorBuild failure [#2760] (https://github.com/opensearch-project/k-NN/pull/2760)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,3 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.2](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
-### Bug Fixes 
-* [Remote Vector Index Build] Add exception logging on submitVectorBuild failure [#2760] (https://github.com/opensearch-project/k-NN/pull/2760)

--- a/remote-index-build-client/src/main/java/org/opensearch/remoteindexbuild/client/RemoteIndexHTTPClient.java
+++ b/remote-index-build-client/src/main/java/org/opensearch/remoteindexbuild/client/RemoteIndexHTTPClient.java
@@ -89,7 +89,7 @@ public class RemoteIndexHTTPClient implements RemoteIndexClient, Closeable {
                 (PrivilegedExceptionAction<String>) () -> httpClient.execute(buildRequest, body -> {
                     if (body.getCode() < SC_OK || body.getCode() > HttpStatus.SC_MULTIPLE_CHOICES) {
                         HttpEntity entity = body.getEntity();
-                        String responseBody = entity != null ? EntityUtils.toString(entity) : "";
+                        String responseBody = entity != null ? EntityUtils.toString(entity) : StringUtils.EMPTY;
                         throw new IOException(
                             String.format(
                                 "Failed to submit build request, got status code: %d, response body: %s",


### PR DESCRIPTION
### Description
When there is failure on submit remote vector build, the full response body is not logged out. This PR logs the full response body to help with debugging build failures.

### Related Issues

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
