### PR TITLE
[Backport ]Fix the exact searcher to use the given radius value as it is when memory optimized search is enabled. (#2755)

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -401,7 +401,9 @@ public abstract class KNNWeight extends Weight {
             .matchedDocsIterator(acceptedDocs)
             .numberOfMatchedDocs(numberOfAcceptedDocs)
             .floatQueryVector(knnQuery.getQueryVector())
-            .byteQueryVector(knnQuery.getByteQueryVector());
+            .byteQueryVector(knnQuery.getByteQueryVector())
+            .isMemoryOptimizedSearchEnabled(knnQuery.isMemoryOptimizedSearch());
+
         if (knnQuery.getContext() != null) {
             exactSearcherContextBuilder.maxResultWindow(knnQuery.getContext().getMaxResultWindow());
         }

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -169,6 +169,7 @@ public class NativeEngineKnnVectorQuery extends Query {
                     .radius(knnQuery.getRadius())
                     .floatQueryVector(knnQuery.getQueryVector())
                     .byteQueryVector(knnQuery.getByteQueryVector())
+                    .isMemoryOptimizedSearchEnabled(knnQuery.isMemoryOptimizedSearch())
                     .build();
                 TopDocs rescoreResult = knnWeight.exactSearch(leafReaderContext, exactSearcherContext);
                 return new PerLeafResult(perLeafResult.getFilterBits(), rescoreResult);
@@ -217,6 +218,7 @@ public class NativeEngineKnnVectorQuery extends Query {
                     .field(knnQuery.getField())
                     .floatQueryVector(knnQuery.getQueryVector())
                     .byteQueryVector(knnQuery.getByteQueryVector())
+                    .isMemoryOptimizedSearchEnabled(knnQuery.isMemoryOptimizedSearch())
                     .build();
                 TopDocs rescoreResult = knnWeight.exactSearch(leafReaderContext, exactSearcherContext);
                 return new PerLeafResult(perLeafeResult.getFilterBits(), rescoreResult);

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -271,6 +271,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .floatQueryVector(queryVector)
             .field(FIELD_NAME)
+            .isMemoryOptimizedSearchEnabled(false)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
 
@@ -484,6 +485,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .field(FIELD_NAME)
             .floatQueryVector(queryVector)
+            .isMemoryOptimizedSearchEnabled(false)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
@@ -824,6 +826,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .floatQueryVector(queryVector)
             .field(FIELD_NAME)
             .radius(radius)
+            .isMemoryOptimizedSearchEnabled(false)
             .maxResultWindow(maxResults)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -941,6 +941,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .useQuantizedVectorsForSearch(true)
             .floatQueryVector(queryVector)
             .field(FIELD_NAME)
+            .isMemoryOptimizedSearchEnabled(false)
             .build();
         when(mockedExactSearcher.searchLeaf(leafReaderContext, exactSearchContext)).thenReturn(buildTopDocs(DOC_ID_TO_SCORES));
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFP16IndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFP16IndexIT.java
@@ -38,8 +38,7 @@ public class MOSFaissFP16IndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     }
 
     public void testWhenNoIndexBuilt() {
-        // TODO : Fix
-        // doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, true, SpaceType.L2, NO_BUILD_HNSW);
-        // doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, false, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, true, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, METHOD_PARAMETERS, false, SpaceType.L2, NO_BUILD_HNSW);
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
@@ -34,8 +34,7 @@ public class MOSFaissFloatIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     }
 
     public void testWhenNoIndexBuilt() {
-        // TODO : Fix this
-        // doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
-        // doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
+        doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
     }
 }


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/k-NN/commit/9a8272ce63f13328319544515c144ee68fbfa6be from https://github.com/opensearch-project/k-NN/pull/2755