### PR TITLE
Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Use right Vector Scorer when segments are initialized using SPI and also corrected the maxConn for MOS [#3117](https://github.com/opensearch-project/k-NN/pull/3117)
 * Use pre-quantized vectors for ADC [#3113](https://github.com/opensearch-project/k-NN/pull/3113)
 * Upgrade Lucene to 10.4.0 [#3135](https://github.com/opensearch-project/k-NN/pull/3135)
+* Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor [#3171](https://github.com/opensearch-project/k-NN/pull/3171)

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ByteVectorIdsExactKNNIterator.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ByteVectorIdsExactKNNIterator.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  */
 class ByteVectorIdsExactKNNIterator implements ExactKNNIterator {
     protected final DocIdSetIterator filterIdsIterator;
-    protected final float[] queryVector;
+    protected final byte[] byteQueryVector;
     protected final KNNByteVectorValues byteVectorValues;
     protected final SpaceType spaceType;
     protected float currentScore = Float.NEGATIVE_INFINITY;
@@ -33,7 +33,7 @@ class ByteVectorIdsExactKNNIterator implements ExactKNNIterator {
         final SpaceType spaceType
     ) throws IOException {
         this.filterIdsIterator = filterIdsIterator;
-        this.queryVector = queryVector;
+        this.byteQueryVector = convertToByteArray(queryVector);
         this.byteVectorValues = byteVectorValues;
         this.spaceType = spaceType;
         // This cannot be moved inside nextDoc() method since it will break when we have nested field, where
@@ -73,16 +73,6 @@ class ByteVectorIdsExactKNNIterator implements ExactKNNIterator {
         final byte[] vector = byteVectorValues.getVector();
         // Calculates a similarity score between the two vectors with a specified function. Higher similarity
         // scores correspond to closer vectors.
-
-        // The query vector of Faiss byte vector is a Float array because ScalarQuantizer accepts it as float array.
-        // To compute the score between this query vector and each vector in KNNByteVectorValues we are casting this query vector into byte
-        // array directly.
-        // This is safe to do so because float query vector already has validated byte values. Do not reuse this direct cast at any other
-        // place.
-        final byte[] byteQueryVector = new byte[queryVector.length];
-        for (int i = 0; i < queryVector.length; i++) {
-            byteQueryVector[i] = (byte) queryVector[i];
-        }
         return spaceType.getKnnVectorSimilarityFunction().compare(byteQueryVector, vector);
     }
 
@@ -96,5 +86,18 @@ class ByteVectorIdsExactKNNIterator implements ExactKNNIterator {
             byteVectorValues.advance(nextDocID);
         }
         return nextDocID;
+    }
+
+    private byte[] convertToByteArray(final float[] queryVector) {
+        // The query vector of Faiss byte vector is a Float array because ScalarQuantizer accepts it as float array.
+        // To compute the score between this query vector and each vector in KNNByteVectorValues we are casting this query vector into byte
+        // array directly.
+        // This is safe to do so because float query vector already has validated byte values. Do not reuse this direct cast at any other
+        // place.
+        final byte[] byteQueryVector = new byte[queryVector.length];
+        for (int i = 0; i < queryVector.length; i++) {
+            byteQueryVector[i] = (byte) queryVector[i];
+        }
+        return byteQueryVector;
     }
 }


### PR DESCRIPTION
### Description

- Move float-to-byte array conversion from computeScore() to constructor
- Extract conversion logic into private convertToByteArray() method
- Eliminates repeated array allocation and conversion on every score calculation


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
