### PR TITLE
Fix KNN build due to Lucene 10.3 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Replace commons-lang with org.apache.commons:commons-lang3 [#2863](https://github.com/opensearch-project/k-NN/pull/2863)
 * Bump OpenSearch-Protobufs to 0.13.0 [#2833](https://github.com/opensearch-project/k-NN/pull/2833)
+* Bump Lucene version to 10.3 and fix build failures [#2878](https://github.com/opensearch-project/k-NN/pull/2878)
 
 ### Bug Fixes
 * Use queryVector length if present in MDC check [#2867](https://github.com/opensearch-project/k-NN/pull/2867)

--- a/build.gradle
+++ b/build.gradle
@@ -341,16 +341,21 @@ dependencies {
     api project(":remote-index-build-client")
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
     compileOnly "org.opensearch.plugin:transport-grpc-spi:${opensearch_version}"
-    compileOnly "org.opensearch:protobufs:0.13.0"
-    compileOnly group: 'com.google.guava', name: 'failureaccess', version:'1.0.2'
-    compileOnly group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
+    compileOnly "org.opensearch:protobufs:${versions.opensearchprotobufs}"
+    // Declare guava as compile time since guava will come from OpenSearch transport-grpc module.
+    compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
+    compileOnly group: 'com.google.errorprone', name: 'error_prone_annotations', version: "${versions.error_prone_annotations}"
+
     api "org.apache.commons:commons-lang3:${versions.commonslang}"
+    // We need to remove errorprone from guava since default guava is not bringing 2.26.1 version
+    // where as OpenSearch is using 2.41.0
+    testFixturesImplementation("com.google.guava:guava:${versions.guava}") {
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
+    testFixturesImplementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: "${versions.error_prone_annotations}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
-    // Add Guava for test configurations since it's needed for testing but excluded from runtime
-    testImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
-    testFixturesImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"
-    testImplementation group: 'org.objenesis', name: 'objenesis', version: '3.3'
+    testImplementation group: 'org.objenesis', name: 'objenesis', version: "${versions.objenesis}"
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${versions.bytebuddy}"
     // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -25,8 +25,12 @@ dependencies {
     api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
     api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
-    // Guava needed for BWC test compilation (ImmutableList, ImmutableMap usage)
-    testImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
+    // We need to remove errorprone from guava since default guava is not bringing 2.26.1 version
+    // where as OpenSearch is using 2.41.0
+    testImplementation("com.google.guava:guava:${versions.guava}") {
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
+
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation(testFixtures(rootProject))
 }

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -8,11 +8,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 apply from : "$rootDir/qa/build.gradle"
 
-dependencies {
-    // Ensure Guava is available for BWC test compilation
-    testImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
-}
-
 String default_bwc_version = System.getProperty("bwc.version")
 String knn_bwc_version = System.getProperty("tests.bwc.version", default_bwc_version)
 boolean isSnapshot = knn_bwc_version.contains("-SNAPSHOT")

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -8,11 +8,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 apply from : "$rootDir/qa/build.gradle"
 
-dependencies {
-    // Ensure Guava is available for BWC test compilation
-    testImplementation group: 'com.google.guava', name: 'guava', version:'33.2.1-jre'
-}
-
 String default_bwc_version = System.getProperty("bwc.version")
 String knn_bwc_version = System.getProperty("tests.bwc.version", default_bwc_version)
 boolean isSnapshot = knn_bwc_version.contains("-SNAPSHOT")

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1030Codec/KNN1030Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1030Codec/KNN1030Codec.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1030Codec;
+
+import lombok.Builder;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene103.Lucene103Codec;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010DerivedSourceStoredFieldsFormat;
+import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;
+import org.opensearch.knn.index.codec.KNN80Codec.KNN80DocValuesFormat;
+import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReadersSupplier;
+
+import java.util.Optional;
+
+/**
+ * KNN Codec that wraps the Lucene Codec which is part of Lucene 10.3
+ */
+
+public class KNN1030Codec extends FilterCodec {
+
+    private static final String NAME = "KNN1030Codec";
+    public static final Codec DEFAULT_DELEGATE = new Lucene103Codec();
+    private static final PerFieldKnnVectorsFormat DEFAULT_KNN_VECTOR_FORMAT = new KNN9120PerFieldKnnVectorsFormat(Optional.empty());
+
+    private final PerFieldKnnVectorsFormat perFieldKnnVectorsFormat;
+    private final StoredFieldsFormat storedFieldsFormat;
+
+    private final MapperService mapperService;
+
+    /**
+     * No arg constructor that uses Lucene101Codec as the delegate
+     */
+    public KNN1030Codec() {
+        this(DEFAULT_DELEGATE, DEFAULT_KNN_VECTOR_FORMAT, null);
+    }
+
+    /**
+     * Sole constructor. When subclassing this codec, create a no-arg ctor and pass the delegate codec
+     * and a unique name to this ctor.
+     *
+     * @param delegate codec that will perform all operations this codec does not override
+     * @param knnVectorsFormat per field format for KnnVector
+     */
+    @Builder
+    public KNN1030Codec(Codec delegate, PerFieldKnnVectorsFormat knnVectorsFormat, MapperService mapperService) {
+        super(NAME, delegate);
+        perFieldKnnVectorsFormat = knnVectorsFormat;
+        this.mapperService = mapperService;
+        this.storedFieldsFormat = getStoredFieldsFormat();
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        return new KNN80DocValuesFormat(delegate.docValuesFormat());
+    }
+
+    @Override
+    public CompoundFormat compoundFormat() {
+        return new KNN80CompoundFormat(delegate.compoundFormat());
+    }
+
+    @Override
+    public KnnVectorsFormat knnVectorsFormat() {
+        return perFieldKnnVectorsFormat;
+    }
+
+    @Override
+    public StoredFieldsFormat storedFieldsFormat() {
+        return storedFieldsFormat;
+    }
+
+    private StoredFieldsFormat getStoredFieldsFormat() {
+        DerivedSourceReadersSupplier derivedSourceReadersSupplier = new DerivedSourceReadersSupplier((segmentReadState) -> {
+            if (segmentReadState.fieldInfos.hasVectorValues()) {
+                return knnVectorsFormat().fieldsReader(segmentReadState);
+            }
+            return null;
+        }, (segmentReadState) -> {
+            if (segmentReadState.fieldInfos.hasDocValues()) {
+                return docValuesFormat().fieldsProducer(segmentReadState);
+            }
+            return null;
+
+        });
+        return new KNN10010DerivedSourceStoredFieldsFormat(delegate.storedFieldsFormat(), derivedSourceReadersSupplier, mapperService);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecService.java
@@ -9,7 +9,7 @@ import org.apache.lucene.codecs.Codec;
 import org.opensearch.index.codec.CodecService;
 import org.opensearch.index.codec.CodecServiceConfig;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010Codec;
+import org.opensearch.knn.index.codec.KNN1030Codec.KNN1030Codec;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 
@@ -37,7 +37,7 @@ public class KNNCodecService extends CodecService {
      */
     @Override
     public Codec codec(String name) {
-        return KNN10010Codec.builder()
+        return KNN1030Codec.builder()
             .delegate(super.codec(name))
             .mapperService(mapperService)
             .knnVectorsFormat(new KNN9120PerFieldKnnVectorsFormat(Optional.ofNullable(mapperService), nativeIndexBuildStrategyFactory))

--- a/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNNCodecVersion.java
@@ -6,12 +6,12 @@
 package org.opensearch.knn.index.codec;
 
 import org.apache.lucene.codecs.Codec;
-import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010Codec;
+import org.opensearch.knn.index.codec.KNN1030Codec.KNN1030Codec;
 
 /**
  * Class contains easy to access information about current default codec.
  */
 public class KNNCodecVersion {
-    public static final Codec CURRENT_DEFAULT = new KNN10010Codec();
-    public static final Codec CURRENT_DEFAULT_DELEGATE = KNN10010Codec.DEFAULT_DELEGATE;
+    public static final Codec CURRENT_DEFAULT = new KNN1030Codec();
+    public static final Codec CURRENT_DEFAULT_DELEGATE = KNN1030Codec.DEFAULT_DELEGATE;
 }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN10010Codec/KNN10010Codec.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN10010Codec/KNN10010Codec.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.KNN10010Codec;
+package org.opensearch.knn.index.codec.backward_codecs.KNN10010Codec;
 
 import lombok.Builder;
 import org.apache.lucene.codecs.Codec;
@@ -12,9 +12,10 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
-import org.apache.lucene.codecs.lucene101.Lucene101Codec;
+import org.apache.lucene.backward_codecs.lucene101.Lucene101Codec;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010DerivedSourceStoredFieldsFormat;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80CompoundFormat;
 import org.opensearch.knn.index.codec.KNN80Codec.KNN80DocValuesFormat;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
@@ -29,7 +30,7 @@ import java.util.Optional;
 public class KNN10010Codec extends FilterCodec {
 
     private static final String NAME = "KNN10010Codec";
-    public static final Codec DEFAULT_DELEGATE = new Lucene101Codec();
+    private static final Codec DEFAULT_DELEGATE = new Lucene101Codec();
     private static final PerFieldKnnVectorsFormat DEFAULT_KNN_VECTOR_FORMAT = new KNN9120PerFieldKnnVectorsFormat(Optional.empty());
 
     private final PerFieldKnnVectorsFormat perFieldKnnVectorsFormat;

--- a/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/QueryUtils.java
@@ -48,7 +48,7 @@ public class QueryUtils {
 
     /**
      * Returns a query that represents the specified TopDocs
-     * This is copied from {@link org.apache.lucene.search.AbstractKnnVectorQuery#createRewrittenQuery}
+     * This is copied from org.apache.lucene.search.AbstractKnnVectorQuery#createRewrittenQuery
      *
      * @param reader the index reader
      * @param topDocs the documents to be retured by the query

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -9,6 +9,8 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
@@ -18,6 +20,8 @@ import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.search.knn.TopKnnCollectorManager;
 import org.apache.lucene.util.BitSet;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -189,13 +193,13 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
 
         // Create a collector + bitset
         final KnnCollector knnCollector = knnCollectorManager.newCollector(visitedLimit, DEFAULT_HNSW_SEARCH_STRATEGY, context);
-        final BitSet bitSet = cardinality == 0 ? null : filterIdsBitSet;
+        final AcceptDocs acceptDocs = getAcceptedDocs(reader, cardinality, filterIdsBitSet);
 
         // Start searching index
         if (targetVector instanceof float[] floatTargetVector) {
-            reader.getVectorReader().search(knnQuery.getField(), floatTargetVector, knnCollector, bitSet);
+            reader.getVectorReader().search(knnQuery.getField(), floatTargetVector, knnCollector, acceptDocs);
         } else {
-            reader.getVectorReader().search(knnQuery.getField(), (byte[]) targetVector, knnCollector, bitSet);
+            reader.getVectorReader().search(knnQuery.getField(), (byte[]) targetVector, knnCollector, acceptDocs);
         }
 
         // Make results to return
@@ -207,4 +211,33 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         addExplainIfRequired(topDocs, knnEngine, spaceType);
         return topDocs;
     }
+
+    private AcceptDocs getAcceptedDocs(SegmentReader reader, int cardinality, BitSet filterIdsBitSet) {
+        final AcceptDocs acceptDocs;
+        if (cardinality == 0) {
+            // We may want to use liveDocs here rather than null, to ensure that deleted docs are not considered in k-NN search
+            // But we are not doing this, because in that case it will break the current behavior of LOF which is similar to
+            // normal faiss based search.
+            acceptDocs = AcceptDocs.fromLiveDocs(null, reader.maxDoc());
+        } else {
+            acceptDocs = new AcceptDocs() {
+                @Override
+                public Bits bits() throws IOException {
+                    return filterIdsBitSet;
+                }
+
+                @Override
+                public DocIdSetIterator iterator() throws IOException {
+                    return new BitSetIterator(filterIdsBitSet, cardinality);
+                }
+
+                @Override
+                public int cost() throws IOException {
+                    return cardinality;
+                }
+            };
+        }
+        return acceptDocs;
+    }
+
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
 
@@ -33,7 +34,7 @@ public interface VectorSearcher extends Closeable {
      * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
      *     if they are all allowed to match.
      */
-    void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException;
+    void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
 
     /**
      * Return the k nearest neighbor documents as determined by comparison of their vector values for
@@ -50,5 +51,5 @@ public interface VectorSearcher extends Closeable {
      * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
      *     if they are all allowed to match.
      */
-    void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException;
+    void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.memoryoptsearch;
 
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 
 import java.io.IOException;
 
@@ -21,8 +22,9 @@ public interface VectorSearcherFactory {
      * @param directory Lucene's Directory.
      * @param fileName Logical file name to load.
      * @param fieldInfo Field info containing metadata for ADC extraction
+     * @param ioContext IOContext to use when opening the file
      * @return Null instance if it is not supported, otherwise return {@link VectorSearcher}
      * @throws IOException
      */
-    VectorSearcher createVectorSearcher(Directory directory, String fileName, FieldInfo fieldInfo) throws IOException;
+    VectorSearcher createVectorSearcher(Directory directory, String fileName, FieldInfo fieldInfo, IOContext ioContext) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -9,6 +9,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
@@ -77,7 +78,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     @Override
-    public void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+    public void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         search(
             VectorEncoding.FLOAT32,
             () -> flatVectorsScorer.getRandomVectorScorer(
@@ -91,7 +92,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     @Override
-    public void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+    public void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         search(
             VectorEncoding.BYTE,
             () -> flatVectorsScorer.getRandomVectorScorer(
@@ -113,7 +114,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         final VectorEncoding vectorEncoding,
         final IOSupplier<RandomVectorScorer> scorerSupplier,
         final KnnCollector knnCollector,
-        final Bits acceptDocs
+        final AcceptDocs acceptDocs
     ) throws IOException {
         if (faissIndex.getTotalNumberOfVectors() == 0 || knnCollector.k() == 0) {
             return;
@@ -133,7 +134,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         // Set up required components for vector search
         final RandomVectorScorer scorer = scorerSupplier.get();
         final KnnCollector collector = createKnnCollector(knnCollector, scorer);
-        final Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs);
+        final Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
 
         if (knnCollector.k() < scorer.maxOrd()) {
             // Do ANN search with Lucene's HNSW graph searcher.

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -10,7 +10,6 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
@@ -25,13 +24,15 @@ import java.io.IOException;
  */
 @Log4j2
 public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactory {
+
     @Override
-    public VectorSearcher createVectorSearcher(final Directory directory, final String fileName, final FieldInfo fieldInfo)
-        throws IOException {
-        final IndexInput indexInput = directory.openInput(
-            fileName,
-            new IOContext(IOContext.Context.DEFAULT, null, null, ReadAdvice.RANDOM)
-        );
+    public VectorSearcher createVectorSearcher(
+        final Directory directory,
+        final String fileName,
+        final FieldInfo fieldInfo,
+        final IOContext ioContext
+    ) throws IOException {
+        final IndexInput indexInput = directory.openInput(fileName, ioContext);
 
         try {
             // Try load it. Not all FAISS index types are currently supported at the moment.
@@ -45,4 +46,5 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
             throw e;
         }
     }
+
 }

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -4,5 +4,6 @@ org.opensearch.knn.index.codec.backward_codecs.KNN940Codec.KNN940Codec
 org.opensearch.knn.index.codec.backward_codecs.KNN950Codec.KNN950Codec
 org.opensearch.knn.index.codec.backward_codecs.KNN990Codec.KNN990Codec
 org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec.KNN9120Codec
-org.opensearch.knn.index.codec.KNN10010Codec.KNN10010Codec
+org.opensearch.knn.index.codec.backward_codecs.KNN10010Codec.KNN10010Codec
+org.opensearch.knn.index.codec.KNN1030Codec.KNN1030Codec
 org.opensearch.knn.index.codec.util.UnitTestCodec

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1030Codec/KNN1030CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1030Codec/KNN1030CodecTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1030Codec;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNNCodecTestCase;
+import org.opensearch.knn.index.codec.KNNCodecVersion;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class KNN1030CodecTests extends KNNCodecTestCase {
+
+    @SneakyThrows
+    public void testMultiFieldsKnnIndex() {
+        testMultiFieldsKnnIndex(KNN1030Codec.builder().delegate(KNNCodecVersion.CURRENT_DEFAULT_DELEGATE).build());
+    }
+
+    @SneakyThrows
+    public void testBuildFromModelTemplate() {
+        testBuildFromModelTemplate(KNN1030Codec.builder().delegate(KNNCodecVersion.CURRENT_DEFAULT_DELEGATE).build());
+    }
+
+    // Ensure that the codec is able to return the correct per field knn vectors format for codec
+    public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
+        final Codec codec = new KNN1030Codec();
+        assertTrue(codec.knnVectorsFormat() instanceof KNN9120PerFieldKnnVectorsFormat);
+    }
+
+    // IMPORTANT: When this Codec is moved to a backwards Codec, this test needs to be removed, because it attempts to
+    // write with a read-only codec, which will fail
+    @SneakyThrows
+    public void testKnnVectorIndex() {
+        Function<MapperService, PerFieldKnnVectorsFormat> perFieldKnnVectorsFormatProvider = (
+            mapperService) -> new KNN9120PerFieldKnnVectorsFormat(Optional.of(mapperService));
+
+        Function<PerFieldKnnVectorsFormat, Codec> knnCodecProvider = (knnVectorFormat) -> KNN1030Codec.builder()
+            .delegate(KNNCodecVersion.CURRENT_DEFAULT_DELEGATE)
+            .knnVectorsFormat(knnVectorFormat)
+            .build();
+
+        testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesProducerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesProducerTests.java
@@ -24,7 +24,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010Codec;
+import org.opensearch.knn.index.codec.backward_codecs.KNN10010Codec.KNN10010Codec;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.engine.KNNEngine;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -61,7 +61,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         // Mocking FAISS engine to return a dummy vector searcher
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
-        when(mockFactory.createVectorSearcher(any(), any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
 
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN1010Codec/KNN10010CodecTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN1010Codec/KNN10010CodecTests.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index.codec.KNN10010Codec;
+package org.opensearch.knn.index.codec.backward_codecs.KNN1010Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.Codec;
@@ -12,6 +12,7 @@ import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
+import org.opensearch.knn.index.codec.backward_codecs.KNN10010Codec.KNN10010Codec;
 
 import java.util.Optional;
 import java.util.function.Function;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
@@ -9,10 +9,12 @@ import lombok.SneakyThrows;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.IOConsumer;
 import org.opensearch.knn.KNNTestCase;
@@ -49,7 +51,7 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;
-            final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE);
+            final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
 
             // Build a query
             final Object query;
@@ -72,12 +74,13 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
                 }
                 query = binaryQuery;
             }
+            AcceptDocs acceptDocs = AcceptDocs.fromLiveDocs(null, TOTAL_NUMBER_OF_VECTORS);
 
             // Start searching
             if (vectorDataType == VectorDataType.FLOAT) {
-                searcher.search((float[]) query, knnCollector, null);
+                searcher.search((float[]) query, knnCollector, acceptDocs);
             } else {
-                searcher.search((byte[]) query, knnCollector, null);
+                searcher.search((byte[]) query, knnCollector, acceptDocs);
             }
             final TopDocs topDocs = knnCollector.topDocs();
             final ScoreDoc[] scoreDocs = topDocs.scoreDocs;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswFP32IndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswFP32IndexTests.java
@@ -11,10 +11,10 @@ import org.opensearch.knn.index.VectorDataType;
 public class FaissCagraHnswFP32IndexTests extends AbstractFaissCagraHnswIndexTests {
 
     public void testKNNSearchFloat32() {
-        // Exhaustive search test
+        // ANN search test
         doTestKNNSearch(true, VectorDataType.FLOAT, KNNVectorSimilarityFunction.EUCLIDEAN);
 
-        // ANN search test
+        // Exhaustive search test
         doTestKNNSearch(false, VectorDataType.FLOAT, KNNVectorSimilarityFunction.EUCLIDEAN);
     }
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -8,11 +8,14 @@ package org.opensearch.knn.memoryoptsearch;
 import lombok.SneakyThrows;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopKnnCollector;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOConsumer;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
@@ -47,7 +50,8 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;
-            final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE);
+            final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
+            AcceptDocs acceptDocs = AcceptDocs.fromLiveDocs(new Bits.MatchAllBits(TOTAL_NUMBER_OF_VECTORS), TOTAL_NUMBER_OF_VECTORS);
 
             // Build a query
             final float[] query = new float[DIMENSION];
@@ -56,7 +60,7 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
             }
 
             // Start searching
-            searcher.search(query, knnCollector, null);
+            searcher.search(query, knnCollector, acceptDocs);
             final TopDocs topDocs = knnCollector.topDocs();
             final ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
@@ -501,13 +502,15 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         // buildInfo.documentIds.size() - 1 -> Will maximize search space, this is equivalent to set efSearch = len(N) - 1
         final int efSearch = exhaustiveSearch ? buildInfo.documentIds.size() + 1 : buildInfo.documentIds.size() - 1;
         final KnnCollector knnCollector = new TopKnnCollector(efSearch, Integer.MAX_VALUE);
-        FixedBitSet acceptDocs = null;
+        FixedBitSet fixedBitSet = null;
         if (filteredIds != null) {
-            acceptDocs = new FixedBitSet(buildInfo.documentIds.getLast() + 10);
+            fixedBitSet = new FixedBitSet(buildInfo.documentIds.getLast() + 10);
             for (long filteredId : filteredIds) {
-                acceptDocs.set((int) filteredId);
+                fixedBitSet.set((int) filteredId);
             }
         }
+
+        AcceptDocs acceptDocs = AcceptDocs.fromLiveDocs(fixedBitSet, buildInfo.documentIds.getLast() + 10);
 
         // Make SegmentReadState and do search
         try (final Directory directory = new MMapDirectory(buildInfo.tempDirPath)) {


### PR DESCRIPTION
### Description
This change allows us to fix the failing builds which was happening to Lucene 10.3 and other changes in core.

### Changes done:
1. Created a new codec KNN1030Codec class for Lucene 10.3 version.
2. Fixed the interface for search for kNN queries to use AcceptedDocs rather than BitSets
3. Fix and cleaned up the guava dependencies for grpc.

### Known Issue
MacOS CI will fail and it is unrelated to this PR. Will raise another PR for the same. GH issue: https://github.com/opensearch-project/k-NN/issues/2876

### Related Issues
https://github.com/opensearch-project/k-NN/issues/2888

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
