### PR TITLE
Add KNN Profiling Info to Core Profiler

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/DefaultKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/DefaultKNNWeight.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.lucene.util.BitSet;
+import org.opensearch.search.profile.ContextualProfileBreakdown;
 
 import static org.opensearch.knn.index.util.IndexUtil.getParametersAtLoading;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
@@ -40,8 +41,8 @@ import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 public class DefaultKNNWeight extends KNNWeight {
     private final NativeMemoryCacheManager nativeMemoryCacheManager;
 
-    public DefaultKNNWeight(KNNQuery query, float boost, Weight filterWeight) {
-        super(query, boost, filterWeight);
+    public DefaultKNNWeight(KNNQuery query, float boost, Weight filterWeight, ContextualProfileBreakdown profile) {
+        super(query, boost, filterWeight, profile);
         this.nativeMemoryCacheManager = NativeMemoryCacheManager.getInstance();
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -7,14 +7,14 @@ package org.opensearch.knn.index.query;
 
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.search.KnnByteVectorQuery;
-import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.common.QueryUtils;
+import org.opensearch.knn.index.query.lucene.ProfileKnnByteVectorQuery;
+import org.opensearch.knn.index.query.lucene.ProfileKnnFloatVectorQuery;
 import org.opensearch.knn.index.query.lucenelib.NestedKnnVectorQueryFactory;
 import org.opensearch.knn.index.query.lucene.LuceneEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
@@ -179,8 +179,8 @@ public class KNNQueryFactory extends BaseQueryFactory {
         if (parentFilter == null) {
             assert expandNested == false : "expandNested is allowed to be true only for nested fields.";
             return vectorDataType == VectorDataType.FLOAT
-                ? new KnnFloatVectorQuery(fieldName, floatQueryVector, k, filterQuery)
-                : new KnnByteVectorQuery(fieldName, byteQueryVector, k, filterQuery);
+                ? new ProfileKnnFloatVectorQuery(fieldName, floatQueryVector, k, filterQuery)
+                : new ProfileKnnByteVectorQuery(fieldName, byteQueryVector, k, filterQuery);
         }
         // If parentFilter is not null, it is a nested query. Therefore, we delegate creation of query to {@link
         // NestedKnnVectorQueryFactory}

--- a/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
@@ -20,6 +20,9 @@ import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.query.iterators.GroupedNestedDocIdSetIterator;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.search.profile.Timer;
+import org.opensearch.search.profile.ContextualProfileBreakdown;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -101,11 +104,24 @@ public class QueryUtils {
     public List<Map<Integer, Float>> doSearch(
         final IndexSearcher indexSearcher,
         final List<LeafReaderContext> leafReaderContexts,
-        final Weight weight
+        final Weight weight,
+        ContextualProfileBreakdown profile
     ) throws IOException {
         List<Callable<Map<Integer, Float>>> tasks = new ArrayList<>(leafReaderContexts.size());
         for (LeafReaderContext leafReaderContext : leafReaderContexts) {
-            tasks.add(() -> searchLeaf(leafReaderContext, weight));
+            tasks.add(() -> {
+                if (profile != null) {
+                    Timer timer = profile.context(leafReaderContext).getTimer(LuceneEngineKnnTimingType.EXPAND_NESTED_ANN);
+                    timer.start();
+                    try {
+                        return searchLeaf(leafReaderContext, weight);
+                    } finally {
+                        timer.stop();
+                    }
+                }
+                return searchLeaf(leafReaderContext, weight);
+
+            });
         }
         return indexSearcher.getTaskExecutor().invokeAll(tasks);
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucene/ProfileDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucene/ProfileDiversifyingChildrenByteKnnVectorQuery.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.QueryTimeout;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.util.Bits;
+import org.opensearch.knn.profile.query.KNNMetrics;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.search.profile.Profilers;
+import org.opensearch.search.profile.Timer;
+
+import java.io.IOException;
+
+public class ProfileDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery {
+
+    private final Profilers profilers;
+
+    public ProfileDiversifyingChildrenByteKnnVectorQuery(
+        String field,
+        byte[] target,
+        Query childFilter,
+        int k,
+        BitSetProducer parentsFilter
+    ) {
+        super(field, target, childFilter, k, parentsFilter);
+        profilers = KNNMetrics.getProfilers();
+    }
+
+    @Override
+    protected TopDocs approximateSearch(
+        LeafReaderContext context,
+        Bits acceptDocs,
+        int visitedLimit,
+        KnnCollectorManager knnCollectorManager
+    ) throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.ANN_SEARCH);
+            timer.start();
+            try {
+                return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+    }
+
+    @Override
+    protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator, QueryTimeout queryTimeout)
+        throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.EXACT_SEARCH);
+            timer.start();
+            try {
+                return super.exactSearch(context, acceptIterator, queryTimeout);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.exactSearch(context, acceptIterator, queryTimeout);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/lucene/ProfileDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucene/ProfileDiversifyingChildrenFloatKnnVectorQuery.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.QueryTimeout;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.util.Bits;
+import org.opensearch.knn.profile.query.KNNMetrics;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.search.profile.Profilers;
+import org.opensearch.search.profile.Timer;
+
+import java.io.IOException;
+
+public class ProfileDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery {
+
+    private final Profilers profilers;
+
+    public ProfileDiversifyingChildrenFloatKnnVectorQuery(
+        String field,
+        float[] target,
+        Query childFilter,
+        int k,
+        BitSetProducer parentsFilter
+    ) {
+        super(field, target, childFilter, k, parentsFilter);
+        profilers = KNNMetrics.getProfilers();
+    }
+
+    @Override
+    protected TopDocs approximateSearch(
+        LeafReaderContext context,
+        Bits acceptDocs,
+        int visitedLimit,
+        KnnCollectorManager knnCollectorManager
+    ) throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.ANN_SEARCH);
+            timer.start();
+            try {
+                return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+    }
+
+    @Override
+    protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator, QueryTimeout queryTimeout)
+        throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.EXACT_SEARCH);
+            timer.start();
+            try {
+                return super.exactSearch(context, acceptIterator, queryTimeout);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.exactSearch(context, acceptIterator, queryTimeout);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/lucene/ProfileKnnByteVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucene/ProfileKnnByteVectorQuery.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.QueryTimeout;
+import org.apache.lucene.search.*;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.util.Bits;
+import org.opensearch.knn.profile.query.KNNMetrics;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.search.profile.Profilers;
+import org.opensearch.search.profile.Timer;
+
+import java.io.IOException;
+
+public class ProfileKnnByteVectorQuery extends KnnByteVectorQuery {
+
+    private final Profilers profilers;
+
+    public ProfileKnnByteVectorQuery(String field, byte[] target, int k, Query filter) {
+        super(field, target, k, filter);
+        profilers = KNNMetrics.getProfilers();
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        return super.rewrite(indexSearcher);
+    }
+
+    @Override
+    protected TopDocs approximateSearch(
+        LeafReaderContext context,
+        Bits acceptDocs,
+        int visitedLimit,
+        KnnCollectorManager knnCollectorManager
+    ) throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.ANN_SEARCH);
+            timer.start();
+            try {
+                return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+    }
+
+    @Override
+    protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator, QueryTimeout queryTimeout)
+        throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.EXACT_SEARCH);
+            timer.start();
+            try {
+                return super.exactSearch(context, acceptIterator, queryTimeout);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.exactSearch(context, acceptIterator, queryTimeout);
+    }
+
+}

--- a/src/main/java/org/opensearch/knn/index/query/lucene/ProfileKnnFloatVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucene/ProfileKnnFloatVectorQuery.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucene;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.QueryTimeout;
+import org.apache.lucene.search.*;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.util.Bits;
+import org.opensearch.knn.profile.query.KNNMetrics;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.search.profile.Profilers;
+import org.opensearch.search.profile.Timer;
+
+import java.io.IOException;
+
+public class ProfileKnnFloatVectorQuery extends KnnFloatVectorQuery {
+
+    private final Profilers profilers;
+
+    public ProfileKnnFloatVectorQuery(String field, float[] target, int k, Query filter) {
+        super(field, target, k, filter);
+        profilers = KNNMetrics.getProfilers();
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        return super.rewrite(indexSearcher);
+    }
+
+    @Override
+    protected TopDocs approximateSearch(
+        LeafReaderContext context,
+        Bits acceptDocs,
+        int visitedLimit,
+        KnnCollectorManager knnCollectorManager
+    ) throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.ANN_SEARCH);
+            timer.start();
+            try {
+                return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+    }
+
+    @Override
+    protected TopDocs exactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator, QueryTimeout queryTimeout)
+        throws IOException {
+        if (profilers != null) {
+            Timer timer = profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getTimer(LuceneEngineKnnTimingType.EXACT_SEARCH);
+            timer.start();
+            try {
+                return super.exactSearch(context, acceptIterator, queryTimeout);
+            } finally {
+                timer.stop();
+            }
+        }
+        return super.exactSearch(context, acceptIterator, queryTimeout);
+    }
+
+}

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/InternalNestedKnnByteVectoryQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/InternalNestedKnnByteVectoryQuery.java
@@ -14,6 +14,10 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+import org.opensearch.knn.profile.query.KNNMetrics;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.search.profile.Profilers;
+import org.opensearch.search.profile.Timer;
 
 import java.io.IOException;
 
