### PR TITLE
Local ref leak bug fix in JNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix integer overflow for while estimating distance computations for efficient filtering [#2903](https://github.com/opensearch-project/k-NN/pull/2903)
 * Fix byte[] radial search for faiss [#2905](https://github.com/opensearch-project/k-NN/pull/2905)
 * Use the unique doc id for MMR rerank rather than internal lucenue doc id which is not unique for multiple shards case. [#2911](https://github.com/opensearch-project/k-NN/pull/2911)
+* Fix local ref leak in JNI [#2916](https://github.com/opensearch-project/k-NN/pull/2916)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -762,10 +762,10 @@ jobjectArray knn_jni::faiss_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInter
 
     jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
 
-    jobject result;
     for(int i = 0; i < resultSize; ++i) {
-        result = jniUtil->NewObject(env, resultClass, allArgs, ids[i], dis[i]);
+        jobject result = jniUtil->NewObject(env, resultClass, allArgs, ids[i], dis[i]);
         jniUtil->SetObjectArrayElement(env, results, i, result);
+        env->DeleteLocalRef(result);
     }
     return results;
 }
@@ -886,10 +886,10 @@ jobjectArray knn_jni::faiss_wrapper::QueryBinaryIndex_WithFilter(knn_jni::JNIUti
 
     jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
 
-    jobject result;
     for(int i = 0; i < resultSize; ++i) {
-        result = jniUtil->NewObject(env, resultClass, allArgs, ids[i], dis[i]);
+        jobject result = jniUtil->NewObject(env, resultClass, allArgs, ids[i], dis[i]);
         jniUtil->SetObjectArrayElement(env, results, i, result);
+        env->DeleteLocalRef(result);
     }
     return results;
 }
@@ -1330,10 +1330,10 @@ jobjectArray knn_jni::faiss_wrapper::RangeSearchWithFilter(knn_jni::JNIUtilInter
 
     jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
 
-    jobject result;
     for (int i = 0; i < resultSize; ++i) {
-        result = jniUtil->NewObject(env, resultClass, allArgs, res.labels[i], res.distances[i]);
+        jobject result = jniUtil->NewObject(env, resultClass, allArgs, res.labels[i], res.distances[i]);
         jniUtil->SetObjectArrayElement(env, results, i, result);
+        env->DeleteLocalRef(result);
     }
 
     return results;


### PR DESCRIPTION
### Description
See original [PR](https://github.com/opensearch-project/k-NN/pull/2879).

When we using [jemalloc](https://jemalloc.net/) to trace native memory allocation, and i found that `Convert2dJavaObjectArrayAndStoreToFloatVector` has a potential memory leak even there is nothing to index and after Full GC run. as following shows:
<img width="1556" height="398" alt="image" src="https://github.com/user-attachments/assets/79b19045-198b-46fa-ad73-db88dd98e560" />

i think it is because that we do not delete local ref. 
like code: `auto vectorArray = (jfloatArray)env->GetObjectArrayElement(array2dJ, i); `
https://github.com/opensearch-project/k-NN/blob/ba979714f43fd3ace77b095ab7e9d3d6a132f718/jni/src/jni_util.cpp#L276-L294
After this patch, i traced again with jemalloc, it shows all memory cleaned.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
