### PR TITLE
Fix copy_to functionality with vector fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix radial search bug returning 0 results for IndexHNSWCagra [#3201](https://github.com/opensearch-project/k-NN/pull/3201)
 * Fix default encoder to SQ 1 bit for faiss 32x compression [#3210](https://github.com/opensearch-project/k-NN/pull/3210)
 * Fix for prefetch failure due to out of bound exception [#3240](https://github.com/opensearch-project/k-NN/pull/3240)
+* Fix copy_to functionality with vector fields [#3162](https://github.com/opensearch-project/k-NN/pull/3162)
 
 ### Refactoring
 * Refactor ExactSearcher to use VectorScorer instead of ExactKNNIterator [#3207](https://github.com/opensearch-project/k-NN/pull/3207)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Preserve raw non-XContent `_source` fields when derived source is enabled [#3402](https://github.com/opensearch-project/k-NN/pull/3402)
 * Fix dimension-based oversampling not applying for 32x compression [#3455](https://github.com/opensearch-project/k-NN/pull/3455)
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
+* Fix copy_to functionality with vector fields [#3162](https://github.com/opensearch-project/k-NN/pull/3162)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
 * Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1776,40 +1776,11 @@ public class OpenSearchIT extends KNNRestTestCase {
         String targetField1 = "target_vector_1";
         String targetField2 = "target_vector_2";
 
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(sourceField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .field("copy_to", new String[] { targetField1, targetField2 })
-            .endObject()
-            .startObject(targetField1)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .startObject(targetField2)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, new String[] { targetField1, targetField2 });
+        buildKnnVectorFieldMapping(builder, targetField1, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        buildKnnVectorFieldMapping(builder, targetField2, 2, SpaceType.L2, KNNEngine.LUCENE, null);
+        String mapping = builder.endObject().endObject().toString();
 
         createKnnIndex(indexName, mapping);
 
@@ -1835,31 +1806,10 @@ public class OpenSearchIT extends KNNRestTestCase {
         String sourceField = "source_vector";
         String targetField = "target_vector";
 
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(sourceField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .field("copy_to", targetField)
-            .endObject()
-            .startObject(targetField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
 
         createKnnIndex(indexName, mapping);
 
@@ -1892,31 +1842,10 @@ public class OpenSearchIT extends KNNRestTestCase {
         String sourceField = "source_vector";
         String targetField = "target_vector";
 
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(sourceField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .field("copy_to", targetField)
-            .endObject()
-            .startObject(targetField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
 
         createKnnIndex(indexName, mapping);
 
@@ -1944,31 +1873,10 @@ public class OpenSearchIT extends KNNRestTestCase {
         String sourceField = "source_vector";
         String targetField = "target_vector";
 
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(sourceField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .field("copy_to", targetField)
-            .endObject()
-            .startObject(targetField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
 
         createKnnIndex(indexName, mapping);
 
@@ -1993,31 +1901,10 @@ public class OpenSearchIT extends KNNRestTestCase {
         String sourceField = "source_vector";
         String targetField = "target_vector";
 
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(sourceField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .field("copy_to", targetField)
-            .endObject()
-            .startObject(targetField)
-            .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject("method")
-            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
 
         createKnnIndex(indexName, mapping);
 
@@ -2036,6 +1923,50 @@ public class OpenSearchIT extends KNNRestTestCase {
         assertEquals(sourceResults.get(0).getDocId(), targetResults.get(0).getDocId());
 
         deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenTargetFieldHasDifferentDimension_thenFail() {
+        String indexName = "test_copy_to_dim_mismatch";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 3, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f })
+        );
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("Vector dimension mismatch"));
+
+        deleteKNNIndex(indexName);
+    }
+
+    private static XContentBuilder buildKnnVectorFieldMapping(
+        XContentBuilder builder,
+        String fieldName,
+        int dimension,
+        SpaceType spaceType,
+        KNNEngine engine,
+        Object copyTo
+    ) throws IOException {
+        builder.startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, engine.getName())
+            .endObject();
+        if (copyTo != null) {
+            builder.field("copy_to", copyTo);
+        }
+        return builder.endObject();
     }
 
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1769,6 +1769,275 @@ public class OpenSearchIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
+    @SneakyThrows
+    public void testCopyTo_whenSearchOnTargetField_thenSuccess() {
+        String indexName = "test_copy_to_search";
+        String sourceField = "source_vector";
+        String targetField1 = "target_vector_1";
+        String targetField2 = "target_vector_2";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(sourceField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .field("copy_to", new String[] { targetField1, targetField2 })
+            .endObject()
+            .startObject(targetField1)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .startObject(targetField2)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        float[] queryVector = { 1.0f, 1.0f };
+        List<KNNResult> results1 = getResults(indexName, targetField1, queryVector, 1);
+        assertEquals(1, results1.size());
+        assertEquals("1", results1.get(0).getDocId());
+
+        List<KNNResult> results2 = getResults(indexName, targetField2, queryVector, 1);
+        assertEquals(1, results2.size());
+        assertEquals("1", results2.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenDocUpdated_thenTargetFieldReflectsUpdate() {
+        String indexName = "test_copy_to_update";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(sourceField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, mapping);
+
+        // Insert doc near [10, 10]
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        // Verify target field finds doc 1 near [10, 10]
+        float[] queryNearTen = { 10.0f, 10.0f };
+        List<KNNResult> results = getResults(indexName, targetField, queryNearTen, 1);
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        // Update doc to be near [1, 1]
+        updateKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        refreshAllIndices();
+
+        // Verify target field reflects the update
+        float[] queryNearOne = { 1.0f, 1.0f };
+        results = getResults(indexName, targetField, queryNearOne, 1);
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenDocDeleted_thenTargetFieldReflectsDeletion() {
+        String indexName = "test_copy_to_delete";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(sourceField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+        assertEquals(2, getDocCount(indexName));
+
+        deleteKnnDoc(indexName, "1");
+        refreshAllIndices();
+        assertEquals(1, getDocCount(indexName));
+
+        // Search on target field should only return doc 2
+        float[] queryVector = { 1.0f, 1.0f };
+        List<KNNResult> results = getResults(indexName, targetField, queryVector, 10);
+        assertEquals(1, results.size());
+        assertEquals("2", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenForceMerge_thenTargetFieldSearchable() {
+        String indexName = "test_copy_to_merge";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(sourceField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 5.0f, 5.0f });
+        addKnnDoc(indexName, "3", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        forceMergeKnnIndex(indexName);
+
+        float[] queryVector = { 1.0f, 1.0f };
+        List<KNNResult> results = getResults(indexName, targetField, queryVector, 2);
+        assertEquals(2, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenSourceAndTargetBothSearched_thenBothReturnResults() {
+        String indexName = "test_copy_to_both";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(sourceField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field("type", "knn_vector")
+            .field("dimension", 2)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        float[] queryVector = { 1.0f, 1.0f };
+
+        // Both source and target should return the same nearest neighbor
+        List<KNNResult> sourceResults = getResults(indexName, sourceField, queryVector, 1);
+        List<KNNResult> targetResults = getResults(indexName, targetField, queryVector, 1);
+
+        assertEquals(1, sourceResults.size());
+        assertEquals(1, targetResults.size());
+        assertEquals(sourceResults.get(0).getDocId(), targetResults.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)
         throws IOException, ParseException {
         final Response searchResponseField = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName, vector, k), k);

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.CompressionTestConfig;
 import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.Version;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -1784,6 +1785,230 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
             assertEquals(0L, result.longValue());
         }
         deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenSearchOnTargetField_thenSuccess() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test_copy_to_search";
+        String sourceField = "source_vector";
+        String targetField1 = "target_vector_1";
+        String targetField2 = "target_vector_2";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, new String[] { targetField1, targetField2 });
+        buildKnnVectorFieldMapping(builder, targetField1, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        buildKnnVectorFieldMapping(builder, targetField2, 2, SpaceType.L2, KNNEngine.LUCENE, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        float[] queryVector = { 1.0f, 1.0f };
+        List<KNNResult> results1 = getResults(indexName, targetField1, queryVector, 1);
+        assertEquals(1, results1.size());
+        assertEquals("1", results1.get(0).getDocId());
+
+        List<KNNResult> results2 = getResults(indexName, targetField2, queryVector, 1);
+        assertEquals(1, results2.size());
+        assertEquals("1", results2.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenDocUpdated_thenTargetFieldReflectsUpdate() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test_copy_to_update";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        // Insert doc near [10, 10]
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        // Verify target field finds doc 1 near [10, 10]
+        float[] queryNearTen = { 10.0f, 10.0f };
+        List<KNNResult> results = getResults(indexName, targetField, queryNearTen, 1);
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        // Update doc to be near [1, 1]
+        updateKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        refreshAllIndices();
+
+        // Verify target field reflects the update
+        float[] queryNearOne = { 1.0f, 1.0f };
+        results = getResults(indexName, targetField, queryNearOne, 1);
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenDocDeleted_thenTargetFieldReflectsDeletion() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test_copy_to_delete";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+        assertEquals(2, getDocCount(indexName));
+
+        deleteKnnDoc(indexName, "1");
+        refreshAllIndices();
+        assertEquals(1, getDocCount(indexName));
+
+        // Search on target field should only return doc 2
+        float[] queryVector = { 1.0f, 1.0f };
+        List<KNNResult> results = getResults(indexName, targetField, queryVector, 10);
+        assertEquals(1, results.size());
+        assertEquals("2", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenForceMerge_thenTargetFieldSearchable() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test_copy_to_merge";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 5.0f, 5.0f });
+        addKnnDoc(indexName, "3", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        forceMergeKnnIndex(indexName);
+
+        float[] queryVector = { 1.0f, 1.0f };
+        List<KNNResult> results = getResults(indexName, targetField, queryVector, 2);
+        assertEquals(2, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenSourceAndTargetBothSearched_thenBothReturnResults() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test_copy_to_both";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 2, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 10.0f });
+        refreshAllIndices();
+
+        float[] queryVector = { 1.0f, 1.0f };
+
+        // Both source and target should return the same nearest neighbor
+        List<KNNResult> sourceResults = getResults(indexName, sourceField, queryVector, 1);
+        List<KNNResult> targetResults = getResults(indexName, targetField, queryVector, 1);
+
+        assertEquals(1, sourceResults.size());
+        assertEquals(1, targetResults.size());
+        assertEquals(sourceResults.get(0).getDocId(), targetResults.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testCopyTo_whenTargetFieldHasDifferentDimension_thenFail() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test_copy_to_dim_mismatch";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties");
+        buildKnnVectorFieldMapping(builder, sourceField, 2, SpaceType.L2, KNNEngine.FAISS, targetField);
+        buildKnnVectorFieldMapping(builder, targetField, 3, SpaceType.L2, KNNEngine.FAISS, null);
+        String mapping = builder.endObject().endObject().toString();
+
+        createKnnIndex(indexName, mapping);
+
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f })
+        );
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("Vector dimension mismatch"));
+
+        deleteKNNIndex(indexName);
+    }
+
+    private static XContentBuilder buildKnnVectorFieldMapping(
+        XContentBuilder builder,
+        String fieldName,
+        int dimension,
+        SpaceType spaceType,
+        KNNEngine engine,
+        Object copyTo
+    ) throws IOException {
+        builder.startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject("method")
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNNConstants.KNN_ENGINE, engine.getName())
+            .endObject();
+        if (copyTo != null) {
+            builder.field("copy_to", copyTo);
+        }
+        return builder.endObject();
     }
 
     private List<KNNResult> getResults(final String indexName, final String fieldName, final float[] vector, final int k)

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Before;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -19,6 +20,8 @@ import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.knn.Pair;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.io.IOException;
@@ -28,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.knn.DerivedSourceUtils.DERIVED_ENABLED_WITH_SEGREP_SETTINGS;
 import static org.opensearch.knn.DerivedSourceUtils.TEST_DIMENSION;
 import static org.opensearch.knn.DerivedSourceUtils.randomVectorSupplier;
@@ -295,6 +299,164 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         assertEquals("Vector 1 should have correct dimension", dimension, retrievedVector1.size());
         assertEquals("Vector 2 should have correct dimension", dimension, retrievedVector2.size());
         assertEquals("Vector 3 should have correct dimension", dimension, retrievedVector3.size());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testDerivedSource_withCopyTo_thenTargetFieldSearchable() {
+        String indexName = "test-derived-copy-to";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+        int dimension = 3;
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.knn.derived_source.enabled", true)
+            .build();
+
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject(sourceField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, settings, mappingBuilder.toString());
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 2.0f, 3.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 20.0f, 30.0f });
+        refreshIndex(indexName);
+
+        // Verify _source is correctly reconstructed with derived source
+        Map<String, Object> doc1Source = getKnnDoc(indexName, "1");
+        assertNotNull("Source vector should be reconstructed from derived source", doc1Source.get(sourceField));
+        List<?> sourceVector = (List<?>) doc1Source.get(sourceField);
+        assertEquals(dimension, sourceVector.size());
+        assertEquals(1.0, ((Number) sourceVector.get(0)).doubleValue(), 0.01);
+
+        // Verify search on target (copy_to) field returns correct results
+        float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        Response searchResponse = searchKNNIndex(indexName, new KNNQueryBuilder(targetField, queryVector, 1), 1);
+        String searchResponseBody = EntityUtils.toString(searchResponse.getEntity());
+        List<KNNResult> results = parseSearchResponse(searchResponseBody, targetField);
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testDerivedSource_withCopyTo_thenSourceMatchesNonDerived() {
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+        int dimension = 3;
+        String derivedIndex = "test-derived-copy-to-enabled";
+        String baselineIndex = "test-derived-copy-to-disabled";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject(sourceField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(
+            derivedIndex,
+            Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put("index.knn.derived_source.enabled", true)
+                .build(),
+            mapping
+        );
+        createKnnIndex(
+            baselineIndex,
+            Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put("index.knn.derived_source.enabled", false)
+                .build(),
+            mapping
+        );
+
+        Float[][] vectors = { { 1.0f, 2.0f, 3.0f }, { 10.0f, 20.0f, 30.0f }, { 5.0f, 5.0f, 5.0f } };
+        for (int i = 0; i < vectors.length; i++) {
+            String docId = String.valueOf(i + 1);
+            addKnnDoc(derivedIndex, docId, sourceField, vectors[i]);
+            addKnnDoc(baselineIndex, docId, sourceField, vectors[i]);
+        }
+        refreshIndex(derivedIndex);
+        refreshIndex(baselineIndex);
+
+        // Verify _source matches between derived and non-derived indices
+        for (int i = 0; i < vectors.length; i++) {
+            String docId = String.valueOf(i + 1);
+            Map<String, Object> derivedDoc = getKnnDoc(derivedIndex, docId);
+            Map<String, Object> baselineDoc = getKnnDoc(baselineIndex, docId);
+            assertEquals("Source field _source mismatch for doc " + docId, baselineDoc.get(sourceField), derivedDoc.get(sourceField));
+        }
+
+        deleteKNNIndex(derivedIndex);
+        deleteKNNIndex(baselineIndex);
+    }
+
+    @SneakyThrows
+    public void testDerivedSource_withCopyTo_whenDimensionMismatch_thenFail() {
+        String indexName = "test-derived-copy-to-dim-mismatch";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.knn.derived_source.enabled", true)
+            .build();
+
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject(sourceField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, 2)
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, 3)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, settings, mappingBuilder.toString());
+
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f })
+        );
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("Vector dimension mismatch"));
 
         deleteKNNIndex(indexName);
     }

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -9,6 +9,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Before;
+import org.opensearch.Version;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -22,6 +23,8 @@ import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.knn.Pair;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.io.IOException;
@@ -340,6 +343,176 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         assertEquals("Vector 1 should have correct dimension", dimension, retrievedVector1.size());
         assertEquals("Vector 2 should have correct dimension", dimension, retrievedVector2.size());
         assertEquals("Vector 3 should have correct dimension", dimension, retrievedVector3.size());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testDerivedSource_withCopyTo_thenTargetFieldSearchable() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test-derived-copy-to";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+        int dimension = 3;
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.knn.derived_source.enabled", true)
+            .build();
+
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject(sourceField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, settings, mappingBuilder.toString());
+
+        addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 2.0f, 3.0f });
+        addKnnDoc(indexName, "2", sourceField, new Float[] { 10.0f, 20.0f, 30.0f });
+        refreshIndex(indexName);
+
+        // Verify _source is correctly reconstructed with derived source
+        Map<String, Object> doc1Source = getKnnDoc(indexName, "1");
+        assertNotNull("Source vector should be reconstructed from derived source", doc1Source.get(sourceField));
+        List<?> sourceVector = (List<?>) doc1Source.get(sourceField);
+        assertEquals(dimension, sourceVector.size());
+        assertEquals(1.0, ((Number) sourceVector.get(0)).doubleValue(), 0.01);
+
+        // Verify search on target (copy_to) field returns correct results
+        float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        Response searchResponse = searchKNNIndex(indexName, new KNNQueryBuilder(targetField, queryVector, 1), 1);
+        String searchResponseBody = EntityUtils.toString(searchResponse.getEntity());
+        List<KNNResult> results = parseSearchResponse(searchResponseBody, targetField);
+        assertEquals(1, results.size());
+        assertEquals("1", results.get(0).getDocId());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testDerivedSource_withCopyTo_thenSourceMatchesNonDerived() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+        int dimension = 3;
+        String derivedIndex = "test-derived-copy-to-enabled";
+        String baselineIndex = "test-derived-copy-to-disabled";
+
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject(sourceField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(
+            derivedIndex,
+            Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put("index.knn.derived_source.enabled", true)
+                .build(),
+            mapping
+        );
+        createKnnIndex(
+            baselineIndex,
+            Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put("index.knn.derived_source.enabled", false)
+                .build(),
+            mapping
+        );
+
+        Float[][] vectors = { { 1.0f, 2.0f, 3.0f }, { 10.0f, 20.0f, 30.0f }, { 5.0f, 5.0f, 5.0f } };
+        for (int i = 0; i < vectors.length; i++) {
+            String docId = String.valueOf(i + 1);
+            addKnnDoc(derivedIndex, docId, sourceField, vectors[i]);
+            addKnnDoc(baselineIndex, docId, sourceField, vectors[i]);
+        }
+        refreshIndex(derivedIndex);
+        refreshIndex(baselineIndex);
+
+        // Verify _source matches between derived and non-derived indices
+        for (int i = 0; i < vectors.length; i++) {
+            String docId = String.valueOf(i + 1);
+            Map<String, Object> derivedDoc = getKnnDoc(derivedIndex, docId);
+            Map<String, Object> baselineDoc = getKnnDoc(baselineIndex, docId);
+            assertEquals("Source field _source mismatch for doc " + docId, baselineDoc.get(sourceField), derivedDoc.get(sourceField));
+        }
+
+        deleteKNNIndex(derivedIndex);
+        deleteKNNIndex(baselineIndex);
+    }
+
+    @SneakyThrows
+    public void testDerivedSource_withCopyTo_whenDimensionMismatch_thenFail() {
+        // copy_to for knn_vector requires OpenSearch 3.6.0+
+        if (Version.CURRENT.before(Version.V_3_6_0)) {
+            return;
+        }
+        String indexName = "test-derived-copy-to-dim-mismatch";
+        String sourceField = "source_vector";
+        String targetField = "target_vector";
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.knn.derived_source.enabled", true)
+            .build();
+
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject(sourceField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, 2)
+            .field("copy_to", targetField)
+            .endObject()
+            .startObject(targetField)
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, 3)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, settings, mappingBuilder.toString());
+
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> addKnnDoc(indexName, "1", sourceField, new Float[] { 1.0f, 1.0f })
+        );
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("Vector dimension mismatch"));
 
         deleteKNNIndex(indexName);
     }


### PR DESCRIPTION
### Description
Previously, adding the copy_to attribute to a vector field would cause an error during indexing. The root cause of this issue is the same as the cause of geo_point issue(opensearch-project/OpenSearch#20540) and has been resolved by opensearch-project/OpenSearch#20542. This PR includes integration tests that verify the copy_to attribute works correctly on vector fields.


### Related Issues
Resolves #2636

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
