### PR TITLE
Add "exact_knn" query clause type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Asymmetric Distance Computation for binary quantized faiss indices [#2733](https://github.com/opensearch-project/k-NN/pull/2733)
 * [BUGFIX] [Remote Vector Index Build] Don't fall back to CPU on terminal failures [#2773](https://github.com/opensearch-project/k-NN/pull/2773)
 * Add KNN timing info to core profiler [#2785](https://github.com/opensearch-project/k-NN/pull/2785)
+* Add "exact_knn" query clause type [#2825](https://github.com/opensearch-project/k-NN/pull/2825)
 
 ### Bug Fixes
 * Fix @ collision in NativeMemoryCacheKeyHelper for vector index filenames containing @ characters [#2810](https://github.com/opensearch-project/k-NN/pull/2810)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -22,6 +22,7 @@ public class KNNConstants {
     public static final String PATH = "path";
     public static final String QUERY = "query";
     public static final String KNN = "knn";
+    public static final String EXACT_KNN = "exact_knn";
     public static final String EXACT_SEARCH = "Exact";
     public static final String ANN_SEARCH = "Approximate-NN";
     public static final String RADIAL_SEARCH = "Radial";
@@ -81,6 +82,7 @@ public class KNNConstants {
     public static final VectorDataType DEFAULT_VECTOR_DATA_TYPE_FIELD = VectorDataType.FLOAT;
     public static final String MINIMAL_MODE_AND_COMPRESSION_FEATURE = "mode_and_compression_feature";
     public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
+    public static final String EXACT_KNN_QUERY_FEATURE = "exact_knn_query_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
     public static final String MODEL_VERSION = "model_version";

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -39,6 +39,7 @@ public class KNNConstants {
     public static final String METHOD_PARAMETER_SPACE_TYPE = "space_type"; // used for mapping parameter
     // used for defining toplevel parameter
     public static final String TOP_LEVEL_PARAMETER_SPACE_TYPE = METHOD_PARAMETER_SPACE_TYPE;
+    public static final String INDEX_PARAMETER_KEY = "index";
     public static final String COMPOUND_EXTENSION = "c";
     public static final String MODEL = "model";
     public static final String MODELS = "models";

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -14,6 +14,7 @@ import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.codec.KNN990Codec.KNN990FlatVectorsFormat;
 import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.codec.params.KNNScalarQuantizedVectorsFormatParams;
@@ -96,6 +97,12 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
                 String.format("Cannot read field type for field [%s] because mapper service is not available", field)
             )
         ).fieldType(field);
+
+        // check if index field level parameter is set to false -> no graphs built
+        boolean indexed = mappedFieldType.getKnnMappingConfig().isIndexed();
+        if (indexed == false) {
+            return new KNN990FlatVectorsFormat(new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()));
+        }
 
         final KNNMappingConfig knnMappingConfig = mappedFieldType.getKnnMappingConfig();
         if (knnMappingConfig.getModelId().isPresent()) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990FlatVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990FlatVectorsFormat.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.hnsw.*;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsReader;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import java.io.IOException;
+
+/**
+ * This is a KNN Vector format that will be used only for flat vectors, when a field is set to index = false.
+ * This format is necessary for making sure that graph files are not created when not needed, and is a wrapper around the
+ * Lucene99FlatVectorsFormat since that class is not included in the "org.apache.lucene.codecs.KnnVectorsFormat" resources file.
+ */
+@Log4j2
+public class KNN990FlatVectorsFormat extends FlatVectorsFormat {
+    private static volatile FlatVectorsFormat FLAT_VECTORS_FORMAT;
+    private static final String FORMAT_NAME = "KNN990FlatVectorsFormat";
+
+    public KNN990FlatVectorsFormat() {
+        this(new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()));
+    }
+
+    public KNN990FlatVectorsFormat(final FlatVectorsFormat flatVectorsFormat) {
+        super(FORMAT_NAME);
+        KNN990FlatVectorsFormat.FLAT_VECTORS_FORMAT = flatVectorsFormat;
+    }
+
+    /**
+     * Returns a {@link FlatVectorsWriter} to write the vectors to the index.
+     *
+     * @param state {@link SegmentWriteState}
+     */
+    @Override
+    public FlatVectorsWriter fieldsWriter(final SegmentWriteState state) throws IOException {
+        return new Lucene99FlatVectorsWriter(state, FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+    }
+
+    /**
+     * Returns a {@link FlatVectorsReader} to read the vectors from the index.
+     *
+     * @param state {@link SegmentReadState}
+     */
+    @Override
+    public FlatVectorsReader fieldsReader(final SegmentReadState state) throws IOException {
+        return new Lucene99FlatVectorsReader(state, FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+    }
+
+    @Override
+    public String toString() {
+        return "KNN990FlatVectorsFormat(name=" + this.getClass().getSimpleName() + ", flatVectorsFormat=" + FLAT_VECTORS_FORMAT + ")";
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -112,6 +112,11 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
                 public KNNLibraryIndexingContext getKnnLibraryIndexingContext() {
                     return libraryContext;
                 }
+
+                @Override
+                public boolean isIndexed() {
+                    return originalMappingParameters.isIndexed();
+                }
             }
         );
 

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNMappingConfig.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNMappingConfig.java
@@ -73,6 +73,15 @@ public interface KNNMappingConfig {
         return Version.CURRENT;
     }
 
+    /**
+     * Returns if field is indexed or not.
+     *
+     * @return boolean index
+     */
+    default boolean isIndexed() {
+        return true;
+    }
+
     default KNNLibraryIndexingContext getKnnLibraryIndexingContext() {
         return null;
     }

--- a/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/OriginalMappingParameters.java
@@ -45,6 +45,7 @@ public final class OriginalMappingParameters {
     private final String compressionLevel;
     private final String modelId;
     private final String topLevelSpaceType;
+    private final boolean indexed;
 
     /**
      * Initialize the parameters from the builder
@@ -60,6 +61,7 @@ public final class OriginalMappingParameters {
         this.compressionLevel = builder.compressionLevel.get();
         this.modelId = builder.modelId.get();
         this.topLevelSpaceType = builder.topLevelSpaceType.get();
+        this.indexed = builder.indexed.get();
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNBuilderAndParserUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNBuilderAndParserUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.join.BitSetProducer;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.XContentLocation;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
+
+public class KNNBuilderAndParserUtils {
+    public static void validateFieldName(String fieldName, String queryName) {
+        if (Strings.isNullOrEmpty(fieldName)) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", queryName));
+        }
+    }
+
+    public static void validateVector(float[] vector, String queryName) {
+        if (vector == null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", queryName));
+        }
+        if (vector.length == 0) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", queryName));
+        }
+    }
+
+    public static void validateVectorDimension(int vectorLength, int expectedDimension) {
+        if (expectedDimension != vectorLength) {
+            throw new IllegalArgumentException(
+                String.format("Query vector has invalid dimension: %d. Dimension should be: %d", vectorLength, expectedDimension)
+            );
+        }
+    }
+
+    public static MappedFieldType validateAndGetFieldType(String fieldName, QueryShardContext context, boolean ignoreUnmapped) {
+        MappedFieldType mappedFieldType = context.fieldMapper(fieldName);
+        if (mappedFieldType == null && ignoreUnmapped) {
+            return null;
+        }
+        if (!(mappedFieldType instanceof KNNVectorFieldType)) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not knn_vector type.", fieldName));
+        }
+        return mappedFieldType;
+    }
+
+    public static void validateExpandNested(boolean expandNested, BitSetProducer parentFilter) {
+        if (parentFilter == null && expandNested) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Invalid value provided for the [%s] field. [%s] is only supported with a nested field.",
+                    EXPAND_NESTED,
+                    EXPAND_NESTED
+                )
+            );
+        }
+    }
+
+    public static float[] floatListToFloatArray(List<Float> floats, String queryName) {
+        if (Objects.isNull(floats) || floats.isEmpty()) {
+            throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be non-null and non-empty", queryName));
+        }
+        float[] vec = new float[floats.size()];
+        for (int i = 0; i < floats.size(); i++) {
+            vec[i] = floats.get(i);
+        }
+        return vec;
+    }
+
+    public static float[] objectsToFloats(List<Object> objs, String queryName) {
+        if (Objects.isNull(objs) || objs.isEmpty()) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "[%s] field 'vector' requires to be non-null and non-empty", queryName)
+            );
+        }
+        float[] vec = new float[objs.size()];
+        for (int i = 0; i < objs.size(); i++) {
+            if ((objs.get(i) instanceof Number) == false) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "[%s] field 'vector' requires to be an array of numbers", queryName)
+                );
+            }
+            vec[i] = ((Number) objs.get(i)).floatValue();
+        }
+        return vec;
+    }
+
+    public static void throwParsingExceptionOnMultipleFields(
+        XContentLocation contentLocation,
+        String processedFieldName,
+        String currentFieldName,
+        String queryName
+    ) {
+        if (processedFieldName != null) {
+            throw new ParsingException(
+                contentLocation,
+                "["
+                    + queryName
+                    + "] query doesn't support multiple fields, found ["
+                    + processedFieldName
+                    + "] and ["
+                    + currentFieldName
+                    + "]"
+            );
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNExactQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNExactQuery.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.opensearch.knn.index.VectorDataType;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Exact k-NN query that performs brute-force distance calculations.
+ * Supports both regular and nested field queries with expand_nested functionality.
+ */
+@Log4j2
+@Getter
+@Builder
+@AllArgsConstructor
+public class KNNExactQuery extends Query {
+
+    private final String field;
+    private final float[] queryVector;
+    private final byte[] byteQueryVector;
+    private String spaceType;
+    private final String indexName;
+    private final VectorDataType vectorDataType;
+    private BitSetProducer parentFilter;
+    private final boolean expandNested;
+    @Setter
+    @Getter
+    private boolean explain;
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new KNNExactWeight(this, boost);
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        visitor.visitLeaf(this);
+    }
+
+    @Override
+    public String toString(String field) {
+        return field;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, Arrays.hashCode(queryVector), Arrays.hashCode(byteQueryVector), spaceType, indexName, parentFilter);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return sameClassAs(other) && equalsTo(getClass().cast(other));
+    }
+
+    public boolean equalsTo(KNNExactQuery other) {
+        if (other == this) return true;
+        return Objects.equals(field, other.field)
+            && Arrays.equals(queryVector, other.queryVector)
+            && Arrays.equals(byteQueryVector, other.byteQueryVector)
+            && Objects.equals(spaceType, other.spaceType)
+            && Objects.equals(indexName, other.indexName)
+            && Objects.equals(parentFilter, other.parentFilter);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNExactQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNExactQueryBuilder.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.WithFieldName;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.mapper.KNNMappingConfig;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.query.parser.KNNExactQueryBuilderParser;
+import org.opensearch.knn.index.util.IndexUtil;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
+import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
+
+/**
+ * Helper class to build the KNN exact query
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Log4j2
+public class KNNExactQueryBuilder extends AbstractQueryBuilder<KNNExactQueryBuilder> implements WithFieldName {
+
+    public static final ParseField VECTOR_FIELD = new ParseField("vector");
+    public static final ParseField SPACE_TYPE_FIELD = new ParseField("space_type");
+    public static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
+    public static final ParseField EXPAND_NESTED_FIELD = new ParseField(EXPAND_NESTED);
+
+    /**
+     * The name for the knn exact query
+     */
+    public static final String NAME = "exact_knn";
+
+    private final String fieldName;
+    private final float[] vector;
+    @Getter
+    private String spaceType;
+    @Getter
+    private boolean ignoreUnmapped;
+    @Getter
+    private Boolean expandNested;
+
+    public static class Builder {
+        private String fieldName;
+        private float[] vector;
+        private String spaceType;
+        private boolean ignoreUnmapped;
+        private String queryName;
+        private float boost = DEFAULT_BOOST;
+        private Boolean expandNested;
+
+        public Builder() {}
+
+        public Builder fieldName(String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        public Builder vector(float[] vector) {
+            this.vector = vector;
+            return this;
+        }
+
+        public Builder spaceType(String spaceType) {
+            this.spaceType = spaceType;
+            return this;
+        }
+
+        public Builder ignoreUnmapped(boolean ignoreUnmapped) {
+            this.ignoreUnmapped = ignoreUnmapped;
+            return this;
+        }
+
+        public Builder queryName(String queryName) {
+            this.queryName = queryName;
+            return this;
+        }
+
+        public Builder boost(float boost) {
+            this.boost = boost;
+            return this;
+        }
+
+        public Builder expandNested(Boolean expandNested) {
+            this.expandNested = expandNested;
+            return this;
+        }
+
+        public KNNExactQueryBuilder build() {
+            validate();
+            return new KNNExactQueryBuilder(fieldName, vector, spaceType, ignoreUnmapped, expandNested).boost(boost).queryName(queryName);
+        }
+
+        private void validate() {
+            KNNBuilderAndParserUtils.validateFieldName(fieldName, NAME);
+            KNNBuilderAndParserUtils.validateVector(vector, NAME);
+
+            if (spaceType != null) {
+                try {
+                    SpaceType.getSpace(spaceType);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(
+                        String.format(Locale.ROOT, "[%s] requires valid space type for exact search, refer to allowed space types.", NAME)
+                    );
+                }
+            }
+        }
+    }
+
+    public static KNNExactQueryBuilder.Builder builder() {
+        return new KNNExactQueryBuilder.Builder();
+    }
+
+    /**
+     * @param in Reads from stream
+     * @throws IOException Throws IO Exception
+     */
+    public KNNExactQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        KNNExactQueryBuilder.Builder builder = KNNExactQueryBuilderParser.streamInput(in, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+        fieldName = builder.fieldName;
+        vector = builder.vector;
+        spaceType = builder.spaceType;
+        ignoreUnmapped = builder.ignoreUnmapped;
+        expandNested = builder.expandNested;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        KNNExactQueryBuilderParser.streamOutput(out, this, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+    }
+
+    /**
+     * @return The field name used in this query
+     */
+    @Override
+    public String fieldName() {
+        return this.fieldName;
+    }
+
+    /**
+     * @return Returns the vector used in this query
+     */
+    public Object vector() {
+        return this.vector;
+    }
+
+    @Override
+    public void doXContent(XContentBuilder builder, Params params) throws IOException {
+        KNNExactQueryBuilderParser.toXContent(builder, params, this);
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) {
+        MappedFieldType mappedFieldType = KNNBuilderAndParserUtils.validateAndGetFieldType(this.fieldName, context, ignoreUnmapped);
+        if (mappedFieldType == null) {
+            return new MatchNoDocsQuery();
+        }
+
+        KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldType) mappedFieldType;
+        KNNMappingConfig knnMappingConfig = knnVectorFieldType.getKnnMappingConfig();
+        QueryConfigFromMapping queryConfigFromMapping = getQueryConfig(knnMappingConfig, knnVectorFieldType);
+
+        SpaceType resolvedSpaceType = this.getSpaceType() != null
+            ? SpaceType.getSpace(this.getSpaceType())
+            : queryConfigFromMapping.getSpaceType();
+        VectorDataType vectorDataType = queryConfigFromMapping.getVectorDataType();
+        knnVectorFieldType.transformQueryVector(vector);
+
+        final String indexName = context.index().getName();
+
+        int vectorLength = VectorDataType.BINARY == vectorDataType ? vector.length * Byte.SIZE : vector.length;
+        KNNBuilderAndParserUtils.validateVectorDimension(vectorLength, knnMappingConfig.getDimension());
+
+        byte[] byteVector = new byte[0];
+        switch (vectorDataType) {
+            case BINARY:
+                byteVector = new byte[vector.length];
+                for (int i = 0; i < vector.length; i++) {
+                    validateByteVectorValue(vector[i], knnVectorFieldType.getVectorDataType());
+                    byteVector[i] = (byte) vector[i];
+                }
+                resolvedSpaceType.validateVector(byteVector);
+                break;
+            case BYTE:
+                for (float v : vector) {
+                    validateByteVectorValue(v, knnVectorFieldType.getVectorDataType());
+                }
+                resolvedSpaceType.validateVector(vector);
+                break;
+            default:
+                resolvedSpaceType.validateVector(vector);
+        }
+
+        BitSetProducer parentFilter = context.getParentFilter();
+        boolean isExpandNested = expandNested == null ? false : expandNested;
+        KNNBuilderAndParserUtils.validateExpandNested(isExpandNested, parentFilter);
+
+        log.debug("Creating exact k-NN query for index:{}, field:{}, spaceType:{}", indexName, fieldName, spaceType);
+
+        KNNExactQuery knnExactQuery = null;
+        switch (vectorDataType) {
+            case BINARY:
+                knnExactQuery = KNNExactQuery.builder()
+                    .field(fieldName)
+                    .byteQueryVector(byteVector)
+                    .indexName(indexName)
+                    .parentFilter(parentFilter)
+                    .spaceType(resolvedSpaceType.getValue())
+                    .vectorDataType(vectorDataType)
+                    .expandNested(isExpandNested)
+                    .build();
+                break;
+            default:
+                knnExactQuery = KNNExactQuery.builder()
+                    .field(fieldName)
+                    .queryVector(vector)
+                    .byteQueryVector(byteVector)
+                    .indexName(indexName)
+                    .parentFilter(parentFilter)
+                    .spaceType(resolvedSpaceType.getValue())
+                    .vectorDataType(vectorDataType)
+                    .expandNested(isExpandNested)
+                    .build();
+        }
+        return knnExactQuery;
+    }
+
+    private KNNExactQueryBuilder.QueryConfigFromMapping getQueryConfig(
+        final KNNMappingConfig knnMappingConfig,
+        final KNNVectorFieldType knnVectorFieldType
+    ) {
+        if (knnMappingConfig.getKnnMethodContext().isPresent()) {
+            KNNMethodContext knnMethodContext = knnMappingConfig.getKnnMethodContext().get();
+            return new KNNExactQueryBuilder.QueryConfigFromMapping(knnMethodContext.getSpaceType(), knnVectorFieldType.getVectorDataType());
+        }
+        throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not built for exact search.", this.fieldName));
+    }
+
+    @Override
+    protected boolean doEquals(KNNExactQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName)
+            && Arrays.equals(vector, other.vector)
+            && Objects.equals(ignoreUnmapped, other.ignoreUnmapped)
+            && Objects.equals(expandNested, other.expandNested);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(fieldName, Arrays.hashCode(vector), ignoreUnmapped, expandNested);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class QueryConfigFromMapping {
+        private final SpaceType spaceType;
+        private final VectorDataType vectorDataType;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNExactWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNExactWeight.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.Getter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.DocIdSetIterator;
+
+import org.opensearch.knn.index.query.iterators.KNNIterator;
+import org.opensearch.knn.indices.ModelDao;
+import org.opensearch.knn.index.query.ExactSearcher.ExactSearcherContext;
+
+import java.io.IOException;
+
+/**
+ * Weight implementation for exact k-NN search using brute-force distance calculations.
+ */
+public class KNNExactWeight extends Weight {
+
+    @Getter
+    private final KNNExactQuery knnExactQuery;
+    private static ModelDao modelDao;
+    private static ExactSearcher DEFAULT_EXACT_SEARCHER;
+    private final float boost;
+    private final ExactSearcher exactSearcher;
+
+    public KNNExactWeight(KNNExactQuery query, float boost) {
+        super(query);
+        this.knnExactQuery = query;
+        this.boost = boost;
+        this.exactSearcher = DEFAULT_EXACT_SEARCHER;
+    }
+
+    public static void initialize(ModelDao modelDao) {
+        initialize(modelDao, new ExactSearcher(modelDao));
+    }
+
+    public static void initialize(ModelDao modelDao, ExactSearcher exactSearcher) {
+        KNNExactWeight.modelDao = modelDao;
+        KNNExactWeight.DEFAULT_EXACT_SEARCHER = exactSearcher;
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+        return explain(context, doc, 0);
+    }
+
+    public Explanation explain(LeafReaderContext context, int doc, float score) {
+        knnExactQuery.setExplain(true);
+        String vectorString = knnExactQuery.getQueryVector() != null
+            ? java.util.Arrays.toString(knnExactQuery.getQueryVector())
+            : java.util.Arrays.toString(knnExactQuery.getByteQueryVector());
+        String description = String.format("exact k-NN search on field [%s] with vector [%s]", knnExactQuery.getField(), vectorString);
+        return Explanation.match(score * boost, description);
+    }
+
+    @Override
+    public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        return new ScorerSupplier() {
+
+            @Override
+            public Scorer get(long leadCost) throws IOException {
+                ExactSearcherContext exactContext = createExactSearcherContext(context);
+                KNNIterator knnIterator = exactSearcher.createIterator(context, exactContext);
+                if (knnIterator == null) {
+                    return KNNScorer.emptyScorer();
+                }
+                return new KNNLazyScorer(knnIterator, boost);
+            }
+
+            @Override
+            public long cost() {
+                return context.reader().maxDoc();
+            }
+        };
+    }
+
+    private ExactSearcherContext createExactSearcherContext(LeafReaderContext context) throws IOException {
+        String userDefinedSpaceType = knnExactQuery.getSpaceType() != null ? knnExactQuery.getSpaceType() : null;
+        return ExactSearcher.ExactSearcherContext.builder()
+            .field(knnExactQuery.getField())
+            .parentsFilter(knnExactQuery.getParentFilter())
+            .floatQueryVector(knnExactQuery.getQueryVector())
+            .byteQueryVector(knnExactQuery.getByteQueryVector())
+            .matchedDocsIterator(DocIdSetIterator.all(context.reader().maxDoc()))
+            .exactKNNSpaceType(userDefinedSpaceType)
+            .build();
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNLazyScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNLazyScorer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.opensearch.knn.index.query.iterators.KNNIterator;
+
+import java.io.IOException;
+
+/**
+ * Lazy scorer for exact k-NN search that computes vector similarities on-demand.
+ * Unlike KNNScorer which uses pre-computed TopDocs, this scorer calculates scores
+ * only when requested, preventing OOM exceptions for large document sets.
+ */
+public class KNNLazyScorer extends Scorer {
+    private final float boost;
+    private final KNNIterator knnIterator;
+    private int currentDoc = -1;
+
+    public KNNLazyScorer(KNNIterator knnIterator, float boost) throws IOException {
+        super();
+        this.knnIterator = knnIterator;
+        this.boost = boost;
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+        return new DocIdSetIterator() {
+            @Override
+            public int docID() {
+                return currentDoc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                currentDoc = knnIterator.nextDoc();
+                if (currentDoc < 0 && currentDoc != NO_MORE_DOCS) {
+                    currentDoc = NO_MORE_DOCS;
+                }
+                return currentDoc;
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                while (currentDoc < target) {
+                    currentDoc = knnIterator.nextDoc();
+                    if (currentDoc == NO_MORE_DOCS) {
+                        break;
+                    }
+                }
+                return currentDoc;
+            }
+
+            @Override
+            public long cost() {
+                return 0;
+            }
+        };
+    }
+
+    @Override
+    public float score() throws IOException {
+        return knnIterator.score() * boost;
+    }
+
+    @Override
+    public int docID() {
+        return currentDoc;
+    }
+
+    @Override
+    public float getMaxScore(int upTo) throws IOException {
+        return Float.MAX_VALUE;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -234,15 +234,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         }
 
         private void validate() {
-            if (Strings.isNullOrEmpty(fieldName)) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", NAME));
-            }
-
-            if (vector == null) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", NAME));
-            } else if (vector.length == 0) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", NAME));
-            }
+            KNNBuilderAndParserUtils.validateFieldName(fieldName, NAME);
+            KNNBuilderAndParserUtils.validateVector(vector, NAME);
 
             if (k == null && minScore == null && maxDistance == null) {
                 throw new IllegalArgumentException(
@@ -424,15 +417,11 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
 
     @Override
     protected Query doToQuery(QueryShardContext context) {
-        MappedFieldType mappedFieldType = context.fieldMapper(this.fieldName);
-
-        if (mappedFieldType == null && ignoreUnmapped) {
+        MappedFieldType mappedFieldType = KNNBuilderAndParserUtils.validateAndGetFieldType(this.fieldName, context, ignoreUnmapped);
+        if (mappedFieldType == null) {
             return new MatchNoDocsQuery();
         }
 
-        if (!(mappedFieldType instanceof KNNVectorFieldType)) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not knn_vector type.", this.fieldName));
-        }
         KNNVectorFieldType knnVectorFieldType = (KNNVectorFieldType) mappedFieldType;
         KNNMappingConfig knnMappingConfig = knnVectorFieldType.getKnnMappingConfig();
         QueryConfigFromMapping queryConfigFromMapping = getQueryConfig(knnMappingConfig, knnVectorFieldType);
@@ -518,15 +507,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         }
 
         int vectorLength = VectorDataType.BINARY == vectorDataType ? vector.length * Byte.SIZE : vector.length;
-        if (knnMappingConfig.getDimension() != vectorLength) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Query vector has invalid dimension: %d. Dimension should be: %d",
-                    vectorLength,
-                    knnMappingConfig.getDimension()
-                )
-            );
-        }
+        KNNBuilderAndParserUtils.validateVectorDimension(vectorLength, knnMappingConfig.getDimension());
 
         byte[] byteVector = new byte[0];
         switch (vectorDataType) {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -21,10 +21,8 @@ import org.opensearch.knn.index.query.lucene.LuceneEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
-import java.util.Locale;
 import java.util.Map;
 
-import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.index.engine.KNNEngine.ENGINES_SUPPORTING_NESTED_FIELDS;
 
@@ -63,16 +61,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
             mappedFieldType = (KNNVectorFieldType) context.getFieldType(fieldName);
         }
 
-        if (parentFilter == null && expandNested) {
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "Invalid value provided for the [%s] field. [%s] is only supported with a nested field.",
-                    EXPAND_NESTED,
-                    EXPAND_NESTED
-                )
-            );
-        }
+        KNNBuilderAndParserUtils.validateExpandNested(expandNested, parentFilter);
 
         // if index = false and graphs are not built, use KNNQuery since engine would not matter
         if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())

--- a/src/main/java/org/opensearch/knn/index/query/iterators/ByteVectorIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/iterators/ByteVectorIdsKNNIterator.java
@@ -9,6 +9,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.vectorvalues.KNNByteVectorValues;
+import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
 
@@ -82,6 +83,15 @@ public class ByteVectorIdsKNNIterator implements KNNIterator {
         final byte[] byteQueryVector = new byte[queryVector.length];
         for (int i = 0; i < queryVector.length; i++) {
             byteQueryVector[i] = (byte) queryVector[i];
+        }
+        // adding l1/linf support for exact search in query so scoring script is not needed
+        if (spaceType.getValue().equals("l1") || spaceType.getValue().equals("linf")) {
+            if (spaceType.getValue().equals("l1")) {
+                return (1 / (1 + KNNScoringUtil.l1Norm(byteQueryVector, vector)));
+            }
+            if (spaceType.getValue().equals("linf")) {
+                return (1 / (1 + KNNScoringUtil.lInfNorm(byteQueryVector, vector)));
+            }
         }
         return spaceType.getKnnVectorSimilarityFunction().compare(byteQueryVector, vector);
     }

--- a/src/main/java/org/opensearch/knn/index/query/iterators/VectorIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/iterators/VectorIdsKNNIterator.java
@@ -92,6 +92,15 @@ public class VectorIdsKNNIterator implements KNNIterator {
     protected float computeScore() throws IOException {
         final float[] vector = knnFloatVectorValues.getVector();
         if (segmentLevelQuantizationInfo == null) {
+            // adding l1/linf support for exact search in query so scoring script is not needed
+            if (spaceType.getValue().equals("l1") || spaceType.getValue().equals("linf")) {
+                if (spaceType.getValue().equals("l1")) {
+                    return (1 / (1 + KNNScoringUtil.l1Norm(queryVector, vector)));
+                }
+                if (spaceType.getValue().equals("linf")) {
+                    return (1 / (1 + KNNScoringUtil.lInfNorm(queryVector, vector)));
+                }
+            }
             return spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector);
         }
 

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNExactQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNExactQueryBuilderParser.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.parser;
+
+import lombok.extern.log4j.Log4j2;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ObjectParser;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.knn.index.query.KNNExactQueryBuilder;
+import org.opensearch.knn.index.query.KNNBuilderAndParserUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
+import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
+import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
+import static org.opensearch.knn.index.query.KNNExactQueryBuilder.NAME;
+import static org.opensearch.knn.index.query.KNNExactQueryBuilder.VECTOR_FIELD;
+import static org.opensearch.knn.index.query.KNNExactQueryBuilder.SPACE_TYPE_FIELD;
+import static org.opensearch.knn.index.query.KNNExactQueryBuilder.EXPAND_NESTED_FIELD;
+import static org.opensearch.knn.index.query.KNNExactQueryBuilder.IGNORE_UNMAPPED_FIELD;
+import static org.opensearch.knn.index.util.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
+
+/**
+ * Helper class for parsing and reverse parsing KNNExactQueryBuilder
+ */
+@Log4j2
+public final class KNNExactQueryBuilderParser {
+
+    private static final ObjectParser<KNNExactQueryBuilder.Builder, Void> INTERNAL_PARSER = createInternalObjectParser();
+
+    private static ObjectParser<KNNExactQueryBuilder.Builder, Void> createInternalObjectParser() {
+        ObjectParser<KNNExactQueryBuilder.Builder, Void> internalParser = new ObjectParser<>(NAME, KNNExactQueryBuilder.Builder::new);
+        internalParser.declareFloat(KNNExactQueryBuilder.Builder::boost, BOOST_FIELD);
+        internalParser.declareString(KNNExactQueryBuilder.Builder::queryName, NAME_FIELD);
+        internalParser.declareFloatArray((b, v) -> b.vector(KNNBuilderAndParserUtils.floatListToFloatArray(v, NAME)), VECTOR_FIELD);
+        internalParser.declareString(KNNExactQueryBuilder.Builder::spaceType, SPACE_TYPE_FIELD);
+        internalParser.declareBoolean((b, v) -> {
+            if (isClusterOnOrAfterMinRequiredVersion("ignore_unmapped")) {
+                b.ignoreUnmapped(v);
+            }
+        }, IGNORE_UNMAPPED_FIELD);
+        internalParser.declareBoolean(KNNExactQueryBuilder.Builder::expandNested, EXPAND_NESTED_FIELD);
+        return internalParser;
+    }
+
+    /**
+     * Stream input for KNNExactQueryBuilder
+     *
+     * @param in stream out
+     * @param minClusterVersionCheck function to check min version
+     * @return KNNExactQueryBuilder.Builder class
+     * @throws IOException on stream failure
+     */
+    public static KNNExactQueryBuilder.Builder streamInput(StreamInput in, Function<String, Boolean> minClusterVersionCheck)
+        throws IOException {
+        KNNExactQueryBuilder.Builder builder = new KNNExactQueryBuilder.Builder();
+        builder.fieldName(in.readString());
+        builder.vector(in.readFloatArray());
+        builder.spaceType(in.readOptionalString());
+
+        if (minClusterVersionCheck.apply("ignore_unmapped")) {
+            builder.ignoreUnmapped(in.readOptionalBoolean());
+        }
+
+        if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
+            builder.expandNested(in.readOptionalBoolean());
+        }
+
+        return builder;
+    }
+
+    /**
+     * Stream output for KNNExactQueryBuilder
+     *
+     * @param out stream out
+     * @param builder KNNExactQueryBuilder to stream
+     * @param minClusterVersionCheck function to check min version
+     * @throws IOException on stream failure
+     */
+    public static void streamOutput(StreamOutput out, KNNExactQueryBuilder builder, Function<String, Boolean> minClusterVersionCheck)
+        throws IOException {
+        out.writeString(builder.fieldName());
+        out.writeFloatArray((float[]) builder.vector());
+        out.writeOptionalString(builder.getSpaceType());
+        if (minClusterVersionCheck.apply("ignore_unmapped")) {
+            out.writeOptionalBoolean(builder.isIgnoreUnmapped());
+        }
+        if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
+            out.writeOptionalBoolean(builder.getExpandNested());
+        }
+    }
+
+    /**
+     * Convert XContent to KNNExactQueryBuilder
+     *
+     * @param parser input parser
+     * @return KNNExactQueryBuilder
+     * @throws IOException on parsing failure
+     */
+    public static KNNExactQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        String fieldName = null;
+        String currentFieldName = null;
+        XContentParser.Token token;
+        KNNExactQueryBuilder.Builder builder = null;
+        List<Object> vector = null;
+
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                KNNBuilderAndParserUtils.throwParsingExceptionOnMultipleFields(
+                    parser.getTokenLocation(),
+                    fieldName,
+                    currentFieldName,
+                    NAME
+                );
+                fieldName = currentFieldName;
+                builder = INTERNAL_PARSER.apply(parser, null);
+            } else {
+                KNNBuilderAndParserUtils.throwParsingExceptionOnMultipleFields(
+                    parser.getTokenLocation(),
+                    fieldName,
+                    parser.currentName(),
+                    NAME
+                );
+                fieldName = parser.currentName();
+                vector = parser.list();
+            }
+        }
+
+        if (builder == null) {
+            builder = KNNExactQueryBuilder.builder().vector(KNNBuilderAndParserUtils.objectsToFloats(vector, NAME));
+        }
+        builder.fieldName(fieldName);
+        return builder.build();
+    }
+
+    /**
+     * Convert KNNExactQueryBuilder to XContent
+     *
+     * @param builder XContent builder to add KNNExactQueryBuilder
+     * @param params ToXContent params
+     * @param knnExactQueryBuilder KNNExactQueryBuilder to convert
+     * @throws IOException on conversion failure
+     */
+    public static void toXContent(XContentBuilder builder, ToXContent.Params params, KNNExactQueryBuilder knnExactQueryBuilder)
+        throws IOException {
+        builder.startObject(NAME);
+        builder.startObject(knnExactQueryBuilder.fieldName());
+
+        builder.field(VECTOR_FIELD.getPreferredName(), knnExactQueryBuilder.vector());
+
+        if (knnExactQueryBuilder.getSpaceType() != null) {
+            builder.field(SPACE_TYPE_FIELD.getPreferredName(), knnExactQueryBuilder.getSpaceType());
+        }
+        if (knnExactQueryBuilder.isIgnoreUnmapped()) {
+            builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), knnExactQueryBuilder.isIgnoreUnmapped());
+        }
+        if (knnExactQueryBuilder.getExpandNested() != null) {
+            builder.field(EXPAND_NESTED_FIELD.getPreferredName(), knnExactQueryBuilder.getExpandNested());
+        }
+        builder.field(BOOST_FIELD.getPreferredName(), knnExactQueryBuilder.boost());
+        if (knnExactQueryBuilder.queryName() != null) {
+            builder.field(NAME_FIELD.getPreferredName(), knnExactQueryBuilder.queryName());
+        }
+
+        builder.endObject();
+        builder.endObject();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -66,6 +66,7 @@ public class IndexUtil {
     private static final Version MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE = Version.V_2_17_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION = Version.V_2_17_0;
     private static final Version MINIMAL_EXPAND_NESTED_FEATURE = Version.V_2_19_0;
+    private static final Version MINIMAL_EXACT_KNN_QUERY_FEATURE = Version.V_3_2_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -431,6 +432,7 @@ public class IndexUtil {
                 put(KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE, MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE);
                 put(KNNConstants.MODEL_VERSION, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION);
                 put(EXPAND_NESTED, MINIMAL_EXPAND_NESTED_FEATURE);
+                put(KNNConstants.EXACT_KNN_QUERY_FEATURE, MINIMAL_EXACT_KNN_QUERY_FEATURE);
             }
         };
 

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -43,6 +43,9 @@ import org.opensearch.knn.index.memory.NativeMemoryLoadStrategy;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.query.KNNWeight;
+import org.opensearch.knn.index.query.KNNExactQueryBuilder;
+import org.opensearch.knn.index.query.KNNExactWeight;
+import org.opensearch.knn.index.query.parser.KNNExactQueryBuilderParser;
 import org.opensearch.knn.index.query.RescoreKNNVectorQuery;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.parser.KNNQueryBuilderParser;
