### PR TITLE
Changed query k functionality so that empty k field is null instead of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Use queryVector length if present in MDC check [#2867](https://github.com/opensearch-project/k-NN/pull/2867)
 * Fix derived source deserialization bug on invalid documents [#2882](https://github.com/opensearch-project/k-NN/pull/2882)
+* Allows k to be nullable to fix filter bug [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -187,6 +187,19 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
         }
     }
 
+    public void testKNNRadialSearchAfterUpgrade() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        if (isRunningAgainstOldCluster()) {
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), createKnnIndexMapping(TEST_FIELD, DIMENSIONS, "hnsw", FAISS_NAME));
+            addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, DOC_ID, NUM_DOCS);
+            flush(testIndex, true);
+        } else {
+            validateKNNSearchDistance(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS);
+            deleteKNNIndex(testIndex);
+        }
+    }
+
     public void testKNNIndexLuceneQuantization() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
         int k = 4;

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/QueryANNIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/QueryANNIT.java
@@ -46,4 +46,24 @@ public class QueryANNIT extends AbstractRollingUpgradeTestCase {
                 deleteKNNIndex(testIndex);
         }
     }
+
+    public void testKNNRadialSearchRollingUpgrade() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        switch (getClusterType()) {
+            case OLD:
+                createKnnIndex(
+                    testIndex,
+                    getKNNDefaultIndexSettings(),
+                    createKnnIndexMapping(TEST_FIELD, DIMENSIONS, ALGORITHM, FAISS_NAME)
+                );
+                addKNNDocs(testIndex, TEST_FIELD, DIMENSIONS, 0, NUM_DOCS);
+                break;
+            case MIXED:
+                validateKNNSearchDistance(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS);
+                break;
+            case UPGRADED:
+                validateKNNSearchDistance(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS);
+                deleteKNNIndex(testIndex);
+        }
+    }
 }

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -84,6 +84,7 @@ public class KNNConstants {
     public static final String TOP_LEVEL_ENGINE_FEATURE = "top_level_engine_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
+    public static final String NULL_K = "null_k";
     public static final String MODEL_VERSION = "model_version";
     public static final String QUANTIZATION_STATE_FILE_SUFFIX = "osknnqstate";
     public static final double ADC_CORRECTION_FACTOR = 2.0;

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -96,7 +96,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     private final String fieldName;
     private final float[] vector;
     @Getter
-    private int k;
+    private Integer k;
     @Getter
     private Float maxDistance;
     @Getter
@@ -218,7 +218,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
 
         public KNNQueryBuilder build() {
             validate();
-            int k = this.k == null ? 0 : this.k;
             return new KNNQueryBuilder(
                 fieldName,
                 vector,
@@ -563,7 +562,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support filters", knnEngine));
         }
 
-        if (k != 0) {
+        if (k != null && k != 0) {
             KNNQueryFactory.CreateQueryRequest createQueryRequest = KNNQueryFactory.CreateQueryRequest.builder()
                 .knnEngine(knnEngine)
                 .indexName(indexName)
@@ -653,14 +652,14 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
      * @param maxDistance Maximum distance for the given vector, if maxDistance is set, then the query type is MAX_DISTANCE
      * @param minScore Minimum score for the given vector, if minScore is set, then the query type is MIN_SCORE
      */
-    private VectorQueryType getVectorQueryType(int k, Float maxDistance, Float minScore) {
+    private VectorQueryType getVectorQueryType(Integer k, Float maxDistance, Float minScore) {
         if (maxDistance != null) {
             return VectorQueryType.MAX_DISTANCE;
         }
         if (minScore != null) {
             return VectorQueryType.MIN_SCORE;
         }
-        if (k != 0) {
+        if (k != null && k != 0) {
             return VectorQueryType.K;
         }
         throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires exactly one of k, distance or score to be set", NAME));

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -45,6 +45,7 @@ import org.opensearch.knn.plugin.stats.KNNCounter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
@@ -268,7 +269,7 @@ public abstract class KNNWeight extends Weight {
 
             @Override
             public Scorer get(long leadCost) throws IOException {
-                final TopDocs topDocs = searchLeaf(context, knnQuery.getK()).getResult();
+                final TopDocs topDocs = searchLeaf(context, Optional.ofNullable(knnQuery.getK()).orElse(0)).getResult();
                 cost = topDocs.scoreDocs.length;
                 if (cost == 0) {
                     return KNNScorer.emptyScorer();
@@ -279,7 +280,7 @@ public abstract class KNNWeight extends Weight {
             @Override
             public long cost() {
                 // Estimate the cost of the scoring operation, if applicable.
-                return cost == -1L ? knnQuery.getK() : cost;
+                return cost == -1L ? Optional.ofNullable(knnQuery.getK()).orElse(0) : cost;
             }
         };
     }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -47,10 +47,10 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
 
     private final KnnCollectorManager knnCollectorManager;
 
-    public MemoryOptimizedKNNWeight(KNNQuery query, float boost, final Weight filterWeight, IndexSearcher searcher, int k) {
+    public MemoryOptimizedKNNWeight(KNNQuery query, float boost, final Weight filterWeight, IndexSearcher searcher, Integer k) {
         super(query, boost, filterWeight);
 
-        if (k > 0) {
+        if (k != null && k > 0) {
             // ANN Search
             if (query.getParentsFilter() == null) {
                 // Non-nested case

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -67,6 +67,7 @@ public class IndexUtil {
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION = Version.V_2_17_0;
     private static final Version MINIMAL_EXPAND_NESTED_FEATURE = Version.V_2_19_0;
     private static final Version MINIMAL_TOP_LEVEL_ENGINE_FEATURE = Version.V_3_2_0;
+    private static final Version MINIMAL_SUPPORTED_VERSION_FOR_NULL_K = Version.V_3_3_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -433,6 +434,7 @@ public class IndexUtil {
                 put(KNNConstants.MODEL_VERSION, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION);
                 put(EXPAND_NESTED, MINIMAL_EXPAND_NESTED_FEATURE);
                 put(KNNConstants.TOP_LEVEL_ENGINE_FEATURE, MINIMAL_TOP_LEVEL_ENGINE_FEATURE);
+                put(KNNConstants.NULL_K, MINIMAL_SUPPORTED_VERSION_FOR_NULL_K);
             }
         };
 

--- a/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
@@ -47,7 +47,7 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
         KNNQueryBuilder knnQueryBuilder = (KNNQueryBuilder) result;
         assertEquals("test_field", knnQueryBuilder.fieldName());
         assertArrayEquals(new float[] { 1.0f, 2.0f, 3.0f }, (float[]) knnQueryBuilder.vector(), 0.001f);
-        assertEquals(5, knnQueryBuilder.getK());
+        assertEquals((Integer) 5, knnQueryBuilder.getK());
     }
 
     @Test

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -197,7 +197,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(getDefaultKNNMethodContext(), 4));
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         KNNQuery query = (KNNQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
-        assertEquals(knnQueryBuilder.getK(), query.getK());
+        assertEquals(knnQueryBuilder.getK(), (Integer) query.getK());
         assertEquals(knnQueryBuilder.fieldName(), query.getField());
         assertEquals(knnQueryBuilder.vector(), query.getQueryVector());
     }
@@ -536,6 +536,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        knnQueryBuilder = (KNNQueryBuilder) knnQueryBuilder.doRewrite(mockQueryShardContext);
         MethodComponentContext methodComponentContext = new MethodComponentContext(
             org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
             ImmutableMap.of()
@@ -562,6 +563,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        knnQueryBuilder = (KNNQueryBuilder) knnQueryBuilder.doRewrite(mockQueryShardContext);
         MethodComponentContext methodComponentContext = new MethodComponentContext(
             org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
             ImmutableMap.of()
@@ -777,7 +779,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         KNNQuery query = (KNNQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
-        assertEquals(knnQueryBuilder.getK(), query.getK());
+        assertEquals(knnQueryBuilder.getK(), (Integer) query.getK());
         assertEquals(knnQueryBuilder.fieldName(), query.getField());
         assertEquals(knnQueryBuilder.vector(), query.getQueryVector());
     }
@@ -983,7 +985,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
                 assertEquals(FIELD_NAME, deserializedKnnQueryBuilder.fieldName());
                 assertArrayEquals(QUERY_VECTOR, (float[]) deserializedKnnQueryBuilder.vector(), 0.0f);
                 if (k != null) {
-                    assertEquals(k.intValue(), deserializedKnnQueryBuilder.getK());
+                    assertEquals(k, deserializedKnnQueryBuilder.getK());
                 } else if (distance != null) {
                     assertEquals(distance.floatValue(), deserializedKnnQueryBuilder.getMaxDistance(), 0.0f);
                 } else {

--- a/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParserTests.java
@@ -493,7 +493,6 @@ public class KNNQueryBuilderParserTests extends KNNTestCase {
         builder.startObject(NAME);
         builder.startObject(FIELD_NAME);
         builder.field(KNNQueryBuilder.VECTOR_FIELD.getPreferredName(), queryVector);
-        builder.field(KNNQueryBuilder.K_FIELD.getPreferredName(), 0);
         builder.field(KNNQueryBuilder.MAX_DISTANCE_FIELD.getPreferredName(), MAX_DISTANCE);
         builder.field(BOOST_FIELD.getPreferredName(), BOOST);
         builder.endObject();

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1967,6 +1967,10 @@ public class KNNRestTestCase extends ODFERestTestCase {
         validateKNNSearch(testIndex, testField, dimension, numDocs, k, null);
     }
 
+    public void validateKNNSearchDistance(String testIndex, String testField, int dimension, int numDocs) throws Exception {
+        validateKNNSearchDistance(testIndex, testField, dimension, numDocs, Float.MAX_VALUE, null);
+    }
+
     // Validate KNN search on a KNN index by generating the query vector from the number of documents in the index
     public void validateKNNSearch(String testIndex, String testField, int dimension, int numDocs, int k, Map<String, ?> methodParameters)
         throws Exception {
@@ -1983,6 +1987,36 @@ public class KNNRestTestCase extends ODFERestTestCase {
 
         assertEquals(k, results.size());
         for (int i = 0; i < k; i++) {
+            assertEquals(numDocs - i - 1, Integer.parseInt(results.get(i).getDocId()));
+        }
+    }
+
+    public void validateKNNSearchDistance(
+        String testIndex,
+        String testField,
+        int dimension,
+        int numDocs,
+        float maxDistance,
+        Map<String, ?> methodParameters
+    ) throws Exception {
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, (float) numDocs);
+
+        Response searchResponse = searchKNNIndex(
+            testIndex,
+            KNNQueryBuilder.builder()
+                .maxDistance(maxDistance)
+                .methodParameters(methodParameters)
+                .fieldName(testField)
+                .vector(queryVector)
+                .build(),
+            numDocs
+        );
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), testField);
+
+        assertEquals(numDocs, results.size());
+        for (int i = 0; i < numDocs; i++) {
             assertEquals(numDocs - i - 1, Integer.parseInt(results.get(i).getDocId()));
         }
     }


### PR DESCRIPTION
### Description
KNNQuery k == 0 and k == null are used interchangeably, this change is to remove this logic (outside of Lucene library calls) by changing k from an int field to an Integer field.

### Related Issues
Resolves [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
Intended to replace PR [#2871](https://github.com/opensearch-project/k-NN/pull/2871)
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
