### PR TITLE
Deprecate confidence_interval parameter in Lucene Scalar Quantizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Maintenance
 * Improve unit tests by tightening asserts [#3112](https://github.com/opensearch-project/k-NN/pull/3112)
+* Deprecate confidence_interval parameter in Lucene Scalar Quantizer [#3168](https://github.com/opensearch-project/k-NN/pull/3168)
 
 ### Bug Fixes
 * The KNN1030Codec does not properly support delegation for non-default codec(s). [#3093](https://github.com/opensearch-project/k-NN/pull/3093)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -99,10 +99,17 @@ public class KNNConstants {
 
     // Lucene specific constants
     public static final String LUCENE_NAME = "lucene";
+    @Deprecated(since = "3.6.0", forRemoval = true)
     public static final String LUCENE_SQ_CONFIDENCE_INTERVAL = "confidence_interval";
+    @Deprecated(since = "3.6.0", forRemoval = true)
     public static final int DYNAMIC_CONFIDENCE_INTERVAL = 0;
+    @Deprecated(since = "3.6.0", forRemoval = true)
     public static final double MINIMUM_CONFIDENCE_INTERVAL = 0.9;
+    @Deprecated(since = "3.6.0", forRemoval = true)
     public static final double MAXIMUM_CONFIDENCE_INTERVAL = 1.0;
+    @Deprecated(since = "3.6.0", forRemoval = true)
+    public static final String CONFIDENCE_INTERVAL_DEPRECATION_MSG =
+        "[Deprecation] The [{}] parameter for the [{}] encoder is deprecated and will be removed in a future release.";
     public static final String LUCENE_SQ_BITS = "bits";
     public static final int LUCENE_SQ_DEFAULT_BITS = 7;
     public static final String MAX_CONNECTIONS = "max_connections";

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParams.java
@@ -21,6 +21,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
  */
 @Getter
 public class KNNScalarQuantizedVectorsFormatParams extends KNNVectorsFormatParams {
+    @Deprecated(since = "3.6.0", forRemoval = true)
     private Float confidenceInterval;
     private int bits;
     private boolean compressFlag;
@@ -53,6 +54,7 @@ public class KNNScalarQuantizedVectorsFormatParams extends KNNVectorsFormatParam
         return true;
     }
 
+    @Deprecated(since = "3.6.0", forRemoval = true)
     private void initConfidenceInterval(final Map<String, Object> params) {
 
         if (params != null && params.containsKey(LUCENE_SQ_CONFIDENCE_INTERVAL)) {

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.engine.lucene;
 
 import com.google.common.collect.ImmutableSet;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
@@ -22,6 +23,7 @@ import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_CONFIDENCE_INTERVAL;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_DEFAULT_BITS;
+import static org.opensearch.knn.common.KNNConstants.CONFIDENCE_INTERVAL_DEPRECATION_MSG;
 import static org.opensearch.knn.common.KNNConstants.MAXIMUM_CONFIDENCE_INTERVAL;
 import static org.opensearch.knn.common.KNNConstants.MINIMUM_CONFIDENCE_INTERVAL;
 
@@ -29,19 +31,21 @@ import static org.opensearch.knn.common.KNNConstants.MINIMUM_CONFIDENCE_INTERVAL
  * Lucene scalar quantization encoder
  */
 public class LuceneSQEncoder implements Encoder {
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(LuceneSQEncoder.class);
+    private static final String CONFIDENCE_INTERVAL_DEPRECATION_KEY = "confidence_interval_deprecated";
     private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT);
-
     private final static List<Integer> LUCENE_SQ_BITS_SUPPORTED = List.of(7);
     private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(ENCODER_SQ)
         .addSupportedDataTypes(SUPPORTED_DATA_TYPES)
-        .addParameter(
-            LUCENE_SQ_CONFIDENCE_INTERVAL,
-            new Parameter.DoubleParameter(
+        .addParameter(LUCENE_SQ_CONFIDENCE_INTERVAL, new Parameter.DoubleParameter(LUCENE_SQ_CONFIDENCE_INTERVAL, null, (v, context) -> {
+            deprecationLogger.deprecate(
+                CONFIDENCE_INTERVAL_DEPRECATION_KEY,
+                CONFIDENCE_INTERVAL_DEPRECATION_MSG,
                 LUCENE_SQ_CONFIDENCE_INTERVAL,
-                null,
-                (v, context) -> v == DYNAMIC_CONFIDENCE_INTERVAL || (v >= MINIMUM_CONFIDENCE_INTERVAL && v <= MAXIMUM_CONFIDENCE_INTERVAL)
-            )
-        )
+                ENCODER_SQ
+            );
+            return v == DYNAMIC_CONFIDENCE_INTERVAL || (v >= MINIMUM_CONFIDENCE_INTERVAL && v <= MAXIMUM_CONFIDENCE_INTERVAL);
+        }))
         .addParameter(
             LUCENE_SQ_BITS,
             new Parameter.IntegerParameter(LUCENE_SQ_BITS, LUCENE_SQ_DEFAULT_BITS, (v, context) -> LUCENE_SQ_BITS_SUPPORTED.contains(v))

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
@@ -5,12 +5,45 @@
 
 package org.opensearch.knn.index.engine.lucene;
 
+import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.Parameter;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
+import java.util.Collections;
+
+import static org.opensearch.knn.common.KNNConstants.CONFIDENCE_INTERVAL_DEPRECATION_MSG;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_CONFIDENCE_INTERVAL;
+
 public class LuceneSQEncoderTests extends KNNTestCase {
+
+    @Override
+    protected boolean enableWarningsCheck() {
+        return true;
+    }
+
     public void testCalculateCompressionLevel() {
         LuceneSQEncoder encoder = new LuceneSQEncoder();
         assertEquals(CompressionLevel.x4, encoder.calculateCompressionLevel(null, null));
+    }
+
+    public void testDeprecationWarning_whenConfidenceIntervalProvided() {
+        Parameter<?> ciParam = new LuceneSQEncoder().getMethodComponent().getParameters().get(LUCENE_SQ_CONFIDENCE_INTERVAL);
+        ciParam.validate(0.95, buildConfigContext());
+        assertWarnings(String.format(CONFIDENCE_INTERVAL_DEPRECATION_MSG.replace("{}", "%s"), LUCENE_SQ_CONFIDENCE_INTERVAL, ENCODER_SQ));
+    }
+
+    public void testNoDeprecationWarning_whenConfidenceIntervalOmitted() {
+        new LuceneSQEncoder().getMethodComponent()
+            .validate(new MethodComponentContext(ENCODER_SQ, Collections.emptyMap()), buildConfigContext());
+        // assertWarnings is not called — OpenSearchTestCase will fail if any unexpected warnings are emitted
+    }
+
+    private KNNMethodConfigContext buildConfigContext() {
+        return KNNMethodConfigContext.builder().dimension(128).versionCreated(Version.CURRENT).vectorDataType(VectorDataType.FLOAT).build();
     }
 }


### PR DESCRIPTION
### Description
The `confidence_interval` parameter in the Lucene SQ encoder is deprecated as of OpenSearch 3.6.0 and will be removed in a future release.

`confidence_interval` was originally passed to `Lucene99ScalarQuantizedVectorsFormat`, but Lucene dropped support for it in `Lucene104HnswScalarQuantizedVectorsFormat` — the confidence interval is now computed automatically from vector dimensionality. The KNN1040 codec currently preserves the parameter via the backward-compatible `Lucene99RWHnswScalarQuantizedVectorsFormat`, but it will have no effect in future codec versions.

### Related Issues

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). - https://github.com/opensearch-project/documentation-website/issues/12100

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
