### PR TITLE
Changed warmup seek to use long instead of int to avoid overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add regex support to derived source transformer include / exclude check [#3031](https://github.com/opensearch-project/k-NN/pull/3031)
 * Correct ef_search parameter for Lucene engine and override mergeLeafResults to return top K results [#3037](https://github.com/opensearch-project/k-NN/pull/3037)
 * Fix efficient filtering in nested k-NN queries [#2990](https://github.com/opensearch-project/k-NN/pull/2990)
+* Changed warmup seek to use long instead of int to avoid overflow [#3067](https://github.com/opensearch-project/k-NN/pull/3067)
 
 ### Refactoring
 * Change ordering of build task and added tests to catch uninitialized libraries [#3024](https://github.com/opensearch-project/k-NN/pull/3024)

--- a/src/main/java/org/opensearch/knn/index/warmup/MemoryOptimizedSearchWarmup.java
+++ b/src/main/java/org/opensearch/knn/index/warmup/MemoryOptimizedSearchWarmup.java
@@ -86,7 +86,7 @@ public class MemoryOptimizedSearchWarmup {
 
         try (IndexInput input = directory.openInput(indexPath.toString(), IOContext.READONCE)) {
             if (input.length() != 0) {
-                for (int i = 0; i < input.length(); i += 4096) {
+                for (long i = 0; i < input.length(); i += 4096) {
                     input.seek(i);
                     input.readByte();
                 }


### PR DESCRIPTION
### Description
This PR fixes an integer overflow bug in the memory-optimized search warmup functionality that prevented proper warmup of large index files (>2GB).

### Related Issues
Resolves #3066

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
