### PR TITLE
Fix MOS reentrant search bug in byte index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix efficient filtering in nested k-NN queries [#2990](https://github.com/opensearch-project/k-NN/pull/2990)
 * Fix nested docs and exact search query when some docs has no vector field present. [#3051](https://github.com/opensearch-project/k-NN/pull/3051)
 * Changed warmup seek to use long instead of int to avoid overflow [#3067](https://github.com/opensearch-project/k-NN/pull/3067)
+* Fix memory-optimized-search reentrant search bug in byte index. [#3071](https://github.com/opensearch-project/k-NN/pull/3071)
 
 ### Refactoring
 * Change ordering of build task and added tests to catch uninitialized libraries [#3024](https://github.com/opensearch-project/k-NN/pull/3024)

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -24,13 +24,14 @@ import org.apache.lucene.search.knn.TopKnnCollectorManager;
 import org.apache.lucene.util.Bits;
 import org.opensearch.common.StopWatch;
 import org.opensearch.knn.index.KNNSettings;
-import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.query.PerLeafResult;
 import org.opensearch.knn.index.query.ResultUtil;
 import org.opensearch.knn.index.query.TopDocsDISI;
 import org.opensearch.knn.index.query.common.QueryUtils;
+import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
 import org.opensearch.knn.index.query.memoryoptsearch.MemoryOptimizedKNNWeight;
 import org.opensearch.knn.index.query.memoryoptsearch.optimistic.OptimisticSearchStrategyUtils;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
@@ -368,7 +369,7 @@ public class NativeEngineKnnVectorQuery extends Query {
             final ReentrantKnnCollectorManager reentrantCollectorManager = new ReentrantKnnCollectorManager(
                 new TopKnnCollectorManager(k, indexSearcher),
                 segmentOrdToResults,
-                knnQuery.getQueryVector(),
+                knnQuery.getVectorDataType() == VectorDataType.FLOAT ? knnQuery.getQueryVector() : knnQuery.getByteQueryVector(),
                 knnQuery.getField()
             );
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractMemoryOptimizedKnnSearchIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractMemoryOptimizedKnnSearchIT.java
@@ -57,7 +57,7 @@ import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_M
 @Log4j2
 public abstract class AbstractMemoryOptimizedKnnSearchIT extends KNNRestTestCase {
     protected static final String INDEX_NAME = "target_index";
-    protected static final int NUM_DOCUMENTS = 200;
+    protected static final int NUM_DOCUMENTS = 400;
     protected static final int TOP_K = 20;
     protected static final String EMPTY_PARAMS = "{}";
     protected static final Consumer<Settings.Builder> NO_ADDITIONAL_SETTINGS = settingsBuilder -> {};
@@ -155,7 +155,8 @@ public abstract class AbstractMemoryOptimizedKnnSearchIT extends KNNRestTestCase
         final Schema schema,
         final IndexingType indexingType,
         final boolean isRadial,
-        final boolean enableMemoryOptimizedSearch
+        final boolean enableMemoryOptimizedSearch,
+        final boolean useForceMerge
     ) {
         // Create HNSW index
         log.info("Create HNSW index, mapping=" + schema.mapping);
@@ -175,9 +176,15 @@ public abstract class AbstractMemoryOptimizedKnnSearchIT extends KNNRestTestCase
         log.info("Flushing " + INDEX_NAME);
         flushIndex(INDEX_NAME);
 
-        // Force merge
-        log.info("Force merging " + INDEX_NAME);
-        forceMergeKnnIndex(INDEX_NAME, 1);
+        if (useForceMerge) {
+            // Force merge
+            log.info("Force merging " + INDEX_NAME);
+            forceMergeKnnIndex(INDEX_NAME, 1);
+        } else {
+            log.info("Skipping force merging");
+        }
+
+        refreshIndex(INDEX_NAME);
 
         // Do search tests
         doKnnSearchTest(documents, schema, indexingType, spaceType, isRadial, false, true);
@@ -198,7 +205,8 @@ public abstract class AbstractMemoryOptimizedKnnSearchIT extends KNNRestTestCase
         final IndexingType indexingType,
         final boolean isRadial
     ) {
-        doKnnSearchTest(spaceType, schema, indexingType, isRadial, true);
+        doKnnSearchTest(spaceType, schema, indexingType, isRadial, true, true);
+        doKnnSearchTest(spaceType, schema, indexingType, isRadial, true, false);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/DiskMode1xCompressionSupportedIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/DiskMode1xCompressionSupportedIT.java
@@ -34,7 +34,8 @@ public class DiskMode1xCompressionSupportedIT extends AbstractMemoryOptimizedKnn
         final Schema schema = new Schema(mappingStr, VectorDataType.FLOAT, Mode.ON_DISK, NO_ADDITIONAL_SETTINGS);
 
         // Start validate dense, sparse cases.
-        doKnnSearchTest(SpaceType.INNER_PRODUCT, schema, IndexingType.DENSE, false, false);
+        doKnnSearchTest(SpaceType.INNER_PRODUCT, schema, IndexingType.DENSE, false, false, true);
+        doKnnSearchTest(SpaceType.INNER_PRODUCT, schema, IndexingType.DENSE, false, false, false);
 
         // Even memory_opt_srch = false, it should have used LuceneOnFaiss regardless, no off-heap is expected.
         assertEquals(0, getTotalGraphsInCache());

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/OptimisticSearchTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/OptimisticSearchTests.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.PerLeafResult;
 import org.opensearch.knn.index.query.common.QueryUtils;
@@ -69,6 +70,9 @@ public class OptimisticSearchTests {
         when(knnQuery.createWeight(any(), any(), anyFloat())).thenReturn(knnWeight);
         when(knnQuery.getK()).thenReturn(DEFAULT_K);
         when(knnQuery.isMemoryOptimizedSearch()).thenReturn(true);
+        when(knnQuery.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(knnQuery.getQueryVector()).thenReturn(new float[8]);
+        when(knnQuery.getField()).thenReturn("field");
     }
 
     @Test

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/ReentrantKnnCollectorManagerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/ReentrantKnnCollectorManagerTests.java
@@ -5,11 +5,15 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import lombok.SneakyThrows;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.CompositeReaderContext;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -22,10 +26,15 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.opensearch.lucene.ReentrantKnnCollectorManager;
 
+import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyInt;
@@ -96,6 +105,146 @@ public class ReentrantKnnCollectorManagerTests {
         try (MockedStatic<FloatVectorValues> mocked = mockStatic(FloatVectorValues.class)) {
             manager.newCollector(10, searchStrategy, ctx);
             mocked.verify(() -> FloatVectorValues.checkField(reader, "vector_field"));
+        }
+    }
+
+    @Test
+    public void testByteVectorTypeNewCollector() {
+        final byte[] query = new byte[100];
+        doTestNewCollector(query);
+    }
+
+    @Test
+    public void testFloatVectorTypeNewCollector() {
+        final float[] query = new float[100];
+        doTestNewCollector(query);
+    }
+
+    @SneakyThrows
+    private void doTestNewCollector(final Object query) {
+        final KnnCollectorManager knnCollectorManager = mock(KnnCollectorManager.class);
+        final KnnCollector defaultDelegateCollector = mock(KnnCollector.class);
+        final KnnCollector seededDelegateCollector = mock(KnnCollector.class);
+        when(knnCollectorManager.newCollector(anyInt(), any(), any())).thenAnswer(invocation -> {
+            final KnnSearchStrategy searchStrategy = invocation.getArgument(1);
+            if (searchStrategy instanceof KnnSearchStrategy.Seeded) {
+                return seededDelegateCollector;
+            }
+
+            return defaultDelegateCollector;
+        });
+
+        final int n = 100;
+        final ScoreDoc[] scoreDocs = new ScoreDoc[n];
+        for (int i = 0; i < n; i++) {
+            scoreDocs[i] = new ScoreDoc(i, i);
+        }
+        final TopDocs topDocs = new TopDocs(new TotalHits(n, TotalHits.Relation.EQUAL_TO), scoreDocs);
+        final Map<Integer, TopDocs> segmentOrdToResults = Collections.singletonMap(0, topDocs);
+        final String field = "field";
+
+        final ReentrantKnnCollectorManager reentrantKnnCollectorManager = new ReentrantKnnCollectorManager(
+            knnCollectorManager,
+            segmentOrdToResults,
+            query,
+            field
+        );
+
+        // LeafReaderContext(CompositeReaderContext parent, LeafReader reader, int ord, int docBase, int leafOrd, int leafDocBase)
+        final Constructor<LeafReaderContext> ctor = LeafReaderContext.class.getDeclaredConstructor(
+            CompositeReaderContext.class,
+            LeafReader.class,
+            int.class,
+            int.class,
+            int.class,
+            int.class
+        );
+        ctor.setAccessible(true);
+
+        // Normal case when iterator is KnnVectorValues.DocIndexIterator
+        LeafReader leafReader = mock(LeafReader.class);
+        if (query instanceof float[]) {
+            final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+            final VectorScorer scorer = mock(VectorScorer.class);
+            final KnnVectorValues.DocIndexIterator docIndexIterator = mock(KnnVectorValues.DocIndexIterator.class);
+            when(scorer.iterator()).thenReturn(docIndexIterator);
+            when(floatVectorValues.scorer(any())).thenReturn(scorer);
+            when(leafReader.getFloatVectorValues(field)).thenReturn(floatVectorValues);
+        } else if (query instanceof byte[]) {
+            final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+            final VectorScorer scorer = mock(VectorScorer.class);
+            final KnnVectorValues.DocIndexIterator docIndexIterator = mock(KnnVectorValues.DocIndexIterator.class);
+            when(scorer.iterator()).thenReturn(docIndexIterator);
+            when(byteVectorValues.scorer(any())).thenReturn(scorer);
+            when(leafReader.getByteVectorValues(field)).thenReturn(byteVectorValues);
+        }
+        LeafReaderContext leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+        KnnCollector knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+
+        assertSame(seededDelegateCollector, knnCollector);
+
+        // Null values check
+        if (query instanceof float[]) {
+            try (MockedStatic<FloatVectorValues> mocked = mockStatic(FloatVectorValues.class)) {
+                mocked.when(() -> FloatVectorValues.checkField(any(LeafReader.class), anyString())).thenAnswer(invocation -> null);
+
+                leafReader = mock(LeafReader.class);
+                leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+                when(leafReader.getByteVectorValues(field)).thenReturn(null);
+                knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+                assertNull(knnCollector);
+            }
+        } else if (query instanceof byte[]) {
+            try (MockedStatic<ByteVectorValues> mocked = mockStatic(ByteVectorValues.class)) {
+                mocked.when(() -> ByteVectorValues.checkField(any(LeafReader.class), anyString())).thenAnswer(invocation -> null);
+
+                leafReader = mock(LeafReader.class);
+                leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+                when(leafReader.getByteVectorValues(field)).thenReturn(null);
+                knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+                assertNull(knnCollector);
+            }
+        }
+
+        // When `scorer` == null
+        leafReader = mock(LeafReader.class);
+        if (query instanceof float[]) {
+            final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+            when(floatVectorValues.scorer(any())).thenReturn(null);
+            when(leafReader.getFloatVectorValues(field)).thenReturn(floatVectorValues);
+            leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+            knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+            assertSame(defaultDelegateCollector, knnCollector);
+        } else if (query instanceof byte[]) {
+            final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+            when(byteVectorValues.scorer(any())).thenReturn(null);
+            when(leafReader.getByteVectorValues(field)).thenReturn(byteVectorValues);
+            leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+            knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+            assertSame(defaultDelegateCollector, knnCollector);
+        }
+
+        // When iterator is not KnnVectorValues.DocIndexIterator
+        if (query instanceof float[]) {
+            final FloatVectorValues floatVectorValues = mock(FloatVectorValues.class);
+            final VectorScorer scorer = mock(VectorScorer.class);
+            final DocIdSetIterator docIterator = mock(DocIdSetIterator.class);
+            when(scorer.iterator()).thenReturn(docIterator);
+            when(floatVectorValues.scorer(any())).thenReturn(scorer);
+            when(leafReader.getFloatVectorValues(field)).thenReturn(floatVectorValues);
+            leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+            knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+            assertSame(defaultDelegateCollector, knnCollector);
+        } else if (query instanceof byte[]) {
+            final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+            final VectorScorer scorer = mock(VectorScorer.class);
+            final DocIdSetIterator docIterator = mock(DocIdSetIterator.class);
+            when(scorer.iterator()).thenReturn(docIterator);
+            when(byteVectorValues.scorer(any())).thenReturn(scorer);
+            when(leafReader.getByteVectorValues(field)).thenReturn(byteVectorValues);
+            leafReaderContext = ctor.newInstance(null, leafReader, 0, 0, 0, 0);
+            knnCollector = reentrantKnnCollectorManager.newCollector(10000, KnnSearchStrategy.Hnsw.DEFAULT, leafReaderContext);
+            assertSame(defaultDelegateCollector, knnCollector);
         }
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/generate/Documents.java
+++ b/src/testFixtures/java/org/opensearch/knn/generate/Documents.java
@@ -162,6 +162,9 @@ public class Documents {
 
         // At least we must have 0.8 recall.
         float matchRatio = (float) matchCount / (float) results.size();
-        assertTrue("Match ratio[=" + matchRatio + "] <= 0.8", matchRatio > 0.8);
+        assertTrue(
+            "Match ratio[=" + matchRatio + "] <= 0.8, matchCount=" + matchCount + ", num results=" + results.size(),
+            matchRatio > 0.8
+        );
     }
 }


### PR DESCRIPTION
### Description
Fix reentrant search when memory optimized search is enabled for byte index.
For byte index, now it passes byte[] query, and create ByteVectorValues.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
https://github.com/opensearch-project/k-NN/issues/3069

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] Commits are signed per the DCO using `--signoff`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