@@ -125,7 +128,6 @@ import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
-import static java.util.Collections.singletonList;
 import static org.opensearch.knn.common.KNNConstants.KNN_THREAD_POOL_PREFIX;
 import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_THREAD_POOL;
@@ -211,7 +213,10 @@ public class KNNPlugin extends Plugin
 
     @Override
     public List<QuerySpec<?>> getQueries() {
-        return singletonList(new QuerySpec<>(KNNQueryBuilder.NAME, KNNQueryBuilder::new, KNNQueryBuilderParser::fromXContent));
+        return ImmutableList.of(
+            new QuerySpec<>(KNNQueryBuilder.NAME, KNNQueryBuilder::new, KNNQueryBuilderParser::fromXContent),
+            new QuerySpec<>(KNNExactQueryBuilder.NAME, KNNExactQueryBuilder::new, KNNExactQueryBuilderParser::fromXContent)
+        );
     }
 
     @Override
@@ -246,6 +251,7 @@ public class KNNPlugin extends Plugin
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
         KNNQueryBuilder.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
+        KNNExactWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         TrainingModelRequest.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
 
         clusterService.addListener(TrainingJobClusterStateListener.getInstance());

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -11,3 +11,4 @@
 
 org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat
 org.opensearch.knn.index.codec.KNN9120Codec.KNN9120HnswBinaryVectorsFormat
