### PR TITLE
Remove error_prone_annotation as log4j 2.25.1 reverted.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -345,19 +345,14 @@ dependencies {
     compileOnly "org.opensearch:protobufs:${versions.opensearchprotobufs}"
     // Declare guava as compile time since guava will come from OpenSearch transport-grpc module.
     compileOnly group: 'com.google.guava', name: 'guava', version: "${versions.guava}"
-    compileOnly group: 'com.google.errorprone', name: 'error_prone_annotations', version: "${versions.error_prone_annotations}"
 
     api "org.apache.commons:commons-lang3:${versions.commonslang}"
-    // We need to remove errorprone from guava since default guava is not bringing 2.26.1 version
-    // where as OpenSearch is using 2.41.0
-    testFixturesImplementation("com.google.guava:guava:${versions.guava}") {
-        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
-    }
-    testFixturesImplementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: "${versions.error_prone_annotations}"
     testFixturesImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy', version: "${versions.bytebuddy}"
     testImplementation group: 'org.objenesis', name: 'objenesis', version: "${versions.objenesis}"
     testImplementation group: 'net.bytebuddy', name: 'byte-buddy-agent', version: "${versions.bytebuddy}"
+    testImplementation("com.google.guava:guava:${versions.guava}")
+    testFixturesImplementation("com.google.guava:guava:${versions.guava}")
     // json-path 2.9.0 depends on slf4j 2.0.11, which conflicts with the version used by OpenSearch core.
     // Excluding slf4j here since json-path is only used for testing, and logging failures in this context are acceptable.
     testFixturesImplementation('com.jayway.jsonpath:json-path:2.9.0') {


### PR DESCRIPTION
### Description
Removing error_prone_annotation as log4j 2.25.1 has been reverted.

Revert PR : https://github.com/opensearch-project/OpenSearch/commit/a08700c8fd9477c873413306ecb6a88d09ef6ede

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
