### PR TITLE
Disable cgroup detection in IT -- Retry

### DIFF
--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -35,285 +35,291 @@ testClusters {
     }
 }
 
-   def versionsBelow2_3 = ["1.", "2.0.", "2.1.", "2.2."]
-   def versionOnOrAfter2_17 = ["2.17", "2.18", "2.19", "2.20", "3."]
+def versionsBelow2_3 = ["1.", "2.0.", "2.1.", "2.2."]
+def versionOnOrAfter2_17 = ["2.17", "2.18", "2.19", "2.20", "3."]
 // Task to run BWC tests against the old cluster
-    task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
-        dependsOn "zipBwcPlugin"
-        useCluster testClusters."${baseName}"
-        systemProperty 'tests.rest.bwcsuite_cluster', 'old_cluster'
-        systemProperty 'tests.is_old_cluster', 'true'
-        systemProperty 'tests.skip_delete_model_index', 'true'
-        systemProperty 'tests.plugin_bwc_version', knn_bwc_version
+task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
+    dependsOn "zipBwcPlugin"
+    useCluster testClusters."${baseName}"
+    systemProperty 'tests.rest.bwcsuite_cluster', 'old_cluster'
+    systemProperty 'tests.is_old_cluster', 'true'
+    systemProperty 'tests.skip_delete_model_index', 'true'
+    systemProperty 'tests.plugin_bwc_version', knn_bwc_version
 
-        // Skip test if version is 1.0 or 1.1 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.0") || knn_bwc_version.startsWith("1.1")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.ModelIT"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexCustomMethodFieldMapping"
-                excludeTestsMatching "org.opensearch.knn.bwc.WarmupIT.testKNNWarmupCustomMethodFieldMapping"
-            }
+    // Skip test if version is 1.0 or 1.1 as they are not supported in those versions
+    if (knn_bwc_version.startsWith("1.0") || knn_bwc_version.startsWith("1.1")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.ModelIT"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexCustomMethodFieldMapping"
+            excludeTestsMatching "org.opensearch.knn.bwc.WarmupIT.testKNNWarmupCustomMethodFieldMapping"
         }
