### PR TITLE
Force NORMAL read advice for .vec file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 * Index setting to disable exact search after ANN Search with Faiss efficient filters [#3022](https://github.com/opensearch-project/k-NN/pull/3022)
+* Force NORMAL read advice for .vec file [#3041](https://github.com/opensearch-project/k-NN/pull/3041)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -20,15 +20,10 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
-import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
-import org.apache.lucene.store.DataAccessHint;
-import org.apache.lucene.store.FileDataHint;
-import org.apache.lucene.store.FileTypeHint;
-import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.IOUtils;
@@ -60,26 +55,22 @@ import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.KNN_FIELD;
  */
 @Log4j2
 public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
+    private static final int RESERVE_TWICE_SPACE = 2;
+    private static final float SUFFICIENT_LOAD_FACTOR = 0.6f;
 
     private final FlatVectorsReader flatVectorsReader;
     private Map<String, String> quantizationStateCacheKeyPerField;
     private final SegmentReadState segmentReadState;
     private final List<String> cacheKeys;
-    private volatile VectorSearcherHolder vectorSearcherHolder;
-    // This lock object ensure that only one thread can initialize vectorSearcherHolder object.
-    // This is needed since we are mappings graphs to memory for memory optimized search lazily. But once we make it eager
-    // the lock object will not be needed
-    private final Object vectorSearcherHolderLockObject;
-    private final IOContext ioContext;
+    private volatile Map<String, VectorSearcherHolder> vectorSearchers;
 
     public NativeEngines990KnnVectorsReader(final SegmentReadState state, final FlatVectorsReader flatVectorsReader) {
         this.flatVectorsReader = flatVectorsReader;
         this.segmentReadState = state;
         this.cacheKeys = getVectorCacheKeysFromSegmentReaderState(state);
-        ioContext = state.context.withHints(FileTypeHint.DATA, FileDataHint.KNN_VECTORS, DataAccessHint.RANDOM);
+
         loadCacheKeyMap();
-        vectorSearcherHolder = new VectorSearcherHolder();
-        vectorSearcherHolderLockObject = new Object();
+        fillVectorSearcherTable();
     }
 
     /**
@@ -144,7 +135,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
      *                     if they are all allowed to match.
      */
     @Override
-    public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+    public void search(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
         // TODO: This is a temporary hack where we are using KNNCollector to initialize the quantization state.
         if (knnCollector instanceof QuantizationConfigKNNCollector) {
             String cacheKey = quantizationStateCacheKeyPerField.get(field);
@@ -161,6 +152,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             ((QuantizationConfigKNNCollector) knnCollector).setQuantizationState(quantizationState);
             return;
         }
+
         if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, true)) {
             return;
         }
@@ -194,8 +186,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
      *                     if they are all allowed to match.
      */
     @Override
-    public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-        // searching with byte vector is not supported by ADC.
+    public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
         if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, false)) {
             return;
         }
@@ -226,10 +217,11 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         final List<Closeable> closeables = new ArrayList<>();
         closeables.add(flatVectorsReader);
 
-        // Close Vector Search
-        if (vectorSearcherHolder != null) {
-            // We don't need to check if VectorSearcher is null or not because during close IoUtils checks it
-            closeables.add(vectorSearcherHolder.getVectorSearcher());
+        // Close vector searchers if loaded.
+        if (vectorSearchers != null) {
+            closeables.addAll(
+                vectorSearchers.values().stream().filter(VectorSearcherHolder::isSet).map(VectorSearcherHolder::getVectorSearcher).toList()
+            );
         }
 
         IOUtils.close(closeables);
@@ -247,7 +239,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         final String field,
         final Object target,
         final KnnCollector knnCollector,
-        final AcceptDocs acceptDocs,
+        final Bits acceptDocs,
         final boolean isFloatVector
     ) throws IOException {
         // Try with memory optimized searcher
@@ -272,6 +264,20 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         }
     }
 