+org.opensearch.knn.index.codec.KNN990Codec.KNN990FlatVectorsFormat

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -139,6 +139,25 @@ public class KNNTestCase extends OpenSearchTestCase {
         };
     }
 
+    public static KNNMappingConfig getMappingConfigForMethodMapping(KNNMethodContext knnMethodContext, int dimension, boolean indexed) {
+        return new KNNMappingConfig() {
+            @Override
+            public Optional<KNNMethodContext> getKnnMethodContext() {
+                return Optional.of(knnMethodContext);
+            }
+
+            @Override
+            public int getDimension() {
+                return dimension;
+            }
+
+            @Override
+            public boolean isIndexed() {
+                return indexed;
+            }
+        };
+    }
+
     public static KNNMappingConfig getMappingConfigForFlatMapping(int dimension) {
         return () -> dimension;
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010CodecTests.java
@@ -48,4 +48,30 @@ public class KNN10010CodecTests extends KNNCodecTestCase {
 
         testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
     }
+
+    @SneakyThrows
+    public void testIndexParameterOnCodec() {
+        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
+            mapperService) -> new KNN9120PerFieldKnnVectorsFormat(Optional.of(mapperService));
+
+        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN10010Codec.builder()
+            .delegate(KNNCodecVersion.CURRENT_DEFAULT_DELEGATE)
+            .knnVectorsFormat(knnVectorFormat)
+            .build();
+
+        testKnnVectorIndexWithIndexParameter(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+    }
+
+    @SneakyThrows
+    public void testNoGraphFileCreationOnCodec() {
+        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
+            mapperService) -> new KNN9120PerFieldKnnVectorsFormat(Optional.of(mapperService));
+
+        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN10010Codec.builder()
+            .delegate(KNNCodecVersion.CURRENT_DEFAULT_DELEGATE)
+            .knnVectorsFormat(knnVectorFormat)
+            .build();
+
+        testNoGraphFilesCreated_IndexParameter(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990FlatVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990FlatVectorsFormatTests.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN990Codec;
+
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsReader;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsWriter;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.store.BaseDirectoryWrapper;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.Version;
+import org.junit.After;
+import org.junit.Assert;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.util.UnitTestCodec;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@Log4j2
+
+public class KNN990FlatVectorsFormatTests extends KNNTestCase {
+    private static final Codec TESTING_CODEC = new UnitTestCodec(() -> new KNN990FlatVectorsFormat());
+    private static final String FLAT_VECTOR_FILE_EXT = ".vec";
+    private static final String FAISS_ENGINE_FILE_EXT = ".faiss";
+    private static final String LUCENE_ENGINE_FILE_EXT = ".vex";
+    private Directory dir;
+    private RandomIndexWriter indexWriter;
+
+    @After
+    public void tearDown() throws Exception {
+        if (dir != null) {
+            dir.close();
+        }
+        super.tearDown();
+    }
+
+    @SneakyThrows
+    public void testReaderAndWriter_whenValidInput_thenSuccess() {
+        final Lucene99FlatVectorsFormat mockedFlatVectorsFormat = Mockito.mock(Lucene99FlatVectorsFormat.class);
+
+        final String segmentName = "test-segment-name";
+
+        final SegmentInfo mockedSegmentInfo = new SegmentInfo(
+            Mockito.mock(Directory.class),
+            Mockito.mock(Version.class),
+            Mockito.mock(Version.class),
+            segmentName,
+            0,
+            false,
+            false,
+            Mockito.mock(Codec.class),
+            Mockito.mock(Map.class),
+            new byte[16],
+            Mockito.mock(Map.class),
+            Mockito.mock(Sort.class)
+        );
+
+        final String segmentSuffix = "test-segment-suffix";
+
+        Directory directory = Mockito.mock(Directory.class);
+        IndexInput input = Mockito.mock(IndexInput.class);
+        Mockito.when(directory.openInput(any(), any())).thenReturn(input);
+
+        String fieldName = "test-field";
+        FieldInfos fieldInfos = Mockito.mock(FieldInfos.class);
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getName()).thenReturn(fieldName);
+        Mockito.when(fieldInfos.fieldInfo(anyInt())).thenReturn(fieldInfo);
+        Mockito.when(fieldInfos.iterator()).thenReturn(new Iterator<FieldInfo>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public FieldInfo next() {
+                return null;
+            }
+        });
+
+        final SegmentReadState mockedSegmentReadState = new SegmentReadState(
+            directory,
+            mockedSegmentInfo,
+            fieldInfos,
+            Mockito.mock(IOContext.class),
+            segmentSuffix
+        );
+
+        final SegmentWriteState mockedSegmentWriteState = new SegmentWriteState(
+            Mockito.mock(InfoStream.class),
+            Mockito.mock(Directory.class),
+            mockedSegmentInfo,
+            Mockito.mock(FieldInfos.class),
+            null,
+            Mockito.mock(IOContext.class)
+        );
+        Mockito.when(mockedFlatVectorsFormat.fieldsReader(mockedSegmentReadState)).thenReturn(Mockito.mock(FlatVectorsReader.class));
+        Mockito.when(mockedFlatVectorsFormat.fieldsWriter(mockedSegmentWriteState)).thenReturn(Mockito.mock(FlatVectorsWriter.class));
+
+        final KNN990FlatVectorsFormat knn990FlatVectorsFormat = new KNN990FlatVectorsFormat(mockedFlatVectorsFormat);
+        try (MockedStatic<CodecUtil> mockedStaticCodecUtil = Mockito.mockStatic(CodecUtil.class)) {
+            mockedStaticCodecUtil.when(
+                () -> CodecUtil.writeIndexHeader(any(IndexOutput.class), anyString(), anyInt(), any(byte[].class), anyString())
+            ).thenAnswer((Answer<Void>) invocation -> null);
+            mockedStaticCodecUtil.when(() -> CodecUtil.retrieveChecksum(any(IndexInput.class)))
+                .thenAnswer((Answer<Void>) invocation -> null);
+            Assert.assertTrue(knn990FlatVectorsFormat.fieldsReader(mockedSegmentReadState) instanceof Lucene99FlatVectorsReader);
+
+            Assert.assertTrue(knn990FlatVectorsFormat.fieldsWriter(mockedSegmentWriteState) instanceof Lucene99FlatVectorsWriter);
+        }
+    }
+
+    @SneakyThrows
+    public void testFlatVectorFormat_whenMultipleFloatVectorFieldIndexed_thenSuccess() {
+        setup();
+        float[] floatVector = { 1.0f, 3.0f, 4.0f };
+
+        FieldType fieldTypeForFloat_Faiss = createVectorField(3, VectorEncoding.FLOAT32, VectorDataType.FLOAT, "faiss");
+        fieldTypeForFloat_Faiss.freeze();
+        addFieldToIndex(new KnnFloatVectorField("faiss_float", floatVector, fieldTypeForFloat_Faiss), indexWriter);
+        FieldType fieldTypeForFloat_Lucene = createVectorField(3, VectorEncoding.FLOAT32, VectorDataType.FLOAT, "lucene");
+        fieldTypeForFloat_Lucene.freeze();
+        addFieldToIndex(new KnnFloatVectorField("lucene_float", floatVector, fieldTypeForFloat_Lucene), indexWriter);
+
+        final IndexReader indexReader = indexWriter.getReader();
+        // ensuring segments are created
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Validate to see if correct values are returned, assumption here is only 1 segment is getting created
+        IndexSearcher searcher = new IndexSearcher(indexReader);
+        final LeafReader leafReader = searcher.getLeafContexts().get(0).reader();
+        SegmentReader segmentReader = Lucene.segmentReader(leafReader);
+        final List<String> faissfiles = getFilesFromSegment(dir, FAISS_ENGINE_FILE_EXT);
+        final List<String> lucenefiles = getFilesFromSegment(dir, LUCENE_ENGINE_FILE_EXT);
+        assertEquals(0, faissfiles.size());
+        assertEquals(0, lucenefiles.size());
+
+        // Even setting IWC to not use compound file it still uses compound file, hence ensuring we don't check .vec
+        // file in case segment uses compound format. use this seed once we fix this to validate everything is
+        // working or not. -Dtests.seed=CAAE1B8D573EEB7E
+        if (segmentReader.getSegmentInfo().info.getUseCompoundFile() == false) {
+            final List<String> vecfiles = getFilesFromSegment(dir, FLAT_VECTOR_FILE_EXT);
+            assertEquals(2, vecfiles.size());
+        }
+
+        final FloatVectorValues floatVectorValuesFaiss = leafReader.getFloatVectorValues("faiss_float");
+        floatVectorValuesFaiss.iterator().nextDoc();
+        assertArrayEquals(floatVector, floatVectorValuesFaiss.vectorValue(floatVectorValuesFaiss.iterator().index()), 0.0f);
+        assertEquals(1, floatVectorValuesFaiss.size());
+        assertEquals(3, floatVectorValuesFaiss.dimension());
+
+        final FloatVectorValues floatVectorValuesLucene = leafReader.getFloatVectorValues("lucene_float");
+        floatVectorValuesLucene.iterator().nextDoc();
+        assertArrayEquals(floatVector, floatVectorValuesLucene.vectorValue(floatVectorValuesLucene.iterator().index()), 0.0f);
+        assertEquals(1, floatVectorValuesLucene.size());
+        assertEquals(3, floatVectorValuesLucene.dimension());
+
+        indexReader.close();
+    }
+
+    @SneakyThrows
+    public void testFlatVectorFormat_whenMultipleByteVectorFieldIndexed_thenSuccess() {
+        setup();
+        byte[] byteVector = { 6, 14 };
+
+        FieldType fieldTypeForByte_Faiss = createVectorField(2, VectorEncoding.BYTE, VectorDataType.BINARY, "faiss");
+        fieldTypeForByte_Faiss.freeze();
+        addFieldToIndex(new KnnByteVectorField("faiss_byte", byteVector, fieldTypeForByte_Faiss), indexWriter);
+        FieldType fieldTypeForByte_Lucene = createVectorField(2, VectorEncoding.BYTE, VectorDataType.BINARY, "lucene");
+        fieldTypeForByte_Lucene.freeze();
+        addFieldToIndex(new KnnByteVectorField("lucene_byte", byteVector, fieldTypeForByte_Lucene), indexWriter);
+
+        final IndexReader indexReader = indexWriter.getReader();
+        // ensuring segments are created
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Validate to see if correct values are returned, assumption here is only 1 segment is getting created
+        IndexSearcher searcher = new IndexSearcher(indexReader);
+        final LeafReader leafReader = searcher.getLeafContexts().get(0).reader();
+        SegmentReader segmentReader = Lucene.segmentReader(leafReader);
+        final List<String> faissfiles = getFilesFromSegment(dir, FAISS_ENGINE_FILE_EXT);
+        final List<String> lucenefiles = getFilesFromSegment(dir, LUCENE_ENGINE_FILE_EXT);
+        assertEquals(0, faissfiles.size());
+        assertEquals(0, lucenefiles.size());
+
+        // Even setting IWC to not use compound file it still uses compound file, hence ensuring we don't check .vec
+        // file in case segment uses compound format. use this seed once we fix this to validate everything is
+        // working or not. -Dtests.seed=CAAE1B8D573EEB7E
+        if (segmentReader.getSegmentInfo().info.getUseCompoundFile() == false) {
+            final List<String> vecfiles = getFilesFromSegment(dir, FLAT_VECTOR_FILE_EXT);
+            assertEquals(2, vecfiles.size());
+        }
+
+        final ByteVectorValues byteVectorValuesFaiss = leafReader.getByteVectorValues("faiss_byte");
+        byteVectorValuesFaiss.iterator().nextDoc();
+        assertArrayEquals(byteVector, byteVectorValuesFaiss.vectorValue(byteVectorValuesFaiss.iterator().index()));
+        assertEquals(1, byteVectorValuesFaiss.size());
+        assertEquals(2, byteVectorValuesFaiss.dimension());
+
+        final ByteVectorValues byteVectorValuesLucene = leafReader.getByteVectorValues("lucene_byte");
+        byteVectorValuesLucene.iterator().nextDoc();
+        assertArrayEquals(byteVector, byteVectorValuesLucene.vectorValue(byteVectorValuesLucene.iterator().index()));
+        assertEquals(1, byteVectorValuesLucene.size());
+        assertEquals(2, byteVectorValuesLucene.dimension());
+
+        indexReader.close();
+    }
+
+    private void setup() throws IOException {
+        dir = newFSDirectory(createTempDir());
+        // on the mock directory Lucene goes ahead and does a search on different fields. We want to avoid that as of
+        // now. Given we have not implemented search for the native engine format using codec, the dir.close fails
+        // with exception. Hence, marking this as false.
+        ((BaseDirectoryWrapper) dir).setCheckIndexOnClose(false);
+        indexWriter = createIndexWriter(dir, null);
+    }
+
+    private RandomIndexWriter createIndexWriter(final Directory dir, String searchMode) throws IOException {
+        final IndexWriterConfig iwc = newIndexWriterConfig();
+        iwc.setMergeScheduler(new SerialMergeScheduler());
+        iwc.setCodec(TESTING_CODEC);
+        iwc.setUseCompoundFile(false);
+        // Set merge policy to no merges so that we create a predictable number of segments.
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+        return new RandomIndexWriter(random(), dir, iwc);
+    }
+
+    private void addFieldToIndex(final Field vectorField, final RandomIndexWriter indexWriter) throws IOException {
+        final Document doc1 = new Document();
+        doc1.add(vectorField);
+        indexWriter.addDocument(doc1);
+    }
+
+    private FieldType createVectorField(int dimension, VectorEncoding vectorEncoding, VectorDataType vectorDataType, String engine) {
+        FieldType flatVectorField = new FieldType();
+        flatVectorField.setTokenized(false);
+        flatVectorField.setIndexOptions(IndexOptions.NONE);
+        flatVectorField.putAttribute(KNNVectorFieldMapper.KNN_FIELD, "true");
+        flatVectorField.putAttribute(KNNConstants.KNN_METHOD, KNNConstants.METHOD_HNSW);
+        flatVectorField.putAttribute(KNNConstants.KNN_ENGINE, engine);
+        flatVectorField.putAttribute(KNNConstants.VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
+        flatVectorField.setVectorAttributes(
+            dimension,
+            vectorEncoding,
+            SpaceType.L2.getKnnVectorSimilarityFunction().getVectorSimilarityFunction()
+        );
+        return flatVectorField;
+    }
+
+    private List<String> getFilesFromSegment(Directory dir, String fileFormat) throws IOException {
+        return Arrays.stream(dir.listAll()).filter(x -> x.contains(fileFormat)).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -63,6 +63,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -89,6 +90,8 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNConstants.PROPERTIES;
+import static org.opensearch.knn.common.KNNConstants.INDEX_PARAMETER_KEY;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
@@ -123,10 +126,19 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             modelDao,
             CURRENT,
             null,
-            new OriginalMappingParameters(VectorDataType.DEFAULT, TEST_DIMENSION, null, null, null, null, SpaceType.UNDEFINED.getValue())
+            new OriginalMappingParameters(
+                VectorDataType.DEFAULT,
+                TEST_DIMENSION,
+                null,
+                null,
+                null,
+                null,
+                SpaceType.UNDEFINED.getValue(),
+                true
+            )
         );
 
-        assertEquals(10, builder.getParameters().size());
+        assertEquals(11, builder.getParameters().size());
         List<String> actualParams = builder.getParameters().stream().map(a -> a.name).collect(Collectors.toList());
         List<String> expectedParams = Arrays.asList(
             "store",
@@ -138,7 +150,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             MODEL_ID,
             MODE_PARAMETER,
             COMPRESSION_LEVEL_PARAMETER,
-            KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE
+            KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE,
+            INDEX_PARAMETER_KEY
         );
         assertEquals(expectedParams, actualParams);
     }
@@ -1328,7 +1341,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                 Mode.NOT_CONFIGURED.getName(),
                 CompressionLevel.NOT_CONFIGURED.getName(),
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                true
             );
             originalMappingParameters.setResolvedKnnMethodContext(knnMethodContext);
             EngineFieldMapper methodFieldMapper = EngineFieldMapper.createFieldMapper(
@@ -1396,7 +1410,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     Mode.NOT_CONFIGURED.getName(),
                     CompressionLevel.NOT_CONFIGURED.getName(),
                     null,
-                    SpaceType.UNDEFINED.getValue()
+                    SpaceType.UNDEFINED.getValue(),
+                    true
                 );
                 originalMappingParameters.setResolvedKnnMethodContext(knnMethodContext);
                 EngineFieldMapper methodFieldMapper = EngineFieldMapper.createFieldMapper(
@@ -1511,7 +1526,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
                     Mode.NOT_CONFIGURED.getName(),
                     CompressionLevel.NOT_CONFIGURED.getName(),
                     MODEL_ID,
-                    SpaceType.UNDEFINED.getValue()
+                    SpaceType.UNDEFINED.getValue(),
+                    true
                 );
 
                 ModelFieldMapper modelFieldMapper = ModelFieldMapper.createFieldMapper(
@@ -1613,7 +1629,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
             null,
-            SpaceType.UNDEFINED.getValue()
+            SpaceType.UNDEFINED.getValue(),
+            true
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
 
@@ -1675,7 +1692,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
             null,
-            SpaceType.UNDEFINED.getValue()
+            SpaceType.UNDEFINED.getValue(),
+            true
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
         luceneFieldMapper = EngineFieldMapper.createFieldMapper(
@@ -1722,7 +1740,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             Mode.NOT_CONFIGURED.getName(),
             CompressionLevel.NOT_CONFIGURED.getName(),
             null,
-            SpaceType.UNDEFINED.getValue()
+            SpaceType.UNDEFINED.getValue(),
+            true
         );
         originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
 
@@ -2344,6 +2363,234 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         );
 
         assertTrue(exception.getMessage().contains("name needs to be set"));