-
-        // Skip test if version is 1.2 or 1.3 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.2") || knn_bwc_version.startsWith("1.3")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testNullParametersOnUpgrade"
-            }
-        }
-
-        // Skip test if version is 1.0, 1.1, 1.2 or 1.3 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
-            }
-        }
-
-        if (knn_bwc_version.startsWith("1.") ||
-                knn_bwc_version.startsWith("2.0.") ||
-                knn_bwc_version.startsWith("2.1.") ||
-                knn_bwc_version.startsWith("2.2.") ||
-                knn_bwc_version.startsWith("2.3.") ||
-                knn_bwc_version.startsWith("2.4")  ||
-                knn_bwc_version.startsWith("2.5.") ||
-                knn_bwc_version.startsWith("2.6.") ||
-                knn_bwc_version.startsWith("2.7.") ||
-                knn_bwc_version.startsWith("2.8.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneByteVector"
-            }
-        }
-        if (knn_bwc_version.startsWith("1.") ||
-                knn_bwc_version.startsWith("2.0.") ||
-                knn_bwc_version.startsWith("2.1.") ||
-                knn_bwc_version.startsWith("2.2.") ||
-                knn_bwc_version.startsWith("2.3.") ||
-                knn_bwc_version.startsWith("2.4")  ||
-                knn_bwc_version.startsWith("2.5.") ||
-                knn_bwc_version.startsWith("2.6.") ||
-                knn_bwc_version.startsWith("2.7.") ||
-                knn_bwc_version.startsWith("2.8.") ||
-                knn_bwc_version.startsWith("2.9.") ||
-                knn_bwc_version.startsWith("2.10.") ||
-                knn_bwc_version.startsWith("2.11.") ||
-                knn_bwc_version.startsWith("2.12.") ||
-                knn_bwc_version.startsWith("2.13.") ||
-                knn_bwc_version.startsWith("2.14.") ||
-                knn_bwc_version.startsWith("2.15.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
-            }
-        }
-
-        // excludes: 1.any; 2.x where x < 17
-        def validPrefixesForQFrameBitEncoderBWCChecks = ['1.'] + ((0..16).collect { "2.${it}." } as Collection<String>)
-        if (validPrefixesForQFrameBitEncoderBWCChecks.any { knn_bwc_version.startsWith(it) }
-                ) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testRandomRotationBWC"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testADC_BWC"
-            }
-        }
-
-
-        if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
-            }
-        }
-        if (!(knn_bwc_version.startsWith("2.13.") ||
-                knn_bwc_version.startsWith("2.14.") ||
-                knn_bwc_version.startsWith("2.15.") ||
-                knn_bwc_version.startsWith("2.16."))) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.ModelIT.testNonKNNIndex_withModelId"
-                excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
-            }
-        }
-
-        if (knn_bwc_version.startsWith("1.") ||
-                knn_bwc_version.startsWith("2.0.") ||
-                knn_bwc_version.startsWith("2.1.") ||
-                knn_bwc_version.startsWith("2.2.") ||
-                knn_bwc_version.startsWith("2.3.") ||
-                knn_bwc_version.startsWith("2.4")  ||
-                knn_bwc_version.startsWith("2.5.") ||
-                knn_bwc_version.startsWith("2.6.") ||
-                knn_bwc_version.startsWith("2.7.") ||
-                knn_bwc_version.startsWith("2.8.") ||
-                knn_bwc_version.startsWith("2.9.") ||
-                knn_bwc_version.startsWith("2.10.") ||
-                knn_bwc_version.startsWith("2.11.") ||
-                knn_bwc_version.startsWith("2.12.") ||
-                knn_bwc_version.startsWith("2.13.") ||
-                knn_bwc_version.startsWith("2.14.") ||
-                knn_bwc_version.startsWith("2.15.") ||
-                knn_bwc_version.startsWith("2.16.") ||
-                knn_bwc_version.startsWith("2.17.") ||
-                knn_bwc_version.startsWith("2.18.") ||
-                knn_bwc_version.startsWith("2.19.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
-            }
-        }
-
-        if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
-            }
-        }
-
-        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
-        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
-        systemProperty 'tests.security.manager', 'false'
     }
