### PR TITLE
Keep a static, dynamically threaded executor to seamlessly switch between thread counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [#3093](https://github.com/opensearch-project/k-NN/pull/3093)
+* Fix thread leak in HNSW merge executor caused by per-call thread pool creation [#3120](https://github.com/opensearch-project/k-NN/pull/3120) 
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
 * Simplify DerivedSourceReaders lifecycle by removing manual ref-counting [#3138](https://github.com/opensearch-project/k-NN/pull/3138)
 * Fix lucene reduce to topK when rescoring is enabled [#3124](https://github.com/opensearch-project/k-NN/pull/3124)

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -25,6 +25,7 @@ import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.IndexModule;
+import org.opensearch.knn.index.codec.KNN1040Codec.KNN1040PerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManagerDto;
@@ -613,6 +614,8 @@ public class KNNSettings {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING, it -> {
             quantizationStateCacheManager.rebuildCache();
         });
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING, KNN1040PerFieldKnnVectorsFormat::updateMergeThreadCount);
     }
 
     /**
@@ -974,6 +977,7 @@ public class KNNSettings {
         this.clusterService = clusterService;
         this.nodeCbAttribute = Optional.empty();
         setSettingsUpdateConsumers();
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(getIndexThreadQty());
     }
 
     public static ByteSizeValue parseknnMemoryCircuitBreakerValue(String sValue, String settingName) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -11,7 +11,6 @@ import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.KNN1040BasePerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KnnVectorsFormatContext;
@@ -27,7 +26,9 @@ import org.opensearch.knn.index.engine.lucene.LuceneCodecFormatResolver;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -40,6 +41,41 @@ import java.util.function.Function;
 public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVectorsFormat {
 
     private static final Tuple<Integer, ExecutorService> DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE = Tuple.tuple(1, null);
+    private static final ThreadPoolExecutor mergeExecutor;
+    private static volatile int mergeThreadCount;
+
+    static {
+        // Use SynchronousQueue so maximumPoolSize governs actual thread creation (matching Lucene's
+        // ConcurrentMergeScheduler.CachedExecutor pattern). CallerRunsPolicy provides graceful
+        // degradation if a resize races with an in-flight merge submission.
+        mergeExecutor = new ThreadPoolExecutor(
+            0,
+            1,
+            60L,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+        mergeExecutor.allowCoreThreadTimeOut(true);
+    }
+
+    /**
+     * Called by KNNSettings when knn.algo_param.index_thread_qty changes at runtime.
+     * Resizes the shared merge executor pool without creating a new instance.
+     */
+    public static void updateMergeThreadCount(int newCount) {
+        mergeThreadCount = newCount;
+        int targetCore = Math.max(newCount, 0);
+        int targetMax = Math.max(newCount, 1);
+        // Always adjust in the safe order to avoid core > max invariant violation
+        if (targetMax >= mergeExecutor.getMaximumPoolSize()) {
+            mergeExecutor.setMaximumPoolSize(targetMax);
+            mergeExecutor.setCorePoolSize(targetCore);
+        } else {
+            mergeExecutor.setCorePoolSize(targetCore);
+            mergeExecutor.setMaximumPoolSize(targetMax);
+        }
+    }
 
     public KNN1040PerFieldKnnVectorsFormat(final Optional<MapperService> mapperService) {
         this(mapperService, new NativeIndexBuildStrategyFactory());
@@ -101,10 +137,10 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
     }
 
     private static Tuple<Integer, ExecutorService> getMergeThreadCountAndExecutorService() {
-        int mergeThreadCount = KNNSettings.getIndexThreadQty();
-        if (mergeThreadCount <= 1) {
+        int threadCount = mergeThreadCount;
+        if (threadCount <= 1) {
             return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
         }
-        return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
+        return Tuple.tuple(threadCount, mergeExecutor);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormat.java
@@ -9,7 +9,6 @@ import org.apache.lucene.backward_codecs.lucene99.Lucene99RWHnswScalarQuantizedV
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.mapper.MapperService;
-import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.backward_codecs.BasePerFieldKnnVectorsFormat;
 import org.opensearch.knn.index.codec.KNN9120Codec.KNN9120HnswBinaryVectorsFormat;
@@ -18,13 +17,50 @@ import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Class provides per field format implementation for Lucene Knn vector type
  */
 public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsFormat {
     private static final Tuple<Integer, ExecutorService> DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE = Tuple.tuple(1, null);
+    private static final ThreadPoolExecutor mergeExecutor;
+    private static volatile int mergeThreadCount;
+
+    static {
+        // Use SynchronousQueue so maximumPoolSize governs actual thread creation (matching Lucene's
+        // ConcurrentMergeScheduler.CachedExecutor pattern). CallerRunsPolicy provides graceful
+        // degradation if a resize races with an in-flight merge submission.
+        mergeExecutor = new ThreadPoolExecutor(
+            0,
+            1,
+            60L,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+        mergeExecutor.allowCoreThreadTimeOut(true);
+    }
+
+    /**
+     * Called by KNNSettings when knn.algo_param.index_thread_qty changes at runtime.
+     * Resizes the shared merge executor pool without creating a new instance.
+     */
+    public static void updateMergeThreadCount(int newCount) {
+        mergeThreadCount = newCount;
+        int targetCore = Math.max(newCount, 0);
+        int targetMax = Math.max(newCount, 1);
+        // Always adjust in the safe order to avoid core > max invariant violation
+        if (targetMax >= mergeExecutor.getMaximumPoolSize()) {
+            mergeExecutor.setMaximumPoolSize(targetMax);
+            mergeExecutor.setCorePoolSize(targetCore);
+        } else {
+            mergeExecutor.setCorePoolSize(targetCore);
+            mergeExecutor.setMaximumPoolSize(targetMax);
+        }
+    }
 
     public KNN9120PerFieldKnnVectorsFormat(final Optional<MapperService> mapperService) {
         this(mapperService, new NativeIndexBuildStrategyFactory());
@@ -93,15 +129,10 @@ public class KNN9120PerFieldKnnVectorsFormat extends BasePerFieldKnnVectorsForma
     }
 
     private static Tuple<Integer, ExecutorService> getMergeThreadCountAndExecutorService() {
-        // To ensure that only once we are fetching the settings per segment, we are fetching the num threads once while
-        // creating the executors
-        int mergeThreadCount = KNNSettings.getIndexThreadQty();
-        // We need to return null whenever the merge threads are <=1, as lucene assumes that if number of threads are 1
-        // then we should be giving a null value of the executor
-        if (mergeThreadCount <= 1) {
+        int threadCount = mergeThreadCount;
+        if (threadCount <= 1) {
             return DEFAULT_MERGE_THREAD_COUNT_AND_EXECUTOR_SERVICE;
-        } else {
-            return Tuple.tuple(mergeThreadCount, Executors.newFixedThreadPool(mergeThreadCount));
         }
+        return Tuple.tuple(threadCount, mergeExecutor);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormatPropertyBasedTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormatPropertyBasedTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.knn.KNNTestCase;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Property-based tests for KNN1040PerFieldKnnVectorsFormat's getMergeThreadCountAndExecutorService method.
+ */
+public class KNN1040PerFieldKnnVectorsFormatPropertyBasedTests extends KNNTestCase {
+
+    private static final int MIN_ITERATIONS = 100;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+        super.tearDown();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Tuple<Integer, ExecutorService> invokeMergeThreadCountAndExecutorService() throws Exception {
+        Method method = KNN1040PerFieldKnnVectorsFormat.class.getDeclaredMethod("getMergeThreadCountAndExecutorService");
+        method.setAccessible(true);
+        return (Tuple<Integer, ExecutorService>) method.invoke(null);
+    }
+
+    /**
+     * For any fixed thread count > 1, multiple calls return the same ExecutorService instance.
+     */
+    public void testExecutorInstanceReuse() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int threadQty = randomIntBetween(2, 16);
+            int callCount = randomIntBetween(2, 50);
+
+            KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(threadQty);
+
+            Tuple<Integer, ExecutorService> firstResult = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(firstResult.v2());
+
+            for (int call = 1; call < callCount; call++) {
+                Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+                assertSame(firstResult.v2(), result.v2());
+                assertEquals(Integer.valueOf(threadQty), result.v1());
+            }
+        }
+    }
+
+    /**
+     * For any two distinct thread counts > 1, changing the count resizes the same executor
+     * and the pool size matches the new value.
+     */
+    public void testSettingChangeResizesPool() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int firstThreadQty = randomIntBetween(2, 16);
+            int secondThreadQty = randomValueOtherThan(firstThreadQty, () -> randomIntBetween(2, 16));
+
+            KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(firstThreadQty);
+            Tuple<Integer, ExecutorService> firstResult = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(firstResult.v2());
+            assertEquals(Integer.valueOf(firstThreadQty), firstResult.v1());
+
+            KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(secondThreadQty);
+            Tuple<Integer, ExecutorService> secondResult = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(secondResult.v2());
+            assertEquals(Integer.valueOf(secondThreadQty), secondResult.v1());
+
+            // Same executor instance, just resized
+            assertSame(firstResult.v2(), secondResult.v2());
+            assertFalse(secondResult.v2().isShutdown());
+            assertEquals(secondThreadQty, ((ThreadPoolExecutor) secondResult.v2()).getCorePoolSize());
+        }
+    }
+
+    /**
+     * For any thread count > 1, the executor's getCorePoolSize() equals that value.
+     */
+    public void testPoolSizeMatchesSetting() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int threadQty = randomIntBetween(2, 16);
+
+            KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(threadQty);
+            Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+            assertNotNull(result.v2());
+            assertEquals(Integer.valueOf(threadQty), result.v1());
+            assertTrue(result.v2() instanceof ThreadPoolExecutor);
+            assertEquals(threadQty, ((ThreadPoolExecutor) result.v2()).getCorePoolSize());
+        }
+    }
+
+    /**
+     * For any concurrency level, all threads receive the same non-null, non-shutdown executor.
+     */
+    public void testConcurrentAccessSafety() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int threadQty = randomIntBetween(2, 16);
+            int concurrencyLevel = randomIntBetween(2, 20);
+
+            KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(threadQty);
+
+            Tuple<Integer, ExecutorService> primed = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(primed.v2());
+
+            CyclicBarrier barrier = new CyclicBarrier(concurrencyLevel);
+            ExecutorService testExecutor = Executors.newFixedThreadPool(concurrencyLevel);
+
+            try {
+                List<Future<Tuple<Integer, ExecutorService>>> futures = new ArrayList<>(concurrencyLevel);
+                for (int t = 0; t < concurrencyLevel; t++) {
+                    futures.add(testExecutor.submit(() -> {
+                        barrier.await();
+                        return invokeMergeThreadCountAndExecutorService();
+                    }));
+                }
+
+                for (Future<Tuple<Integer, ExecutorService>> future : futures) {
+                    Tuple<Integer, ExecutorService> result = future.get();
+                    assertNotNull(result.v2());
+                    assertFalse(result.v2().isShutdown());
+                    assertSame(primed.v2(), result.v2());
+                    assertEquals(Integer.valueOf(threadQty), result.v1());
+                }
+            } finally {
+                testExecutor.shutdown();
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormatTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.knn.KNNTestCase;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Unit tests for boundary conditions in KNN1040PerFieldKnnVectorsFormat's
+ * getMergeThreadCountAndExecutorService method.
+ */
+public class KNN1040PerFieldKnnVectorsFormatTests extends KNNTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+        super.tearDown();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Tuple<Integer, ExecutorService> invokeMergeThreadCountAndExecutorService() throws Exception {
+        Method method = KNN1040PerFieldKnnVectorsFormat.class.getDeclaredMethod("getMergeThreadCountAndExecutorService");
+        method.setAccessible(true);
+        return (Tuple<Integer, ExecutorService>) method.invoke(null);
+    }
+
+    /**
+     * When thread count is 1, the method should return (1, null).
+     */
+    public void testGetMergeThreadCount_whenThreadQtyIsOne_thenReturnsDefaultTuple() throws Exception {
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(1);
+
+        Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(1), result.v1());
+        assertNull(result.v2());
+    }
+
+    /**
+     * When thread count is 0, the method should return (1, null).
+     */
+    public void testGetMergeThreadCount_whenThreadQtyIsZero_thenReturnsDefaultTuple() throws Exception {
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+
+        Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(1), result.v1());
+        assertNull(result.v2());
+    }
+
+    /**
+     * When thread count transitions from > 1 to <= 1, the method returns null executor.
+     */
+    public void testGetMergeThreadCount_whenTransitionFromHighToLow_thenReturnsNull() throws Exception {
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(4);
+        Tuple<Integer, ExecutorService> highResult = invokeMergeThreadCountAndExecutorService();
+        assertNotNull(highResult.v2());
+
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(1);
+        Tuple<Integer, ExecutorService> lowResult = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(1), lowResult.v1());
+        assertNull(lowResult.v2());
+    }
+
+    /**
+     * When thread count transitions from <= 1 to > 1, the executor is returned with correct pool size.
+     */
+    public void testGetMergeThreadCount_whenTransitionFromLowToHigh_thenReturnsExecutor() throws Exception {
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(1);
+        Tuple<Integer, ExecutorService> lowResult = invokeMergeThreadCountAndExecutorService();
+        assertNull(lowResult.v2());
+
+        KNN1040PerFieldKnnVectorsFormat.updateMergeThreadCount(4);
+        Tuple<Integer, ExecutorService> highResult = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(4), highResult.v1());
+        assertNotNull(highResult.v2());
+        assertFalse(highResult.v2().isShutdown());
+        assertTrue(highResult.v2() instanceof ThreadPoolExecutor);
+        assertEquals(4, ((ThreadPoolExecutor) highResult.v2()).getCorePoolSize());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatPropertyBasedTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatPropertyBasedTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.knn.KNNTestCase;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Property-based tests for KNN9120PerFieldKnnVectorsFormat's getMergeThreadCountAndExecutorService method.
+ */
+public class KNN9120PerFieldKnnVectorsFormatPropertyBasedTests extends KNNTestCase {
+
+    private static final int MIN_ITERATIONS = 100;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+        super.tearDown();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Tuple<Integer, ExecutorService> invokeMergeThreadCountAndExecutorService() throws Exception {
+        Method method = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredMethod("getMergeThreadCountAndExecutorService");
+        method.setAccessible(true);
+        return (Tuple<Integer, ExecutorService>) method.invoke(null);
+    }
+
+    /**
+     * For any fixed thread count > 1, multiple calls return the same ExecutorService instance.
+     */
+    public void testExecutorInstanceReuse() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int threadQty = randomIntBetween(2, 16);
+            int callCount = randomIntBetween(2, 50);
+
+            KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(threadQty);
+
+            Tuple<Integer, ExecutorService> firstResult = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(firstResult.v2());
+
+            for (int call = 1; call < callCount; call++) {
+                Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+                assertSame(firstResult.v2(), result.v2());
+                assertEquals(Integer.valueOf(threadQty), result.v1());
+            }
+        }
+    }
+
+    /**
+     * For any two distinct thread counts > 1, changing the count resizes the same executor
+     * and the pool size matches the new value.
+     */
+    public void testSettingChangeResizesPool() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int firstThreadQty = randomIntBetween(2, 16);
+            int secondThreadQty = randomValueOtherThan(firstThreadQty, () -> randomIntBetween(2, 16));
+
+            KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(firstThreadQty);
+            Tuple<Integer, ExecutorService> firstResult = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(firstResult.v2());
+            assertEquals(Integer.valueOf(firstThreadQty), firstResult.v1());
+
+            KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(secondThreadQty);
+            Tuple<Integer, ExecutorService> secondResult = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(secondResult.v2());
+            assertEquals(Integer.valueOf(secondThreadQty), secondResult.v1());
+
+            // Same executor instance, just resized
+            assertSame(firstResult.v2(), secondResult.v2());
+            assertFalse(secondResult.v2().isShutdown());
+            assertEquals(secondThreadQty, ((ThreadPoolExecutor) secondResult.v2()).getCorePoolSize());
+        }
+    }
+
+    /**
+     * For any thread count > 1, the executor's getCorePoolSize() equals that value.
+     */
+    public void testPoolSizeMatchesSetting() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int threadQty = randomIntBetween(2, 16);
+
+            KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(threadQty);
+            Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+            assertNotNull(result.v2());
+            assertEquals(Integer.valueOf(threadQty), result.v1());
+            assertTrue(result.v2() instanceof ThreadPoolExecutor);
+            assertEquals(threadQty, ((ThreadPoolExecutor) result.v2()).getCorePoolSize());
+        }
+    }
+
+    /**
+     * For any concurrency level, all threads receive the same non-null, non-shutdown executor.
+     */
+    public void testConcurrentAccessSafety() throws Exception {
+        for (int iteration = 0; iteration < MIN_ITERATIONS; iteration++) {
+            int threadQty = randomIntBetween(2, 16);
+            int concurrencyLevel = randomIntBetween(2, 20);
+
+            KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(threadQty);
+
+            Tuple<Integer, ExecutorService> primed = invokeMergeThreadCountAndExecutorService();
+            assertNotNull(primed.v2());
+
+            CyclicBarrier barrier = new CyclicBarrier(concurrencyLevel);
+            ExecutorService testExecutor = Executors.newFixedThreadPool(concurrencyLevel);
+
+            try {
+                List<Future<Tuple<Integer, ExecutorService>>> futures = new ArrayList<>(concurrencyLevel);
+                for (int t = 0; t < concurrencyLevel; t++) {
+                    futures.add(testExecutor.submit(() -> {
+                        barrier.await();
+                        return invokeMergeThreadCountAndExecutorService();
+                    }));
+                }
+
+                for (Future<Tuple<Integer, ExecutorService>> future : futures) {
+                    Tuple<Integer, ExecutorService> result = future.get();
+                    assertNotNull(result.v2());
+                    assertFalse(result.v2().isShutdown());
+                    assertSame(primed.v2(), result.v2());
+                    assertEquals(Integer.valueOf(threadQty), result.v1());
+                }
+            } finally {
+                testExecutor.shutdown();
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/backward_codecs/KNN9120Codec/KNN9120PerFieldKnnVectorsFormatTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.knn.KNNTestCase;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Unit tests for boundary conditions in KNN9120PerFieldKnnVectorsFormat's
+ * getMergeThreadCountAndExecutorService method.
+ */
+public class KNN9120PerFieldKnnVectorsFormatTests extends KNNTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+        super.tearDown();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Tuple<Integer, ExecutorService> invokeMergeThreadCountAndExecutorService() throws Exception {
+        Method method = KNN9120PerFieldKnnVectorsFormat.class.getDeclaredMethod("getMergeThreadCountAndExecutorService");
+        method.setAccessible(true);
+        return (Tuple<Integer, ExecutorService>) method.invoke(null);
+    }
+
+    /**
+     * When thread count is 1, the method should return (1, null).
+     */
+    public void testGetMergeThreadCount_whenThreadQtyIsOne_thenReturnsDefaultTuple() throws Exception {
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(1);
+
+        Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(1), result.v1());
+        assertNull(result.v2());
+    }
+
+    /**
+     * When thread count is 0, the method should return (1, null).
+     */
+    public void testGetMergeThreadCount_whenThreadQtyIsZero_thenReturnsDefaultTuple() throws Exception {
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(0);
+
+        Tuple<Integer, ExecutorService> result = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(1), result.v1());
+        assertNull(result.v2());
+    }
+
+    /**
+     * When thread count transitions from > 1 to <= 1, the method returns null executor.
+     */
+    public void testGetMergeThreadCount_whenTransitionFromHighToLow_thenReturnsNull() throws Exception {
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(4);
+        Tuple<Integer, ExecutorService> highResult = invokeMergeThreadCountAndExecutorService();
+        assertNotNull(highResult.v2());
+
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(1);
+        Tuple<Integer, ExecutorService> lowResult = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(1), lowResult.v1());
+        assertNull(lowResult.v2());
+    }
+
+    /**
+     * When thread count transitions from <= 1 to > 1, the executor is returned with correct pool size.
+     */
+    public void testGetMergeThreadCount_whenTransitionFromLowToHigh_thenReturnsExecutor() throws Exception {
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(1);
+        Tuple<Integer, ExecutorService> lowResult = invokeMergeThreadCountAndExecutorService();
+        assertNull(lowResult.v2());
+
+        KNN9120PerFieldKnnVectorsFormat.updateMergeThreadCount(4);
+        Tuple<Integer, ExecutorService> highResult = invokeMergeThreadCountAndExecutorService();
+
+        assertEquals(Integer.valueOf(4), highResult.v1());
+        assertNotNull(highResult.v2());
+        assertFalse(highResult.v2().isShutdown());
+        assertTrue(highResult.v2() instanceof ThreadPoolExecutor);
+        assertEquals(4, ((ThreadPoolExecutor) highResult.v2()).getCorePoolSize());
+    }
+}

