### PR TITLE
[BUGFIX]Catch Merge IOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Bug Fixes
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [#3093](https://github.com/opensearch-project/k-NN/pull/3093)
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
+* Catch Merge IOException [#3140](https://github.com/opensearch-project/k-NN/pull/3140)
 
 ### Refactoring
 

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -417,9 +417,6 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryInd
         return knn_jni::faiss_wrapper::QueryIndex(&jniUtil, env, indexPointerJ, queryVectorJ, kJ, methodParamsJ, parentIdsJ);
 
     }
-    catch (const faiss::FaissException& e) {
-        std::cout << "====> query get faiss exception:" << e.what() << "\n";
-    }
     catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -166,7 +166,6 @@ public class NativeIndexWriter {
                 knnVectorValuesSupplier.get(),
                 nativeIndexParams
             );
-            System.out.println(indexBuilder.getClass());
             indexBuilder.buildAndWriteIndex(nativeIndexParams);
             CodecUtil.writeFooter(output);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -132,6 +132,7 @@ public class NativeIndexWriter {
             throw new MergePolicy.MergeAbortedException("KNN Merge aborted.");
         } catch (Exception ex) {
             log.error("Merge exception happened for field {}", fieldInfo.name, ex);
+            throw new IOException("Merge exception happened for field: " + fieldInfo.name, ex);
         }
     }
 
@@ -165,6 +166,7 @@ public class NativeIndexWriter {
                 knnVectorValuesSupplier.get(),
                 nativeIndexParams
             );
+            System.out.println(indexBuilder.getClass());
             indexBuilder.buildAndWriteIndex(nativeIndexParams);
             CodecUtil.writeFooter(output);
         }

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -11,5 +11,6 @@ grant {
     permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512_spr";
     permission java.net.SocketPermission "*", "connect,resolve";
     permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.io.FilePermission "/proc/cpuinfo", "read";
 };

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -35,6 +35,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.index.vectorvalues.TestVectorValues;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.engine.MethodComponentContext;
@@ -717,6 +718,76 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
                 () -> knn80DocValuesConsumer.addKNNBinaryField(fieldInfoArray[0], randomVectorDocValuesProducer, true)
             );
             mergeHelper.verify(MergeAbortChecker::isMergeAborted, atLeastOnce());
+        }
+    }
+
+    public void testAddKNNBinaryField_fromScratch_faiss_merge_with_ThrowIOException() throws IOException {
+        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        int docsInSegment = 100;
+        String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+
+        KNNEngine knnEngine = KNNEngine.FAISS;
+        SpaceType spaceType = SpaceType.INNER_PRODUCT;
+        int dimension = 16;
+
+        SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
+            .directory(directory)
+            .segmentName(segmentName)
+            .docsInSegment(docsInSegment)
+            .codec(codec)
+            .build();
+
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .versionCreated(Version.CURRENT)
+            .build();
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            knnEngine,
+            spaceType,
+            new MethodComponentContext(METHOD_HNSW, ImmutableMap.of(METHOD_PARAMETER_M, 16, METHOD_PARAMETER_EF_CONSTRUCTION, 512))
+        );
+
+        String parameterString = XContentFactory.jsonBuilder()
+            .map(knnEngine.getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext).getLibraryParameters())
+            .toString();
+
+        FieldInfo[] fieldInfoArray = new FieldInfo[] {
+            KNNCodecTestUtil.FieldInfoBuilder.builder(fieldName)
+                .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+                .addAttribute(KNNConstants.KNN_ENGINE, knnEngine.getName())
+                .addAttribute(KNNConstants.SPACE_TYPE, spaceType.getValue())
+                .addAttribute(KNNConstants.PARAMETERS, parameterString)
+                .build() };
+
+        FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
+        SegmentWriteState state = new SegmentWriteState(null, directory, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+
+        long initialRefreshOperations = KNNGraphValue.REFRESH_TOTAL_OPERATIONS.getValue();
+
+        // Add documents to the field
+        KNN80DocValuesConsumer knn80DocValuesConsumer = new KNN80DocValuesConsumer(null, state);
+        TestVectorValues.RandomVectorDocValuesProducer randomVectorDocValuesProducer = new TestVectorValues.RandomVectorDocValuesProducer(
+            docsInSegment,
+            dimension
+        );
+
+        try (MockedStatic<JNIService> mockjniService = mockStatic(JNIService.class);) {
+            mockjniService.when(
+                () -> JNIService.createIndex(
+                    any(int[].class),
+                    any(long.class),
+                    any(int.class),
+                    any(IndexOutputWithBuffer.class),
+                    any(Map.class),
+                    any(KNNEngine.class)
+                )
+            ).thenThrow(new RuntimeException("IO exception"));
+            mockjniService.when(() -> JNIService.initIndex(any(long.class), any(int.class), any(Map.class), any(KNNEngine.class)))
+                .thenThrow(new RuntimeException("IO exception"));
+            expectThrows(
+                IOException.class,
+                () -> knn80DocValuesConsumer.addKNNBinaryField(fieldInfoArray[0], randomVectorDocValuesProducer, true)
+            );
         }
     }
 }


### PR DESCRIPTION
### Description
#2529 we made faiss engine can abort.  so we catch some exceptions. 

## BUGFIX1: Exception
but when there is some runtime exception in native io, like disk io exception, other runtime exceptions. it should be catch by `Lucene#ConcurrentMergeScheduler`

https://github.com/opensearch-project/k-NN/blob/7f19fa7dc38e6315957fa99a1b95fbc543206381/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java#L115-L136

we need made runtime exception throw to lucene level which can be handled by `ConcurrentMergeScheduler#handleMergeException` in NativeIndexWriter.java#L134

## BUGFIX2: permission Access
In MergeAbortChecker we changed MergeThread accessibility in code: https://github.com/opensearch-project/k-NN/blob/7f19fa7dc38e6315957fa99a1b95fbc543206381/src/main/java/org/apache/lucene/index/MergeAbortChecker.java#L33-L42

so we need add `suppressAccessChecks` and `accessDeclaredMemberspermission` into plugin-security.policy

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
