### PR TITLE
Support ADC in Lucene-on-faiss initial commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Add random rotation feature to binary encoder for improving recall on certain datasets [#2718](https://github.com/opensearch-project/k-NN/pull/2718)
 * Asymmetric Distance Computation for binary quantized faiss indices [#2733](https://github.com/opensearch-project/k-NN/pull/2733)
-* [BUGFIX] [Remote Vector Index Build] Don't fall back to CPU on terminal failures [#2773](https://github.com/opensearch-project/k-NN/pull/2773)
 * Add KNN timing info to core profiler [#2785](https://github.com/opensearch-project/k-NN/pull/2785)
 * Patch for supporting nested search in IndexBinaryHNSWCagra [#2824](https://github.com/opensearch-project/k-NN/pull/2824)
-
+* Support Asymmetric Distance Computation in Lucene-on-Faiss [#2781](https://github.com/opensearch-project/k-NN/pull/2781)
 
 ### Bug Fixes
+* [Remote Vector Index Build] Don't fall back to CPU on terminal failures [#2773](https://github.com/opensearch-project/k-NN/pull/2773)
 * Fix @ collision in NativeMemoryCacheKeyHelper for vector index filenames containing @ characters [#2810](https://github.com/opensearch-project/k-NN/pull/2810)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -29,6 +29,8 @@ import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.UUIDs;
 import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 import org.opensearch.knn.index.codec.util.NativeMemoryCacheKeyHelper;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -36,9 +38,12 @@ import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationStateCacheManager;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationStateReadConfig;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -63,11 +68,23 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
     private final SegmentReadState segmentReadState;
     private final List<String> cacheKeys;
     private volatile Map<String, VectorSearcherHolder> vectorSearchers;
+    private final Map<String, Boolean> adcEnabledCache;
+
+    private static class AdcConfig {
+        final boolean isEnabled;
+        final SpaceType spaceType;
+
+        AdcConfig(boolean isEnabled, SpaceType spaceType) {
+            this.isEnabled = isEnabled;
+            this.spaceType = spaceType;
+        }
+    }
 
     public NativeEngines990KnnVectorsReader(final SegmentReadState state, final FlatVectorsReader flatVectorsReader) {
         this.flatVectorsReader = flatVectorsReader;
         this.segmentReadState = state;
         this.cacheKeys = getVectorCacheKeysFromSegmentReaderState(state);
+        this.adcEnabledCache = new HashMap<>();
 
         loadCacheKeyMap();
         fillVectorSearcherTable();
@@ -152,8 +169,10 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             ((QuantizationConfigKNNCollector) knnCollector).setQuantizationState(quantizationState);
             return;
         }
-
-        if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, true)) {
+        // get adc and spaceType from FieldInfo using caching mechanism to avoid repeated work. It should only be calculated
+        // once per Reader construction. There is no cache invalidation logic since adc is a static mapping parameter.
+        AdcConfig adcConfig = getAdcConfig(field);
+        if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, true, adcConfig.isEnabled, adcConfig.spaceType)) {
             return;
         }
 
@@ -187,7 +206,8 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
      */
     @Override
     public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
-        if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, false)) {
+        // searching with byte vector is not supported by ADC.
+        if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, false, false, null)) {
             return;
         }
 
@@ -240,12 +260,24 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         final Object target,
         final KnnCollector knnCollector,
         final Bits acceptDocs,