+    }
+
+    // index tests -> disabling graph creation
+    public void testIndexParameter_notDefined_DefaultToTrue() throws IOException {
+        String fieldName = TEST_FIELD_NAME;
+        String indexName = TEST_INDEX_NAME;
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 2)
+            .endObject();
+
+        final KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext(indexName, settings)
+        );
+
+        assertTrue(builder.getOriginalParameters().isIndexed());
+    }
+
+    public void testIndexParameter_MultipleVectorFields_LuceneAndFalseIndex() throws IOException {
+        String indexName = TEST_INDEX_NAME;
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES)
+            .startObject("my_vector1")
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 2)
+            .startObject(KNN_METHOD)
+            .field(NAME, "hnsw")
+            .field(KNN_ENGINE, "lucene")
+            .endObject()
+            .endObject()
+            .startObject("my_vector2")
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 2)
+            .field(INDEX_PARAMETER_KEY, false)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Map<String, Object> params = xContentBuilderToMap(xContentBuilder);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) params.get("properties");
+
+        assertTrue(properties.containsKey("my_vector1"));
+        assertTrue(properties.containsKey("my_vector2"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> vector1Mapping = (Map<String, Object>) properties.get("my_vector1");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> vector1Method = (Map<String, Object>) vector1Mapping.get(KNN_METHOD);
+
+        assertNull(vector1Mapping.get(INDEX_PARAMETER_KEY));
+        assertEquals("lucene", vector1Method.get(KNN_ENGINE));
+        assertEquals(KNN_VECTOR_TYPE, vector1Mapping.get(TYPE_FIELD_NAME));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> vector2Mapping = (Map<String, Object>) properties.get("my_vector2");
+        assertEquals(false, vector2Mapping.get(INDEX_PARAMETER_KEY));
+        assertEquals(KNN_VECTOR_TYPE, vector2Mapping.get(TYPE_FIELD_NAME));
+
+        // checking for 2 vector fields in index
+        assertEquals(2, properties.size());
+
+        KNNVectorFieldMapper.Builder builder1 = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            "my_vector1",
+            vector1Mapping,
+            buildParserContext(indexName, settings)
+        );
+        KNNVectorFieldMapper.Builder builder2 = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            "my_vector2",
+            vector2Mapping,
+            buildParserContext(indexName, settings)
+        );
+        Mapper.BuilderContext builderContext1 = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper1 = builder1.build(builderContext1);
+        Mapper.BuilderContext builderContext2 = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper2 = builder2.build(builderContext2);
+
+        assertTrue(knnVectorFieldMapper1 instanceof EngineFieldMapper);
+        assertTrue(knnVectorFieldMapper2 instanceof EngineFieldMapper);
+        assertTrue(knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getKnnMethodContext().isPresent());
+        assertEquals(
+            "lucene",
+            knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getKnnMethodContext().get().getKnnEngine().getName()
+        );
+        assertFalse(knnVectorFieldMapper2.fieldType().getKnnMappingConfig().isIndexed());
+    }
+
+    public void testIndexParameter_MultipleVectorFields_FaissAndFalseIndex() throws IOException {
+        String indexName = TEST_INDEX_NAME;
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES)
+            .startObject("my_vector1")
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 2)
+            .field(INDEX_PARAMETER_KEY, true)
+            .startObject(KNN_METHOD)
+            .field(NAME, "hnsw")
+            .field(KNN_ENGINE, "faiss")
+            .endObject()
+            .endObject()
+            .startObject("my_vector2")
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 2)
+            .field(INDEX_PARAMETER_KEY, false)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        Map<String, Object> params = xContentBuilderToMap(xContentBuilder);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) params.get("properties");
+
+        assertTrue(properties.containsKey("my_vector1"));
+        assertTrue(properties.containsKey("my_vector2"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> vector1Mapping = (Map<String, Object>) properties.get("my_vector1");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> vector1Method = (Map<String, Object>) vector1Mapping.get(KNN_METHOD);
+
+        assertEquals(true, vector1Mapping.get(INDEX_PARAMETER_KEY));
+        assertEquals("faiss", vector1Method.get(KNN_ENGINE));
+        assertEquals(KNN_VECTOR_TYPE, vector1Mapping.get(TYPE_FIELD_NAME));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> vector2Mapping = (Map<String, Object>) properties.get("my_vector2");
+        assertEquals(false, vector2Mapping.get(INDEX_PARAMETER_KEY));
+        assertEquals(KNN_VECTOR_TYPE, vector2Mapping.get(TYPE_FIELD_NAME));
+
+        // checking for 2 vector fields in index
+        assertEquals(2, properties.size());
+
+        KNNVectorFieldMapper.Builder builder1 = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            "my_vector1",
+            vector1Mapping,
+            buildParserContext(indexName, settings)
+        );
+        KNNVectorFieldMapper.Builder builder2 = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            "my_vector2",
+            vector2Mapping,
+            buildParserContext(indexName, settings)
+        );
+        Mapper.BuilderContext builderContext1 = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper1 = builder1.build(builderContext1);
+        Mapper.BuilderContext builderContext2 = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper2 = builder2.build(builderContext2);
+
+        assertTrue(knnVectorFieldMapper1 instanceof EngineFieldMapper);
+        assertTrue(knnVectorFieldMapper2 instanceof EngineFieldMapper);
+        assertTrue(knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getKnnMethodContext().isPresent());
+        assertEquals("faiss", knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getKnnMethodContext().get().getKnnEngine().getName());
+        assertFalse(knnVectorFieldMapper2.fieldType().getKnnMappingConfig().isIndexed());
+    }
+
+    public void testIndexParameter_IndexVersionBefore3_0_0_ValidButIndexAlwaysTrue() throws IOException {
+        String fieldName = TEST_FIELD_NAME;
+        String indexName = TEST_INDEX_NAME;
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 4)
+            .field(INDEX_PARAMETER_KEY, false)
+            .endObject();
+
+        Settings settings = Settings.builder().put(settings(Version.V_2_15_0).build()).put(KNN_INDEX, true).build();
+
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder),
+            buildLegacyParserContext(indexName, settings, Version.V_2_15_0)
+        );
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
+
+        assertTrue(knnVectorFieldMapper instanceof EngineFieldMapper);
+        assertTrue(knnVectorFieldMapper.fieldType().getKnnMappingConfig().getKnnMethodContext().isPresent());
+        assertTrue(knnVectorFieldMapper.fieldType().getKnnMappingConfig().getModelId().isEmpty());
+        assertTrue(knnVectorFieldMapper.fieldType().getKnnMappingConfig().isIndexed());
+    }
+
+    public void testIndexParameter_NotKnnIndex_FalseIndex() throws IOException {
+        String fieldName = TEST_FIELD_NAME;
+        String indexName = TEST_INDEX_NAME;
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, false).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, 2)
+            .field(INDEX_PARAMETER_KEY, false)
+            .endObject();
+
+        final KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext(indexName, settings)
+        );
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper = builder.build(builderContext);
+
+        assertTrue(knnVectorFieldMapper instanceof FlatVectorFieldMapper);
+        assertFalse(builder.getOriginalParameters().isIndexed());
     }
 
     private void validateBuilderAfterParsing(

--- a/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/OriginalMappingParametersTests.java
@@ -18,11 +18,11 @@ public class OriginalMappingParametersTests extends KNNTestCase {
 
     public void testIsLegacy() {
         assertTrue(
-            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, null, SpaceType.UNDEFINED.getValue())
+            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, null, SpaceType.UNDEFINED.getValue(), true)
                 .isLegacyMapping()
         );
         assertFalse(
-            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, "model-id", SpaceType.UNDEFINED.getValue())
+            new OriginalMappingParameters(VectorDataType.DEFAULT, 123, null, null, null, "model-id", SpaceType.UNDEFINED.getValue(), true)
                 .isLegacyMapping()
         );
         assertFalse(
@@ -33,7 +33,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 Mode.ON_DISK.getName(),
                 null,
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                true
             ).isLegacyMapping()
         );
         assertFalse(
@@ -44,7 +45,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 null,
                 CompressionLevel.x2.getName(),
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                true
             ).isLegacyMapping()
         );
         assertFalse(
@@ -55,7 +57,8 @@ public class OriginalMappingParametersTests extends KNNTestCase {
                 null,
                 null,
                 null,
-                SpaceType.UNDEFINED.getValue()
+                SpaceType.UNDEFINED.getValue(),
+                true
             ).isLegacyMapping()
         );
     }