--- a/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/models/quantizationState/QuantizationStateCacheTests.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.index.KNNSettings.KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING;
 import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING;
 import static org.opensearch.knn.index.KNNSettings.QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING;
 
@@ -76,7 +77,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -136,7 +141,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -177,7 +186,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -238,7 +251,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         // Mocking ClusterService
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -295,7 +312,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         // Mocking ClusterService
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
@@ -359,7 +380,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -416,7 +441,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -467,7 +496,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -528,7 +561,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -583,7 +620,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService
@@ -651,7 +692,11 @@ public class QuantizationStateCacheTests extends KNNTestCase {
         Settings settings = Settings.builder().build();
         ClusterSettings clusterSettings = new ClusterSettings(
             settings,
-            ImmutableSet.of(QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING, QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING)
+            ImmutableSet.of(
+                QUANTIZATION_STATE_CACHE_SIZE_LIMIT_SETTING,
+                QUANTIZATION_STATE_CACHE_EXPIRY_TIME_MINUTES_SETTING,
+                KNN_ALGO_PARAM_INDEX_THREAD_QTY_SETTING
+            )
         );
 
         // Mocking ClusterService


### PR DESCRIPTION
### Description
Fix thread leak in HNSW merge executor

KNN9120PerFieldKnnVectorsFormat.getMergeThreadCountAndExecutorService() was creating a new Executors.newFixedThreadPool() on every invocation. Since this is called per field per segment during flush/merge, thread pools accumulated unboundedly under continuous indexing (77k+ leaked threads observed).

This PR replaces the per-call allocation with a static, dynamically sized executor that is reused across calls and changes thread count when knn.algo_param.index_thread_qty changes.

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/3102

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
