### PR TITLE
Introduce NativeEngines990KnnVectorsScorer to decouple native SIMD scoring selection from FaissMemoryOptimizedSearcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add Prefetch functionality to prefetch vectors during ANN Search for MemoryOptimizedSearch. [#3173](https://github.com/opensearch-project/k-NN/pull/3173)
 * Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor [#3171](https://github.com/opensearch-project/k-NN/pull/3171)
 * Add VectorScorers for BinaryDocValues and nested best child scoring [#3179](https://github.com/opensearch-project/k-NN/pull/3179)
+* Introduce NativeEngines990KnnVectorsScorer to decouple native SIMD scoring selection from FaissMemoryOptimizedSearcher [#3184](https://github.com/opensearch-project/k-NN/pull/3184)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsFormat.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -35,7 +36,7 @@ import java.io.IOException;
 public class NativeEngines990KnnVectorsFormat extends KnnVectorsFormat {
     /** The format for storing, reading, merging vectors on disk */
     private static final FlatVectorsFormat flatVectorsFormat = new Lucene99FlatVectorsFormat(
-        new PrefetchableFlatVectorScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer())
+        new PrefetchableFlatVectorScorer(new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer()))
     );
     private static final String FORMAT_NAME = "NativeEngines990KnnVectorsFormat";
     private final int approximateThreshold;

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer;
+import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
+
+import java.io.IOException;
+
+/**
+ * A {@link FlatVectorsScorer} that transparently selects between native SIMD-optimized scoring
+ * and pure-Java scoring based on whether the underlying vector values are memory-mapped.
+ *
+ * <p>When the bottom-level {@link FloatVectorValues} implements {@link MMapVectorValues},
+ * this scorer returns a {@link NativeRandomVectorScorer} for hardware-accelerated computation.
+ * Otherwise, it delegates to the wrapped {@link FlatVectorsScorer}.
+ */
+@RequiredArgsConstructor
+public class NativeEngines990KnnVectorsScorer implements FlatVectorsScorer {
+    private final FlatVectorsScorer delegate;
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        float[] target
+    ) throws IOException {
+        final SimdVectorComputeService.SimilarityFunctionType nativeType = getNativeFunctionType(similarityFunction);
+        if (nativeType != null) {
+            final FloatVectorValues bottomValues = WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues);
+            if (bottomValues instanceof MMapVectorValues mmapValues) {
+                return new NativeRandomVectorScorer(target, vectorValues, mmapValues, nativeType);
+            }
+        }
+        return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+    }
+
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues,
+        byte[] target
+    ) throws IOException {
+        return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
+    }
+
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues
+    ) throws IOException {
+        return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
+    }
+
+    private static SimdVectorComputeService.SimilarityFunctionType getNativeFunctionType(
+        final VectorSimilarityFunction similarityFunction
+    ) {
+        return switch (similarityFunction) {
+            case MAXIMUM_INNER_PRODUCT -> SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT;
+            case EUCLIDEAN -> SimdVectorComputeService.SimilarityFunctionType.FP16_L2;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -9,7 +9,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
@@ -29,7 +28,6 @@ import org.opensearch.knn.common.RobustUniqueRandomIterator;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
-import org.opensearch.knn.jni.SimdVectorComputeService;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
 
@@ -58,7 +56,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     private final VectorSimilarityFunction vectorSimilarityFunction;
     private final long fileSize;
     private boolean isAdc;
-    private SimdVectorComputeService.SimilarityFunctionType nativeSimilarityFunctionType;
 
     public FaissMemoryOptimizedSearcher(final IndexInput indexInput, final FieldInfo fieldInfo, final FlatVectorsScorer flatVectorsScorer)
         throws IOException {
@@ -90,7 +87,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         );
 
         this.hnsw = extractFaissHnsw(faissIndex);
-        this.nativeSimilarityFunctionType = determineNativeFunctionType();
     }
 
     private static FaissHNSW extractFaissHnsw(final FaissIndex faissIndex) {
@@ -106,35 +102,13 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         final KnnVectorValues knnVectorValues = isAdc
             ? faissIndex.getByteValues(getSlicedIndexInput())
             : faissIndex.getFloatValues(getSlicedIndexInput());
-        final FloatVectorValues bottomKnnVectorValues = WrappedFloatVectorValues.getBottomFloatVectorValues(knnVectorValues);
-        final boolean useNativeScoring = bottomKnnVectorValues instanceof MMapVectorValues;
-        final IOSupplier<RandomVectorScorer> scorerSupplier;
 
-        if (useNativeScoring) {
-            // We can use native scoring.
-            scorerSupplier = () -> new NativeRandomVectorScorer(
-                target,
-                knnVectorValues,
-                (MMapVectorValues) bottomKnnVectorValues,
-                nativeSimilarityFunctionType
-            );
-        } else {
-            // Falling back to default scoring using pure Java.
-            scorerSupplier = () -> flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, knnVectorValues, target);
-        }
-
-        search(VectorEncoding.FLOAT32, scorerSupplier, knnCollector, acceptDocs);
-    }
-
-    private SimdVectorComputeService.SimilarityFunctionType determineNativeFunctionType() {
-        if (vectorSimilarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT) {
-            return SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT;
-        } else if (vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN) {
-            return SimdVectorComputeService.SimilarityFunctionType.FP16_L2;
-        }
-
-        // At the moment, we only support FP16, it's fine to return null.
-        return null;
+        search(
+            VectorEncoding.FLOAT32,
+            () -> flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, knnVectorValues, target),
+            knnCollector,
+            acceptDocs
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/NativeRandomVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/NativeRandomVectorScorer.java
@@ -5,9 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss;
 
-import lombok.NonNull;
 import org.apache.lucene.index.KnnVectorValues;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.jni.SimdVectorComputeService;
 
@@ -21,21 +19,12 @@ import java.io.IOException;
  * memory-mapped vector chunks, and delegates all similarity scoring operations to the
  * {@link SimdVectorComputeService}. The underlying native library is expected to
  * leverage SIMD instructions (e.g., AVX, AVX512, or NEON) to accelerate computations.
+ * <p>
+ * Extends {@link AbstractRandomVectorScorer} so that it can be wrapped by
+ * {@link org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer} for
+ * prefetch-enabled bulk scoring during HNSW graph traversal.
  */
-public class NativeRandomVectorScorer implements RandomVectorScorer {
-
-    // Backing {@link KnnVectorValues} used for document–vector association.
-    @NonNull
-    private final KnnVectorValues knnVectorValues;
-
-    // Array of address–size pairs describing memory-mapped vector chunks.
-    private long[] addressAndSize;
-
-    // Maximum vector id available for scoring.
-    private int maxOrd;
-
-    // Index value of the native similarity function type.
-    private int nativeFunctionTypeOrd;
+public class NativeRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
 
     /**
      * Constructs a native-backed scorer for computing similarity between the given query
@@ -52,11 +41,8 @@ public class NativeRandomVectorScorer implements RandomVectorScorer {
         final MMapVectorValues mmapVectorValues,
         final SimdVectorComputeService.SimilarityFunctionType similarityFunctionType
     ) {
-        this.knnVectorValues = knnVectorValues;
-        this.addressAndSize = mmapVectorValues.getAddressAndSize();
-        this.maxOrd = knnVectorValues.size();
-        this.nativeFunctionTypeOrd = similarityFunctionType.ordinal();
-        SimdVectorComputeService.saveSearchContext(query, addressAndSize, nativeFunctionTypeOrd);
+        super(knnVectorValues);
+        SimdVectorComputeService.saveSearchContext(query, mmapVectorValues.getAddressAndSize(), similarityFunctionType.ordinal());
     }
 
     /**
@@ -86,37 +72,5 @@ public class NativeRandomVectorScorer implements RandomVectorScorer {
     @Override
     public float score(final int internalVectorId) throws IOException {
         return SimdVectorComputeService.scoreSimilarity(internalVectorId);
-    }
-
-    /**
-     * Returns the maximum vector id for scoring.
-     *
-     * @return the maximum vector id
-     */
-    @Override
-    public int maxOrd() {
-        return maxOrd;
-    }
-
-    /**
-     * Maps an internal vector ordinal to its corresponding document ID.
-     *
-     * @param ord the internal vector id
-     * @return the document ID associated with the given vector id
-     */
-    @Override
-    public int ordToDoc(int ord) {
-        return knnVectorValues.ordToDoc(ord);
-    }
-
-    /**
-     * Returns a filtered {@link Bits} view representing accepted documents.
-     *
-     * @param acceptDocs the bit set of accepted documents
-     * @return a {@link Bits} object describing acceptable vector ids for scoring
-     */
-    @Override
-    public Bits getAcceptOrds(Bits acceptDocs) {
-        return knnVectorValues.getAcceptOrds(acceptDocs);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorerTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.scorer;
+
+import junit.framework.TestCase;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.mockito.MockedStatic;
+import org.opensearch.knn.jni.SimdVectorComputeService;
+import org.opensearch.knn.memoryoptsearch.faiss.MMapVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer;
+import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+public class NativeEngines990KnnVectorsScorerTests extends TestCase {
+
+    private final FlatVectorsScorer delegate = mock(FlatVectorsScorer.class);
+    private final NativeEngines990KnnVectorsScorer scorer = new NativeEngines990KnnVectorsScorer(delegate);
+
+    public void testFloatVector_mmapValues_euclidean_returnsNativeScorer() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        FloatVectorValues mmapValues = mock(FloatVectorValues.class, withSettings().extraInterfaces(MMapVectorValues.class));
+        when(((MMapVectorValues) mmapValues).getAddressAndSize()).thenReturn(new long[] { 100L, 200L });
+        float[] target = new float[] { 1.0f, 2.0f };
+
+        try (
+            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class);
+            MockedStatic<SimdVectorComputeService> ignored = mockStatic(SimdVectorComputeService.class)
+        ) {
+            wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(mmapValues);
+
+            RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target);
+
+            assertNotNull(result);
+            assertTrue(result instanceof NativeRandomVectorScorer);
+            verifyNoInteractions(delegate);
+        }
+    }
+
+    public void testFloatVector_mmapValues_maxInnerProduct_returnsNativeScorer() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        FloatVectorValues mmapValues = mock(FloatVectorValues.class, withSettings().extraInterfaces(MMapVectorValues.class));
+        when(((MMapVectorValues) mmapValues).getAddressAndSize()).thenReturn(new long[] { 100L, 200L });
+        float[] target = new float[] { 1.0f, 2.0f };
+
+        try (
+            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class);
+            MockedStatic<SimdVectorComputeService> ignored = mockStatic(SimdVectorComputeService.class)
+        ) {
+            wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(mmapValues);
+
+            RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, vectorValues, target);
+
+            assertNotNull(result);
+            assertTrue(result instanceof NativeRandomVectorScorer);
+            verifyNoInteractions(delegate);
+        }
+    }
+
+    public void testFloatVector_nonMmapValues_delegatesToWrapped() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        FloatVectorValues plainValues = mock(FloatVectorValues.class);
+        float[] target = new float[] { 1.0f, 2.0f };
+        RandomVectorScorer expectedScorer = mock(RandomVectorScorer.class);
+
+        try (MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class)) {
+            wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(plainValues);
+            when(delegate.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target)).thenReturn(expectedScorer);
+
+            RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target);
+
+            assertSame(expectedScorer, result);
+        }
+    }
+
+    public void testFloatVector_unsupportedSimilarity_delegatesToWrapped() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        float[] target = new float[] { 1.0f, 2.0f };
+        RandomVectorScorer expectedScorer = mock(RandomVectorScorer.class);
+
+        when(delegate.getRandomVectorScorer(VectorSimilarityFunction.COSINE, vectorValues, target)).thenReturn(expectedScorer);
+
+        RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.COSINE, vectorValues, target);
+
+        assertSame(expectedScorer, result);
+    }
+
+    public void testFloatVector_dotProduct_delegatesToWrapped() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        float[] target = new float[] { 1.0f, 2.0f };
+        RandomVectorScorer expectedScorer = mock(RandomVectorScorer.class);
+
+        when(delegate.getRandomVectorScorer(VectorSimilarityFunction.DOT_PRODUCT, vectorValues, target)).thenReturn(expectedScorer);
+
+        RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.DOT_PRODUCT, vectorValues, target);
+
+        assertSame(expectedScorer, result);
+    }
+
+    public void testFloatVector_nullBottomValues_delegatesToWrapped() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        float[] target = new float[] { 1.0f, 2.0f };
+        RandomVectorScorer expectedScorer = mock(RandomVectorScorer.class);
+
+        try (MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class)) {
+            wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(null);
+            when(delegate.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target)).thenReturn(expectedScorer);
+
+            RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target);
+
+            assertSame(expectedScorer, result);
+        }
+    }
+
+    public void testByteVector_delegatesToWrapped() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        byte[] target = new byte[] { 1, 2 };
+        RandomVectorScorer expectedScorer = mock(RandomVectorScorer.class);
+
+        when(delegate.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target)).thenReturn(expectedScorer);
+
+        RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target);
+
+        assertSame(expectedScorer, result);
+    }
+
+    public void testScorerSupplier_delegatesToWrapped() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        RandomVectorScorerSupplier expectedSupplier = mock(RandomVectorScorerSupplier.class);
+
+        when(delegate.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, vectorValues)).thenReturn(expectedSupplier);
+
+        RandomVectorScorerSupplier result = scorer.getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, vectorValues);
+
+        assertSame(expectedSupplier, result);
+        verify(delegate).getRandomVectorScorerSupplier(VectorSimilarityFunction.EUCLIDEAN, vectorValues);
+    }
+}


