### PR TITLE
Adds a process to make initially null k value null again on rewrite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Replace commons-lang with org.apache.commons:commons-lang3 [#2863](https://github.com/opensearch-project/k-NN/pull/2863)
 ### Bug Fixes
+* Adds a process to make initially null k value null again on rewrite. [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
 * Use queryVector length if present in MDC check [#2867](https://github.com/opensearch-project/k-NN/pull/2867)
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -739,11 +739,12 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         QueryBuilder rewrittenFilter;
         if (Objects.nonNull(filter)) {
             rewrittenFilter = filter.rewrite(queryShardContext);
+            Integer nulledK = this.k == 0 ? null : this.k;
             if (rewrittenFilter != filter) {
                 KNNQueryBuilder rewrittenQueryBuilder = KNNQueryBuilder.builder()
                     .fieldName(this.fieldName)
                     .vector(this.vector)
-                    .k(this.k)
+                    .k(nulledK)
                     .maxDistance(this.maxDistance)
                     .minScore(this.minScore)
                     .methodParameters(this.methodParameters)


### PR DESCRIPTION
### Description
The rewritten query references the QueryRewriteContext after a null `k` is rewritten as zero [here](https://github.com/opensearch-project/k-NN/blob/53e2c3a303e29162eb516d7db42a432bc1ab5966/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java#L221). This change reverts `k` to null so that the query can be validated. This change also makes sure that `k = 0` is invalid for an initial query.

### Related Issues
Resolves [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
