### PR TITLE
Made threading persistent for KNN9120PerFieldKnnVectorsFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Improve unit tests by tightening asserts [#3112](https://github.com/opensearch-project/k-NN/pull/3112)
 
 ### Bug Fixes
+* Fix thread leak in HNSW merge executor caused by per-call thread pool creation [#3119](https://github.com/opensearch-project/k-NN/pull/3119)
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
 
 ### Refactoring

--- a/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatPropertyBasedTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatPropertyBasedTests.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Property-based tests for KNN9120PerFieldKnnVectorsFormat's getMergeThreadCountAndExecutorService method.
+ */
+public class KNN9120PerFieldKnnVectorsFormatPropertyBasedTests extends KNNTestCase {
+
+    private static final int MIN_ITERATIONS = 100;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        resetCachedExecutorState();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        resetCachedExecutorState();
+        super.tearDown();
+    }
+
+    /**
+     * Reset the static cached executor fields via reflection so tests are isolated.
+     */
+    private void resetCachedExecutorState() throws Exception {
+        Field executorField = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredField("cachedMergeExecutorService");
+        executorField.setAccessible(true);
+        ExecutorService existing = (ExecutorService) executorField.get(null);
+        if (existing != null) {
+            existing.shutdown();
+        }
+        executorField.set(null, null);
+
+        Field threadCountField = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredField("cachedMergeThreadCount");
+        threadCountField.setAccessible(true);
+        threadCountField.set(null, 0);
+    }
+
+    /**
+     * Invoke the private static synchronized getMergeThreadCountAndExecutorService method via reflection.
+     */
+    @SuppressWarnings("unchecked")
+    private Tuple<Integer, ExecutorService> invokeMergeThreadCountAndExecutorService() throws Exception {
+        Method method = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredMethod("getMergeThreadCountAndExecutorService");
+        method.setAccessible(true);
+        return (Tuple<Integer, ExecutorService>) method.invoke(null);
+    }
+
+    /**
+     * For any fixed Index_Thread_Qty > 1, multiple calls to getMergeThreadCountAndExecutorService()
+     * return the same ExecutorService instance (reference equality).
+     */
+    public void testExecutorInstanceReuse() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            resetCachedExecutorState();
+
+            int threadQty = randomIntBetween(2, 16);
+            int callCount = randomIntBetween(2, 50);
+
+            try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+                mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(threadQty);
+                mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+                // First call establishes the cached executor
+                Tuple<Integer, ExecutorService> firstResult = invokeMergeThreadCountAndExecutorService();
+                assertNotNull(
+                    "Iteration " + iteration + ": first call with threadQty=" + threadQty + " should return non-null executor",
+                    firstResult.v2()
+                );
+
+                // Subsequent calls should return the exact same instance
+                for (int call = 1; call < callCount; call++) {
+                    Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+                    assertSame(
+                        "Iteration "
+                            + iteration
+                            + ": call "
+                            + call
+                            + " of "
+                            + callCount
+                            + " with threadQty="
+                            + threadQty
+                            + " should return same executor instance (reference equality)",
+                        firstResult.v2(),
+                        result.v2()
+                    );
+                    assertEquals("Iteration " + iteration + ": thread count should match setting", Integer.valueOf(threadQty), result.v1());
+                }
+            }
+        }
+    }
+
+    /**
+     * For any two distinct values of Index_Thread_Qty both greater than 1, changing the setting
+     * from the first value to the second and calling getMergeThreadCountAndExecutorService()
+     * returns a different ExecutorService instance, and the previous instance is shut down.
+     */
+    public void testSettingChangeCausesRecreation() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            resetCachedExecutorState();
+
+            int firstThreadQty = randomIntBetween(2, 16);
+            int secondThreadQty = randomValueOtherThan(firstThreadQty, () -> randomIntBetween(2, 16));
+
+            try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+                mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(firstThreadQty);
+                mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+                // First call with the initial thread count
+                Tuple<Integer, ExecutorService> firstResult = invokeMergeThreadCountAndExecutorService();
+                assertNotNull(
+                    "Iteration " + iteration + ": first call with threadQty=" + firstThreadQty + " should return non-null executor",
+                    firstResult.v2()
+                );
+                assertEquals(
+                    "Iteration " + iteration + ": first thread count should match setting",
+                    Integer.valueOf(firstThreadQty),
+                    firstResult.v1()
+                );
+
+                ExecutorService firstExecutor = firstResult.v2();
+
+                // Change the setting to a different value
+                mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(secondThreadQty);
+
+                // Second call should produce a new executor
+                Tuple<Integer, ExecutorService> secondResult = invokeMergeThreadCountAndExecutorService();
+                assertNotNull(
+                    "Iteration " + iteration + ": second call with threadQty=" + secondThreadQty + " should return non-null executor",
+                    secondResult.v2()
+                );
+                assertEquals(
+                    "Iteration " + iteration + ": second thread count should match new setting",
+                    Integer.valueOf(secondThreadQty),
+                    secondResult.v1()
+                );
+
+                assertNotSame(
+                    "Iteration "
+                        + iteration
+                        + ": changing threadQty from "
+                        + firstThreadQty
+                        + " to "
+                        + secondThreadQty
+                        + " should produce a different executor instance",
+                    firstExecutor,
+                    secondResult.v2()
+                );
+
+                assertTrue(
+                    "Iteration "
+                        + iteration
+                        + ": old executor should be shut down after setting change from "
+                        + firstThreadQty
+                        + " to "
+                        + secondThreadQty,
+                    firstExecutor.isShutdown()
+                );
+            }
+        }
+    }
+
+    /**
+     * For any value of Index_Thread_Qty greater than 1, the ExecutorService returned by
+     * getMergeThreadCountAndExecutorService() is a ThreadPoolExecutor with getCorePoolSize()
+     * equal to that value.
+     */
+    public void testPoolSizeMatchesSetting() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            resetCachedExecutorState();
+
+            int threadQty = randomIntBetween(2, 16);
+
+            try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+                mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(threadQty);
+                mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+                Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+                assertNotNull("Iteration " + iteration + ": executor should be non-null for threadQty=" + threadQty, result.v2());
+                assertEquals(
+                    "Iteration " + iteration + ": returned thread count should match setting",
+                    Integer.valueOf(threadQty),
+                    result.v1()
+                );
+
+                assertTrue(
+                    "Iteration " + iteration + ": executor should be a ThreadPoolExecutor for threadQty=" + threadQty,
+                    result.v2() instanceof ThreadPoolExecutor
+                );
+
+                ThreadPoolExecutor poolExecutor = (ThreadPoolExecutor) result.v2();
+                assertEquals(
+                    "Iteration " + iteration + ": core pool size should equal threadQty=" + threadQty,
+                    threadQty,
+                    poolExecutor.getCorePoolSize()
+                );
+            }
+        }
+    }
+
+    /**
+     * For any number of concurrent threads calling getMergeThreadCountAndExecutorService()
+     * simultaneously (with a fixed Index_Thread_Qty > 1), every thread receives a non-null,
+     * non-shutdown ExecutorService, and all threads receive the same instance.
+     */
+    public void testConcurrentAccessSafety() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            resetCachedExecutorState();
+
+            int threadQty = randomIntBetween(2, 16);
+            int concurrencyLevel = randomIntBetween(2, 20);
+
+            try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+                mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(threadQty);
+                mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+                // Prime the cache in the main thread where MockedStatic is active.
+                Tuple<Integer, ExecutorService> primed = invokeMergeThreadCountAndExecutorService();
+                assertNotNull("Iteration " + iteration + ": primed executor should be non-null for threadQty=" + threadQty, primed.v2());
+
+                // Spawn concurrent threads. Each thread creates its own MockedStatic scope
+                // so that KNNSettings.getIndexThreadQty() returns the same threadQty value,
+                // ensuring the synchronized method hits the cached path.
+                CyclicBarrier barrier = new CyclicBarrier(concurrencyLevel);
+                ExecutorService testExecutor = Executors.newFixedThreadPool(concurrencyLevel);
+                final int capturedThreadQty = threadQty;
+
+                try {
+                    List<Future<Tuple<Integer, ExecutorService>>> futures = new ArrayList<>(concurrencyLevel);
+                    for (int t = 0; t < concurrencyLevel; t++) {
+                        futures.add(testExecutor.submit(() -> {
+                            try (MockedStatic<KNNSettings> threadMock = Mockito.mockStatic(KNNSettings.class)) {
+                                threadMock.when(KNNSettings::getIndexThreadQty).thenReturn(capturedThreadQty);
+                                threadMock.when(KNNSettings::state).thenCallRealMethod();
+                                barrier.await();
+                                return invokeMergeThreadCountAndExecutorService();
+                            }
+                        }));
+                    }
+
+                    List<Tuple<Integer, ExecutorService>> results = new ArrayList<>(concurrencyLevel);
+                    for (Future<Tuple<Integer, ExecutorService>> future : futures) {
+                        results.add(future.get());
+                    }
+
+                    for (int i = 0; i < results.size(); i++) {
+                        Tuple<Integer, ExecutorService> result = results.get(i);
+                        assertNotNull(
+                            "Iteration " + iteration + ": concurrent thread " + i + " should have non-null executor",
+                            result.v2()
+                        );
+                        assertFalse(
+                            "Iteration " + iteration + ": concurrent thread " + i + " executor should not be shut down",
+                            result.v2().isShutdown()
+                        );
+                        assertSame(
+                            "Iteration " + iteration + ": concurrent thread " + i + " should receive same executor instance as primed",
+                            primed.v2(),
+                            result.v2()
+                        );
+                        assertEquals(
+                            "Iteration " + iteration + ": concurrent thread " + i + " thread count should match setting",
+                            Integer.valueOf(capturedThreadQty),
+                            result.v1()
+                        );
+                    }
+                } finally {
+                    testExecutor.shutdown();
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN9120Codec;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.KNNSettings;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Unit tests for boundary conditions in KNN9120PerFieldKnnVectorsFormat's
+ * getMergeThreadCountAndExecutorService method.
+ */
+public class KNN9120PerFieldKnnVectorsFormatTests extends KNNTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        resetCachedExecutorState();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        resetCachedExecutorState();
+        super.tearDown();
+    }
+
+    /**
+     * Reset the static cached executor fields via reflection so tests are isolated.
+     */
+    private void resetCachedExecutorState() throws Exception {
+        Field executorField = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredField("cachedMergeExecutorService");
+        executorField.setAccessible(true);
+        ExecutorService existing = (ExecutorService) executorField.get(null);
+        if (existing != null) {
+            existing.shutdown();
+        }
+        executorField.set(null, null);
+
+        Field threadCountField = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredField("cachedMergeThreadCount");
+        threadCountField.setAccessible(true);
+        threadCountField.set(null, 0);
+    }
+
+    /**
+     * Invoke the private static synchronized getMergeThreadCountAndExecutorService method via reflection.
+     */
+    @SuppressWarnings("unchecked")
+    private Tuple<Integer, ExecutorService> invokeMergeThreadCountAndExecutorService() throws Exception {
+        Method method = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredMethod("getMergeThreadCountAndExecutorService");
+        method.setAccessible(true);
+        return (Tuple<Integer, ExecutorService>) method.invoke(null);
+    }
+
+    /**
+     * When Index_Thread_Qty = 1, the method should return (1, null).
+     */
+    public void testGetMergeThreadCount_whenThreadQtyIsOne_thenReturnsDefaultTuple() throws Exception {
+        try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+            mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(1);
+            mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+            Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+            assertEquals(Integer.valueOf(1), result.v1());
+            assertNull(result.v2());
+        }
+    }
+
+    /**
+     * When Index_Thread_Qty = 0, the method should return (1, null).
+     */
+    public void testGetMergeThreadCount_whenThreadQtyIsZero_thenReturnsDefaultTuple() throws Exception {
+        try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+            mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(0);
+            mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+            Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+            assertEquals(Integer.valueOf(1), result.v1());
+            assertNull(result.v2());
+        }
+    }
+
+    /**
+     * When Index_Thread_Qty transitions from > 1 to <= 1, the cached executor should be shut down.
+     */
+    public void testGetMergeThreadCount_whenTransitionFromHighToLow_thenShutsCachedExecutor() throws Exception {
+        try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+            mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+            // First call with thread qty > 1 to create a cached executor
+            mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(4);
+            Tuple<Integer, ExecutorService> highResult = invokeMergeThreadCountAndExecutorService();
+            ExecutorService createdExecutor = highResult.v2();
+            assertNotNull(createdExecutor);
+            assertFalse(createdExecutor.isShutdown());
+
+            // Now transition to thread qty <= 1
+            mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(1);
+            Tuple<Integer, ExecutorService> lowResult = invokeMergeThreadCountAndExecutorService();
+
+            assertEquals(Integer.valueOf(1), lowResult.v1());
+            assertNull(lowResult.v2());
+            // The previously cached executor should now be shut down
+            assertTrue(createdExecutor.isShutdown());
+        }
+    }
+
+    /**
+     * When Index_Thread_Qty transitions from <= 1 to > 1, a new executor should be created.
+     */
+    public void testGetMergeThreadCount_whenTransitionFromLowToHigh_thenCreatesNewExecutor() throws Exception {
+        try (MockedStatic<KNNSettings> mockedSettings = Mockito.mockStatic(KNNSettings.class)) {
+            mockedSettings.when(KNNSettings::state).thenCallRealMethod();
+
+            // First call with thread qty <= 1
+            mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(1);
+            Tuple<Integer, ExecutorService> lowResult = invokeMergeThreadCountAndExecutorService();
+            assertNull(lowResult.v2());
+
+            // Now transition to thread qty > 1
+            mockedSettings.when(KNNSettings::getIndexThreadQty).thenReturn(4);
+            Tuple<Integer, ExecutorService> highResult = invokeMergeThreadCountAndExecutorService();
+
+            assertEquals(Integer.valueOf(4), highResult.v1());
+            assertNotNull(highResult.v2());
+            assertFalse(highResult.v2().isShutdown());
+            assertTrue(highResult.v2() instanceof ThreadPoolExecutor);
+            assertEquals(4, ((ThreadPoolExecutor) highResult.v2()).getCorePoolSize());
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fix thread leak in HNSW merge executor

KNN9120PerFieldKnnVectorsFormat.getMergeThreadCountAndExecutorService() was creating a new Executors.newFixedThreadPool() on every invocation. Since this is called per field per segment during flush/merge, thread pools accumulated unboundedly under continuous indexing (77k+ leaked threads observed).

This PR replaces the per-call allocation with a cached singleton executor that is reused across calls and only recreated when knn.algo_param.index_thread_qty changes. The previous executor is gracefully shut down on recreation or when the setting drops to ≤ 1.

<img width="1800" height="900" alt="thread_leak_comparison" src="https://github.com/user-attachments/assets/3342c321-4604-4274-b97a-7ae978ad9a87" />


### Related Issues
Resolves (https://github.com/opensearch-project/k-NN/issues/3102)

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