+
+    // Skip test if version is 1.2 or 1.3 as they are not supported in those versions
+    if (knn_bwc_version.startsWith("1.2") || knn_bwc_version.startsWith("1.3")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testNullParametersOnUpgrade"
+        }
+    }
+
+    // Skip test if version is 1.0, 1.1, 1.2 or 1.3 as they are not supported in those versions
+    if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
+        }
+    }
+
+    if (knn_bwc_version.startsWith("1.") ||
+            knn_bwc_version.startsWith("2.0.") ||
+            knn_bwc_version.startsWith("2.1.") ||
+            knn_bwc_version.startsWith("2.2.") ||
+            knn_bwc_version.startsWith("2.3.") ||
+            knn_bwc_version.startsWith("2.4")  ||
+            knn_bwc_version.startsWith("2.5.") ||
+            knn_bwc_version.startsWith("2.6.") ||
+            knn_bwc_version.startsWith("2.7.") ||
+            knn_bwc_version.startsWith("2.8.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneByteVector"
+        }
+    }
+    if (knn_bwc_version.startsWith("1.") ||
+            knn_bwc_version.startsWith("2.0.") ||
+            knn_bwc_version.startsWith("2.1.") ||
+            knn_bwc_version.startsWith("2.2.") ||
+            knn_bwc_version.startsWith("2.3.") ||
+            knn_bwc_version.startsWith("2.4")  ||
+            knn_bwc_version.startsWith("2.5.") ||
+            knn_bwc_version.startsWith("2.6.") ||
+            knn_bwc_version.startsWith("2.7.") ||
+            knn_bwc_version.startsWith("2.8.") ||
+            knn_bwc_version.startsWith("2.9.") ||
+            knn_bwc_version.startsWith("2.10.") ||
+            knn_bwc_version.startsWith("2.11.") ||
+            knn_bwc_version.startsWith("2.12.") ||
+            knn_bwc_version.startsWith("2.13.") ||
+            knn_bwc_version.startsWith("2.14.") ||
+            knn_bwc_version.startsWith("2.15.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
+        }
+    }
+
+    // excludes: 1.any; 2.x where x < 17
+    def validPrefixesForQFrameBitEncoderBWCChecks = ['1.'] + ((0..16).collect { "2.${it}." } as Collection<String>)
+    if (validPrefixesForQFrameBitEncoderBWCChecks.any { knn_bwc_version.startsWith(it) }
+            ) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testRandomRotationBWC"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testADC_BWC"
+        }
+    }
+
+
+    if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
+        }
+    }
+    if (!(knn_bwc_version.startsWith("2.13.") ||
+            knn_bwc_version.startsWith("2.14.") ||
+            knn_bwc_version.startsWith("2.15.") ||
+            knn_bwc_version.startsWith("2.16."))) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.ModelIT.testNonKNNIndex_withModelId"
+            excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
+        }
+    }
+
+    if (knn_bwc_version.startsWith("1.") ||
+            knn_bwc_version.startsWith("2.0.") ||
+            knn_bwc_version.startsWith("2.1.") ||
+            knn_bwc_version.startsWith("2.2.") ||
+            knn_bwc_version.startsWith("2.3.") ||
+            knn_bwc_version.startsWith("2.4")  ||
+            knn_bwc_version.startsWith("2.5.") ||
+            knn_bwc_version.startsWith("2.6.") ||
+            knn_bwc_version.startsWith("2.7.") ||
+            knn_bwc_version.startsWith("2.8.") ||
+            knn_bwc_version.startsWith("2.9.") ||
+            knn_bwc_version.startsWith("2.10.") ||
+            knn_bwc_version.startsWith("2.11.") ||
+            knn_bwc_version.startsWith("2.12.") ||
+            knn_bwc_version.startsWith("2.13.") ||
+            knn_bwc_version.startsWith("2.14.") ||
+            knn_bwc_version.startsWith("2.15.") ||
+            knn_bwc_version.startsWith("2.16.") ||
+            knn_bwc_version.startsWith("2.17.") ||
+            knn_bwc_version.startsWith("2.18.") ||
+            knn_bwc_version.startsWith("2.19.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
+        }
+    }
+
+    if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
+        }
+    }
+
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    systemProperty 'tests.security.manager', 'false'
+}
 
 // All nodes are upgraded to latest version and run the tests
