### PR TITLE
[Bug] Ensure that entryPoints DISI and entryPoints count are same

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -220,7 +220,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
             return new KnnCollector.Decorator(ordinalTranslatedKnnCollector) {
                 @Override
                 public KnnSearchStrategy getSearchStrategy() {
-                    return new RandomEntryPointsKnnSearchStrategy(
+                    return RandomEntryPointsKnnSearchStrategy.getInstance(
                         cagraHNSW.getNumBaseLevelSearchEntryPoints(),
                         cagraHNSW.getTotalNumberOfVectors(),
                         knnCollector.getSearchStrategy()
@@ -238,16 +238,30 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
      * Note that doc-id-iterator returns a random ids in `nextDoc` method without sorting, and might return duplicated ids.
      */
     static class RandomEntryPointsKnnSearchStrategy extends KnnSearchStrategy.Seeded {
-        public RandomEntryPointsKnnSearchStrategy(
+
+        public static RandomEntryPointsKnnSearchStrategy getInstance(
             final int numberOfEntryPoints,
             final long totalNumberOfVectors,
             final KnnSearchStrategy originalStrategy
         ) {
-            super(
-                generateRandomEntryPoints(numberOfEntryPoints, Math.toIntExact(totalNumberOfVectors)),
-                numberOfEntryPoints,
-                originalStrategy
-            );
+
+            int entryPoints = getTotalNumberOfEntryPoints(numberOfEntryPoints, Math.toIntExact(totalNumberOfVectors));
+
+            final DocIdSetIterator docIdSetIterator = generateRandomEntryPoints(entryPoints, Math.toIntExact(totalNumberOfVectors));
+
+            return new RandomEntryPointsKnnSearchStrategy(docIdSetIterator, entryPoints, originalStrategy);
+        }
+
+        private RandomEntryPointsKnnSearchStrategy(
+            final DocIdSetIterator entryPoints,
+            final int numberOfEntryPoints,
+            final KnnSearchStrategy originalStrategy
+        ) {
+            super(entryPoints, numberOfEntryPoints, originalStrategy);
+        }
+
+        private static int getTotalNumberOfEntryPoints(int numberOfEntryPoints, int totalVectors) {
+            return numberOfEntryPoints >= totalVectors ? totalVectors : numberOfEntryPoints;
         }
 
         private static DocIdSetIterator generateRandomEntryPoints(final int numberOfEntryPoints, int totalNumberOfVectors) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/RandomEntryPointsKnnSearchStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/RandomEntryPointsKnnSearchStrategyTests.java
@@ -23,7 +23,11 @@ public class RandomEntryPointsKnnSearchStrategyTests {
 
         // Create strategy
         final FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy strategy =
-            new FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy(numEntries, numVectors, mock(KnnSearchStrategy.class));
+            FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy.getInstance(
+                numEntries,
+                numVectors,
+                mock(KnnSearchStrategy.class)
+            );
 
         // Validate #entry points
         assertEquals(numEntries, strategy.numberOfEntryPoints());
@@ -45,10 +49,14 @@ public class RandomEntryPointsKnnSearchStrategyTests {
 
         // Create strategy
         final FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy strategy =
-            new FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy(numEntries, numVectors, mock(KnnSearchStrategy.class));
+            FaissMemoryOptimizedSearcher.RandomEntryPointsKnnSearchStrategy.getInstance(
+                numEntries,
+                numVectors,
+                mock(KnnSearchStrategy.class)
+            );
 
         // Validate #entry points
-        assertEquals(numEntries, strategy.numberOfEntryPoints());
+        assertEquals(numVectors, strategy.numberOfEntryPoints());
 
         // We should get exactly `numEntries` vector ids.
         final DocIdSetIterator iterator = strategy.entryPoints();


### PR DESCRIPTION
### Description
Ensure that entryPoints DISI and entryPoints count are same

### Fix for the failing test:
```
Suite: Test class org.opensearch.knn.memoryoptsearch.MOSFaissFP16IndexIT
MOSFaissFP16IndexIT > testNestedFloatIndexWithIP FAILED
    org.opensearch.client.ResponseException: method [POST], host [http://127.0.0.1:45049/], URI [/target_index/_search], status line [HTTP/1.1 400 Bad Request]
    {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"The number of entry points provided is less than the number of entry points requested"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"target_index","node":"eiXkx3hmQkm0Kk6JMo85NA","reason":{"type":"illegal_argument_exception","reason":"The number of entry points provided is less than the number of entry points requested"}}],"caused_by":{"type":"illegal_argument_exception","reason":"The number of entry points provided is less than the number of entry points requested","caused_by":{"type":"illegal_argument_exception","reason":"The number of entry points provided is less than the number of entry points requested"}}},"status":400}
        at __randomizedtesting.SeedInfo.seed([102EC50925EF88A4:7C6700A518AA8292]:0)
        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:494)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:383)
        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:358)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doNestedQuery(AbstractMemoryOptimizedKnnSearchIT.java:473)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doKnnSearchTest(AbstractMemoryOptimizedKnnSearchIT.java:253)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doKnnSearchTest(AbstractMemoryOptimizedKnnSearchIT.java:191)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doKnnSearchTest(AbstractMemoryOptimizedKnnSearchIT.java:209)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doTestNestedIndex(AbstractMemoryOptimizedKnnSearchIT.java:149)
        at app//org.opensearch.knn.memoryoptsearch.AbstractMemoryOptimizedKnnSearchIT.doTestNestedIndex(AbstractMemoryOptimizedKnnSearchIT.java:120)
        at app//org.opensearch.knn.memoryoptsearch.MOSFaissFP16IndexIT.testNestedFloatIndexWithIP(MOSFaissFP16IndexIT.java:37)
```

Exception cause: https://github.com/apache/lucene/blob/6f5451ca1aa1817a3b7a4d24576a23b71e9a1f95/lucene/core/src/java/org/apache/lucene/util/hnsw/SeededHnswGraphSearcher.java#L37-L55

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
