### PR TITLE
Don't fall back to CPU on terminal exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.2](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+### Bug Fixes
+* [BUGFIX] [Remote Vector Index Build] Don't fall back to CPU on terminal failures [#2773](https://github.com/opensearch-project/k-NN/pull/2773)

--- a/src/main/java/org/opensearch/knn/common/exception/TerminalIOException.java
+++ b/src/main/java/org/opensearch/knn/common/exception/TerminalIOException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.common.exception;
+
+import org.opensearch.knn.index.codec.nativeindex.remote.DefaultVectorRepositoryAccessor;
+
+import java.io.IOException;
+
+/**
+ * Custom exception class to distinguish between terminal IOExceptions (in the case of writing to index output,
+ * for example) and non-terminal (e.g. reading from S3). See {@link DefaultVectorRepositoryAccessor#readFromRepository}.
+ * Useful in GPU builds for determining whether to fall back to CPU build or terminate build altogether.
+ */
+public class TerminalIOException extends IOException {
+    public TerminalIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
+++ b/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.store;
 
 import org.apache.lucene.store.IndexOutput;
+import org.opensearch.knn.common.exception.TerminalIOException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,7 +73,11 @@ public class IndexOutputWithBuffer {
             assert bytesRead <= outputBuffer.length;
             // However many bytes we read, write it to the IndexOutput if != -1
             if (bytesRead != -1) {
-                indexOutput.writeBytes(outputBuffer, 0, bytesRead);
+                try {
+                    indexOutput.writeBytes(outputBuffer, 0, bytesRead);
+                } catch (IOException e) {
+                    throw new TerminalIOException("Failed to write to indexOutput", e);
+                }
             }
         }
     }

--- a/src/main/java/org/opensearch/knn/plugin/stats/KNNRemoteIndexBuildValue.java
+++ b/src/main/java/org/opensearch/knn/plugin/stats/KNNRemoteIndexBuildValue.java
@@ -89,4 +89,11 @@ public enum KNNRemoteIndexBuildValue {
     public void decrementBy(long delta) {
         value.add(delta * -1);
     }
+
+    /**
+     * Reset the value to 0L.
+     */
+    public void reset() {
+        value.reset();
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
+import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
 import org.opensearch.cluster.ClusterName;
@@ -40,6 +41,7 @@ import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.index.vectorvalues.TestVectorValues;
+import org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -164,6 +166,19 @@ abstract class RemoteIndexBuildTests extends KNNTestCase {
         when(clusterSettings.get(KNN_REMOTE_VECTOR_REPOSITORY_SETTING)).thenReturn("test-repo-name");
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         KNNSettings.state().setClusterService(clusterService);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        resetRemoteBuildStats();
+    }
+
+    private void resetRemoteBuildStats() {
+        for (KNNRemoteIndexBuildValue knnRemoteIndexBuildValue : KNNRemoteIndexBuildValue.values()) {
+            knnRemoteIndexBuildValue.reset();
+        }
     }
 
     public static IndexSettings createTestIndexSettings() {


### PR DESCRIPTION
### Description
From the issue:

> Currently, if a k-NN index graph build fails at segment level for GPU based index acceleration, we always fallback to to CPU. But there are some hard failures like IndexInput is closed or index is deleted. We fallback to CPU and then again hit same hard failure before failing the shard. Ideally in case of hard failures we should throw the exception out and shouldn't fall back to CPU.

This PR introduces a new exception to signal to the remote build process that no fall back strategy should be invoked, instead the exception should be rethrown to the caller to terminate the build altogether.

### Related Issues
Resolves #2766 

### Check List
- [X] New functionality includes testing.
~- [] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [X] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
