### PR TITLE
Skipping deletion of .tasks index

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -47,6 +47,7 @@ public class KNNConstants {
     public static final String MODEL_BLOB_PARAMETER = "model_blob";
     public static final String MODEL_INDEX_MAPPING_PATH = "mappings/model-index.json";
     public static final String MODEL_INDEX_NAME = ".opensearch-knn-models";
+    public static final String TASKS_INDEX_NAME = ".tasks";
     public static final String PLUGIN_NAME = "knn";
     public static final String MODEL_METADATA_FIELD = "knn-models";
     public static final Integer BYTES_PER_KILOBYTES = 1024;

--- a/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/ODFERestTestCase.java
@@ -57,6 +57,7 @@ import static org.opensearch.knn.TestUtils.SECURITY_AUDITLOG_PREFIX;
 import static org.opensearch.knn.TestUtils.SKIP_DELETE_MODEL_INDEX;
 import static org.opensearch.knn.common.KNNConstants.MODELS;
 import static org.opensearch.knn.common.KNNConstants.MODEL_INDEX_NAME;
+import static org.opensearch.knn.common.KNNConstants.TASKS_INDEX_NAME;
 
 /**
  * ODFE integration test base class to support both security disabled and enabled ODFE cluster.
@@ -218,6 +219,7 @@ public abstract class ODFERestTestCase extends OpenSearchRestTestCase {
         return indexName == null
             || OPENDISTRO_SECURITY.equals(indexName)
             || IMMUTABLE_INDEX_PREFIXES.stream().anyMatch(indexName::startsWith)
-            || MODEL_INDEX_NAME.equals(indexName);
+            || MODEL_INDEX_NAME.equals(indexName)
+            || TASKS_INDEX_NAME.equals(indexName);
     }
 }


### PR DESCRIPTION
### Description
Integration tests with security are failing for 3.5 build. since it fails to delete the index with 403 exceptions. Skipping deletion of .tasks

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
