### PR TITLE
[Backport 3.1] Fix indexing for 16x and 8x compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.2](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+### Bug Fixes
+* Fix indexing for 16x and 8x compression [#3019](https://github.com/opensearch-project/k-NN/pull/3019)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -176,4 +176,7 @@ public class KNNConstants {
     // Repository-S3
     public static final String S3 = "s3";
     public static final String BUCKET = "bucket";
+
+    // Bit manipulation constants for quantization
+    public static final int BYTE_ALIGNMENT_MASK = 7; // Used for rounding up to nearest byte (Byte.SIZE - 1)
 }

--- a/src/main/java/org/opensearch/knn/quantization/models/quantizationState/OneBitScalarQuantizationState.java
+++ b/src/main/java/org/opensearch/knn/quantization/models/quantizationState/OneBitScalarQuantizationState.java
@@ -13,6 +13,7 @@ import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
+import static org.opensearch.knn.common.KNNConstants.BYTE_ALIGNMENT_MASK;
 
 import java.io.IOException;
 
@@ -117,14 +118,14 @@ public final class OneBitScalarQuantizationState implements QuantizationState {
     @Override
     public int getBytesPerVector() {
         // Calculate the number of bytes required for one-bit quantization
-        return meanThresholds.length;
+        return (meanThresholds.length + BYTE_ALIGNMENT_MASK) / Byte.SIZE;
     }
 
     @Override
     public int getDimensions() {
         // For one-bit quantization, the dimension for indexing is just the length of the thresholds array.
         // Align the original dimensions to the next multiple of 8
-        return (meanThresholds.length + 7) & ~7;
+        return (meanThresholds.length + BYTE_ALIGNMENT_MASK) & ~BYTE_ALIGNMENT_MASK;
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ModeAndCompressionIT.java
@@ -215,6 +215,97 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testLowDimensionCompression_whenValid_ThenSucceed() {
+        int[] testDimensions = { 2, 5, 12 };
+
+        XContentBuilder builder;
+        for (int dimension : testDimensions) {
+            for (String compressionLevel : COMPRESSION_LEVELS) {
+                String indexName = INDEX_NAME + "_dim" + dimension + "_" + compressionLevel;
+                builder = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(FIELD_NAME)
+                    .field("type", "knn_vector")
+                    .field("dimension", dimension)
+                    .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel)
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                String mapping = builder.toString();
+                validateIndexWithDimension(indexName, mapping, dimension);
+                logger.info("Dimension {} with compression level {}", dimension, compressionLevel);
+                validateSearchWithDimension(
+                    indexName,
+                    METHOD_PARAMETER_EF_SEARCH,
+                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH,
+                    compressionLevel,
+                    Mode.NOT_CONFIGURED.getName(),
+                    dimension
+                );
+            }
+
+            for (String compressionLevel : COMPRESSION_LEVELS) {
+                for (String mode : Mode.NAMES_ARRAY) {
+                    String indexName = INDEX_NAME + "_dim" + dimension + "_" + compressionLevel + "_" + mode;
+                    builder = XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("properties")
+                        .startObject(FIELD_NAME)
+                        .field("type", "knn_vector")
+                        .field("dimension", dimension)
+                        .field(MODE_PARAMETER, mode)
+                        .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel)
+                        .endObject()
+                        .endObject()
+                        .endObject();
+                    String mapping = builder.toString();
+                    validateIndexWithDimension(indexName, mapping, dimension);
+                    logger.info("Dimension {} with compression level {} and mode {}", dimension, compressionLevel, mode);
+                    validateSearchWithDimension(
+                        indexName,
+                        METHOD_PARAMETER_EF_SEARCH,
+                        KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH,
+                        compressionLevel,
+                        mode,
+                        dimension
+                    );
+                }
+            }
+
+            for (String mode : Mode.NAMES_ARRAY) {
+                String indexName = INDEX_NAME + "_dim" + dimension + "_" + mode;
+                builder = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(FIELD_NAME)
+                    .field("type", "knn_vector")
+                    .field("dimension", dimension)
+                    .field(MODE_PARAMETER, mode)
+                    .endObject()
+                    .endObject()
+                    .endObject();
+                String mapping = builder.toString();
+                validateIndexWithDimension(indexName, mapping, dimension);
+                logger.info(
+                    "Dimension {} with mode {} and compression level {}",
+                    dimension,
+                    mode,
+                    CompressionLevel.NOT_CONFIGURED.getName()
+                );
+                validateSearchWithDimension(
+                    indexName,
+                    METHOD_PARAMETER_EF_SEARCH,
+                    KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH,
+                    CompressionLevel.NOT_CONFIGURED.getName(),
+                    mode,
+                    dimension
+                );
+            }
+        }
+    }
+
+    @SneakyThrows
     public void testQueryRescoreEnabledAndDisabled() {
         XContentBuilder builder;
         String mode = Mode.ON_DISK.getName();
@@ -548,6 +639,114 @@ public class ModeAndCompressionIT extends KNNRestTestCase {
         createKnnIndex(indexName, mapping);
         addKNNDocs(indexName, FIELD_NAME, DIMENSION, 0, NUM_DOCS);
         forceMergeKnnIndex(indexName, 1);
+    }
+
+    @SneakyThrows
+    private void validateIndexWithDimension(String indexName, String mapping, int dimension) {
+        createKnnIndex(indexName, mapping);
+        addKNNDocs(indexName, FIELD_NAME, dimension, 0, NUM_DOCS);
+        forceMergeKnnIndex(indexName, 1);
+    }
+
+    @SneakyThrows
+    private void validateSearchWithDimension(
+        String indexName,
+        String methodParameterName,
+        int methodParameterValue,
+        String compressionLevelString,
+        String mode,
+        int dimension
+    ) {
+        float[] testVector = new float[dimension];
+        Arrays.fill(testVector, 1.0f);
+
+        // Basic search
+        Response response = searchKNNIndex(
+            indexName,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(FIELD_NAME)
+                .field("vector", testVector)
+                .field("k", K)
+                .startObject(METHOD_PARAMETER)
+                .field(methodParameterName, methodParameterValue)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            K
+        );
+        assertOK(response);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<Float> knnResults = parseSearchResponseScore(responseBody, FIELD_NAME);
+        assertEquals(K, knnResults.size());
+
+        // Do exact search and gather right scores for the documents
+        Response exactSearchResponse = searchKNNIndex(
+            indexName,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("script_score")
+                .startObject("query")
+                .field("match_all")
+                .startObject()
+                .endObject()
+                .endObject()
+                .startObject("script")
+                .field("source", "knn_score")
+                .field("lang", "knn")
+                .startObject("params")
+                .field("field", FIELD_NAME)
+                .field("query_value", testVector)
+                .field("space_type", SpaceType.L2.getValue())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            K
+        );
+        assertOK(exactSearchResponse);
+        String exactSearchResponseBody = EntityUtils.toString(exactSearchResponse.getEntity());
+        List<Float> exactSearchKnnResults = parseSearchResponseScore(exactSearchResponseBody, FIELD_NAME);
+        assertEquals(NUM_DOCS, exactSearchKnnResults.size());
+        if (Mode.ON_DISK.getName().equals(mode)) {
+            Assert.assertEquals(exactSearchKnnResults, knnResults);
+        }
+
+        // Search with rescore
+        response = searchKNNIndex(
+            indexName,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(FIELD_NAME)
+                .field("vector", testVector)
+                .field("k", K)
+                .startObject(RescoreParser.RESCORE_PARAMETER)
+                .field(RescoreParser.RESCORE_OVERSAMPLE_PARAMETER, 2.0f)
+                .endObject()
+                .startObject(METHOD_PARAMETER)
+                .field(methodParameterName, methodParameterValue)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            K
+        );
+        assertOK(response);
+        responseBody = EntityUtils.toString(response.getEntity());
+        knnResults = parseSearchResponseScore(responseBody, FIELD_NAME);
+        assertEquals(K, knnResults.size());
+        if (Mode.ON_DISK.getName().equals(mode)) {
+            Assert.assertEquals(exactSearchKnnResults, knnResults);
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizationState/QuantizationStateTests.java
@@ -206,6 +206,179 @@ public class QuantizationStateTests extends KNNTestCase {
         assertEquals(ramEstimatorRamBytesUsed, state.ramBytesUsed());
     }
 
+    public void testMultiBitScalarQuantizationStateGetDimensions_withAlignedThresholds() {
+        ScalarQuantizationParams params = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.TWO_BIT).build();
+        float[][] thresholds = { { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f }, { 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f } };
+
+        MultiBitScalarQuantizationState state = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .thresholds(thresholds)
+            .build();
+
+        int expectedDimensions = 16; // 2 bit levels × 8 dims already aligned
+        assertEquals(expectedDimensions, state.getDimensions());
+    }
+
+    public void testMultiBitScalarQuantizationStateGetDimensions_withUnalignedThresholds() {
+        ScalarQuantizationParams params = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.TWO_BIT).build();
+
+        // Case 1: 3D with 2 bits: 3*2=6 bits → align to 8 bits
+        float[][] thresholds = { { 0.1f, 0.2f, 0.3f }, { 1.1f, 1.2f, 1.3f } };
+        MultiBitScalarQuantizationState state = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .thresholds(thresholds)
+            .build();
+        int expectedDimensions = 8; // 6 bits aligned to 8
+        assertEquals(expectedDimensions, state.getDimensions());
+
+        // Case 2: 2D with 3 bit levels: 2*3=6 bits → align to 8 bits
+        float[][] thresholds1 = { { 0.5f, 1.5f }, { 1.0f, 2.0f }, { 1.5f, 2.5f } };
+        MultiBitScalarQuantizationState state1 = new MultiBitScalarQuantizationState(params, thresholds1, null);
+        int expectedDimensions1 = 8; // 6 bits aligned to 8
+        assertEquals(expectedDimensions1, state1.getDimensions());
+    }
+
+    public void testMultiBitScalarQuantizationState_getBytesPerVector() {
+        // Test 2D with 2 bits (16x compression)
+        ScalarQuantizationParams params2bit = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.TWO_BIT).build();
+        float[][] thresholds2D = { { 0.5f, 1.5f }, { 1.0f, 2.0f } };
+        MultiBitScalarQuantizationState state2D = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params2bit)
+            .thresholds(thresholds2D)
+            .build();
+        assertEquals(1, state2D.getBytesPerVector()); // 4 bits = 1 byte
+
+        // Test 12D with 2 bits (16x compression)
+        float[][] thresholds12D = new float[2][12];
+        MultiBitScalarQuantizationState state12D = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params2bit)
+            .thresholds(thresholds12D)
+            .build();
+        assertEquals(3, state12D.getBytesPerVector()); // 24 bits = 3 bytes
+
+        // Test 2D with 4 bits (8x compression)
+        ScalarQuantizationParams params4bit = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.FOUR_BIT).build();
+        float[][] thresholds2D_4bit = new float[4][2];
+        MultiBitScalarQuantizationState state2D_4bit = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params4bit)
+            .thresholds(thresholds2D_4bit)
+            .build();
+        assertEquals(1, state2D_4bit.getBytesPerVector()); // 8 bits = 1 byte
+
+        // Test 12D with 4 bits (8x compression)
+        float[][] thresholds12D_4bit = new float[4][12];
+        MultiBitScalarQuantizationState state12D_4bit = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params4bit)
+            .thresholds(thresholds12D_4bit)
+            .build();
+        assertEquals(6, state12D_4bit.getBytesPerVector()); // 48 bits = 6 bytes
+    }
+
+    public void testOneBitScalarQuantizationState_getBytesPerVector() {
+        ScalarQuantizationParams params = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
+
+        // Test 2D with 1 bit (32x compression)
+        float[] thresholds2D = { 0.5f, 1.5f };
+        OneBitScalarQuantizationState state2D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds2D)
+            .build();
+        assertEquals(1, state2D.getBytesPerVector()); // 2 bits = 1 byte
+
+        // Test 12D with 1 bit (32x compression)
+        float[] thresholds12D = new float[12];
+        OneBitScalarQuantizationState state12D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds12D)
+            .build();
+        assertEquals(2, state12D.getBytesPerVector()); // 12 bits = 2 bytes
+    }
+
+    public void testMultiBitScalarQuantizationState_getDimensions_fixedLogic() {
+        // Test 2D with 2 bits: 2*2=4 bits → align to 8 bits
+        ScalarQuantizationParams params2bit = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.TWO_BIT).build();
+        float[][] thresholds2D = { { 0.5f, 1.5f }, { 1.0f, 2.0f } };
+        MultiBitScalarQuantizationState state2D = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params2bit)
+            .thresholds(thresholds2D)
+            .build();
+        assertEquals(8, state2D.getDimensions()); // 4 bits aligned to 8
+
+        // Test 12D with 2 bits: 12*2=24 bits → already aligned
+        float[][] thresholds12D = new float[2][12];
+        MultiBitScalarQuantizationState state12D = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params2bit)
+            .thresholds(thresholds12D)
+            .build();
+        assertEquals(24, state12D.getDimensions()); // 24 bits already aligned
+
+        // Test 5D with 4 bits: 5*4=20 bits → align to 24 bits
+        ScalarQuantizationParams params4bit = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.FOUR_BIT).build();
+        float[][] thresholds5D_4bit = new float[4][5];
+        MultiBitScalarQuantizationState state5D_4bit = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params4bit)
+            .thresholds(thresholds5D_4bit)
+            .build();
+        assertEquals(24, state5D_4bit.getDimensions()); // 20 bits aligned to 24
+
+        // Test 12D with 4 bits: 12*4=48 bits → already aligned
+        float[][] thresholds12D_4bit = new float[4][12];
+        MultiBitScalarQuantizationState state12D_4bit = MultiBitScalarQuantizationState.builder()
+            .quantizationParams(params4bit)
+            .thresholds(thresholds12D_4bit)
+            .build();
+        assertEquals(48, state12D_4bit.getDimensions()); // 48 bits already aligned
+    }
+
+    public void testOneBitScalarQuantizationStateGetDimensions_withDimensionNotMultipleOf8_thenSuccess() {
+        ScalarQuantizationParams params = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
+
+        // Case 1: 5 dimensions (should align to 8)
+        float[] thresholds1 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f };
+        OneBitScalarQuantizationState state1 = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds1)
+            .build();
+        int expectedDimensions1 = 8; // The next multiple of 8
+        assertEquals(expectedDimensions1, state1.getDimensions());
+
+        // Case 2: 7 dimensions (should align to 8)
+        float[] thresholds2 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f };
+        OneBitScalarQuantizationState state2 = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds2)
+            .build();
+        int expectedDimensions2 = 8; // The next multiple of 8
+        assertEquals(expectedDimensions2, state2.getDimensions());
+
+        // Case 3: 8 dimensions (already aligned to 8)
+        float[] thresholds3 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f };
+        OneBitScalarQuantizationState state3 = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds3)
+            .build();
+        int expectedDimensions3 = 8; // Already aligned to 8
+        assertEquals(expectedDimensions3, state3.getDimensions());
+
+        // Case 4: 10 dimensions (should align to 16)
+        float[] thresholds4 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f, 9.5f };
+        OneBitScalarQuantizationState state4 = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds4)
+            .build();
+        int expectedDimensions4 = 16; // The next multiple of 8
+        assertEquals(expectedDimensions4, state4.getDimensions());
+
+        // Case 5: 16 dimensions (already aligned to 16)
+        float[] thresholds5 = { 0.5f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f, 9.5f, 10.5f, 11.5f, 12.5f, 13.5f, 14.5f, 15.5f };
+        OneBitScalarQuantizationState state5 = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds5)
+            .build();
+        int expectedDimensions5 = 16; // Already aligned to 16
+        assertEquals(expectedDimensions5, state5.getDimensions());
+    }
+
     private long alignSize(long size) {
         return (size + 7) & ~7;  // Align to 8 bytes boundary
     }


