### PR TITLE
Update validation for cases when k is greater than total results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * Fix indexing for 16x and 8x compression [#3019](https://github.com/opensearch-project/k-NN/pull/3019)
 * Block index creation for Faiss engine with cosine similarity and byte vectors due to normalization incompatibility [#3002](https://github.com/opensearch-project/k-NN/pull/3002)
+* Update validation for cases when k is greater than total results [#3038](https://github.com/opensearch-project/k-NN/pull/3038)
 
 ### Refactoring
 * Change ordering of build task and added tests to catch uninitialized libraries [#3024](https://github.com/opensearch-project/k-NN/pull/3024)

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/optimistic/OptimisticSearchStrategyUtils.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/optimistic/OptimisticSearchStrategyUtils.java
@@ -51,7 +51,7 @@ public class OptimisticSearchStrategyUtils {
      *                      used for boundary checks or optimizations
      * @return the score value that would appear at position {@code k} if all scores
      *         were globally sorted in descending order
-     * @throws IllegalArgumentException if {@code k} is less than 1 or greater than {@code totalResults}
+     * @throws IllegalArgumentException if either {@code k} or {@code totalResults} is less than 1
      */
     public static float findKthLargestScore(final List<PerLeafResult> results, final int k, final int totalResults) {
         if (totalResults <= 0) {
@@ -60,11 +60,8 @@ public class OptimisticSearchStrategyUtils {
         if (k <= 0) {
             throw new IllegalArgumentException("K must be greater than zero, got=" + k);
         }
-        if (k > totalResults) {
-            throw new IllegalArgumentException("K must be less than total results, got=" + k + ", totalResults=" + totalResults);
-        }
 
-        // If fewer than k scores, return the minimum score
+        // If fewer than or equal to k scores, return the minimum score
         if (totalResults <= k) {
             float min = Float.MAX_VALUE;
             for (final PerLeafResult result : results) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/OptimisticSearchStrategyUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/OptimisticSearchStrategyUtilsTests.java
@@ -68,7 +68,6 @@ public class OptimisticSearchStrategyUtilsTests {
     public void testInvalidK() {
         List<PerLeafResult> results = List.of(perLeaf(1.0f, 2.0f));
         assertThrows(IllegalArgumentException.class, () -> findKthLargestScore(results, 0, 2));
-        assertThrows(IllegalArgumentException.class, () -> findKthLargestScore(results, 3, 2));
     }
 
     @Test
@@ -89,5 +88,13 @@ public class OptimisticSearchStrategyUtilsTests {
         List<PerLeafResult> results = List.of(perLeaf(10f, 9f, 8f), perLeaf(7f, 6f), perLeaf(5f, 4f));
         // Combined sorted: [10, 9, 8, 7, 6, 5, 4]
         assertEquals(4f, findKthLargestScore(results, 7, 7), 1e-6);
+    }
+
+    @Test
+    public void testTotalResultsLessThanK() {
+        List<PerLeafResult> results = List.of(perLeaf(9.0f, 7.0f), perLeaf(5.0f));
+        // When totalResults < k, should return minimum score
+        float score = findKthLargestScore(results, 5, 3);
+        assertEquals(5.0f, score, 1e-6);
     }
 }


### PR DESCRIPTION
### Description
It is acceptable scenario if a segment has less numner of results than K. In that case, we will find the min score from available results.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
#3017 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
