### PR TITLE
Added check-files job to ensure that required workflows runs when there are changes right files

### DIFF
--- a/.github/actions/check-files/action.yml
+++ b/.github/actions/check-files/action.yml
@@ -1,0 +1,30 @@
+name: 'KNN Check Files Changed'
+description: 'Check if specific files have changed for KNN repo'
+inputs:
+  files:
+    description: 'Files to check for changes'
+outputs:
+  files_changed:
+    description: 'Whether any files changed'
+    value: ${{ steps.changed-files.outputs.any_changed }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Combine files
+      id: combine-files
+      shell: bash
+      run: |
+        DEFAULT_FILES="build.gradle,settings.gradle,src/**,build-tools/**,buildSrc/**,gradle/**,jni/**"
+        COMBINED_FILES="$DEFAULT_FILES,${{ inputs.files }}"
+        echo "combined_files=$COMBINED_FILES" >> $GITHUB_OUTPUT
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v47.0.0
+      with:
+        files: ${{ steps.combine-files.outputs.combined_files }}
+        files_separator: ","
+    - name: Debug output
+      shell: bash
+      run: |
+        echo "Files changed: ${{ steps.changed-files.outputs.any_changed }}"
+        echo "Combined files: ${{ steps.combine-files.outputs.combined_files }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,22 +17,14 @@ jobs:
     name: Check file for Build and Test k-NN
     runs-on: ubuntu-latest
     outputs:
-      RUN_BUILD_AND_TEST: ${{ steps.changed-files-specific.outputs.any_changed }}
+      RUN_BUILD_AND_TEST: ${{ steps.check.outputs.files_changed }}
     steps:
       - uses: actions/checkout@v6
-      - name: Get changed files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v47.0.0
+      - name: Check files
+        id: check
+        uses: ./.github/actions/check-files
         with:
-          files: |
-            build.gradle
-            settings.gradle
-            src/**
-            build-tools/**
-            buildSrc/**
-            gradle/**
-            jni/**
-            .github/workflows/CI.yml
+          files: .github/workflows/CI.yml
 
   Get-CI-Image-Tag:
     needs: check-files

--- a/.github/workflows/remote_index_build.yml
+++ b/.github/workflows/remote_index_build.yml
@@ -16,22 +16,14 @@ jobs:
     name: Check file for Build and Test k-NN using Remote Index Builder
     runs-on: ubuntu-latest
     outputs:
-      RUN_IT_TEST: ${{ steps.changed-files-specific.outputs.any_changed }}
+      RUN_IT_TEST: ${{ steps.check.outputs.files_changed }}
     steps:
       - uses: actions/checkout@v6
-      - name: Get changed files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v47.0.0
+      - name: Check files
+        id: check
+        uses: ./.github/actions/check-files
         with:
-          files: |
-            build.gradle
-            settings.gradle
-            src/**
-            build-tools/**
-            buildSrc/**
-            gradle/**
-            jni/**
-            .github/workflows/remote_index_build.yml
+          files: .github/workflows/remote_index_build.yml
 
   Remote-Index-Build-IT-Tests:
     needs: check-files

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -16,26 +16,18 @@ jobs:
     name: Check file for Test k-NN on Secure Cluster
     runs-on: ubuntu-latest
     outputs:
-      RUN_IT_TEST: ${{ steps.changed-files-specific.outputs.any_changed }}
+      RUN_SECURE_IT_TEST: ${{ steps.check.outputs.files_changed }}
     steps:
       - uses: actions/checkout@v6
-      - name: Get changed files
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v47.0.0
+      - name: Check files
+        id: check
+        uses: ./.github/actions/check-files
         with:
-          files: |
-            build.gradle
-            settings.gradle
-            src/**
-            build-tools/**
-            buildSrc/**
-            gradle/**
-            jni/**
-            .github/workflows/test_security.yml
+          files: .github/workflows/test_security.yml
 
   Get-CI-Image-Tag:
     needs: check-files
-    if: needs.check-files.outputs.RUN_IT_TEST == 'true'
+    if: needs.check-files.outputs.RUN_SECURE_IT_TEST == 'true'
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch
@@ -106,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check results
-        if: ${{ needs.check-files.outputs.RUN_IT_TEST && needs.integ-test-with-security-linux.result == 'failure' }}
+        if: ${{ needs.check-files.outputs.RUN_SECURE_IT_TEST && needs.integ-test-with-security-linux.result == 'failure' }}
         run: |
           echo "Integration tests failed, failing the check-results step"
           exit 1


### PR DESCRIPTION
### Description
Added check-files job to ensure that required workflows runs when there are changes right files. This change adds 2 more steps for CI.yml, test-security.yml and remote-index.yml

1. Check Files: This ensures that only a specific set of files are changed and returns if those files are changed or not.
2. Check results: This ensures that if check files is true we go and validate if the ITs and other gradle runs are successful or not. If they are not successful, error is thrown and step fails.

With this change we will not make the `Check results` mandatory to be successful before we can merge any PR.

## What was problem with older approach?
In the older approach we made few CIs required but those CIs doesn't run if a PR has release notes or changes only in `.md` files. Due to this the PRs were not able to get merged since required steps were not completed. More details can be found here: https://opensearch.slack.com/archives/C04UTNM338A/p1765568895862329


### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
