### PR TITLE
Bumping up Faiss from 0cbc2a885cde923d80c4bf9c9d6f4d81665f3f64 to 2929bf471bcfbc161e6e97356d33582af29a6c05

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -65,7 +65,7 @@ pip install cmake==3.24.0
 
 #### Faiss Dependencies
 
-To build the *faiss* JNI library, you need to have openmp, lapack and blas installed. For more information on *faiss* 
+To build the *faiss* JNI library, you need to have openmp, lapack, gflags and blas installed. For more information on *faiss* 
 dependencies, please refer to [their documentation](https://github.com/facebookresearch/faiss/blob/main/INSTALL.md).
 
 [Openblas](https://www.openblas.net/) can be used for both lapack and blas. To install on Mac, run:
@@ -81,6 +81,11 @@ brew install libomp
 Additionally, the `gcc` toolchain might need to be installed on Mac. To install, run:
 ```bash
 brew install gcc
+```
+
+Lastly, `gflags` is required. To install, run:
+```bash
+brew install gflags
 ```
 
 ## Use an Editor

--- a/jni/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch
+++ b/jni/patches/faiss/0001-Custom-patch-to-support-multi-vector.patch
@@ -1,4 +1,4 @@
-From e775a8e65da96232822d5aed77f538592fccffda Mon Sep 17 00:00:00 2001
+From e9e7e9d82a0a7bbeebceaa6bb85213a1164f6acf Mon Sep 17 00:00:00 2001
 From: Heemin Kim <heemin@amazon.com>
 Date: Tue, 30 Jan 2024 14:43:56 -0800
 Subject: [PATCH] Add IDGrouper for HNSW
@@ -17,8 +17,9 @@ Signed-off-by: Heemin Kim <heemin@amazon.com>
  faiss/utils/GroupHeap.h    | 182 ++++++++++++++++++++++++++++
  tests/CMakeLists.txt       |   2 +
  tests/test_group_heap.cpp  |  98 +++++++++++++++
+ tests/test_hamming.cpp     |  10 +-
  tests/test_id_grouper.cpp  | 241 +++++++++++++++++++++++++++++++++++++
- 13 files changed, 889 insertions(+), 4 deletions(-)
+ 14 files changed, 894 insertions(+), 9 deletions(-)
  create mode 100644 faiss/impl/IDGrouper.cpp
  create mode 100644 faiss/impl/IDGrouper.h
  create mode 100644 faiss/utils/GroupHeap.h
@@ -26,10 +27,10 @@ Signed-off-by: Heemin Kim <heemin@amazon.com>
  create mode 100644 tests/test_id_grouper.cpp
 
 diff --git a/faiss/CMakeLists.txt b/faiss/CMakeLists.txt
-index 2871d974..d0bcec6a 100644
+index 0ad036967..8ee79bd9f 100644
 --- a/faiss/CMakeLists.txt
 +++ b/faiss/CMakeLists.txt
-@@ -55,6 +55,7 @@ set(FAISS_SRC
+@@ -56,6 +56,7 @@ set(FAISS_SRC
    impl/AuxIndexStructures.cpp
    impl/CodePacker.cpp
    impl/IDSelector.cpp
@@ -37,7 +38,7 @@ index 2871d974..d0bcec6a 100644
    impl/FaissException.cpp
    impl/HNSW.cpp
    impl/NSG.cpp
-@@ -151,6 +152,7 @@ set(FAISS_HEADERS
+@@ -156,6 +157,7 @@ set(FAISS_HEADERS
    impl/AuxIndexStructures.h
    impl/CodePacker.h
    impl/IDSelector.h
@@ -45,19 +46,19 @@ index 2871d974..d0bcec6a 100644
    impl/DistanceComputer.h
    impl/FaissAssert.h
    impl/FaissException.h
-@@ -186,6 +188,7 @@ set(FAISS_HEADERS
-   invlists/InvertedListsIOHook.h
+@@ -198,6 +200,7 @@ set(FAISS_HEADERS
+   invlists/OnDiskInvertedLists.h
    utils/AlignedTable.h
    utils/bf16.h
 +  utils/GroupHeap.h
    utils/Heap.h
+   utils/NeuralNet.h
    utils/WorkerThread.h
-   utils/distances.h
 diff --git a/faiss/Index.h b/faiss/Index.h
-index f57140ec..8f511e5d 100644
+index f189bf3af..0f4b0b2fa 100644
 --- a/faiss/Index.h
 +++ b/faiss/Index.h
-@@ -51,8 +51,9 @@
+@@ -53,8 +53,9 @@
  namespace faiss {
  
  /// Forward declarations see impl/AuxIndexStructures.h, impl/IDSelector.h
@@ -68,7 +69,7 @@ index f57140ec..8f511e5d 100644
  struct RangeSearchResult;
  struct DistanceComputer;
  
-@@ -64,6 +65,9 @@ struct DistanceComputer;
+@@ -88,6 +89,9 @@ inline size_t get_numeric_type_size(NumericType numeric_type) {
  struct SearchParameters {
      /// if non-null, only these IDs will be considered during search.
      IDSelector* sel = nullptr;
@@ -79,35 +80,35 @@ index f57140ec..8f511e5d 100644
      virtual ~SearchParameters() {}
  };
 diff --git a/faiss/IndexHNSW.cpp b/faiss/IndexHNSW.cpp
-index 6a1186ca..9c8a8255 100644
+index 7af8adb3b..0f912b003 100644
 --- a/faiss/IndexHNSW.cpp
 +++ b/faiss/IndexHNSW.cpp
-@@ -301,10 +301,17 @@ void IndexHNSW::search(
-         const SearchParameters* params_in) const {
+@@ -305,10 +305,17 @@ void IndexHNSW::search(
+         const SearchParameters* params) const {
      FAISS_THROW_IF_NOT(k > 0);
  
 -    using RH = HeapBlockResultHandler<HNSW::C>;
 -    RH bres(n, distances, labels, k);
-+    if (params_in && params_in->grp) {
++    if (params && params->grp) {
 +        using RH = GroupedHeapBlockResultHandler<HNSW::C>;
-+        RH bres(n, distances, labels, k, params_in->grp);
++        RH bres(n, distances, labels, k, params->grp);
  
--    hnsw_search(this, n, x, bres, params_in);
-+        hnsw_search(this, n, x, bres, params_in);
+-    hnsw_search(this, n, x, bres, params);
++        hnsw_search(this, n, x, bres, params);
 +    } else {
 +        using RH = HeapBlockResultHandler<HNSW::C>;
 +        RH bres(n, distances, labels, k);
 +
-+        hnsw_search(this, n, x, bres, params_in);
++        hnsw_search(this, n, x, bres, params);
 +    }
  
      if (is_similarity_metric(this->metric_type)) {
          // we need to revert the negated distances
 diff --git a/faiss/IndexIDMap.cpp b/faiss/IndexIDMap.cpp
-index dc84052b..3f375e7b 100644
+index 595851116..123e8f2ff 100644
 --- a/faiss/IndexIDMap.cpp
 +++ b/faiss/IndexIDMap.cpp
-@@ -102,6 +102,23 @@ struct ScopedSelChange {
+@@ -164,6 +164,23 @@ struct ScopedSelChange {
      }
  };
  
@@ -131,7 +132,7 @@ index dc84052b..3f375e7b 100644
  } // namespace
  
  template <typename IndexT>
-@@ -114,6 +131,8 @@ void IndexIDMapTemplate<IndexT>::search(
+@@ -177,6 +194,8 @@ void IndexIDMapTemplate<IndexT>::search(
          const SearchParameters* params) const {
      IDSelectorTranslated this_idtrans(this->id_map, nullptr);
      ScopedSelChange sel_change;
@@ -140,7 +141,7 @@ index dc84052b..3f375e7b 100644
  
      if (params && params->sel) {
          auto idtrans = dynamic_cast<const IDSelectorTranslated*>(params->sel);
-@@ -131,6 +150,16 @@ void IndexIDMapTemplate<IndexT>::search(
+@@ -194,6 +213,16 @@ void IndexIDMapTemplate<IndexT>::search(
              sel_change.set(params_non_const, &this_idtrans);
          }
      }
@@ -154,11 +155,11 @@ index dc84052b..3f375e7b 100644
 +            grp_change.set(params_non_const, &this_idgrptrans);
 +        }
 +    }
-     index->search(n, x, k, distances, labels, params);
+     index->search(n, x, numeric_type, k, distances, labels, params);
      idx_t* li = labels;
  #pragma omp parallel for
 diff --git a/faiss/IndexIDMap.h b/faiss/IndexIDMap.h
-index 2d164123..a68887bd 100644
+index cfe43377e..6a5fa92a5 100644
 --- a/faiss/IndexIDMap.h
 +++ b/faiss/IndexIDMap.h
 @@ -9,6 +9,7 @@
@@ -169,7 +170,7 @@ index 2d164123..a68887bd 100644
  #include <faiss/impl/IDSelector.h>
  
  #include <unordered_map>
-@@ -124,4 +125,25 @@ struct IDSelectorTranslated : IDSelector {
+@@ -147,4 +148,25 @@ struct IDSelectorTranslated : IDSelector {
      }
  };
  
@@ -196,10 +197,10 @@ index 2d164123..a68887bd 100644
 +
  } // namespace faiss
 diff --git a/faiss/impl/HNSW.cpp b/faiss/impl/HNSW.cpp
-index c3693fd9..7ae28062 100644
+index 3baa65678..6fc392dd9 100644
 --- a/faiss/impl/HNSW.cpp
 +++ b/faiss/impl/HNSW.cpp
-@@ -906,6 +906,12 @@ int extract_k_from_ResultHandler(ResultHandler<C>& res) {
+@@ -929,6 +929,12 @@ int extract_k_from_ResultHandler(ResultHandler<C>& res) {
      if (auto hres = dynamic_cast<RH::SingleResultHandler*>(&res)) {
          return hres->k;
      }
@@ -214,7 +215,7 @@ index c3693fd9..7ae28062 100644
  
 diff --git a/faiss/impl/IDGrouper.cpp b/faiss/impl/IDGrouper.cpp
 new file mode 100644
-index 00000000..ca9f5fda
+index 000000000..ca9f5fda7
 --- /dev/null
 +++ b/faiss/impl/IDGrouper.cpp
 @@ -0,0 +1,51 @@
@@ -271,7 +272,7 @@ index 00000000..ca9f5fda
 +} // namespace faiss
 diff --git a/faiss/impl/IDGrouper.h b/faiss/impl/IDGrouper.h
 new file mode 100644
-index 00000000..d56113d9
+index 000000000..d56113d97
 --- /dev/null
 +++ b/faiss/impl/IDGrouper.h
 @@ -0,0 +1,51 @@
@@ -327,7 +328,7 @@ index 00000000..d56113d9
 +
 +} // namespace faiss
 diff --git a/faiss/impl/ResultHandler.h b/faiss/impl/ResultHandler.h
-index 3116eb24..126ed015 100644
+index b5544e0f8..8ad574373 100644
 --- a/faiss/impl/ResultHandler.h
 +++ b/faiss/impl/ResultHandler.h
 @@ -14,6 +14,8 @@
@@ -339,7 +340,7 @@ index 3116eb24..126ed015 100644
  #include <faiss/utils/Heap.h>
  #include <faiss/utils/partitioning.h>
  
-@@ -286,6 +288,193 @@ struct HeapBlockResultHandler : BlockResultHandler<C, use_sel> {
+@@ -301,6 +303,193 @@ struct HeapBlockResultHandler : TopkBlockResultHandler<C, use_sel> {
      }
  };
  
@@ -535,7 +536,7 @@ index 3116eb24..126ed015 100644
   *
 diff --git a/faiss/utils/GroupHeap.h b/faiss/utils/GroupHeap.h
 new file mode 100644
-index 00000000..3b7078da
+index 000000000..3b7078da6
 --- /dev/null
 +++ b/faiss/utils/GroupHeap.h
 @@ -0,0 +1,182 @@
@@ -723,10 +724,10 @@ index 00000000..3b7078da
 +} // namespace faiss
 \ No newline at end of file
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index c41edf0c..87ab2020 100644
+index 285b9090e..0edafafcc 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
-@@ -27,6 +27,8 @@ set(FAISS_TEST_SRC
+@@ -26,6 +26,8 @@ set(FAISS_TEST_SRC
    test_approx_topk.cpp
    test_RCQ_cropping.cpp
    test_distances_simd.cpp
@@ -737,7 +738,7 @@ index c41edf0c..87ab2020 100644
    test_hnsw.cpp
 diff --git a/tests/test_group_heap.cpp b/tests/test_group_heap.cpp
 new file mode 100644
-index 00000000..0e8fe7a7
+index 000000000..0e8fe7a7e
 --- /dev/null
 +++ b/tests/test_group_heap.cpp
 @@ -0,0 +1,98 @@
@@ -839,9 +840,52 @@ index 00000000..0e8fe7a7
 +        ASSERT_EQ(sorted_ids[i], binary_heap_ids[i]);
 +    }
 +}
+diff --git a/tests/test_hamming.cpp b/tests/test_hamming.cpp
+index 883f8f5b5..7b2a9264d 100644
+--- a/tests/test_hamming.cpp
++++ b/tests/test_hamming.cpp
+@@ -37,7 +37,7 @@ std::stringstream get_correct_hamming_example(
+         const size_t code_size,
+         std::shared_ptr<std::vector<uint8_t>> a,
+         std::shared_ptr<std::vector<uint8_t>> b,
+-        std::shared_ptr<std::vector<long>> true_ids,
++        std::shared_ptr<std::vector<int64_t>> true_ids,
+         // regular Hamming (bit-level distances)
+         std::shared_ptr<std::vector<int>> true_bit_distances,
+         // generalized Hamming (byte-level distances)
+@@ -278,7 +278,7 @@ TEST(TestHamming, test_hamming_knn) {
+ 
+     auto a = std::make_shared<std::vector<uint8_t>>();
+     auto b = std::make_shared<std::vector<uint8_t>>();
+-    auto true_ids = std::make_shared<std::vector<long>>();
++    auto true_ids = std::make_shared<std::vector<int64_t>>();
+     auto true_bit_distances = std::make_shared<std::vector<int>>();
+     auto true_byte_distances = std::make_shared<std::vector<int>>();
+ 
+@@ -298,9 +298,9 @@ TEST(TestHamming, test_hamming_knn) {
+                 true_byte_distances);
+ 
+         // run test on generalized_hammings_knn_hc
+-        std::vector<long> ids_gen(na * k);
++        std::vector<int64_t> ids_gen(na * k);
+         std::vector<int> dist_gen(na * k);
+-        faiss::int_maxheap_array_t res = {
++        auto res = faiss::int_maxheap_array_t {
+                 na, k, ids_gen.data(), dist_gen.data()};
+         faiss::generalized_hammings_knn_hc(
+                 &res, a->data(), b->data(), nb, code_size, true);
+@@ -308,7 +308,7 @@ TEST(TestHamming, test_hamming_knn) {
+         ASSERT_EQ(dist_gen, *true_byte_distances) << assert_str.str();
+ 
+         // run test on hammings_knn
+-        std::vector<long> ids_ham_knn(na * k, 0);
++        std::vector<int64_t> ids_ham_knn(na * k, 0);
+         std::vector<int> dist_ham_knn(na * k, 0);
+         res = {na, k, ids_ham_knn.data(), dist_ham_knn.data()};
+         faiss::hammings_knn(&res, a->data(), b->data(), nb, code_size, true);
 diff --git a/tests/test_id_grouper.cpp b/tests/test_id_grouper.cpp
 new file mode 100644
-index 00000000..6601795b
+index 000000000..6601795b8
 --- /dev/null
 +++ b/tests/test_id_grouper.cpp
 @@ -0,0 +1,241 @@
@@ -1087,5 +1131,4 @@ index 00000000..6601795b
 +    delete[] xb;
 +}
 -- 
-2.37.0
-
+2.39.5 (Apple Git-154)

--- a/jni/patches/faiss/0002-Enable-precomp-table-to-be-shared-ivfpq.patch
+++ b/jni/patches/faiss/0002-Enable-precomp-table-to-be-shared-ivfpq.patch
@@ -1,31 +1,29 @@
-From 1605542c1f4f7982fe0c5447090ae96f84f27484 Mon Sep 17 00:00:00 2001
+From cf3c7e5e962534b79209cb3c0f52fb3755bc60ec Mon Sep 17 00:00:00 2001
 From: John Mazanec <jmazane@amazon.com>
-Date: Wed, 21 Feb 2024 15:34:15 -0800
-Subject: [PATCH] Enable precomp table to be shared ivfpq
-
-Changes IVFPQ and IVFPQFastScan indices to be able to share the
-precomputed table amongst other instances. Switches var to a pointer and
-add necessary functions to set them correctly.
+Date: Fri, 1 Aug 2025 17:09:28 -0700
+Subject: [PATCH] Changes IVFPQ and IVFPQFastScan indices to be able to share
+ the precomputed table amongst other instances. Switches var to a pointer and
+ add necessary functions to set them correctly.
 
 Adds a tests to validate the behavior.
 
 Signed-off-by: John Mazanec <jmazane@amazon.com>
 ---
- faiss/IndexIVFPQ.cpp                 |  47 +++++++-
+ faiss/IndexIVFPQ.cpp                 |  48 +++++++-
  faiss/IndexIVFPQ.h                   |  16 ++-
- faiss/IndexIVFPQFastScan.cpp         |  47 ++++++--
- faiss/IndexIVFPQFastScan.h           |  11 +-
+ faiss/IndexIVFPQFastScan.cpp         |  49 ++++++--
+ faiss/IndexIVFPQFastScan.h           |  12 +-
  tests/CMakeLists.txt                 |   1 +
  tests/test_disable_pq_sdc_tables.cpp |   4 +-
  tests/test_ivfpq_share_table.cpp     | 173 +++++++++++++++++++++++++++
- 7 files changed, 284 insertions(+), 15 deletions(-)
+ 7 files changed, 287 insertions(+), 16 deletions(-)
  create mode 100644 tests/test_ivfpq_share_table.cpp
 
 diff --git a/faiss/IndexIVFPQ.cpp b/faiss/IndexIVFPQ.cpp
-index e9d6eead2..97c8c010d 100644
+index 41e0192ff..b1e6e0f09 100644
 --- a/faiss/IndexIVFPQ.cpp
 +++ b/faiss/IndexIVFPQ.cpp
-@@ -58,6 +58,29 @@ IndexIVFPQ::IndexIVFPQ(
+@@ -62,6 +62,29 @@ IndexIVFPQ::IndexIVFPQ(
      polysemous_training = nullptr;
      do_polysemous_training = false;
      polysemous_ht = 0;
@@ -55,7 +53,7 @@ index e9d6eead2..97c8c010d 100644
  }
  
  /****************************************************************
-@@ -463,11 +486,23 @@ void IndexIVFPQ::precompute_table() {
+@@ -475,11 +498,24 @@ void IndexIVFPQ::precompute_table() {
              use_precomputed_table,
              quantizer,
              pq,
@@ -77,10 +75,11 @@ index e9d6eead2..97c8c010d 100644
 +    use_precomputed_table = _use_precomputed_table;
 +}
 +
++
  namespace {
  
  #define TIC t0 = get_cycles()
-@@ -647,7 +682,7 @@ struct QueryTables {
+@@ -659,7 +695,7 @@ struct QueryTables {
  
              fvec_madd(
                      pq.M * pq.ksub,
@@ -89,7 +88,7 @@ index e9d6eead2..97c8c010d 100644
                      -2.0,
                      sim_table_2,
                      sim_table);
-@@ -676,7 +711,7 @@ struct QueryTables {
+@@ -688,7 +724,7 @@ struct QueryTables {
                  k >>= cpq.nbits;
  
                  // get corresponding table
@@ -98,7 +97,7 @@ index e9d6eead2..97c8c010d 100644
                          (ki * pq.M + cm * Mf) * pq.ksub;
  
                  if (polysemous_ht == 0) {
-@@ -706,7 +741,7 @@ struct QueryTables {
+@@ -718,7 +754,7 @@ struct QueryTables {
              dis0 = coarse_dis;
  
              const float* s =
@@ -107,7 +106,7 @@ index e9d6eead2..97c8c010d 100644
              for (int m = 0; m < pq.M; m++) {
                  sim_table_ptrs[m] = s;
                  s += pq.ksub;
-@@ -726,7 +761,7 @@ struct QueryTables {
+@@ -738,7 +774,7 @@ struct QueryTables {
                  int ki = k & ((uint64_t(1) << cpq.nbits) - 1);
                  k >>= cpq.nbits;
  
@@ -116,7 +115,7 @@ index e9d6eead2..97c8c010d 100644
                          (ki * pq.M + cm * Mf) * pq.ksub;
  
                  for (int m = m0; m < m0 + Mf; m++) {
-@@ -1343,6 +1378,8 @@ IndexIVFPQ::IndexIVFPQ() {
+@@ -1357,6 +1393,8 @@ IndexIVFPQ::IndexIVFPQ() {
      do_polysemous_training = false;
      polysemous_ht = 0;
      polysemous_training = nullptr;
@@ -126,7 +125,7 @@ index e9d6eead2..97c8c010d 100644
  
  struct CodeCmp {
 diff --git a/faiss/IndexIVFPQ.h b/faiss/IndexIVFPQ.h
-index 7bf97ec0f..f647e5f87 100644
+index fdcb79e44..19f42119c 100644
 --- a/faiss/IndexIVFPQ.h
 +++ b/faiss/IndexIVFPQ.h
 @@ -48,7 +48,8 @@ struct IndexIVFPQ : IndexIVF {
@@ -141,16 +140,16 @@ index 7bf97ec0f..f647e5f87 100644
              Index* quantizer,
 @@ -58,6 +59,10 @@ struct IndexIVFPQ : IndexIVF {
              size_t nbits_per_idx,
-             MetricType metric = METRIC_L2);
- 
+             MetricType metric = METRIC_L2,
+             bool own_invlists = true);
++ 
 +    IndexIVFPQ(const IndexIVFPQ& orig);
 +
 +    ~IndexIVFPQ();
-+
+ 
      void encode_vectors(
              idx_t n,
-             const float* x,
-@@ -139,6 +144,15 @@ struct IndexIVFPQ : IndexIVF {
+@@ -147,6 +152,15 @@ struct IndexIVFPQ : IndexIVF {
      /// build precomputed table
      void precompute_table();
  
@@ -167,26 +166,26 @@ index 7bf97ec0f..f647e5f87 100644
  };
  
 diff --git a/faiss/IndexIVFPQFastScan.cpp b/faiss/IndexIVFPQFastScan.cpp
-index 9d1cdfcae..647644e36 100644
+index 0e876bdb3..8d06c986e 100644
 --- a/faiss/IndexIVFPQFastScan.cpp
 +++ b/faiss/IndexIVFPQFastScan.cpp
-@@ -42,6 +42,8 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(
-         : IndexIVFFastScan(quantizer, d, nlist, 0, metric), pq(d, M, nbits) {
+@@ -43,6 +43,8 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(
+           pq(d, M, nbits) {
      by_residual = false; // set to false by default because it's faster
  
 +    precomputed_table = new AlignedTable<float>();
 +    owns_precomputed_table = true;
-     init_fastscan(M, nbits, nlist, metric, bbs);
+     init_fastscan(&pq, M, nbits, nlist, metric, bbs, own_invlists);
  }
  
-@@ -49,6 +51,17 @@ IndexIVFPQFastScan::IndexIVFPQFastScan() {
+@@ -50,8 +52,19 @@ IndexIVFPQFastScan::IndexIVFPQFastScan() {
      by_residual = false;
      bbs = 0;
      M2 = 0;
 +    precomputed_table = new AlignedTable<float>();
 +    owns_precomputed_table = true;
-+}
-+
+ }
+ 
 +IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQFastScan& orig)
 +        : IndexIVFFastScan(orig), pq(orig.pq) {
 +    by_residual = orig.by_residual;
@@ -194,10 +193,12 @@ index 9d1cdfcae..647644e36 100644
 +    M2 = orig.M2;
 +    precomputed_table = new AlignedTable<float>(*orig.precomputed_table);
 +    owns_precomputed_table = true;
- }
- 
++ }
++
  IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
-@@ -67,13 +80,15 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
+         : IndexIVFFastScan(
+                   orig.quantizer,
+@@ -76,14 +89,16 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
      ntotal = orig.ntotal;
      is_trained = orig.is_trained;
      nprobe = orig.nprobe;
@@ -211,14 +212,16 @@ index 9d1cdfcae..647644e36 100644
 -        memcpy(precomputed_table.get(),
 -               orig.precomputed_table.data(),
 -               precomputed_table.nbytes());
+-    }
 +    if (precomputed_table->nbytes() > 0) {
 +        memcpy(precomputed_table->get(),
 +               orig.precomputed_table->data(),
 +               precomputed_table->nbytes());
-     }
++     }
  
-     for (size_t i = 0; i < nlist; i++) {
-@@ -98,6 +113,12 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
+ #pragma omp parallel for if (nlist > 100)
+     for (idx_t i = 0; i < nlist; i++) {
+@@ -108,6 +123,12 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
      orig_invlists = orig.invlists;
  }
  
@@ -231,7 +234,7 @@ index 9d1cdfcae..647644e36 100644
  /*********************************************************
   * Training
   *********************************************************/
-@@ -123,11 +144,23 @@ void IndexIVFPQFastScan::precompute_table() {
+@@ -133,11 +154,23 @@ void IndexIVFPQFastScan::precompute_table() {
              use_precomputed_table,
              quantizer,
              pq,
@@ -256,7 +259,7 @@ index 9d1cdfcae..647644e36 100644
  /*********************************************************
   * Code management functions
   *********************************************************/
-@@ -225,7 +258,7 @@ void IndexIVFPQFastScan::compute_LUT(
+@@ -235,7 +268,7 @@ void IndexIVFPQFastScan::compute_LUT(
                      if (cij >= 0) {
                          fvec_madd_simd(
                                  dim12,
@@ -266,7 +269,7 @@ index 9d1cdfcae..647644e36 100644
                                  ip_table.get() + i * dim12,
                                  tab);
 diff --git a/faiss/IndexIVFPQFastScan.h b/faiss/IndexIVFPQFastScan.h
-index a2cce3266..1e1f0049c 100644
+index 531976dd4..975304bb8 100644
 --- a/faiss/IndexIVFPQFastScan.h
 +++ b/faiss/IndexIVFPQFastScan.h
 @@ -38,7 +38,8 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
@@ -279,7 +282,7 @@ index a2cce3266..1e1f0049c 100644
  
      IndexIVFPQFastScan(
              Index* quantizer,
-@@ -51,6 +52,10 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
+@@ -52,6 +53,10 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
  
      IndexIVFPQFastScan();
  
@@ -290,25 +293,26 @@ index a2cce3266..1e1f0049c 100644
      // built from an IndexIVFPQ
      explicit IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs = 32);
  
-@@ -60,6 +65,10 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
- 
+@@ -62,6 +67,11 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
      /// build precomputed table, possibly updating use_precomputed_table
      void precompute_table();
+ 
 +    /// Pass in externally a precomputed
 +    void set_precomputed_table(
 +            AlignedTable<float>* precompute_table,
 +            int _use_precomputed_table);
- 
++
      /// same as the regular IVFPQ encoder. The codes are not reorganized by
      /// blocks a that point
+     void encode_vectors(
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index ae6cc7878..16c99e04d 100644
+index 0edafafcc..a7514e517 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
-@@ -38,6 +38,7 @@ set(FAISS_TEST_SRC
-   test_callback.cpp
-   test_utils.cpp
+@@ -40,6 +40,7 @@ set(FAISS_TEST_SRC
    test_hamming.cpp
+   test_mmap.cpp
+   test_zerocopy.cpp
 +  test_ivfpq_share_table.cpp
  )
  
@@ -508,5 +512,4 @@ index 000000000..f827315d8
 +            "IVF16,PQ8x4fsr", "/tmp/ivfpqfsip", faiss::METRIC_INNER_PRODUCT);
 +}
 -- 
-2.37.0
-
+2.39.5 (Apple Git-154)

--- a/jni/patches/faiss/0003-Custom-patch-to-support-range-search-params.patch
+++ b/jni/patches/faiss/0003-Custom-patch-to-support-range-search-params.patch
@@ -1,7 +1,7 @@
-From af6770b505a32b2c4eab2036d2509dec4b137f28 Mon Sep 17 00:00:00 2001
+From 38ac6abaa528e5ade42d60155aea7e1ea4e80899 Mon Sep 17 00:00:00 2001
 From: Junqiu Lei <junqiu@amazon.com>
-Date: Tue, 23 Apr 2024 17:18:56 -0700
-Subject: [PATCH] Custom patch to support range search params
+Date: Fri, 1 Aug 2025 17:20:56 -0700
+Subject: [PATCH] [PATCH] Custom patch to support range search params
 
 Signed-off-by: Junqiu Lei <junqiu@amazon.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Junqiu Lei <junqiu@amazon.com>
  1 file changed, 24 insertions(+), 4 deletions(-)
 
 diff --git a/faiss/IndexIDMap.cpp b/faiss/IndexIDMap.cpp
-index 3f375e7b..11f3a847 100644
+index 123e8f2ff..8c7a893e3 100644
 --- a/faiss/IndexIDMap.cpp
 +++ b/faiss/IndexIDMap.cpp
-@@ -176,11 +176,31 @@ void IndexIDMapTemplate<IndexT>::range_search(
+@@ -256,11 +256,31 @@ void IndexIDMapTemplate<IndexT>::range_search(
          RangeSearchResult* result,
          const SearchParameters* params) const {
      if (params) {
@@ -36,18 +36,17 @@ index 3f375e7b..11f3a847 100644
 +
 +        if (params->grp) {
 +            auto idtrans = dynamic_cast<const IDGrouperTranslated*>(params->grp);
- 
--        index->range_search(n, x, radius, result, &internal_search_parameters);
 +            if (!idtrans) {
 +                auto params_non_const = const_cast<SearchParameters*>(params);
 +                this_idgrptrans.grp = params->grp;
 +                grp_change.set(params_non_const, &this_idgrptrans);
 +            }
 +        }
+ 
+-        index->range_search(n, x, radius, result, &internal_search_parameters);
 +        index->range_search(n, x, radius, result, params);
      } else {
          index->range_search(n, x, radius, result);
      }
 -- 
-2.39.0
-
+2.39.5 (Apple Git-154)

--- a/jni/patches/faiss/0004-Custom-patch-to-support-binary-vector.patch
+++ b/jni/patches/faiss/0004-Custom-patch-to-support-binary-vector.patch
@@ -1,20 +1,19 @@
-From 4d374aa47d4415cbda04b299788988f4ff6e5da0 Mon Sep 17 00:00:00 2001
+From 084843c17d1ac2b36e4f8f30bce1f55b7fc0aa20 Mon Sep 17 00:00:00 2001
 From: Heemin Kim <heemin@amazon.com>
-Date: Wed, 10 Jul 2024 16:06:36 -0700
-Subject: [PATCH] 0004-Custom-patch-to-support-binary-vector
+Date: Fri, 1 Aug 2025 17:38:26 -0700
+Subject: [PATCH] [PATCH] 0004-Custom-patch-to-support-binary-vector
 
 Signed-off-by: Heemin Kim <heemin@amazon.com>
 ---
- faiss/IndexBinaryHNSW.cpp |  59 +++++++++++++------
- faiss/IndexBinaryIVF.cpp  |  28 +++++++--
- tests/test_id_grouper.cpp | 117 +++++++++++++++++++++++++++++++++++++-
- 3 files changed, 179 insertions(+), 25 deletions(-)
+ faiss/IndexBinaryHNSW.cpp | 62 +++++++++++++++++++++++++++------------
+ faiss/IndexBinaryIVF.cpp  | 28 ++++++++++++++----
+ 2 files changed, 65 insertions(+), 25 deletions(-)
 
 diff --git a/faiss/IndexBinaryHNSW.cpp b/faiss/IndexBinaryHNSW.cpp
-index f1bda08f..32627cb0 100644
+index 41f68c126..02646a8fd 100644
 --- a/faiss/IndexBinaryHNSW.cpp
 +++ b/faiss/IndexBinaryHNSW.cpp
-@@ -189,37 +189,62 @@ void IndexBinaryHNSW::train(idx_t n, const uint8_t* x) {
+@@ -200,6 +200,40 @@ void IndexBinaryHNSW::train(idx_t n, const uint8_t* x) {
      is_trained = true;
  }
  
@@ -51,9 +50,11 @@ index f1bda08f..32627cb0 100644
 +
 +} // anonymous namespace
 +
- void IndexBinaryHNSW::search(
-         idx_t n,
-         const uint8_t* x,
++
+ void IndexBinaryHNSW::train(idx_t n, const void* x, NumericType numeric_type) {
+     IndexBinary::train(n, x, numeric_type);
+ }
+@@ -210,31 +244,21 @@ void IndexBinaryHNSW::search(
          idx_t k,
          int32_t* distances,
          idx_t* labels,
@@ -69,20 +70,13 @@ index f1bda08f..32627cb0 100644
  
 -    using RH = HeapBlockResultHandler<HNSW::C>;
 -    RH bres(n, distances_f, labels, k);
-+    if (params_in && params_in->grp) {
-+        using RH = GroupedHeapBlockResultHandler<HNSW::C>;
-+        RH bres(n, distances_f, labels, k, params_in->grp);
- 
+-
 -#pragma omp parallel
 -    {
 -        VisitedTable vt(ntotal);
 -        std::unique_ptr<DistanceComputer> dis(get_distance_computer());
 -        RH::SingleResultHandler res(bres);
-+        hnsw_search(this, n, x, bres, params_in);
-+    } else {
-+        using RH = HeapBlockResultHandler<HNSW::C>;
-+        RH bres(n, distances_f, labels, k);
- 
+-
 -#pragma omp for
 -        for (idx_t i = 0; i < n; i++) {
 -            res.begin(i);
@@ -90,15 +84,22 @@ index f1bda08f..32627cb0 100644
 -            hnsw.search(*dis, res, vt);
 -            res.end();
 -        }
++    if (params_in && params_in->grp) {
++        using RH = GroupedHeapBlockResultHandler<HNSW::C>;
++        RH bres(n, distances_f, labels, k, params_in->grp);
++        hnsw_search(this, n, x, bres, params_in);
++    } else {
++        using RH = HeapBlockResultHandler<HNSW::C>;
++        RH bres(n, distances_f, labels, k);
 +        hnsw_search(this, n, x, bres, params_in);
      }
  
  #pragma omp parallel for
 diff --git a/faiss/IndexBinaryIVF.cpp b/faiss/IndexBinaryIVF.cpp
-index ab1b9fd8..de996df3 100644
+index b0edf0914..604f91385 100644
 --- a/faiss/IndexBinaryIVF.cpp
 +++ b/faiss/IndexBinaryIVF.cpp
-@@ -113,25 +113,41 @@ void IndexBinaryIVF::search(
+@@ -120,25 +120,41 @@ void IndexBinaryIVF::search(
          idx_t k,
          int32_t* distances,
          idx_t* labels,
@@ -146,149 +147,6 @@ index ab1b9fd8..de996df3 100644
      indexIVF_stats.search_time += getmillisecs() - t0;
  }
  
-diff --git a/tests/test_id_grouper.cpp b/tests/test_id_grouper.cpp
-index 6601795b..bd8ab5f9 100644
---- a/tests/test_id_grouper.cpp
-+++ b/tests/test_id_grouper.cpp
-@@ -14,10 +14,10 @@
- #include <faiss/IndexIDMap.h>
- #include <faiss/MetricType.h>
- #include <faiss/impl/IDGrouper.h>
-+#include "faiss/IndexBinaryHNSW.h"
- 
- // 64-bit int
- using idx_t = faiss::idx_t;
--
- using namespace faiss;
- 
- TEST(IdGrouper, get_group) {
-@@ -172,7 +172,58 @@ TEST(IdGrouper, bitmap_with_hnsw) {
-     delete[] xb;
- }
- 
--TEST(IdGrouper, bitmap_with_hnswn_idmap) {
-+TEST(IdGrouper, bitmap_with_binary_hnsw) {
-+    int d = 16;   // dimension
-+    int nb = 10; // database size
-+
-+    std::vector<uint8_t> database(nb * (d / 8));
-+    for (size_t i = 0; i < nb * (d / 8); i++) {
-+        database[i] = rand() % 0x100;
-+    }
-+
-+    uint64_t bitmap[1] = {};
-+    faiss::IDGrouperBitmap id_grouper(1, bitmap);
-+    for (int i = 0; i < nb; i++) {
-+        if (i % 2 == 1) {
-+            id_grouper.set_group(i);
-+        }
-+    }
-+
-+    int k = 10;
-+    int m = 8;
-+    faiss::IndexBinary* index =
-+            new faiss::IndexBinaryHNSW(d, m);
-+    index->add(nb, database.data()); // add vectors to the index
-+
-+    // search
-+    idx_t* I = new idx_t[k];
-+    int32_t* D = new int32_t[k];
-+
-+    auto pSearchParameters = new faiss::SearchParametersHNSW();
-+    pSearchParameters->grp = &id_grouper;
-+
-+    index->search(1, database.data(), k, D, I, pSearchParameters);
-+
-+    std::unordered_set<int> group_ids;
-+    ASSERT_EQ(0, I[0]);
-+    ASSERT_EQ(0, D[0]);
-+    group_ids.insert(id_grouper.get_group(I[0]));
-+    for (int j = 1; j < 5; j++) {
-+        ASSERT_NE(-1, I[j]);
-+        ASSERT_NE(std::numeric_limits<int32_t>::max(), D[j]);
-+        group_ids.insert(id_grouper.get_group(I[j]));
-+    }
-+    for (int j = 5; j < k; j++) {
-+        ASSERT_EQ(-1, I[j]);
-+        ASSERT_EQ(std::numeric_limits<int32_t>::max(), D[j]);
-+    }
-+    ASSERT_EQ(5, group_ids.size());
-+
-+    delete[] I;
-+    delete[] D;
-+}
-+
-+TEST(IdGrouper, bitmap_with_hnsw_idmap) {
-     int d = 1;   // dimension
-     int nb = 10; // database size
- 
-@@ -239,3 +290,65 @@ TEST(IdGrouper, bitmap_with_hnswn_idmap) {
-     delete[] D;
-     delete[] xb;
- }
-+
-+TEST(IdGrouper, bitmap_with_binary_hnsw_idmap) {
-+    int d = 16;   // dimension
-+    int nb = 10; // database size
-+
-+    std::vector<uint8_t> database(nb * (d / 8));
-+    for (size_t i = 0; i < nb * (d / 8); i++) {
-+        database[i] = rand() % 0x100;
-+    }
-+
-+    idx_t* xids = new idx_t[nb];
-+    uint64_t bitmap[1] = {};
-+    faiss::IDGrouperBitmap id_grouper(1, bitmap);
-+    int num_grp = 0;
-+    int grp_size = 2;
-+    int id_in_grp = 0;
-+    for (int i = 0; i < nb; i++) {
-+        xids[i] = i + num_grp;
-+        id_in_grp++;
-+        if (id_in_grp == grp_size) {
-+            id_grouper.set_group(i + num_grp + 1);
-+            num_grp++;
-+            id_in_grp = 0;
-+        }
-+    }
-+
-+    int k = 10;
-+    int m = 8;
-+
-+    faiss::IndexBinary* index =
-+            new faiss::IndexBinaryHNSW(d, m);
-+    faiss::IndexBinaryIDMap id_map =
-+            faiss::IndexBinaryIDMap(index); // add vectors to the index
-+    id_map.add_with_ids(nb, database.data(), xids);
-+
-+    // search
-+    idx_t* I = new idx_t[k];
-+    int32_t* D = new int32_t[k];
-+
-+    auto pSearchParameters = new faiss::SearchParametersHNSW();
-+    pSearchParameters->grp = &id_grouper;
-+
-+    id_map.search(1, database.data(), k, D, I, pSearchParameters);
-+
-+    std::unordered_set<int> group_ids;
-+    ASSERT_EQ(0, I[0]);
-+    ASSERT_EQ(0, D[0]);
-+    group_ids.insert(id_grouper.get_group(I[0]));
-+    for (int j = 1; j < 5; j++) {
-+        ASSERT_NE(-1, I[j]);
-+        ASSERT_NE(std::numeric_limits<int32_t>::max(), D[j]);
-+        group_ids.insert(id_grouper.get_group(I[j]));
-+    }
-+    for (int j = 5; j < k; j++) {
-+        ASSERT_EQ(-1, I[j]);
-+        ASSERT_EQ(std::numeric_limits<int32_t>::max(), D[j]);
-+    }
-+    ASSERT_EQ(5, group_ids.size());
-+
-+    delete[] I;
-+    delete[] D;
-+}
-\ No newline at end of file
 -- 
-2.39.3 (Apple Git-146)
+2.39.5 (Apple Git-154)
 

--- a/jni/patches/faiss/0005-Custom-patch-to-support-multi-vector-IndexHNSW-search_level_0.patch
+++ b/jni/patches/faiss/0005-Custom-patch-to-support-multi-vector-IndexHNSW-search_level_0.patch
@@ -1,21 +1,20 @@
-From 9ef5e349ca5893da07898d7f1d22b0a81f17fddc Mon Sep 17 00:00:00 2001
+From 379afe61155bac7f46aa332c00e67d31edb256d6 Mon Sep 17 00:00:00 2001
 From: AnnTian Shao <anntians@amazon.com>
-Date: Thu, 3 Apr 2025 21:21:11 +0000
-Subject: [PATCH] Add multi-vector-support faiss patch to
+Date: Fri, 1 Aug 2025 18:04:23 -0700
+Subject: [PATCH] [PATCH] Add multi-vector-support faiss patch to
  IndexHNSW::search_level_0
 
 Signed-off-by: AnnTian Shao <anntians@amazon.com>
 ---
- faiss/IndexHNSW.cpp       | 123 +++++++++++++++++++++++++-----------
- faiss/index_factory.cpp   |   7 ++-
- tests/test_id_grouper.cpp | 128 ++++++++++++++++++++++++++++++++++++++
- 3 files changed, 222 insertions(+), 36 deletions(-)
+ faiss/IndexHNSW.cpp     | 117 ++++++++++++++++++++++++++++++----------
+ faiss/index_factory.cpp |   7 ++-
+ 2 files changed, 94 insertions(+), 30 deletions(-)
 
 diff --git a/faiss/IndexHNSW.cpp b/faiss/IndexHNSW.cpp
-index eee3e99c6..7c5dfe020 100644
+index 0f912b003..5cf1b0cdb 100644
 --- a/faiss/IndexHNSW.cpp
 +++ b/faiss/IndexHNSW.cpp
-@@ -286,6 +286,61 @@ void hnsw_search(
+@@ -294,6 +294,61 @@ void hnsw_search(
      hnsw_stats.combine({n1, n2, ndis, nhops});
  }
  
@@ -77,22 +76,13 @@ index eee3e99c6..7c5dfe020 100644
  } // anonymous namespace
  
  void IndexHNSW::search(
-@@ -419,46 +474,44 @@ void IndexHNSW::search_level_0(
-     FAISS_THROW_IF_NOT(k > 0);
-     FAISS_THROW_IF_NOT(nprobe > 0);
+@@ -446,38 +501,42 @@ void IndexHNSW::search_level_0(
  
--    const SearchParametersHNSW* params = nullptr;
--
--    if (params_in) {
--        params = dynamic_cast<const SearchParametersHNSW*>(params_in);
--        FAISS_THROW_IF_NOT_MSG(params, "params type invalid");
--    }
--
      storage_idx_t ntotal = hnsw.levels.size();
  
 -    using RH = HeapBlockResultHandler<HNSW::C>;
 -    RH bres(n, distances, labels, k);
- 
+-
 -#pragma omp parallel
 -    {
 -        std::unique_ptr<DistanceComputer> qdis(
@@ -100,14 +90,30 @@ index eee3e99c6..7c5dfe020 100644
 -        HNSWStats search_stats;
 -        VisitedTable vt(ntotal);
 -        RH::SingleResultHandler res(bres);
-+    if (params_in && params_in->grp) {
++    if (params && params->grp) {
 +        using RH = GroupedHeapBlockResultHandler<HNSW::C>;
-+        RH bres(n, distances, labels, k, params_in->grp);
++        RH bres(n, distances, labels, k, params->grp);
  
 -#pragma omp for
 -        for (idx_t i = 0; i < n; i++) {
 -            res.begin(i);
 -            qdis->set_query(x + i * d);
++        hnsw_search_level_0(
++                this,
++                n,
++                x,
++                k,
++                nearest,
++                nearest_d,
++                distances,
++                labels,
++                nprobe, // n_probes
++                search_type, // search_type
++                params,
++                bres);
++    } else {
++        using RH = HeapBlockResultHandler<HNSW::C>;
++        RH bres(n, distances, labels, k);  
  
 -            hnsw.search_level_0(
 -                    *qdis.get(),
@@ -135,33 +141,18 @@ index eee3e99c6..7c5dfe020 100644
 +                labels,
 +                nprobe, // n_probes
 +                search_type, // search_type
-+                params_in,
-+                bres);
-+    } else {
-+        using RH = HeapBlockResultHandler<HNSW::C>;
-+        RH bres(n, distances, labels, k);
-+
-+        hnsw_search_level_0(
-+                this,
-+                n,
-+                x,
-+                k,
-+                nearest,
-+                nearest_d,
-+                distances,
-+                labels,
-+                nprobe, // n_probes
-+                search_type, // search_type
-+                params_in,
++                params,
 +                bres);
      }
++
      if (is_similarity_metric(this->metric_type)) {
  // we need to revert the negated distances
+ #pragma omp parallel for
 diff --git a/faiss/index_factory.cpp b/faiss/index_factory.cpp
-index 8ff4bfec7..24e65b632 100644
+index baf7a760f..9b59b7a55 100644
 --- a/faiss/index_factory.cpp
 +++ b/faiss/index_factory.cpp
-@@ -453,6 +453,11 @@ IndexHNSW* parse_IndexHNSW(
+@@ -467,6 +467,11 @@ IndexHNSW* parse_IndexHNSW(
          return re_match(code_string, pattern, sm);
      };
  
@@ -173,7 +164,7 @@ index 8ff4bfec7..24e65b632 100644
      if (match("Flat|")) {
          return new IndexHNSWFlat(d, hnsw_M, mt);
      }
-@@ -781,7 +786,7 @@ std::unique_ptr<Index> index_factory_sub(
+@@ -801,7 +806,7 @@ std::unique_ptr<Index> index_factory_sub(
  
      // HNSW variants (it was unclear in the old version that the separator was a
      // "," so we support both "_" and ",")
@@ -182,152 +173,6 @@ index 8ff4bfec7..24e65b632 100644
          int hnsw_M = mres_to_int(sm[1], 32);
          // We also accept empty code string (synonym of Flat)
          std::string code_string =
-diff --git a/tests/test_id_grouper.cpp b/tests/test_id_grouper.cpp
-index bd8ab5f9d..ebe16a364 100644
---- a/tests/test_id_grouper.cpp
-+++ b/tests/test_id_grouper.cpp
-@@ -172,6 +172,65 @@ TEST(IdGrouper, bitmap_with_hnsw) {
-     delete[] xb;
- }
- 
-+TEST(IdGrouper, bitmap_with_hnsw_cagra) {
-+    int d = 1;   // dimension
-+    int nb = 10; // database size
-+
-+    std::mt19937 rng;
-+    std::uniform_real_distribution<> distrib;
-+
-+    float* xb = new float[d * nb];
-+
-+    for (int i = 0; i < nb; i++) {
-+        for (int j = 0; j < d; j++)
-+            xb[d * i + j] = distrib(rng);
-+        xb[d * i] += i / 1000.;
-+    }
-+
-+    uint64_t bitmap[1] = {};
-+    faiss::IDGrouperBitmap id_grouper(1, bitmap);
-+    for (int i = 0; i < nb; i++) {
-+        if (i % 2 == 1) {
-+            id_grouper.set_group(i);
-+        }
-+    }
-+
-+    int k = 10;
-+    int m = 8;
-+    faiss::Index* index =
-+            new faiss::IndexHNSWCagra(d, m, faiss::MetricType::METRIC_L2);
-+    index->add(nb, xb); // add vectors to the index
-+    dynamic_cast<faiss::IndexHNSWCagra*>(index)->base_level_only=true;
-+
-+    // search
-+    idx_t* I = new idx_t[k];
-+    float* D = new float[k];
-+
-+    auto pSearchParameters = new faiss::SearchParametersHNSW();
-+    pSearchParameters->grp = &id_grouper;
-+
-+    index->search(1, xb, k, D, I, pSearchParameters);
-+
-+    std::unordered_set<int> group_ids;
-+    ASSERT_EQ(0, I[0]);
-+    ASSERT_EQ(0, D[0]);
-+    group_ids.insert(id_grouper.get_group(I[0]));
-+    for (int j = 1; j < 5; j++) {
-+        ASSERT_NE(-1, I[j]);
-+        ASSERT_NE(std::numeric_limits<float>::max(), D[j]);
-+        group_ids.insert(id_grouper.get_group(I[j]));
-+    }
-+    for (int j = 5; j < k; j++) {
-+        ASSERT_EQ(-1, I[j]);
-+        ASSERT_EQ(std::numeric_limits<float>::max(), D[j]);
-+    }
-+    ASSERT_EQ(5, group_ids.size());
-+
-+    delete[] I;
-+    delete[] D;
-+    delete[] xb;
-+}
-+
- TEST(IdGrouper, bitmap_with_binary_hnsw) {
-     int d = 16;   // dimension
-     int nb = 10; // database size
-@@ -291,6 +350,75 @@ TEST(IdGrouper, bitmap_with_hnsw_idmap) {
-     delete[] xb;
- }
- 
-+TEST(IdGrouper, bitmap_with_hnsw_cagra_idmap) {
-+    int d = 1;   // dimension
-+    int nb = 10; // database size
-+
-+    std::mt19937 rng;
-+    std::uniform_real_distribution<> distrib;
-+
-+    float* xb = new float[d * nb];
-+    idx_t* xids = new idx_t[d * nb];
-+
-+    for (int i = 0; i < nb; i++) {
-+        for (int j = 0; j < d; j++)
-+            xb[d * i + j] = distrib(rng);
-+        xb[d * i] += i / 1000.;
-+    }
-+
-+    uint64_t bitmap[1] = {};
-+    faiss::IDGrouperBitmap id_grouper(1, bitmap);
-+    int num_grp = 0;
-+    int grp_size = 2;
-+    int id_in_grp = 0;
-+    for (int i = 0; i < nb; i++) {
-+        xids[i] = i + num_grp;
-+        id_in_grp++;
-+        if (id_in_grp == grp_size) {
-+            id_grouper.set_group(i + num_grp + 1);
-+            num_grp++;
-+            id_in_grp = 0;
-+        }
-+    }
-+
-+    int k = 10;
-+    int m = 8;
-+    faiss::Index* index =
-+            new faiss::IndexHNSWCagra(d, m, faiss::MetricType::METRIC_L2);
-+    faiss::IndexIDMap id_map =
-+            faiss::IndexIDMap(index); // add vectors to the index
-+    id_map.add_with_ids(nb, xb, xids);
-+    dynamic_cast<faiss::IndexHNSWCagra*>(id_map.index)->base_level_only=true;
-+
-+    // search
-+    idx_t* I = new idx_t[k];
-+    float* D = new float[k];
-+
-+    auto pSearchParameters = new faiss::SearchParametersHNSW();
-+    pSearchParameters->grp = &id_grouper;
-+
-+    id_map.search(1, xb, k, D, I, pSearchParameters);
-+
-+    std::unordered_set<int> group_ids;
-+    ASSERT_EQ(0, I[0]);
-+    ASSERT_EQ(0, D[0]);
-+    group_ids.insert(id_grouper.get_group(I[0]));
-+    for (int j = 1; j < 5; j++) {
-+        ASSERT_NE(-1, I[j]);
-+        ASSERT_NE(std::numeric_limits<float>::max(), D[j]);
-+        group_ids.insert(id_grouper.get_group(I[j]));
-+    }
-+    for (int j = 5; j < k; j++) {
-+        ASSERT_EQ(-1, I[j]);
-+        ASSERT_EQ(std::numeric_limits<float>::max(), D[j]);
-+    }
-+    ASSERT_EQ(5, group_ids.size());
-+
-+    delete[] I;
-+    delete[] D;
-+    delete[] xb;
-+}
-+
- TEST(IdGrouper, bitmap_with_binary_hnsw_idmap) {
-     int d = 16;   // dimension
-     int nb = 10; // database size
 -- 
-2.47.1
+2.39.5 (Apple Git-154)
 

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -58,12 +58,12 @@ IndexService::IndexService(std::unique_ptr<FaissMethods> _faissMethods) : faissM
 void IndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if (auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
         if (auto * indexScalarQuantizer = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
-            indexScalarQuantizer->codes.reserve(indexScalarQuantizer->code_size * numVectors);
+            indexScalarQuantizer->codes.owned_data.reserve(indexScalarQuantizer->code_size * numVectors);
         }
     }
     if (auto * indexHNSW = dynamic_cast<faiss::IndexHNSW *>(index)) {
         if(auto * indexFlat = dynamic_cast<faiss::IndexFlat *>(indexHNSW->storage)) {
-            indexFlat->codes.reserve(indexFlat->code_size * numVectors);
+            indexFlat->codes.owned_data.reserve(indexFlat->code_size * numVectors);
         }
     }
 }
@@ -162,7 +162,7 @@ BinaryIndexService::BinaryIndexService(std::unique_ptr<FaissMethods> _faissMetho
 void BinaryIndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if (auto * indexBinaryHNSW = dynamic_cast<faiss::IndexBinaryHNSW *>(index)) {
         auto * indexBinaryFlat = dynamic_cast<faiss::IndexBinaryFlat *>(indexBinaryHNSW->storage);
-        indexBinaryFlat->xb.reserve(dim * numVectors / 8);
+        indexBinaryFlat->xb.owned_data.reserve(dim * numVectors / 8);
     }
 }
 
@@ -259,7 +259,7 @@ ByteIndexService::ByteIndexService(std::unique_ptr<FaissMethods> _faissMethods)
 void ByteIndexService::allocIndex(faiss::Index * index, size_t dim, size_t numVectors) {
     if (auto * indexHNSWSQ = dynamic_cast<faiss::IndexHNSWSQ *>(index)) {
         if(auto * indexScalarQuantizer = dynamic_cast<faiss::IndexScalarQuantizer *>(indexHNSWSQ->storage)) {
-            indexScalarQuantizer->codes.reserve(indexScalarQuantizer->code_size * numVectors);
+            indexScalarQuantizer->codes.owned_data.reserve(indexScalarQuantizer->code_size * numVectors);
         }
     }
 }

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -528,7 +528,7 @@ jlong knn_jni::faiss_wrapper::LoadIndexWithStreamADC(faiss::IOReader* ioReader, 
 
     // altered storage containing the distance computer override.
     auto* alteredStorage = new knn_jni::faiss_wrapper::FaissIndexBQ(
-        indexReader->d, std::move(codesIndex->xb), metricType
+        indexReader->d, std::move(codesIndex->xb.owned_data), metricType
     );
 
     // alteredIndexHNSW is effectively a placeholder before we pass the preexisting HNSW structure.


### PR DESCRIPTION
### Description
Bumping up Faiss commit rom 0cbc2a885cde923d80c4bf9c9d6f4d81665f3f64 to 2929bf471bcfbc161e6e97356d33582af29a6c05.

This is required to have Faiss GPU support for FP16, Byte and Binary. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
