### PR TITLE
Force core :server error prone annotations version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Replace commons-lang with org.apache.commons:commons-lang3 [#2863](https://github.com/opensearch-project/k-NN/pull/2863)
 * Bump OpenSearch-Protobufs to 0.13.0 [#2833](https://github.com/opensearch-project/k-NN/pull/2833)
+* Bump 'com.google.errorprone:error_prone_annotations' to 2.41.0 [#2885](https://github.com/opensearch-project/k-NN/pull/2885
 
 ### Bug Fixes
 * Use queryVector length if present in MDC check [#2867](https://github.com/opensearch-project/k-NN/pull/2867)

--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,12 @@ configurations {
     zipArchive
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'com.google.errorprone:error_prone_annotations:2.41.0'
+    }
+}
+
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
### Description

There seems to be a newly introduced dependency conflict with error_prone_annotations.
https://github.com/opensearch-project/OpenSearch/commit/b9c5bc70661380650e769707cef8127ba9becd80#diff-56915d53ea588a229a43cca18bc96695cb3aec2812cb24f8514062ca0d9ccb41R101-R103

2.26.1 is included with `guava:33.2.1-jre` so KNN sees both versions.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestFixturesJava'.
> Could not resolve all files for configuration ':testFixturesCompileClasspath'.
   > Could not resolve com.google.errorprone:error_prone_annotations:2.26.1.
     Required by:
         root project : > com.google.guava:guava:33.2.1-jre
      > Conflict found for module 'com.google.errorprone:error_prone_annotations': between versions 2.41.0 and 2.26.1
> There is 1 more failure with an identical cause.
```

This new version of error_prone_annotations is visible through `:test:framework`.
```
./gradlew :dependencyInsight --configuration testFixturesCompileClasspath --dependency com.google.errorprone:error_prone_annotations


> Task :dependencyInsight
com.google.errorprone:error_prone_annotations:2.26.1 FAILED
   Failures:
      - Could not resolve com.google.errorprone:error_prone_annotations:2.26.1.
          - Conflict found for module 'com.google.errorprone:error_prone_annotations': between versions 2.41.0 and 2.26.1

com.google.errorprone:error_prone_annotations:2.26.1 FAILED
\--- com.google.guava:guava:33.2.1-jre
     \--- root project :
          \--- root project : (*)

com.google.errorprone:error_prone_annotations:2.41.0 FAILED
   Failures:
      - Could not resolve com.google.errorprone:error_prone_annotations:2.41.0. (already reported)

com.google.errorprone:error_prone_annotations:2.41.0 FAILED
\--- org.opensearch:opensearch:3.3.0-SNAPSHOT:20250917.232945-101
     +--- root project :
     |    \--- root project : (*)
     \--- org.opensearch.test:framework:3.3.0-SNAPSHOT:20250917.232945-101
          \--- root project : (*)
```

which in turn gets it from taking a dependency on `:server`:

```
./gradlew :test:framework:dependencyInsight --dependency com.google.errorprone:error_prone_annotations --configuration compileClasspath

com.google.errorprone:error_prone_annotations:2.41.0
\--- project :server
     \--- compileClasspath
```

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
