### PR TITLE
Add Prefetch functionality to prefetch vectors during ANN Search for MemoryOptimizedSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,4 +29,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Use pre-quantized vectors for ADC [#3113](https://github.com/opensearch-project/k-NN/pull/3113)
 * Upgrade Lucene to 10.4.0 [#3135](https://github.com/opensearch-project/k-NN/pull/3135)
 * Speedup FP16 bulk similarity by precomputing the tail mask [#3172](https://github.com/opensearch-project/k-NN/pull/3172)
+* Add Prefetch functionality to prefetch vectors during ANN Search for MemoryOptimizedSearch. [#3173](https://github.com/opensearch-project/k-NN/pull/3173)
 * Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor [#3171](https://github.com/opensearch-project/k-NN/pull/3171)

--- a/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
+++ b/src/main/java/org/opensearch/knn/common/featureflags/KNNFeatureFlags.java
@@ -26,6 +26,8 @@ public class KNNFeatureFlags {
 
     // Feature flags
     private static final String KNN_FORCE_EVICT_CACHE_ENABLED = "knn.feature.cache.force_evict.enabled";
+    private static final String KNN_PREFETCH_ENABLED = "knn.feature.prefetch.enabled";
+    private static final boolean KNN_PREFETCH_ENABLED_DEFAULT_VALUE = true;
 
     @VisibleForTesting
     public static final Setting<Boolean> KNN_FORCE_EVICT_CACHE_ENABLED_SETTING = Setting.boolSetting(
@@ -35,8 +37,15 @@ public class KNNFeatureFlags {
         Dynamic
     );
 
+    public static final Setting<Boolean> KNN_PREFETCH_ENABLED_SETTING = Setting.boolSetting(
+        KNN_PREFETCH_ENABLED,
+        KNN_PREFETCH_ENABLED_DEFAULT_VALUE,
+        NodeScope,
+        Dynamic
+    );
+
     public static List<Setting<?>> getFeatureFlags() {
-        return ImmutableList.of(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING);
+        return ImmutableList.of(KNN_FORCE_EVICT_CACHE_ENABLED_SETTING, KNN_PREFETCH_ENABLED_SETTING);
     }
 
     /**
@@ -45,5 +54,12 @@ public class KNNFeatureFlags {
      */
     public static boolean isForceEvictCacheEnabled() {
         return Booleans.parseBoolean(KNNSettings.state().getSettingValue(KNN_FORCE_EVICT_CACHE_ENABLED).toString(), false);
+    }
+
+    public static boolean isPrefetchEnabled() {
+        return Booleans.parseBoolean(
+            KNNSettings.state().getSettingValue(KNN_PREFETCH_ENABLED).toString(),
+            KNN_PREFETCH_ENABLED_DEFAULT_VALUE
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.io.IOException;
 public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     /** The format for storing, reading, merging vectors on disk */
     private static final FlatVectorsFormat flatVectorsFormat = new Lucene99FlatVectorsFormat(
-        FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+        new PrefetchableFlatVectorScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer())
     );
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
     private final int approximateThreshold;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -354,7 +354,13 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         // Start creating searcher
         final String fileName = KNNCodecUtil.getNativeEngineFileFromFieldInfo(fieldInfo, segmentReadState.segmentInfo);
         if (fileName != null) {
-            return () -> searcherFactory.createVectorSearcher(segmentReadState.directory, fileName, fieldInfo, ioContext);
+            return () -> searcherFactory.createVectorSearcher(
+                segmentReadState.directory,
+                fileName,
+                fieldInfo,
+                ioContext,
+                flatVectorsReader.getFlatVectorScorer()
+            );
         }
 
         // Not supported

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchHelper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Helper class to prefetch vector data from disk to improve query performance.
+ * <p>
+ * Prefetches vector data using exact byte range strategy. Vectors are grouped together when
+ * the end of a vector (start offset + vector size) falls within 128KB from the group's start offset.
+ * This minimizes I/O operations while fetching only the exact bytes needed.
+ * <p>
+ * Prefetching is controlled by {@link KNNFeatureFlags#isPrefetchEnabled()}. When disabled,
+ * no prefetch operations are performed.
+ * <p>
+ * <b>Example:</b><br>
+ * Given vectors at offsets [100KB, 120KB, 300KB] with 10KB vector size:
+ * <ul>
+ *   <li>Group 1: Prefetch 40KB (100KB to 130KB, covers vectors at 100KB and 120KB)</li>
+ *   <li>Group 2: Prefetch 10KB (300KB to 310KB, covers vector at 300KB)</li>
+ * </ul>
+ * Result: 2 prefetch operations, 50KB total prefetched (vs 6 random seeks without prefetch)
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PrefetchHelper {
+
+    // TODO: If needed we can get this value via Cluster Settings
+    private static final long BYTES_128 = 128 * 1024;
+
+    /**
+     * Prefetches vector data from disk using exact byte range strategy.
+     * <p>
+     * Vectors are sorted by offset and grouped when the end of a vector falls within 128KB
+     * from the group start. Each group is prefetched with exact byte range needed.
+     * Returns early if prefetch is disabled, ordinals are null, or fewer than 2 vectors.
+     *
+     * @param indexInput the index input to prefetch from
+     * @param baseOffset the base offset in the file where vectors start
+     * @param oneVectorByteSize the size of one vector in bytes
+     * @param ordsToPrefetch array of vector ordinals to prefetch
+     * @param numOrds number of valid ordinals in the array
+     * @throws IOException if an I/O error occurs during prefetch
+     */
+    public static void prefetch(
+        final IndexInput indexInput,
+        final long baseOffset,
+        final long oneVectorByteSize,
+        final int[] ordsToPrefetch,
+        final int numOrds
+    ) throws IOException {
+        if (ordsToPrefetch == null || numOrds <= 1) {
+            return;
+        }
+        if (KNNFeatureFlags.isPrefetchEnabled()) {
+            prefetchExactVectorSize(indexInput, baseOffset, oneVectorByteSize, ordsToPrefetch, numOrds);
+        } else {
+            log.debug("KNNVectors Prefetch is disabled");
+        }
+    }
+
+    /**
+     * Prefetches vectors using exact byte ranges.
+     * <p>
+     * Groups vectors within 128KB ranges and prefetches only the exact bytes needed for each group.
+     *
+     * @param indexInput the index input to prefetch from
+     * @param baseOffset the base offset in the file where vectors start
+     * @param oneVectorByteSize the size of one vector in bytes
+     * @param ordsToPrefetch array of vector ordinals to prefetch
+     * @param numOrds number of valid ordinals in the array
+     * @throws IOException if an I/O error occurs during prefetch
+     */
+    private static void prefetchExactVectorSize(
+        final IndexInput indexInput,
+        final long baseOffset,
+        final long oneVectorByteSize,
+        final int[] ordsToPrefetch,
+        final int numOrds
+    ) throws IOException {
+        Arrays.sort(ordsToPrefetch, 0, numOrds);
+
+        int groupCount = 1;
+        long groupStartOffset = baseOffset + (long) ordsToPrefetch[0] * oneVectorByteSize;
+
+        for (int i = 1; i < numOrds; i++) {
+            long currentOffset = baseOffset + (long) ordsToPrefetch[i] * oneVectorByteSize;
+            if ((currentOffset + oneVectorByteSize) - groupStartOffset > BYTES_128) {
+                long prevOffset = baseOffset + (long) ordsToPrefetch[i - 1] * oneVectorByteSize;
+                indexInput.prefetch(groupStartOffset, (prevOffset + oneVectorByteSize) - groupStartOffset);
+                groupCount++;
+                groupStartOffset = currentOffset;
+            }
+        }
+        // Prefetch final group
+        long lastOffset = baseOffset + (long) ordsToPrefetch[numOrds - 1] * oneVectorByteSize;
+        indexInput.prefetch(groupStartOffset, (lastOffset + oneVectorByteSize) - groupStartOffset);
+
+        log.trace("Prefetching grouped [{}] vectors where num of ords was [{}] using exact prefetch size", groupCount, numOrds);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchableFlatVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchableFlatVectorScorer.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+
+import java.io.IOException;
+
+/**
+ * A Prefetchable {@link FlatVectorsScorer} that wraps another scorer and adds prefetching capabilities for doing
+ * search. For all other cases it just delegates to the underlying scorer.
+ */
+@Log4j2
+public class PrefetchableFlatVectorScorer implements FlatVectorsScorer {
+
+    private final FlatVectorsScorer delegateScorer;
+
+    /**
+     * Constructs a new prefetchable scorer wrapper.
+     *
+     * @param delegateScorer the underlying scorer to delegate to
+     */
+    public PrefetchableFlatVectorScorer(final FlatVectorsScorer delegateScorer) {
+        this.delegateScorer = delegateScorer;
+    }
+
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues
+    ) throws IOException {
+        return delegateScorer.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        float[] target
+    ) throws IOException {
+        return new PrefetchableRandomVectorScorer(
+            (RandomVectorScorer.AbstractRandomVectorScorer) delegateScorer.getRandomVectorScorer(similarityFunction, vectorValues, target)
+        );
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        byte[] target
+    ) throws IOException {
+        return new PrefetchableRandomVectorScorer(
+            (RandomVectorScorer.AbstractRandomVectorScorer) delegateScorer.getRandomVectorScorer(similarityFunction, vectorValues, target)
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "PrefetchableFlatVectorScorer()";
+    }
+
+    /**
+     * A {@link RandomVectorScorer} that prefetches vector data before bulk scoring operations during search.
+     *
+     * <p>This scorer delegates all operations to an underlying scorer, but intercepts {@link
+     * #bulkScore} to prefetch the required vectors before scoring.
+     */
+    @Log4j2
+    static class PrefetchableRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+
+        private final RandomVectorScorer.AbstractRandomVectorScorer delegate;
+
+        /**
+         * Constructs a new prefetchable random vector scorer.
+         *
+         * @param delegate the underlying scorer to delegate to
+         */
+        public PrefetchableRandomVectorScorer(final RandomVectorScorer.AbstractRandomVectorScorer delegate) {
+            super(delegate.values());
+            this.delegate = delegate;
+        }
+
+        @Override
+        public float score(int node) throws IOException {
+            return delegate.score(node);
+        }
+
+        /**
+         * Scores multiple nodes with prefetching optimization.
+         *
+         * <p>Prefetches vector data before delegating to the underlying scorer for improved
+         * performance.
+         *
+         * @param nodes    array of node ordinals to score
+         * @param scores   output array for computed scores
+         * @param numNodes number of nodes to score
+         * @return the maximum score computed
+         * @throws IOException if an I/O error occurs
+         */
+        @Override
+        public float bulkScore(int[] nodes, float[] scores, int numNodes) throws IOException {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(values(), nodes, numNodes);
+            return delegate.bulkScore(nodes, scores, numNodes);
+        }
+
+        @Override
+        public int maxOrd() {
+            return delegate.maxOrd();
+        }
+
+        @Override
+        public int ordToDoc(int ord) {
+            return delegate.ordToDoc(ord);
+        }
+
+        @Override
+        public Bits getAcceptOrds(Bits acceptDocs) {
+            return delegate.getAcceptOrds(acceptDocs);
+        }
+
+        @Override
+        public KnnVectorValues values() {
+            return delegate.values();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.KnnVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexFloatFlat;
+import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
+
+import java.io.IOException;
+
+/**
+ * Utility class that performs prefetching of vector data for upcoming node accesses during graph traversal.
+ * <p>
+ * Prefetching hints the underlying storage to load vector data into memory ahead of time, reducing I/O latency
+ * during scoring operations. This is particularly beneficial for memory-optimized (off-heap) search where vector
+ * data is read directly from disk-backed index inputs.
+ * <p>
+ * Supports prefetching for the following {@link KnnVectorValues} implementations:
+ * <ul>
+ *   <li>{@link FaissIndexFloatFlat.FloatVectorValuesImpl} — FAISS flat float vector storage</li>
+ *   <li>{@link FaissIndexBinaryFlat.ByteVectorValuesImpl} — FAISS flat binary vector storage</li>
+ *   <li>{@link HasIndexSlice} — Lucene native vector storage backed by a sliced index input</li>
+ * </ul>
+ */
+@Log4j2
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+class PrefetchableVectorValuesHelper {
+
+    /**
+     * Attempts to prefetch vector data for the given node ordinals.
+     * <p>
+     * If the provided {@link KnnVectorValues} implementation supports prefetching, this method will issue
+     * prefetch hints for the specified nodes. Otherwise, it logs an informational message and returns without
+     * performing any prefetch.
+     *
+     * @param vectorValues the vector values instance to prefetch from
+     * @param nodes        array of node ordinals whose vector data should be prefetched
+     * @param numNodes     number of valid entries in the {@code nodes} array to prefetch
+     * @throws IOException if an I/O error occurs during prefetching
+     */
+    public static void mayBeDoPrefetch(final KnnVectorValues vectorValues, final int[] nodes, final int numNodes) throws IOException {
+        switch (vectorValues) {
+            case FaissIndexFloatFlat.FloatVectorValuesImpl floatImpl:
+                floatImpl.prefetch(nodes, numNodes);
+                break;
+            case FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl:
+                binaryImpl.prefetch(nodes, numNodes);
+                break;
+            case HasIndexSlice luceneKNNVectorValues:
+                // Since Lucene uses HasIndexSlice, we can use the slice to prefetch and for lucene base offset for
+                // sliced index input is always 0.
+                PrefetchHelper.prefetch(luceneKNNVectorValues.getSlice(), 0, vectorValues.getVectorByteLength(), nodes, numNodes);
+                break;
+            default:
+                log.warn("Not able to do prefetch on instance {}", vectorValues.getClass().getSimpleName());
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -26,5 +27,11 @@ public interface VectorSearcherFactory {
      * @return Null instance if it is not supported, otherwise return {@link VectorSearcher}
      * @throws IOException
      */
-    VectorSearcher createVectorSearcher(Directory directory, String fileName, FieldInfo fieldInfo, IOContext ioContext) throws IOException;
+    VectorSearcher createVectorSearcher(
+        Directory directory,
+        String fileName,
+        FieldInfo fieldInfo,
+        IOContext ioContext,
+        FlatVectorsScorer vectorScorer
+    ) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexFloatFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexFloatFlat.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.codec.scorer.PrefetchHelper;
 
 import java.io.IOException;
 import java.util.Map;
@@ -81,39 +82,43 @@ public class FaissIndexFloatFlat extends FaissIndex {
 
     @Override
     public FloatVectorValues getFloatValues(final IndexInput indexInput) {
-        @RequiredArgsConstructor
-        class FloatVectorValuesImpl extends FloatVectorValues {
-            final IndexInput indexInput;
-            final float[] buffer = new float[dimension];
-
-            @Override
-            public float[] vectorValue(int internalVectorId) throws IOException {
-                indexInput.seek(floatVectors.getBaseOffset() + internalVectorId * oneVectorByteSize);
-                indexInput.readFloats(buffer, 0, buffer.length);
-                return buffer;
-            }
-
-            @Override
-            public FloatVectorValues copy() {
-                return new FloatVectorValuesImpl(indexInput.clone());
-            }
-
-            @Override
-            public int dimension() {
-                return dimension;
-            }
-
-            @Override
-            public int size() {
-                return totalNumberOfVectors;
-            }
-        }
-
         return new FloatVectorValuesImpl(indexInput);
     }
 
     @Override
     public ByteVectorValues getByteValues(IndexInput indexInput) {
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support " + ByteVectorValues.class.getSimpleName());
+    }
+
+    @RequiredArgsConstructor
+    public class FloatVectorValuesImpl extends FloatVectorValues {
+        final IndexInput indexInput;
+        final float[] buffer = new float[dimension];
+
+        @Override
+        public float[] vectorValue(int internalVectorId) throws IOException {
+            indexInput.seek(floatVectors.getBaseOffset() + internalVectorId * oneVectorByteSize);
+            indexInput.readFloats(buffer, 0, buffer.length);
+            return buffer;
+        }
+
+        public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
+            PrefetchHelper.prefetch(indexInput, floatVectors.getBaseOffset(), oneVectorByteSize, ordsToPrefetch, numOrds);
+        }
+
+        @Override
+        public FloatVectorValues copy() {
+            return new FloatVectorValuesImpl(indexInput.clone());
+        }
+
+        @Override
+        public int dimension() {
+            return dimension;
+        }
+
+        @Override
+        public int size() {
+            return totalNumberOfVectors;
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -60,7 +60,8 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     private boolean isAdc;
     private SimdVectorComputeService.SimilarityFunctionType nativeSimilarityFunctionType;
 
-    public FaissMemoryOptimizedSearcher(final IndexInput indexInput, final FieldInfo fieldInfo) throws IOException {
+    public FaissMemoryOptimizedSearcher(final IndexInput indexInput, final FieldInfo fieldInfo, final FlatVectorsScorer flatVectorsScorer)
+        throws IOException {
         this.indexInput = indexInput;
         this.fileSize = indexInput.length();
         this.faissIndex = FaissIndex.load(indexInput);
@@ -81,7 +82,12 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
             spaceType = isAdc ? SpaceType.getSpace(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)) : null;
         }
 
-        this.flatVectorsScorer = FlatVectorsScorerProvider.getFlatVectorsScorer(knnVectorSimilarityFunction, isAdc, spaceType);
+        this.flatVectorsScorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            knnVectorSimilarityFunction,
+            isAdc,
+            spaceType,
+            flatVectorsScorer
+        );
 
         this.hnsw = extractFaissHnsw(faissIndex);
         this.nativeSimilarityFunctionType = determineNativeFunctionType();

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss;
 
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.FieldInfo;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.store.Directory;
@@ -30,13 +31,14 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
         final Directory directory,
         final String fileName,
         final FieldInfo fieldInfo,
-        final IOContext ioContext
+        final IOContext ioContext,
+        final FlatVectorsScorer vectorScorer
     ) throws IOException {
         final IndexInput indexInput = directory.openInput(fileName, ioContext);
 
         try {
             // Try load it. Not all FAISS index types are currently supported at the moment.
-            return new FaissMemoryOptimizedSearcher(indexInput, fieldInfo);
+            return new FaissMemoryOptimizedSearcher(indexInput, fieldInfo, vectorScorer);
         } catch (UnsupportedFaissIndexException e) {
             // Clean up input stream.
             try {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -6,7 +6,6 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.experimental.UtilityClass;
-import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
@@ -23,7 +22,6 @@ import java.util.Map;
 
 @UtilityClass
 public class FlatVectorsScorerProvider {
-    private static final FlatVectorsScorer DELEGATE_VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
     private static final FlatVectorsScorer HAMMING_VECTOR_SCORER = new HammingFlatVectorsScorer();
     private static final Map<SpaceType, FlatVectorsScorer> ADC_FLAT_SCORERS = initializeAdcFlatScorers();
 
@@ -39,15 +37,6 @@ public class FlatVectorsScorerProvider {
     }
 
     /**
-     * Returns the FlatVectorsScorer based on the similarity function.
-     * @param similarityFunction the vector similarity function to use
-     * @return FlatVectorsScorer instance
-     */
-    public static FlatVectorsScorer getFlatVectorsScorer(final KNNVectorSimilarityFunction similarityFunction) {
-        return getFlatVectorsScorer(similarityFunction, false, null);
-    }
-
-    /**
      * Returns the FlatVectorsScorer based on the similarity function, or if adc is enabled based on the SpaceType.
      * @param similarityFunction the vector similarity function to use
      * @param isAdc whether ADC (Asymmetric Distance Computation) is enabled
@@ -57,7 +46,8 @@ public class FlatVectorsScorerProvider {
     public static FlatVectorsScorer getFlatVectorsScorer(
         final KNNVectorSimilarityFunction similarityFunction,
         final boolean isAdc,
-        final SpaceType spaceType
+        final SpaceType spaceType,
+        final FlatVectorsScorer delegateScorer
     ) {
         if (isAdc) {
             // Note: we cannot leverage KNNVectorSimilarityFunction here as it is HAMMING for ADC, so we must use SpaceType.
@@ -67,10 +57,10 @@ public class FlatVectorsScorerProvider {
             return HAMMING_VECTOR_SCORER;
         }
 
-        return DELEGATE_VECTOR_SCORER;
+        return delegateScorer;
     }
 
-    public static class ADCFlatVectorsScorer implements FlatVectorsScorer {
+    private static class ADCFlatVectorsScorer implements FlatVectorsScorer {
         private final KNNVectorSimilarityFunction knnSimilarityFunction;
         private final SpaceType spaceType;
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
@@ -10,6 +10,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
+import org.opensearch.knn.index.codec.scorer.PrefetchHelper;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissSection;
 
 import java.io.IOException;
@@ -57,35 +58,40 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
 
     @Override
     public ByteVectorValues getByteValues(final IndexInput indexInput) throws IOException {
-        @RequiredArgsConstructor
-        class ByteVectorValuesImpl extends ByteVectorValues {
-            final IndexInput indexInput;
-            final byte[] buffer = new byte[codeSize];
-
-            @Override
-            public byte[] vectorValue(int internalVectorId) throws IOException {
-                final long offset = binaryFlatVectorSection.getBaseOffset() + (long) internalVectorId * codeSize;
-                indexInput.seek(offset);
-                indexInput.readBytes(buffer, 0, codeSize);
-                return buffer;
-            }
-
-            @Override
-            public int dimension() {
-                return dimension;
-            }
-
-            @Override
-            public int size() {
-                return totalNumberOfVectors;
-            }
-
-            @Override
-            public ByteVectorValues copy() {
-                return new ByteVectorValuesImpl(indexInput.clone());
-            }
-        }
 
         return new ByteVectorValuesImpl(indexInput);
+    }
+
+    @RequiredArgsConstructor
+    public class ByteVectorValuesImpl extends ByteVectorValues {
+        final IndexInput indexInput;
+        final byte[] buffer = new byte[codeSize];
+
+        @Override
+        public byte[] vectorValue(int internalVectorId) throws IOException {
+            final long offset = binaryFlatVectorSection.getBaseOffset() + (long) internalVectorId * codeSize;
+            indexInput.seek(offset);
+            indexInput.readBytes(buffer, 0, codeSize);
+            return buffer;
+        }
+
+        public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
+            PrefetchHelper.prefetch(indexInput, binaryFlatVectorSection.getBaseOffset(), codeSize, ordsToPrefetch, numOrds);
+        }
+
+        @Override
+        public int dimension() {
+            return dimension;
+        }
+
+        @Override
+        public int size() {
+            return totalNumberOfVectors;
+        }
+
+        @Override
+        public ByteVectorValues copy() {
+            return new ByteVectorValuesImpl(indexInput.clone());
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/KNNTestCase.java
+++ b/src/test/java/org/opensearch/knn/KNNTestCase.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.store.IndexInput;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
@@ -33,8 +34,10 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -196,5 +199,72 @@ public class KNNTestCase extends OpenSearchTestCase {
      */
     protected int adjustDimensionForSearch(final int dimension, final VectorDataType vectorDataType) {
         return VectorDataType.BINARY == vectorDataType ? dimension / Byte.SIZE : dimension;
+    }
+
+    /**
+     * IndexInput wrapper that tracks prefetch calls for testing.
+     */
+    protected static class TrackingIndexInput extends IndexInput {
+        private final IndexInput delegate;
+        public final List<PrefetchCall> prefetchCalls = new ArrayList<>();
+
+        public TrackingIndexInput(IndexInput delegate) {
+            super(delegate.toString());
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void prefetch(long offset, long length) throws IOException {
+            prefetchCalls.add(new PrefetchCall(offset, length));
+            delegate.prefetch(offset, length);
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public long getFilePointer() {
+            return delegate.getFilePointer();
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            delegate.seek(pos);
+        }
+
+        @Override
+        public long length() {
+            return delegate.length();
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+            return delegate.slice(sliceDescription, offset, length);
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            return delegate.readByte();
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            delegate.readBytes(b, offset, len);
+        }
+
+        @Override
+        public void readFloats(float[] floats, int offset, int len) throws IOException {
+            delegate.readFloats(floats, offset, len);
+        }
+
+        @Override
+        public IndexInput clone() {
+            return new TrackingIndexInput(delegate.clone());
+        }
+
+        public record PrefetchCall(long offset, long length) {
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.KNN990Codec;
 
 import com.google.common.collect.ImmutableSet;
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
@@ -89,7 +90,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockSearcher.getByteVectorValues()).thenReturn(mock(ByteVectorValues.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mockSearcher);
 
         final FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {
@@ -124,7 +125,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
     public void testWhenMemoryOptimizedSearchIsEnabled_mixedCase() {
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {
             // Prepare field infos
@@ -154,10 +155,11 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
             });
 
             mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
-
-            final NativeEngines990KnnVectorsReader reader_field_2 = createReader(fieldInfos, filesInSegment, null);
-            final NativeEngines990KnnVectorsReader reader_field_3 = createReader(fieldInfos, filesInSegment, null);
-            final NativeEngines990KnnVectorsReader reader_field_4 = createReader(fieldInfos, filesInSegment, null);
+            FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+            final NativeEngines990KnnVectorsReader reader_field_2 = createReader(fieldInfos, filesInSegment, flatVectorsReader);
+            final NativeEngines990KnnVectorsReader reader_field_3 = createReader(fieldInfos, filesInSegment, flatVectorsReader);
+            final NativeEngines990KnnVectorsReader reader_field_4 = createReader(fieldInfos, filesInSegment, flatVectorsReader);
 
             assertFalse(getVectorSearcherHolders(reader_field_2).isSet());
             assertFalse(getVectorSearcherHolders(reader_field_3).isSet());

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchHelperTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.mockito.MockedStatic;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.featureflags.KNNFeatureFlags;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mockStatic;
+
+public class PrefetchHelperTests extends KNNTestCase {
+
+    public void testPrefetch_whenNullOrds_thenNoOp() throws IOException {
+        TrackingIndexInput trackingInput = createTrackingInput(1024);
+        PrefetchHelper.prefetch(trackingInput, 0L, 16L, null, 0);
+        assertTrue(trackingInput.prefetchCalls.isEmpty());
+    }
+
+    public void testPrefetch_whenZeroOrds_thenNoOp() throws IOException {
+        TrackingIndexInput trackingInput = createTrackingInput(1024);
+        int[] ords = { 0, 1, 2 };
+        PrefetchHelper.prefetch(trackingInput, 0L, 16L, ords, 0);
+        assertTrue(trackingInput.prefetchCalls.isEmpty());
+    }
+
+    public void testPrefetch_whenSingleOrd_thenNoOp() throws IOException {
+        TrackingIndexInput trackingInput = createTrackingInput(200 * 1024);
+        int[] ords = { 5 };
+        PrefetchHelper.prefetch(trackingInput, 100L, 16L, ords, 1);
+        assertTrue(trackingInput.prefetchCalls.isEmpty());
+    }
+
+    public void testPrefetch_whenPrefetchDisabled_thenNoPrefetch() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(false);
+            TrackingIndexInput trackingInput = createTrackingInput(200 * 1024);
+            int[] ords = { 0, 1, 2 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 3);
+            assertEquals(0, trackingInput.prefetchCalls.size());
+            assertTrue(trackingInput.prefetchCalls.isEmpty());
+        }
+    }
+
+    public void testPrefetch_whenVectorsWithinSameGroup_thenSingleExactPrefetch() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+            TrackingIndexInput trackingInput = createTrackingInput(200 * 1024);
+            int[] ords = { 0, 1, 2 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 3);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(3 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenVectorsSpanMultipleGroups_thenMultipleExactPrefetches() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+            TrackingIndexInput trackingInput = createTrackingInput(500 * 1024);
+            int[] ords = { 0, 100, 300 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 3);
+            assertEquals(2, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(101 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(300 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+        }
+    }
+
+    public void testPrefetch_whenNumOrdsLessThanArrayLength_thenOnlyPrefetchesNumOrds() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(200 * 1024);
+            int[] ords = { 0, 1, 2, 3, 4 };
+            PrefetchHelper.prefetch(trackingInput, 0L, 8L, ords, 2);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(16L, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenUnorderedOrds_thenSortsAndGroups() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(500 * 1024);
+            int[] ords = { 300, 0, 100 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 3);
+            assertEquals(2, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(101 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(300 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+        }
+    }
+
+    public void testPrefetch_whenBaseOffsetNonZero_thenOffsetsCalculatedCorrectly() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(200 * 1024);
+            long baseOffset = 10000L;
+            int[] ords = { 0, 1 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, baseOffset, vectorSize, ords, 2);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(baseOffset, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(2 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenVectorsExactly128KBApart_thenCreatesNewGroup() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(300 * 1024);
+            int[] ords = { 0, 128 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 2);
+            assertEquals(2, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(128 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+        }
+    }
+
+    public void testPrefetch_whenVectorsJustUnder128KBApart_thenSameGroup() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(300 * 1024);
+            int[] ords = { 0, 127 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 2);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(128 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenMultipleGroupsAndFileBoundary_thenRespectsFileLength() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            int fileSize = 350 * 1024;
+            TrackingIndexInput trackingInput = createTrackingInput(fileSize);
+            int[] ords = { 0, 100, 340 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 3);
+            assertEquals(2, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(101 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(340 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+        }
+    }
+
+    public void testPrefetch_whenFinalVectorEndsExactlyAtFileLength_thenPrefetchesExactly() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            int fileSize = 100 * 1024;
+            TrackingIndexInput trackingInput = createTrackingInput(fileSize);
+            int[] ords = { 0, 99 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 2);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(100 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(fileSize, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenGroupLengthExactly128KB_thenPrefetches128KB() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(300 * 1024);
+            int[] ords = { 0, 127 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 2);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(128 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenMultipleVectorsAt128KBIntervals_thenMultipleGroups() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(600 * 1024);
+            int[] ords = { 0, 128, 256 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 3);
+            assertEquals(3, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(128 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+            assertEquals(256 * vectorSize, trackingInput.prefetchCalls.get(2).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(2).length());
+        }
+    }
+
+    public void testPrefetch_whenDuplicateOrds_thenSortsAndDeduplicatesInPrefetch() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(200 * 1024);
+            int[] ords = { 5, 2, 5, 2, 10 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 5);
+            assertEquals(1, trackingInput.prefetchCalls.size());
+            assertEquals(2 * vectorSize, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(9 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+        }
+    }
+
+    public void testPrefetch_whenThreeOrMoreGroups_thenCreatesAllGroups() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(800 * 1024);
+            int[] ords = { 0, 50, 200, 400, 600 };
+            long vectorSize = 1024L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 5);
+            assertEquals(4, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(51 * vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(200 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+            assertEquals(400 * vectorSize, trackingInput.prefetchCalls.get(2).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(2).length());
+            assertEquals(600 * vectorSize, trackingInput.prefetchCalls.get(3).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(3).length());
+        }
+    }
+
+    public void testPrefetch_whenVectorEndExactly128KBPlusOneByte_thenCreatesNewGroup() throws IOException {
+        try (MockedStatic<KNNFeatureFlags> mockedFlags = mockStatic(KNNFeatureFlags.class)) {
+            mockedFlags.when(KNNFeatureFlags::isPrefetchEnabled).thenReturn(true);
+
+            TrackingIndexInput trackingInput = createTrackingInput(300 * 1024);
+            int[] ords = { 0, 127 };
+            long vectorSize = 1025L;
+            PrefetchHelper.prefetch(trackingInput, 0L, vectorSize, ords, 2);
+            assertEquals(2, trackingInput.prefetchCalls.size());
+            assertEquals(0L, trackingInput.prefetchCalls.get(0).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(0).length());
+            assertEquals(127 * vectorSize, trackingInput.prefetchCalls.get(1).offset());
+            assertEquals(vectorSize, trackingInput.prefetchCalls.get(1).length());
+        }
+    }
+
+    private TrackingIndexInput createTrackingInput(int sizeInBytes) throws IOException {
+        ByteBuffersDirectory dir = new ByteBuffersDirectory();
+        try (IndexOutput out = dir.createOutput("test", IOContext.DEFAULT)) {
+            out.writeBytes(new byte[sizeInBytes], sizeInBytes);
+        }
+        IndexInput delegate = dir.openInput("test", IOContext.DEFAULT);
+        return new TrackingIndexInput(delegate);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableFlatVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableFlatVectorScorerTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.junit.Test;
+import org.opensearch.knn.KNNTestCase;
+
+/**
+ * Tests that {@link PrefetchableFlatVectorScorer} overrides all methods from {@link
+ * org.apache.lucene.codecs.hnsw.FlatVectorsScorer}.
+ */
+public class PrefetchableFlatVectorScorerTests extends KNNTestCase {
+
+    @Test
+    public void testDeclaredMethodsOverridden() {
+        implTestDeclaredMethodsOverridden(FlatVectorsScorer.class, PrefetchableFlatVectorScorer.class);
+        implTestDeclaredMethodsOverridden(
+            PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer.class.getSuperclass(),
+            PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer.class
+        );
+    }
+
+    private void implTestDeclaredMethodsOverridden(Class<?> interfaceClass, Class<?> implClass) {
+        for (final Method superClassMethod : interfaceClass.getDeclaredMethods()) {
+            final int modifiers = superClassMethod.getModifiers();
+            if (Modifier.isFinal(modifiers)) continue;
+            if (Modifier.isStatic(modifiers)) continue;
+            try {
+                final Method subClassMethod = implClass.getDeclaredMethod(superClassMethod.getName(), superClassMethod.getParameterTypes());
+                assertEquals("getReturnType() difference", superClassMethod.getReturnType(), subClassMethod.getReturnType());
+            } catch (NoSuchMethodException e) {
+                fail(implClass + " needs to override '" + superClassMethod + "'");
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelperTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import org.apache.lucene.codecs.lucene95.OffHeapFloatVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.store.IndexInput;
+import org.mockito.MockedStatic;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexFloatFlat;
+import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PrefetchableVectorValuesHelperTests extends KNNTestCase {
+
+    private final int[] nodes = { 0, 1, 2 };
+    private final int numNodes = 3;
+
+    public void testMayBeDoPrefetch_whenFloatVectorValuesImpl_thenDelegates() throws IOException {
+        FaissIndexFloatFlat.FloatVectorValuesImpl floatImpl = mock(FaissIndexFloatFlat.FloatVectorValuesImpl.class);
+
+        PrefetchableVectorValuesHelper.mayBeDoPrefetch(floatImpl, nodes, numNodes);
+
+        verify(floatImpl).prefetch(nodes, numNodes);
+    }
+
+    public void testMayBeDoPrefetch_whenByteVectorValuesImpl_thenDelegates() throws IOException {
+        FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl = mock(FaissIndexBinaryFlat.ByteVectorValuesImpl.class);
+
+        PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, numNodes);
+
+        verify(binaryImpl).prefetch(nodes, numNodes);
+    }
+
+    public void testMayBeDoPrefetch_whenHasIndexSlice_thenCallsPrefetchHelper() throws IOException {
+        IndexInput mockSlice = mock(IndexInput.class);
+        when(mockSlice.length()).thenReturn(200L * 1024);
+        int vectorByteLength = 16;
+
+        OffHeapFloatVectorValues hasSliceValues = mock(OffHeapFloatVectorValues.class);
+        when(hasSliceValues.getSlice()).thenReturn(mockSlice);
+        when(hasSliceValues.getVectorByteLength()).thenReturn(vectorByteLength);
+
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(hasSliceValues, nodes, numNodes);
+
+            mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, numNodes));
+        }
+    }
+
+    public void testMayBeDoPrefetch_whenUnsupportedType_thenNoException() throws IOException {
+        KnnVectorValues unsupported = mock(FloatVectorValues.class);
+
+        // Should not throw, just logs
+        PrefetchableVectorValuesHelper.mayBeDoPrefetch(unsupported, nodes, numNodes);
+    }
+
+    public void testMayBeDoPrefetch_whenNullNodes_thenDelegatesAsIs() throws IOException {
+        FaissIndexFloatFlat.FloatVectorValuesImpl floatImpl = mock(FaissIndexFloatFlat.FloatVectorValuesImpl.class);
+
+        PrefetchableVectorValuesHelper.mayBeDoPrefetch(floatImpl, null, 0);
+
+        verify(floatImpl).prefetch(null, 0);
+    }
+
+    public void testMayBeDoPrefetch_whenZeroNumNodes_thenDelegatesAsIs() throws IOException {
+        FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl = mock(FaissIndexBinaryFlat.ByteVectorValuesImpl.class);
+
+        PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, 0);
+
+        verify(binaryImpl).prefetch(nodes, 0);
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
@@ -53,7 +54,11 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
     ) {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
-            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, NO_ADC_NEEDED);
+            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+                input,
+                NO_ADC_NEEDED,
+                FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+            );
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
@@ -46,7 +47,11 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
             // TODO: adc placeholder. isAdc false and SpaceType L2 are noops for the MemoryOptimizedSearcher here.
-            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null);
+            final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+                input,
+                null,
+                FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+            );
 
             // Make collector
             final int k = isApproximateSearch ? EF_SEARCH : TOTAL_NUMBER_OF_VECTORS;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -7,7 +7,9 @@ package org.opensearch.knn.memoryoptsearch;
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
@@ -113,6 +115,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     private static final int TOTAL_NUM_DOCS_IN_SEGMENT = 300;
     private static final int TOP_K = 30;
     private static final float NO_FILTERING = Float.NaN;
+    private static final FlatVectorsScorer SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
 
     public void test32xQuantizedBinaryIndexType() {
         final TestingSpec testingSpec = new TestingSpec(
@@ -575,12 +578,9 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         // Make SegmentReadState and do search
         try (final Directory directory = directoryClass.getConstructor(Path.class).newInstance(buildInfo.tempDirPath)) {
             final SegmentReadState readState = new SegmentReadState(directory, segmentInfo, fieldInfos, IOContext.DEFAULT);
-            try (
-                NativeEngines990KnnVectorsReader vectorsReader = new NativeEngines990KnnVectorsReader(
-                    readState,
-                    mock(FlatVectorsReader.class)
-                )
-            ) {
+            FlatVectorsReader mockedFlatVectorReader = mock(FlatVectorsReader.class);
+            when(mockedFlatVectorReader.getFlatVectorScorer()).thenReturn(SCORER);
+            try (NativeEngines990KnnVectorsReader vectorsReader = new NativeEngines990KnnVectorsReader(readState, mockedFlatVectorReader)) {
                 if (vectorDataType == VectorDataType.FLOAT) {
                     vectorsReader.search(TARGET_FIELD, (float[]) query, knnCollector, acceptDocs);
                 } else if (vectorDataType == VectorDataType.BYTE || vectorDataType == VectorDataType.BINARY) {
@@ -910,7 +910,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k = 100;
 
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
 
         // Use a non-seeded strategy (default HNSW strategy)
         final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
@@ -941,7 +941,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k = 100;
 
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
 
         // Create a Seeded strategy with known seed entry points
         final int numSeeds = 5;
@@ -1010,7 +1010,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         }
 
         // First, do exhaustive search to get ground truth
-        final FaissMemoryOptimizedSearcher exhaustiveSearcher = new FaissMemoryOptimizedSearcher(input, null);
+        final FaissMemoryOptimizedSearcher exhaustiveSearcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
         final KnnCollector exhaustiveCollector = new TopKnnCollector(totalVectors, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
         final AcceptDocs acceptDocs = AcceptDocs.fromLiveDocs(null, totalVectors);
         exhaustiveSearcher.search(query, exhaustiveCollector, acceptDocs);
@@ -1023,7 +1023,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
 
         // Now search with a seeded collector on a fresh searcher
         input.seek(0);
-        final FaissMemoryOptimizedSearcher seededSearcher = new FaissMemoryOptimizedSearcher(input, null);
+        final FaissMemoryOptimizedSearcher seededSearcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
 
         final int numSeeds = 3;
         final DocIdSetIterator seedDocs = new DocIdSetIterator() {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
@@ -27,7 +28,12 @@ public class FlatVectorsScorerProviderTests extends KNNTestCase {
     @SneakyThrows
     public void testHammingScoring() {
         // Get hamming scorer
-        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(KNNVectorSimilarityFunction.HAMMING);
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            KNNVectorSimilarityFunction.HAMMING,
+            false,
+            null,
+            null
+        );
 
         // Test byte[] vector and query
         final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
@@ -77,7 +83,12 @@ public class FlatVectorsScorerProviderTests extends KNNTestCase {
 
     @SneakyThrows
     private void doTest(final KNNVectorSimilarityFunction knnVectorSimilarityFunction, final boolean isFloat) {
-        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(knnVectorSimilarityFunction);
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            knnVectorSimilarityFunction,
+            false,
+            null,
+            FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+        );
 
         if (isFloat) {
             final FloatVectorValues vectorValues = mock(FloatVectorValues.class);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/CagraKnnCollectorCreationTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/CagraKnnCollectorCreationTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopKnnCollector;
@@ -21,6 +23,7 @@ import org.opensearch.knn.memoryoptsearch.FaissHNSWTests;
  */
 public class CagraKnnCollectorCreationTests extends KNNTestCase {
     private static final int TOTAL_VECTORS = 300;
+    private static final FlatVectorsScorer SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
 
     /**
      * When the collector has a non-seeded strategy and the index is CAGRA HNSW,
@@ -29,7 +32,7 @@ public class CagraKnnCollectorCreationTests extends KNNTestCase {
     @SneakyThrows
     public void testCreateKnnCollector_whenNonSeeded_thenWrapsWithRandomEntryPoints() {
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
 
         // Create a non-seeded collector
         final KnnCollector originalCollector = new TopKnnCollector(100, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
@@ -56,7 +59,7 @@ public class CagraKnnCollectorCreationTests extends KNNTestCase {
     @SneakyThrows
     public void testCreateKnnCollector_whenSeeded_thenPreservesOriginalStrategy() {
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
 
         // Create a seeded strategy
         final DocIdSetIterator seedDocs = new DocIdSetIterator() {


### PR DESCRIPTION
### Description
Add Prefetch functionality to prefetch vectors during ANN Search for MemoryOptimizedSearch.

What changes are present:
1. A new PrefetchableVectorScorer is created, which wraps FlatVectorScorer, which is then passed to FlatVectorFormat.
2. PrefetchableVectorScorer mainly calls the delegate scorer, just in case of bulkScore it calls prefetch first.
3. Moved the prefetch behind a FF.
4. Passed the FlatVectorScorer from FlatVectorFormat to FaissMemoryOptimizedSearcher to ensure that searcher can start using PrefetchableVectorScorer.
5. As of now, Prefetch is working for Byte, Fp32 and in ANN flow.

### Next Steps
1. Integrate the Prefetchable Scorer with NativeScorer(which uses BulkSIMD).
2. Integrate changes in the ADCScorer.
3. @VijayanB is working on implementing Scorer with ExactSearch which will bring Prefetch functionality to ExactSearch too.


### Related Issues
https://github.com/opensearch-project/k-NN/issues/2577

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