-    task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
-        dependsOn "testAgainstOldCluster"
-        dependsOn rootProject.tasks.buildJniLib
-        dependsOn rootProject.tasks.assemble
-        useCluster testClusters."${baseName}"
-        doFirst {
-            testClusters."${baseName}".environment("LD_LIBRARY_PATH", "$rootDir/jni/build/release")
-            testClusters."${baseName}".systemProperty("java.library.path", "$rootDir/jni/build/release")
-            testClusters."${baseName}".upgradeAllNodesAndPluginsToNextVersion([rootProject.tasks.bundlePlugin.archiveFile])
-        }
-        systemProperty 'tests.rest.bwcsuite_cluster', 'upgraded_cluster'
-        systemProperty 'tests.skip_delete_model_index', 'true'
-        systemProperty 'tests.is_old_cluster', 'false'
-        systemProperty 'tests.plugin_bwc_version', knn_bwc_version
-
-        // Skip test if version is 1.0 or 1.1 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.0") || knn_bwc_version.startsWith("1.1")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.ModelIT"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexCustomMethodFieldMapping"
-                excludeTestsMatching "org.opensearch.knn.bwc.WarmupIT.testKNNWarmupCustomMethodFieldMapping"
-            }
-        }
-
-        // Skip test if version is 1.2 or 1.3 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.2") || knn_bwc_version.startsWith("1.3")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testNullParametersOnUpgrade"
-            }
-        }
-
-        // Skip test if version is 1.0, 1.1, 1.2 or 1.3 as they are not supported in those versions
-        if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
-            }
-        }
-
-        if (knn_bwc_version.startsWith("1.") ||
-                knn_bwc_version.startsWith("2.0.") ||
-                knn_bwc_version.startsWith("2.1.") ||
-                knn_bwc_version.startsWith("2.2.") ||
-                knn_bwc_version.startsWith("2.3.") ||
-                knn_bwc_version.startsWith("2.4")  ||
-                knn_bwc_version.startsWith("2.5.") ||
-                knn_bwc_version.startsWith("2.6.") ||
-                knn_bwc_version.startsWith("2.7.") ||
-                knn_bwc_version.startsWith("2.8.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneByteVector"
-            }
-        }
-        if (knn_bwc_version.startsWith("1.") ||
-                knn_bwc_version.startsWith("2.0.") ||
-                knn_bwc_version.startsWith("2.1.") ||
-                knn_bwc_version.startsWith("2.2.") ||
-                knn_bwc_version.startsWith("2.3.") ||
-                knn_bwc_version.startsWith("2.4")  ||
-                knn_bwc_version.startsWith("2.5.") ||
-                knn_bwc_version.startsWith("2.6.") ||
-                knn_bwc_version.startsWith("2.7.") ||
-                knn_bwc_version.startsWith("2.8.") ||
-                knn_bwc_version.startsWith("2.9.") ||
-                knn_bwc_version.startsWith("2.10.") ||
-                knn_bwc_version.startsWith("2.11.") ||
-                knn_bwc_version.startsWith("2.12.") ||
-                knn_bwc_version.startsWith("2.13.") ||
-                knn_bwc_version.startsWith("2.14.") ||
-                knn_bwc_version.startsWith("2.15.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
-            }
-        }
-
-        def validPrefixesForQFrameBitEncoderBWCChecks = ['1.'] + ((0..16).collect { "2.${it}." } as Collection<String>)
-        if (validPrefixesForQFrameBitEncoderBWCChecks.any { knn_bwc_version.startsWith(it) }) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testRandomRotationBWC"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testADC_BWC"
-            }
-        }
-
-        if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
-            }
-        }
-
-        if (!(knn_bwc_version.startsWith("2.13.") ||
-                knn_bwc_version.startsWith("2.14.") ||
-                knn_bwc_version.startsWith("2.15.") ||
-                knn_bwc_version.startsWith("2.16."))) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.ModelIT.testNonKNNIndex_withModelId"
-                excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
-                excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
-            }
-        }
-
-        if (knn_bwc_version.startsWith("1.") ||
-                knn_bwc_version.startsWith("2.0.") ||
-                knn_bwc_version.startsWith("2.1.") ||
-                knn_bwc_version.startsWith("2.2.") ||
-                knn_bwc_version.startsWith("2.3.") ||
-                knn_bwc_version.startsWith("2.4")  ||
-                knn_bwc_version.startsWith("2.5.") ||
-                knn_bwc_version.startsWith("2.6.") ||
-                knn_bwc_version.startsWith("2.7.") ||
-                knn_bwc_version.startsWith("2.8.") ||
-                knn_bwc_version.startsWith("2.9.") ||
-                knn_bwc_version.startsWith("2.10.") ||
-                knn_bwc_version.startsWith("2.11.") ||
-                knn_bwc_version.startsWith("2.12.") ||
-                knn_bwc_version.startsWith("2.13.") ||
-                knn_bwc_version.startsWith("2.14.") ||
-                knn_bwc_version.startsWith("2.15.") ||
-                knn_bwc_version.startsWith("2.16.") ||
-                knn_bwc_version.startsWith("2.17.") ||
-                knn_bwc_version.startsWith("2.18.") ||
-                knn_bwc_version.startsWith("2.19.")) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
-            }
-        }
-
-        if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
-            filter {
-                excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
-            }
-        }
-
-        nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
-        nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
-        systemProperty 'tests.security.manager', 'false'
+task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
+    dependsOn "testAgainstOldCluster"
+    dependsOn rootProject.tasks.buildJniLib
+    dependsOn rootProject.tasks.assemble
+    useCluster testClusters."${baseName}"
+    doFirst {
+        testClusters."${baseName}".environment("LD_LIBRARY_PATH", "$rootDir/jni/build/release")
+        testClusters."${baseName}".systemProperty("java.library.path", "$rootDir/jni/build/release")
+        testClusters."${baseName}".upgradeAllNodesAndPluginsToNextVersion([rootProject.tasks.bundlePlugin.archiveFile])
     }
