### PR TITLE
Gradle ban System.loadLibrary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Maintenance
 * Added gradle task to generate task dependency graph ([#3032](https://github.com/opensearch-project/k-NN/pull/3032))
+* Added new gradle task validateLibraryUsage so that System.loadLibrary cannot be run outside KNNLibraryLoader ([#3033](https://github.com/opensearch-project/k-NN/pull/3033))
 
 ### Bug Fixes
 * Fix indexing for 16x and 8x compression [#3019](https://github.com/opensearch-project/k-NN/pull/3019)

--- a/GRADLE_GRAPH.md
+++ b/GRADLE_GRAPH.md
@@ -12,82 +12,84 @@ graph TD
     check --> build
     assemble --> build
     spotlessCheck --> check
-    javadoc --> check
     jacocoTestReport --> check
+    javadoc --> check
     spotlessJavaCheck --> spotlessCheck
     spotlessJavaApply --> spotlessJavaCheck
     spotlessInternalRegisterDependencies --> spotlessJava
     clean --> spotlessJava
     spotlessJava --> spotlessJavaApply
-    delombok --> javadoc
-    generateEffectiveLombokConfig --> compileJava
-    compileJava --> delombok
     integTest --> jacocoTestReport
     compileJava --> classes
     processResources --> classes
-    bundlePlugin --> integTest
-    test --> integTest
+    generateEffectiveLombokConfig --> compileJava
+    buildJniTest --> test
     compileTestFixturesJava --> compileTestJava
     generateTestEffectiveLombokConfig --> compileTestJava
     compileJava --> compileTestFixturesJava
     generateTestFixturesEffectiveLombokConfig --> compileTestFixturesJava
-    pluginProperties --> bundlePlugin
-    jar --> bundlePlugin
-    generateNotice --> bundlePlugin
     copyPluginPropertiesTemplate --> pluginProperties
-    classes --> jar
+    pluginProperties --> testClasses
     processTestResources --> testClasses
     compileTestJava --> testClasses
-    pluginProperties --> testClasses
     testFixturesClasses --> testFixturesJar
     compileTestFixturesJava --> testFixturesClasses
     processTestFixturesResources --> testFixturesClasses
-    cmakeJniLib --> buildJniLib
-    buildJniTest --> test
+    classes --> jar
+    compileJava --> validateLibraryUsage
     buildJniLib --> buildJniTest
     prepareJavaAgent --> buildJniTest
     precommit --> buildJniTest
-    thirdPartyAudit --> precommit
-    forbiddenPatterns --> precommit
-    jarHell --> precommit
-    forbiddenApis --> precommit
-    licenseHeaders --> precommit
-    testingConventions --> precommit
-    validatePom --> precommit
-    filepermissions --> precommit
+    cmakeJniLib --> buildJniLib
     dependencyLicenses --> precommit
+    validatePom --> precommit
+    licenseHeaders --> precommit
+    forbiddenApis --> precommit
+    thirdPartyAudit --> precommit
+    filepermissions --> precommit
+    testingConventions --> precommit
+    forbiddenPatterns --> precommit
     loggerUsageCheck --> precommit
-    thirdPartyAuditResources --> thirdPartyAudit
-    testClasses --> jarHell
-    testFixturesJar --> jarHell
-    jar --> jarHell
-    forbiddenApisTestFixtures --> forbiddenApis
+    jarHell --> precommit
+    validatePluginZipPom --> validatePom
+    validateNebulaPom --> validatePom
+    generatePomFileForPluginZipPublication --> validatePluginZipPom
+    generatePomFileForNebulaPublication --> validatePluginZipPom
+    generatePomFileForNebulaPublication --> validateNebulaPom
+    generatePomFileForPluginZipPublication --> validateNebulaPom
     forbiddenApisTest --> forbiddenApis
+    forbiddenApisTestFixtures --> forbiddenApis
     forbiddenApisMain --> forbiddenApis
-    testFixturesClasses --> forbiddenApisTestFixtures
-    jar --> forbiddenApisTestFixtures
-    forbiddenApisResources --> forbiddenApisTestFixtures
     testClasses --> forbiddenApisTest
     testFixturesJar --> forbiddenApisTest
     jar --> forbiddenApisTest
     forbiddenApisResources --> forbiddenApisTest
+    testFixturesClasses --> forbiddenApisTestFixtures
+    jar --> forbiddenApisTestFixtures
+    forbiddenApisResources --> forbiddenApisTestFixtures
     jar --> forbiddenApisMain
     forbiddenApisResources --> forbiddenApisMain
+    thirdPartyAuditResources --> thirdPartyAudit
     testClasses --> testingConventions
     testFixturesJar --> testingConventions
     jar --> testingConventions
-    validateNebulaPom --> validatePom
-    validatePluginZipPom --> validatePom
-    generatePomFileForNebulaPublication --> validateNebulaPom
-    generatePomFileForPluginZipPublication --> validateNebulaPom
-    generatePomFileForPluginZipPublication --> validatePluginZipPom
-    generatePomFileForNebulaPublication --> validatePluginZipPom
     compileTestJava --> loggerUsageCheck
-    javadocJar --> assemble
-    sourcesJar --> assemble
+    testClasses --> jarHell
+    testFixturesJar --> jarHell
+    jar --> jarHell
+    bundlePlugin --> integTest
+    test --> integTest
+    pluginProperties --> bundlePlugin
+    jar --> bundlePlugin
+    generateNotice --> bundlePlugin
+    delombok --> javadoc
+    compileJava --> delombok
     bundlePlugin --> assemble
     generatePom --> assemble
-    javadoc --> javadocJar
+    sourcesJar --> assemble
+    javadocJar --> assemble
     generatePomFileForPluginZipPublication --> generatePom
     generatePomFileForNebulaPublication --> generatePom
+    javadoc --> javadocJar
+    jar ==> validateLibraryUsage
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,27 @@ if (!usingRemoteCluster) {
     }
 }
 
+tasks.register('validateLibraryUsage') {
+    dependsOn compileJava
+    doLast {
+        fileTree('build/classes').include('**/*.class').each { classFile ->
+            if (classFile.absolutePath.contains('KNNLibraryLoader')) return
+
+            def bytes = classFile.bytes
+            def foundLoadLibrary = scanForLoadLibrary(bytes)
+
+            if (foundLoadLibrary) {
+                throw new GradleException("System.loadLibrary call found in ${classFile.absolutePath}. Add any JNI library loading functionality into KNNLibraryLoader!")
+            }
+        }
+    }
+}
+
+static def scanForLoadLibrary(byte[] classBytes) {
+    def bytesAsString = new String(classBytes, "ISO-8859-1")
+    return bytesAsString.contains("java/lang/System") && bytesAsString.contains("loadLibrary")
+}
+
 check.dependsOn spotlessCheck
 check.dependsOn jacocoTestReport
 
@@ -356,19 +377,23 @@ tasks.register('generateTaskGraph') {
         def taskDeps = [:]
         def mustRunAfter = [:]
         
+        def finalizedBy = [:]
+        
         def collectDeps
         collectDeps = { task ->
             if (taskDeps.containsKey(task.name)) return
             
             def deps = task.taskDependencies.getDependencies(task)
             def mustRunAfterTasks = task.mustRunAfter.getDependencies(task)
+            def finalizedByTasks = task.finalizedBy.getDependencies(task)
             
+            finalizedBy[task.name] = finalizedByTasks.collect { it.name }.findAll { it != task.name }
 
             // Combine regular dependencies and mustRunAfter, filter out self-dependencies
             def allDeps = (deps + mustRunAfterTasks).collect { it.name }.unique().findAll { it != task.name }
             taskDeps[task.name] = allDeps
             
-            (deps + mustRunAfterTasks).each { collectDeps(it) }
+            (deps + mustRunAfterTasks + finalizedByTasks).each { collectDeps(it) }
         }
         
         collectDeps(buildTask)
@@ -422,6 +447,13 @@ tasks.register('generateTaskGraph') {
         reducedDeps.each { taskName, deps ->
             deps.each { dep ->
                 mermaid << "    ${dep} --> ${taskName}"
+            }
+        }
+        
+        // Generate bold arrows for finalizedBy relationships
+        finalizedBy.each { taskName, finalizedTasks ->
+            finalizedTasks.each { finalizedTask ->
+                mermaid << "    ${taskName} ==> ${finalizedTask}"
             }
         }
         
@@ -533,6 +565,8 @@ tasks.register('buildJniLib', Exec) {
     logger.lifecycle("Build command: ${args.join(' ')}")
     commandLine args
 }
+
+jar.finalizedBy validateLibraryUsage
 
 tasks.register('buildJniTest', Test) {
     dependsOn buildJniLib


### PR DESCRIPTION
### Description
Added new gradle task validateLibraryUsage so that System.loadLibrary cannot be run outside of KNNLibraryLoader

### Related Issues
Makes sure that #3005 does not happen again

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
