### PR TITLE
[Perf-Enhancement] Use right Vector Scorer when segments are initialized using SPI and also corrected the maxConn for MOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 * Make Merge in nativeEngine can Abort [#2529](https://github.com/opensearch-project/k-NN/pull/2529)
 * Use pre-quantized vectors from native engines for exact search [#3095](https://github.com/opensearch-project/k-NN/pull/3095)
+* Use right Vector Scorer when segments are initialized using SPI and also corrected the maxConn for MOS [#3117](https://github.com/opensearch-project/k-NN/pull/3117)
 

--- a/build.gradle
+++ b/build.gradle
@@ -585,6 +585,8 @@ tasks.register('buildJniTest', Test) {
 
 test {
     dependsOn buildJniTest
+    // This will ensure that Unit test also uses optimized Vector Scorers and Pananma APIs
+    jvmArgs '--add-modules=jdk.incubator.vector'
     systemProperty 'tests.security.manager', 'false'
     systemProperty "java.library.path", "$rootDir/jni/build/release"
     //this change enables mockito-inline that supports mocking of static classes/calls

--- a/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java
@@ -8,8 +8,6 @@ package org.opensearch.knn.index.codec;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
-import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
@@ -157,11 +155,7 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
         // mapperService is already checked for null or valid instance type at caller, hence we don't need
         // addition isPresent check here.
         final int approximateThreshold = getApproximateThresholdValue();
-        return new NativeEngines990KnnVectorsFormat(
-            new Lucene99FlatVectorsFormat(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()),
-            approximateThreshold,
-            nativeIndexBuildStrategyFactory
-        );
+        return new NativeEngines990KnnVectorsFormat(approximateThreshold, nativeIndexBuildStrategyFactory);
     }
 
     private int getApproximateThresholdValue() {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHnswGraph.java
@@ -195,6 +195,9 @@ public class FaissHnswGraph extends HnswGraph {
 
     @Override
     public int maxConn() {
-        return faissHnsw.getMaxNumNeighbors();
+        // The maximum number of neighbors in bottom layer of HNSW in faiss and also in lucene is 2*M. But the
+        // expectation from this function is to return M. The factor of 2 is already taken care by Lucene in
+        // graph searcher class. Hence, we are dividing here by 2 to ensure that we return correct value of M.
+        return faissHnsw.getMaxNumNeighbors() / 2;
     }
 }


### PR DESCRIPTION
### Description

#### Enhancements

This change contains 2 improvements for Memory Optimized Search:
1. When a segment is initialized using SPI in case of shard movements or a cluster restart etc, then use the correct VectorScorer coming from `FlatVectorScorerUtil.getLucene99FlatVectorsScorer()`. This same scorer is used when segment is created for the [first time](https://github.com/opensearch-project/k-NN/blob/0495458f3832242956f72a171cd2b4e752b409c9/src/main/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormat.java#L160-L164). FlatVectorScorerUtil either returns a DefaultVectorScorer or returns a PanamaVectorScorer. For our usecases mostly we should get `PanamaVectorScorer` which is superior than `DefaultVectorScorer`
2. For Memory Optimized search, return 16 as max conn when M=16 rather than 32. Since last layer of HNSW has 2*M neighbors we were returning neighbors list size as max conn, but ideally it should be M/2 . Lucene itself takes cares of doing 2*M in [graph searcher](https://github.com/apache/lucene/blob/65d91569c6abc08bead550534c5a5d35444946a2/lucene/core/src/java/org/apache/lucene/util/hnsw/HnswGraphSearcher.java#L282-L285). This is also consistent with Lucene where they return M as [maxConn](https://github.com/apache/lucene/blob/65d91569c6abc08bead550534c5a5d35444946a2/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java#L545).

#### Bug fix
1. Fixed a bug with approximate graph threshold where if we have 2 indices with 2 different thresholds then the index which will get created at last its thresholds will be used in the older indices new segment. I added a unit test to ensure that to repro the test.
2. NativeEngine format was using Lucene engine for its max dimensions. Fixed it to use Faiss Engine. Even though both Lucene and Faiss uses 16K as max dimension so no customer impact but this is still a bug. Added UT for the same.

### Expectation
1. With change 1, we should see some improvements in latency, although it will not be drastic but it will be consistent to how Lucene works. 
2. For change 2, there should be little bit less pressure on heap per query per segment, but its a good to have optimization which may come handy in high QPS scenarios.
3. Bug fixes should now ensure that approx graph threshold is used correctly.

### Related Issues
There is no GH for this. I found these inconsistencies in the code during my code reading and deep-dive.


### Check List
- [x] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
