### PR TITLE
Remove accessUnixDomainSocket permission

### DIFF
--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -6,7 +6,6 @@ grant {
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512";
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512_spr";
     permission java.net.SocketPermission "*", "connect,resolve";
-    permission java.net.NetPermission "accessUnixDomainSocket";
     permission java.lang.RuntimePermission "accessDeclaredMembers";
     permission java.io.FilePermission "/proc/cpuinfo", "read";
 };


### PR DESCRIPTION
### Description
Testing to see if rvib client works without accessUnixDomainSocket permission on windows.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
