### PR TITLE
Update Visitor to delegate for other fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Use the unique doc id for MMR rerank rather than internal lucenue doc id which is not unique for multiple shards case. [#2911](https://github.com/opensearch-project/k-NN/pull/2911)
 * Fix local ref leak in JNI [#2916](https://github.com/opensearch-project/k-NN/pull/2916)
 * Fix rescoring logic for nested exact search [#2921](https://github.com/opensearch-project/k-NN/pull/2921)
+* Update Visitor to delegate for other fields [#2925](https://github.com/opensearch-project/k-NN/pull/2925)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitor.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitor.java
@@ -36,4 +36,29 @@ public class DerivedSourceStoredFieldVisitor extends StoredFieldVisitor {
     public Status needsField(FieldInfo fieldInfo) throws IOException {
         return delegate.needsField(fieldInfo);
     }
+
+    @Override
+    public void stringField(FieldInfo fieldInfo, String value) throws IOException {
+        delegate.stringField(fieldInfo, value);
+    }
+
+    @Override
+    public void intField(FieldInfo fieldInfo, int value) throws IOException {
+        delegate.intField(fieldInfo, value);
+    }
+
+    @Override
+    public void longField(FieldInfo fieldInfo, long value) throws IOException {
+        delegate.longField(fieldInfo, value);
+    }
+
+    @Override
+    public void floatField(FieldInfo fieldInfo, float value) throws IOException {
+        delegate.floatField(fieldInfo, value);
+    }
+
+    @Override
+    public void doubleField(FieldInfo fieldInfo, double value) throws IOException {
+        delegate.doubleField(fieldInfo, value);
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitorTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.derivedsource;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.opensearch.index.mapper.SourceFieldMapper;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class DerivedSourceStoredFieldVisitorTests extends OpenSearchTestCase {
+
+    private static final String TEST_ORIGINAL_VALUE = "original";
+    private static final String TEST_TRANSFORMED_VALUE = "transformed";
+    private static final String TEST_VALUE = "test";
+    private static final String TEST_STRING_VALUE = "test-value";
+    private static final int TEST_DOC_ID = 123;
+    private static final long TEST_LONG_VALUE = 42L;
+    private static final int TEST_INT_VALUE = 42;
+
+    public void testBinaryField_whenSourceField_thenInjectsVectors() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder(SourceFieldMapper.NAME).build();
+
+        byte[] originalValue = TEST_ORIGINAL_VALUE.getBytes();
+        byte[] transformedValue = TEST_TRANSFORMED_VALUE.getBytes();
+        int documentId = TEST_DOC_ID;
+
+        when(transformer.injectVectors(documentId, originalValue)).thenReturn(transformedValue);
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, documentId, transformer);
+
+        visitor.binaryField(fieldInfo, originalValue);
+
+        verify(transformer).injectVectors(documentId, originalValue);
+        verify(delegate).binaryField(fieldInfo, transformedValue);
+    }
+
+    public void testBinaryField_whenNonSourceField_thenDelegatesDirectly() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("other-field").build();
+
+        byte[] value = TEST_VALUE.getBytes();
+        int documentId = TEST_DOC_ID;
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, documentId, transformer);
+
+        visitor.binaryField(fieldInfo, value);
+
+        verify(delegate).binaryField(fieldInfo, value);
+        verifyNoInteractions(transformer);
+    }
+
+    public void testBinaryField_whenNullValue_thenHandlesGracefully() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("other-field").build();
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, TEST_DOC_ID, transformer);
+
+        visitor.binaryField(fieldInfo, (byte[]) null);
+
+        verify(delegate).binaryField(fieldInfo, (byte[]) null);
+        verifyNoInteractions(transformer);
+    }
+
+    public void testNeedsField_delegatesToDelegate() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+
+        when(delegate.needsField(fieldInfo)).thenReturn(StoredFieldVisitor.Status.YES);
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, TEST_DOC_ID, transformer);
+
+        StoredFieldVisitor.Status result = visitor.needsField(fieldInfo);
+
+        assertEquals(StoredFieldVisitor.Status.YES, result);
+        verify(delegate).needsField(fieldInfo);
+    }
+
+    public void testStringField_delegatesToDelegate() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test-field").build();
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, TEST_DOC_ID, transformer);
+
+        visitor.stringField(fieldInfo, TEST_STRING_VALUE);
+
+        verify(delegate).stringField(fieldInfo, TEST_STRING_VALUE);
+    }
+
+    public void testLongField_delegatesToDelegate() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test-field").build();
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, TEST_DOC_ID, transformer);
+
+        visitor.longField(fieldInfo, TEST_LONG_VALUE);
+
+        verify(delegate).longField(fieldInfo, TEST_LONG_VALUE);
+    }
+
+    public void testIntField_delegatesToDelegate() throws IOException {
+        StoredFieldVisitor delegate = mock(StoredFieldVisitor.class);
+        DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test-field").build();
+
+        DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, TEST_DOC_ID, transformer);
+
+        visitor.intField(fieldInfo, TEST_INT_VALUE);
+
+        verify(delegate).intField(fieldInfo, TEST_INT_VALUE);
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
@@ -27,6 +27,8 @@ import java.util.Random;
 import java.util.function.Supplier;
 
 import static org.opensearch.knn.KNNRestTestCase.PROPERTIES_FIELD;
+import static org.opensearch.knn.KNNRestTestCase.REQUIRED_FIELD;
+import static org.opensearch.knn.KNNRestTestCase.ROUTING_FIELD;
 import static org.opensearch.knn.TestUtils.BWC_VERSION;
 
 public class DerivedSourceUtils {
@@ -95,6 +97,8 @@ public class DerivedSourceUtils {
         public int docCount = DOCS;
         @Builder.Default
         public Settings settings = null;
+        @Builder.Default
+        public Boolean isRoutingEnabled = false;
 
         public void init() {
             assert random != null;
@@ -112,7 +116,11 @@ public class DerivedSourceUtils {
 
         @SneakyThrows
         public String getMapping() {
-            XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject(PROPERTIES_FIELD);
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            if (isRoutingEnabled) {
+                builder.startObject(ROUTING_FIELD).field(REQUIRED_FIELD, true).endObject();
+            }
+            builder.startObject(PROPERTIES_FIELD);
             for (FieldContext context : fields) {
                 context.buildMapping(builder);
             }


### PR DESCRIPTION
### Description
When creating a custom Visitor for Derived Source, the implementation needed to invoke the delegate's methods (such as 'stringField', 'intField', 'longField') rather than calling the superclass methods, which were empty implementations.

Metadata fields like routing rely on the stringField method to transfer information from documents to SearchHit objects. Due to the previous implementation, the 'routing' field was missing from search responses because the methods weren't properly delegated to FieldVisitor's implementations.

### Related Issues
#2852 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
