### PR TITLE
Fix score conversion logic for radial exact search (#3110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Added new exception type to signify expected warmup behavior [#3070](https://github.com/opensearch-project/k-NN/pull/3070)
 * Add derived source handling for when field is excluded in source on indexing [#3049](https://github.com/opensearch-project/k-NN/pull/3049)
 * Fix patch to have a valid score conversion for BinaryCagra. [#2983](https://github.com/opensearch-project/k-NN/pull/2983)
+* Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
 
 ### Refactoring
 * Change ordering of build task and added tests to catch uninitialized libraries [#3024](https://github.com/opensearch-project/k-NN/pull/3024)

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -104,9 +104,9 @@ public class ExactSearcher {
         // We need to use the given radius when memory optimized search is enabled. Since it relies on Lucene's scoring framework, the given
         // max distance is already converted min score then saved in `radius`. Thus, we don't need a score translation which does not make
         // sense as it is treating min score as a max distance otherwise.
-        final float minScore = context.isMemoryOptimizedSearchEnabled
-            ? context.getRadius()
-            : spaceType.scoreTranslation(context.getRadius());
+        // For FAISS exact search, radius is in FAISS distance space (e.g., inner product for cosine).
+        // We need to convert it to OpenSearch score space using the reverse translation.
+        final float minScore = context.isMemoryOptimizedSearchEnabled ? context.getRadius() : engine.score(context.getRadius(), spaceType);
 
         return filterDocsByMinScore(context, iterator, minScore);
     }


### PR DESCRIPTION
(cherry picked from commit e327675aa7c404ab0cac533a826bca0febb53fdd)

### Description
- Backports #3110 to 3.5

### Related Issues
Resolves backport for #3110 to 3.5
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
