### PR TITLE
[BulkSimd PR1] Added MMapByteVectorValues for FP16 in LuceneOnFaiss.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,9 +289,22 @@ publishing {
 
 compileJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
+
+    // Since MemorySegment is not available until JDK22, exclude it when packaging and only include it for Java22+.
+    def javaExt = project.extensions.getByType(JavaPluginExtension)
+    if (javaExt.sourceCompatibility <= JavaVersion.VERSION_21 || javaExt.targetCompatibility <= JavaVersion.VERSION_21) {
+        exclude("org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorJDK22.java")
+    }
 }
 compileTestJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])
+}
+javadoc {
+    // Block generating Java doc as it will complain MemorySegment is under preview for Java21.
+    def javaExt = project.extensions.getByType(JavaPluginExtension)
+    if (javaExt.sourceCompatibility <= JavaVersion.VERSION_21 || javaExt.targetCompatibility <= JavaVersion.VERSION_21) {
+        exclude("org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorJDK22.java")
+    }
 }
 compileTestFixturesJava {
     options.compilerArgs.addAll(["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor'])

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractor.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import org.apache.lucene.store.IndexInput;
+
+/**
+ * From {@link IndexInput}, this class tries to extract mapped address with size.
+ * When {@link IndexInput} created from {@link org.apache.lucene.store.MMapDirectory} was given, then we can extract
+ * mapped pointer from it for faster computation.
+ */
+public interface MemorySegmentAddressExtractor {
+    /**
+     * Try to extract {@code MemorySegment[]} from given input stream, and return address and size info of them.
+     *
+     * @param indexInput : Input stream
+     * @return null if it fails to extract mapped pointer otherwise it will return an array having address and size.
+     *         Ex: address_i = array[i], size_i = array[i + 1].
+     */
+    long[] extractAddressAndSize(IndexInput indexInput);
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorJDK21.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorJDK21.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.store.IndexInput;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Since {@code MemorySegment} is not made officially in JDK21, we first extract {@code MemorySegment[]} from {@link IndexInput},
+ * and have it as Object then use reflection to collect address and size info.
+ */
+@Log4j2
+public final class MemorySegmentAddressExtractorJDK21 implements MemorySegmentAddressExtractor {
+    private static final java.lang.reflect.Method ADDRESS_METHOD;
+    private static final java.lang.reflect.Method BYTE_SIZE_METHOD;
+
+    // Get the handle when loading once.
+    static {
+        java.lang.reflect.Method addressMethod = null;
+        java.lang.reflect.Method byteSizeMethod = null;
+        try {
+            Class<?> clazz = Class.forName("java.lang.foreign.MemorySegment");
+            addressMethod = clazz.getMethod("address");
+            byteSizeMethod = clazz.getMethod("byteSize");
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            // Running on JDK where MemorySegment/address() doesn't exist
+        }
+        ADDRESS_METHOD = addressMethod;
+        BYTE_SIZE_METHOD = byteSizeMethod;
+    }
+
+    /**
+     * Extracts address and size info of {@code MemorySegment[]} from the given {@code indexInput}.
+     * <p>
+     * When using {@code MMapDirectory}, the {@code indexInput} may be an instance of
+     * {@code MemorySegmentIndexInput$SingleSegmentImpl} or {@code MemorySegmentIndexInput$MultiSegmentImpl}.
+     * These classes wrap mapped pointers in {@code MemorySegment} objects stored in a field named {@code segments}.
+     * This method detects the {@code segments} field, extracts its value, and returns it.
+     * <p>
+     * If the corresponding `segments` cannot be found, this method simply returns {@code null}.
+     * In that case, the search logic falls back to the default scorer, which loads vectors
+     * into the JVM heap and performs distance calculations there.
+     * <p>
+     *
+     * @param indexInput the input from which to extract memory segments
+     * @return an array of address and size info extracted from the input, or null if it's not found.
+     *         ex: address_i = array[i], size_i = array[i + 1]
+     */
+    @Override
+    public long[] extractAddressAndSize(final IndexInput indexInput) {
+        if (ADDRESS_METHOD == null || BYTE_SIZE_METHOD == null) {
+            // Runtime JDK does not support MemorySegment.
+            return null;
+        }
+
+        try {
+            // MMapDirectory in Lucene will return MemorySegmentIndexInput$SingleSegmentImpl or .$MultiSegmentImpl.
+            // Thus, get the super class (e.g. MemorySegmentIndexInput) to acquire `MemorySegment[] segments`.
+            final Field f = indexInput.getClass().getSuperclass().getDeclaredField("segments");
+            f.setAccessible(true);
+            // We're expecting this to be MemorySegment[]
+            final Object objSegments = f.get(indexInput);
+            if (objSegments == null || !objSegments.getClass().isArray()) {
+                // It's not MemorySegment[]
+                return null;
+            }
+            final int numSegments = Array.getLength(objSegments);
+            final long[] addressAndSize = new long[2 * numSegments];
+            for (int segmentIndex = 0; segmentIndex < numSegments; segmentIndex++) {
+                final Object memorySegment = Array.get(objSegments, segmentIndex);
+                if (memorySegment == null) {
+                    // Memory segments does not have complete mapped regions.
+                    return null;
+                }
+                final int addressIndex = 2 * segmentIndex;
+                final int sizeIndex = 2 * segmentIndex + 1;
+                addressAndSize[addressIndex] = (long) ADDRESS_METHOD.invoke(memorySegment);
+                addressAndSize[sizeIndex] = (long) BYTE_SIZE_METHOD.invoke(memorySegment);
+            }
+
+            return addressAndSize;
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException | InaccessibleObjectException
+            | InvocationTargetException e) {
+            // Ignore
+            log.warn("Failed to extract MemorySegment[] from IndexInput, error message={}", e.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorJDK22.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorJDK22.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.store.IndexInput;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+
+/**
+ * For JDK 22 and later, the Foreign Function  &amp; Memory (FFM) API is part of the standard, so we no longer need to rely on reflection.
+ * This class relies on reflection to extract {@code MemorySegment[]} from {@code IndexInput}.
+ * And after acquired {@code MemorySegment[]}, it will use it right away to collect address and mapped size.
+ */
+@Log4j2
+public final class MemorySegmentAddressExtractorJDK22 implements MemorySegmentAddressExtractor {
+    /**
+     * Extracts address and size info of {@code MemorySegment[]} from the given {@code indexInput}.
+     * <p>
+     * When using {@code MMapDirectory}, the {@code indexInput} may be an instance of
+     * {@code MemorySegmentIndexInput$SingleSegmentImpl} or {@code MemorySegmentIndexInput$MultiSegmentImpl}.
+     * These classes wrap mapped pointers in {@code MemorySegment} objects stored in a field named {@code segments}.
+     * This method detects the {@code segments} field, extracts its value, and returns it.
+     * <p>
+     * If the corresponding `segments` cannot be found, this method simply returns {@code null}.
+     * In that case, the search logic falls back to the default scorer, which loads vectors
+     * into the JVM heap and performs distance calculations there.
+     * <p>
+     *
+     * @param indexInput the input from which to extract memory segments
+     * @return an array of address and size info extracted from the input, or null if it's not found.
+     *         ex: address_i = array[i], size_i = array[i + 1]
+     */
+    @Override
+    public long[] extractAddressAndSize(final IndexInput indexInput) {
+        try {
+            // MMapDirectory in Lucene will return MemorySegmentIndexInput$SingleSegmentImpl or .$MultiSegmentImpl.
+            // Thus, get the super class (e.g. MemorySegmentIndexInput) to acquire `MemorySegment[] segments`.
+            final Field f = indexInput.getClass().getSuperclass().getDeclaredField("segments");
+            f.setAccessible(true);
+            final MemorySegment[] segments = (MemorySegment[]) f.get(indexInput);
+            if (segments == null || segments.length == 0) {
+                return null;
+            }
+            final long[] addressAndSize = new long[2 * segments.length];
+            for (int segmentIndex = 0; segmentIndex < segments.length; ++segmentIndex) {
+                final int addressIndex = 2 * segmentIndex;
+                final int sizeIndex = 2 * segmentIndex + 1;
+                final MemorySegment segment = segments[segmentIndex];
+                if (segment == null) {
+                    // Memory segments does not have complete mapped regions.
+                    return null;
+                }
+                addressAndSize[addressIndex] = segments[segmentIndex].address();
+                addressAndSize[sizeIndex] = segments[segmentIndex].byteSize();
+            }
+            return addressAndSize;
+        } catch (NoSuchFieldException | IllegalAccessException | InaccessibleObjectException e) {
+            // Ignore
+            log.warn("Failed to extract MemorySegment[] from IndexInput, error message={}", e.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorUtil.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.store.IndexInput;
+
+/**
+ * This class instantiates a {@code MemorySegment} address and size extractor when it is loaded.
+ * It first attempts to load MemorySegmentAddressExtractorJDK22+; if that fails,
+ * it falls back to {@link MemorySegmentAddressExtractorJDK21}.
+ *
+ * <p>
+ * Note that MemorySegmentAddressExtractorJDK22+ is only included when the project
+ * is compiled with JDK&nbsp;22+ compatibility.
+ * </p>
+ *
+ * <p>
+ * Both extractors use reflection to obtain the private {@code MemorySegment[]} field from
+ * {@link IndexInput}. In particular, {@link org.apache.lucene.store.MMapDirectory} returns
+ * an internal {@link IndexInput} implementation that stores {@code MemorySegment[]} in
+ * a private field named {@code segment}. Reflection is used to access this field and
+ * extract address and size information.
+ * </p>
+ *
+ * <p>
+ * For JDK&nbsp;21, {@link MemorySegmentAddressExtractorJDK21} also uses reflection to indirectly
+ * invoke the {@code address()} and {@code byteSize()} methods of {@code MemorySegment}.
+ * Since {@code MemorySegment} only became a standard API in JDK&nbsp;22+, reflection is the
+ * only option unless the {@code --enable-preview} flag is explicitly provided.
+ * </p>
+ *
+ * <pre>
+ * +-----------------------------+        (reflection)        +--------------------------------------+
+ * |          IndexInput         |  ----------------------->  |  MemorySegmentAddressExtractorJDK22  |
+ * |  segments: MemorySegment[]  |                            |  Address[], Size[]                   |
+ * +-----------------------------+                            +--------------------------------------+
+ *
+ * +-----------------------------+        (reflection)        +--------------------------------------+
+ * |          IndexInput         |  ----------------------->  |  MemorySegmentAddressExtractorJDK21  |
+ * |  segments: MemorySegment[]  |                     ^      |  Address[], Size[]                   |
+ * +-----------------------------+                     |      +--------------------------------------+
+ *                                                     |
+ *             (reflection on MemorySegment methods)   +--> MemorySegment#address()
+ *                                                         MemorySegment#byteSize()
+ * </pre>
+ */
+@Log4j2
+public final class MemorySegmentAddressExtractorUtil {
+    private static final MemorySegmentAddressExtractor INSTANCE;
+
+    static {
+        MemorySegmentAddressExtractor instance;
+        try {
+            try {
+                // Try to load the JDK22-optimized class which will be packaged only for compile_target = 22+.
+                Class<?> clazz = Class.forName("org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorJDK22");
+                instance = (MemorySegmentAddressExtractor) clazz.getDeclaredConstructor().newInstance();
+            } catch (ClassNotFoundException e) {
+                log.warn("Failed to load MemorySegmentAddressExtractorJDK22, falling back to MemorySegmentAddressExtractorJDK21", e);
+                // Class not found: fall back to JDK21 version
+                instance = new MemorySegmentAddressExtractorJDK21();
+            }
+        } catch (Throwable t) {
+            // Any other errors (constructor, reflection issues)
+            log.error("Failed to instantiate MemorySegmentAddressExtractor", t);
+            instance = (indexInput) -> null;
+        }
+        INSTANCE = instance;
+    }
+
+    public static long[] tryExtractAddressAndSize(final IndexInput indexInput) {
+        return INSTANCE.extractAddressAndSize(indexInput);
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexScalarQuantizedFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexScalarQuantizedFlat.java
@@ -7,10 +7,12 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
 import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueReconstructor;
 import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueReconstructorFactory;
 import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizerType;
@@ -25,6 +27,7 @@ import java.util.Map;
  * For example, the quantization type `QT_8BIT` indicates that each element in a vector is quantized into 8bits. Therefore, each element
  * will occupy exactly one byte, a vector would occupy exactly the size of dimensions.
  */
+@Log4j2
 @Getter
 public class FaissIndexScalarQuantizedFlat extends FaissIndex {
     private static EnumMap<FaissQuantizerType, VectorEncoding> VECTOR_DATA_TYPES = new EnumMap<>(
@@ -158,6 +161,25 @@ public class FaissIndexScalarQuantizedFlat extends FaissIndex {
             }
         }
 
+        if (quantizerType == FaissQuantizerType.QT_FP16) {
+            // Faiss SIMD bulk only supported for FP16 for now.
+            final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(indexInput);
+            if (addressAndSize != null) {
+                // Return MMapByteVectorValues having pointers pointing to mmap regions.
+                return new MMapByteVectorValues(
+                    indexInput,
+                    oneVectorByteSize,
+                    flatVectors.getBaseOffset(),
+                    dimension,
+                    totalNumberOfVectors,
+                    addressAndSize
+                );
+            } else {
+                log.warn("Failed to extract mapped pointers from IndexInput, falling back to ByteVectorValuesImpl.");
+            }
+        }
+
+        // Return default implementation
         return new ByteVectorValuesImpl(indexInput);
     }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -6,7 +6,9 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
@@ -79,13 +81,25 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
     @Override
     public void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        final KnnVectorValues knnVectorValues;
+        final boolean useNativeScoring;
+        if (isAdc) {
+            knnVectorValues = faissIndex.getByteValues(getSlicedIndexInput());
+            useNativeScoring = knnVectorValues instanceof MMapByteVectorValues;
+        } else {
+            knnVectorValues = faissIndex.getFloatValues(getSlicedIndexInput());
+            useNativeScoring = knnVectorValues instanceof MMapFloatVectorValues;
+        }
+
+        if (useNativeScoring) {
+            // We can use native scoring.
+            // TODO : This will be covered in Part-2 PR.
+        }
+
+        // Falling back to default scoring using pure Java.
         search(
             VectorEncoding.FLOAT32,
-            () -> flatVectorsScorer.getRandomVectorScorer(
-                vectorSimilarityFunction,
-                isAdc ? faissIndex.getByteValues(getSlicedIndexInput()) : faissIndex.getFloatValues(getSlicedIndexInput()),
-                target
-            ),
+            () -> flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, knnVectorValues, target),
             knnCollector,
             acceptDocs
         );
@@ -93,13 +107,16 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
     @Override
     public void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        final ByteVectorValues byteVectorValues = faissIndex.getByteValues(getSlicedIndexInput());
+        if (byteVectorValues instanceof MMapByteVectorValues) {
+            // We can use native scoring.
+            // TODO : This will be covered in Part-2 PR.
+        }
+
+        // Falling back to default scoring using pure Java.
         search(
             VectorEncoding.BYTE,
-            () -> flatVectorsScorer.getRandomVectorScorer(
-                vectorSimilarityFunction,
-                faissIndex.getByteValues(getSlicedIndexInput()),
-                target
-            ),
+            () -> flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, byteVectorValues, target),
             knnCollector,
             acceptDocs
         );

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapByteVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapByteVectorValues.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.Getter;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * Encapsulates raw pointers to memory-mapped regions associated with a given {@link IndexInput}.
+ * <p>
+ * The list of addresses and sizes can be passed to native scoring code for improved performance.
+ * Native code may operate directly on these mapped pointers to perform computations efficiently.
+ * <p>
+ * Users can still retrieve vector bytes via the {@code vectorValue} API, which lazily creates
+ * an internal buffer and returns it after filling in the requested bytes.
+ */
+public class MMapByteVectorValues extends ByteVectorValues {
+    private final IndexInput indexInput;
+    @Getter
+    // oneVectorByteSize == Float.BYTES * Dimension. Ex: 3072 bytes for 768 dimensions.
+    private final long oneVectorByteSize;
+    @Getter
+    // Start offset pointing to flat vectors section in Faiss index.
+    private final long baseOffset;
+    // Vector dimension
+    private final int dimension;
+    // Total number of vectors stored in Faiss index.
+    private final int totalNumberOfVectors;
+    // It has address and size per MemorySegment extracted from MemorySegmentIndexInput.
+    // e.g. address_i = addressAndSize[i], mapped_size_i = addressAndSize[i + 1]
+    // For example, if a given IndexInput had 2 MemorySegments, then addressAndSize[0] has the address of the first MemorySegment
+    // and addressAndSize[1] has the size of mapped region. Similarly, addressAndSize[2] has the address of the second MemorySegment, and
+    // addressAndSize[3] has the size of the second mapped region.
+    @Getter
+    private final long[] addressAndSize;
+    // Internal buffer that lazily created.
+    private byte[] buffer;
+
+    public MMapByteVectorValues(
+        final IndexInput indexInput,
+        final long oneVectorByteSize,
+        final long baseOffset,
+        final int dimension,
+        final int totalNumberOfVectors,
+        final long[] addressAndSize
+    ) {
+        this.indexInput = indexInput;
+        this.oneVectorByteSize = oneVectorByteSize;
+        this.baseOffset = baseOffset;
+        this.dimension = dimension;
+        this.totalNumberOfVectors = totalNumberOfVectors;
+        if (addressAndSize == null || addressAndSize.length == 0) {
+            throw new IllegalArgumentException(
+                "Empty `addressAndSize` was provided in "
+                    + MMapByteVectorValues.class.getSimpleName()
+                    + ". Is null?="
+                    + (addressAndSize == null)
+            );
+        }
+        this.addressAndSize = addressAndSize;
+    }
+
+    @Override
+    public byte[] vectorValue(int internalVectorId) throws IOException {
+        indexInput.seek(baseOffset + internalVectorId * oneVectorByteSize);
+        // Lazy initialization, in general this method is not expected to be called during search.
+        // During search, distance calculation will be done in a separated C++ code.
+        if (buffer == null) {
+            buffer = new byte[(int) oneVectorByteSize];
+        }
+        indexInput.readBytes(buffer, 0, buffer.length);
+        return buffer;
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public int size() {
+        return totalNumberOfVectors;
+    }
+
+    @Override
+    public ByteVectorValues copy() throws IOException {
+        return new MMapByteVectorValues(indexInput.clone(), oneVectorByteSize, baseOffset, dimension, totalNumberOfVectors, addressAndSize);
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.Getter;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * Encapsulates raw pointers to memory-mapped regions associated with a given {@link IndexInput}.
+ * <p>
+ * The list of addresses and sizes can be passed to native scoring code for improved performance.
+ * Native code may operate directly on these mapped pointers to perform computations efficiently.
+ * <p>
+ * Users can still retrieve vector bytes via the {@code vectorValue} API, which lazily creates
+ * an internal buffer and returns it after filling in the requested bytes.
+ */
+public class MMapFloatVectorValues extends FloatVectorValues {
+    private final IndexInput indexInput;
+    @Getter
+    // oneVectorByteSize == Float.BYTES * Dimension. Ex: 3072 bytes for 768 dimensions.
+    private final long oneVectorByteSize;
+    @Getter
+    // Start offset pointing to flat vectors section in Faiss index.
+    private final long baseOffset;
+    // Vector dimension
+    private final int dimension;
+    // Total number of vectors stored in Faiss index.
+    private final int totalNumberOfVectors;
+    // It has address and size per MemorySegment extracted from MemorySegmentIndexInput.
+    // e.g. address_i = addressAndSize[i], mapped_size_i = addressAndSize[i + 1]
+    // For example, if a given IndexInput had 2 MemorySegments, then addressAndSize[0] has the address of the first MemorySegment
+    // and addressAndSize[1] has the size of mapped region. Similarly, addressAndSize[2] has the address of the second MemorySegment, and
+    // addressAndSize[3] has the size of the second mapped region.
+    @Getter
+    private final long[] addressAndSize;
+    // Internal buffer that lazily created.
+    private float[] buffer;
+
+    public MMapFloatVectorValues(
+        final IndexInput indexInput,
+        final long baseOffset,
+        final int dimension,
+        final int totalNumberOfVectors,
+        final long[] addressAndSize
+    ) {
+        this.indexInput = indexInput;
+        this.oneVectorByteSize = Float.BYTES * dimension;
+        this.baseOffset = baseOffset;
+        this.dimension = dimension;
+        this.totalNumberOfVectors = totalNumberOfVectors;
+        if (addressAndSize == null || addressAndSize.length == 0) {
+            throw new IllegalArgumentException(
+                "Empty `addressAndSize` was provided in "
+                    + MMapFloatVectorValues.class.getSimpleName()
+                    + ". Is null?="
+                    + (addressAndSize == null)
+            );
+        }
+        this.addressAndSize = addressAndSize;
+    }
+
+    @Override
+    public float[] vectorValue(int internalVectorId) throws IOException {
+        indexInput.seek(baseOffset + internalVectorId * oneVectorByteSize);
+        // Lazy initialization, in general this method is not expected to be called during search.
+        // During search, distance calculation will be done in a separated C++ code.
+        if (buffer == null) {
+            buffer = new float[(int) dimension];
+        }
+        indexInput.readFloats(buffer, 0, buffer.length);
+        return buffer;
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public int size() {
+        return totalNumberOfVectors;
+    }
+
+    @Override
+    public FloatVectorValues copy() throws IOException {
+        return new MMapFloatVectorValues(indexInput.clone(), baseOffset, dimension, totalNumberOfVectors, addressAndSize);
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MMapByteVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MMapByteVectorValuesTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
+import org.opensearch.knn.generate.SearchTestHelper;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapByteVectorValues;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MMapByteVectorValuesTests extends LuceneTestCase {
+    @Test
+    @SneakyThrows
+    public void testValidBytesLoad() {
+        // Creat temp dir
+        final Path tempDirPath = createTempDir();
+        final String fileName = "test.vec";
+        final int numVectors = 100;
+        final int dimension = 128;
+        final int oneVectorByteSize = Float.BYTES * dimension;
+
+        try (final Directory directory = new MMapDirectory(tempDirPath)) {
+            // Write vectors
+            final List<float[]> vectors = new ArrayList<>();
+            try (final IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                for (int i = 0; i < numVectors; i++) {
+                    for (int j = 0; j < dimension; j++) {
+                        final float[] vector = SearchTestHelper.generateOneSingleFloatVector(dimension, -2, 2, false);
+                        vectors.add(vector);
+                        for (final float val : vector) {
+                            output.writeInt(Float.floatToIntBits(val));
+                        }
+                    }
+                }
+            }
+
+            // Read validation
+            try (final IndexInput input = directory.openInput(fileName, IOContext.DEFAULT)) {
+                final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(input);
+                assertNotNull(addressAndSize);
+                final MMapByteVectorValues values = new MMapByteVectorValues(
+                    input,
+                    oneVectorByteSize,
+                    0,
+                    oneVectorByteSize,
+                    numVectors,
+                    addressAndSize
+                );
+
+                // Ensure properties are correct.
+                assertEquals(oneVectorByteSize, values.getOneVectorByteSize());
+                assertEquals(oneVectorByteSize, values.getVectorByteLength());
+                assertEquals(addressAndSize, values.getAddressAndSize());
+
+                // Ensure reads are correct
+                // This will not be used in optimization path, but hnsw graph searcher will call this when traversing top level layers.
+                for (int i = 0; i < numVectors; i++) {
+                    final byte[] rawFloatVector = values.vectorValue(i);
+                    final float[] expectedVector = vectors.get(i);
+                    compareBytesToFloat(rawFloatVector, expectedVector);
+                }
+
+                // Now, validating mmap read
+                final Unsafe unsafe = getUnsafe();
+                final byte[] buffer = new byte[oneVectorByteSize];
+                long address = addressAndSize[0];
+
+                for (int i = 0; i < numVectors; i++) {
+                    // Per each vector, load and compare values
+                    final float[] expectedVector = vectors.get(i);
+                    for (int k = 0; k < oneVectorByteSize; ++k) {
+                        buffer[k] = unsafe.getByte(address++);
+                    }
+                    compareBytesToFloat(buffer, expectedVector);
+                }
+            }
+        }
+    }
+
+    // Unsafe is used for reading bytes directly from internal mapped pointer
+    private static Unsafe getUnsafe() {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            return (Unsafe) f.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void compareBytesToFloat(final byte[] rawFloatVector, final float[] expected) {
+        // Convert raw bytes to float[]
+        final FloatBuffer fb = ByteBuffer.wrap(rawFloatVector).order(ByteOrder.nativeOrder()).asFloatBuffer();
+        final float[] acquiredVectors = new float[fb.remaining()];
+        fb.get(acquiredVectors);
+
+        // Compare two vectors
+        assertEquals(expected.length, acquiredVectors.length);
+
+        for (int j = 0; j < expected.length; j++) {
+            assertEquals(expected[j], acquiredVectors[j], 1e-6);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MMapFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MMapFloatVectorValuesTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.knn.generate.SearchTestHelper;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MMapFloatVectorValuesTests extends LuceneTestCase {
+    @SneakyThrows
+    public void testValidBytesLoad() {
+        // Creat temp dir
+        final Path tempDirPath = createTempDir();
+        final String fileName = "test.vec";
+        final int numVectors = 100;
+        final int dimension = 128;
+        final int oneVectorByteSize = Float.BYTES * dimension;
+
+        try (final Directory directory = new MMapDirectory(tempDirPath)) {
+            // Write vectors
+            final List<float[]> vectors = new ArrayList<>();
+            try (final IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                for (int i = 0; i < numVectors; i++) {
+                    for (int j = 0; j < dimension; j++) {
+                        final float[] vector = SearchTestHelper.generateOneSingleFloatVector(dimension, -2, 2, false);
+                        vectors.add(vector);
+                        for (final float val : vector) {
+                            output.writeInt(Float.floatToIntBits(val));
+                        }
+                    }
+                }
+            }
+
+            // Read validation
+            try (final IndexInput input = directory.openInput(fileName, IOContext.DEFAULT)) {
+                final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(input);
+                assertNotNull(addressAndSize);
+                final MMapFloatVectorValues values = new MMapFloatVectorValues(input, 0, dimension, numVectors, addressAndSize);
+
+                // Ensure properties are correct.
+                assertEquals(oneVectorByteSize, values.getOneVectorByteSize());
+                assertEquals(oneVectorByteSize, values.getVectorByteLength());
+                assertEquals(addressAndSize, values.getAddressAndSize());
+
+                // Ensure reads are correct
+                // This will not be used in optimization path, but hnsw graph searcher will call this when traversing top level layers.
+                for (int i = 0; i < numVectors; i++) {
+                    final float[] rawFloatVector = values.vectorValue(i);
+                    final float[] expectedVector = vectors.get(i);
+                    compareFloats(rawFloatVector, expectedVector);
+                }
+
+                // Now, validating mmap read
+                final Unsafe unsafe = getUnsafe();
+                final byte[] buffer = new byte[oneVectorByteSize];
+                final float[] acquiredVector = new float[dimension];
+                long address = addressAndSize[0];
+
+                for (int i = 0; i < numVectors; i++) {
+                    // Per each vector, load and compare values
+                    final float[] expectedVector = vectors.get(i);
+                    for (int k = 0; k < oneVectorByteSize; ++k) {
+                        buffer[k] = unsafe.getByte(address++);
+                    }
+                    FloatBuffer fb = ByteBuffer.wrap(buffer).order(ByteOrder.nativeOrder()).asFloatBuffer();
+                    fb.get(acquiredVector);
+                    compareFloats(acquiredVector, expectedVector);
+                }
+            }
+        }
+    }
+
+    // Unsafe is used for reading bytes directly from internal mapped pointer
+    private static Unsafe getUnsafe() {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            return (Unsafe) f.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void compareFloats(final float[] acquiredVectors, final float[] expected) {
+        assertEquals(expected.length, acquiredVectors.length);
+
+        for (int j = 0; j < expected.length; j++) {
+            assertEquals(expected[j], acquiredVectors[j], 1e-6);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MemorySegmentAddressExtractorTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class MemorySegmentAddressExtractorTests extends LuceneTestCase {
+    @Test
+    @SneakyThrows
+    public void extractMemorySegmentTest() {
+        // Create repo
+        final Path tempDirPath = createTempDir();
+
+        // Create a dummy file
+        final int tmpFileSize = 1333;
+        final Path tempFile = Paths.get(tempDirPath.toFile().getAbsolutePath(), "test.bin");
+        Files.write(tempFile, new byte[tmpFileSize]);
+
+        // Create directory
+        try (final Directory directory = new MMapDirectory(tempDirPath)) {
+            try (final IndexInput indexInput = directory.openInput(tempFile.getFileName().toString(), IOContext.DEFAULT)) {
+                final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(indexInput);
+
+                // Should be non-empty array
+                assertNotNull(addressAndSize);
+                assertTrue(addressAndSize.length > 0);
+                assertEquals(0, addressAndSize.length % 2);
+
+                // Get size
+                long size = 0;
+                for (int i = 1; i < addressAndSize.length; i += 2) {
+                    size += addressAndSize[i];
+                }
+                assertEquals(tmpFileSize, size);
+            }
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void extractMemorySegmentShouldNullTest() {
+        // Create repo
+        final Path tempDirPath = createTempDir();
+
+        // Create a dummy file
+        final int tmpFileSize = 1333;
+        final Path tempFile = Paths.get(tempDirPath.toFile().getAbsolutePath(), "test.bin");
+        Files.write(tempFile, new byte[tmpFileSize]);
+
+        // Create directory
+        try (final Directory directory = new NIOFSDirectory(tempDirPath)) {
+            try (final IndexInput indexInput = directory.openInput(tempFile.getFileName().toString(), IOContext.DEFAULT)) {
+                final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(indexInput);
+
+                // Should be null
+                assertNull(addressAndSize);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This is the first PR to support native scoring in LuceneOnFaiss. 

RFC : https://github.com/opensearch-project/k-NN/issues/2875

In this first PR, FP16 flat index will return `MMapByteVectorValues` having `MemorySegment[]` extracted from MemorySegment$IndexInput. Each `MemorySegment` will have a raw pointer pointing to mapped region in memory.
Passing the raw pointer for distance calculation will be dealt with in the second PR. This PR is mostly set-up for the second PR.

Since the actual distance calculation is not there, still the distance calculation will be conducted in Java side.
This PR is mostly focusing on extracting `MemorySegment` from IndexInput.


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.
- [O] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
