### PR TITLE
Simplify DerivedSourceReaders lifecycle by removing manual ref-counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [#3093](https://github.com/opensearch-project/k-NN/pull/3093)
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
-* Simplify DerivedSourceReaders lifecycle by removing manual ref-counting [#3137](https://github.com/opensearch-project/k-NN/pull/3137)
+* Simplify DerivedSourceReaders lifecycle by removing manual ref-counting [#3138](https://github.com/opensearch-project/k-NN/pull/3138)
 
 ### Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [#3093](https://github.com/opensearch-project/k-NN/pull/3093)
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
+* Simplify DerivedSourceReaders lifecycle by removing manual ref-counting [#3137](https://github.com/opensearch-project/k-NN/pull/3137)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -99,7 +99,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
             return new KNN10010DerivedSourceStoredFieldsReader(
                 delegate.clone(),
                 derivedVectorFields,
-                derivedSourceReaders.cloneWithMerge(),
+                derivedSourceReaders.clone(),
                 segmentReadState,
                 shouldInject
             );
@@ -130,7 +130,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
             return new KNN10010DerivedSourceStoredFieldsReader(
                 delegate.getMergeInstance(),
                 derivedVectorFields,
-                derivedSourceReaders.cloneWithMerge(),
+                derivedSourceReaders.getMergeInstance(),
                 segmentReadState,
                 false
             );

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -6,70 +6,97 @@
 package org.opensearch.knn.index.codec.derivedsource;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Class holds the readers necessary to implement derived source. Important to note that if a segment does not have
- * any of these fields, the values will be null. Caller needs to check if these are null before using.
+ * Holds the Lucene readers required to reconstruct vector fields for derived source.
+ *
+ * <p>Derived source allows OpenSearch to reconstruct the original {@code _source} document from
+ * stored field data rather than persisting raw source bytes. This class bundles the two readers
+ * needed for that reconstruction:
+ * <ul>
+ *   <li>{@link KnnVectorsReader} - reads raw vector values from the segment.</li>
+ *   <li>{@link DocValuesProducer} - reads doc-values (e.g. quantized or nested vector data).
+ *   This is needed for backward compatibility for indices created before 2.17 </li>
+ * </ul>
+ *
+ * <p>Either reader may be {@code null} when the corresponding field type is absent in a segment;
+ * callers must null-check before use.
+ *
+ * <p><b>Lifecycle:</b> The owning instance (created via the public constructor) is responsible for
+ * closing both underlying readers. Cloned instances (via {@link #clone()}) and merge instances
+ * (via {@link #getMergeInstance()}) are non-owning: their {@link #close()} is a no-op, so only
+ * the original instance drives resource cleanup.
  */
-@RequiredArgsConstructor
 @Getter
-public final class DerivedSourceReaders implements Closeable {
+public final class DerivedSourceReaders implements Cloneable, Closeable {
     @Nullable
     private final KnnVectorsReader knnVectorsReader;
     @Nullable
     private final DocValuesProducer docValuesProducer;
-
-    // Copied from lucene (https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java):
-    // We need to reference count these readers because they may be shared amongst different instances.
-    // "Counts how many other readers share the core objects
-    // (freqStream, proxStream, tis, etc.) of this reader;
-    // when coreRef drops to 0, these core objects may be
-    // closed. A given instance of SegmentReader may be
-    // closed, even though it shares core objects with other
-    // SegmentReaders":
-    private final AtomicInteger ref = new AtomicInteger(1);
+    private final Closeable onClose;
 
     /**
-     * Returns this DerivedSourceReaders object with incremented reference count
+     * Creates an owning instance. Closing this instance will close both underlying readers.
      *
-     * @return DerivedSourceReaders object with incremented reference count
+     * @param knnVectorsReader  reader for raw vector values; may be {@code null}.
+     * @param docValuesProducer reader for doc-values; may be {@code null}.
      */
-    public DerivedSourceReaders cloneWithMerge() {
-        // For cloning, we dont need to reference count. In Lucene, the merging will actually not close any of the
-        // readers, so it should only be handled by the original code. See
-        // https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L3372
-        // for more details
-        return this;
+    public DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer) {
+        assert knnVectorsReader != null || docValuesProducer != null : "At least one reader must be non-null";
+        this.knnVectorsReader = knnVectorsReader;
+        this.docValuesProducer = docValuesProducer;
+        this.onClose = () -> IOUtils.closeWhileHandlingException(knnVectorsReader, docValuesProducer);
     }
 
+    private DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer, Closeable onClose) {
+        assert knnVectorsReader != null || docValuesProducer != null : "At least one reader must be non-null";
+        this.knnVectorsReader = knnVectorsReader;
+        this.docValuesProducer = docValuesProducer;
+        this.onClose = onClose;
+    }
+
+    /**
+     * Returns a non-owning view of this instance for use during Lucene segment merges.
+     * The returned instance's {@link #close()} is a no-op; the original instance retains
+     * ownership of the underlying readers. See
+     * <a href="https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L3372">IndexWriter</a>
+     * for context on why merging does not close readers.
+     *
+     * {@link #clone()} and {@link #getMergeInstance()} are kept separate to avoid any side effects between the two
+     * if the behavior ever changes
+     *
+     * @return a non-owning {@code DerivedSourceReaders} sharing the same underlying readers.
+     */
+    public DerivedSourceReaders getMergeInstance() {
+        return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, () -> {});
+    }
+
+    /**
+     * Returns a non-owning shallow clone sharing the same underlying readers.
+     * The cloned instance's {@link #close()} is a no-op.
+     *
+     * {@link #clone()} and {@link #getMergeInstance()} are kept separate to avoid any side effects between the two
+     * if the behavior ever changes
+     *
+     * @return a non-owning {@code DerivedSourceReaders} sharing the same underlying readers.
+     */
+    @Override
+    public DerivedSourceReaders clone() {
+        return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, () -> {});
+    }
+
+    /**
+     * Closes the underlying readers if this is an owning instance. No-op for cloned or merge instances.
+     */
     @Override
     public void close() throws IOException {
-        decRef();
-    }
-
-    private void incRef() {
-        int count;
-        while ((count = ref.get()) > 0) {
-            if (ref.compareAndSet(count, count + 1)) {
-                return;
-            }
-        }
-        throw new AlreadyClosedException("DerivedSourceReaders is already closed");
-    }
-
-    private void decRef() throws IOException {
-        if (ref.decrementAndGet() == 0) {
-            IOUtils.close(knnVectorsReader, docValuesProducer);
-        }
+        onClose.close();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -52,7 +52,7 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
         assert knnVectorsReader != null || docValuesProducer != null : "At least one reader must be non-null";
         this.knnVectorsReader = knnVectorsReader;
         this.docValuesProducer = docValuesProducer;
-        this.onClose = () -> IOUtils.closeWhileHandlingException(knnVectorsReader, docValuesProducer);
+        this.onClose = () -> IOUtils.close(knnVectorsReader, docValuesProducer);
     }
 
     private DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer, Closeable onClose) {

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.codec.derivedsource;
 import lombok.Getter;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
 import org.opensearch.common.Nullable;
 
@@ -32,7 +33,9 @@ import java.io.IOException;
  * <p><b>Lifecycle:</b> The owning instance (created via the public constructor) is responsible for
  * closing both underlying readers. Cloned instances (via {@link #clone()}) and merge instances
  * (via {@link #getMergeInstance()}) are non-owning: their {@link #close()} is a no-op, so only
- * the original instance drives resource cleanup.
+ * the original instance drives resource cleanup. Calling {@link #clone()} or
+ * {@link #getMergeInstance()} on a closed owning instance throws
+ * {@link org.apache.lucene.store.AlreadyClosedException}.
  */
 @Getter
 public final class DerivedSourceReaders implements Cloneable, Closeable {
@@ -41,6 +44,7 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
     @Nullable
     private final DocValuesProducer docValuesProducer;
     private final Closeable onClose;
+    private boolean closed;
 
     /**
      * Creates an owning instance. Closing this instance will close both underlying readers.
@@ -75,6 +79,7 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
      * @return a non-owning {@code DerivedSourceReaders} sharing the same underlying readers.
      */
     public DerivedSourceReaders getMergeInstance() {
+        ensureOpen();
         return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, () -> {});
     }
 
@@ -89,6 +94,7 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
      */
     @Override
     public DerivedSourceReaders clone() {
+        ensureOpen();
         return new DerivedSourceReaders(knnVectorsReader, docValuesProducer, () -> {});
     }
 
@@ -97,6 +103,18 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
      */
     @Override
     public void close() throws IOException {
-        onClose.close();
+        if (!closed) {
+            onClose.close();
+            closed = true;
+        }
     }
+
+    /**
+     * Throws {@link AlreadyClosedException} if this instance has been closed.
+     */
+    private void ensureOpen() {
+        if (closed) {
+            throw new AlreadyClosedException("DerivedSourceReader is closed");
+        }
+    };
 }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReaders.java
@@ -53,10 +53,7 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
      * @param docValuesProducer reader for doc-values; may be {@code null}.
      */
     public DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer) {
-        assert knnVectorsReader != null || docValuesProducer != null : "At least one reader must be non-null";
-        this.knnVectorsReader = knnVectorsReader;
-        this.docValuesProducer = docValuesProducer;
-        this.onClose = () -> IOUtils.close(knnVectorsReader, docValuesProducer);
+        this(knnVectorsReader, docValuesProducer, () -> IOUtils.close(knnVectorsReader, docValuesProducer));
     }
 
     private DerivedSourceReaders(KnnVectorsReader knnVectorsReader, DocValuesProducer docValuesProducer, Closeable onClose) {
@@ -116,5 +113,5 @@ public final class DerivedSourceReaders implements Cloneable, Closeable {
         if (closed) {
             throw new AlreadyClosedException("DerivedSourceReader is closed");
         }
-    };
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersTests.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.codec.derivedsource;
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.mockito.Mock;
 import org.opensearch.knn.KNNTestCase;
 
@@ -47,6 +48,20 @@ public class DerivedSourceReadersTests extends KNNTestCase {
         mergeInstance.close(); // no-op
         verify(mockKnnVectorsReader, never()).close();
         verify(mockDocValuesProducer, never()).close();
+    }
+
+    @SneakyThrows
+    public void testCloneAfterCloseThrows() {
+        readers = new DerivedSourceReaders(mockKnnVectorsReader, mockDocValuesProducer);
+        readers.close();
+        expectThrows(AlreadyClosedException.class, () -> readers.clone());
+    }
+
+    @SneakyThrows
+    public void testGetMergeInstanceAfterCloseThrows() {
+        readers = new DerivedSourceReaders(mockKnnVectorsReader, mockDocValuesProducer);
+        readers.close();
+        expectThrows(AlreadyClosedException.class, () -> readers.getMergeInstance());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceReadersTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.codecs.KnnVectorsReader;
 import org.mockito.Mock;
 import org.opensearch.knn.KNNTestCase;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class DerivedSourceReadersTests extends KNNTestCase {
@@ -23,20 +24,33 @@ public class DerivedSourceReadersTests extends KNNTestCase {
     private DerivedSourceReaders readers;
 
     @SneakyThrows
-    public void testInitialReferenceCount() {
+    public void testClose() {
         readers = new DerivedSourceReaders(mockKnnVectorsReader, mockDocValuesProducer);
-
-        // Initial reference count is 1, so closing once should trigger actual close
         readers.close();
-
         verify(mockKnnVectorsReader).close();
         verify(mockDocValuesProducer).close();
     }
 
     @SneakyThrows
+    public void testCloneDoesNotClose() {
+        readers = new DerivedSourceReaders(mockKnnVectorsReader, mockDocValuesProducer);
+        DerivedSourceReaders clone = readers.clone();
+        clone.close(); // should be no-op
+        verify(mockKnnVectorsReader, never()).close();
+        verify(mockDocValuesProducer, never()).close();
+    }
+
+    @SneakyThrows
+    public void testGetMergeInstanceDoesNotClose() {
+        readers = new DerivedSourceReaders(mockKnnVectorsReader, mockDocValuesProducer);
+        DerivedSourceReaders mergeInstance = readers.getMergeInstance();
+        mergeInstance.close(); // no-op
+        verify(mockKnnVectorsReader, never()).close();
+        verify(mockDocValuesProducer, never()).close();
+    }
+
+    @SneakyThrows
     public void testNullReaders() {
-        // Test with null readers to ensure no NPE
-        DerivedSourceReaders nullReaders = new DerivedSourceReaders(null, null);
-        nullReaders.close(); // Should not throw any exception
+        expectThrows(AssertionError.class, () -> new DerivedSourceReaders(null, null));
     }
 }


### PR DESCRIPTION
### Description
Reference counting for the underlying readers (StoredFieldsReader in this case) is already handled by Lucene's SegmentReader, so DerivedSourceReaders does not need its own ref-count.

StoredFieldsReader.clone() is called by Lucene on every document read (e.g. get/_source fetch), so the cloned instance must not close the underlying readers — only the owning instance should. This is achieved by delegating close behavior to a Closeable onClose: the public constructor registers a real close action, while clone() and getMergeInstance() produce non-owning instances with a no-op close.

### Related Issues
Resolves #[OpenSearch#20622](https://github.com/opensearch-project/OpenSearch/issues/20622) and https://github.com/opensearch-project/k-NN/issues/3191

### Repro attempt and logs

I modified the code and added some logs to understand when the readers where getting closed. For certain conditions freeReaderContext tries to close the OpensearchReaderManager on a cloned instance of storedfieldsReader. Ideally this should not happen but there seems to a race condition hard to pinpoint on where exactly the ref turns 0 and it tries to close the underlying readers. 

The clone implementation is now consistent with [Lucene90CompressingStoredFieldsReader.java](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/lucene90/compressing/Lucene90CompressingStoredFieldsReader.java#L103)

```
[2026-03-01T18:31:55,056][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][decRef] refCount 3
[2026-03-01T18:31:55,157][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][tryIncRef] current refCount 3
[2026-03-01T18:31:55,163][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][decRef] refCount 4
[2026-03-01T18:31:55,163][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][decRef] refCount 3
[2026-03-01T18:31:55,163][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][tryIncRef] current refCount 1
[2026-03-01T18:31:55,163][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][decRef] refCount 2
[2026-03-01T18:31:55,163][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][tryIncRef] current refCount 1
[2026-03-01T18:31:55,164][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][decRef] refCount 2
[2026-03-01T18:31:55,164][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][tryIncRef] current refCount 1
[2026-03-01T18:31:55,238][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][decRef] refCount 2
[2026-03-01T18:31:55,238][INFO ][o.o.i.e.OpenSearchReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [OpenSearchReaderManager][tryIncRef] current refCount 1
[2026-03-01T18:31:55,238][INFO ][o.o.i.e.I.ExternalReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [ExternalReaderManger][decRef] refCount 2
[2026-03-01T18:31:55,238][INFO ][o.o.i.e.I.ExternalReaderManager][758a3538f5f3cafd60a93ee69f8ad6f5] [ExternalReaderManger][decRef] refCount 1
[2026-03-01T18:31:55,239][INFO ][o.o.s.SearchService      ][758a3538f5f3cafd60a93ee69f8ad6f5] Attempting to free reader context
[2026-03-01T18:31:55,239][INFO ][o.o.s.i.ReaderContext    ][758a3538f5f3cafd60a93ee69f8ad6f5] [ReaderContext] closing reader context, refCount 1
[2026-03-01T18:31:55,239][WARN ][o.o.k.i.c.d.DerivedSourceReaders][758a3538f5f3cafd60a93ee69f8ad6f5] Attempted to close a cloned DerivedSourceReaders. This is a no-op to avoid closing the original readers

```
### Testing
The change was tested using reindex(calls freeReaderContext underneath) and force merge operations to make sure it works

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


