### PR TITLE
Replace commons-lang with org.apache.commons:commons-lang3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.3](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+### Maintenance
+* Replace commons-lang with org.apache.commons:commons-lang3 [#2863](https://github.com/opensearch-project/k-NN/pull/2863)
 ### Refactoring
 * Refactored the KNN Stat files for better readability.
 

--- a/build.gradle
+++ b/build.gradle
@@ -369,8 +369,7 @@ dependencies {
     implementation 'com.github.oshi:oshi-core:6.4.13'
     api "net.java.dev.jna:jna:${versions.jna}"
     api "net.java.dev.jna:jna-platform:${versions.jna}"
-    // OpenSearch core is using slf4j 2.0.17. Therefore, we cannot change the version here.
-    implementation 'org.slf4j:slf4j-api:2.0.17'
+    implementation "org.slf4j:slf4j-api:${versions.slf4j}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -349,7 +349,7 @@ dependencies {
     compileOnly "org.opensearch:protobufs:0.6.0"
     compileOnly group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
     compileOnly group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
-    api group: 'commons-lang', name: 'commons-lang', version: '2.6'
+    api "org.apache.commons:commons-lang3:${versions.commonslang}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     // Add Guava for test configurations since it's needed for testing but excluded from runtime
     testImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
@@ -370,7 +370,7 @@ dependencies {
     api "net.java.dev.jna:jna:${versions.jna}"
     api "net.java.dev.jna:jna-platform:${versions.jna}"
     // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -369,7 +369,7 @@ dependencies {
     implementation 'com.github.oshi:oshi-core:6.4.13'
     api "net.java.dev.jna:jna:${versions.jna}"
     api "net.java.dev.jna:jna-platform:${versions.jna}"
-    // OpenSearch core is using slf4j 1.7.36. Therefore, we cannot change the version here.
+    // OpenSearch core is using slf4j 2.0.17. Therefore, we cannot change the version here.
     implementation 'org.slf4j:slf4j-api:2.0.17'
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
 }


### PR DESCRIPTION
### Description

Make build.gradle use the version library for commons-lang3 and slf4j. This should fix the vulnerability [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v) and avoid us having to bump versions to be the same with core. 

### Related Issues
Resolves [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v)

### Check List
- [X] Commits are signed per the DCO using `--signoff`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
