### PR TITLE
 Refactor to not use parallel for MMR rerank.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix blocking old indices created before 2.18 to use memory optimized search. [#2918](https://github.com/opensearch-project/k-NN/pull/2918)
 
 ### Refactoring
+* Refactor to not use parallel for MMR rerank. [#2968](https://github.com/opensearch-project/k-NN/pull/2968)
 
 ### Enhancements
 * Removed VectorSearchHolders map from NativeEngines990KnnVectorsReader [#2948](https://github.com/opensearch-project/k-NN/pull/2948)


### PR DESCRIPTION
### Description
 Refactor to not use parallel for MMR rerank. Because now OpenSearch core will detect if there is any thread not shut down after running the tests. The parallelStream will use the common thread pool which doesn't auto shut down. 

And to use the OpenSearch managed thread pool there will also be a check on the request size. Once it hit the thread pool request queue limit it will be rejected. But in our use case the size depends on the candidates which is a dynamic number so it is tricky to control. Besides the MMR rerank is the CPU heavy work. Even though the parallel can help but it doesn't speed up too much because the number CPU is limited. So we decide to remove the paralle.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
