### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,16 +22,19 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+
       - name: publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           # For zip
           ./gradlew publishPluginZipPublicationToSnapshotsRepository
           # For jar

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -5,6 +5,7 @@
 
 repositories {
     mavenLocal()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ buildscript {
     // This isn't applying from repositories.gradle so repeating git diff it here
     repositories {
         mavenLocal()
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
@@ -255,7 +256,7 @@ publishing {
     repositories {
         maven {
             name = "Snapshots"
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
             credentials {
                 username "$System.env.SONATYPE_USERNAME"
                 password "$System.env.SONATYPE_PASSWORD"

--- a/remote-index-build-client/build.gradle
+++ b/remote-index-build-client/build.gradle
@@ -15,6 +15,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
     maven { url = uri("https://aws.oss.sonatype.org/content/repositories/snapshots") }
     mavenCentral()
     maven { url = uri("https://plugins.gradle.org/m2/") }


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Related Issues
Part of a campaign from https://github.com/opensearch-project/opensearch-build/issues/5551

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
