### PR TITLE
[BugFix] Fix integer overflow for memory optimized search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [#3093](https://github.com/opensearch-project/k-NN/pull/3093)
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
 * Fix bugs in optimistic search for nested Cagra index [#3155](https://github.com/opensearch-project/k-NN/pull/3155)
+* Fix integer overflow for memory optimized search [#3130](https://github.com/opensearch-project/k-NN/pull/3130)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSW.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissHNSW.java
@@ -74,7 +74,7 @@ public class FaissHNSW {
 
         // Load `offsets` into memory.
         size = input.readLong();
-        offsetsReader = MonotonicIntegerSequenceEncoder.encode(Math.toIntExact(size), input);
+        offsetsReader = MonotonicIntegerSequenceEncoder.encode(Math.toIntExact(size), input, false);
         Objects.requireNonNull(offsetsReader);
 
         // Mark neighbor list section.

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MonotonicIntegerSequenceEncoder.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MonotonicIntegerSequenceEncoder.java
@@ -33,6 +33,10 @@ public class MonotonicIntegerSequenceEncoder {
      * @throws IOException
      */
     public static DirectMonotonicReader encode(final int numElements, final IndexInput input) throws IOException {
+        return encode(numElements, input, true);
+    }
+
+    public static DirectMonotonicReader encode(final int numElements, final IndexInput input, final boolean isInteger) throws IOException {
         // Prepare a buffer for meta
         ByteBuffersDataOutput dataOutput = new ByteBuffersDataOutput();
         ByteBuffersIndexOutput dataIndexOutput = new ByteBuffersIndexOutput(
@@ -57,14 +61,12 @@ public class MonotonicIntegerSequenceEncoder {
             DIRECT_MONOTONIC_BLOCK_SHIFT
         );
 
-        // Encode integer sequence.
+        // Encode integer or long sequence.
         boolean isIdenticalMapping = true;
-        for (long i = 0; i < numElements; i++) {
-            final long value = Math.toIntExact(input.readLong());
-            if (value != i) {
-                isIdenticalMapping = false;
-            }
-            encoder.add(value);
+        if (isInteger) {
+            isIdenticalMapping = encodeInteger(encoder, numElements, input);
+        } else {
+            isIdenticalMapping = encodeLong(encoder, numElements, input);
         }
 
         encoder.finish();
@@ -91,5 +93,29 @@ public class MonotonicIntegerSequenceEncoder {
             DIRECT_MONOTONIC_BLOCK_SHIFT
         );
         return DirectMonotonicReader.getInstance(encodingMeta, dataInput);
+    }
+
+    private static boolean encodeInteger(DirectMonotonicWriter encoder, final int numElements, final IndexInput input) throws IOException {
+        boolean isIdenticalMapping = true;
+        for (long i = 0; i < numElements; i++) {
+            final long value = Math.toIntExact(input.readLong());
+            if (value != i) {
+                isIdenticalMapping = false;
+            }
+            encoder.add(value);
+        }
+        return isIdenticalMapping;
+    }
+
+    private static boolean encodeLong(DirectMonotonicWriter encoder, final int numElements, final IndexInput input) throws IOException {
+        boolean isIdenticalMapping = true;
+        for (long i = 0; i < numElements; i++) {
+            final long value = input.readLong();
+            if (value != i) {
+                isIdenticalMapping = false;
+            }
+            encoder.add(value);
+        }
+        return isIdenticalMapping;
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MonotonicIntegerSequenceEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MonotonicIntegerSequenceEncoderTests.java
@@ -112,6 +112,24 @@ public class MonotonicIntegerSequenceEncoderTests extends KNNTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testIncreasingSequenceWithLongEncoder() {
+        // Create a sequence
+        final int size = 100000;
+        final IndexInput input = createSequence((i) -> i / 5, size);
+
+        // Call encode
+        DirectMonotonicReader reader = MonotonicIntegerSequenceEncoder.encode(size, input, false);
+
+        // It should not be null
+        assertNotNull(reader);
+
+        // Validate values
+        for (int i = 0; i < size; ++i) {
+            assertEquals(i / 5, reader.get(i));
+        }
+    }
+
     private static IndexInput createSequence(Function<Long, Long> mapping, int length) throws IOException {
         ByteBuffersDataOutput dataOutput = new ByteBuffersDataOutput();
         ByteBuffersIndexOutput dataIndexOutput = new ByteBuffersIndexOutput(


### PR DESCRIPTION
### Description
When memory_optimized_search is enabled for large-scale vector indexes, an "Integer Overflow" error may occur. The root cause lies in the data type mismatch during the conversion of the Faiss HNSW `offsets` array from long to int, which fails to accommodate large offset values.

### Related Issues
Resolves #3108
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