+    private void fillVectorSearcherTable() {
+        // We need sufficient memory space for this table as it will be queried for every single search.
+        // Hence, having larger space to approximate a perfect hash here.
+        vectorSearchers = new HashMap<>(RESERVE_TWICE_SPACE * segmentReadState.fieldInfos.size(), SUFFICIENT_LOAD_FACTOR);
+
+        for (final FieldInfo fieldInfo : segmentReadState.fieldInfos) {
+            final IOSupplier<VectorSearcher> searcherIOSupplier = getVectorSearcherSupplier(fieldInfo);
+            if (searcherIOSupplier != null) {
+                // This field type is supported
+                vectorSearchers.put(fieldInfo.getName(), new VectorSearcherHolder());
+            }
+        }
+    }
+
     private static List<String> getVectorCacheKeysFromSegmentReaderState(SegmentReadState segmentReadState) {
         final List<String> cacheKeys = new ArrayList<>();
 
@@ -288,28 +294,48 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
     }
 
     private VectorSearcher loadMemoryOptimizedSearcherIfRequired(final String fieldName) {
-        if (vectorSearcherHolder.isSet()) {
-            return vectorSearcherHolder.getVectorSearcher();
+        final VectorSearcherHolder searcherHolder = vectorSearchers.get(fieldName);
+        if (searcherHolder == null) {
+            // This is not KNN field or unsupported field.
+            return null;
         }
 
-        synchronized (vectorSearcherHolderLockObject) {
-            if (vectorSearcherHolder.isSet()) {
-                return vectorSearcherHolder.getVectorSearcher();
+        if (searcherHolder.isSet()) {
+            return searcherHolder.getVectorSearcher();
+        }
+
+        synchronized (searcherHolder) {
+            if (searcherHolder.isSet()) {
+                return searcherHolder.getVectorSearcher();
             }
-            final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(fieldName);
-            final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
-            // It's supported. There can be a case where a certain index type underlying is not yet supported while
-            // KNNEngine itself supports memory optimized searching.
-            if (searcherSupplier != null) {
-                try {
-                    vectorSearcherHolder.setVectorSearcher(searcherSupplier.get());
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+
+            VectorSearcher searcher = null;
+
+            try {
+                final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(fieldName);
+                if (fieldInfo != null) {
+                    final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
+                    if (searcherSupplier != null) {
+                        searcher = searcherSupplier.get();
+                        if (searcher != null) {
+                            // It's supported. There can be a case where a certain index type underlying is not yet supported while
+                            // KNNEngine
+                            // itself supports memory optimized searching.
+                            searcherHolder.setVectorSearcher(searcher);
+                        }
+                    }
                 }
-            } else {
-                log.error("Failed to load memory optimized searcher for field [{}]", fieldName);
+
+                return searcher;
+            } catch (Exception e) {
+                // Close opened searchers first, then suppress
+                try {
+                    IOUtils.closeWhileHandlingException(searcher);
+                } catch (Exception closeException) {
+                    log.error(closeException.getMessage(), closeException);
+                }
+                throw new RuntimeException(e);
             }
-            return vectorSearcherHolder.getVectorSearcher();
         }
     }
 
@@ -319,6 +345,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         if (attributes == null || attributes.containsKey(KNN_FIELD) == false) {
             return null;
         }
+
         // Try to get KNN engine from fieldInfo.
         final KNNEngine knnEngine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
 
@@ -337,7 +364,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         // Start creating searcher
         final String fileName = KNNCodecUtil.getNativeEngineFileFromFieldInfo(fieldInfo, segmentReadState.segmentInfo);
         if (fileName != null) {
-            return () -> searcherFactory.createVectorSearcher(segmentReadState.directory, fileName, fieldInfo, ioContext);
+            return () -> searcherFactory.createVectorSearcher(segmentReadState.directory, fileName);
         }
 
         // Not supported


### PR DESCRIPTION
### Description
This PR is to force using NORMAL read advice for .vec file to disable Lucene's default RANDOM access read advice which degrades exact search performance.

Please see https://github.com/opensearch-project/k-NN/issues/3043 for more details.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
