### PR TITLE
NMSLIB Mac OS build failure fix.

### DIFF
--- a/jni/cmake/init-nmslib.cmake
+++ b/jni/cmake/init-nmslib.cmake
@@ -21,6 +21,7 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0003-Added-streaming-apis-for-vector-index-loading-in-Hnsw.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0004-Added-a-new-save-apis-in-Hnsw-with-streaming-interfa.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0005-Add-util-include-to-fix-pragma-error.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0006-Add-AppleClang-in-NMSLIB-build-and-logging-invalid-compiler.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib)

--- a/jni/patches/nmslib/0006-Add-AppleClang-in-NMSLIB-build-and-logging-invalid-compiler.patch
+++ b/jni/patches/nmslib/0006-Add-AppleClang-in-NMSLIB-build-and-logging-invalid-compiler.patch
@@ -1,0 +1,35 @@
+From d1640229cbaff2fce8bc20735a3f6b5237e06775 Mon Sep 17 00:00:00 2001
+From: Dooyong Kim <kdooyong@amazon.com>
+Date: Mon, 22 Sep 2025 21:17:08 -0700
+Subject: [PATCH] Added AppleClang, and logging invalid compiler id.
+
+Signed-off-by: Dooyong Kim <kdooyong@amazon.com>
+---
+ similarity_search/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/similarity_search/CMakeLists.txt b/similarity_search/CMakeLists.txt
+index bc6ef3c..e73997e 100644
+--- a/similarity_search/CMakeLists.txt
++++ b/similarity_search/CMakeLists.txt
+@@ -55,7 +55,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+     endif()
+     set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wunreachable-code -Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -fpic")
+     set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wunreachable-code -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -fpic")
+-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
++elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+     if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+         # MACOSX
+         set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread -fpic ${SIMD_FLAGS}")
+@@ -70,7 +70,7 @@ elseif(WIN32)
+          message(FATAL_ERROR "On Windows, only MSVC version should be >= 12, code 1800, current version ${MSVC_VERSION}!") 
+     endif()
+ else ()
+-    message(FATAL_ERROR "Unrecognized compiler (use GCC, Clang, Intel compiler, or MSVC (on Windows)!")
++    message(FATAL_ERROR "Unrecognized compiler (use GCC, AppleClang, Clang, Intel compiler, or MSVC (on Windows)! Compiler was ${CMAKE_CXX_COMPILER_ID}")
+ endif()
+ 
+ if (WITH_EXTRAS)
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
### Description
CI Mac container seems like using 'AppleClang' while this is not the list in NMSLIB's CMake.
So this PR is fixing its CMake to use 'AppleClang'. 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
