### PR TITLE
Join filter clauses of nested k-NN queries to root-parent scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update validation for cases when k is greater than total results [#3038](https://github.com/opensearch-project/k-NN/pull/3038)
 * Add regex support to derived source transformer include / exclude check [#3031](https://github.com/opensearch-project/k-NN/pull/3031)
 * Correct ef_search parameter for Lucene engine and override mergeLeafResults to return top K results [#3037](https://github.com/opensearch-project/k-NN/pull/3037)
+* Fix efficient filtering in nested k-NN queries [#2990](https://github.com/opensearch-project/k-NN/pull/2990)
 
 ### Refactoring
 * Change ordering of build task and added tests to catch uninitialized libraries [#3024](https://github.com/opensearch-project/k-NN/pull/3024)

--- a/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
@@ -10,12 +10,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
+
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
+import org.opensearch.common.lucene.search.Queries;
 import org.opensearch.index.mapper.ObjectMapper;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryShardContext;
@@ -26,11 +25,8 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -102,7 +98,8 @@ public abstract class BaseQueryFactory {
             )
         );
 
-        // preserve nestedStack
+        // We want to evaluate the filter node's query at the root level.
+        // Unwind and preserve the nested object stack.
         Deque<ObjectMapper> nestedLevelStack = new LinkedList<>();
         ObjectMapper objectMapper = null;
         if (queryShardContext.nestedScope() != null) {
@@ -118,56 +115,47 @@ public abstract class BaseQueryFactory {
         } catch (IOException e) {
             throw new RuntimeException("Cannot create query with filter", e);
         } finally {
+            // Rewind the nested object stack before returning.
             while ((objectMapper = nestedLevelStack.peek()) != null) {
                 queryShardContext.nestedScope().nextLevel(objectMapper);
                 nestedLevelStack.pop();
             }
         }
-        BitSetProducer parentFilter = queryShardContext.getParentFilter();
-        if (parentFilter != null) {
-            boolean mightMatch = new NestedHelper(queryShardContext.getMapperService()).mightMatchNestedDocs(filterQuery);
-            if (mightMatch) {
-                return filterQuery;
-            } else if (filterQuery instanceof OpenSearchToParentBlockJoinQuery) {
-                // this case would happen when path = null, and filter is nested
-                return ((OpenSearchToParentBlockJoinQuery) filterQuery).getChildQuery();
-            } else if (filterQuery instanceof BooleanQuery) {
-                KNNQueryVisitor knnQueryVisitor = new KNNQueryVisitor();
-                filterQuery.visit(knnQueryVisitor);
-                BooleanQuery.Builder builder = (new BooleanQuery.Builder()).add(
-                    new ToChildBlockJoinQuery(filterQuery, parentFilter),
-                    BooleanClause.Occur.FILTER
-                );
-                for (Query q : knnQueryVisitor.nestedQuery) {
-                    builder.add(q, BooleanClause.Occur.FILTER);
+
+        if (filterQuery != null && queryShardContext.getParentFilter() != null) {
+            // This k-NN query is executing in nested context. Query nodes beneath nested
+            // queries must match child documents. However, the efficient filter query in
+            // the k-NN API is designed to work with root-level parent documents. Joining
+            // down to child documents is therefore required to make this work.
+
+            // To-parent joins which target the root level can simply be unwrapped to get
+            // a query matching the desired child documents.
+            if (filterQuery instanceof OpenSearchToParentBlockJoinQuery) {
+                final OpenSearchToParentBlockJoinQuery toParentQuery = (OpenSearchToParentBlockJoinQuery) filterQuery;
+
+                if (toParentQuery.getPath() == null) {
+                    return toParentQuery.getChildQuery();
                 }
-                return builder.build();
             }
-            return new ToChildBlockJoinQuery(filterQuery, parentFilter);
+
+            // Set up for performing the join.
+            final Query parentQuery = Queries.newNonNestedFilter();
+            final BitSetProducer parentFilter = queryShardContext.bitsetFilter(parentQuery);
+
+            // mightMatchNestedDocs() is conservative and only returns false if the query
+            // can never match a nested document. If it returns true, a filter to exclude
+            // nested documents should be applied first to guarantee they never match.
+            final Query nonNestedFilterQuery;
+
+            if (new NestedHelper(queryShardContext.getMapperService()).mightMatchNestedDocs(filterQuery)) {
+                nonNestedFilterQuery = Queries.filtered(filterQuery, parentQuery);
+            } else {
+                nonNestedFilterQuery = filterQuery;
+            }
+
+            return new ToChildBlockJoinQuery(nonNestedFilterQuery, parentFilter);
         }
+
         return filterQuery;
-    }
-
-    @Getter
-    static class KNNQueryVisitor extends QueryVisitor {
-        List<Query> nestedQuery;
-
-        public KNNQueryVisitor() {
-            nestedQuery = new ArrayList<>();
-        }
-
-        public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
-            if (parent instanceof BooleanQuery && occur == BooleanClause.Occur.FILTER) {
-                Collection<Query> collection = ((BooleanQuery) parent).getClauses(BooleanClause.Occur.FILTER);
-                for (Query q : collection) {
-                    if (q instanceof OpenSearchToParentBlockJoinQuery) {
-                        nestedQuery.add(((OpenSearchToParentBlockJoinQuery) q).getChildQuery());
-                    } else {
-                        q.visit(this);
-                    }
-                }
-            }
-            return this;
-        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
+++ b/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
@@ -43,6 +43,8 @@ import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
 import static org.opensearch.knn.common.KNNConstants.TYPE_NESTED;
 import static org.opensearch.knn.common.KNNConstants.VECTOR;
 
+import static org.hamcrest.Matchers.containsString;
+
 /**
  * This class contains the IT for some advanced and tricky use-case of filters.
  * <a href="https://github.com/opensearch-project/k-NN/issues/1356">Github issue</a>
@@ -172,7 +174,7 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
      */
     @SneakyThrows
     @ExpectRemoteBuildValidation
-    public void testFiltering_whenNestedKNNAndFilterFieldWithNoNestedContextInFilterQuery_thenSuccess() {
+    public void testFiltering_whenNestedKNNAndFilterFieldWithNoNestedContextInFilterQuery_thenFailure() {
         for (final String engine : enginesToTest) {
             // Set up the index with nested k-nn and metadata fields
             createKnnIndex(INDEX_NAME, createNestedMappings(1, engine));
@@ -202,7 +204,8 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
             builder.endObject();
             builder.endObject().endObject().endObject().endObject().endObject().endObject();
 
-            validateFilterSearch(builder.toString(), engine);
+            final AssertionError error = expectThrows(AssertionError.class, () -> validateFilterSearch(builder.toString(), engine));
+            assertThat(error.getMessage(), containsString("expected:<" + DOCUMENT_IN_RESPONSE + "> but was:<0>"));
 
             // cleanup
             deleteKNNIndex(INDEX_NAME);

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
@@ -396,7 +396,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
         assertEquals(ToChildBlockJoinQuery.class, query.getFilterQuery().getClass());
     }
 
-    public void testCreate_whenNestedVectorAndFilterField_thenReturnSameFilterQuery() {
+    public void testCreate_whenNestedVectorAndFilterField_thenReturnToChildBlockJoinQueryForFilters() {
         MapperService mockMapperService = mock(MapperService.class);
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         when(mockQueryShardContext.getMapperService()).thenReturn(mockMapperService);
@@ -422,7 +422,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             .build();
         KNNQuery query = (KNNQuery) KNNQueryFactory.create(createQueryRequest);
         mockedNestedHelper.close();
-        assertEquals(FILTER_QUERY.getClass(), query.getFilterQuery().getClass());
+        assertEquals(ToChildBlockJoinQuery.class, query.getFilterQuery().getClass());
     }
 
     public void testCreate_whenFaissWithParentFilter_thenSuccess() {


### PR DESCRIPTION
### Description
Fixes parent document efficient filtering for nested k-NN queries by making the efficient filter query always operate in parent context, and joining down to children.

This is a minimal fix for the issue. It explicitly removes special casing for the efficient filter query to "select" whether it would execute in parent or child context, because that did not work correctly. Since the existing documentation suggests that the efficient filter query only operates in parent context, the efficient filter query is now always required to be in parent context, and test cases are updated accordingly. (To query in child context instead, use a nested query node within the efficient filter--this is tested by the integration cases and supported.)

### Related Issues
Resolves #2222
Unknown #2771

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
