### PR TITLE
Use right doc id for MMR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix invalid cosine score range in LuceneOnFaiss [#2892](https://github.com/opensearch-project/k-NN/pull/2892)
 * Allows k to be nullable to fix filter bug [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
 * Fix integer overflow for while estimating distance computations for efficient filtering [#2903](https://github.com/opensearch-project/k-NN/pull/2903)
+* Use the unique doc id for MMR rerank rather than internal lucenue doc id which is not unique for multiple shards case. [#2911](https://github.com/opensearch-project/k-NN/pull/2911)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
@@ -472,7 +472,8 @@ public class MMRUtil {
                         }
                     } catch (Exception e) {
                         throw new IllegalArgumentException(
-                            String.format("%s: unexpected value at the vector field [%s]. error: %s", baseError, fieldPath, e.getMessage())
+                            String.format("%s: unexpected value at the vector field [%s]. error: %s", baseError, fieldPath, e.getMessage()),
+                            e
                         );
                     }
                     if (isFloatVector) {

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -284,6 +284,16 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Create KNN Index with custom shard num
+     */
+    protected void createKnnIndex(String index, String mapping, int shardNum) throws IOException {
+        Settings defaultSettings = getKNNDefaultIndexSettings();
+        Settings settings = Settings.builder().put(defaultSettings).put("number_of_shards", shardNum).build();
+        createIndex(index, settings);
+        putMappingRequest(index, mapping);
+    }
+
+    /**
      * Builds a KNN Index for dimension and index, with on_disk mode
      */
     protected void createOnDiskIndex(String index, Integer dimensions, SpaceType spaceType) throws IOException {


### PR DESCRIPTION
### Description
Use right doc id for MMR. We should use the unique doc id rather than the internal lucene doc id. That doc id is not always unique especially when we have multiple nodes. That id of the search hit can be -1 if the hit is passed from one node to another one.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
