### PR TITLE
Fixes integer overflow for efficient filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix derived source deserialization bug on invalid documents [#2882](https://github.com/opensearch-project/k-NN/pull/2882)
 * Fix invalid cosine score range in LuceneOnFaiss [#2892](https://github.com/opensearch-project/k-NN/pull/2892)
 * Allows k to be nullable to fix filter bug [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
+* Fix integer overflow for while estimating distance computations for efficient filtering [#2903](https://github.com/opensearch-project/k-NN/pull/2903)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -68,6 +68,10 @@ public class KNNQuery extends Query {
     // TODO: ThreadContext does not work with logger, remove this from here once its figured out
     private int shardId;
 
+    /**
+     * @deprecated Use builder instead
+     */
+    @Deprecated
     public KNNQuery(
         final String field,
         final float[] queryVector,
@@ -78,6 +82,10 @@ public class KNNQuery extends Query {
         this(field, queryVector, null, k, indexName, null, parentsFilter, VectorDataType.FLOAT, null);
     }
 
+    /**
+     * @deprecated Use builder instead
+     */
+    @Deprecated
     public KNNQuery(
         final String field,
         final float[] queryVector,
@@ -90,6 +98,10 @@ public class KNNQuery extends Query {
         this(field, queryVector, null, k, indexName, filterQuery, parentsFilter, VectorDataType.FLOAT, rescoreContext);
     }
 
+    /**
+     * @deprecated Use builder instead
+     */
+    @Deprecated
     public KNNQuery(
         final String field,
         final byte[] byteQueryVector,
@@ -103,6 +115,10 @@ public class KNNQuery extends Query {
         this(field, null, byteQueryVector, k, indexName, filterQuery, parentsFilter, vectorDataType, rescoreContext);
     }
 
+    /**
+     * @deprecated Use builder instead
+     */
+    @Deprecated
     private KNNQuery(
         final String field,
         final float[] queryVector,
@@ -126,13 +142,9 @@ public class KNNQuery extends Query {
     }
 
     /**
-     * Constructor for KNNQuery with query vector, index name and parent filter
-     *
-     * @param field field name
-     * @param queryVector query vector
-     * @param indexName index name
-     * @param parentsFilter parent filter
+     * @deprecated Use builder instead
      */
+    @Deprecated
     public KNNQuery(String field, float[] queryVector, String indexName, BitSetProducer parentsFilter) {
         this(field, queryVector, null, 0, indexName, null, parentsFilter, VectorDataType.FLOAT, null);
     }
@@ -168,6 +180,10 @@ public class KNNQuery extends Query {
     public KNNQuery filterQuery(Query filterQuery) {
         this.filterQuery = filterQuery;
         return this;
+    }
+
+    public int getQueryDimension() {
+        return this.queryVector != null ? this.queryVector.length : this.byteQueryVector.length;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -183,7 +183,17 @@ public class KNNQuery extends Query {
     }
 
     public int getQueryDimension() {
-        return this.queryVector != null ? this.queryVector.length : this.byteQueryVector.length;
+        return switch (vectorDataType) {
+            case FLOAT, BYTE -> {
+                assert queryVector != null;
+                yield queryVector.length;
+            }
+            case BINARY -> {
+                assert byteQueryVector != null;
+                yield byteQueryVector.length * Byte.SIZE;
+            }
+            default -> queryVector.length;
+        };
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQuery.java
@@ -184,15 +184,14 @@ public class KNNQuery extends Query {
 
     public int getQueryDimension() {
         return switch (vectorDataType) {
-            case FLOAT, BYTE -> {
-                assert queryVector != null;
-                yield queryVector.length;
-            }
             case BINARY -> {
                 assert byteQueryVector != null;
                 yield byteQueryVector.length * Byte.SIZE;
             }
-            default -> queryVector.length;
+            default -> {
+                assert queryVector != null;
+                yield queryVector.length;
+            }
         };
     }
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -92,6 +92,7 @@ public abstract class KNNWeight extends Weight {
 
     public KNNWeight(KNNQuery query, float boost, Weight filterWeight) {
         super(query);
+        assert query != null : "query must not be null";
         this.knnQuery = query;
         this.boost = boost;
         this.filterWeight = filterWeight;

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -183,7 +183,7 @@ public abstract class KNNWeight extends Weight {
                 sb.append(KNNConstants.EXACT_SEARCH)
                     .append(" since filtered threshold value = ")
                     .append(filterThresholdValue)
-                    .append(" is greater than or equal to cardinality = ")
+                    .append(" is greater than or equal to estimated distance computations = ")
                     .append(cardinality);
             } else if (!isExactSearchThresholdSettingSet(filterThresholdValue) && isMaxDistCompGreaterThanEstimatedDistComp(cardinality)) {
                 sb.append(KNNConstants.EXACT_SEARCH)

--- a/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExplainTests.java
@@ -569,7 +569,7 @@ public class ExplainTests extends KNNWeightTestCase {
                     EXACT_SEARCH,
                     VectorDataType.BINARY.name(),
                     SpaceType.HAMMING.getValue(),
-                    "is greater than or equal to cardinality",
+                    "is greater than or equal to estimated distance computations",
                     "since filtered threshold value"
                 );
             }
@@ -624,7 +624,7 @@ public class ExplainTests extends KNNWeightTestCase {
                 VectorDataType.FLOAT.name(),
                 SpaceType.L2.getValue(),
                 "since max distance computation",
-                "is greater than or equal to cardinality"
+                "is greater than or equal to estimated distance computations"
             );
         }
         assertEquals(docIdSetIterator.cost(), actualDocIds.size());

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryTests.java
@@ -5,14 +5,20 @@
 
 package org.opensearch.knn.index.query;
 
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class KNNQueryTests extends OpenSearchTestCase {
 
     public void getQueryDimensions() {
-        KNNQuery query = KNNQuery.builder().queryVector(new float[] { 1.0f, 2.0f, 3.0f }).build();
+        KNNQuery query = KNNQuery.builder().queryVector(new float[] { 1.0f, 2.0f, 3.0f }).vectorDataType(VectorDataType.FLOAT).build();
         assertEquals(3, query.getQueryDimension());
-        query = KNNQuery.builder().byteQueryVector(new byte[] { 0, 1 }).build();
+        query = KNNQuery.builder().queryVector(new float[] { 1.0f, 2.0f, 3.0f }).vectorDataType(VectorDataType.BYTE).build();
+        assertEquals(3, query.getQueryDimension());
+        query = KNNQuery.builder().byteQueryVector(new byte[] { 0, 1 }).vectorDataType(VectorDataType.BINARY).build();
+        assertEquals(16, query.getQueryDimension());
+
+        query = KNNQuery.builder().queryVector(new float[] { 0, 1 }).build();
         assertEquals(2, query.getQueryDimension());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class KNNQueryTests extends OpenSearchTestCase {
+
+    public void getQueryDimensions() {
+        KNNQuery query = KNNQuery.builder().queryVector(new float[] { 1.0f, 2.0f, 3.0f }).build();
+        assertEquals(3, query.getQueryDimension());
+        query = KNNQuery.builder().byteQueryVector(new byte[] { 0, 1 }).build();
+        assertEquals(2, query.getQueryDimension());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTestCase.java
@@ -23,7 +23,6 @@ import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
@@ -75,7 +74,6 @@ public class KNNWeightTestCase extends KNNTestCase {
     protected static MockedStatic<JNIService> jniServiceMockedStatic;
 
     protected static MockedStatic<KNNSettings> knnSettingsMockedStatic;
-    protected static MockedStatic<FieldInfoExtractor> fieldInfoExtractorMockedStatic;
 
     @BeforeClass
     public static void setUpClass() throws Exception {

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTestCase.java
@@ -23,6 +23,7 @@ import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
 import org.opensearch.knn.index.memory.NativeMemoryAllocation;
@@ -74,6 +75,7 @@ public class KNNWeightTestCase extends KNNTestCase {
     protected static MockedStatic<JNIService> jniServiceMockedStatic;
 
     protected static MockedStatic<KNNSettings> knnSettingsMockedStatic;
+    protected static MockedStatic<FieldInfoExtractor> fieldInfoExtractorMockedStatic;
 
     @BeforeClass
     public static void setUpClass() throws Exception {

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -1139,7 +1139,10 @@ public class KNNWeightTests extends KNNWeightTestCase {
 
         try (
             MockedStatic<FieldInfoExtractor> fieldInfoExtractorMockedStatic = mockStatic(FieldInfoExtractor.class);
-            MockedStatic<BitSet> bitSetMockedStatic = Mockito.mockStatic(BitSet.class)
+            MockedStatic<BitSet> bitSetMockedStatic = Mockito.mockStatic(BitSet.class);
+            MockedStatic<SegmentLevelQuantizationInfo> segmentLevelQuantizationInfoMockedStatic = Mockito.mockStatic(
+                SegmentLevelQuantizationInfo.class
+            )
         ) {
             // Given
             // Mock segment
@@ -1189,9 +1192,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             fieldInfoExtractorMockedStatic.when(() -> FieldInfoExtractor.getFieldInfo(reader, FIELD_NAME)).thenReturn(mockFieldInfo);
 
             // Mock Quantization
-            MockedStatic<SegmentLevelQuantizationInfo> segmentLevelQuantizationInfoMockedStatic = Mockito.mockStatic(
-                SegmentLevelQuantizationInfo.class
-            );
+
             segmentLevelQuantizationInfoMockedStatic.when(() -> SegmentLevelQuantizationInfo.build(any(), any(), anyString(), any()))
                 .thenReturn(null);
 
@@ -1670,22 +1671,6 @@ public class KNNWeightTests extends KNNWeightTestCase {
 
             // Given
             int k = 3;
-            jniServiceMockedStatic.when(
-                () -> JNIService.queryIndex(anyLong(), eq(QUERY_VECTOR), eq(k), eq(HNSW_METHOD_PARAMETERS), any(), any(), anyInt(), any())
-            ).thenReturn(getFilteredKNNQueryResults());
-
-            jniServiceMockedStatic.when(
-                () -> JNIService.queryBinaryIndex(
-                    anyLong(),
-                    eq(BYTE_QUERY_VECTOR),
-                    eq(k),
-                    eq(HNSW_METHOD_PARAMETERS),
-                    any(),
-                    any(),
-                    anyInt(),
-                    any()
-                )
-            ).thenReturn(getFilteredKNNQueryResults());
             final SegmentReader reader = mockSegmentReader();
             final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
             when(leafReaderContext.reader()).thenReturn(reader);


### PR DESCRIPTION
Estimating distance calculation can run into int overflow if the filter docs cardinality is high. This happens because distance calculation involves multiplying dimension and filter docs cardinality

### Related Issues
Resolves [#[2901]](https://github.com/opensearch-project/k-NN/issues/2901)

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
