### PR TITLE
Fix StopWatch IllegalStateException in KNN query execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix rescoring logic for nested exact search [#2921](https://github.com/opensearch-project/k-NN/pull/2921)
 * Update Visitor to delegate for other fields [#2925](https://github.com/opensearch-project/k-NN/pull/2925)
 * Fix blocking old indices created before 2.18 to use memory optimized search. [#2918](https://github.com/opensearch-project/k-NN/pull/2918)
-* Fix Backwards Compatability on Segment Merge for Disk-Based vector search [#2994](https://github.com/opensearch-project/k-NN/pull/2994) 
+* Fix Backwards Compatability on Segment Merge for Disk-Based vector search [#2994](https://github.com/opensearch-project/k-NN/pull/2994)
+* Fix StopWatch IllegalStateException in KNN query execution [#3001](https://github.com/opensearch-project/k-NN/pull/3001)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -334,7 +334,7 @@ public abstract class KNNWeight extends Weight {
 
         final StopWatch annStopWatch = startStopWatch(log);
         final TopDocs topDocs = approximateSearch(context, filterBitSet, filterCardinality, k);
-        stopStopWatchAndLog(log, stopWatch, "ANN search", knnQuery.getShardId(), segmentName, knnQuery.getField());
+        stopStopWatchAndLog(log, annStopWatch, "ANN search", knnQuery.getShardId(), segmentName, knnQuery.getField());
 
         if (knnQuery.isExplain()) {
             knnExplanation.addLeafResult(context.id(), topDocs.scoreDocs.length);

--- a/src/main/java/org/opensearch/knn/profile/StopWatchUtils.java
+++ b/src/main/java/org/opensearch/knn/profile/StopWatchUtils.java
@@ -29,9 +29,19 @@ public final class StopWatchUtils {
     ) {
 
         if (stopWatch != null && log.isDebugEnabled()) {
-            stopWatch.stop();
-            final String logMessage = prefixMessage + " shard: [{}], segment: [{}], field: [{}], time in nanos:[{}] ";
-            log.debug(logMessage, shardId, segmentName, field, stopWatch.totalTime().nanos());
+            try {
+                stopWatch.stop();
+                final String logMessage = prefixMessage + " shard: [{}], segment: [{}], field: [{}], time in nanos:[{}] ";
+                log.debug(logMessage, shardId, segmentName, field, stopWatch.totalTime().nanos());
+            } catch (IllegalStateException e) {
+                log.error(
+                    "StopWatch was already stopped for operation: {} on shard: [{}], segment: [{}], field: [{}]",
+                    prefixMessage,
+                    shardId,
+                    segmentName,
+                    field
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
Fix StopWatch IllegalStateException in KNN query execution that was causing searches to fail with "Can't stop StopWatch: it's not running" error when opensearch debug logs are enabled. 

The issue occurred when the wrong StopWatch instance was being used for timing ANN search in KNNWeight.searchLeaf().

### Testing
```
% curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'       
{
  "transient": {                
    "logger.org.opensearch": "debug"
  }              
}
'
{"acknowledged":true,"persistent":{},"transient":{"logger":{"org":{"opensearch":"debug"}}}}
```

```
% curl -X PUT "http://localhost:9200/knn-index1" -H "Content-Type: application/json" -d'
{
  "mappings": {
    "properties": {
      "my_vector": {
        "type": "knn_vector",
        "dimension": 3
      }
    }
  },
  "settings": {
    "index.knn": true
  }
}'
{"acknowledged":true,"shards_acknowledged":true,"index":"knn-index1"}
```
```
% curl -X PUT "http://localhost:9200/knn-index1/_doc/1" -H "Content-Type: application/json" -d'
{
    "my_vector": [0.2, 0.3, 0.4]
}'
{"_index":"knn-index1","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}

% curl -X PUT "http://localhost:9200/knn-index1/_doc/2" -H "Content-Type: application/json" -d'
{
    "my_vector": [0.1, 0.7, 0.2]
}'
{"_index":"knn-index1","_id":"2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}

% curl -X PUT "http://localhost:9200/knn-index1/_doc/3" -H "Content-Type: application/json" -d'
{
    "my_vector": [0.8, 0.2, 0.1]
}'
{"_index":"knn-index1","_id":"3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1}
```

```
// No issues
% curl -X GET "http://localhost:9200/knn-index1/_search"
{"took":991,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":3,"relation":"eq"},"max_score":1.0,"hits":[{"_index":"knn-index1","_id":"1","_score":1.0,"_source":{"my_vector":[0.2,0.3,0.4]}},{"_index":"knn-index1","_id":"2","_score":1.0,"_source":{"my_vector":[0.1,0.7,0.2]}},{"_index":"knn-index1","_id":"3","_score":1.0,"_source":{"my_vector":[0.8,0.2,0.1]}}]}}

// No issues, no longer running into illegal_state_exception like before
% curl -X GET "http://localhost:9200/knn-index1/_search" -H "Content-Type: application/json" -d'
{
  "query": {
    "knn": {
      "my_vector": {
        "vector": [0.1, 0.5, 0.3],
        "k": 2
      }
    }
  }
}'
{"took":50,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":3,"relation":"eq"},"max_score":0.952381,"hits":[{"_index":"knn-index1","_id":"2","_score":0.952381,"_source":{"my_vector":[0.1,0.7,0.2]}},{"_index":"knn-index1","_id":"1","_score":0.9433963,"_source":{"my_vector":[0.2,0.3,0.4]}},{"_index":"knn-index1","_id":"3","_score":0.61728394,"_source":{"my_vector":[0.8,0.2,0.1]}}]}}
```

### Related Issues
Resolves #2989 
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