### PR DESCRIPTION
### Description
Currently indexing fails for 16x and 8x compression with error Caused by: java.lang.Exception: Number of IDs does not match number of vectors, which is thrown at https://github.com/opensearch-project/k-NN/blob/main/jni/src/faiss_index_service.cpp#L224.

The issue is that (dim / 8) at https://github.com/opensearch-project/k-NN/blob/main/jni/src/faiss_index_service.cpp#L218 is overestimating the number of bytes per vector, resulting in a mismatch between numVectors and numIds. The dim comes from getDimensions of MultiBitScalarQuantizationState at https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/quantization/models/quantizationState/MultiBitScalarQuantizationState.java#L182. Currently, the getDimensions method first aligns original vector dimension to nearest multiple of 8, then multiplies by bit quantization. This is incorrect, the method is supposed to first multiply original vector dimension by bit quantization, then align to nearest multiple of 8. See below example:
2D vector with 16x compression:

Current getDimensions (Wrong):

    align 2D vector to 8 -> multiply 8 by 2 bit quantization = 16 -> at JNI layer 16 dim / 8 = 2 bytes per vector (wrong)

PR Fix:

    multiply 2D by 2 bit quantization = 4 -> align 4 to 8 -> at JNI layer 8 dim / 8 = 1 byte per vector (correct)

During deep dive, we also found that getBytesPerVector is returning bits instead of bytes, even though the code uses it as bytes, ref https://github.com/opensearch-project/k-NN/blob/main/src/main/java/org/opensearch/knn/index/codec/transfer/OffHeapVectorTransfer.java#L43.

So this PR updates both getDimensions and getBytesPerVector methods to fix 16x and 8x compression.

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/2898

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