+    // Disable cgroup detection. When initializing MBean in Log4J, if container was detected it will try to get
+    // `jdk.internal.platform.CgroupInfo.getMountPoint()` for the mount point which causes NPE for now.
+    // So, disabling this cgroup detection for CI.
+    testClusters."${baseName}".nodes.forEach { node ->
+        node.jvmArgs("-XX:-UseContainerSupport -Djdk.disableLinuxContainerSupport=true")
+    }
+    systemProperty 'tests.rest.bwcsuite_cluster', 'upgraded_cluster'
+    systemProperty 'tests.skip_delete_model_index', 'true'
+    systemProperty 'tests.is_old_cluster', 'false'
+    systemProperty 'tests.plugin_bwc_version', knn_bwc_version
+
+    // Skip test if version is 1.0 or 1.1 as they are not supported in those versions
+    if (knn_bwc_version.startsWith("1.0") || knn_bwc_version.startsWith("1.1")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.ModelIT"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexCustomMethodFieldMapping"
+            excludeTestsMatching "org.opensearch.knn.bwc.WarmupIT.testKNNWarmupCustomMethodFieldMapping"
+        }
+    }
+
+    // Skip test if version is 1.2 or 1.3 as they are not supported in those versions
+    if (knn_bwc_version.startsWith("1.2") || knn_bwc_version.startsWith("1.3")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testNullParametersOnUpgrade"
+        }
+    }
+
+    // Skip test if version is 1.0, 1.1, 1.2 or 1.3 as they are not supported in those versions
+    if (knn_bwc_version.startsWith("1.") || knn_bwc_version.startsWith("2.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testEmptyParametersOnUpgrade"
+        }
+    }
+
+    if (knn_bwc_version.startsWith("1.") ||
+            knn_bwc_version.startsWith("2.0.") ||
+            knn_bwc_version.startsWith("2.1.") ||
+            knn_bwc_version.startsWith("2.2.") ||
+            knn_bwc_version.startsWith("2.3.") ||
+            knn_bwc_version.startsWith("2.4")  ||
+            knn_bwc_version.startsWith("2.5.") ||
+            knn_bwc_version.startsWith("2.6.") ||
+            knn_bwc_version.startsWith("2.7.") ||
+            knn_bwc_version.startsWith("2.8.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneByteVector"
+        }
+    }
+    if (knn_bwc_version.startsWith("1.") ||
+            knn_bwc_version.startsWith("2.0.") ||
+            knn_bwc_version.startsWith("2.1.") ||
+            knn_bwc_version.startsWith("2.2.") ||
+            knn_bwc_version.startsWith("2.3.") ||
+            knn_bwc_version.startsWith("2.4")  ||
+            knn_bwc_version.startsWith("2.5.") ||
+            knn_bwc_version.startsWith("2.6.") ||
+            knn_bwc_version.startsWith("2.7.") ||
+            knn_bwc_version.startsWith("2.8.") ||
+            knn_bwc_version.startsWith("2.9.") ||
+            knn_bwc_version.startsWith("2.10.") ||
+            knn_bwc_version.startsWith("2.11.") ||
+            knn_bwc_version.startsWith("2.12.") ||
+            knn_bwc_version.startsWith("2.13.") ||
+            knn_bwc_version.startsWith("2.14.") ||
+            knn_bwc_version.startsWith("2.15.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneQuantization"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexBinaryForceMerge"
+        }
+    }
+
+    def validPrefixesForQFrameBitEncoderBWCChecks = ['1.'] + ((0..16).collect { "2.${it}." } as Collection<String>)
+    if (validPrefixesForQFrameBitEncoderBWCChecks.any { knn_bwc_version.startsWith(it) }) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testRandomRotationBWC"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testADC_BWC"
+        }
+    }
+
+    if (versionsBelow2_3.any {knn_bwc_version.startsWith(it) }) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.QueryANNIT.testQueryOnLuceneIndex"
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testKNNIndexLuceneForceMerge"
+        }
+    }
+
+    if (!(knn_bwc_version.startsWith("2.13.") ||
+            knn_bwc_version.startsWith("2.14.") ||
+            knn_bwc_version.startsWith("2.15.") ||
+            knn_bwc_version.startsWith("2.16."))) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.ModelIT.testNonKNNIndex_withModelId"
+            excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.PainlessScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withFaissEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withNmslibEngine"
+            excludeTestsMatching "org.opensearch.knn.bwc.ScriptScoringIT.testNonKNNIndex_withMethodParams_withLuceneEngine"
+        }
+    }
+
+    if (knn_bwc_version.startsWith("1.") ||
+            knn_bwc_version.startsWith("2.0.") ||
+            knn_bwc_version.startsWith("2.1.") ||
+            knn_bwc_version.startsWith("2.2.") ||
+            knn_bwc_version.startsWith("2.3.") ||
+            knn_bwc_version.startsWith("2.4")  ||
+            knn_bwc_version.startsWith("2.5.") ||
+            knn_bwc_version.startsWith("2.6.") ||
+            knn_bwc_version.startsWith("2.7.") ||
+            knn_bwc_version.startsWith("2.8.") ||
+            knn_bwc_version.startsWith("2.9.") ||
+            knn_bwc_version.startsWith("2.10.") ||
+            knn_bwc_version.startsWith("2.11.") ||
+            knn_bwc_version.startsWith("2.12.") ||
+            knn_bwc_version.startsWith("2.13.") ||
+            knn_bwc_version.startsWith("2.14.") ||
+            knn_bwc_version.startsWith("2.15.") ||
+            knn_bwc_version.startsWith("2.16.") ||
+            knn_bwc_version.startsWith("2.17.") ||
+            knn_bwc_version.startsWith("2.18.") ||
+            knn_bwc_version.startsWith("2.19.")) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.DerivedSourceBWCRestartIT"
+        }
+    }
+
+    if (versionOnOrAfter2_17.any {knn_bwc_version.startsWith(it) }) {
+        filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testBlockModeAndCompressionBefore2_17_0"
+        }
+    }
+
+    nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
+    nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    systemProperty 'tests.security.manager', 'false'
+}


### PR DESCRIPTION
### Description
This PR is to disable cgroup detection in Log4j to avoid this below error:

```
 java.lang.ExceptionInInitializerError
»  	at org.opensearch.bootstrap.Bootstrap.initializeProbes(Bootstrap.java:177)
»  	at org.opensearch.bootstrap.Bootstrap.setup(Bootstrap.java:199)
»  	at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:404)
»  	at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:180)
»  	at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:171)
»  	at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
»  	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
»  	at org.opensearch.cli.Command.main(Command.java:101)
»  	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:137)
»  	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:103)
»  Caused by: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
»  	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:80)
»  	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:114)
»  	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:177)
»  	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
»  	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
»  	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
»  	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
»  	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
»  	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
»  	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
»  	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:687)
»  	at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(ManagementFactory.java:389)
»  	at org.opensearch.monitor.process.ProcessProbe.<clinit>(ProcessProbe.java:51)
»  	... 10 more
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
