### PR TITLE
Enable ACORN when having filtering rate < 60% for LuceneOnFaiss

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -38,6 +38,9 @@ import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
  */
 @Log4j2
 public class MemoryOptimizedKNNWeight extends KNNWeight {
+    // Enable ACORN optimization when having filtering rate < 60%.
+    private static final KnnSearchStrategy.Hnsw DEFAULT_HNSW_SEARCH_STRATEGY = new KnnSearchStrategy.Hnsw(60);
+
     private final KnnCollectorManager knnCollectorManager;
 
     public MemoryOptimizedKNNWeight(KNNQuery query, float boost, final Weight filterWeight, IndexSearcher searcher, int k) {
@@ -171,7 +174,7 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         }
 
         // Create a collector + bitset
-        final KnnCollector knnCollector = knnCollectorManager.newCollector(visitedLimit, KnnSearchStrategy.Hnsw.DEFAULT, context);
+        final KnnCollector knnCollector = knnCollectorManager.newCollector(visitedLimit, DEFAULT_HNSW_SEARCH_STRATEGY, context);
         final BitSet bitSet = cardinality == 0 ? null : filterIdsBitSet;
 
         // Start searching index


### PR DESCRIPTION
### Description
Enabling [ACORN](https://github.com/apache/lucene/pull/14160) when filtering rate < 60% for LuceneOnFaiss.
Lucene's main branch is applying Acorn for 60% filtering case -- [code](https://github.com/apache/lucene/blame/main/lucene/core/src/java/org/apache/lucene/search/knn/KnnSearchStrategy.java#L30)
But this is disabled by default in release/lucene/10.2.2 branch that we're using -- [code](https://github.com/apache/lucene/blame/releases/lucene/10.2.2/lucene/core/src/java/org/apache/lucene/search/knn/KnnSearchStrategy.java#L30)

Therefore, we enabling the optimization in KNN.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
