### PR TITLE
[Backport 3.3] Fix indexing for 16x and 8x compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update Visitor to delegate for other fields [#2925](https://github.com/opensearch-project/k-NN/pull/2925)
 * Fix blocking old indices created before 2.18 to use memory optimized search. [#2918](https://github.com/opensearch-project/k-NN/pull/2918)
 * Fix Backwards Compatability on Segment Merge for Disk-Based vector search [#2994](https://github.com/opensearch-project/k-NN/pull/2994) 
+* Fix indexing for 16x and 8x compression [#3019](https://github.com/opensearch-project/k-NN/pull/3019)
 
 ### Refactoring
 * Refactored the KNN Stat files for better readability.

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -206,4 +206,7 @@ public class KNNConstants {
     public static final String VECTOR_FIELD_DATA_TYPE = "vector_field_data_type";
     public static final String VECTOR_FIELD_SPACE_TYPE = "vector_field_space_type";
     public static final String MMR_RERANK_CONTEXT = "mmr.rerank_context";
+
+    // Bit manipulation constants for quantization
+    public static final int BYTE_ALIGNMENT_MASK = 7; // Used for rounding up to nearest byte (Byte.SIZE - 1)
 }

--- a/src/main/java/org/opensearch/knn/quantization/models/quantizationState/MultiBitScalarQuantizationState.java
+++ b/src/main/java/org/opensearch/knn/quantization/models/quantizationState/MultiBitScalarQuantizationState.java
@@ -15,6 +15,7 @@ import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import static org.opensearch.knn.common.KNNConstants.BYTE_ALIGNMENT_MASK;
 
 import java.io.IOException;
 
@@ -175,7 +176,8 @@ public final class MultiBitScalarQuantizationState implements QuantizationState 
         }
 
         // Calculate the number of bytes required for multi-bit quantization
-        return thresholds.length * thresholds[0].length;
+        int totalBits = thresholds.length * thresholds[0].length;
+        return (totalBits + BYTE_ALIGNMENT_MASK) / Byte.SIZE;
     }
 
     @Override
@@ -187,13 +189,13 @@ public final class MultiBitScalarQuantizationState implements QuantizationState 
             throw new IllegalStateException("Error in getting Dimension: The thresholds array is not initialized.");
         }
         int originalDimensions = thresholds[0].length;
+        int bitsPerDimension = thresholds.length;
 
-        // Align the original dimensions to the next multiple of 8 for each bit level
-        int alignedDimensions = (originalDimensions + 7) & ~7;
+        // First multiply by bits, then align to multiple of 8 for binary dimension
+        int totalBinaryDimensions = originalDimensions * bitsPerDimension;
+        int alignedBinaryDimensions = (totalBinaryDimensions + BYTE_ALIGNMENT_MASK) & ~BYTE_ALIGNMENT_MASK;
 
-        // The final dimension count should consider the bit levels
-        return thresholds.length * alignedDimensions;
-
+        return alignedBinaryDimensions;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/quantization/models/quantizationState/OneBitScalarQuantizationState.java
+++ b/src/main/java/org/opensearch/knn/quantization/models/quantizationState/OneBitScalarQuantizationState.java
@@ -16,6 +16,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
 import org.opensearch.knn.quantization.util.QuantizationUtils.FloatArrayWrapper;
+import static org.opensearch.knn.common.KNNConstants.BYTE_ALIGNMENT_MASK;
 
 import java.io.IOException;
 
@@ -187,14 +188,14 @@ public final class OneBitScalarQuantizationState implements QuantizationState {
     @Override
     public int getBytesPerVector() {
         // Calculate the number of bytes required for one-bit quantization
-        return meanThresholds.length;
+        return (meanThresholds.length + BYTE_ALIGNMENT_MASK) / Byte.SIZE;
     }
 
     @Override
     public int getDimensions() {
         // For one-bit quantization, the dimension for indexing is just the length of the thresholds array.
         // Align the original dimensions to the next multiple of 8
-        return (meanThresholds.length + 7) & ~7;
+        return (meanThresholds.length + BYTE_ALIGNMENT_MASK) & ~BYTE_ALIGNMENT_MASK;
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -215,6 +215,97 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testLowDimensionCompression_whenValid_ThenSucceed() {
+        int[] testDimensions = { 2, 5, 12 };
+
+        XContentBuilder builder;
+        for (int dimension : testDimensions) {
+            for (String compressionLevel : COMPRESSION_LEVELS) {
+                String indexName = INDEX_NAME + "_dim" + dimension + "_" + compressionLevel;
+                builder = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(FIELD_NAME)
+                    .field("type", "knn_vector")
+                    .field("dimension", dimension)
+                    .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel)
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                String mapping = builder.toString();
+                validateIndexWithDimension(indexName, mapping, dimension);
+                logger.info("Dimension {} with compression level {}", dimension, compressionLevel);
+                validateSearchWithDimension(
+                    indexName,
+                    METHOD_PARAMETER_EF_SEARCH,
+                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH,
+                    compressionLevel,
+                    Mode.NOT_CONFIGURED.getName(),
+                    dimension
+                );
+            }
+
+            for (String compressionLevel : COMPRESSION_LEVELS) {
+                for (String mode : Mode.NAMES_ARRAY) {
+                    String indexName = INDEX_NAME + "_dim" + dimension + "_" + compressionLevel + "_" + mode;
+                    builder = XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("properties")
+                        .startObject(FIELD_NAME)
+                        .field("type", "knn_vector")
+                        .field("dimension", dimension)
+                        .field(MODE_PARAMETER, mode)
+                        .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel)
+                        .endObject()
+                        .endObject()
+                        .endObject();
+                    String mapping = builder.toString();
+                    validateIndexWithDimension(indexName, mapping, dimension);
+                    logger.info("Dimension {} with compression level {} and mode {}", dimension, compressionLevel, mode);
+                    validateSearchWithDimension(
+                        indexName,
+                        METHOD_PARAMETER_EF_SEARCH,
+                        KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH,
+                        compressionLevel,
+                        mode,
+                        dimension
+                    );
+                }
+            }
+
+            for (String mode : Mode.NAMES_ARRAY) {
+                String indexName = INDEX_NAME + "_dim" + dimension + "_" + mode;
+                builder = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(FIELD_NAME)
+                    .field("type", "knn_vector")
+                    .field("dimension", dimension)
+                    .field(MODE_PARAMETER, mode)
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                String mapping = builder.toString();
+                validateIndexWithDimension(indexName, mapping, dimension);
+                logger.info(
+                    "Dimension {} with mode {} and compression level {}",
+                    dimension,
+                    mode,
+                    CompressionLevel.NOT_CONFIGURED.getName()
+                );
+                validateSearchWithDimension(
+                    indexName,
+                    METHOD_PARAMETER_EF_SEARCH,
+                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH,
+                    CompressionLevel.NOT_CONFIGURED.getName(),
+                    mode,
+                    dimension
+                );
+            }
+        }
+    }
+
+    @SneakyThrows
     public void testQueryRescoreEnabledAndDisabled() {
         XContentBuilder builder;
         String mode = Mode.ON_DISK.getName();
@@ -548,6 +639,114 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
         createKnnIndex(indexName, mapping);
         addKNNDocs(indexName, FIELD_NAME, DIMENSION, 0, NUM_DOCS);
         forceMergeKnnIndex(indexName, 1);
+    }
+
+    @SneakyThrows
+    private void validateIndexWithDimension(String indexName, String mapping, int dimension) {
+        createKnnIndex(indexName, mapping);
+        addKNNDocs(indexName, FIELD_NAME, dimension, 0, NUM_DOCS);
+        forceMergeKnnIndex(indexName, 1);
+    }
+
+    @SneakyThrows
+    private void validateSearchWithDimension(
+        String indexName,
+        String methodParameterName,
+        int methodParameterValue,
+        String compressionLevelString,
+        String mode,
+        int dimension
+    ) {
+        float[] testVector = new float[dimension];
+        Arrays.fill(testVector, 1.0f);
+
+        // Basic search
+        Response response = searchKNNIndex(
+            indexName,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(FIELD_NAME)
+                .field("vector", testVector)
+                .field("k", K)
+                .startObject(METHOD_PARAMETER)
+                .field(methodParameterName, methodParameterValue)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            K
+        );
+        assertOK(response);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<Float> knnResults = parseSearchResponseScore(responseBody, FIELD_NAME);
+        assertEquals(K, knnResults.size());
+
+        // Do exact search and gather right scores for the documents
+        Response exactSearchResponse = searchKNNIndex(
+            indexName,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("script_score")
+                .startObject("query")
+                .field("match_all")
+                .startObject()
+                .endObject()
+                .endObject()
+                .startObject("script")
+                .field("source", "knn_score")
+                .field("lang", "knn")
+                .startObject("params")
+                .field("field", FIELD_NAME)
+                .field("query_value", testVector)
+                .field("space_type", SpaceType.L2.getValue())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            K
+        );
+        assertOK(exactSearchResponse);
+        String exactSearchResponseBody = EntityUtils.toString(exactSearchResponse.getEntity());
+        List<Float> exactSearchKnnResults = parseSearchResponseScore(exactSearchResponseBody, FIELD_NAME);
+        assertEquals(NUM_DOCS, exactSearchKnnResults.size());
+        if (Mode.ON_DISK.getName().equals(mode)) {
+            Assert.assertEquals(exactSearchKnnResults, knnResults);
+        }
+
+        // Search with rescore
+        response = searchKNNIndex(
+            indexName,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(FIELD_NAME)
+                .field("vector", testVector)
+                .field("k", K)
+                .startObject(RescoreParser.RESCORE_PARAMETER)
+                .field(RescoreParser.RESCORE_OVERSAMPLE_PARAMETER, 2.0f)
+                .endObject()
+                .startObject(METHOD_PARAMETER)
+                .field(methodParameterName, methodParameterValue)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            K
+        );
+        assertOK(response);
+        responseBody = EntityUtils.toString(response.getEntity());
+        knnResults = parseSearchResponseScore(responseBody, FIELD_NAME);
+        assertEquals(K, knnResults.size());
+        if (Mode.ON_DISK.getName().equals(mode)) {
+            Assert.assertEquals(exactSearchKnnResults, knnResults);
+        }
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Currently indexing fails for 16x and 8x compression with error Caused by: java.lang.Exception: Number of IDs does not match number of vectors, which is thrown at https://github.com/opensearch-project/k-NN/blob/main/jni/src/faiss_index_service.cpp#L224.

The issue is that (dim / 8) at https://github.com/opensearch-project/k-NN/blob/main/jni/src/faiss_index_service.cpp#L218 is overestimating the number of bytes per vector, resulting in a mismatch between numVectors and numIds. The dim comes from getDimensions of MultiBitScalarQuantizationState at https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/quantization/models/quantizationState/MultiBitScalarQuantizationState.java#L182. Currently, the getDimensions method first aligns original vector dimension to nearest multiple of 8, then multiplies by bit quantization. This is incorrect, the method is supposed to first multiply original vector dimension by bit quantization, then align to nearest multiple of 8. See below example:
2D vector with 16x compression:

Current getDimensions (Wrong):

    align 2D vector to 8 -> multiply 8 by 2 bit quantization = 16 -> at JNI layer 16 dim / 8 = 2 bytes per vector (wrong)

PR Fix:

    multiply 2D by 2 bit quantization = 4 -> align 4 to 8 -> at JNI layer 8 dim / 8 = 1 byte per vector (correct)

During deep dive, we also found that getBytesPerVector is returning bits instead of bytes, even though the code uses it as bytes, ref https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransfer.java#L43.

So this PR updates both getDimensions and getBytesPerVector methods to fix 16x and 8x compression.

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/2898

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
