### PR TITLE
Bring back custom codec tests which was ignored during lucene upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -501,7 +501,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:${versions.slf4j}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-security', version: "${opensearch_build}"
     // Commenting this out till CustomCodec plugin is ready after Lucene 10.4.0 upgrade in OS Core.
-    //zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: "${opensearch_build}"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: "${opensearch_build}"
 }
 
 task windowsPatches(type:Exec) {
@@ -654,8 +654,6 @@ integTest {
     commonIntegTest(it, project, integTestDependOnJniLib, opensearch_tmp_dir, _numNodes)
     filter {
         excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
-        // Excluding till custom codec plugin upgrades
-        excludeTestsMatching "org.opensearch.knn.integ.codecs.CustomCodecsIT"
     }
     mustRunAfter test
 }
@@ -666,8 +664,6 @@ task integTestRemoteIndexBuild(type: RestIntegTestTask) {
         // Temporarily skipping this test class, see: https://github.com/opensearch-project/k-NN/issues/2726
         excludeTestsMatching "org.opensearch.knn.index.SegmentReplicationIT"
         excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
-        // Excluding till custom codec plugin upgrades
-        excludeTestsMatching "org.opensearch.knn.integ.codecs.CustomCodecsIT"
     }
     systemProperty("test.remoteBuild", System.getProperty("test.remoteBuild"))
     systemProperty("test.bucket", System.getProperty("test.bucket"))
@@ -694,7 +690,7 @@ def commonIntegTestClusters(OpenSearchCluster cluster, _numNodes){
     if (System.getProperty("security.enabled") != null) {
         configureSecurityPlugin(cluster)
     }
-    /*else {
+    else {
         // Only install custom codecs plugin
         configurations.zipArchive.asFileTree.filter(f -> f.name.contains("custom-codecs")).each {
             cluster.plugin(provider(new Callable<RegularFile>() {
@@ -709,7 +705,7 @@ def commonIntegTestClusters(OpenSearchCluster cluster, _numNodes){
             }
           }))
        }
-    }*/
+    }
 
     cluster.plugin(project.tasks.bundlePlugin.archiveFile)
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {


### PR DESCRIPTION
### Description
Bring back custom codec tests which was ignored during lucene upgrade, since custom codec plugin was not ready.

Ref: https://github.com/opensearch-project/k-NN/pull/3135

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
