### PR TITLE
Backport/backport #2994 to 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix rescoring logic for nested exact search [#2921](https://github.com/opensearch-project/k-NN/pull/2921)
 * Update Visitor to delegate for other fields [#2925](https://github.com/opensearch-project/k-NN/pull/2925)
 * Fix blocking old indices created before 2.18 to use memory optimized search. [#2918](https://github.com/opensearch-project/k-NN/pull/2918)
+* Fix Backwards Compatability on Segment Merge for Disk-Based vector search [#2994](https://github.com/opensearch-project/k-NN/pull/2994) 
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -111,6 +111,7 @@ task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {
     if (validPrefixesForQFrameBitEncoderBWCChecks.any { knn_bwc_version.startsWith(it) }
             ) {
         filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testDiskBasedMergeBWC"
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testRandomRotationBWC"
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testADC_BWC"
         }
@@ -260,6 +261,7 @@ task testRestartUpgrade(type: StandaloneRestIntegTestTask) {
     def validPrefixesForQFrameBitEncoderBWCChecks = ['1.'] + ((0..16).collect { "2.${it}." } as Collection<String>)
     if (validPrefixesForQFrameBitEncoderBWCChecks.any { knn_bwc_version.startsWith(it) }) {
         filter {
+            excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testDiskBasedMergeBWC"
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testRandomRotationBWC"
             excludeTestsMatching "org.opensearch.knn.bwc.IndexingIT.testADC_BWC"
         }

--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.util.Version;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -77,12 +76,12 @@ public class FieldInfoExtractor {
      * @param fieldInfo {@link FieldInfo}
      * @return {@link QuantizationConfig}
      */
-    public static QuantizationConfig extractQuantizationConfig(final FieldInfo fieldInfo, Version luceneVersion) {
+    public static QuantizationConfig extractQuantizationConfig(final FieldInfo fieldInfo) {
         String quantizationConfigString = fieldInfo.getAttribute(QFRAMEWORK_CONFIG);
         if (StringUtils.isEmpty(quantizationConfigString)) {
             return QuantizationConfig.EMPTY;
         }
-        return QuantizationConfigParser.fromCsv(quantizationConfigString, luceneVersion);
+        return QuantizationConfigParser.fromCsv(quantizationConfigString);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
+++ b/src/main/java/org/opensearch/knn/index/KNNIndexShard.java
@@ -267,15 +267,10 @@ public class KNNIndexShard {
                 final SegmentLevelQuantizationInfo segmentLevelQuantizationInfo = SegmentLevelQuantizationInfo.build(
                     reader,
                     fieldInfo,
-                    fieldInfo.name,
-                    reader.getSegmentInfo().info.getVersion()
+                    fieldInfo.name
                 );
                 // obtain correct VectorDataType for this field based on the quantization state and if ADC is enabled.
-                VectorDataType vectorDataType = determineVectorDataType(
-                    fieldInfo,
-                    segmentLevelQuantizationInfo,
-                    reader.getSegmentInfo().info.getVersion()
-                );
+                VectorDataType vectorDataType = determineVectorDataType(fieldInfo, segmentLevelQuantizationInfo);
 
                 engineFiles.addAll(
                     getEngineFileContexts(
@@ -327,14 +322,10 @@ public class KNNIndexShard {
     }
 
     @VisibleForTesting
-    VectorDataType determineVectorDataType(
-        FieldInfo fieldInfo,
-        SegmentLevelQuantizationInfo segmentLevelQuantizationInfo,
-        org.apache.lucene.util.Version segmentVersion
-    ) {
+    VectorDataType determineVectorDataType(FieldInfo fieldInfo, SegmentLevelQuantizationInfo segmentLevelQuantizationInfo) {
 
         // First check if quantization config is empty
-        if (FieldInfoExtractor.extractQuantizationConfig(fieldInfo, segmentVersion) == QuantizationConfig.EMPTY) {
+        if (FieldInfoExtractor.extractQuantizationConfig(fieldInfo) == QuantizationConfig.EMPTY) {
             // If empty, get from attributes with default FLOAT
             return VectorDataType.get(fieldInfo.attributes().getOrDefault(VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue()));
         }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -150,7 +150,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
                 .getQuantizationState(
                     new QuantizationStateReadConfig(
                         segmentReadState,
-                        QuantizationService.getInstance().getQuantizationParams(fieldInfo, segmentReadState.segmentInfo.getVersion()),
+                        QuantizationService.getInstance().getQuantizationParams(fieldInfo),
                         field,
                         cacheKey
                     )

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -229,10 +229,7 @@ public class NativeEngines990KnnVectorsWriter extends KnnVectorsWriter {
     ) throws IOException {
 
         final QuantizationService quantizationService = QuantizationService.getInstance();
-        final QuantizationParams quantizationParams = quantizationService.getQuantizationParams(
-            fieldInfo,
-            segmentWriteState.segmentInfo.getVersion()
-        );
+        final QuantizationParams quantizationParams = quantizationService.getQuantizationParams(fieldInfo);
         QuantizationState quantizationState = null;
         if (quantizationParams != null && totalLiveDocs > 0) {
             initQuantizationStateWriterIfNecessary();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -175,7 +175,7 @@ public class NativeIndexWriter {
         final Map<String, Object> parameters;
         VectorDataType vectorDataType;
         if (quantizationState != null) {
-            vectorDataType = QuantizationService.getInstance().getVectorDataTypeForTransfer(fieldInfo, state.segmentInfo.getVersion());
+            vectorDataType = QuantizationService.getInstance().getVectorDataTypeForTransfer(fieldInfo);
         } else {
             vectorDataType = extractVectorDataType(fieldInfo);
         }
@@ -274,7 +274,7 @@ public class NativeIndexWriter {
         parameters.put(KNNConstants.INDEX_THREAD_QTY, KNNSettings.getIndexThreadQty());
         parameters.put(KNNConstants.MODEL_ID, fieldInfo.attributes().get(MODEL_ID));
         parameters.put(KNNConstants.MODEL_BLOB_PARAMETER, model.getModelBlob());
-        if (FieldInfoExtractor.extractQuantizationConfig(fieldInfo, state.segmentInfo.getVersion()) != QuantizationConfig.EMPTY) {
+        if (FieldInfoExtractor.extractQuantizationConfig(fieldInfo) != QuantizationConfig.EMPTY) {
             IndexUtil.updateVectorDataTypeToParameters(parameters, VectorDataType.BINARY);
         } else {
             IndexUtil.updateVectorDataTypeToParameters(parameters, model.getModelMetadata().getVectorDataType());

--- a/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParser.java
+++ b/src/main/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParser.java
@@ -66,24 +66,20 @@ public class QuantizationConfigParser {
      * @param csv Csv format of quantization config
      * @return Quantization config
      */
-    public static QuantizationConfig fromCsv(String csv, org.apache.lucene.util.Version luceneVersion) {
+    public static QuantizationConfig fromCsv(String csv) {
         if (csv == null || csv.isEmpty()) {
             return QuantizationConfig.EMPTY;
         }
-
-        if (luceneVersion.onOrAfter(org.apache.lucene.util.Version.LUCENE_10_2_2)) {
-            return parseCurrentVersion(csv);
-        } else {
-            return parseLegacyVersion(csv);
-        }
-    }
-
-    private static QuantizationConfig parseCurrentVersion(String csv) {
         String[] csvArray = CSVUtil.parse(csv);
-        if (csvArray.length != 4) {
+        int csvArrayLength = csvArray.length;
+
+        // if csv nonnull and nonempty, then the only valid lengths are 2 and 4.
+        // For forwards compatability with adding more options we can reserve length > 4 and update this below check.
+        if (csvArrayLength != 2 && csvArrayLength != 4) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid csv for quantization config: \"%s\"", csv));
         }
 
+        // Parse common fields (type and bits)
         String typeValue = getValueOrThrow(TYPE_NAME, csvArray[0]);
         if (!typeValue.equals(BINARY_TYPE)) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Unsupported quantization type: \"%s\"", typeValue));
@@ -91,40 +87,26 @@ public class QuantizationConfigParser {
 
         String bitsValue = getValueOrThrow(BIT_COUNT_NAME, csvArray[1]);
         int bitCount = Integer.parseInt(bitsValue);
-
-        String isEnableRandomRotationValue = getValueOrThrow(RANDOM_ROTATION_NAME, csvArray[2]);
-        boolean isEnableRandomRotation = Boolean.parseBoolean(isEnableRandomRotationValue);
-
-        String isEnableADCValue = getValueOrThrow(ADC_NAME, csvArray[3]);
-        boolean isEnableADC = Boolean.parseBoolean(isEnableADCValue);
-
         ScalarQuantizationType quantizationType = ScalarQuantizationType.fromId(bitCount);
+
+        // RR is disabled by default, and it must be disabled for old segments since the extra quantization info is not present.
+        boolean isEnableRandomRotation = QFrameBitEncoder.DEFAULT_ENABLE_RANDOM_ROTATION;
+        // ADC is disabled by default, and it must be disabled for old segments since the extra quantization info is not present.
+        boolean isEnableADC = QFrameBitEncoder.DEFAULT_ENABLE_ADC;
+
+        // parse "random_rotation" and "enable_adc" from csv if length 4
+        if (csvArrayLength == 4) {
+            String isEnableRandomRotationValue = getValueOrThrow(RANDOM_ROTATION_NAME, csvArray[2]);
+            isEnableRandomRotation = Boolean.parseBoolean(isEnableRandomRotationValue);
+
+            String isEnableADCValue = getValueOrThrow(ADC_NAME, csvArray[3]);
+            isEnableADC = Boolean.parseBoolean(isEnableADCValue);
+        }
+
         return QuantizationConfig.builder()
             .quantizationType(quantizationType)
             .enableRandomRotation(isEnableRandomRotation)
             .enableADC(isEnableADC)
-            .build();
-    }
-
-    private static QuantizationConfig parseLegacyVersion(String csv) {
-        String[] csvArray = CSVUtil.parse(csv);
-        if (csvArray.length != 2) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid csv for quantization config: \"%s\"", csv));
-        }
-
-        String typeValue = getValueOrThrow(TYPE_NAME, csvArray[0]);
-        if (!typeValue.equals(BINARY_TYPE)) {
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Unsupported quantization type: \"%s\"", typeValue));
-        }
-
-        String bitsValue = getValueOrThrow(BIT_COUNT_NAME, csvArray[1]);
-        int bitCount = Integer.parseInt(bitsValue);
-
-        ScalarQuantizationType quantizationType = ScalarQuantizationType.fromId(bitCount);
-        return QuantizationConfig.builder()
-            .quantizationType(quantizationType)
-            .enableRandomRotation(QFrameBitEncoder.DEFAULT_ENABLE_RANDOM_ROTATION)  // default value for legacy version
-            .enableADC(QFrameBitEncoder.DEFAULT_ENABLE_ADC)  // default value for legacy version
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/quantizationservice/QuantizationService.java
+++ b/src/main/java/org/opensearch/knn/index/quantizationservice/QuantizationService.java
@@ -8,7 +8,6 @@ package org.opensearch.knn.index.quantizationservice;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.util.Version;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
@@ -115,11 +114,10 @@ public final class QuantizationService<T, R> {
      * Retrieves quantization parameters from the FieldInfo.
      * @param fieldInfo The {@link FieldInfo} object containing metadata about the field for which the quantization parameters
      *                  are being determined.
-     * @param luceneVersion {@link Version} lucene version present in the segment, used for BWC.
      * @return The {@link QuantizationParams} corresponding to the provided field information.
      */
-    public QuantizationParams getQuantizationParams(final FieldInfo fieldInfo, Version luceneVersion) {
-        QuantizationConfig quantizationConfig = extractQuantizationConfig(fieldInfo, luceneVersion);
+    public QuantizationParams getQuantizationParams(final FieldInfo fieldInfo) {
+        QuantizationConfig quantizationConfig = extractQuantizationConfig(fieldInfo);
         if (quantizationConfig != QuantizationConfig.EMPTY && quantizationConfig.getQuantizationType() != null) {
             return ScalarQuantizationParams.builder()
                 .sqType(quantizationConfig.getQuantizationType())
@@ -136,11 +134,10 @@ public final class QuantizationService<T, R> {
      *
      * @param fieldInfo The {@link FieldInfo} object containing metadata about the field for which the vector data type
      *                  is being determined.
-     * @param luceneVersion {@link Version} lucene version present in the segment, used for BWC.
      * @return The {@link VectorDataType} to be used during the vector transfer process
      */
-    public VectorDataType getVectorDataTypeForTransfer(final FieldInfo fieldInfo, Version luceneVersion) {
-        QuantizationConfig quantizationConfig = extractQuantizationConfig(fieldInfo, luceneVersion);
+    public VectorDataType getVectorDataTypeForTransfer(final FieldInfo fieldInfo) {
+        QuantizationConfig quantizationConfig = extractQuantizationConfig(fieldInfo);
         if (quantizationConfig != QuantizationConfig.EMPTY && quantizationConfig.getQuantizationType() != null) {
             return VectorDataType.BINARY;
         }

--- a/src/main/java/org/opensearch/knn/index/query/DefaultKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/DefaultKNNWeight.java
@@ -72,8 +72,7 @@ public class DefaultKNNWeight extends KNNWeight {
         final SegmentLevelQuantizationInfo segmentLevelQuantizationInfo = SegmentLevelQuantizationInfo.build(
             reader,
             fieldInfo,
-            knnQuery.getField(),
-            segmentLuceneVersion
+            knnQuery.getField()
         );
 
         // We need to first get index allocation
@@ -117,8 +116,7 @@ public class DefaultKNNWeight extends KNNWeight {
             final int[] parentIds = getParentIdsArray(context);
             if (k > 0) {
                 if (knnQuery.getVectorDataType() == VectorDataType.BINARY
-                    || quantizedVector != null
-                        && quantizationService.getVectorDataTypeForTransfer(fieldInfo, segmentLuceneVersion) == VectorDataType.BINARY) {
+                    || quantizedVector != null && quantizationService.getVectorDataTypeForTransfer(fieldInfo) == VectorDataType.BINARY) {
                     results = JNIService.queryBinaryIndex(
                         indexAllocation.getMemoryAddress(),
                         // TODO: In the future, quantizedVector can have other data types than byte

--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -220,12 +220,7 @@ public class ExactSearcher {
         SegmentLevelQuantizationInfo segmentLevelQuantizationInfo = null;
         if (exactSearcherContext.isUseQuantizedVectorsForSearch()) {
             // Build Segment Level Quantization info.
-            segmentLevelQuantizationInfo = SegmentLevelQuantizationInfo.build(
-                reader,
-                fieldInfo,
-                exactSearcherContext.getField(),
-                reader.getSegmentInfo().info.getVersion()
-            );
+            segmentLevelQuantizationInfo = SegmentLevelQuantizationInfo.build(reader, fieldInfo, exactSearcherContext.getField());
             // Quantize the Query Vector Once. Or transform it in the case of ADC.
             if (SegmentLevelQuantizationUtil.isAdcEnabled(segmentLevelQuantizationInfo)) {
                 SegmentLevelQuantizationUtil.transformVectorWithADC(

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -482,8 +482,7 @@ public abstract class KNNWeight extends Weight {
         final SegmentLevelQuantizationInfo segmentLevelQuantizationInfo = SegmentLevelQuantizationInfo.build(
             reader,
             fieldInfo,
-            knnQuery.getField(),
-            reader.getSegmentInfo().info.getVersion()
+            knnQuery.getField()
         );
 
         List<String> engineFiles = KNNCodecUtil.getEngineFiles(knnEngine.getExtension(), knnQuery.getField(), reader.getSegmentInfo().info);

--- a/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfo.java
+++ b/src/main/java/org/opensearch/knn/index/query/SegmentLevelQuantizationInfo.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.util.Version;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
 import org.opensearch.knn.quantization.models.quantizationParams.QuantizationParams;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
@@ -31,17 +30,12 @@ public class SegmentLevelQuantizationInfo {
      * @param leafReader {@link LeafReader}
      * @param fieldInfo {@link FieldInfo}
      * @param fieldName {@link String}
-     * @param luceneVersion {@link Version} lucene version present in the segment, used for BWC.
      * @return {@link SegmentLevelQuantizationInfo}
      * @throws IOException exception while creating the {@link SegmentLevelQuantizationInfo} object.
      */
-    public static SegmentLevelQuantizationInfo build(
-        final LeafReader leafReader,
-        final FieldInfo fieldInfo,
-        final String fieldName,
-        Version luceneVersion
-    ) throws IOException {
-        final QuantizationParams quantizationParams = QuantizationService.getInstance().getQuantizationParams(fieldInfo, luceneVersion);
+    public static SegmentLevelQuantizationInfo build(final LeafReader leafReader, final FieldInfo fieldInfo, final String fieldName)
+        throws IOException {
+        final QuantizationParams quantizationParams = QuantizationService.getInstance().getQuantizationParams(fieldInfo);
         if (quantizationParams == null) {
             return null;
         }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -96,7 +96,7 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                 // KNN search
                 if (quantizedTargetVector != null) {
                     // Quantization case
-                    if (quantizationService.getVectorDataTypeForTransfer(fieldInfo, segmentLuceneVersion) == VectorDataType.BINARY) {
+                    if (quantizationService.getVectorDataTypeForTransfer(fieldInfo) == VectorDataType.BINARY) {
                         return queryIndex(
                             quantizedTargetVector,
                             cardinality,
@@ -112,7 +112,7 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                     // Should never occur, safety if ever any other quantization is added
                     throw new IllegalStateException(
                         "VectorDataType for transfer acquired ["
-                            + quantizationService.getVectorDataTypeForTransfer(fieldInfo, segmentLuceneVersion)
+                            + quantizationService.getVectorDataTypeForTransfer(fieldInfo)
                             + "] while it is expected to get ["
                             + VectorDataType.BINARY
                             + "]"

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -18,7 +18,6 @@ import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOSupplier;
-import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
 import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -63,7 +62,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         SpaceType spaceType = null;
         if (fieldInfo != null) {
             // Extract ADC info from fieldInfo to determine scorer.
-            final QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo, Version.LATEST);
+            final QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo);
             this.isAdc = quantizationConfig.isEnableADC();
             spaceType = isAdc ? SpaceType.getSpace(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)) : null;
         }

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardUnitTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardUnitTests.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index;
 
 import junit.framework.TestCase;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.util.Version;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opensearch.knn.common.FieldInfoExtractor;
@@ -26,7 +25,6 @@ public class KNNIndexShardUnitTests extends TestCase {
      */
     public void testDetermineVectorDataType() {
         KNNIndexShard knnIndexShard = new KNNIndexShard(null);
-        Version testVersion = Version.LATEST;
 
         // ----- Test Case 1: Empty Quantization Config with default FLOAT -----
         // Setup mocks
@@ -38,11 +36,11 @@ public class KNNIndexShardUnitTests extends TestCase {
 
         // Setup FieldInfoExtractor mock behavior using mockStatic
         try (MockedStatic<FieldInfoExtractor> fieldInfoExtractorMock = Mockito.mockStatic(FieldInfoExtractor.class)) {
-            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo1, testVersion))
+            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo1))
                 .thenReturn(QuantizationConfig.EMPTY);
 
             // Directly call the method
-            VectorDataType result1 = knnIndexShard.determineVectorDataType(fieldInfo1, segmentLevelQuantizationInfo1, testVersion);
+            VectorDataType result1 = knnIndexShard.determineVectorDataType(fieldInfo1, segmentLevelQuantizationInfo1);
 
             // Verify default FLOAT is returned
             assertEquals(VectorDataType.FLOAT, result1);
@@ -57,11 +55,11 @@ public class KNNIndexShardUnitTests extends TestCase {
         SegmentLevelQuantizationInfo segmentLevelQuantizationInfo2 = Mockito.mock(SegmentLevelQuantizationInfo.class);
 
         try (MockedStatic<FieldInfoExtractor> fieldInfoExtractorMock = Mockito.mockStatic(FieldInfoExtractor.class)) {
-            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo2, testVersion))
+            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo2))
                 .thenReturn(QuantizationConfig.EMPTY);
 
             // Directly call the method
-            VectorDataType result2 = knnIndexShard.determineVectorDataType(fieldInfo2, segmentLevelQuantizationInfo2, testVersion);
+            VectorDataType result2 = knnIndexShard.determineVectorDataType(fieldInfo2, segmentLevelQuantizationInfo2);
 
             // Verify BINARY is returned based on attributes
             assertEquals(VectorDataType.BINARY, result2);
@@ -79,14 +77,13 @@ public class KNNIndexShardUnitTests extends TestCase {
             // Setup for non-empty quantization config
             QuantizationConfig nonEmptyConfig = QuantizationConfig.builder().build();
 
-            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo3, testVersion))
-                .thenReturn(nonEmptyConfig);
+            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo3)).thenReturn(nonEmptyConfig);
 
             // Setup for ADC enabled
             segmentLevelQuantUtilMock.when(() -> SegmentLevelQuantizationUtil.isAdcEnabled(segmentLevelQuantizationInfo3)).thenReturn(true);
 
             // Directly call the method
-            VectorDataType result3 = knnIndexShard.determineVectorDataType(fieldInfo3, segmentLevelQuantizationInfo3, testVersion);
+            VectorDataType result3 = knnIndexShard.determineVectorDataType(fieldInfo3, segmentLevelQuantizationInfo3);
 
             // Verify FLOAT is returned when ADC is enabled
             assertEquals(VectorDataType.FLOAT, result3);
@@ -104,15 +101,14 @@ public class KNNIndexShardUnitTests extends TestCase {
             // Setup for non-empty quantization config
             QuantizationConfig nonEmptyConfig = QuantizationConfig.builder().build();
 
-            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo4, testVersion))
-                .thenReturn(nonEmptyConfig);
+            fieldInfoExtractorMock.when(() -> FieldInfoExtractor.extractQuantizationConfig(fieldInfo4)).thenReturn(nonEmptyConfig);
 
             // Setup for ADC disabled
             segmentLevelQuantUtilMock.when(() -> SegmentLevelQuantizationUtil.isAdcEnabled(segmentLevelQuantizationInfo4))
                 .thenReturn(false);
 
             // Directly call the method
-            VectorDataType result4 = knnIndexShard.determineVectorDataType(fieldInfo4, segmentLevelQuantizationInfo4, testVersion);
+            VectorDataType result4 = knnIndexShard.determineVectorDataType(fieldInfo4, segmentLevelQuantizationInfo4);
 
             // Verify BINARY is returned when ADC is disabled
             assertEquals(VectorDataType.BINARY, result4);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterFlushTests.java
@@ -183,7 +183,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
                     () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
                 ).thenReturn(nativeIndexWriter);
@@ -268,7 +268,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(quantizationParams);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
                 try {
                     when(quantizationService.train(quantizationParams, expectedVectorValuesSuppliers.get(i), vectorsPerField.get(i).size()))
                         .thenReturn(quantizationState);
@@ -368,7 +368,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSupplier.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
                     () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
                 ).thenReturn(nativeIndexWriter);
@@ -443,7 +443,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
                     () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
                 ).thenReturn(nativeIndexWriter);
@@ -518,7 +518,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
                     () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
                 ).thenReturn(nativeIndexWriter);
@@ -602,7 +602,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
                 nativeIndexWriterMockedStatic.when(
                     () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
                 ).thenReturn(nativeIndexWriter);
@@ -689,7 +689,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(quantizationParams);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
                 try {
                     when(quantizationService.train(quantizationParams, expectedVectorValuesSuppliers.get(i), vectorsPerField.get(i).size()))
                         .thenReturn(quantizationState);
@@ -789,7 +789,7 @@ public class NativeEngines990KnnVectorsWriterFlushTests extends OpenSearchTestCa
                     () -> KNNVectorValuesFactory.getVectorValuesSupplier(VectorDataType.FLOAT, docsWithFieldSet, vectorsPerField.get(i))
                 ).thenReturn(expectedVectorValuesSuppliers.get(i));
 
-                when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(quantizationParams);
+                when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
                 try {
                     when(quantizationService.train(quantizationParams, expectedVectorValuesSuppliers.get(i), vectorsPerField.get(i).size()))
                         .thenReturn(quantizationState);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriterMergeTests.java
@@ -164,7 +164,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
                 () -> KNNVectorValuesFactory.getKNNVectorValuesSupplierForMerge(VectorDataType.FLOAT, fieldInfo, mergeState)
             ).thenReturn(knnVectorValuesSupplier);
 
-            when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
                 () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
             ).thenReturn(nativeIndexWriter);
@@ -235,7 +235,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
                 () -> KNNVectorValuesFactory.getKNNVectorValuesSupplierForMerge(VectorDataType.FLOAT, fieldInfo, mergeState)
             ).thenReturn(knnVectorValuesSupplier);
 
-            when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
                 () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
             ).thenReturn(nativeIndexWriter);
@@ -297,7 +297,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
                 () -> KNNVectorValuesFactory.getKNNVectorValuesSupplierForMerge(VectorDataType.FLOAT, fieldInfo, mergeState)
             ).thenReturn(knnVectorValuesSupplier);
 
-            when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(null);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(null);
             nativeIndexWriterMockedStatic.when(
                 () -> NativeIndexWriter.getWriter(fieldInfo, segmentWriteState, null, nativeIndexBuildStrategyFactory)
             ).thenReturn(nativeIndexWriter);
@@ -360,7 +360,7 @@ public class NativeEngines990KnnVectorsWriterMergeTests extends OpenSearchTestCa
                 () -> KNNVectorValuesFactory.getKNNVectorValuesSupplierForMerge(VectorDataType.FLOAT, fieldInfo, mergeState)
             ).thenReturn(knnVectorValuesSupplier);
 
-            when(quantizationService.getQuantizationParams(fieldInfo, Version.LATEST)).thenReturn(quantizationParams);
+            when(quantizationService.getQuantizationParams(fieldInfo)).thenReturn(quantizationParams);
             try {
                 // Fix mock to use the supplier
                 when(quantizationService.train(eq(quantizationParams), any(Supplier.class), eq((long) mergedVectors.size()))).thenReturn(

--- a/src/test/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/qframe/QuantizationConfigParserTests.java
@@ -5,29 +5,24 @@
 
 package org.opensearch.knn.index.engine.qframe;
 
-import org.apache.lucene.util.Version;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 public class QuantizationConfigParserTests extends KNNTestCase {
 
     public void testFromCsv() {
-        assertEquals(QuantizationConfig.EMPTY, QuantizationConfigParser.fromCsv("", Version.LATEST));
-        assertEquals(QuantizationConfig.EMPTY, QuantizationConfigParser.fromCsv(null, Version.LATEST));
+        assertEquals(QuantizationConfig.EMPTY, QuantizationConfigParser.fromCsv(""));
+        assertEquals(QuantizationConfig.EMPTY, QuantizationConfigParser.fromCsv(null));
 
         expectThrows(
             IllegalArgumentException.class,
-            () -> QuantizationConfigParser.fromCsv(
-                QuantizationConfigParser.TYPE_NAME + "=" + QuantizationConfigParser.BINARY_TYPE,
-                Version.LATEST
-            )
+            () -> QuantizationConfigParser.fromCsv(QuantizationConfigParser.TYPE_NAME + "=" + QuantizationConfigParser.BINARY_TYPE)
         );
 
         expectThrows(
             IllegalArgumentException.class,
             () -> QuantizationConfigParser.fromCsv(
-                QuantizationConfigParser.TYPE_NAME + "=invalid," + QuantizationConfigParser.BIT_COUNT_NAME + "=4",
-                Version.LATEST
+                QuantizationConfigParser.TYPE_NAME + "=invalid," + QuantizationConfigParser.BIT_COUNT_NAME + "=4"
             )
         );
 
@@ -39,8 +34,7 @@ public class QuantizationConfigParserTests extends KNNTestCase {
                     + QuantizationConfigParser.BINARY_TYPE
                     + ",invalid=4"
                     + QuantizationConfigParser.BIT_COUNT_NAME
-                    + "=4",
-                Version.LATEST
+                    + "=4"
             )
         );
 
@@ -52,8 +46,28 @@ public class QuantizationConfigParserTests extends KNNTestCase {
                     + QuantizationConfigParser.BINARY_TYPE
                     + ","
                     + QuantizationConfigParser.BIT_COUNT_NAME
-                    + "=invalid",
-                Version.LATEST
+                    + "=invalid"
+            )
+        );
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> QuantizationConfigParser.fromCsv(
+                QuantizationConfigParser.TYPE_NAME
+                    + "="
+                    + QuantizationConfigParser.BINARY_TYPE
+                    + ","
+                    + QuantizationConfigParser.BIT_COUNT_NAME
+                    + "=4"
+                    + ","
+                    + QuantizationConfigParser.RANDOM_ROTATION_NAME
+                    + "=false"
+                    + ","
+                    + QuantizationConfigParser.ADC_NAME
+                    + "=false"
+                    + ","
+                    + "OTHER_FIFTH_OPTION"
+                    + "=20"
             )
         );
 
@@ -71,8 +85,7 @@ public class QuantizationConfigParserTests extends KNNTestCase {
                     + "=false"
                     + ","
                     + QuantizationConfigParser.ADC_NAME
-                    + "=false",
-                Version.LATEST
+                    + "=false"
             )
         );
     }
@@ -87,25 +100,19 @@ public class QuantizationConfigParserTests extends KNNTestCase {
     }
 
     public void testFromCsv_bwc() {
-        // version selected somewhat arbitrarily; 990 is the version w quantization codecs.
-        // The important thing is that the version < 10.2.1.
-        Version previousVersion990 = Version.LUCENE_9_9_0;
-
         assertEquals(
             QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).enableRandomRotation(false).build(),
-            QuantizationConfigParser.fromCsv("type=binary,bits=2", previousVersion990)
-        );
-
-        // Test lucene > 10.0 but < 10.2.1
-        Version previousVersion101 = Version.LUCENE_10_1_0;
-        assertEquals(
-            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).enableRandomRotation(false).build(),
-            QuantizationConfigParser.fromCsv("type=binary,bits=2", previousVersion101)
+            QuantizationConfigParser.fromCsv("type=binary,bits=2")
         );
 
         assertEquals(
             QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).enableRandomRotation(false).build(),
-            QuantizationConfigParser.fromCsv("type=binary,bits=2,random_rotation=false,enable_adc=false", Version.LATEST)
+            QuantizationConfigParser.fromCsv("type=binary,bits=2")
+        );
+
+        assertEquals(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.TWO_BIT).enableRandomRotation(false).build(),
+            QuantizationConfigParser.fromCsv("type=binary,bits=2,random_rotation=false,enable_adc=false")
         );
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -1193,7 +1193,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
 
             // Mock Quantization
 
-            segmentLevelQuantizationInfoMockedStatic.when(() -> SegmentLevelQuantizationInfo.build(any(), any(), anyString(), any()))
+            segmentLevelQuantizationInfoMockedStatic.when(() -> SegmentLevelQuantizationInfo.build(any(), any(), anyString()))
                 .thenReturn(null);
 
             jniServiceMockedStatic.when(
@@ -1667,7 +1667,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
             QuantizationService quantizationService = Mockito.mock(QuantizationService.class);
             quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
             QuantizationParams quantizationParams = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
-            when(quantizationService.getQuantizationParams(any(FieldInfo.class), any(Version.class))).thenReturn(quantizationParams);
+            when(quantizationService.getQuantizationParams(any(FieldInfo.class))).thenReturn(quantizationParams);
 
             // Given
             int k = 3;
@@ -1711,8 +1711,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         try (MockedStatic<QuantizationService> quantizationServiceMockedStatic = Mockito.mockStatic(QuantizationService.class)) {
             QuantizationService quantizationService = Mockito.mock(QuantizationService.class);
             ScalarQuantizationParams quantizationParams = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
-            Mockito.when(quantizationService.getQuantizationParams(any(FieldInfo.class), any(Version.class)))
-                .thenReturn(quantizationParams);
+            Mockito.when(quantizationService.getQuantizationParams(any(FieldInfo.class))).thenReturn(quantizationParams);
             quantizationServiceMockedStatic.when(QuantizationService::getInstance).thenReturn(quantizationService);
 
             float[] meanThresholds = new float[] { 1.2f, 2.3f, 3.4f, 4.5f };

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -81,6 +81,7 @@ import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Rule;
@@ -1099,6 +1100,20 @@ public class KNNRestTestCase extends ODFERestTestCase {
     }
 
     /**
+     * Get the segments information for an index
+     * @param index index name
+     * @return the parsed segments information as a Map
+     */
+    protected Map<String, Object> getSegments(final String index) throws Exception {
+        Request request = new Request("GET", "/" + index + "/_segments");
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        return createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+    }
+
+    /**
      * Utility to update  settings
      */
     protected void updateClusterSettings(String settingKey, Object value) throws Exception {
@@ -1967,6 +1982,38 @@ public class KNNRestTestCase extends ODFERestTestCase {
         client().performRequest(waitForGreen);
     }
 
+    // Adds KNN Docs through the bulk API with additional fields. Similar to addKnnDoc but via bulk instead of 1 by 1.
+    public void addKNNDocsWithParkingAndRating(String indexName, String fieldName, int dimension, int firstDocID, int numDocs)
+        throws IOException {
+        Request request = new Request("POST", "/_bulk");
+        request.addParameter("refresh", "true");
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = firstDocID; i < firstDocID + numDocs; i++) {
+            float[] indexVector = new float[dimension];
+            Arrays.fill(indexVector, (float) (i + ((float) i * 0.1f)));
+
+            sb.append("{ \"index\" : { \"_index\" : \"")
+                .append(indexName)
+                .append("\", \"_id\" : \"")
+                .append(i)
+                .append("\" } }\n")
+                .append("{ \"")
+                .append(fieldName)
+                .append("\" : ")
+                .append(Arrays.toString(indexVector))
+                .append(", \"parking\" : \"")
+                .append(i % 2 == 0 ? "true" : "false")
+                .append("\", \"rating\" : ")
+                .append((i % 7) + 3)
+                .append(" }\n");
+        }
+
+        request.setJsonEntity(sb.toString());
+        Response response = client().performRequest(request);
+        assertEquals(response.getStatusLine().getStatusCode(), 200);
+    }
+
     // Add KNN docs into a KNN index by providing the initial documentID and number of documents
     public void addKNNDocs(String testIndex, String testField, int dimension, int firstDocID, int numDocs) throws IOException {
         for (int i = firstDocID; i < firstDocID + numDocs; i++) {
@@ -2012,6 +2059,75 @@ public class KNNRestTestCase extends ODFERestTestCase {
         for (int i = 0; i < k; i++) {
             assertEquals(numDocs - i - 1, Integer.parseInt(results.get(i).getDocId()));
         }
+    }
+
+    // calls the /_segments API and parses segment response. Used in BWC tests.
+    protected Map<String, Object> getSegments(final String index, final int num) throws Exception {
+        Request request = new Request("GET", "/" + index + "/_segments");
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        Map<String, Object> out = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        logger.info("[BWC KNN {}] results: {}", num, out);
+        return out;
+    }
+
+    // Validate that all segments in an index are the same lucene version. Used in BWC tests.
+    protected void validateSegmentsSameVersion(final String index) throws Exception {
+        Map<String, Object> segmentsResponse = getSegments(index, 1);
+        logger.info("Segments response: {}", segmentsResponse);
+
+        Map<String, Object> indices = (Map<String, Object>) segmentsResponse.get("indices");
+        if (indices == null) {
+            logger.error("No indices found in segments response");
+            return;
+        }
+
+        Map<String, Object> indexData = (Map<String, Object>) indices.get(index);
+        if (indexData == null) {
+            logger.error("No data found for index: {}", index);
+            return;
+        }
+
+        Map<String, Object> shards = (Map<String, Object>) indexData.get("shards");
+        if (shards == null) {
+            logger.error("No shards found for index: {}", index);
+            return;
+        }
+
+        Set<String> versions = new HashSet<>();
+
+        for (Object shardList : shards.values()) {
+            List<Map<String, Object>> shardData = (List<Map<String, Object>>) shardList;
+            for (Map<String, Object> shard : shardData) {
+                Map<String, Object> segments = (Map<String, Object>) shard.get("segments");
+                if (segments != null) {
+                    for (Object segmentData : segments.values()) {
+                        Map<String, Object> segment = (Map<String, Object>) segmentData;
+                        Boolean isSearchable = (Boolean) segment.get("search");
+                        String version = (String) segment.get("version");
+                        if (version != null && isSearchable != null && isSearchable) {
+                            versions.add(version);
+                        }
+                    }
+                }
+            }
+        }
+
+        logger.info("Found versions: {}", versions);
+        assertEquals("All segments should have the same version", 1, versions.size());
+    }
+
+    protected Map<String, Object> getMappingAndPrint(final String index, final int num) throws Exception {
+        Request request = new Request("GET", "/" + index + "/_mapping");
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        Map<String, Object> out = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        logger.info("[BWC KNN {}] results: {}", num, out);
+        return out;
     }
 
     public void validateKNNSearchDistance(


### PR DESCRIPTION
 # Description
Backports #2994 to 3.3
* Add BWC check



* Use knnsearch to cause 9.12 segments to be flushed



* retry CI and qa:spotlessApply



* Add TimeUnit sleep as merging not completing in the runner but working locally



* Remove search validation; just refresh



* Address Vikash's comment and remove luceneVersion from quantizationConfig method signatures



* fix merge against main



* qa:spotlessApply



* move csv length checks to top



* Add extra unit test for 5 values should throw exception



---------


(cherry picked from commit fd71813fa984293516245631d291c23298f54716)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
