### PR TITLE
Update delete_backport_branch workflow to include release-chores branches

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.repository == 'opensearch-project/k-NN' && startsWith(github.event.pull_request.head.ref,'backport/')
+    if: github.repository == 'opensearch-project/k-NN' && (startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/'))
     steps:
     - name: Delete merged branch
       uses: actions/github-script@v7


### PR DESCRIPTION
This PR updates the delete_backport_branch workflow to automatically delete branches that start with 'release-chores/' after they are merged, in addition to the existing condition for 'backport/' branches.