### PR TITLE
[Backporting to 3.1] Enable ACORN when having filtering rate < 60% for LuceneOnFaiss

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -37,6 +37,9 @@ import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
  */
 @Log4j2
 public class MemoryOptimizedKNNWeight extends KNNWeight {
+    // Enable ACORN optimization when having filtering rate < 60%.
+    private static final KnnSearchStrategy.Hnsw DEFAULT_HNSW_SEARCH_STRATEGY = new KnnSearchStrategy.Hnsw(60);
+
     private final KnnCollectorManager knnCollectorManager;
 
     public MemoryOptimizedKNNWeight(KNNQuery query, float boost, final Weight filterWeight, IndexSearcher searcher, int k) {
@@ -168,7 +171,7 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         }
 
         // Create a collector + bitset
-        final KnnCollector knnCollector = knnCollectorManager.newCollector(visitedLimit, KnnSearchStrategy.Hnsw.DEFAULT, context);
+        final KnnCollector knnCollector = knnCollectorManager.newCollector(visitedLimit, DEFAULT_HNSW_SEARCH_STRATEGY, context);
         final BitSet bitSet = cardinality == 0 ? null : filterIdsBitSet;
 
         // Start searching index


### PR DESCRIPTION
### Description
Backporting https://github.com/opensearch-project/k-NN/pull/2791