-        final boolean isFloatVector
+        final boolean isFloatVector,
+        final boolean isAdc,
+        final SpaceType spaceType
     ) throws IOException {
         // Try with memory optimized searcher
-        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(field);
+        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(field, isAdc);
 
         if (memoryOptimizedSearcher != null) {
+            if (isAdc) {
+                return trySearchWithMemoryOptimizedSearchAndADC(
+                    memoryOptimizedSearcher,
+                    (float[]) target,
+                    knnCollector,
+                    acceptDocs,
+                    spaceType
+                );
+            }
+
             if (isFloatVector) {
                 memoryOptimizedSearcher.search((float[]) target, knnCollector, acceptDocs);
             } else {
@@ -254,6 +286,24 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             return true;
         }
         return false;
+    }
+
+    private boolean trySearchWithMemoryOptimizedSearchAndADC(
+        final VectorSearcher memoryOptimizedSearcher,
+        float[] target,
+        final KnnCollector knnCollector,
+        final Bits acceptDocs,
+        final SpaceType spaceType
+    ) throws IOException {
+        // from NativeEngines990KnnVectorsReader if searching with Byte. Should never hit the below path.
+        if (spaceType == null) return false;
+
+        if (memoryOptimizedSearcher instanceof FaissMemoryOptimizedSearcher faissMemoryOptimizedSearcher) {
+            faissMemoryOptimizedSearcher.searchWithAdc(target, knnCollector, acceptDocs, spaceType);
+            return true;
+        }
+        return false;
+
     }
 
     private void loadCacheKeyMap() {
@@ -270,7 +320,8 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         vectorSearchers = new HashMap<>(RESERVE_TWICE_SPACE * segmentReadState.fieldInfos.size(), SUFFICIENT_LOAD_FACTOR);
 
         for (final FieldInfo fieldInfo : segmentReadState.fieldInfos) {
-            final IOSupplier<VectorSearcher> searcherIOSupplier = getVectorSearcherSupplier(fieldInfo);
+            // TODO: verify that adc does not change this calculation/break anything
+            final IOSupplier<VectorSearcher> searcherIOSupplier = getVectorSearcherSupplier(fieldInfo, false);
             if (searcherIOSupplier != null) {
                 // This field type is supported
                 vectorSearchers.put(fieldInfo.getName(), new VectorSearcherHolder());
@@ -293,7 +344,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         return cacheKeys;
     }
 
-    private VectorSearcher loadMemoryOptimizedSearcherIfRequired(final String fieldName) {
+    private VectorSearcher loadMemoryOptimizedSearcherIfRequired(final String fieldName, boolean isAdc) {
         final VectorSearcherHolder searcherHolder = vectorSearchers.get(fieldName);
         if (searcherHolder == null) {
             // This is not KNN field or unsupported field.
@@ -314,7 +365,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             try {
                 final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(fieldName);
                 if (fieldInfo != null) {
-                    final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
+                    final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo, isAdc);
                     if (searcherSupplier != null) {
                         searcher = searcherSupplier.get();
                         if (searcher != null) {
@@ -339,13 +390,12 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         }
     }
 
-    private IOSupplier<VectorSearcher> getVectorSearcherSupplier(final FieldInfo fieldInfo) {
+    private IOSupplier<VectorSearcher> getVectorSearcherSupplier(final FieldInfo fieldInfo, boolean isAdc) {
         // Skip non-knn fields.
         final Map<String, String> attributes = fieldInfo.attributes();
         if (attributes == null || attributes.containsKey(KNN_FIELD) == false) {
             return null;
         }
-
         // Try to get KNN engine from fieldInfo.
         final KNNEngine knnEngine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
 
@@ -364,11 +414,29 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         // Start creating searcher
         final String fileName = KNNCodecUtil.getNativeEngineFileFromFieldInfo(fieldInfo, segmentReadState.segmentInfo);
         if (fileName != null) {
-            return () -> searcherFactory.createVectorSearcher(segmentReadState.directory, fileName);
+            return () -> searcherFactory.createVectorSearcher(segmentReadState.directory, fileName, isAdc);
         }
 
         // Not supported
         return null;
+    }
+
+    private AdcConfig getAdcConfig(String field) {
+        boolean isAdcEnabled = adcEnabledCache.computeIfAbsent(field, f -> {
+            FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(f);
+            String qframeConfig = fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG);
+            if (qframeConfig != null) {
+                QuantizationConfig config = QuantizationConfigParser.fromCsv(qframeConfig, segmentReadState.segmentInfo.getVersion());
+                return config.isEnableADC();
+            }
+            return false;
+        });
+
+        SpaceType spaceType = isAdcEnabled
+            ? SpaceType.getSpace(segmentReadState.fieldInfos.fieldInfo(field).getAttribute(KNNConstants.SPACE_TYPE))
+            : null;
+
+        return new AdcConfig(isAdcEnabled, spaceType);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
@@ -124,9 +124,6 @@ public class MemoryOptimizedSearchSupportSpec {
     private static boolean isSupportedQuantization(final QuantizationConfig quantizationConfig) {
         final ScalarQuantizationType quantizationType = quantizationConfig.getQuantizationType();
 
-        // ADC is not yet supported for memory optimized search.
-        if (quantizationConfig.isEnableADC()) return false;
-
         return quantizationType == ScalarQuantizationType.ONE_BIT
             || quantizationType == ScalarQuantizationType.TWO_BIT
             || quantizationType == ScalarQuantizationType.FOUR_BIT;

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -123,6 +123,20 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                     );
                 }
 
+                if (adcTransformedVector != null) {
+                    // ADC case
+                    return queryIndex(
+                        adcTransformedVector,
+                        cardinality,
+                        cardinality + 1,
+                        context,
+                        filterIdsBitSet,
+                        reader,
+                        knnEngine,
+                        spaceType
+                    );
+                }
+
                 // fallback to float
                 return queryIndex(
                     knnQuery.getQueryVector(),

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.store.Directory;
 
 import java.io.IOException;
@@ -19,8 +20,9 @@ public interface VectorSearcherFactory {
      *
      * @param directory Lucene's Directory.
      * @param fileName Logical file name to load.
+     * @param fieldInfo Field info containing metadata for ADC extraction
      * @return Null instance if it is not supported, otherwise return {@link VectorSearcher}
      * @throws IOException
      */
-    VectorSearcher createVectorSearcher(Directory directory, String fileName, boolean isAdc) throws IOException;
+    VectorSearcher createVectorSearcher(Directory directory, String fileName, FieldInfo fieldInfo) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -22,5 +22,5 @@ public interface VectorSearcherFactory {
      * @return Null instance if it is not supported, otherwise return {@link VectorSearcher}
      * @throws IOException
      */
-    VectorSearcher createVectorSearcher(Directory directory, String fileName) throws IOException;
+    VectorSearcher createVectorSearcher(Directory directory, String fileName, boolean isAdc) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -104,7 +104,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         final VectorEncoding vectorEncoding,
         final IOSupplier<RandomVectorScorer> scorerSupplier,
         final KnnCollector knnCollector,
-        final Bits acceptDocs // here need to see if it can be modified in both usages.
+        final Bits acceptDocs
     ) throws IOException {
         if (faissIndex.getTotalNumberOfVectors() == 0 || knnCollector.k() == 0) {
             return;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -11,11 +11,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.Version;
-import org.opensearch.knn.common.FieldInfoExtractor;
-import org.opensearch.knn.common.KNNConstants;
-import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
@@ -37,13 +32,8 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
         );
 
         try {
-            // Extract ADC info from fieldInfo
-            final QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo, Version.LATEST);
-            final boolean isAdc = quantizationConfig.isEnableADC();
-            final SpaceType spaceType = isAdc ? SpaceType.getSpace(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)) : null;
-
             // Try load it. Not all FAISS index types are currently supported at the moment.
-            return new FaissMemoryOptimizedSearcher(indexInput, isAdc, spaceType);
+            return new FaissMemoryOptimizedSearcher(indexInput, fieldInfo);
         } catch (UnsupportedFaissIndexException e) {
             // Clean up input stream.
             try {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -23,7 +23,7 @@ import java.io.IOException;
  */
 public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactory {
     @Override
-    public VectorSearcher createVectorSearcher(final Directory directory, final String fileName) throws IOException {
+    public VectorSearcher createVectorSearcher(final Directory directory, final String fileName, boolean isAdc) throws IOException {
         final IndexInput indexInput = directory.openInput(
             fileName,
             new IOContext(IOContext.Context.DEFAULT, null, null, ReadAdvice.RANDOM)
@@ -31,7 +31,7 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
 
         try {
             // Try load it. Not all FAISS index types are currently supported at the moment.
-            return new FaissMemoryOptimizedSearcher(indexInput);
+            return new FaissMemoryOptimizedSearcher(indexInput, isAdc);
         } catch (UnsupportedFaissIndexException e) {
             // Clean up input stream.
             try {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -5,11 +5,17 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss;
 
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.Version;
+import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
@@ -23,15 +29,21 @@ import java.io.IOException;
  */
 public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactory {
     @Override
-    public VectorSearcher createVectorSearcher(final Directory directory, final String fileName, boolean isAdc) throws IOException {
+    public VectorSearcher createVectorSearcher(final Directory directory, final String fileName, final FieldInfo fieldInfo)
+        throws IOException {
         final IndexInput indexInput = directory.openInput(
             fileName,
             new IOContext(IOContext.Context.DEFAULT, null, null, ReadAdvice.RANDOM)
         );
 
         try {
+            // Extract ADC info from fieldInfo
+            final QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo, Version.LATEST);
+            final boolean isAdc = quantizationConfig.isEnableADC();
+            final SpaceType spaceType = isAdc ? SpaceType.getSpace(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)) : null;
+
             // Try load it. Not all FAISS index types are currently supported at the moment.
-            return new FaissMemoryOptimizedSearcher(indexInput, isAdc);
+            return new FaissMemoryOptimizedSearcher(indexInput, isAdc, spaceType);
         } catch (UnsupportedFaissIndexException e) {
             // Clean up input stream.
             try {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -18,13 +18,51 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
 
 @UtilityClass
 public class FlatVectorsScorerProvider {
     private static final FlatVectorsScorer DELEGATE_VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
     private static final FlatVectorsScorer HAMMING_VECTOR_SCORER = new HammingFlatVectorsScorer();
+    private static final Map<SpaceType, FlatVectorsScorer> ADC_FLAT_SCORERS = initializeAdcFlatScorers();
 
+    private static Map<SpaceType, FlatVectorsScorer> initializeAdcFlatScorers() {
+        Map<SpaceType, FlatVectorsScorer> scorers = new EnumMap<>(SpaceType.class);
+        scorers.put(SpaceType.L2, new ADCFlatVectorsScorer(KNNVectorSimilarityFunction.EUCLIDEAN, SpaceType.L2));
+        scorers.put(SpaceType.COSINESIMIL, new ADCFlatVectorsScorer(KNNVectorSimilarityFunction.COSINE, SpaceType.COSINESIMIL));
+        scorers.put(
+            SpaceType.INNER_PRODUCT,
+            new ADCFlatVectorsScorer(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, SpaceType.INNER_PRODUCT)
+        );
+        return scorers;
+    }
+
+    /**
+     * Returns the FlatVectorsScorer based on the similarity function.
+     * @param similarityFunction the vector similarity function to use
+     * @return FlatVectorsScorer instance
+     */
     public static FlatVectorsScorer getFlatVectorsScorer(final KNNVectorSimilarityFunction similarityFunction) {
+        return getFlatVectorsScorer(similarityFunction, false, null);
+    }
+
+    /**
+     * Returns the FlatVectorsScorer based on the similarity function, or if adc is enabled based on the SpaceType.
+     * @param similarityFunction the vector similarity function to use
+     * @param isAdc whether ADC (Asymmetric Distance Computation) is enabled
+     * @param spaceType the space type for vector comparison
+     * @return FlatVectorsScorer instance
+     */
+    public static FlatVectorsScorer getFlatVectorsScorer(
+        final KNNVectorSimilarityFunction similarityFunction,
+        final boolean isAdc,
+        final SpaceType spaceType
+    ) {
+        if (isAdc) {
+            // Note: we cannot leverage KNNVectorSimilarityFunction here as it is HAMMING for ADC, so we must use SpaceType.
+            return ADC_FLAT_SCORERS.get(spaceType);
+        }
         if (similarityFunction == KNNVectorSimilarityFunction.HAMMING) {
             return HAMMING_VECTOR_SCORER;
         }
@@ -56,43 +94,40 @@ public class FlatVectorsScorerProvider {
             KnnVectorValues knnVectorValues,
             float[] target
         ) {
-            if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
-                if (spaceType == SpaceType.HAMMING) {
-                    throw new IllegalArgumentException("hamming distance unsupported by ADC");
-                } else if (spaceType == SpaceType.L2) {
-                    return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
-                        @Override
-                        public float score(int internalVectorId) throws IOException {
-                            final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                            return SpaceType.L2.scoreTranslation(KNNScoringUtil.l2SquaredADC(target, quantizedByteVector));
-                        }
-                    };
-                } else if (spaceType == SpaceType.COSINESIMIL) {
-                    return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
-                        @Override
-                        public float score(int internalVectorId) throws IOException {
-                            final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                            return SpaceType.COSINESIMIL.scoreTranslation(1 - KNNScoringUtil.innerProductADC(target, quantizedByteVector));
-                        }
-                    };
-                } else if (spaceType == SpaceType.INNER_PRODUCT) {
-                    return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
-                        @Override
-                        public float score(int internalVectorId) throws IOException {
-                            final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                            return SpaceType.INNER_PRODUCT.scoreTranslation(
-                                -1 * KNNScoringUtil.innerProductADC(target, quantizedByteVector)
-                            );
-                        }
-                    };
-                } else {
-                    throw new IllegalArgumentException("Unsupported space type: " + spaceType);
-                }
+            if (!(knnVectorValues instanceof ByteVectorValues byteVectorValues)) {
+                throw new IllegalArgumentException(
+                    "Expected "
+                        + ByteVectorValues.class.getSimpleName()
+                        + " for ADC scorer, got "
+                        + knnVectorValues.getClass().getSimpleName()
+                );
             }
 
-            throw new IllegalArgumentException(
-                "Expected " + ByteVectorValues.class.getSimpleName() + " for ADC scorer, got " + knnVectorValues.getClass().getSimpleName()
-            );
+            return switch (spaceType) {
+                case HAMMING -> throw new IllegalArgumentException("hamming distance unsupported by ADC");
+                case L2 -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                    @Override
+                    public float score(int internalVectorId) throws IOException {
+                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                        return SpaceType.L2.scoreTranslation(KNNScoringUtil.l2SquaredADC(target, quantizedByteVector));
+                    }
+                };
+                case COSINESIMIL -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                    @Override
+                    public float score(int internalVectorId) throws IOException {
+                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                        return SpaceType.COSINESIMIL.scoreTranslation(1 - KNNScoringUtil.innerProductADC(target, quantizedByteVector));
+                    }
+                };
+                case INNER_PRODUCT -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                    @Override
+                    public float score(int internalVectorId) throws IOException {
+                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                        return SpaceType.INNER_PRODUCT.scoreTranslation(-1 * KNNScoringUtil.innerProductADC(target, quantizedByteVector));
+                    }
+                };
+                default -> throw new IllegalArgumentException("Unsupported space type: " + spaceType);
+            };
         }
 
         @Override

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -64,7 +64,7 @@ public class FlatVectorsScorerProvider {
                         @Override
                         public float score(int internalVectorId) throws IOException {
                             final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                            return KNNScoringUtil.l2SquaredADC(target, quantizedByteVector);
+                            return SpaceType.L2.scoreTranslation(KNNScoringUtil.l2SquaredADC(target, quantizedByteVector));
                         }
                     };
                 } else if (spaceType == SpaceType.COSINESIMIL) {
@@ -72,7 +72,7 @@ public class FlatVectorsScorerProvider {
                         @Override
                         public float score(int internalVectorId) throws IOException {
                             final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                            return KNNScoringUtil.innerProductADC(target, quantizedByteVector);
+                            return SpaceType.COSINESIMIL.scoreTranslation(1 - KNNScoringUtil.innerProductADC(target, quantizedByteVector));
                         }
                     };
                 } else if (spaceType == SpaceType.INNER_PRODUCT) {
@@ -80,7 +80,9 @@ public class FlatVectorsScorerProvider {
                         @Override
                         public float score(int internalVectorId) throws IOException {
                             final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                            return KNNScoringUtil.innerProductADC(target, quantizedByteVector);
+                            return SpaceType.INNER_PRODUCT.scoreTranslation(
+                                -1 * KNNScoringUtil.innerProductADC(target, quantizedByteVector)
+                            );
                         }
                     };
                 } else {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -9,11 +9,14 @@ import lombok.experimental.UtilityClass;
 import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
 
@@ -21,6 +24,7 @@ import java.io.IOException;
 public class FlatVectorsScorerProvider {
     private static final FlatVectorsScorer DELEGATE_VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
     private static final FlatVectorsScorer HAMMING_VECTOR_SCORER = new HammingFlatVectorsScorer();
+    private static final ADCFlatVectorsScorer ADC_FLAT_VECTORS_SCORER = new ADCFlatVectorsScorer();
 
     public static FlatVectorsScorer getFlatVectorsScorer(final KNNVectorSimilarityFunction similarityFunction) {
         if (similarityFunction == KNNVectorSimilarityFunction.HAMMING) {
@@ -28,6 +32,97 @@ public class FlatVectorsScorerProvider {
         }
 
         return DELEGATE_VECTOR_SCORER;
+    }
+
+    public static ADCFlatVectorsScorer getAdcFlatVectorScorer(final KNNVectorSimilarityFunction similarityFunction) {
+        return ADC_FLAT_VECTORS_SCORER;
+    }
+
+    public static class ADCFlatVectorsScorer implements FlatVectorsScorer {
+        public RandomVectorScorer getRandomVectorScorerForAdc(
+            VectorSimilarityFunction vectorSimilarityFunction,
+            KnnVectorValues knnVectorValues,
+            float[] target,
+            SpaceType spaceType
+        ) {
+            if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
+                // TODO: do we need to worry about the score translation for each of the spaces in this case since it might not be handled
+                // by rescoring in the hamming case?
+                // also, we need an integration test with rescoring on and with rescoring off for ADC.
+                if (spaceType == SpaceType.HAMMING) {
+                    throw new IllegalArgumentException("hamming distance unsupported by ADC");
+                } else if (spaceType == SpaceType.L2) {
+                    return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                        @Override
+                        public float score(int internalVectorId) throws IOException {
+                            final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                            return KNNScoringUtil.l2SquaredADC(target, quantizedByteVector);
+                        }
+                    };
+                } else if (spaceType == SpaceType.COSINESIMIL) {
+                    return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                        @Override
+                        public float score(int internalVectorId) throws IOException {
+                            final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                            return KNNScoringUtil.innerProductADC(target, quantizedByteVector);
+                        }
+                    };
+                } else if (spaceType == SpaceType.INNER_PRODUCT) {
+                    return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                        @Override
+                        public float score(int internalVectorId) throws IOException {
+                            final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                            return KNNScoringUtil.innerProductADC(target, quantizedByteVector);
+                        }
+                    };
+                } else {
+                    throw new IllegalArgumentException("Unsupported space type: " + spaceType);
+                }
+            }
+
+            throw new IllegalArgumentException(
+                "Cannot call the overridden function for adc."
+                    + ByteVectorValues.class.getSimpleName()
+                    + " for hamming vector scorer, got "
+                    + knnVectorValues.getClass().getSimpleName()
+            );
+        }
+
+        @Override
+        public RandomVectorScorer getRandomVectorScorer(
+            VectorSimilarityFunction vectorSimilarityFunction,
+            KnnVectorValues knnVectorValues,
+            byte[] target
+        ) {
+            throw new IllegalArgumentException(
+                "Cannot call the overridden function for adc."
+                    + ByteVectorValues.class.getSimpleName()
+                    + " for hamming vector scorer, got "
+                    + knnVectorValues.getClass().getSimpleName()
+            );
+        }
+
+        @Override
+        public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+            VectorSimilarityFunction similarityFunction,
+            KnnVectorValues vectorValues
+        ) throws IOException {
+            return null;
+        }
+
+        @Override
+        public RandomVectorScorer getRandomVectorScorer(
+            VectorSimilarityFunction vectorSimilarityFunction,
+            KnnVectorValues knnVectorValues,
+            float[] target
+        ) {
+            throw new IllegalArgumentException(
+                "Cannot call the overridden function for adc."
+                    + FloatVectorValues.class.getSimpleName()
+                    + " for hamming vector scorer, got "
+                    + knnVectorValues.getClass().getSimpleName()
+            );
+        }
     }
 
     private static class HammingFlatVectorsScorer implements FlatVectorsScorer {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -104,7 +104,6 @@ public class FlatVectorsScorerProvider {
             }
 
             return switch (spaceType) {
-                case HAMMING -> throw new IllegalArgumentException("hamming distance unsupported by ADC");
                 case L2 -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
                     @Override
                     public float score(int internalVectorId) throws IOException {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryHnswIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissBinaryHnswIndex.java
@@ -61,7 +61,7 @@ public class FaissBinaryHnswIndex extends FaissBinaryIndex implements FaissHNSWP
 
     @Override
     public FloatVectorValues getFloatValues(IndexInput indexInput) throws IOException {
-        throw new UnsupportedOperationException(FaissBinaryHnswIndex.class.getSimpleName() + " doees not support FloatVectorValues.");
+        throw new UnsupportedOperationException(FaissBinaryHnswIndex.class.getSimpleName() + " does not support FloatVectorValues.");
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -127,12 +127,13 @@ public class KNNScoringUtil {
      */
     public static float l2SquaredADC(float[] queryVector, byte[] inputVector) {
         // we cannot defer to VectorUtil as it does not support ADC.
+        // TODO: add batching logic similar to C++ to improve performance.
         float score = 0;
 
         for (int i = 0; i < queryVector.length; ++i) {
             int byteIndex = i / 8;
             int bitOffset = 7 - (i % 8);
-            int bitValue = (inputVector[byteIndex] & (1 << bitOffset)) != 0 ? 1 : 0;
+            int bitValue = (inputVector[byteIndex] >> bitOffset) & 1;
 
             // Calculate squared difference
             float diff = bitValue - queryVector[i];
@@ -165,7 +166,7 @@ public class KNNScoringUtil {
             // Extract the bit for this dimension
             int byteIndex = i / 8;
             int bitOffset = 7 - (i % 8);
-            int bitValue = (inputVector[byteIndex] & (1 << bitOffset)) != 0 ? 1 : 0;
+            int bitValue = (inputVector[byteIndex] >> bitOffset) & 1;
 
             // Calculate product and accumulate
             score += bitValue * queryVector[i];

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -61,7 +62,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         // Mocking FAISS engine to return a dummy vector searcher
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
-        when(mockFactory.createVectorSearcher(any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(mockFactory.createVectorSearcher(any(), any(), anyBoolean())).thenReturn(mock(VectorSearcher.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
 
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -62,7 +61,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         // Mocking FAISS engine to return a dummy vector searcher
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
-        when(mockFactory.createVectorSearcher(any(), any(), anyBoolean())).thenReturn(mock(VectorSearcher.class));
+        when(mockFactory.createVectorSearcher(any(), any(), any())).thenReturn(mock(VectorSearcher.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
 
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -42,7 +42,8 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
     public void doTestKNNSearch(boolean isApproximateSearch) {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
-            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input);
+            // TODO: adc placeholder. Note that ADC is not yet supported for cagra since binary hnsw is not supported.
+            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, false);
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -15,7 +15,6 @@ import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.IOConsumer;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 
@@ -44,7 +43,7 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
             // TODO: adc placeholder. isAdc false and SpaceType L2 are noops for the MemoryOptimizedSearcher here.
-            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, false, SpaceType.L2);
+            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null);
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.IOConsumer;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 
@@ -42,8 +43,8 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
     public void doTestKNNSearch(boolean isApproximateSearch) {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
-            // TODO: adc placeholder. Note that ADC is not yet supported for cagra since binary hnsw is not supported.
-            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, false);
+            // TODO: adc placeholder. isAdc false and SpaceType L2 are noops for the MemoryOptimizedSearcher here.
+            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, false, SpaceType.L2);
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -104,7 +104,6 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     private static final String BINARY_HSNW_INDEX_DESCRIPTION = "BHNSW16,Flat";
     private static final Map<String, Object> EMTPY_ENCODER_PARAMETERS = Map.of();
     private static final int DIMENSIONS = 128;
-    private static final int BINARY_DIMENSIONS = DIMENSIONS / 8; // For binary quantization
     private static final int TOTAL_NUM_DOCS_IN_SEGMENT = 300;
     private static final int TOP_K = 30;
     private static final float NO_FILTERING = Float.NaN;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -693,7 +693,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         // It can happen that match ratio between FAISS and MemOptimizedSearch is lower than 80%, but if it happens with a recall lower than
         // 0.8 indicates something's off. We use a smaller match threshold for ADC.
         if (isAdc) {
-            assertFalse(matchRatio < 0.7 && recall < 0.8);
+            assertFalse(matchRatio < 0.6 && recall < 0.8);
         } else {
             assertFalse(matchRatio < 0.8 && recall < 0.8);
         }


### PR DESCRIPTION
### Description
Draft implementation to integrate asymmetric distance calculation (ADC) with lucene-on-faiss.

This implementation uses the following low-level approach:
- Within the `NativeEngines990KnnVectorsReader` see from the `FieldInfo` if adc is enabled or not. We need to check here so we can obtain the original `SpaceType`, as this information is lost for binary indices when it is changed to hamming.
- Add new split within `trySearchWithMemoryOptimizedSearch` on if adc is enabled or not.
- Add `isAdc` parameter to `createVectorSearcher` method.
- Add new method `searchWithAdc`. The reason for a new method is that preexisting scorer supplier logic depends on the query and document vector types matching (`float/float` or `byte/byte`), whereas ADC is `float/byte`. 
- Create new ADC scorer, leveraging java logic originally implemented for ADC exact search.

### Related Issues
Resolves #2714 

### Check List
- [X] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
