### PR TITLE
Clean up submodules in remote index build test workflow.

### DIFF
--- a/.github/workflows/remote_index_build.yml
+++ b/.github/workflows/remote_index_build.yml
@@ -108,6 +108,9 @@ jobs:
 
       - name: Run tests
         run: |
+          echo "Cleaning up submodules first ..."
+          rm -rf .git/modules/* &>/dev/null || true
+          rm -rf ./jni/external/* &>/dev/null || true
           if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw
           then
             if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq


### PR DESCRIPTION
### Description
For some reason, mbox still remains in remote-index-build container which is affecting other unrelated CIs to be fail as shown below.

```
CMake Error at cmake/init-faiss.cmake:54 (message):
  Failed to apply patch:

  fatal: previous rebase directory

  /home/ec2-user/actions-runner/_work/k-NN/k-NN/.git/modules/jni/external/faiss/rebase-apply
  still exists but mbox given.
```

So this PR is adding a pre-step removing all submodules within the container for fresh start.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
