### PR TITLE
Reinstate RRIT after fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 * Added gradle task to generate task dependency graph ([#3032](https://github.com/opensearch-project/k-NN/pull/3032))
 * Added new gradle task validateLibraryUsage so that System.loadLibrary cannot be run outside KNNLibraryLoader ([#3033](https://github.com/opensearch-project/k-NN/pull/3033))
+* Adds RandomRotationIT back ([#3052](https://github.com/opensearch-project/k-NN/pull/3052))
 
 ### Bug Fixes
 * Fix indexing for 16x and 8x compression [#3019](https://github.com/opensearch-project/k-NN/pull/3019)

--- a/src/test/java/org/opensearch/knn/index/RandomRotationIT.java
+++ b/src/test/java/org/opensearch/knn/index/RandomRotationIT.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableList;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.Ignore;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -110,8 +109,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         return responseBody;
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testRandomRotation() {
         String responseControl = makeQBitIndex(QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, false);
@@ -127,8 +124,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         assertEquals(3, testFirstHitId);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSourceConsistencyRRvsNonRR() {
         String rrIndex = "rr-index";
@@ -193,8 +188,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(nonRrIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSourceConsistencyRRReindexToRR() {
         String sourceIndex = "rr-source";
@@ -245,8 +238,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(destIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSourceConsistencyReindexToNonRR() {
         String rrIndex = "rr-source";
@@ -315,8 +306,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(nonRrIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testReindexNonRRToRROrderChange() {
         String nonRrIndex = "non-rr-source";
@@ -387,8 +376,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(rrIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSnapshotRestoreConsistency() {
         String indexName = "rr-snapshot-test-" + randomLowerCaseString();


### PR DESCRIPTION
### Description
RandomRotationIT was causing failures in OpenSearch release build due to a deeper issue #3016 . These tests were ignored in PR #3014. Now that the deeper issue is fixed, we can reinstate these tests.

### Related Issues
Resolves #3016

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