--- a/src/test/java/org/opensearch/knn/index/query/KNNExactQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNExactQueryBuilderTests.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.junit.Before;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.util.IndexUtil;
+import org.opensearch.knn.index.util.KNNClusterUtil;
+import org.apache.lucene.search.join.BitSetProducer;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
+
+public class KNNExactQueryBuilderTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "myvector";
+    private static final float[] QUERY_VECTOR = new float[] { 1.0f, 2.0f, 3.0f, 4.0f };
+    private static final String SPACE_TYPE = "innerproduct";
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ClusterSettings clusterSettings = mock(ClusterSettings.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        KNNSettings.state().setClusterService(clusterService);
+    }
+
+    public void testEmptyVector() {
+        /**
+         * null query vector
+         */
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(null).spaceType(SPACE_TYPE).build()
+        );
+        /**
+         * empty query vector
+         */
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(new float[0]).spaceType(SPACE_TYPE).build()
+        );
+    }
+
+    public void testInvalidSpaceType() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).spaceType("cosinesimilarity").build()
+        );
+    }
+
+    public void testIgnoreUnmapped() throws IOException {
+        KNNExactQueryBuilder.Builder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .ignoreUnmapped(true);
+        assertTrue(builder.build().isIgnoreUnmapped());
+
+        Query query = builder.build().doToQuery(mock(QueryShardContext.class));
+        assertNotNull(query);
+        assertThat(query, instanceOf(MatchNoDocsQuery.class));
+        builder.ignoreUnmapped(false);
+        expectThrows(IllegalArgumentException.class, () -> builder.build().doToQuery(mock(QueryShardContext.class)));
+    }
+
+    public void testEmptyFieldName() {
+        /**
+         * empty field name
+         */
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNExactQueryBuilder.builder().fieldName("").vector(QUERY_VECTOR).spaceType(SPACE_TYPE).build()
+        );
+        /**
+         * null field name
+         */
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> KNNExactQueryBuilder.builder().fieldName(null).vector(QUERY_VECTOR).spaceType(SPACE_TYPE).build()
+        );
+    }
+
+    public void testValidSpaceTypes() {
+        String[] validSpaceTypes = { "l2", "cosinesimil", "innerproduct", "hamming", "l1", "linf" };
+        for (String spaceType : validSpaceTypes) {
+            KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+                .fieldName(FIELD_NAME)
+                .vector(QUERY_VECTOR)
+                .spaceType(spaceType)
+                .build();
+            assertEquals(spaceType, builder.getSpaceType());
+        }
+    }
+
+    public void testExpandNested() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .expandNested(true)
+            .build();
+        assertTrue(builder.getExpandNested());
+
+        builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .expandNested(false)
+            .build();
+        assertFalse(builder.getExpandNested());
+
+        builder = KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).spaceType(SPACE_TYPE).build();
+        assertNull(builder.getExpandNested());
+    }
+
+    public void testDoToQuery_Normal() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .build();
+
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(getDefaultKNNMethodContext(), 4));
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+
+        KNNExactQuery query = (KNNExactQuery) builder.doToQuery(mockQueryShardContext);
+        assertNotNull(query);
+        assertEquals(builder.fieldName(), query.getField());
+        assertEquals(builder.vector(), query.getQueryVector());
+        assertEquals(builder.getSpaceType(), query.getSpaceType());
+    }
+
+    public void testDoToQuery_NoSpaceType() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).build();
+
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(getDefaultKNNMethodContext(), 4));
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+
+        KNNExactQuery query = (KNNExactQuery) builder.doToQuery(mockQueryShardContext);
+        assertNotNull(query);
+        assertEquals(builder.fieldName(), query.getField());
+        assertEquals(builder.vector(), query.getQueryVector());
+        assertEquals(SpaceType.DEFAULT.getValue(), query.getSpaceType());
+    }
+
+    public void testDoToQuery_InvalidFieldType() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .build();
+
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mock(MappedFieldType.class)); // Not KNNVectorFieldType
+
+        expectThrows(IllegalArgumentException.class, () -> builder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testDoToQuery_WrongVectorDimension() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(new float[] { 1.0f, 2.0f })
+            .spaceType(SPACE_TYPE)
+            .build();
+
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(getDefaultKNNMethodContext(), 4)); // 4
+                                                                                                                                      // dimensions
+                                                                                                                                      // expected
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+
+        expectThrows(IllegalArgumentException.class, () -> builder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testExpandNestedWithoutParentFilter() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .expandNested(true)
+            .build();
+
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(getDefaultKNNMethodContext(), 4));
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        when(mockQueryShardContext.getParentFilter()).thenReturn(null); // No parent filter
+
+        expectThrows(IllegalArgumentException.class, () -> builder.doToQuery(mockQueryShardContext));
+    }
+
+    public void testBuilderDefaults() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).build();
+
+        assertNull(builder.getSpaceType()); // Should be null by default
+        assertFalse(builder.isIgnoreUnmapped()); // Should be false by default
+        assertNull(builder.getExpandNested()); // Should be null by default
+    }
+
+    public void testNestedFieldsWithExpandNested() {
+        KNNExactQueryBuilder builder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .expandNested(true)
+            .build();
+
+        Index dummyIndex = new Index("dummy", "dummy");
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        BitSetProducer mockParentFilter = mock(BitSetProducer.class);
+
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(getDefaultKNNMethodContext(), 4));
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        when(mockQueryShardContext.getParentFilter()).thenReturn(mockParentFilter);
+
+        KNNExactQuery query = (KNNExactQuery) builder.doToQuery(mockQueryShardContext);
+        assertNotNull(query);
+        assertTrue(query.isExpandNested());
+        assertEquals(mockParentFilter, query.getParentFilter());
+    }
+
+    public void testSerialization() throws Exception {
+        assertSerialization(Version.CURRENT);
+        assertSerialization(Version.V_2_3_0);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        final List<NamedWriteableRegistry.Entry> entries = ClusterModule.getNamedWriteables();
+        entries.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, KNNExactQueryBuilder.NAME, KNNExactQueryBuilder::new));
+        return new NamedWriteableRegistry(entries);
+    }
+
+    private void assertSerialization(final Version version) throws Exception {
+        final KNNExactQueryBuilder knnExactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .expandNested(true)
+            .build();
+
+        final ClusterService clusterService = mockClusterService(version);
+
+        final KNNClusterUtil knnClusterUtil = KNNClusterUtil.instance();
+        knnClusterUtil.initialize(clusterService);
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(version);
+            output.writeNamedWriteable(knnExactQueryBuilder);
+
+            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry())) {
+                in.setVersion(version);
+                final QueryBuilder deserializedQuery = in.readNamedWriteable(QueryBuilder.class);
+
+                assertNotNull(deserializedQuery);
+                assertTrue(deserializedQuery instanceof KNNExactQueryBuilder);
+                final KNNExactQueryBuilder deserializedKnnExactQueryBuilder = (KNNExactQueryBuilder) deserializedQuery;
+                assertEquals(FIELD_NAME, deserializedKnnExactQueryBuilder.fieldName());
+                assertArrayEquals(QUERY_VECTOR, (float[]) deserializedKnnExactQueryBuilder.vector(), 0.0f);
+                assertEquals(SPACE_TYPE, deserializedKnnExactQueryBuilder.getSpaceType());
+                assertFalse(deserializedKnnExactQueryBuilder.isIgnoreUnmapped());
+                if (version.onOrAfter(IndexUtil.minimalRequiredVersionMap.get("expand_nested_docs"))) {
+                    assertTrue(deserializedKnnExactQueryBuilder.getExpandNested());
+                } else {
+                    assertNull(deserializedKnnExactQueryBuilder.getExpandNested());
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNExactWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNExactWeightTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.*;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.query.iterators.KNNIterator;
+import org.opensearch.knn.index.query.iterators.VectorIdsKNNIterator;
+import org.opensearch.knn.index.vectorvalues.KNNFloatVectorValues;
+import org.opensearch.knn.indices.ModelDao;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.opensearch.knn.plugin.script.KNNScoringUtil;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.opensearch.knn.KNNRestTestCase.INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.*;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+
+public class KNNExactWeightTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "test_field";
+    private static final float[] QUERY_VECTOR = { 1.0f, 0.0f };
+    private static final float BOOST = 2.0f;
+    private static final String SPACE_TYPE = "innerproduct";
+
+    @SneakyThrows
+    public void testScorerSupplier_ReturnsLazyScorer() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        when(mockQuery.getField()).thenReturn(FIELD_NAME);
+        when(mockQuery.getQueryVector()).thenReturn(QUERY_VECTOR);
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(mockIterator);
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = weight.scorerSupplier(mockContext);
+        Scorer scorer = supplier.get(0);
+
+        assertTrue(scorer instanceof KNNLazyScorer);
+        verify(mockSearcher).createIterator(eq(mockContext), any());
+    }
+
+    @SneakyThrows
+    public void testScorerSupplier_NullIterator_ReturnsEmptyScorer() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(null);
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = weight.scorerSupplier(mockContext);
+        Scorer scorer = supplier.get(0);
+
+        assertEquals(NO_MORE_DOCS, scorer.iterator().nextDoc());
+    }
+
+    @SneakyThrows
+    public void testLazyScorerIntegration() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        when(mockQuery.getField()).thenReturn(FIELD_NAME);
+        when(mockQuery.getQueryVector()).thenReturn(QUERY_VECTOR);
+
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1, 5, NO_MORE_DOCS);
+        when(mockIterator.score()).thenReturn(0.8f, 0.6f);
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(mockIterator);
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = weight.scorerSupplier(mockContext);
+        Scorer scorer = supplier.get(0);
+        DocIdSetIterator iterator = scorer.iterator();
+
+        assertEquals(1, iterator.nextDoc());
+        assertEquals(1.6f, scorer.score(), 0.0f); // 0.8 * 2.0 boost
+
+        assertEquals(5, iterator.nextDoc());
+        assertEquals(1.2f, scorer.score(), 0.0f); // 0.6 * 2.0 boost
+
+        assertEquals(NO_MORE_DOCS, iterator.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testLazyScoring_ScoreNotCalledUntilRequested() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        when(mockQuery.getField()).thenReturn(FIELD_NAME);
+        when(mockQuery.getQueryVector()).thenReturn(QUERY_VECTOR);
+
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1, 2, NO_MORE_DOCS);
+        when(mockIterator.score()).thenReturn(0.8f, 0.6f);
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(mockIterator);
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = weight.scorerSupplier(mockContext);
+        Scorer scorer = supplier.get(0);
+        DocIdSetIterator iterator = scorer.iterator();
+
+        // verifying score() was not called yet
+        assertEquals(1, iterator.nextDoc());
+        verify(mockIterator, never()).score();
+
+        // verifying score() was called exactly once
+        assertEquals(1.6f, scorer.score(), 0.0f);
+        verify(mockIterator, times(1)).score();
+
+        // verifying score() still only called once
+        assertEquals(2, iterator.nextDoc());
+        verify(mockIterator, times(1)).score();
+
+        // verifying score() was called second time
+        assertEquals(1.2f, scorer.score(), 0.0f);
+        verify(mockIterator, times(2)).score();
+    }
+
+    @SneakyThrows
+    public void testExplain() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        when(mockQuery.getField()).thenReturn(FIELD_NAME);
+        when(mockQuery.getQueryVector()).thenReturn(QUERY_VECTOR);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = mock(LeafReaderContext.class);
+
+        Explanation explanation = weight.explain(mockContext, 1, 0.5f);
+
+        assertEquals(1.0f, explanation.getValue().floatValue(), 0.0f); // 0.5 * 2.0 boost
+        assertTrue(explanation.getDescription().contains("exact k-NN search"));
+        assertTrue(explanation.getDescription().contains(FIELD_NAME));
+        verify(mockQuery).setExplain(true);
+    }
+
+    public void testIsCacheable() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+
+        assertTrue(weight.isCacheable(mock(LeafReaderContext.class)));
+    }
+
+    @SneakyThrows
+    public void testExactSearchContextCreation() {
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        when(mockQuery.getField()).thenReturn(FIELD_NAME);
+        when(mockQuery.getQueryVector()).thenReturn(QUERY_VECTOR);
+        when(mockQuery.getSpaceType()).thenReturn(SPACE_TYPE);
+        when(mockQuery.getParentFilter()).thenReturn(null);
+        when(mockQuery.getByteQueryVector()).thenReturn(null);
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(mockIterator);
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = weight.scorerSupplier(mockContext);
+        supplier.get(0);
+
+        verify(mockSearcher).createIterator(eq(mockContext), any(ExactSearcher.ExactSearcherContext.class));
+    }
+
+    @SneakyThrows
+    public void testNestedQueryWithParentFilter() {
+        BitSetProducer mockParentFilter = mock(BitSetProducer.class);
+
+        KNNExactQuery mockQuery = mock(KNNExactQuery.class);
+        when(mockQuery.getField()).thenReturn(FIELD_NAME);
+        when(mockQuery.getQueryVector()).thenReturn(QUERY_VECTOR);
+        when(mockQuery.getSpaceType()).thenReturn(SPACE_TYPE);
+        when(mockQuery.getParentFilter()).thenReturn(mockParentFilter);
+        when(mockQuery.isExpandNested()).thenReturn(true);
+        when(mockQuery.getByteQueryVector()).thenReturn(null);
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(mockIterator);
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight weight = new KNNExactWeight(mockQuery, BOOST);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = weight.scorerSupplier(mockContext);
+        Scorer scorer = supplier.get(0);
+
+        assertTrue(scorer instanceof KNNLazyScorer);
+        verify(mockSearcher).createIterator(eq(mockContext), any(ExactSearcher.ExactSearcherContext.class));
+    }
+
+    @SneakyThrows
+    public void testExactSearch_thenCorrectDocOrderWithCorrectScores() {
+        float[][] docVectors = {
+            { 0.5f, 0.0f },  // inner product = 0.5 (second)
+            { 1.0f, 0.0f },  // inner product = 1.0 (first)
+            { 0.0f, 1.0f }   // inner product = 0.0 (third)
+        };
+
+        KNNFloatVectorValues vectorValues = mock(KNNFloatVectorValues.class);
+        when(vectorValues.nextDoc()).thenReturn(0, 1, 2, NO_MORE_DOCS);
+        when(vectorValues.getVector()).thenReturn(docVectors[0]).thenReturn(docVectors[1]).thenReturn(docVectors[2]);
+
+        VectorIdsKNNIterator realIterator = new VectorIdsKNNIterator(null, QUERY_VECTOR, vectorValues, SpaceType.getSpace(SPACE_TYPE));
+
+        float[] expectedScores = new float[docVectors.length];
+        for (int i = 0; i < docVectors.length; i++) {
+            expectedScores[i] = KNNWeight.normalizeScore(-KNNScoringUtil.innerProduct(QUERY_VECTOR, docVectors[i]));
+        }
+
+        ExactSearcher mockSearcher = mock(ExactSearcher.class);
+        when(mockSearcher.createIterator(any(), any())).thenReturn(realIterator);
+
+        final KNNExactQuery query = KNNExactQuery.builder()
+            .field(FIELD_NAME)
+            .queryVector(QUERY_VECTOR)
+            .indexName(INDEX_NAME)
+            .spaceType(SPACE_TYPE)
+            .build();
+
+        ModelDao mockModelDao = mock(ModelDao.class);
+        KNNExactWeight.initialize(mockModelDao, mockSearcher);
+
+        KNNExactWeight knnExactWeight = new KNNExactWeight(query, 1.0f);
+        LeafReaderContext mockContext = createMockLeafReaderContext();
+
+        ScorerSupplier supplier = knnExactWeight.scorerSupplier(mockContext);
+        Scorer scorer = supplier.get(0);
+        DocIdSetIterator iterator = scorer.iterator();
+
+        // verify that documents returned in ID order with correct scores
+        assertEquals(0, iterator.nextDoc());
+        assertEquals(expectedScores[0], scorer.score(), 0.001f);
+
+        assertEquals(1, iterator.nextDoc());
+        assertEquals(expectedScores[1], scorer.score(), 0.001f);
+
+        assertEquals(2, iterator.nextDoc());
+        assertEquals(expectedScores[2], scorer.score(), 0.001f);
+
+        assertEquals(NO_MORE_DOCS, iterator.nextDoc());
+    }
+
+    private LeafReaderContext createMockLeafReaderContext() {
+        LeafReaderContext mockContext = mock(LeafReaderContext.class);
+        LeafReader mockReader = mock(LeafReader.class);
+        when(mockContext.reader()).thenReturn(mockReader);
+        when(mockReader.maxDoc()).thenReturn(100);
+        return mockContext;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNLazyScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNLazyScorerTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.query.iterators.KNNIterator;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+public class KNNLazyScorerTests extends KNNTestCase {
+
+    public void testIteratorNextDoc() throws IOException {
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(1, 2, DocIdSetIterator.NO_MORE_DOCS);
+
+        KNNLazyScorer scorer = new KNNLazyScorer(mockIterator, 1.0f);
+        DocIdSetIterator iterator = scorer.iterator();
+
+        assertEquals(1, iterator.nextDoc());
+        assertEquals(2, iterator.nextDoc());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
+
+        verify(mockIterator, times(3)).nextDoc();
+    }
+
+    public void testScoreWithBoost() throws IOException {
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockIterator.score()).thenReturn(0.8f);
+
+        KNNLazyScorer scorer = new KNNLazyScorer(mockIterator, 2.0f);
+
+        assertEquals(1.6f, scorer.score(), 0.0f);
+        verify(mockIterator, times(1)).score();
+    }
+
+    public void testDocID() throws IOException {
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(5);
+
+        KNNLazyScorer scorer = new KNNLazyScorer(mockIterator, 1.0f);
+        DocIdSetIterator iterator = scorer.iterator();
+        iterator.nextDoc();
+
+        assertEquals(5, scorer.docID());
+    }
+
+    public void testIteratorAdvance() throws IOException {
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        when(mockIterator.nextDoc()).thenReturn(3, 7, DocIdSetIterator.NO_MORE_DOCS);
+
+        KNNLazyScorer scorer = new KNNLazyScorer(mockIterator, 1.0f);
+        DocIdSetIterator iterator = scorer.iterator();
+
+        assertEquals(7, iterator.advance(5));
+        verify(mockIterator, times(2)).nextDoc();
+    }
+
+    public void testGetMaxScore() throws IOException {
+        KNNIterator mockIterator = mock(KNNIterator.class);
+        KNNLazyScorer scorer = new KNNLazyScorer(mockIterator, 1.0f);
+        assertEquals(Float.MAX_VALUE, scorer.getMaxScore(100), 0.0f);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/parser/KNNExactQueryBuilderParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/KNNExactQueryBuilderParserTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.parser;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.query.KNNExactQueryBuilder;
+
+import java.io.IOException;
+
+import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
+import static org.opensearch.knn.index.query.KNNExactQueryBuilder.*;
+
+public class KNNExactQueryBuilderParserTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "myvector";
+    private static final Float BOOST = 10.5f;
+    private static final String SPACE_TYPE = "innerproduct";
+    private static final float[] QUERY_VECTOR = { 1.0f, 2.0f, 3.0f, 4.0f };
+
+    public void testFromXContent_Basic() throws IOException {
+        KNNExactQueryBuilder knnExactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnExactQueryBuilder.fieldName());
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), knnExactQueryBuilder.vector());
+        builder.field(KNNExactQueryBuilder.SPACE_TYPE_FIELD.getPreferredName(), knnExactQueryBuilder.getSpaceType());
+        builder.endObject();
+        builder.endObject();
+
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNExactQueryBuilder actualBuilder = KNNExactQueryBuilderParser.fromXContent(contentParser);
+
+        assertEquals(knnExactQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_WithExpandNested() throws IOException {
+        KNNExactQueryBuilder knnExactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .expandNested(true)
+            .build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnExactQueryBuilder.fieldName());
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), knnExactQueryBuilder.vector());
+        builder.field(KNNExactQueryBuilder.SPACE_TYPE_FIELD.getPreferredName(), knnExactQueryBuilder.getSpaceType());
+        builder.field(KNNExactQueryBuilder.EXPAND_NESTED_FIELD.getPreferredName(), knnExactQueryBuilder.getExpandNested());
+        builder.endObject();
+        builder.endObject();
+
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNExactQueryBuilder actualBuilder = KNNExactQueryBuilderParser.fromXContent(contentParser);
+
+        assertEquals(knnExactQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_WithIgnoreUnmapped() throws IOException {
+        KNNExactQueryBuilder knnExactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType(SPACE_TYPE)
+            .ignoreUnmapped(true)
+            .build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(knnExactQueryBuilder.fieldName());
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), knnExactQueryBuilder.vector());
+        builder.field(KNNExactQueryBuilder.SPACE_TYPE_FIELD.getPreferredName(), knnExactQueryBuilder.getSpaceType());
+        builder.field(KNNExactQueryBuilder.IGNORE_UNMAPPED_FIELD.getPreferredName(), knnExactQueryBuilder.isIgnoreUnmapped());
+        builder.endObject();
+        builder.endObject();
+
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        KNNExactQueryBuilder actualBuilder = KNNExactQueryBuilderParser.fromXContent(contentParser);
+
+        assertEquals(knnExactQueryBuilder, actualBuilder);
+    }
+
+    public void testFromXContent_whenMultiFields_thenException() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(FIELD_NAME + "1");
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), QUERY_VECTOR);
+        builder.endObject();
+        builder.startObject(FIELD_NAME + "2");
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), QUERY_VECTOR);
+        builder.endObject();
+        builder.endObject();
+        XContentParser contentParser = createParser(builder);
+        contentParser.nextToken();
+        Exception exception = expectThrows(ParsingException.class, () -> KNNExactQueryBuilderParser.fromXContent(contentParser));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("[exact_knn] query doesn't support multiple fields"));
+    }
+
+    public void testToXContent_BoostOnly_thenSucceed() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), QUERY_VECTOR);
+        builder.field(BOOST_FIELD.getPreferredName(), BOOST);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        KNNExactQueryBuilder knnExactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .boost(BOOST)
+            .build();
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNExactQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnExactQueryBuilder);
+        testBuilder.endObject();
+        assertEquals(builder.toString(), testBuilder.toString());
+    }
+
+    public void testToXContent_BoostSpaceTypeNested_thenSucceed() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.startObject(NAME);
+        builder.startObject(FIELD_NAME);
+        builder.field(KNNExactQueryBuilder.VECTOR_FIELD.getPreferredName(), QUERY_VECTOR);
+        builder.field(SPACE_TYPE_FIELD.getPreferredName(), SPACE_TYPE);
+        builder.field(EXPAND_NESTED_FIELD.getPreferredName(), true);
+        builder.field(BOOST_FIELD.getPreferredName(), BOOST);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        KNNExactQueryBuilder knnExactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .boost(BOOST)
+            .spaceType(SPACE_TYPE)
+            .expandNested(true)
+            .build();
+        XContentBuilder testBuilder = XContentFactory.jsonBuilder();
+        testBuilder.startObject();
+        KNNExactQueryBuilderParser.toXContent(testBuilder, EMPTY_PARAMS, knnExactQueryBuilder);
+        testBuilder.endObject();
+        assertEquals(builder.toString(), testBuilder.toString());
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/IndexParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/IndexParameterIT.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import lombok.SneakyThrows;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.SpaceType;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.TestUtils.*;
+import static org.opensearch.knn.common.KNNConstants.INDEX_PARAMETER_KEY;
+
+public class IndexParameterIT extends KNNRestTestCase {
+    private final static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f };
+    private final static int DIMENSION = 2;
+    private final static int K = 1;
+    private static final String INDEX_NAME = "test_index";
+    private static final String FIELD_NAME = "test_field";
+    private static final SpaceType TEST_SPACE_TYPE_L2 = SpaceType.L2;
+
+    // approximate_threshold = -1 tests
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdNegOne_thenNoGraphsBuilt_NoException_Faiss() {
+        createTestIndexWithIndexParameterWithEngine(false, -1, "faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexTrue_ApproxThresholdNegOne_thenNoGraphsBuilt_NoException_Faiss() {
+        createTestIndexWithIndexParameterWithEngine(true, -1, "faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdNegOne_thenNoGraphsBuilt_NoException_Lucene() {
+        createTestIndexWithIndexParameterWithEngine(false, -1, "lucene");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexTrue_ApproxThresholdNegOne_thenGraphsBuilt_NoException_Lucene() {
+        createTestIndexWithIndexParameterWithEngine(true, -1, "lucene");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because since index = true, fall back to approx_threshold
+        // and lucene doesn't pick up that setting so graphs are built
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    // approximate_threshold > 0 tests
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdAboveZero_DocCountLess_thenNoGraphsBuilt_NoException_Faiss() {
+        createTestIndexWithIndexParameterWithEngine(false, 2, "faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexTrue_ApproxThresholdAboveZero_DocCountLess_thenNoGraphsBuilt_NoException_Faiss() {
+        createTestIndexWithIndexParameterWithEngine(true, 2, "faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdAboveZero_DocCountMore_thenNoGraphsBuilt_Faiss() {
+        createTestIndexWithIndexParameterWithEngine(false, 1, "faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdAboveZero_DocCountLess_thenNoGraphsBuilt_Lucene() {
+        createTestIndexWithIndexParameterWithEngine(false, 1, "lucene");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    // approximate_threshold = 0 tests
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdZero_thenNoGraphsBuilt_Faiss() {
+        createTestIndexWithIndexParameterWithEngine(false, 0, "faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testIndexFalse_ApproxThresholdZero_thenNoGraphsBuilt_Lucene() {
+        createTestIndexWithIndexParameterWithEngine(false, 0, "lucene");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+
+        // the following search does not throw an exception because of KNNWeight's isExactSearchRequire method:
+        // since no native engine files are created, defaults to exact search
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testCreateIndexWithoutIndexParameter_Faiss() {
+        createTestIndexWithNoIndexParameter("faiss");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testCreateIndexWithoutIndexParameter_Lucene() {
+        createTestIndexWithNoIndexParameter("lucene");
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testNonKnnIndices() {
+        createNonKnnIndex(false);
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteKNNIndex(INDEX_NAME);
+
+        createNonKnnIndex(true);
+        addKnnDoc(INDEX_NAME, "0", FIELD_NAME, TEST_VECTOR);
+        validateKNNScriptScoreSearch(INDEX_NAME, FIELD_NAME, DIMENSION, 1, K, TEST_SPACE_TYPE_L2);
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    private void createNonKnnIndex(boolean indexed) throws IOException {
+        Settings settings = Settings.builder()
+            .put(NUMBER_OF_SHARDS, 1)
+            .put(NUMBER_OF_REPLICAS, 0)
+            .put(INDEX_KNN, false)
+            .put("index.use_compound_file", false)
+            .build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(INDEX_PARAMETER_KEY, indexed)
+            .endObject()
+            .endObject()
+            .endObject();
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+    }
+
+    private void createTestIndexWithIndexParameterWithEngine(boolean indexed, int approxThreshold, String engine) throws IOException {
+        Settings settings;
+        Settings.Builder settingsBuilder = Settings.builder().put("index.use_compound_file", false);
+        settingsBuilder.put(buildKNNIndexSettings(approxThreshold));
+        settings = settingsBuilder.build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(INDEX_PARAMETER_KEY, indexed)
+            .startObject("method")
+            .field("engine", engine)
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, settings, mapping);
+    }
+
+    private void createTestIndexWithNoIndexParameter(String engine) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject("method")
+            .field("engine", engine)
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String mapping = builder.toString();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/integ/KNNExactQueryIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNExactQueryIT.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNJsonIndexMappingsBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNExactQueryBuilder;
+import org.opensearch.knn.plugin.script.KNNScoringUtil;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.QUERY;
+import static org.opensearch.knn.common.KNNConstants.EXACT_KNN;
+import static org.opensearch.knn.common.KNNConstants.VECTOR;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+@Log4j2
+public class KNNExactQueryIT extends KNNRestTestCase {
+
+    private static final float[] QUERY_VECTOR = { 1.0f, 2.0f, 3.0f };
+    private static final byte[] BYTE_QUERY_VECTOR = { 1, 2, 3 };
+    private static final int DIMENSION = 3;
+    private static final int SIZE = 5;
+    private static final String FIELD_NAME_NESTED = "nested_test";
+    private static final String FIELD_NAME_FILTER = "color";
+
+    @SneakyThrows
+    public void testKNNExactQuery_Basic() {
+        createTestIndex(false);
+        for (int i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType("innerproduct")
+            .build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = SpaceType.INNER_PRODUCT.getKnnVectorSimilarityFunction().compare(QUERY_VECTOR, new float[] { i, i, i });
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_BasicLucene() {
+        createTestIndex(true);
+        for (int i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType("innerproduct")
+            .build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = SpaceType.INNER_PRODUCT.getKnnVectorSimilarityFunction().compare(QUERY_VECTOR, new float[] { i, i, i });
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_NoSpaceTypeDefined_ThenIndexSpaceTypeL2Used() {
+        createTestIndex(false);
+        for (int i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = SpaceType.L2.getKnnVectorSimilarityFunction().compare(QUERY_VECTOR, new float[] { i, i, i });
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_SpaceTypeL1() {
+        createTestIndex(false);
+        for (int i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType("l1")
+            .build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = 1 / (1 + KNNScoringUtil.l1Norm(QUERY_VECTOR, new float[] { i, i, i }));
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_Lucene_SpaceTypeLINF() {
+        createTestIndex(true);
+        for (int i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType("linf")
+            .build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = 1 / (1 + KNNScoringUtil.lInfNorm(QUERY_VECTOR, new float[] { i, i, i }));
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_ByteL1() {
+        createTestIndex_Byte(false);
+        for (byte i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType("l1")
+            .build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = 1 / (1 + KNNScoringUtil.l1Norm(BYTE_QUERY_VECTOR, new byte[] { (byte) i, (byte) i, (byte) i }));
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_Binary() {
+        createTestIndex_Binary(false);
+        for (byte i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = SpaceType.HAMMING.getKnnVectorSimilarityFunction()
+                .compare(BYTE_QUERY_VECTOR, new byte[] { (byte) i, (byte) i, (byte) i });
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_LuceneBinary() {
+        createTestIndex_Binary(true);
+        for (byte i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+        refreshIndex(INDEX_NAME);
+        forceMergeKnnIndex(INDEX_NAME);
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = SpaceType.HAMMING.getKnnVectorSimilarityFunction()
+                .compare(BYTE_QUERY_VECTOR, new byte[] { (byte) i, (byte) i, (byte) i });
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_LuceneByteLINF() {
+        createTestIndex_Byte(true);
+        for (byte i = 0; i < SIZE; i++) {
+            addKnnDoc(INDEX_NAME, String.valueOf(i), FIELD_NAME, new float[] { i, i, i });
+        }
+        refreshIndex(INDEX_NAME);
+        forceMergeKnnIndex(INDEX_NAME);
+
+        KNNExactQueryBuilder exactQueryBuilder = KNNExactQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .spaceType("linf")
+            .build();
+
+        Response searchResponse = validateKNNExactSearch(INDEX_NAME, exactQueryBuilder);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            expectedResults[i] = 1 / (1 + KNNScoringUtil.lInfNorm(BYTE_QUERY_VECTOR, new byte[] { (byte) i, (byte) i, (byte) i }));
+        }
+
+        assertEquals(SIZE, results.size());
+        for (int i = 0; i < SIZE; i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId)], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testKNNExactQuery_WithFiltering() {
+        createTestIndex(false);
+        for (byte i = 0; i < SIZE; i++) {
+            String color = i % 2 == 0 ? "blue" : "red";
+            addKnnDocWithAttributes(String.valueOf(i), new float[] { i, i, i }, ImmutableMap.of(FIELD_NAME_FILTER, color));
+        }
+        refreshIndex(INDEX_NAME);
+        forceMergeKnnIndex(INDEX_NAME);
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject(QUERY);
+        queryBuilder.startObject("bool");
+        queryBuilder.startArray("filter");
+        queryBuilder.startObject().startObject("term").startObject(FIELD_NAME_FILTER);
+        queryBuilder.field("value", "blue");
+        queryBuilder.endObject().endObject().endObject();
+        queryBuilder.endArray();
+        queryBuilder.startArray("must");
+        queryBuilder.startObject().startObject(EXACT_KNN).startObject(FIELD_NAME);
+        queryBuilder.field(VECTOR, QUERY_VECTOR);
+        queryBuilder.field("space_type", "innerproduct");
+        queryBuilder.endObject().endObject().endObject();
+        queryBuilder.endArray();
+        queryBuilder.endObject().endObject().endObject();
+
+        Response searchResponse = searchKNNIndex(INDEX_NAME, queryBuilder, SIZE);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), FIELD_NAME);
+
+        float[] expectedResults = new float[(SIZE / 2) + 1];
+        for (int i = 0; i < SIZE; i += 2) {
+            expectedResults[i / 2] = SpaceType.INNER_PRODUCT.getKnnVectorSimilarityFunction()
+                .compare(QUERY_VECTOR, new float[] { i, i, i });
+        }
+
+        assertEquals((SIZE / 2) + 1, results.size());
+        for (int i = 0; i < results.size(); i++) {
+            String docId = results.get(i).getDocId();
+            assertEquals(expectedResults[Integer.parseInt(docId) / 2], results.get(i).getScore(), 0.00001);
+        }
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    public void createTestIndex(boolean isLucene) throws IOException {
+        String mapping;
+        if (isLucene) {
+            mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(FIELD_NAME)
+                .dimension(DIMENSION)
+                .method(getLuceneMethod())
+                .build()
+                .getIndexMapping();
+        } else {
+            mapping = KNNJsonIndexMappingsBuilder.builder().fieldName(FIELD_NAME).dimension(DIMENSION).build().getIndexMapping();
+        }
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    public void createTestIndex_Byte(boolean isLucene) throws IOException {
+        String mapping;
+        if (isLucene) {
+            mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(FIELD_NAME)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.BYTE.getValue())
+                .method(getLuceneMethod())
+                .build()
+                .getIndexMapping();
+        } else {
+            mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(FIELD_NAME)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.BYTE.getValue())
+                .build()
+                .getIndexMapping();
+        }
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    public void createTestIndex_Binary(boolean isLucene) throws IOException {
+        String mapping = KNNJsonIndexMappingsBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .dimension(DIMENSION * 8)
+            .vectorDataType(VectorDataType.BINARY.getValue())
+            .method(getBinaryMethod(isLucene))
+            .build()
+            .getIndexMapping();
+        createKnnIndex(INDEX_NAME, mapping);
+    }
+
+    private Response validateKNNExactSearch(String testIndex, KNNExactQueryBuilder knnExactQueryBuilder) throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        knnExactQueryBuilder.doXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject().endObject();
+        return searchKNNIndex(testIndex, builder, SIZE);
+    }
+
+    private KNNJsonIndexMappingsBuilder.Method getLuceneMethod() {
+        return KNNJsonIndexMappingsBuilder.Method.builder().methodName(METHOD_HNSW).engine(KNNEngine.LUCENE.getName()).build();
+    }
+
+    private KNNJsonIndexMappingsBuilder.Method getBinaryMethod(boolean isLucene) {
+        return KNNJsonIndexMappingsBuilder.Method.builder()
+            .methodName(METHOD_HNSW)
+            .spaceType(SpaceType.HAMMING.getValue())
+            .engine(isLucene ? KNNEngine.LUCENE.getName() : KNNEngine.FAISS.getName())
+            .build();
+    }
+}


### PR DESCRIPTION
### Description
Currently, if a user wants to perform exact search on a field with index.knn set to true, a score script query must be used. As mentioned in #2368 and #1079, script scoring has the extra hop of script compilation and requires users to have script score knowledge which may not be intuitive. Adding a separate KNN exact query clause `exact_knn` could simplify this use-case and make carrying out exact search less ambiguous for users. In addition, this query will have the option for users to specify a space type that will be used for exact search (which can be different from the one in the index), which is a benefit of script scoring that will be maintained.

Example of query with `exact_knn`:
```
{
  "size": 2,
  "query": {
    "exact_knn": {
      "my_vector": {
        "vector": [2, 3, 5, 6],
        "space_type": "l2"
      }
    }
  }
}
```

Note: This query type will also support nested fields/querying, will add that soon.

### Related Issues
Resolves Problem 2 of #2368

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
