### PR TITLE
Add python end to end test module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,18 +232,20 @@ allprojects {
     }
 
     afterEvaluate {
-        project.dependencyLicenses.enabled = false
-        project.thirdPartyAudit.enabled = false
-        project.loggerUsageCheck.enabled = false
-        project.forbiddenApis.ignoreFailures = true
-        project.forbiddenPatterns {
-            setEnabled(false)
+        if (project.name != 'e2e') {
+            project.dependencyLicenses.enabled = false
+            project.thirdPartyAudit.enabled = false
+            project.loggerUsageCheck.enabled = false
+            project.forbiddenApis.ignoreFailures = true
+            project.forbiddenPatterns {
+                setEnabled(false)
+            }
+            project.testingConventions.enabled = false
+            project.validateNebulaPom.enabled = false
+            project.forbiddenApis.ignoreFailures = true
         }
-        project.testingConventions.enabled = false
-        project.validateNebulaPom.enabled = false
         project.licenseFile = rootProject.file('LICENSE.txt')
         project.noticeFile = rootProject.file('NOTICE.txt')
-        project.forbiddenApis.ignoreFailures = true
     }
 }
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,66 @@
+# OpenSearch k-NN E2E Tests
+
+Python-based end-to-end tests for the OpenSearch k-NN plugin against external clusters.
+
+## Setup
+
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+### Using Gradle (Recommended):
+```bash
+# Run all tests against localhost:9200
+./gradlew :e2e:runTests
+
+# Run against custom cluster
+./gradlew :e2e:runTests -Dopensearch.host=my-cluster.com -Dopensearch.port=9200
+
+# Run against multi-node cluster
+./gradlew :e2e:runTests -Dopensearch.nodes=3
+
+# Run specific test pattern
+./gradlew :e2e:runTests -Dtest.pattern="test_knn_basic"
+
+# Run with custom credentials
+./gradlew :e2e:runTests -Dopensearch.username=myuser -Dopensearch.password=mypass
+```
+
+### Using Python directly:
+```bash
+# All tests
+python run_tests.py
+
+# Specific test pattern
+python run_tests.py -k "test_knn_basic"
+
+# With pytest directly
+pytest -v
+```
+
+## Test Structure
+
+- `conftest.py` - Pytest fixtures and configuration
+- `tests/test_knn_basic.py` - Basic k-NN functionality tests
+
+## Configuration
+
+### Gradle Task Parameters
+- `-Dopensearch.host` - Cluster host (default: localhost)
+- `-Dopensearch.port` - Cluster port (default: 9200)
+- `-Dopensearch.username` - Username (default: admin)
+- `-Dopensearch.password` - Password (default: admin)
+- `-Dopensearch.ssl` - Use SSL (default: true)
+- `-Dopensearch.nodes` - Number of nodes (default: 1)
+- `-Dtest.pattern` - Test pattern to match
+
+### Environment Variables
+- `OPENSEARCH_HOST` - Cluster host (default: localhost)
+- `OPENSEARCH_PORT` - Cluster port (default: 9200)
+- `OPENSEARCH_USERNAME` - Username (default: admin)
+- `OPENSEARCH_PASSWORD` - Password (default: admin)
+- `OPENSEARCH_USE_SSL` - Use SSL (default: true)
+- `OPENSEARCH_NODES` - Number of nodes (default: 1)

