### PR TITLE
fix: Use pypi for codecov to address glibc error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,9 +97,10 @@ jobs:
 
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          use_pypi: true
 
   Build-k-NN-MacOS:
     strategy:


### PR DESCRIPTION
### Description
Fixes codecov upload which has been failing since December 2024 with:
```
[PYI-11137:ERROR] Failed to load Python shared library '/tmp/_MEIVvDM9M/libpython3.9.so.1.0':
  /lib64/libm.so.6: version `GLIBC_2.29' not found
```
This matches the approach used by https://github.com/opensearch-project/neural-search/blob/main/.github/workflows/CI.yml#L57.

The codecov docs explain the `use_pypi` flag as:
> Use the pypi version of the CLI instead of from cli.codecov.io. If specified, integrity checking will be bypassed.

This pypi version should come with its own Python libraries to avoid the above error.

### Related Issues
N/A

### Check List
- [X] New functionality includes testing. 
 - Coverage is shown below.
~- [ ] New functionality has been documented.~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [X] Commits are signed per the DCO using `--signoff`.
~- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