### PR DESCRIPTION
### Description
Previously, FaissMemoryOptimizedSearcher was responsible for detecting MMap-backed vectors and choosing between NativeRandomVectorScorer and the default Java scorer. This logic is now extracted into a dedicated FlatVectorsScorer decorator that sits in the codec scoring chain, making native SIMD acceleration available to all scoring paths (including HNSW graph traversal with prefetch support).

By placing NativeEngines990KnnVectorsScorer inside PrefetchableFlatVectorScorer in the decorator chain, the native scorer now benefits from prefetch-enabled bulk scoring during HNSW graph traversal. Previously, NativeRandomVectorScorer was instantiated directly in FaissMemoryOptimizedSearcher, bypassing the prefetch layer entirely. With this change, PrefetchableFlatVectorScorer can wrap the NativeRandomVectorScorer returned by NativeEngines990KnnVectorsScorer, issuing prefetch hints for memory-mapped vector data before native SIMD scoring, reducing memory access latency during graph neighbor evaluation.

Key changes:
- Add NativeEngines990KnnVectorsScorer which wraps a FlatVectorsScorer delegate and transparently returns NativeRandomVectorScorer when the bottom-level FloatVectorValues implements MMapVectorValues and the similarity function is EUCLIDEAN or MAXIMUM_INNER_PRODUCT
- Simplify FaissMemoryOptimizedSearcher by removing the native scoring branch and determineNativeFunctionType(); it now unconditionally delegates to the FlatVectorsScorer
- Refactor NativeRandomVectorScorer to extend AbstractRandomVectorScorer, removing manual maxOrd/ordToDoc/getAcceptOrds overrides, enabling it to be wrapped by PrefetchableFlatVectorScorer for prefetch-enabled bulk scoring during HNSW graph traversal
- Wire the new scorer into NativeEngines990KnnVectorsFormat between the Lucene99 flat vectors scorer and PrefetchableFlatVectorScorer
- Add unit tests covering all routing branches

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
