### PR TITLE
Add expandNested support to "exact_knn" query clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [BUGFIX] [Remote Vector Index Build] Don't fall back to CPU on terminal failures [#2773](https://github.com/opensearch-project/k-NN/pull/2773)
 * Add KNN timing info to core profiler [#2785](https://github.com/opensearch-project/k-NN/pull/2785)
 * Add "exact_knn" query clause type [#2826](https://github.com/opensearch-project/k-NN/pull/2826)
+* Add expandNested support for "exact_knn" query [#2846](https://github.com/opensearch-project/k-NN/pull/2846)
 
 ### Bug Fixes
 * Fix @ collision in NativeMemoryCacheKeyHelper for vector index filenames containing @ characters [#2810](https://github.com/opensearch-project/k-NN/pull/2810)

--- a/src/main/java/org/opensearch/knn/index/query/ExactKNNByteQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactKNNByteQuery.java
@@ -22,9 +22,10 @@ public class ExactKNNByteQuery extends ExactKNNQuery {
         String indexName,
         VectorDataType vectorDataType,
         BitSetProducer parentFilter,
+        boolean expandNested,
         byte[] byteQueryVector
     ) {
-        super(field, spaceType, indexName, vectorDataType, parentFilter);
+        super(field, spaceType, indexName, vectorDataType, parentFilter, expandNested);
         this.byteQueryVector = byteQueryVector;
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/ExactKNNFloatQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactKNNFloatQuery.java
@@ -22,9 +22,10 @@ public class ExactKNNFloatQuery extends ExactKNNQuery {
         String indexName,
         VectorDataType vectorDataType,
         BitSetProducer parentFilter,
+        boolean expandNested,
         float[] queryVector
     ) {
-        super(field, spaceType, indexName, vectorDataType, parentFilter);
+        super(field, spaceType, indexName, vectorDataType, parentFilter, expandNested);
         this.queryVector = queryVector;
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/ExactKNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactKNNQuery.java
@@ -31,16 +31,25 @@ public abstract class ExactKNNQuery extends Query {
     private final String indexName;
     private final VectorDataType vectorDataType;
     private BitSetProducer parentFilter;
+    private boolean expandNested;
     @Setter
     @Getter
     private boolean explain;
 
-    protected ExactKNNQuery(String field, String spaceType, String indexName, VectorDataType vectorDataType, BitSetProducer parentFilter) {
+    protected ExactKNNQuery(
+        String field,
+        String spaceType,
+        String indexName,
+        VectorDataType vectorDataType,
+        BitSetProducer parentFilter,
+        boolean expandNested
+    ) {
         this.field = field;
         this.spaceType = spaceType;
         this.indexName = indexName;
         this.vectorDataType = vectorDataType;
         this.parentFilter = parentFilter;
+        this.expandNested = expandNested;
     }
 
     @Override
@@ -60,7 +69,7 @@ public abstract class ExactKNNQuery extends Query {
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, spaceType, indexName, vectorDataType, parentFilter);
+        return Objects.hash(field, spaceType, indexName, vectorDataType, parentFilter, expandNested);
     }
 
     @Override
@@ -73,6 +82,7 @@ public abstract class ExactKNNQuery extends Query {
         return Objects.equals(field, other.field)
             && Objects.equals(spaceType, other.spaceType)
             && Objects.equals(indexName, other.indexName)
-            && Objects.equals(parentFilter, other.parentFilter);
+            && Objects.equals(parentFilter, other.parentFilter)
+            && Objects.equals(expandNested, other.expandNested);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/ExactKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactKNNWeight.java
@@ -94,6 +94,7 @@ public class ExactKNNWeight extends Weight {
                     .matchedDocsIterator(matchedDocsIterator)
                     .parentsFilter(exactKNNQuery.getParentFilter())
                     .exactKNNSpaceType(exactKNNQuery.getSpaceType())
+                    .expandNested(exactKNNQuery.isExpandNested())
                     .build();
             default:
                 return ExactSearcher.ExactSearcherContext.builder()
@@ -102,6 +103,7 @@ public class ExactKNNWeight extends Weight {
                     .matchedDocsIterator(matchedDocsIterator)
                     .parentsFilter(exactKNNQuery.getParentFilter())
                     .exactKNNSpaceType(exactKNNQuery.getSpaceType())
+                    .expandNested(exactKNNQuery.isExpandNested())
                     .build();
         }
     }

--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -191,6 +191,7 @@ public class ExactSearcher {
         }
         final SpaceType spaceType = resolvedSpaceType;
         boolean isNestedRequired = exactSearcherContext.getParentsFilter() != null;
+        boolean isExpandNested = exactSearcherContext.isExpandNested();
 
         if (VectorDataType.BINARY == vectorDataType) {
             KNNVectorValues<byte[]> vectorValues;
@@ -208,7 +209,8 @@ public class ExactSearcher {
                     exactSearcherContext.getByteQueryVector(),
                     (KNNBinaryVectorValues) vectorValues,
                     spaceType,
-                    exactSearcherContext.getParentsFilter().getBitSet(leafReaderContext)
+                    exactSearcherContext.getParentsFilter().getBitSet(leafReaderContext),
+                    isExpandNested
                 );
             }
             return new BinaryVectorIdsKNNIterator(
@@ -227,7 +229,8 @@ public class ExactSearcher {
                     exactSearcherContext.getFloatQueryVector(),
                     (KNNByteVectorValues) vectorValues,
                     spaceType,
-                    exactSearcherContext.getParentsFilter().getBitSet(leafReaderContext)
+                    exactSearcherContext.getParentsFilter().getBitSet(leafReaderContext),
+                    isExpandNested
                 );
             }
             return new ByteVectorIdsKNNIterator(
@@ -271,7 +274,8 @@ public class ExactSearcher {
                 spaceType,
                 exactSearcherContext.getParentsFilter().getBitSet(leafReaderContext),
                 quantizedQueryVector,
-                segmentLevelQuantizationInfo
+                segmentLevelQuantizationInfo,
+                isExpandNested
             );
         }
         return new VectorIdsKNNIterator(
@@ -317,5 +321,6 @@ public class ExactSearcher {
         VectorSimilarityFunction similarityFunction;
         Boolean isMemoryOptimizedSearchEnabled;
         String exactKNNSpaceType;
+        boolean expandNested;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/iterators/NestedBinaryVectorIdsKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/iterators/NestedBinaryVectorIdsKNNIterator.java
@@ -17,19 +17,23 @@ import java.io.IOException;
  * This iterator iterates filterIdsArray to scoreif filter is provided else it iterates over all docs.
  * However, it dedupe docs per each parent doc
  * of which ID is set in parentBitSet and only return best child doc with the highest score.
+ * When expandNested is true, it returns ALL child docs instead of just the best one.
  */
 public class NestedBinaryVectorIdsKNNIterator extends BinaryVectorIdsKNNIterator {
     private final BitSet parentBitSet;
+    private final boolean expandNested;
 
     public NestedBinaryVectorIdsKNNIterator(
         @Nullable final DocIdSetIterator filterIdsIterator,
         final byte[] queryVector,
         final KNNBinaryVectorValues binaryVectorValues,
         final SpaceType spaceType,
-        final BitSet parentBitSet
+        final BitSet parentBitSet,
+        final boolean expandNested
     ) throws IOException {
         super(filterIdsIterator, queryVector, binaryVectorValues, spaceType);
         this.parentBitSet = parentBitSet;
+        this.expandNested = expandNested;
     }
 
     public NestedBinaryVectorIdsKNNIterator(
@@ -40,18 +44,32 @@ public class NestedBinaryVectorIdsKNNIterator extends BinaryVectorIdsKNNIterator
     ) throws IOException {
         super(null, queryVector, binaryVectorValues, spaceType);
         this.parentBitSet = parentBitSet;
+        this.expandNested = false;
     }
 
     /**
      * Advance to the next best child doc per parent and update score with the best score among child docs from the parent.
+     * When expandNested is true, returns ALL child docs instead of just the best one.
      * DocIdSetIterator.NO_MORE_DOCS is returned when there is no more docs
      *
-     * @return next best child doc id
+     * @return next child doc id (best child when expandNested=false, all children when expandNested=true)
      */
     @Override
     public int nextDoc() throws IOException {
         if (docId == DocIdSetIterator.NO_MORE_DOCS) {
             return DocIdSetIterator.NO_MORE_DOCS;
+        }
+
+        if (expandNested) {
+            int currentParent = parentBitSet.nextSetBit(docId);
+            if (currentParent != DocIdSetIterator.NO_MORE_DOCS && docId < currentParent) {
+                currentScore = computeScore();
+                int currentDocId = docId;
+                docId = getNextDocId();
+                return currentDocId;
+            }
+            docId = getNextDocId();
+            return nextDoc();
         }
 
         currentScore = Float.NEGATIVE_INFINITY;

--- a/src/main/java/org/opensearch/knn/index/query/parser/ExactKNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/ExactKNNQueryBuilderParser.java
@@ -20,10 +20,12 @@ import java.util.function.Function;
 
 import static org.opensearch.index.query.AbstractQueryBuilder.BOOST_FIELD;
 import static org.opensearch.index.query.AbstractQueryBuilder.NAME_FIELD;
+import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
 import static org.opensearch.knn.index.query.ExactKNNQueryBuilder.NAME;
 import static org.opensearch.knn.index.query.ExactKNNQueryBuilder.VECTOR_FIELD;
 import static org.opensearch.knn.index.query.ExactKNNQueryBuilder.SPACE_TYPE_FIELD;
 import static org.opensearch.knn.index.query.ExactKNNQueryBuilder.IGNORE_UNMAPPED_FIELD;
+import static org.opensearch.knn.index.query.ExactKNNQueryBuilder.EXPAND_NESTED_FIELD;
 import static org.opensearch.knn.index.util.IndexUtil.isClusterOnOrAfterMinRequiredVersion;
 
 /**
@@ -45,6 +47,7 @@ public final class ExactKNNQueryBuilderParser {
                 b.ignoreUnmapped(v);
             }
         }, IGNORE_UNMAPPED_FIELD);
+        internalParser.declareBoolean(ExactKNNQueryBuilder.Builder::expandNested, EXPAND_NESTED_FIELD);
         return internalParser;
     }
 
@@ -66,6 +69,9 @@ public final class ExactKNNQueryBuilderParser {
         if (minClusterVersionCheck.apply("ignore_unmapped")) {
             builder.ignoreUnmapped(in.readOptionalBoolean());
         }
+        if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
+            builder.expandNested(in.readOptionalBoolean());
+        }
 
         return builder;
     }
@@ -85,6 +91,9 @@ public final class ExactKNNQueryBuilderParser {
         out.writeOptionalString(builder.getSpaceType());
         if (minClusterVersionCheck.apply("ignore_unmapped")) {
             out.writeOptionalBoolean(builder.isIgnoreUnmapped());
+        }
+        if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
+            out.writeOptionalBoolean(builder.getExpandNested());
         }
     }
 
@@ -147,6 +156,9 @@ public final class ExactKNNQueryBuilderParser {
         builder.field(BOOST_FIELD.getPreferredName(), exactKNNQueryBuilder.boost());
         if (exactKNNQueryBuilder.queryName() != null) {
             builder.field(NAME_FIELD.getPreferredName(), exactKNNQueryBuilder.queryName());
+        }
+        if (exactKNNQueryBuilder.getExpandNested() != null) {
+            builder.field(EXPAND_NESTED, exactKNNQueryBuilder.getExpandNested());
         }
 
         builder.endObject();

--- a/src/test/java/org/opensearch/knn/index/query/ExactKNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExactKNNWeightTests.java
@@ -256,6 +256,7 @@ public class ExactKNNWeightTests extends KNNTestCase {
             INDEX_NAME,
             VectorDataType.FLOAT,
             null,
+            false,
             QUERY_VECTOR
         );
 

--- a/src/test/java/org/opensearch/knn/index/query/iterators/NestedBinaryVectorIdsKNNIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/iterators/NestedBinaryVectorIdsKNNIteratorTests.java
@@ -54,7 +54,8 @@ public class NestedBinaryVectorIdsKNNIteratorTests extends TestCase {
             queryVector,
             values,
             spaceType,
-            parentBitSet
+            parentBitSet,
+            false
         );
         assertEquals(filterIds[0], iterator.nextDoc());
         assertEquals(expectedScores.get(0), iterator.score());
@@ -88,5 +89,46 @@ public class NestedBinaryVectorIdsKNNIteratorTests extends TestCase {
         assertEquals(expectedScores.get(2), iterator.score());
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
         verify(values, never()).advance(anyInt());
+    }
+
+    @SneakyThrows
+    public void testNextDoc_whenIterateExpandNested_thenReturnAllChildDocsPerParent() {
+        final SpaceType spaceType = SpaceType.HAMMING;
+        final byte[] queryVector = { 1, 2, 3 };
+        final int[] filterIds = { 0, 2, 3 };
+        // Parent id for 0 -> 1
+        // Parent id for 2, 3 -> 4
+        // In bit representation, it is 10010. In long, it is 18.
+        final BitSet parentBitSet = new FixedBitSet(new long[] { 18 }, 5);
+        final List<byte[]> dataVectors = Arrays.asList(new byte[] { 11, 12, 13 }, new byte[] { 14, 15, 16 }, new byte[] { 17, 18, 19 });
+        final List<Float> expectedScores = dataVectors.stream()
+            .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector))
+            .collect(Collectors.toList());
+
+        KNNBinaryVectorValues values = mock(KNNBinaryVectorValues.class);
+        when(values.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
+
+        FixedBitSet filterBitSet = new FixedBitSet(4);
+        for (int id : filterIds) {
+            when(values.advance(id)).thenReturn(id);
+            filterBitSet.set(id);
+        }
+
+        // Execute and verify
+        NestedBinaryVectorIdsKNNIterator iterator = new NestedBinaryVectorIdsKNNIterator(
+            new BitSetIterator(filterBitSet, filterBitSet.length()),
+            queryVector,
+            values,
+            spaceType,
+            parentBitSet,
+            true
+        );
+        assertEquals(filterIds[0], iterator.nextDoc());
+        assertEquals(expectedScores.get(0), iterator.score());
+        assertEquals(filterIds[1], iterator.nextDoc());
+        assertEquals(expectedScores.get(1), iterator.score());
+        assertEquals(filterIds[2], iterator.nextDoc());
+        assertEquals(expectedScores.get(2), iterator.score());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/iterators/NestedByteVectorIdsKNNIteratorTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/iterators/NestedByteVectorIdsKNNIteratorTests.java
@@ -55,7 +55,8 @@ public class NestedByteVectorIdsKNNIteratorTests extends TestCase {
             queryVector,
             values,
             spaceType,
-            parentBitSet
+            parentBitSet,
+            false
         );
         assertEquals(filterIds[0], iterator.nextDoc());
         assertEquals(expectedScores.get(0), iterator.score());
@@ -90,5 +91,47 @@ public class NestedByteVectorIdsKNNIteratorTests extends TestCase {
         assertEquals(expectedScores.get(2), iterator.score());
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
         verify(values, never()).advance(anyInt());
+    }
+
+    @SneakyThrows
+    public void testNextDoc_whenIterateExpandNested_thenReturnAllChildDocsPerParent() {
+        final SpaceType spaceType = SpaceType.L2;
+        final byte[] byteQueryVector = { 1, 2, 3 };
+        final float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        final int[] filterIds = { 0, 2, 3 };
+        // Parent id for 0 -> 1
+        // Parent id for 2, 3 -> 4
+        // In bit representation, it is 10010. In long, it is 18.
+        final BitSet parentBitSet = new FixedBitSet(new long[] { 18 }, 5);
+        final List<byte[]> dataVectors = Arrays.asList(new byte[] { 11, 12, 13 }, new byte[] { 17, 18, 19 }, new byte[] { 14, 15, 16 });
+        final List<Float> expectedScores = dataVectors.stream()
+            .map(vector -> spaceType.getKnnVectorSimilarityFunction().compare(byteQueryVector, vector))
+            .collect(Collectors.toList());
+
+        KNNByteVectorValues values = mock(KNNByteVectorValues.class);
+        when(values.getVector()).thenReturn(dataVectors.get(0), dataVectors.get(1), dataVectors.get(2));
+
+        FixedBitSet filterBitSet = new FixedBitSet(4);
+        for (int id : filterIds) {
+            when(values.advance(id)).thenReturn(id);
+            filterBitSet.set(id);
+        }
+
+        // Execute and verify
+        NestedByteVectorIdsKNNIterator iterator = new NestedByteVectorIdsKNNIterator(
+            new BitSetIterator(filterBitSet, filterBitSet.length()),
+            queryVector,
+            values,
+            spaceType,
+            parentBitSet,
+            true
+        );
+        assertEquals(filterIds[0], iterator.nextDoc());
+        assertEquals(expectedScores.get(0), iterator.score());
+        assertEquals(filterIds[1], iterator.nextDoc());
+        assertEquals(expectedScores.get(1), iterator.score());
+        assertEquals(filterIds[2], iterator.nextDoc());
+        assertEquals(expectedScores.get(2), iterator.score());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
     }
 }


### PR DESCRIPTION
### Description
This is a follow-up to https://github.com/opensearch-project/k-NN/pull/2826, and adds support for the expandNested query parameter in the exact_knn query. This allows for all child document scores to be retrieved instead of only the highest-scoring one.

Example of query with expandNested:

```
{
  "size": 2,
  "query": {
    "exact_knn": {
      "my_vector": {
        "vector": [2, 3, 5, 6],
        "space_type": "l2",
        "expand_nested_docs": "true"
      }
    }
  }
}
```

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
