### PR TITLE
Reenable reindex ITs, using async reindex + polling and search source…

### DIFF
--- a/src/test/java/org/opensearch/knn/index/RandomRotationIT.java
+++ b/src/test/java/org/opensearch/knn/index/RandomRotationIT.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableList;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.Ignore;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -110,8 +109,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         return responseBody;
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testRandomRotation() {
         String responseControl = makeQBitIndex(QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, false);
@@ -127,12 +124,10 @@ public class RandomRotationIT extends KNNRestTestCase {
         assertEquals(3, testFirstHitId);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSourceConsistencyRRvsNonRR() {
-        String rrIndex = "rr-index";
-        String nonRrIndex = "non-rr-index";
+        String rrIndex = "source-consistency-rr-index";
+        String nonRrIndex = "source-consistency-non-rr-index";
 
         makeOnlyQBitIndex(rrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
         makeOnlyQBitIndex(nonRrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, false, SpaceType.INNER_PRODUCT);
@@ -193,12 +188,10 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(nonRrIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSourceConsistencyRRReindexToRR() {
-        String sourceIndex = "rr-source";
-        String destIndex = "rr-dest";
+        String sourceIndex = "rr2rr-source-" + randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
+        String destIndex = "rr2rr-dest-" + randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
 
         makeOnlyQBitIndex(sourceIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
 
@@ -208,10 +201,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         }
 
         forceMergeKnnIndex(sourceIndex);
-
-        makeOnlyQBitIndex(destIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
-        reindex(sourceIndex, destIndex);
-        forceMergeKnnIndex(destIndex);
 
         float[] query = { 0.25f, -1.0f };
         XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
@@ -226,8 +215,14 @@ public class RandomRotationIT extends KNNRestTestCase {
             .endObject()
             .endObject();
 
-        String sourceResponse = EntityUtils.toString(searchKNNIndex(sourceIndex, queryBuilder, 10).getEntity());
-        String destResponse = EntityUtils.toString(searchKNNIndex(destIndex, queryBuilder, 10).getEntity());
+        // Search source BEFORE reindex
+        String sourceResponse = EntityUtils.toString(searchKNNIndexWithRetry(sourceIndex, queryBuilder.toString(), 10).getEntity());
+
+        makeOnlyQBitIndex(destIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
+        reindexWithRetry(sourceIndex, destIndex);
+        forceMergeKnnIndex(destIndex);
+
+        String destResponse = EntityUtils.toString(searchKNNIndexWithRetry(destIndex, queryBuilder.toString(), 10).getEntity());
 
         List<Object> sourceHits = parseSearchResponseHits(sourceResponse);
         List<Object> destHits = parseSearchResponseHits(destResponse);
@@ -245,12 +240,10 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(destIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSourceConsistencyReindexToNonRR() {
-        String rrIndex = "rr-source";
-        String nonRrIndex = "non-rr-dest";
+        String rrIndex = "rr2nonrr-source-" + randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
+        String nonRrIndex = "rr2nonrr-dest-" + randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
 
         makeOnlyQBitIndex(rrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
 
@@ -260,10 +253,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         }
 
         forceMergeKnnIndex(rrIndex);
-
-        makeOnlyQBitIndex(nonRrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, false, SpaceType.INNER_PRODUCT);
-        reindex(rrIndex, nonRrIndex);
-        forceMergeKnnIndex(nonRrIndex);
 
         float[] query = { 0.25f, -1.0f };
         XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
@@ -278,19 +267,18 @@ public class RandomRotationIT extends KNNRestTestCase {
             .endObject()
             .endObject();
 
-        String rrResponse = EntityUtils.toString(searchKNNIndex(rrIndex, queryBuilder, 10).getEntity());
-        String nonRrResponse = EntityUtils.toString(searchKNNIndex(nonRrIndex, queryBuilder, 10).getEntity());
+        // Search source BEFORE reindex
+        String rrResponse = EntityUtils.toString(searchKNNIndexWithRetry(rrIndex, queryBuilder.toString(), 10).getEntity());
+
+        makeOnlyQBitIndex(nonRrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, false, SpaceType.INNER_PRODUCT);
+        reindexWithRetry(rrIndex, nonRrIndex);
+        forceMergeKnnIndex(nonRrIndex);
+
+        String nonRrResponse = EntityUtils.toString(searchKNNIndexWithRetry(nonRrIndex, queryBuilder.toString(), 10).getEntity());
 
         List<Object> rrHits = parseSearchResponseHits(rrResponse);
         List<Object> nonRrHits = parseSearchResponseHits(nonRrResponse);
 
-        // for (int i = 0; i < rrHits.size(); i++) {
-        // Map<String, Object> rrHit = (Map<String, Object>) rrHits.get(i);
-        // Map<String, Object> nonRrHit = (Map<String, Object>) nonRrHits.get(i);
-        // assertVectorEquals((List<Double>) ((Map<String, Object>) rrHit.get("_source")).get(TEST_FIELD_NAME),
-        // (List<Double>) ((Map<String, Object>) nonRrHit.get("_source")).get(TEST_FIELD_NAME));
-        // }
-        //
         // Verify source vectors are the same using document ID mapping
         Map<String, List<Double>> nonRrVectorMap = nonRrHits.stream()
             .collect(
@@ -315,12 +303,10 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(nonRrIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testReindexNonRRToRROrderChange() {
-        String nonRrIndex = "non-rr-source";
-        String rrIndex = "rr-dest";
+        String nonRrIndex = "order-change-non-rr-source";
+        String rrIndex = "order-change-rr-dest";
 
         makeOnlyQBitIndex(nonRrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, false, SpaceType.INNER_PRODUCT);
 
@@ -334,10 +320,6 @@ public class RandomRotationIT extends KNNRestTestCase {
 
         forceMergeKnnIndex(nonRrIndex);
 
-        makeOnlyQBitIndex(rrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
-        reindex(nonRrIndex, rrIndex);
-        forceMergeKnnIndex(rrIndex);
-
         float[] query = { 0.25f, -1.0f };
         XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
             .startObject()
@@ -350,8 +332,12 @@ public class RandomRotationIT extends KNNRestTestCase {
             .endObject()
             .endObject()
             .endObject();
-
         String nonRrResponse = EntityUtils.toString(searchKNNIndex(nonRrIndex, queryBuilder, 3).getEntity());
+
+        makeOnlyQBitIndex(rrIndex, QFrameBitEncoder.ENABLE_RANDOM_ROTATION_PARAM, 2, 1, true, SpaceType.INNER_PRODUCT);
+        reindex(nonRrIndex, rrIndex);
+        forceMergeKnnIndex(rrIndex);
+
         String rrResponse = EntityUtils.toString(searchKNNIndex(rrIndex, queryBuilder, 3).getEntity());
 
         List<Object> nonRrHits = parseSearchResponseHits(nonRrResponse);
@@ -387,8 +373,6 @@ public class RandomRotationIT extends KNNRestTestCase {
         deleteKNNIndex(rrIndex);
     }
 
-    // Tests are failing on ci-runner without error and passing locally. Flaky ignored for now.
-    @Ignore
     @SneakyThrows
     public void testSnapshotRestoreConsistency() {
         String indexName = "rr-snapshot-test-" + randomLowerCaseString();


### PR DESCRIPTION
… index before reindex.

### Description
#### Problem
Two integration tests (`testSourceConsistencyReindexToNonRR` and `testSourceConsistencyRRReindexToRR`) were failing on CI with `503 Service Unavailable` errors but passing locally.

#### Root Cause Analysis
From CI logs, the failure occurred when searching the source index (`rr-source`) after reindex operations. The `503` error with `"all shards failed"` indicated the source index shard became unavailable.

Contributing factors:
1. **Index name collision** - Both tests used the same index name `rr-source`, risking state pollution between tests
2. **Search timing** - Source index was searched after reindex+forceMerge operations, which could corrupt/close shards on resource-constrained CI runners
3. **Remote index build fallback** - Random enabling of remote build without repository setup caused `RepositoryMissingException` during flush/merge

#### Changes Made

##### RandomRotationIT.java
1. **Unique index names per test** - Changed from static `rr-source` to `rr2rr-source-{random}` and `rr2nonrr-source-{random}`
2. **Search source before reindex** - Moved source index search to before the reindex operation to avoid post-reindex shard issues
3. **Use retry methods** - Call `searchKNNIndexWithRetry` and `reindexWithRetry` for resilience

##### KNNRestTestCase.java
1. **Added `searchKNNIndexWithRetry`** - Retries search up to 5 times with 2s delay on 503 errors
2. **Added `reindexWithRetry`** - Async reindex with task polling for completion

### Related Issues
Resolves #3016 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
