### PR TITLE
Fix @ collision in NativeMemoryCacheKeyHelper and add unit tests

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/util/NativeMemoryCacheKeyHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/NativeMemoryCacheKeyHelper.java
@@ -10,6 +10,9 @@ import org.apache.lucene.index.SegmentInfo;
 import java.util.Base64;
 
 public final class NativeMemoryCacheKeyHelper {
+
+    public static final String KEY_DELIMITER = "@";
+
     private NativeMemoryCacheKeyHelper() {}
 
     /**
@@ -22,7 +25,7 @@ public final class NativeMemoryCacheKeyHelper {
      */
     public static String constructCacheKey(final String vectorIndexFileName, final SegmentInfo segmentInfo) {
         final String segmentId = Base64.getEncoder().encodeToString(segmentInfo.getId());
-        final String cacheKey = vectorIndexFileName + "@" + segmentId;
+        final String cacheKey = vectorIndexFileName + KEY_DELIMITER + segmentId;
         return cacheKey;
     }
 
@@ -35,7 +38,7 @@ public final class NativeMemoryCacheKeyHelper {
      * @return : Vector file name, if the given cacheKey was invalid format, returns null.
      */
     public static String extractVectorIndexFileName(final String cacheKey) {
-        final int indexOfDelimiter = cacheKey.indexOf('@');
+        final int indexOfDelimiter = cacheKey.lastIndexOf(KEY_DELIMITER);
         if (indexOfDelimiter != -1) {
             final String vectorFileName = cacheKey.substring(0, indexOfDelimiter);
             return vectorFileName;

--- a/src/test/java/org/opensearch/knn/index/codec/util/NativeMemoryCacheKeyHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/util/NativeMemoryCacheKeyHelperTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.util;
+
+import org.apache.lucene.index.SegmentInfo;
+import org.opensearch.knn.KNNTestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NativeMemoryCacheKeyHelperTests extends KNNTestCase {
+
+    public void test_constructCacheKey_thenSuccess() {
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        when(segmentInfo.getId()).thenReturn(new byte[] { 1, 2, 3, 4 });
+
+        String result = NativeMemoryCacheKeyHelper.constructCacheKey("test.faiss", segmentInfo);
+
+        assertTrue(result.contains("@"));
+        assertTrue(result.startsWith("test.faiss@"));
+    }
+
+    public void test_extractVectorIndexFileName_thenSuccess() {
+        String result = NativeMemoryCacheKeyHelper.extractVectorIndexFileName("_0_165_test_field.faiss@AQIDBA==");
+
+        assertEquals("_0_165_test_field.faiss", result);
+    }
+
+    public void test_extractVectorIndexFileNameWithAtInFilename_thenSuccess() {
+        String result = NativeMemoryCacheKeyHelper.extractVectorIndexFileName("test@field.faiss@AQIDBA==");
+
+        assertEquals("test@field.faiss", result);
+    }
+
+    public void test_extractVectorIndexFileNameInvalidFormat_thenReturnsNull() {
+        String result = NativeMemoryCacheKeyHelper.extractVectorIndexFileName("invalidkey");
+
+        assertNull(result);
+    }
+
+    public void test_roundTripWithAtInFilename_thenSuccess() {
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        when(segmentInfo.getId()).thenReturn(new byte[] { 1, 2, 3, 4 });
+        String originalFileName = "test@field@name.faiss";
+
+        String cacheKey = NativeMemoryCacheKeyHelper.constructCacheKey(originalFileName, segmentInfo);
+        String extractedFileName = NativeMemoryCacheKeyHelper.extractVectorIndexFileName(cacheKey);
+
+        assertEquals(originalFileName, extractedFileName);
+    }
+}


### PR DESCRIPTION
Change:
- Use lastIndexOf('@') instead of indexOf('@') to handle filenames containing '@'
- Add comprehensive unit tests covering edge cases and collision scenarios

Fixes issue where vector index filenames containing '@' characters would be incorrectly parsed when extracting from cache keys.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
