### PR TITLE
Removed VectorSearchHolders map from NativeEngines990KnnVectorsReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,34 +4,15 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 3.3](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+## [Unreleased 3.4](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
-* Support native Maximal Marginal Relevance [#2868](https://github.com/opensearch-project/k-NN/pull/2868)
-* Support lateInteraction feature using painess script [#2909](https://github.com/opensearch-project/k-NN/pull/2909)
 ### Maintenance
-* Replace commons-lang with org.apache.commons:commons-lang3 [#2863](https://github.com/opensearch-project/k-NN/pull/2863)
-* Bump OpenSearch-Protobufs to 0.13.0 [#2833](https://github.com/opensearch-project/k-NN/pull/2833)
-* Bump Lucene version to 10.3 and fix build failures [#2878](https://github.com/opensearch-project/k-NN/pull/2878)
 * Onboard to s3 snapshots ([#2943](https://github.com/opensearch-project/k-NN/pull/2943))
 
 ### Bug Fixes
-* Use queryVector length if present in MDC check [#2867](https://github.com/opensearch-project/k-NN/pull/2867)
-* Fix derived source deserialization bug on invalid documents [#2882](https://github.com/opensearch-project/k-NN/pull/2882)
-* Fix invalid cosine score range in LuceneOnFaiss [#2892](https://github.com/opensearch-project/k-NN/pull/2892)
-* Allows k to be nullable to fix filter bug [#2836](https://github.com/opensearch-project/k-NN/issues/2836)
-* Fix integer overflow for while estimating distance computations for efficient filtering [#2903](https://github.com/opensearch-project/k-NN/pull/2903)
-* Fix AVX2 detection on other platforms [#2912](https://github.com/opensearch-project/k-NN/pull/2912)
-* Fix byte[] radial search for faiss [#2905](https://github.com/opensearch-project/k-NN/pull/2905)
-* Use the unique doc id for MMR rerank rather than internal lucenue doc id which is not unique for multiple shards case. [#2911](https://github.com/opensearch-project/k-NN/pull/2911)
-* Fix local ref leak in JNI [#2916](https://github.com/opensearch-project/k-NN/pull/2916)
-* Fix rescoring logic for nested exact search [#2921](https://github.com/opensearch-project/k-NN/pull/2921)
-* Update Visitor to delegate for other fields [#2925](https://github.com/opensearch-project/k-NN/pull/2925)
 * Fix blocking old indices created before 2.18 to use memory optimized search. [#2918](https://github.com/opensearch-project/k-NN/pull/2918)
 
 ### Refactoring
-* Refactored the KNN Stat files for better readability.
-* Change to use the function defined in core to check if system generate search factory is enabled or not []()
 
 ### Enhancements
-* Added engine as a top-level optional parameter while creating vector field [#2736](https://github.com/opensearch-project/k-NN/pull/2736)
-* Migrate k-NN plugin to use GRPC transport-grpc SPI interface [#2833](https://github.com/opensearch-project/k-NN/pull/2833)
+* Removed VectorSearchHolders map from NativeEngines990KnnVectorsReader [#2948](https://github.com/opensearch-project/k-NN/pull/2948)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -60,14 +60,16 @@ import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.KNN_FIELD;
  */
 @Log4j2
 public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
-    private static final int RESERVE_TWICE_SPACE = 2;
-    private static final float SUFFICIENT_LOAD_FACTOR = 0.6f;
 
     private final FlatVectorsReader flatVectorsReader;
     private Map<String, String> quantizationStateCacheKeyPerField;
     private final SegmentReadState segmentReadState;
     private final List<String> cacheKeys;
-    private volatile Map<String, VectorSearcherHolder> vectorSearchers;
+    private volatile VectorSearcherHolder vectorSearcherHolder;
+    // This lock object ensure that only one thread can initialize vectorSearcherHolder object.
+    // This is needed since we are mappings graphs to memory for memory optimized search lazily. But once we make it eager
+    // the lock object will not be needed
+    private final Object vectorSearcherHolderLockObject;
     private final IOContext ioContext;
 
     public NativeEngines990KnnVectorsReader(final SegmentReadState state, final FlatVectorsReader flatVectorsReader) {
@@ -76,7 +78,8 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         this.cacheKeys = getVectorCacheKeysFromSegmentReaderState(state);
         ioContext = state.context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM);
         loadCacheKeyMap();
-        fillVectorSearcherTable();
+        vectorSearcherHolder = new VectorSearcherHolder();
+        vectorSearcherHolderLockObject = new Object();
     }
 
     /**
@@ -223,11 +226,10 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         final List<Closeable> closeables = new ArrayList<>();
         closeables.add(flatVectorsReader);
 
-        // Close vector searchers if loaded.
-        if (vectorSearchers != null) {
-            closeables.addAll(
-                vectorSearchers.values().stream().filter(VectorSearcherHolder::isSet).map(VectorSearcherHolder::getVectorSearcher).toList()
-            );
+        // Close Vector Search
+        if (vectorSearcherHolder != null) {
+            // We don't need to check if VectorSearcher is null or not because during close IoUtils checks it
+            closeables.add(vectorSearcherHolder.getVectorSearcher());
         }
 
         IOUtils.close(closeables);
@@ -270,20 +272,6 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         }
     }
 
-    private void fillVectorSearcherTable() {
-        // We need sufficient memory space for this table as it will be queried for every single search.
-        // Hence, having larger space to approximate a perfect hash here.
-        vectorSearchers = new HashMap<>(RESERVE_TWICE_SPACE * segmentReadState.fieldInfos.size(), SUFFICIENT_LOAD_FACTOR);
-
-        for (final FieldInfo fieldInfo : segmentReadState.fieldInfos) {
-            final IOSupplier<VectorSearcher> searcherIOSupplier = getVectorSearcherSupplier(fieldInfo);
-            if (searcherIOSupplier != null) {
-                // This field type is supported
-                vectorSearchers.put(fieldInfo.getName(), new VectorSearcherHolder());
-            }
-        }
-    }
-
     private static List<String> getVectorCacheKeysFromSegmentReaderState(SegmentReadState segmentReadState) {
         final List<String> cacheKeys = new ArrayList<>();
 
@@ -300,48 +288,28 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
     }
 
     private VectorSearcher loadMemoryOptimizedSearcherIfRequired(final String fieldName) {
-        final VectorSearcherHolder searcherHolder = vectorSearchers.get(fieldName);
-        if (searcherHolder == null) {
-            // This is not KNN field or unsupported field.
-            return null;
+        if (vectorSearcherHolder.isSet()) {
+            return vectorSearcherHolder.getVectorSearcher();
         }
 
-        if (searcherHolder.isSet()) {
-            return searcherHolder.getVectorSearcher();
-        }
-
-        synchronized (searcherHolder) {
-            if (searcherHolder.isSet()) {
-                return searcherHolder.getVectorSearcher();
+        synchronized (vectorSearcherHolderLockObject) {
+            if (vectorSearcherHolder.isSet()) {
+                return vectorSearcherHolder.getVectorSearcher();
             }
-
-            VectorSearcher searcher = null;
-
-            try {
-                final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(fieldName);
-                if (fieldInfo != null) {
-                    final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
-                    if (searcherSupplier != null) {
-                        searcher = searcherSupplier.get();
-                        if (searcher != null) {
-                            // It's supported. There can be a case where a certain index type underlying is not yet supported while
-                            // KNNEngine
-                            // itself supports memory optimized searching.
-                            searcherHolder.setVectorSearcher(searcher);
-                        }
-                    }
-                }
-
-                return searcher;
-            } catch (Exception e) {
-                // Close opened searchers first, then suppress
+            final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(fieldName);
+            final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
+            // It's supported. There can be a case where a certain index type underlying is not yet supported while
+            // KNNEngine itself supports memory optimized searching.
+            if (searcherSupplier != null) {
                 try {
-                    IOUtils.closeWhileHandlingException(searcher);
-                } catch (Exception closeException) {
-                    log.error(closeException.getMessage(), closeException);
+                    vectorSearcherHolder.setVectorSearcher(searcherSupplier.get());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
-                throw new RuntimeException(e);
+            } else {
+                log.error("Failed to load memory optimized searcher for field [{}]", fieldName);
             }
+            return vectorSearcherHolder.getVectorSearcher();
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -14,17 +14,18 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
+import org.junit.Assert;
 import org.mockito.MockedStatic;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -32,8 +33,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.KNN_FIELD;
 
 public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
     @SneakyThrows
@@ -45,27 +44,23 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         // Load vector searchers
         final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, Collections.emptySet());
 
-        final Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder> vectorSearchers = getVectorSearcherHolders(reader);
-        assertTrue(vectorSearchers.isEmpty());
+        final NativeEngines990KnnVectorsReader.VectorSearcherHolder vectorSearchers = getVectorSearcherHolders(reader);
+        assertFalse(vectorSearchers.isSet());
     }
 
     @SneakyThrows
     public void testWhenMemoryOptimizedSearchIsEnabled_mixedCase() {
-        // Prepare field infos
-        // - field1: Non KNN field
-        // - field2: KNN field, but using Lucene engine
-        // - field3: KNN field, FAISS
-        // - field4: KNN field, FAISS
-        // - field5: KNN field, FAISS, but it does not have file for some reason.
-
-        // Mocking FAISS engine to return a dummy vector searcher
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {
             // Prepare field infos
+            // - field1: Non KNN field
+            // - field2: KNN field, but using Lucene engine
+            // - field3: KNN field, FAISS
+            // - field4: KNN field, FAISS
+            // - field5: KNN field, FAISS, but it does not have file for some reason.
             final FieldInfo[] fieldInfoArray = new FieldInfo[] {
                 createFieldInfo("field1", null, 0),
                 createFieldInfo("field2", KNNEngine.LUCENE, 1),
@@ -75,7 +70,6 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
             final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
             final Set<String> filesInSegment = Set.of("_0_165_field3.faiss", "_0_165_field4.faiss");
 
-            // Replace static 'getEngine' to return mockFaiss
             mockedStatic.when(() -> KNNEngine.getEngine(any())).thenAnswer(invocation -> {
                 final String strArg = invocation.getArgument(0);
                 // Intercept FAISS engine to return mock
@@ -89,65 +83,34 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
 
             mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
 
-            // Load reader
-            final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, filesInSegment);
+            final NativeEngines990KnnVectorsReader reader_field_2 = createReader(fieldInfos, filesInSegment);
+            final NativeEngines990KnnVectorsReader reader_field_3 = createReader(fieldInfos, filesInSegment);
+            final NativeEngines990KnnVectorsReader reader_field_4 = createReader(fieldInfos, filesInSegment);
 
-            // Check the size of `vectorSearcher`
-            final Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder> vectorSearchers = getVectorSearcherHolders(reader);
-
-            // Validate #searchers
-            assertEquals(2, vectorSearchers.size());
-
-            // Make sure all searchers are not initialized
-            for (final NativeEngines990KnnVectorsReader.VectorSearcherHolder holder : vectorSearchers.values()) {
-                assertFalse(holder.isSet());
-            }
-
-            // Try search for unsupported field types.
-            for (final String unsupportedField : Arrays.asList("field1", "field2", "field5")) {
-                try {
-                    reader.search(unsupportedField, new float[] { 1, 2, 3, 4 }, null, null);
-                    fail();
-                } catch (final UnsupportedOperationException e) {}
-            }
-
-            // Make sure all searchers are not initialized yet
-            for (final NativeEngines990KnnVectorsReader.VectorSearcherHolder holder : vectorSearchers.values()) {
-                assertFalse(holder.isSet());
-            }
+            assertFalse(getVectorSearcherHolders(reader_field_2).isSet());
+            assertFalse(getVectorSearcherHolders(reader_field_3).isSet());
+            assertFalse(getVectorSearcherHolders(reader_field_4).isSet());
 
             // Try search for supported field types
-            for (final String supportedField : Arrays.asList("field3", "field4")) {
-                reader.search(supportedField, new float[] { 1, 2, 3, 4 }, null, null);
-            }
+            reader_field_2.search("field3", new float[] { 1, 2, 3, 4 }, null, null);
+            reader_field_3.search("field4", new float[] { 1, 2, 3, 4 }, null, null);
+            Assert.assertThrows(
+                UnsupportedOperationException.class,
+                () -> { reader_field_4.search("field5", new float[] { 1, 2, 3, 4 }, null, null); }
+            );
 
-            // Now, all searchers must be lazy initialized.
-            for (final NativeEngines990KnnVectorsReader.VectorSearcherHolder holder : vectorSearchers.values()) {
-                assertTrue(holder.isSet());
-            }
+            // Check holders are set now
+            assertTrue(getVectorSearcherHolders(reader_field_2).isSet());
+            assertTrue(getVectorSearcherHolders(reader_field_3).isSet());
         }
-    }
-
-    @SneakyThrows
-    public void testWhenMemoryOptimizedSearchIsNotEnabled() {
-        // Prepare field infos
-        final FieldInfo[] fieldInfoArray = new FieldInfo[] {};
-        final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
-
-        // Load reader
-        final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, Collections.emptySet());
-
-        // Check the size of `vectorSearcher`
-        final Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder> vectorSearchers = getVectorSearcherHolders(reader);
-        assertTrue(vectorSearchers.isEmpty());
     }
 
     private static FieldInfo createFieldInfo(final String fieldName, final KNNEngine engine, final int fieldNo) {
         final KNNCodecTestUtil.FieldInfoBuilder builder = KNNCodecTestUtil.FieldInfoBuilder.builder(fieldName);
         builder.fieldNumber(fieldNo);
         if (engine != null) {
-            builder.addAttribute(KNN_FIELD, "true");
-            builder.addAttribute(KNN_ENGINE, engine.getName());
+            builder.addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true");
+            builder.addAttribute(KNNConstants.KNN_ENGINE, engine.getName());
         }
         return builder.build();
     }
@@ -169,12 +132,12 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    private static Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder> getVectorSearcherHolders(
+    private static NativeEngines990KnnVectorsReader.VectorSearcherHolder getVectorSearcherHolders(
         final NativeEngines990KnnVectorsReader reader
     ) {
         // Get searcher table
-        final Field tableField = NativeEngines990KnnVectorsReader.class.getDeclaredField("vectorSearchers");
+        final Field tableField = NativeEngines990KnnVectorsReader.class.getDeclaredField("vectorSearcherHolder");
         tableField.setAccessible(true);
-        return (Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder>) tableField.get(reader);
+        return (NativeEngines990KnnVectorsReader.VectorSearcherHolder) tableField.get(reader);
     }
 }


### PR DESCRIPTION
### Description
Removed VectorSearchHolders map from NativeEngines990KnnVectorsReader since NativeEngines990KnnVectorsReader is per field. Hence it doesn't need to understand other fields and have to lazy init the VectorSearchHolder object.

The current merged code is functionally correct, but it assumes that we have a single NativeEngines990KnnVectorsReader for a segment for all the fields, which is not the case. Hence correcting the code to ensure that in future we don't build any extra logic on top of this assumption.


### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/2938

### Check List
- [X] New functionality includes testing.
~- [ ] New functionality has been documented.~
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
