### PR TITLE
Use queryVector length if present in MDC check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.3](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Maintenance
 * Replace commons-lang with org.apache.commons:commons-lang3 [#2863](https://github.com/opensearch-project/k-NN/pull/2863)
+### Bug Fixes
+* Use queryVector length if present in MDC check [#2867](https://github.com/opensearch-project/k-NN/pull/2867)
 ### Refactoring
 * Refactored the KNN Stat files for better readability.
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -597,7 +597,7 @@ public abstract class KNNWeight extends Weight {
     }
 
     private boolean isMDCGreaterThanFilterIdCnt(int filterIdsCount) {
-        return KNNConstants.MAX_DISTANCE_COMPUTATIONS >= filterIdsCount * (knnQuery.getVectorDataType() == VectorDataType.FLOAT
+        return KNNConstants.MAX_DISTANCE_COMPUTATIONS >= filterIdsCount * (knnQuery.getQueryVector() != null
             ? knnQuery.getQueryVector().length
             : knnQuery.getByteQueryVector().length);
     }


### PR DESCRIPTION
### Description

Currently any query with a filter that yields more docs than k against a byte[] index will fail. See #2866 .

I suspect that this issue is due to us keeping byteVector [null](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java#L688) when creating a query with a FAISS engine. Then when we go into this [line](https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/query/KNNWeight.java#L602) we run into a NPE.

Since only either `queryVector` or `byteVector` can be populated here we can replace this with a conditional check to avoid the NPE.

### Related Issues
Resolves #2866 

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