--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -1,0 +1,51 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+plugins {
+    id 'opensearch.build'
+}
+
+
+task runTests(type: Exec) {
+    description 'Run Python e2e tests against external OpenSearch cluster'
+    group 'verification'
+    
+    def host = System.getProperty('opensearch.host', 'localhost')
+    def port = System.getProperty('opensearch.port', '9200')
+    def username = System.getProperty('opensearch.username', '')
+    def password = System.getProperty('opensearch.password', '')
+    def useSSL = System.getProperty('opensearch.ssl', 'false')
+    def numNodes = System.getProperty('opensearch.nodes', '1')
+    def testPattern = System.getProperty('test.pattern', '')
+    
+    environment 'OPENSEARCH_HOST', host
+    environment 'OPENSEARCH_PORT', port
+    environment 'OPENSEARCH_USERNAME', username
+    environment 'OPENSEARCH_PASSWORD', password
+    environment 'OPENSEARCH_USE_SSL', useSSL
+    environment 'OPENSEARCH_NODES', numNodes
+    
+    def pythonCmd = Os.isFamily(Os.FAMILY_WINDOWS) ? 'python' : 'python3'
+    def args = [pythonCmd, '-m', 'pytest', '-v']
+    
+    if (testPattern) {
+        args.addAll(['-k', testPattern])
+    }
+    
+    commandLine args
+    
+    doFirst {
+        println "Running e2e tests against cluster at ${host}:${port} with ${numNodes} nodes"
+        if (testPattern) {
+            println "Test pattern: ${testPattern}"
+        }
+    }
+    
+    doLast {
+        println "E2E tests completed"
+    }
+}

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,89 @@
+#  Copyright OpenSearch Contributors
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import os
+from opensearchpy import OpenSearch
+import uuid
+from packaging import version
+from version_utils import normalize_version
+from faker import Faker
+
+# Global variable to store cluster version
+cluster_version = '1.0'
+
+@pytest.fixture(scope="session")
+def opensearch_client():
+    """Create OpenSearch client for external cluster"""
+    client = create_client()
+    info = client.info()
+    num_nodes = int(os.getenv('OPENSEARCH_NODES', '1'))
+    print(f"Connected to OpenSearch {info['version']['number']} ({num_nodes} nodes)")
+    yield client
+    client.close()
+
+@pytest.fixture
+def faker():
+    """Seeded faker for reproducible test data"""
+    fake = Faker()
+    fake.seed_instance(42)
+    return fake
+
+@pytest.fixture
+def test_index():
+    """Generate unique test index name"""
+    return f"test_knn_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def index_manager(opensearch_client):
+    """Manages index cleanup after tests"""
+    indices_to_delete = []
+
+    def register_index(index_name):
+        indices_to_delete.append(index_name)
+        return index_name
+
+    yield register_index
+
+    # Cleanup all registered indices
+    for index in indices_to_delete:
+        opensearch_client.indices.delete(index=index, ignore=404)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Filter tests based on cluster version"""
+    # Get cluster version during collection
+    try:
+        client = create_client()
+        info = client.info()
+        detected_version = normalize_version(info['version']['number'])
+        client.close()
+        print(f"Detected cluster version: {detected_version}")
+    except:
+        detected_version = '1.0'
+        print("Could not detect cluster version, using default 1.0")
+    
+    for item in items:
+        min_ver = getattr(item.function, '_min_version', '1.0')
+        max_ver = getattr(item.function, '_max_version', '3.1')
+
+        if not (version.parse(min_ver) <= version.parse(detected_version) <= version.parse(max_ver)):
+            item.add_marker(pytest.mark.skip(f"Version {detected_version} not in range {min_ver}-{max_ver}"))
+
+def create_client():
+    """Create OpenSearch client for version detection"""
+    host = os.getenv('OPENSEARCH_HOST', 'localhost')
+    port = int(os.getenv('OPENSEARCH_PORT', '9200'))
+    username = os.getenv('OPENSEARCH_USERNAME', '')
+    password = os.getenv('OPENSEARCH_PASSWORD', '')
+    use_ssl = os.getenv('OPENSEARCH_USE_SSL', 'false').lower() == 'true'
+    
+    return OpenSearch(
+        hosts=[{'host': host, 'port': port}],
+        http_auth=(username, password),
+        use_ssl=use_ssl,
+        verify_certs=False,
+        ssl_show_warn=False
+    )
+

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,9 @@
+[tool:pytest]
+testpaths = .
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short
+markers =
+    slow: marks tests as slow
+    integration: marks tests as integration tests

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,8 @@
+opensearch-py>=2.0.0
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+requests>=2.28.0
+numpy>=1.21.0
+pyyaml>=6.0
+packaging>=21.0
+faker>=37.4.0

--- a/e2e/run_tests.py
+++ b/e2e/run_tests.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+#  Copyright OpenSearch Contributors
+#  SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E Test Runner for OpenSearch k-NN Plugin
+"""
+import os
+import sys
+import subprocess
+import argparse
+
+def run_tests(test_pattern=None, verbose=False):
+    """Run e2e tests against external OpenSearch cluster"""
+    cmd = ["python", "-m", "pytest"]
+    
+    if verbose:
+        cmd.append("-v")
+    
+    if test_pattern:
+        cmd.extend(["-k", test_pattern])
+    
+    # Set environment
+    env = os.environ.copy()
+    
+    print(f"Running command: {' '.join(cmd)}")
+    result = subprocess.run(cmd, env=env)
+    return result.returncode
+
+def main():
+    parser = argparse.ArgumentParser(description="Run k-NN e2e tests")
+    parser.add_argument("-k", "--pattern", help="Test pattern to match")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    
+    args = parser.parse_args()
+
+    exit_code = run_tests(args.pattern, args.verbose)
+    sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()

