### PR TITLE
[Bug] Fixed generating random entry points for CagraIndex in MOS when numVectors < entryPoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix score conversion logic for radial exact search [#3110](https://github.com/opensearch-project/k-NN/pull/3110)
 * Fix lucene reduce to topK when rescoring is enabled [#3124](https://github.com/opensearch-project/k-NN/pull/3124)
 * Fix bugs in optimistic search for nested Cagra index [#3155](https://github.com/opensearch-project/k-NN/pull/3155)
+* Fixed generating random entry points for CagraIndex in MOS when numVectors < entryPoints [#3161](https://github.com/opensearch-project/k-NN/pull/3161)
 * Fix integer overflow for memory optimized search [#3130](https://github.com/opensearch-project/k-NN/pull/3130)
 
 ### Refactoring

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -251,6 +251,9 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         }
 
         private static DocIdSetIterator generateRandomEntryPoints(final int numberOfEntryPoints, int totalNumberOfVectors) {
+            if (numberOfEntryPoints >= totalNumberOfVectors) {
+                return DocIdSetIterator.all(totalNumberOfVectors);
+            }
             return new DocIdSetIterator() {
                 final RobustUniqueRandomIterator robustUniqueRandomIterator = new RobustUniqueRandomIterator(
                     totalNumberOfVectors,

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/RandomEntryPointsKnnSearchStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/RandomEntryPointsKnnSearchStrategyTests.java
@@ -36,4 +36,26 @@ public class RandomEntryPointsKnnSearchStrategyTests {
             assertTrue(internalVectorId < numVectors);
         }
     }
+
+    @Test
+    @SneakyThrows
+    public void testRandomEntryPointsGeneration_whenNumVectorsIsLessThanNumEntries_thenSuccess() {
+        final int numEntries = 100;
+        final long numVectors = 10;
+
+        // Create strategy
+        final FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy strategy =
+            new FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy(numEntries, numVectors, mock(KnnSearchStrategy.class));
+
+        // Validate #entry points
+        assertEquals(numEntries, strategy.numberOfEntryPoints());
+
+        // We should get exactly `numEntries` vector ids.
+        final DocIdSetIterator iterator = strategy.entryPoints();
+        for (int i = 0; i < numVectors; ++i) {
+            final int internalVectorId = iterator.nextDoc();
+            assertTrue(internalVectorId >= 0);
+            assertTrue(internalVectorId < numVectors);
+        }
+    }
 }


### PR DESCRIPTION
### Description
Fixed generating random entry points for CagraIndex in MOS when numVectors < entryPoints. If numVectors < entryPoints then because of this https://github.com/opensearch-project/k-NN/blob/612b5496744ea0dcbf7d233c49f2f5980e6276e1/src/main/java/org/opensearch/knn/common/RobustUniqueRandomIterator.java#L70-L72 we were getting exceptions in test. 

Fixed the bug by ensuring if numVectors < entryPoints, then just return all docs as EntryPoints. This generally will not happen in production, but since in tests we test with less number of docs, this can happen.

Stack Trace:
```
REPRODUCE WITH: ./gradlew ':integTestRemoteIndexBuild' --tests 'org.opensearch.knn.memoryoptsearch.MOSFaissFP16IndexIT.testNestedFloatIndexWithCosine' -Dtests.seed=D5DF3F8273AE53AC -Dtests.security.manager=false -Dtests.locale=ee-Latn-GH -Dtests.timezone=Australia/Melbourne -Druntime.java=21
MOSFaissFP16IndexIT > testNestedFloatIndexWithCosine FAILED
    org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:39515/], URI [/target_index/_search], status line [HTTP/1.1 400 Bad Request]
    {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"numPopulate[32] > maxValExclusive[30]"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"target_index","node":"vi4LR8FNTCi_gfl7YpzJwA","reason":{"type":"illegal_argument_exception","reason":"numPopulate[32] > maxValExclusive[30]"}}],"caused_by":{"type":"illegal_argument_exception","reason":"numPopulate[32] > maxValExclusive[30]","caused_by":{"type":"illegal_argument_exception","reason":"numPopulate[32] > maxValExclusive[30]"}}},"status":400}
        at __randomizedtesting.SeedInfo.seed([D5DF3F8273AE53AC:75A77C81721BB783]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:494)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:383)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:358)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doNestedQuery(AbstractMemoryOptimizedKnnSearchIT.java:473)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doKnnSearchTest(AbstractMemoryOptimizedKnnSearchIT.java:253)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doKnnSearchTest(AbstractMemoryOptimizedKnnSearchIT.java:191)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doKnnSearchTest(AbstractMemoryOptimizedKnnSearchIT.java:209)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doTestNestedIndex(AbstractMemoryOptimizedKnnSearchIT.java:149)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doTestNestedIndex(AbstractMemoryOptimizedKnnSearchIT.java:120)
        at app//org.opensearch.knn.memoryoptsearch.MOSFaissFP16IndexIT.testNestedFloatIndexWithCosine(MOSFaissFP16IndexIT.java:46)
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
