### PR TITLE
Use commons-lang3 to patch CVE-2025-48924

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -349,7 +349,7 @@ dependencies {
     compileOnly "org.opensearch:protobufs:0.6.0"
     compileOnly group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
     compileOnly group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
-    api group: 'commons-lang', name: 'commons-lang', version: '2.6'
+    api group: 'commons-lang3', name: 'commons-lang3', version: '3.18'
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     // Add Guava for test configurations since it's needed for testing but excluded from runtime
     testImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'


### PR DESCRIPTION
Patch vulnerability CVE-2025-48924

### Description

Switch k-nn package to use commons-lang3 at version 3.18 to fix vulnerability [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v)


This PR will patch 
### Related Issues
[CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v)

### Check List
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