--- a/e2e/tests/test_knn_basic.py
+++ b/e2e/tests/test_knn_basic.py
@@ -1,0 +1,130 @@
+#  Copyright OpenSearch Contributors
+#  SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+from opensearchpy import OpenSearch
+
+from version_utils import version_range
+
+
+class TestKNNBasic:
+    """Basic k-NN functionality tests"""
+
+    @version_range(min_version='3.0')
+    def test_knn_index_creation(self, opensearch_client: OpenSearch, test_index, index_manager):
+
+        index_manager(test_index)
+
+        """Test creating k-NN index"""
+        body = {
+            "settings": {
+              "knn": True,
+            },
+            "mappings": {
+                "properties": {
+                    "vector": {
+                        "type": "knn_vector",
+                        "dimension": 3,
+                        "method": {
+                            "name": "hnsw",
+                            "space_type": "l2",
+                            "engine": "faiss"
+                        }
+                    }
+                }
+            }
+        }
+        
+        response = opensearch_client.indices.create(index=test_index, body=body)
+        assert response["acknowledged"]
+
+    @version_range(min_version='3.1')
+    def test_knn_document_indexing(self, opensearch_client: OpenSearch, test_index, index_manager, faker):
+
+        index_manager(test_index)
+
+        """Test indexing documents with vectors"""
+        body = {
+            "settings": {
+              "knn": True,
+            },
+            "mappings": {
+                "properties": {
+                    "vector": {
+                        "type": "knn_vector",
+                        "dimension": 3
+                    }
+                }
+            }
+        }
+        
+        opensearch_client.indices.create(index=test_index, body=body)
+        
+        # Index test documents
+        docs = [
+            {"vector": [1.0, 2.0, 3.0], "title": faker.word()},
+            {"vector": [2.0, 3.0, 4.0], "title": faker.word()},
+            {"vector": [3.0, 4.0, 5.0], "title": faker.word()}
+        ]
+        
+        for i, doc in enumerate(docs):
+            opensearch_client.index(index=test_index, id=i, body=doc)
+        
+        opensearch_client.indices.refresh(index=test_index)
+        
+        # Verify documents
+        count = opensearch_client.count(index=test_index)
+        assert count["count"] == 3
+    
+    def test_knn_search(self, opensearch_client: OpenSearch, test_index, index_manager, faker):
+
+        index_manager(test_index)
+
+        """Test k-NN search functionality"""
+        body = {
+            "settings": {
+              "knn": True,
+            },
+            "mappings": {
+                "properties": {
+                    "vector": {
+                        "type": "knn_vector",
+                        "dimension": 3
+                    }
+                }
+            }
+        }
+        
+        opensearch_client.indices.create(index=test_index, body=body)
+        
+        # Index test documents
+        docs = [
+            {"vector": [1.0, 1.0, 1.0], "title": "doc1"},
+            {"vector": [2.0, 2.0, 2.0], "title": "doc2"},
+            {"vector": [10.0, 10.0, 10.0], "title": "doc3"}
+        ]
+        
+        for i, doc in enumerate(docs):
+            opensearch_client.index(index=test_index, id=i, body=doc)
+        
+        opensearch_client.indices.refresh(index=test_index)
+
+        # Perform k-NN search
+        query = {
+            "size": 2,
+            "query": {
+                "knn": {
+                    "vector": {
+                        "vector": [1.5, 1.5, 1.5],
+                        "k": 2
+                    }
+                }
+            }
+        }
+        
+        response = opensearch_client.search(index=test_index, body=query)
+        
+        assert len(response["hits"]["hits"]) == 2
+        # Verify we got results
+        assert all("title" in hit["_source"] for hit in response["hits"]["hits"])

--- a/e2e/version_utils.py
+++ b/e2e/version_utils.py
@@ -1,0 +1,18 @@
+#  Copyright OpenSearch Contributors
+#  SPDX-License-Identifier: Apache-2.0
+
+def version_range(min_version='1.0', max_version='3.1'):
+    """Decorator to specify version range for tests"""
+    def decorator(func):
+        func._min_version = min_version
+        func._max_version = max_version
+        return func
+    return decorator
+
+def normalize_version(version_string):
+    """Normalize version string by removing -SNAPSHOT and extra parts"""
+    # Remove -SNAPSHOT and other suffixes
+    version = version_string.split('-')[0]
+    # Keep only major.minor (e.g., 3.1.0 -> 3.1)
+    parts = version.split('.')
+    return f"{parts[0]}.{parts[1]}" if len(parts) >= 2 else version

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,4 @@ include ":qa"
 include ":qa:rolling-upgrade"
 include ":qa:restart-upgrade"
 include ":remote-index-build-client"
-
+include ":e2e"


### PR DESCRIPTION
### Description
Draft PR to add basic python integ test framework. 

As part of it, it adds a few basic python integration tests. It also adds a cluster version filter so that we can write tests on main that will work against older clusters. 

### Related Issues
#2783

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
