### PR TITLE
Increase timeout to 40minutes for FaissIT.

### DIFF
--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -11,12 +11,14 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.VectorUtil;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
@@ -82,6 +84,7 @@ import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class FaissIT extends KNNRestTestCase {
     private static final String DOC_ID_1 = "doc1";
     private static final String DOC_ID_2 = "doc2";


### PR DESCRIPTION
### Description
Sometime FaissIT takes more than 20 minutes often making ITs suite failing.
Jenkins build is failing because of the reason - https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/10879/pipeline/153/
This happened time to time in the past, and we usually rerun until it makes cut.
Thus, increasing the timeout for 40 minutes to give lenient time budget for running FaissIT.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