@@ -52,6 +56,19 @@ public class InternalNestedKnnByteVectoryQuery extends KnnByteVectorQuery implem
 
     @Override
     public TopDocs knnExactSearch(LeafReaderContext context, DocIdSetIterator acceptIterator) throws IOException {
+        Profilers profilers = KNNMetrics.getProfilers();
+        if (profilers != null) {
+            Timer timer = (Timer) profilers.getCurrentQueryProfiler()
+                .getTopBreakdown()
+                .context(context)
+                .getMetric(LuceneEngineKnnTimingType.INTERNAL_EXACT.toString());
+            timer.start();
+            try {
+                return super.exactSearch(context, acceptIterator, null);
+            } finally {
+                timer.stop();
+            }
+        }
         return super.exactSearch(context, acceptIterator, null);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactory.java
@@ -7,9 +7,9 @@ package org.opensearch.knn.index.query.lucenelib;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
-import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
-import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.opensearch.knn.index.query.common.QueryUtils;
+import org.opensearch.knn.index.query.lucene.ProfileDiversifyingChildrenByteKnnVectorQuery;
+import org.opensearch.knn.index.query.lucene.ProfileDiversifyingChildrenFloatKnnVectorQuery;
 
 /**
  * A class to create a nested knn vector query for lucene
@@ -42,7 +42,7 @@ public class NestedKnnVectorQueryFactory {
                 new InternalNestedKnnByteVectoryQuery(fieldName, vector, filterQuery, k, parentFilter)
             ).queryUtils(QueryUtils.getInstance()).build();
         }
-        return new DiversifyingChildrenByteKnnVectorQuery(fieldName, vector, filterQuery, k, parentFilter);
+        return new ProfileDiversifyingChildrenByteKnnVectorQuery(fieldName, vector, filterQuery, k, parentFilter);
     }
 
     /**
@@ -72,6 +72,6 @@ public class NestedKnnVectorQueryFactory {
                 new InternalNestedKnnFloatVectoryQuery(fieldName, vector, filterQuery, k, parentFilter)
             ).queryUtils(QueryUtils.getInstance()).build();
         }
-        return new DiversifyingChildrenFloatKnnVectorQuery(fieldName, vector, filterQuery, k, parentFilter);
+        return new ProfileDiversifyingChildrenFloatKnnVectorQuery(fieldName, vector, filterQuery, k, parentFilter);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -24,6 +24,7 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
+import org.opensearch.search.profile.ContextualProfileBreakdown;
 
 import java.io.IOException;
 
@@ -40,8 +41,15 @@ import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 public class MemoryOptimizedKNNWeight extends KNNWeight {
     private final KnnCollectorManager knnCollectorManager;
 
-    public MemoryOptimizedKNNWeight(KNNQuery query, float boost, final Weight filterWeight, IndexSearcher searcher, int k) {
-        super(query, boost, filterWeight);
+    public MemoryOptimizedKNNWeight(
+        KNNQuery query,
+        float boost,
+        final Weight filterWeight,
+        IndexSearcher searcher,
+        int k,
+        ContextualProfileBreakdown profile
+    ) {
+        super(query, boost, filterWeight, profile);
 
         if (k > 0) {
             // ANN Search

--- a/src/main/java/org/opensearch/knn/profile/LongMetric.java
+++ b/src/main/java/org/opensearch/knn/profile/LongMetric.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.profile;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.opensearch.search.profile.ProfileMetric;
+
+import java.util.Map;
+
+public class LongMetric extends ProfileMetric {
+
+    @Getter
+    @Setter
+    private Long value;
+
+    public LongMetric(String name) {
+        super(name);
+        value = 0L;
+    }
+
+    @Override
+    public Map<String, Long> toBreakdownMap() {
+        return Map.of(getName(), value);
+    }
+}

--- a/src/main/java/org/opensearch/knn/profile/query/KNNMetrics.java
+++ b/src/main/java/org/opensearch/knn/profile/query/KNNMetrics.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.profile.query;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.opensearch.knn.profile.LongMetric;
+import org.opensearch.search.profile.ProfileMetric;
+import org.opensearch.search.profile.Profilers;
+import org.opensearch.search.profile.Timer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+public class KNNMetrics {
+
+    public static final String NUM_NESTED_DOCS = "num_nested_docs";
+    public static final String CARDINALITY = "cardinality";
+
+    @Getter
+    @Setter
+    private static Profilers profilers;
+
+    public static Collection<Supplier<ProfileMetric>> getKNNQueryMetrics() {
+        Collection<Supplier<ProfileMetric>> metrics = new ArrayList<>();
+        for (KNNQueryTimingType type : KNNQueryTimingType.values()) {
+            metrics.add(() -> new Timer(type.toString()));
+        }
+
+        metrics.add(() -> new LongMetric(CARDINALITY));
+
+        return metrics;
+    }
+
+    public static Collection<Supplier<ProfileMetric>> getNativeMetrics() {
+        Collection<Supplier<ProfileMetric>> metrics = getKNNQueryMetrics();
+        for (NativeEngineKnnTimingType type : NativeEngineKnnTimingType.values()) {
+            metrics.add(() -> new Timer(type.toString()));
+        }
+
+        metrics.add(() -> new LongMetric(NUM_NESTED_DOCS));
+
+        return metrics;
+    }
+
+    public static Collection<Supplier<ProfileMetric>> getLuceneMetrics() {
+        Collection<Supplier<ProfileMetric>> metrics = new ArrayList<>();
+        for (LuceneEngineKnnTimingType type : LuceneEngineKnnTimingType.values()) {
+            metrics.add(() -> new Timer(type.toString()));
+        }
+
+        return metrics;
+    }
+}

--- a/src/main/java/org/opensearch/knn/profile/query/KNNQueryTimingType.java
+++ b/src/main/java/org/opensearch/knn/profile/query/KNNQueryTimingType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.profile.query;
+
+import java.util.Locale;
+
+public enum KNNQueryTimingType {
+    ANN_SEARCH,
+    EXACT_SEARCH,
+    BITSET_CREATION,
+    EXACT_SEARCH_AFTER_ANN,
+    EXACT_SEARCH_AFTER_FILTER;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/opensearch/knn/profile/query/LuceneEngineKnnTimingType.java
+++ b/src/main/java/org/opensearch/knn/profile/query/LuceneEngineKnnTimingType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.profile.query;
+
+import java.util.Locale;
+
+public enum LuceneEngineKnnTimingType {
+    EXACT_SEARCH,
+    ANN_SEARCH,
+    EXPAND_NESTED_ANN,
+    BITSET_CREATION,
+    EXPAND_NESTED_EXACT,
+    INTERNAL_EXACT,
+    RESCORE;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/opensearch/knn/profile/query/NativeEngineKnnTimingType.java
+++ b/src/main/java/org/opensearch/knn/profile/query/NativeEngineKnnTimingType.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.profile.query;
+
+import java.util.Locale;
+
+public enum NativeEngineKnnTimingType {
+    EXPAND_NESTED_DOCS,
+    RESCORE;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -35,18 +35,18 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
+import org.opensearch.knn.profile.query.KNNMetrics;
+import org.opensearch.knn.profile.query.KNNQueryTimingType;
+import org.opensearch.knn.profile.query.LuceneEngineKnnTimingType;
+import org.opensearch.knn.profile.query.NativeEngineKnnTimingType;
+import org.opensearch.search.profile.query.QueryTimingType;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX;
-import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN;
+import static org.opensearch.knn.index.KNNSettings.*;
 
 public class OpenSearchIT extends KNNRestTestCase {
 
@@ -1252,6 +1252,525 @@ public class OpenSearchIT extends KNNRestTestCase {
 
         assertThat(EntityUtils.toString(exception.getResponse().getEntity()), containsString("name needs to be set"));
 
+    }
+
+    public void testKNNSearchWithProfilerEnabled() throws Exception {
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector1 = { (float) i, (float) (i + 1) };
+            Float[] vector2 = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDoc(INDEX_NAME, Integer.toString(i), Arrays.asList("vector1", "vector2"), Arrays.asList(vector1, vector2));
+        }
+        int k = 10; // nearest 10 neighbors
+
+        // Create knn search body, all fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "*" })
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        assertEquals(k, parseSearchResponseFieldsCount(responseBody, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(responseBody, "vector2"));
+
+        // Create knn search body, some fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("fields", new String[] { "vector1", "vector2" })
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        response = searchKNNIndex(INDEX_NAME, builder, k);
+        responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        assertEquals(k, parseSearchResponseFieldsCount(responseBody, "vector1"));
+        assertEquals(k, parseSearchResponseFieldsCount(responseBody, "vector2"));
+
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_LuceneNested() throws Exception {
+        int dimension = 3;
+        String nestedFieldPath = "nested_field.my_vector";
+        String mapping = createKnnIndexNestedMapping(dimension, nestedFieldPath, "lucene");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        for (int i = 1; i <= 20; ++i) {
+            Float[] vector = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDocWithNestedField(INDEX_NAME, Integer.toString(i), nestedFieldPath, vector);
+        }
+
+        int k = 10; // nearest 10 neighbors
+
+        // Create knn search body, all fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("nested")
+            .field("path", "nested_field")
+            .startObject("query")
+            .startObject("knn")
+            .startObject("nested_field.my_vector")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        List<Long> results = parseProfileMetric(responseBody, QueryTimingType.SCORE.toString(), true);
+        assertEquals(2, results.size());
+
+        // Create knn search body, all fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("nested")
+            .field("path", "nested_field")
+            .startObject("query")
+            .startObject("knn")
+            .startObject("nested_field.my_vector")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .field("expand_nested_docs", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        response = searchKNNIndex(INDEX_NAME, builder, k);
+        responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        results = parseProfileMetric(responseBody, NativeEngineKnnTimingType.RESCORE.toString(), true);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_FaissNested() throws Exception {
+        int dimension = 3;
+        String nestedFieldPath = "nested_field.my_vector";
+        String mapping = createKnnIndexNestedMapping(dimension, nestedFieldPath, "faiss");
+        createKnnIndex(INDEX_NAME, mapping);
+
+        for (int i = 1; i <= 20; ++i) {
+            Float[] vector = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDocWithNestedField(INDEX_NAME, Integer.toString(i), nestedFieldPath, vector);
+        }
+
+        int k = 10; // nearest 10 neighbors
+
+        // Create knn search body, all fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("nested")
+            .field("path", "nested_field")
+            .startObject("query")
+            .startObject("knn")
+            .startObject("nested_field.my_vector")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        List<Long> results = parseProfileMetric(responseBody, NativeEngineKnnTimingType.EXPAND_NESTED_DOCS.toString(), true);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, NativeEngineKnnTimingType.RESCORE.toString(), true);
+        for (Long result : results) {
+            assertEquals(0L, result.longValue());
+        }
+
+        // Create knn search body, all fields
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("nested")
+            .field("path", "nested_field")
+            .startObject("query")
+            .startObject("knn")
+            .startObject("nested_field.my_vector")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", k)
+            .field("expand_nested_docs", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        response = searchKNNIndex(INDEX_NAME, builder, k);
+        responseBody = EntityUtils.toString(response.getEntity());
+        results = parseProfileMetric(responseBody, NativeEngineKnnTimingType.EXPAND_NESTED_DOCS.toString(), true);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, NativeEngineKnnTimingType.RESCORE.toString(), true);
+        for (Long result : results) {
+            assertEquals(0L, result.longValue());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_MultipleResults() throws Exception {
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector1 = { (float) i, (float) (i + 1) };
+            Float[] vector2 = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDoc(INDEX_NAME, Integer.toString(i), Arrays.asList("vector1", "vector2"), Arrays.asList(vector1, vector2));
+        }
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("bool")
+            .startArray("should")
+            .startObject()
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("k", 5)
+            .endObject()
+            .endObject()
+            .endObject()
+            .startObject()
+            .startObject("knn")
+            .startObject("vector1")
+            .field("vector", new float[] { 3.0f, 3.0f })
+            .field("k", 3)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, 10);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        List<Long> result = parseProfileMetric(responseBody, QueryTimingType.SCORE.toString(), true);
+        assertEquals(2, result.size());
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_LuceneFilter() throws Exception {
+        int dim = 3;
+        String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "lucene", "l2", false);
+        createKnnIndex(INDEX_NAME, mapping);
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDocWithNumericField(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector, "rating", i);
+        }
+        float[] query = new float[dim];
+        Arrays.fill(query, 2);
+
+        int k = 1;
+        // Create knn search, P <= k
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", query)
+            .field("k", k)
+            .startObject("filter")
+            .startObject("bool")
+            .startArray("must")
+            .startObject()
+            .startObject("range")
+            .startObject("rating")
+            .field("gte", 8)
+            .field("lte", 14)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        List<Long> results = parseProfileMetric(responseBody, LuceneEngineKnnTimingType.EXACT_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, LuceneEngineKnnTimingType.ANN_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_FaissFilter() throws Exception {
+        int dim = 3;
+        String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "faiss", "l2", false);
+        createKnnIndex(INDEX_NAME, mapping);
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDocWithNumericField(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector, "rating", i);
+        }
+        float[] query = new float[dim];
+        Arrays.fill(query, 2);
+
+        int k = 7;
+        // Create knn search, P <= k
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", query)
+            .field("k", k)
+            .startObject("filter")
+            .startObject("bool")
+            .startArray("must")
+            .startObject()
+            .startObject("range")
+            .startObject("rating")
+            .field("gte", 8)
+            .field("lte", 14)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        List<Long> results = parseProfileMetric(responseBody, KNNMetrics.CARDINALITY, false);
+        for (Long result : results) {
+            assertEquals(7L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, KNNQueryTimingType.ANN_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertEquals(0L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, KNNQueryTimingType.EXACT_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+
+        // update FT so that ANN is performed (filtered result P = 7)
+        updateIndexSettings(INDEX_NAME, Settings.builder().put(ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 3));
+
+        k = 1;
+        // Create knn search, P > k
+        builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", query)
+            .field("k", k)
+            .startObject("filter")
+            .startObject("bool")
+            .startArray("must")
+            .startObject()
+            .startObject("range")
+            .startObject("rating")
+            .field("gte", 8)
+            .field("lte", 14)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        response = searchKNNIndex(INDEX_NAME, builder, k);
+        responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        results = parseProfileMetric(responseBody, KNNMetrics.CARDINALITY, false);
+        for (Long result : results) {
+            assertEquals(7L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, KNNQueryTimingType.ANN_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, KNNQueryTimingType.EXACT_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_Rescore() throws Exception {
+        int dim = 3;
+        int k = 2;
+        createOnDiskIndex(INDEX_NAME, dim, SpaceType.L2); // by default uses 32x and FAISS IVF
+
+        float[][] vectors = new float[1][dim];
+        for (int i = 0; i < dim; i++) {
+            vectors[0][i] = 2;
+        }
+        bulkAddKnnDocs(INDEX_NAME, FIELD_NAME, vectors, vectors.length);
+        refreshIndex(INDEX_NAME);
+        float[] query = new float[dim];
+        Arrays.fill(query, 1);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", query)
+            .field("k", k)
+            .field("rescore", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+
+        String responseString = EntityUtils.toString(response.getEntity());
+        System.out.println(responseString);
+        assertEquals(1, parseIds(responseString).size());
+        List<Long> results = parseProfileMetric(responseString, NativeEngineKnnTimingType.RESCORE.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_RescoreLucene() throws Exception {
+        int dim = 3;
+        int k = 2;
+        String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "lucene", "l2", false);
+        createKnnIndex(INDEX_NAME, mapping);
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDocWithNumericField(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector, "rating", i);
+        }
+        float[] query = new float[dim];
+        Arrays.fill(query, 2);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", query)
+            .field("k", k)
+            .field("rescore", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+
+        String responseString = EntityUtils.toString(response.getEntity());
+        System.out.println(responseString);
+        assertEquals(2, parseIds(responseString).size());
+        List<Long> results = parseProfileMetric(responseString, LuceneEngineKnnTimingType.RESCORE.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void testKNNSearchWithProfilerEnabled_Radial() throws Exception {
+        createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
+        // Add docs with knn_vector fields
+        for (int i = 1; i <= 20; i++) {
+            Float[] vector1 = { (float) i, (float) (i + 1) };
+            Float[] vector2 = { (float) i, (float) (i + 1), (float) (i + 2) };
+            addKnnDoc(INDEX_NAME, Integer.toString(i), Arrays.asList("vector1", "vector2"), Arrays.asList(vector1, vector2));
+        }
+        int k = 10; // nearest 10 neighbors
+
+        // Create knn search body, all fields
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("profile", true)
+            .startObject("query")
+            .startObject("knn")
+            .startObject("vector2")
+            .field("vector", new float[] { 2.0f, 2.0f, 2.0f })
+            .field("max_distance", 10)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Response response = searchKNNIndex(INDEX_NAME, builder, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        System.out.println(responseBody);
+        List<Long> results = parseProfileMetric(responseBody, KNNQueryTimingType.ANN_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertNotEquals(0L, result.longValue());
+        }
+        results = parseProfileMetric(responseBody, KNNQueryTimingType.EXACT_SEARCH.toString(), false);
+        for (Long result : results) {
+            assertEquals(0L, result.longValue());
+        }
+        deleteKNNIndex(INDEX_NAME);
     }
 
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -191,7 +191,7 @@ public class ExplainTests extends KNNWeightTestCase {
         query.setExplain(true);
 
         final float boost = 1;
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         // When
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
@@ -263,7 +263,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .rescoreContext(rescoreContext)
             .explain(true)
             .build();
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 1.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 1.0f, null, null);
 
         final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
             // setting to true, so that if quantization details are present we want to do search on the quantized
@@ -339,7 +339,7 @@ public class ExplainTests extends KNNWeightTestCase {
 
         final float boost = 1;
 
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         // When
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
@@ -415,7 +415,7 @@ public class ExplainTests extends KNNWeightTestCase {
         query.setExplain(true);
 
         final float boost = 1;
-        KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         // When
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
@@ -466,7 +466,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .vectorDataType(VectorDataType.FLOAT)
             .explain(true)
             .build();
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 1.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 1.0f, null, null);
 
         Map<String, String> attributesMap = Map.of(
             SPACE_TYPE,
@@ -547,7 +547,7 @@ public class ExplainTests extends KNNWeightTestCase {
 
             query.setExplain(true);
             final float boost = (float) randomDoubleBetween(0, 10, true);
-            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
             final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
             assertNotNull(knnScorer);
@@ -601,7 +601,7 @@ public class ExplainTests extends KNNWeightTestCase {
         query.setExplain(true);
 
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
@@ -653,7 +653,7 @@ public class ExplainTests extends KNNWeightTestCase {
         query.setExplain(true);
 
         final float boost = 1;
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
         knnWeight.getKnnExplanation().addKnnScorer(leafReaderContext, knnScorer);
@@ -725,7 +725,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .methodParameters(HNSW_METHOD_PARAMETERS)
             .build();
         final float boost = 1;
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
 
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
         assertNotNull(knnScorer);
@@ -818,7 +818,7 @@ public class ExplainTests extends KNNWeightTestCase {
             .methodParameters(HNSW_METHOD_PARAMETERS)
             .build();
         final float boost = 1;
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
         final ExactSearcher.ExactSearcherContext exactSearchContext = ExactSearcher.ExactSearcherContext.builder()
             // setting to true, so that if quantization details are present we want to do search on the quantized
             // vectors as this flow is used in first pass of search.

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -165,7 +165,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
 
         KNNWeight.initialize(modelDao);
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -229,7 +229,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(modelMetadata.getSpaceType()).thenReturn(spaceType);
 
         KNNWeight.initialize(modelDao);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -255,7 +255,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
     public void testScorer_whenNoVectorFieldsInDocument_thenEmptyScorerIsReturned() {
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, null);
         KNNWeight.initialize(null);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -299,7 +299,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .thenReturn(knnQueryResults);
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, null);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -397,7 +397,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
                 .build();
 
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
         final FieldInfos fieldInfos = mock(FieldInfos.class);
         final FieldInfo fieldInfo = mock(FieldInfo.class);
         final Map<String, String> attributesMap = ImmutableMap.of(
@@ -480,7 +480,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .build();
 
         final float boost = 1.0F;
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -628,7 +628,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(filterScorer.iterator()).thenReturn(DocIdSetIterator.all(filterDocIds.length + 1));
 
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         final FieldInfos fieldInfos = mock(FieldInfos.class);
         final FieldInfo fieldInfo = mock(FieldInfo.class);
@@ -726,7 +726,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(filterScorer.iterator()).thenReturn(DocIdSetIterator.all(filterDocIds.length + 1));
 
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         final FieldInfos fieldInfos = mock(FieldInfos.class);
         final FieldInfo fieldInfo = mock(FieldInfo.class);
@@ -828,7 +828,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             when(liveDocsBits.get(filterDocId)).thenReturn(true);
 
             final float boost = (float) randomDoubleBetween(0, 10, true);
-            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
             final Map<String, String> attributesMap = ImmutableMap.of(
                 KNN_ENGINE,
                 KNNEngine.FAISS.getName(),
@@ -911,7 +911,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .indexName(INDEX_NAME)
             .methodParameters(HNSW_METHOD_PARAMETERS)
             .build();
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 1.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 1.0f, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -1001,7 +1001,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(liveDocsBits.get(filterDocId)).thenReturn(true);
 
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
         final Map<String, String> attributesMap = ImmutableMap.of(
             KNN_ENGINE,
             KNNEngine.FAISS.getName(),
@@ -1082,7 +1082,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, k, INDEX_NAME, FILTER_QUERY, null, null);
 
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
         final Map<String, String> attributesMap = ImmutableMap.of(
             KNN_ENGINE,
             KNNEngine.FAISS.getName(),
@@ -1173,7 +1173,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             );
 
             final float boost = (float) randomDoubleBetween(0, 10, true);
-            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
             final Map<String, String> attributesMap = ImmutableMap.of(
                 KNN_ENGINE,
                 KNNEngine.FAISS.getName(),
@@ -1227,7 +1227,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(filterScorer.iterator()).thenReturn(DocIdSetIterator.empty());
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, FILTER_QUERY, null, null);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, filterQueryWeight, null);
 
         final FieldInfos fieldInfos = mock(FieldInfos.class);
         final FieldInfo fieldInfo = mock(FieldInfo.class);
@@ -1276,7 +1276,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
 
         final KNNQuery query = new KNNQuery(FIELD_NAME, QUERY_VECTOR, K, INDEX_NAME, FILTER_QUERY, parentFilter, null);
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, filterQueryWeight, null);
 
         // Execute
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);
@@ -1328,7 +1328,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .methodParameters(HNSW_METHOD_PARAMETERS)
             .parentsFilter(bitSetProducer)
             .build();
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, 0.0f, null, null);
         // Execute
         Scorer knnScorer = knnWeight.scorer(leafReaderContext);
 
@@ -1381,7 +1381,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .methodParameters(HNSW_METHOD_PARAMETERS)
             .build();
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -1523,7 +1523,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             .methodParameters(HNSW_METHOD_PARAMETERS)
             .build();
         final float boost = (float) randomDoubleBetween(0, 10, true);
-        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+        final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
 
         final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
         final SegmentReader reader = mock(SegmentReader.class);
@@ -1620,7 +1620,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
                 .build();
 
             final float boost = (float) randomDoubleBetween(0, 10, true);
-            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+            final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
             final FieldInfos fieldInfos = mock(FieldInfos.class);
             final FieldInfo fieldInfo = mock(FieldInfo.class);
             final Map<String, String> attributesMap = ImmutableMap.of(
@@ -1704,7 +1704,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
                     .build();
 
                 final float boost = (float) randomDoubleBetween(0, 10, true);
-                final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null);
+                final KNNWeight knnWeight = new DefaultKNNWeight(query, boost, null, null);
                 final FieldInfos fieldInfos = mock(FieldInfos.class);
                 final FieldInfo fieldInfo = mock(FieldInfo.class);
                 final Map<String, String> attributesMap = ImmutableMap.of(

--- a/src/test/java/org/opensearch/knn/index/query/common/QueryUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/common/QueryUtilsTests.java
@@ -66,7 +66,7 @@ public class QueryUtilsTests extends TestCase {
         when(weight.scorer(leafReaderContext2)).thenReturn(scorer);
 
         // Run
-        List<Map<Integer, Float>> results = queryUtils.doSearch(indexSearcher, leafReaderContexts, weight);
+        List<Map<Integer, Float>> results = queryUtils.doSearch(indexSearcher, leafReaderContexts, weight, null);
 
         // Verify
         assertEquals(2, results.size());

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/ExpandNestedEDocsQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/ExpandNestedEDocsQueryTests.java
@@ -121,7 +121,7 @@ public class ExpandNestedEDocsQueryTests extends TestCase {
         when(finalQuery.createWeight(indexSearcher, scoreMode, boost)).thenReturn(expectedWeight);
 
         QueryUtils queryUtils = mock(QueryUtils.class);
-        when(queryUtils.doSearch(indexSearcher, reader.leaves(), queryWeight)).thenReturn(perLeafResults);
+        when(queryUtils.doSearch(indexSearcher, reader.leaves(), queryWeight, null)).thenReturn(perLeafResults);
         when(queryUtils.createBits(any(), any())).thenReturn(queryFilterBits);
         when(queryUtils.getAllSiblings(any(), any(), any(), any())).thenReturn(allSiblings);
         when(queryUtils.createDocAndScoreQuery(eq(reader), any())).thenReturn(finalQuery);

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -712,6 +712,43 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Utility to create a Knn Index Mapping with nested field
+     *
+     * @param dimensions dimension of the vector
+     * @param fieldPath  path of the nested field, e.g. "my_nested_field.my_vector"
+     * @return mapping string for the nested field
+     */
+    protected String createKnnIndexNestedMapping(Integer dimensions, String fieldPath, String engine) throws IOException {
+        String[] fieldPathArray = fieldPath.split("\\.");
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+
+        for (int i = 0; i < fieldPathArray.length; i++) {
+            xContentBuilder.startObject(fieldPathArray[i]);
+            if (i == fieldPathArray.length - 1) {
+                xContentBuilder.field("type", "knn_vector")
+                    .field("dimension", dimensions.toString())
+                    .startObject(KNN_METHOD)
+                    .field(NAME, METHOD_HNSW)
+                    .field(KNN_ENGINE, engine)
+                    .endObject();
+            } else {
+                xContentBuilder.field("type", "nested").startObject("properties");
+            }
+        }
+
+        for (int i = fieldPathArray.length - 1; i >= 0; i--) {
+            if (i != fieldPathArray.length - 1) {
+                xContentBuilder.endObject();
+            }
+            xContentBuilder.endObject();
+        }
+
+        xContentBuilder.endObject().endObject();
+
+        return xContentBuilder.toString();
+    }
+
+    /**
      * Get index mapping as map
      *
      * @param index name of index to fetch
@@ -820,6 +857,32 @@ public class KNNRestTestCase extends ODFERestTestCase {
         builder.endObject();
 
         Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
+        request.setJsonEntity(builder.toString());
+        client().performRequest(request);
+
+        request = new Request("POST", "/" + index + "/_refresh");
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+    }
+
+    /**
+     * Add a single KNN Doc with a numeric field to an index
+     */
+    protected <T> void addKnnDocWithNumericField(
+        String index,
+        String docId,
+        String vectorFieldName,
+        T vector,
+        String numericFieldName,
+        long val
+    ) throws IOException {
+        Request request = new Request("POST", "/" + index + "/_doc/" + docId + "?refresh=true");
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(vectorFieldName, vector)
+            .field(numericFieldName, val)
+            .endObject();
         request.setJsonEntity(builder.toString());
         client().performRequest(request);
 
@@ -1271,6 +1334,23 @@ public class KNNRestTestCase extends ODFERestTestCase {
         ).map().get("hits")).get("hits");
 
         return hits.stream().map(hit -> (Double) ((Map<String, Object>) hit).get("_score")).collect(Collectors.toList());
+    }
+
+    protected List<Long> parseProfileMetric(String searchResponseBody, String metric, boolean children) {
+        List<Object> values;
+        if (children) {
+            values = JsonPath.read(
+                searchResponseBody,
+                String.format(Locale.ROOT, "$.profile.shards[*].searches[*].query[*].children[*].breakdown.%s", metric)
+            );
+        } else {
+            values = JsonPath.read(
+                searchResponseBody,
+                String.format(Locale.ROOT, "$.profile.shards[*].searches[*].query[*].breakdown.%s", metric)
+            );
+        }
+        if (values == null) throw new RuntimeException("Could not find metric in profile breakdown");
+        return values.stream().map(value -> ((Number) value).longValue()).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
### Description
Adds Exact Search and ANN Search timing info to the profile breakdown for each `KNNQuery`, `NativeEngineKnnVectorQuery` or `LuceneEngineKnnVectorQuery`. **Currently, the core repo has a PR to implement a plugin extension point (https://github.com/opensearch-project/OpenSearch/pull/18656). Until then, `KNNPlugin` is still a WIP so please ignore.** 

Timers are found in the enums `KNNQueryTimingType`, `LuceneEngineKnnTimingType`, `NativeEngineTimingType`. In addition, the filter cardinality (KNNQuery, Native query) and num_nested_docs (Native query) stats are included in the profile breakdown. Feel free to suggest changes or more timers/other stats to the profiler!

### Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/pull/17146
Resolves https://github.com/opensearch-project/k-NN/issues/2286
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
