### PR TITLE
Include opensearchknn_simd in build configurations

### DIFF
--- a/release-notes/opensearch-k-NN.release-notes-3.4.0.0.md
+++ b/release-notes/opensearch-k-NN.release-notes-3.4.0.0.md
@@ -22,3 +22,6 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.4.0
 ### Enhancements
 * Removed VectorSearchHolders map from NativeEngines990KnnVectorsReader ([#2948](https://github.com/opensearch-project/k-NN/pull/2948))
 * Native scoring for FP16 ([#2922](https://github.com/opensearch-project/k-NN/pull/2922))
+
+### Infrastructure
+* Include opensearchknn_simd in build configurations ([#3025](https://github.com/opensearch-project/k-NN/pull/3025))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -130,7 +130,7 @@ fi
 # Build k-NN lib and plugin through gradle tasks
 cd $work_dir
 ./gradlew build --no-daemon --refresh-dependencies -x integTest -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Dbuild.lib.commit_patches=false -Dnmslib_simd_flags=$NMSLIB_SIMD_FLAGS
-./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss -Davx512.enabled=false -Davx512_spr.enabled=false -Davx2.enabled=false -Dbuild.lib.commit_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dbuild.snapshot=$SNAPSHOT
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512.enabled=false -Davx512_spr.enabled=false -Davx2.enabled=false -Dbuild.lib.commit_patches=false -Dnproc.count=${NPROC_COUNT:-1} -Dbuild.snapshot=$SNAPSHOT
 
 if [ "$PLATFORM" != "windows" ] && [ "$ARCHITECTURE" = "x64" ]; then
   echo "Building k-NN library nmslib with gcc 10 on non-windows x64"
@@ -141,13 +141,13 @@ if [ "$PLATFORM" != "windows" ] && [ "$ARCHITECTURE" = "x64" ]; then
   # Skip applying patches as patches were applied already from previous :buildJniLib task
   # If we apply patches again, it fails with conflict
   rm -rf jni/build/CMakeCache.txt jni/build/CMakeFiles
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss -Davx2.enabled=true -Davx512.enabled=false -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx2.enabled=true -Davx512.enabled=false -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT
 
   echo "Building k-NN library after enabling AVX512"
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss -Davx512.enabled=true -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512.enabled=true -Davx512_spr.enabled=false -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT
 
   echo "Building k-NN library after enabling AVX512_SPR"
-  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss -Davx512_spr.enabled=true -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT
+  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512_spr.enabled=true -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT
 
 else
   ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib -Dbuild.lib.commit_patches=false -Dbuild.lib.apply_patches=false -Dbuild.snapshot=$SNAPSHOT

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -2,6 +2,10 @@ grant {
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_nmslib";
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss";
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_common";
+    permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd";
+    permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd_avx2";
+    permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd_avx512";
+    permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd_avx512_spr";
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx2";
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512";
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512_spr";


### PR DESCRIPTION
### Description
- Include opensearchknn_simd in build configurations for all AVX variants                                                                                                                         
- Add security permissions for SIMD library loading (base and AVX variants)                                                                                                                       
- Update build script to compile SIMD alongside FAISS libraries 

### Related Issues
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
