### PR TITLE
AVX512, default Bulk SIMD for Faiss Scalar Quantized Index.

### DIFF
--- a/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
@@ -188,16 +188,20 @@ static FORCE_INLINE void readDataCorrections(const uint8_t* ptr, float& ax, floa
 
 // Scalar fallback for int4BitDotProduct
 // q has 4 * binaryCodeBytes bytes (4 bit planes), d has binaryCodeBytes bytes
+// Uses std::memcpy for uint64_t loads to avoid undefined behavior from unaligned
+// reinterpret_cast when binaryCodeBytes is not a multiple of 8. Compilers optimize
+// the 8-byte memcpy into a single mov instruction — zero runtime cost.
 static FORCE_INLINE int64_t int4BitDotProduct(const uint8_t* q, const uint8_t* d, const int32_t binaryCodeBytes) {
     int64_t result = 0;
     for (int32_t bitPlane = 0 ; bitPlane < 4 ; ++bitPlane) {
-        const auto* qPlane = reinterpret_cast<const uint64_t*>(q + bitPlane * binaryCodeBytes);
-        const auto* dPtr = reinterpret_cast<const uint64_t*>(d);
         const int32_t words = binaryCodeBytes >> 3;
 
         int64_t subResult = 0;
         for (int32_t w = 0 ; w < words ; ++w) {
-            subResult += __builtin_popcountll(qPlane[w] & dPtr[w]);
+            uint64_t qWord, dWord;
+            std::memcpy(&qWord, q + bitPlane * binaryCodeBytes + w * 8, sizeof(uint64_t));
+            std::memcpy(&dWord, d + w * 8, sizeof(uint64_t));
+            subResult += __builtin_popcountll(qWord & dWord);
         }
 
         const int32_t remainStart = words * 8;

--- a/jni/src/simd/similarity_function/avx512_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/avx512_simd_similarity_function.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstring>
 #include <stdint.h>
 #include <cmath>
 
@@ -263,6 +264,345 @@ struct AVX512SPRFP16L2 final : BaseSimilarityFunction<BulkScoreTransformFunc, Sc
 
 
 //
+// BBQ (ADC: 4-bit query x 1-bit data) - AVX512 SIMD implementation
+//
+// The query is 4-bit quantized and transposed into 4 bit planes (via transposeHalfByte).
+// Each bit plane has `binaryCodeBytes` bytes. The int4BitDotProduct computes:
+//   Result = popcount(plane0 AND data) * 1
+//          + popcount(plane1 AND data) * 2
+//          + popcount(plane2 AND data) * 4
+//          + popcount(plane3 AND data) * 8
+//
+
+static constexpr float FOUR_BIT_SCALE = 1.0f / 15.0f;
+
+// Reads the per-vector correction factors from a potentially unaligned address.
+// On-disk layout after binaryCode: [lowerInterval(f32)][upperInterval(f32)][additionalCorrection(f32)][quantizedComponentSum(i32)]
+// Because oneVectorByteSize may not be a multiple of 4, subsequent vectors can start at
+// non-4-byte-aligned offsets, making reinterpret_cast<float*> undefined behaviour.
+static FORCE_INLINE void readDataCorrections(const uint8_t* ptr, float& ax, float& lx, float& additional, float& x1) {
+    float lower, upper;
+    std::memcpy(&lower,      ptr,      sizeof(float));
+    std::memcpy(&upper,      ptr + 4,  sizeof(float));
+    std::memcpy(&additional, ptr + 8,  sizeof(float));
+    int32_t componentSum;
+    std::memcpy(&componentSum, ptr + 12, sizeof(int32_t));
+    ax = lower;
+    lx = upper - lower;
+    x1 = static_cast<float>(componentSum);
+}
+
+// Scalar fallback for int4BitDotProduct
+// q has 4 * binaryCodeBytes bytes (4 bit planes), d has binaryCodeBytes bytes
+// Uses std::memcpy for uint64_t loads to avoid undefined behavior from unaligned
+// reinterpret_cast when binaryCodeBytes is not a multiple of 8. Compilers optimize
+// the 8-byte memcpy into a single mov instruction — zero runtime cost.
+static FORCE_INLINE int64_t int4BitDotProduct(const uint8_t* q, const uint8_t* d, const int32_t binaryCodeBytes) {
+    int64_t result = 0;
+    for (int32_t bitPlane = 0 ; bitPlane < 4 ; ++bitPlane) {
+        const int32_t words = binaryCodeBytes >> 3;
+
+        int64_t subResult = 0;
+        for (int32_t w = 0 ; w < words ; ++w) {
+            uint64_t qWord, dWord;
+            std::memcpy(&qWord, q + bitPlane * binaryCodeBytes + w * 8, sizeof(uint64_t));
+            std::memcpy(&dWord, d + w * 8, sizeof(uint64_t));
+            subResult += __builtin_popcountll(qWord & dWord);
+        }
+
+        const int32_t remainStart = words * 8;
+        for (int32_t r = remainStart ; r < binaryCodeBytes ; ++r) {
+            subResult += __builtin_popcount((q[bitPlane * binaryCodeBytes + r] & d[r]) & 0xFF);
+        }
+
+        result += subResult << bitPlane;
+    }
+    return result;
+}
+
+// AVX512 per-byte popcount using nibble LUT (works on all AVX512F/BW targets).
+// Uses vpshufb with a 4-bit lookup table to count bits in each byte of a 512-bit register.
+static FORCE_INLINE __m512i avx512_popcnt_epi8(const __m512i v) {
+    // Nibble popcount lookup table: {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4} replicated across all 64-byte lanes
+    // index : value : popcount
+    //   0     : 0000  : 0
+    //   1     : 0001  : 1
+    //   2     : 0010  : 1
+    //   3     : 0011  : 2
+    //   ...
+    //   15    : 1111  : 4
+    // Example:
+    // 0x0403030203020201LL
+    // Split it, we get:
+    // 0x04 03 03 02 03 02 02 01
+    //        index 9 -----^  ^----- index 8
+    // Witch maps to
+    // LUT[8]  = 1 -> 01b, the last value
+    // LUT[9]  = 2 -> 02b, the second value from right
+    // LUT[10] = 2
+    // LUT[11] = 3
+    // LUT[12] = 2
+    // LUT[13] = 3
+    // LUT[14] = 3
+    // LUT[15] = 4 -> the first value 0x04
+    alignas(64) static const __m512i popLut = _mm512_setr_epi64(
+        0x0302020102010100LL, 0x0403030203020201LL,
+        0x0302020102010100LL, 0x0403030203020201LL,
+        0x0302020102010100LL, 0x0403030203020201LL,
+        0x0302020102010100LL, 0x0403030203020201LL);
+    const __m512i lowMask = _mm512_set1_epi8(0x0F);
+
+    // Split each byte into low and high nibbles, look up popcount for each, sum
+    // Example:
+    // v = 0b10110110
+    // Split:
+    //   hi = 1011 (11) → popcount = 3
+    //   lo = 0110 (6)  → popcount = 2
+    // Instead of popcount, we can do table look-up, and we get:
+    // LUT[11] = 3
+    // LUT[6]  = 2
+    // 3 + 2 = 5 = popcount(10110110)
+    __m512i lo = _mm512_and_si512(v, lowMask);
+    __m512i hi = _mm512_and_si512(_mm512_srli_epi16(v, 4), lowMask);
+    __m512i cntLo = _mm512_shuffle_epi8(popLut, lo);
+    __m512i cntHi = _mm512_shuffle_epi8(popLut, hi);
+    return _mm512_add_epi8(cntLo, cntHi);
+}
+
+// AVX512 SIMD batched int4BitDotProduct.
+// Processes 64 bytes per iteration
+// Uses LUT-based per-byte popcount on each plane, then weights by 1/2/4/8.
+template <int BATCH_SIZE>
+static FORCE_INLINE void avx512_4bitDotProductBatch(
+    const uint8_t* queryPtr,
+    uint8_t** dataVecs,
+    const int32_t binaryCodeBytes,
+    float* results) {
+
+    // Query vector is transposed
+    const uint8_t* plane0 = queryPtr;
+    const uint8_t* plane1 = queryPtr + binaryCodeBytes;
+    const uint8_t* plane2 = queryPtr + 2 * binaryCodeBytes;
+    const uint8_t* plane3 = queryPtr + 3 * binaryCodeBytes;
+
+    // 64-bit accumulators to avoid overflow (each iteration can add up to 64*120 = 7680 per 64-byte chunk)
+    __m512i acc[BATCH_SIZE];
+    #pragma unroll
+    for (int32_t b = 0 ; b < BATCH_SIZE ; ++b) {
+        acc[b] = _mm512_setzero_si512();
+    }
+
+    int32_t i = 0;
+    for ( ; i + 64 <= binaryCodeBytes ; i += 64) {
+        // Load 64 bytes from each query plane (shared across all data vectors)
+        __m512i q0 = _mm512_loadu_si512(plane0 + i);
+        __m512i q1 = _mm512_loadu_si512(plane1 + i);
+        __m512i q2 = _mm512_loadu_si512(plane2 + i);
+        __m512i q3 = _mm512_loadu_si512(plane3 + i);
+
+        // Prefetch next chunk
+        if (i + 64 < binaryCodeBytes) {
+            __builtin_prefetch(plane0 + i + 64);
+            for (int32_t b = 0 ; b < BATCH_SIZE ; ++b) {
+                __builtin_prefetch(dataVecs[b] + i + 64);
+            }
+        }
+
+        #pragma unroll
+        for (int32_t b = 0 ; b < BATCH_SIZE ; ++b) {
+            // Load 64 bytes of data vector's binary code
+            __m512i d = _mm512_loadu_si512(dataVecs[b] + i);
+
+            // AND each plane with data, then per-byte popcount
+            __m512i p0 = avx512_popcnt_epi8(_mm512_and_si512(q0, d));
+            __m512i p1 = avx512_popcnt_epi8(_mm512_and_si512(q1, d));
+            __m512i p2 = avx512_popcnt_epi8(_mm512_and_si512(q2, d));
+            __m512i p3 = avx512_popcnt_epi8(_mm512_and_si512(q3, d));
+
+            // Weight: p0*1 + p1*2 + p2*4 + p3*8
+            // Max per byte: 8*1 + 8*2 + 8*4 + 8*8 = 120, fits in uint8_t
+            // Note: _mm512_slli_epi16 shifts 16-bit lanes, but since popcount values are at most 8 (0b00001000),
+            // shifting left by 1/2/3 won't cause cross-byte bleed within 16-bit lanes (high bits of low byte are 0).
+            __m512i weighted = _mm512_add_epi8(p0, _mm512_slli_epi16(p1, 1)); // -> weighted += p2 << 1
+            weighted = _mm512_add_epi8(weighted, _mm512_slli_epi16(p2, 2)); // -> weighted += p2 << 2
+            weighted = _mm512_add_epi8(weighted, _mm512_slli_epi16(p3, 3)); // -> weighted += p2 << 3
+
+            // Horizontal sum: u8 -> u64 via _mm512_sad_epu8 (sum of absolute differences against zero)
+            // _mm512_sad_epu8 sums 8 consecutive u8 values into u64 lanes
+            // "SAD" : feeling or showing sorrow; unhappy.
+            // kidding, SAD = Sum of Absolute Differences i.e. sum(|a[i] - b[i]|)
+            // _mm512_sad_epu8(weighted, _mm512_setzero_si512()) -> |weighted[i] - 0| = weighted[i]
+            // so it becomes, sum(weighted[i]), just a sum.
+            __m512i sad = _mm512_sad_epu8(weighted, _mm512_setzero_si512());
+
+            // Accumulate into 64-bit accumulators
+            acc[b] = _mm512_add_epi64(acc[b], sad);
+        }
+    }
+
+    // Horizontal sum of 64-bit accumulators into results
+    #pragma unroll
+    for (int32_t b = 0 ; b < BATCH_SIZE ; ++b) {
+        results[b] = static_cast<float>(_mm512_reduce_add_epi64(acc[b]));
+    }
+
+    // Scalar tail for remaining bytes (< 64)
+    for ( ; i < binaryCodeBytes ; ++i) {
+        uint8_t q0b = plane0[i], q1b = plane1[i], q2b = plane2[i], q3b = plane3[i];
+        for (int32_t b = 0 ; b < BATCH_SIZE ; ++b) {
+            uint8_t db = dataVecs[b][i];
+            results[b] += static_cast<float>(
+                __builtin_popcount((q0b & db) & 0xFF) * 1
+              + __builtin_popcount((q1b & db) & 0xFF) * 2
+              + __builtin_popcount((q2b & db) & 0xFF) * 4
+              + __builtin_popcount((q3b & db) & 0xFF) * 8);
+        }
+    }
+}
+
+template <bool IsMaxIP>
+struct AVX512BBQSimilarityFunction final : SimilarityFunction {
+    HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
+                                            int32_t* internalVectorIds,
+                                            float* scores,
+                                            const int32_t numVectors) {
+        const auto* queryPtr = reinterpret_cast<const uint8_t*>(srchContext->queryVectorSimdAligned);
+        const int32_t dim = srchContext->dimension;
+        const int32_t binaryCodeBytes = (dim + 7) / 8;
+
+        // Read query correction factors from tmpBuffer
+        const auto* queryCorrectionPtr = reinterpret_cast<const float*>(srchContext->tmpBuffer.data());
+        const float ay = queryCorrectionPtr[0];
+        const float ly = (queryCorrectionPtr[1] - queryCorrectionPtr[0]) * FOUR_BIT_SCALE;
+        const float queryAdditional = queryCorrectionPtr[2];
+        int32_t y1Raw; std::memcpy(&y1Raw, &queryCorrectionPtr[3], sizeof(int32_t));
+        const float y1 = static_cast<float>(y1Raw);
+        const float centroidDp = queryCorrectionPtr[4];
+
+        int32_t processedCount = 0;
+        constexpr int32_t vecBlock = 8;
+        constexpr int32_t vecHalfBlock = 4;
+        uint8_t* vectors[vecBlock];
+
+        // Batch size 8
+        for ( ; (processedCount + vecBlock) <= numVectors ; processedCount += vecBlock) {
+            srchContext->getVectorPointersInBulk(vectors, &internalVectorIds[processedCount], vecBlock);
+            avx512_4bitDotProductBatch<vecBlock>(queryPtr, vectors, binaryCodeBytes, &scores[processedCount]);
+
+            #pragma unroll
+            for (int32_t i = 0 ; i < vecBlock ; ++i) {
+                if ((i + 1) < vecBlock) {
+                    __builtin_prefetch(vectors[i + 1] + binaryCodeBytes);
+                }
+                float ax, lx, additional, x1;
+                readDataCorrections(vectors[i] + binaryCodeBytes, ax, lx, additional, x1);
+
+                scores[processedCount + i] = ax * ay * dim
+                                           + ay * lx * x1
+                                           + ax * ly * y1
+                                           + lx * ly * scores[processedCount + i];
+
+                if constexpr (IsMaxIP) {
+                    scores[processedCount + i] += queryAdditional + additional - centroidDp;
+                } else {
+                    scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
+                }
+            }
+        }
+
+        // Batch size 4
+        for ( ; (processedCount + vecHalfBlock) <= numVectors ; processedCount += vecHalfBlock) {
+            srchContext->getVectorPointersInBulk(vectors, &internalVectorIds[processedCount], vecHalfBlock);
+            avx512_4bitDotProductBatch<vecHalfBlock>(queryPtr, vectors, binaryCodeBytes, &scores[processedCount]);
+
+            #pragma unroll
+            for (int32_t i = 0 ; i < vecHalfBlock ; ++i) {
+                if ((i + 1) < vecHalfBlock) {
+                    __builtin_prefetch(vectors[i + 1] + binaryCodeBytes);
+                }
+                float ax, lx, additional, x1;
+                readDataCorrections(vectors[i] + binaryCodeBytes, ax, lx, additional, x1);
+
+                scores[processedCount + i] = ax * ay * dim
+                                           + ay * lx * x1
+                                           + ax * ly * y1
+                                           + lx * ly * scores[processedCount + i];
+
+                if constexpr (IsMaxIP) {
+                    scores[processedCount + i] += queryAdditional + additional - centroidDp;
+                } else {
+                    scores[processedCount + i] =
+                        std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
+                }
+            }
+        }
+
+        // Tail: remaining vectors (scalar)
+        for ( ; processedCount < numVectors ; ++processedCount) {
+            const auto* dataVec = srchContext->getVectorPointer(internalVectorIds[processedCount]);
+            const float qcDist = static_cast<float>(
+                int4BitDotProduct(queryPtr, dataVec, binaryCodeBytes));
+
+            float ax, lx, additional, x1;
+            readDataCorrections(dataVec + binaryCodeBytes, ax, lx, additional, x1);
+
+            scores[processedCount] = ax * ay * dim
+                                   + ay * lx * x1
+                                   + ax * ly * y1
+                                   + lx * ly * qcDist;
+
+            if constexpr (IsMaxIP) {
+                scores[processedCount] += queryAdditional + additional - centroidDp;
+            } else {
+                scores[processedCount] =
+                    std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount]);
+            }
+        }
+
+        if constexpr (IsMaxIP) {
+            FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else {
+            FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
+        }
+    }
+
+    float calculateSimilarity(SimdVectorSearchContext* srchContext, const int32_t internalVectorId) {
+        const auto* queryPtr = reinterpret_cast<const uint8_t*>(srchContext->queryVectorSimdAligned);
+        const int32_t dim = srchContext->dimension;
+        const int32_t binaryCodeBytes = (dim + 7) / 8;
+
+        const auto* queryCorrectionPtr = reinterpret_cast<const float*>(srchContext->tmpBuffer.data());
+        const float ay = queryCorrectionPtr[0];
+        const float ly = (queryCorrectionPtr[1] - queryCorrectionPtr[0]) * FOUR_BIT_SCALE;
+        const float queryAdditional = queryCorrectionPtr[2];
+        int32_t y1Raw2; std::memcpy(&y1Raw2, &queryCorrectionPtr[3], sizeof(int32_t));
+        const float y1 = static_cast<float>(y1Raw2);
+        const float centroidDp = queryCorrectionPtr[4];
+
+        const auto* dataVec = srchContext->getVectorPointer(internalVectorId);
+        const float qcDist = static_cast<float>(
+            int4BitDotProduct(queryPtr, dataVec, binaryCodeBytes));
+
+        float ax, lx, additional, x1;
+        readDataCorrections(dataVec + binaryCodeBytes, ax, lx, additional, x1);
+
+        float score = ax * ay * dim
+                      + ay * lx * x1
+                      + ax * ly * y1
+                      + lx * ly * qcDist;
+
+        if constexpr (IsMaxIP) {
+            score += queryAdditional + additional - centroidDp;
+            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+        } else {
+            score = std::max(0.0F, queryAdditional + additional - 2 * score);
+            return FaissScoreToLuceneScoreTransform::l2Transform(score);
+        }
+    }
+};
+
+
+//
 // FP16
 //
 // 1. Max IP
@@ -270,12 +610,24 @@ AVX512SPRFP16MaxIP<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, Fai
 // 2. L2
 AVX512SPRFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> FP16_L2_SIMIL_FUNC;
 
+//
+// BBQ
+//
+// 1. Max IP
+AVX512BBQSimilarityFunction<true> BBQ_IP_SIMIL_FUNC;
+// 2. L2
+AVX512BBQSimilarityFunction<false> BBQ_L2_SIMIL_FUNC;
+
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
     if (nativeFunctionType == NativeSimilarityFunctionType::FP16_MAXIMUM_INNER_PRODUCT) {
         return &FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_L2) {
         return &FP16_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::BBQ_IP) {
+        return &BBQ_IP_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::BBQ_L2) {
+        return &BBQ_L2_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstring>
 #include <stdint.h>
 #include <cmath>
 
@@ -44,12 +45,268 @@ DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::ipToMaxIpTransfo
 // 2. L2
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> DEFAULT_FP16_L2_SIMIL_FUNC;
 
+
+//
+// BBQ (ADC: 4-bit query x 1-bit data) - Default (non-SIMD) implementation
+//
+// Pure C++ implementation written for compiler auto-vectorization with -O3.
+// No SIMD intrinsics. Uses __builtin_popcount[ll] and std::memcpy.
+//
+// The query is 4-bit quantized and transposed into 4 bit planes (via transposeHalfByte).
+// Each bit plane has `binaryCodeBytes` bytes. The int4BitDotProduct computes:
+//   Result = popcount(plane0 AND data) * 1
+//          + popcount(plane1 AND data) * 2
+//          + popcount(plane2 AND data) * 4
+//          + popcount(plane3 AND data) * 8
+//
+
+static constexpr float FOUR_BIT_SCALE = 1.0f / 15.0f;
+
+// Reads the per-vector correction factors from a potentially unaligned address.
+// On-disk layout after binaryCode: [lowerInterval(f32)][upperInterval(f32)][additionalCorrection(f32)][quantizedComponentSum(i32)]
+static FORCE_INLINE void readDataCorrections(const uint8_t* ptr, float& ax, float& lx, float& additional, float& x1) {
+    float lower, upper;
+    std::memcpy(&lower,      ptr,      sizeof(float));
+    std::memcpy(&upper,      ptr + 4,  sizeof(float));
+    std::memcpy(&additional, ptr + 8,  sizeof(float));
+    int32_t componentSum;
+    std::memcpy(&componentSum, ptr + 12, sizeof(int32_t));
+    ax = lower;
+    lx = upper - lower;
+    x1 = static_cast<float>(componentSum);
+}
+
+// Scalar int4BitDotProduct
+// q has 4 * binaryCodeBytes bytes (4 bit planes), d has binaryCodeBytes bytes.
+// Uses std::memcpy for uint64_t loads to avoid undefined behavior from unaligned
+// reinterpret_cast when binaryCodeBytes is not a multiple of 8.
+static FORCE_INLINE int64_t int4BitDotProduct(const uint8_t* q, const uint8_t* d, const int32_t binaryCodeBytes) {
+    int64_t result = 0;
+    for (int32_t bitPlane = 0 ; bitPlane < 4 ; ++bitPlane) {
+        const int32_t words = binaryCodeBytes >> 3;
+
+        int64_t subResult = 0;
+        for (int32_t w = 0 ; w < words ; ++w) {
+            uint64_t qWord, dWord;
+            std::memcpy(&qWord, q + bitPlane * binaryCodeBytes + w * 8, sizeof(uint64_t));
+            std::memcpy(&dWord, d + w * 8, sizeof(uint64_t));
+            subResult += __builtin_popcountll(qWord & dWord);
+        }
+
+        const int32_t remainStart = words * 8;
+        for (int32_t r = remainStart ; r < binaryCodeBytes ; ++r) {
+            subResult += __builtin_popcount((q[bitPlane * binaryCodeBytes + r] & d[r]) & 0xFF);
+        }
+
+        result += subResult << bitPlane;
+    }
+    return result;
+}
+
+// Default (non-SIMD) batched int4BitDotProduct.
+// Processes one batch element at a time with the byte loop as the inner loop,
+// giving the compiler the best auto-vectorization opportunity across the byte dimension.
+template <int BATCH_SIZE>
+static FORCE_INLINE void default4bitDotProductBatch(
+    const uint8_t* queryPtr,
+    uint8_t** dataVecs,
+    const int32_t binaryCodeBytes,
+    float* results) {
+
+    const uint8_t* plane0 = queryPtr;
+    const uint8_t* plane1 = queryPtr + binaryCodeBytes;
+    const uint8_t* plane2 = queryPtr + 2 * binaryCodeBytes;
+    const uint8_t* plane3 = queryPtr + 3 * binaryCodeBytes;
+
+    const int32_t words = binaryCodeBytes >> 3;
+    const int32_t remainStart = words * 8;
+
+    for (int32_t b = 0 ; b < BATCH_SIZE ; ++b) {
+        int64_t acc = 0;
+        const uint8_t* data = dataVecs[b];
+
+        // 8-byte word loop — compiler can auto-vectorize this
+        for (int32_t w = 0 ; w < words ; ++w) {
+            const int32_t offset = w * 8;
+            uint64_t dWord;
+            std::memcpy(&dWord, data + offset, sizeof(uint64_t));
+
+            uint64_t q0, q1, q2, q3;
+            std::memcpy(&q0, plane0 + offset, sizeof(uint64_t));
+            std::memcpy(&q1, plane1 + offset, sizeof(uint64_t));
+            std::memcpy(&q2, plane2 + offset, sizeof(uint64_t));
+            std::memcpy(&q3, plane3 + offset, sizeof(uint64_t));
+
+            acc += __builtin_popcountll(q0 & dWord) * 1
+                 + __builtin_popcountll(q1 & dWord) * 2
+                 + __builtin_popcountll(q2 & dWord) * 4
+                 + __builtin_popcountll(q3 & dWord) * 8;
+        }
+
+        // Byte remainder — handles non-multiple-of-8 binaryCodeBytes
+        for (int32_t r = remainStart ; r < binaryCodeBytes ; ++r) {
+            uint8_t db = data[r];
+            acc += __builtin_popcount((plane0[r] & db) & 0xFF) * 1
+                 + __builtin_popcount((plane1[r] & db) & 0xFF) * 2
+                 + __builtin_popcount((plane2[r] & db) & 0xFF) * 4
+                 + __builtin_popcount((plane3[r] & db) & 0xFF) * 8;
+        }
+
+        results[b] = static_cast<float>(acc);
+    }
+}
+
+template <bool IsMaxIP>
+struct DefaultBBQSimilarityFunction final : SimilarityFunction {
+    HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
+                                            int32_t* internalVectorIds,
+                                            float* scores,
+                                            const int32_t numVectors) {
+        const auto* queryPtr = reinterpret_cast<const uint8_t*>(srchContext->queryVectorSimdAligned);
+        const int32_t dim = srchContext->dimension;
+        const int32_t binaryCodeBytes = (dim + 7) / 8;
+
+        // Read query correction factors from tmpBuffer
+        const auto* queryCorrectionPtr = reinterpret_cast<const float*>(srchContext->tmpBuffer.data());
+        const float ay = queryCorrectionPtr[0];
+        const float ly = (queryCorrectionPtr[1] - queryCorrectionPtr[0]) * FOUR_BIT_SCALE;
+        const float queryAdditional = queryCorrectionPtr[2];
+        int32_t y1Raw; std::memcpy(&y1Raw, &queryCorrectionPtr[3], sizeof(int32_t));
+        const float y1 = static_cast<float>(y1Raw);
+        const float centroidDp = queryCorrectionPtr[4];
+
+        int32_t processedCount = 0;
+        constexpr int32_t vecBlock = 8;
+        constexpr int32_t vecHalfBlock = 4;
+        uint8_t* vectors[vecBlock];
+
+        // Batch size 8
+        for ( ; (processedCount + vecBlock) <= numVectors ; processedCount += vecBlock) {
+            srchContext->getVectorPointersInBulk(vectors, &internalVectorIds[processedCount], vecBlock);
+            default4bitDotProductBatch<vecBlock>(queryPtr, vectors, binaryCodeBytes, &scores[processedCount]);
+
+            for (int32_t i = 0 ; i < vecBlock ; ++i) {
+                float ax, lx, additional, x1;
+                readDataCorrections(vectors[i] + binaryCodeBytes, ax, lx, additional, x1);
+
+                scores[processedCount + i] = ax * ay * dim
+                                           + ay * lx * x1
+                                           + ax * ly * y1
+                                           + lx * ly * scores[processedCount + i];
+
+                if constexpr (IsMaxIP) {
+                    scores[processedCount + i] += queryAdditional + additional - centroidDp;
+                } else {
+                    scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
+                }
+            }
+        }
+
+        // Batch size 4
+        for ( ; (processedCount + vecHalfBlock) <= numVectors ; processedCount += vecHalfBlock) {
+            srchContext->getVectorPointersInBulk(vectors, &internalVectorIds[processedCount], vecHalfBlock);
+            default4bitDotProductBatch<vecHalfBlock>(queryPtr, vectors, binaryCodeBytes, &scores[processedCount]);
+
+            for (int32_t i = 0 ; i < vecHalfBlock ; ++i) {
+                float ax, lx, additional, x1;
+                readDataCorrections(vectors[i] + binaryCodeBytes, ax, lx, additional, x1);
+
+                scores[processedCount + i] = ax * ay * dim
+                                           + ay * lx * x1
+                                           + ax * ly * y1
+                                           + lx * ly * scores[processedCount + i];
+
+                if constexpr (IsMaxIP) {
+                    scores[processedCount + i] += queryAdditional + additional - centroidDp;
+                } else {
+                    scores[processedCount + i] =
+                        std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
+                }
+            }
+        }
+
+        // Tail: remaining vectors (scalar)
+        for ( ; processedCount < numVectors ; ++processedCount) {
+            const auto* dataVec = srchContext->getVectorPointer(internalVectorIds[processedCount]);
+            const float qcDist = static_cast<float>(
+                int4BitDotProduct(queryPtr, dataVec, binaryCodeBytes));
+
+            float ax, lx, additional, x1;
+            readDataCorrections(dataVec + binaryCodeBytes, ax, lx, additional, x1);
+
+            scores[processedCount] = ax * ay * dim
+                                   + ay * lx * x1
+                                   + ax * ly * y1
+                                   + lx * ly * qcDist;
+
+            if constexpr (IsMaxIP) {
+                scores[processedCount] += queryAdditional + additional - centroidDp;
+            } else {
+                scores[processedCount] =
+                    std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount]);
+            }
+        }
+
+        if constexpr (IsMaxIP) {
+            FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else {
+            FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
+        }
+    }
+
+    float calculateSimilarity(SimdVectorSearchContext* srchContext, const int32_t internalVectorId) {
+        const auto* queryPtr = reinterpret_cast<const uint8_t*>(srchContext->queryVectorSimdAligned);
+        const int32_t dim = srchContext->dimension;
+        const int32_t binaryCodeBytes = (dim + 7) / 8;
+
+        const auto* queryCorrectionPtr = reinterpret_cast<const float*>(srchContext->tmpBuffer.data());
+        const float ay = queryCorrectionPtr[0];
+        const float ly = (queryCorrectionPtr[1] - queryCorrectionPtr[0]) * FOUR_BIT_SCALE;
+        const float queryAdditional = queryCorrectionPtr[2];
+        int32_t y1Raw; std::memcpy(&y1Raw, &queryCorrectionPtr[3], sizeof(int32_t));
+        const float y1 = static_cast<float>(y1Raw);
+        const float centroidDp = queryCorrectionPtr[4];
+
+        const auto* dataVec = srchContext->getVectorPointer(internalVectorId);
+        const float qcDist = static_cast<float>(
+            int4BitDotProduct(queryPtr, dataVec, binaryCodeBytes));
+
+        float ax, lx, additional, x1;
+        readDataCorrections(dataVec + binaryCodeBytes, ax, lx, additional, x1);
+
+        float score = ax * ay * dim
+                    + ay * lx * x1
+                    + ax * ly * y1
+                    + lx * ly * qcDist;
+
+        if constexpr (IsMaxIP) {
+            score += queryAdditional + additional - centroidDp;
+            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+        } else {
+            score = std::max(0.0F, queryAdditional + additional - 2 * score);
+            return FaissScoreToLuceneScoreTransform::l2Transform(score);
+        }
+    }
+};
+
+//
+// BBQ
+//
+// 1. Max IP
+DefaultBBQSimilarityFunction<true> BBQ_IP_SIMIL_FUNC;
+// 2. L2
+DefaultBBQSimilarityFunction<false> BBQ_L2_SIMIL_FUNC;
+
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
     if (nativeFunctionType == NativeSimilarityFunctionType::FP16_MAXIMUM_INNER_PRODUCT) {
         return &DEFAULT_FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_L2) {
         return &DEFAULT_FP16_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::BBQ_IP) {
+        return &BBQ_IP_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::BBQ_L2) {
+        return &BBQ_L2_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/Faiss104ScalerQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/Faiss104ScalerQuantizedVectorScorer.java
@@ -132,8 +132,12 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
         final float[] targetCopy = ArrayUtil.copyOfSubArray(target, 0, target.length);
 
         // Perform scalar quantization
-        final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms =
-            quantizer.scalarQuantize(targetCopy, scratch, scalarEncoding.getQueryBits(), quantizedByteVectorValues.getCentroid());
+        final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms = quantizer.scalarQuantize(
+            targetCopy,
+            scratch,
+            scalarEncoding.getQueryBits(),
+            quantizedByteVectorValues.getCentroid()
+        );
 
         // Transpose half-bytes (nibbles) for SIMD-friendly layout
         OptimizedScalarQuantizer.transposeHalfByte(scratch, targetQuantized);
@@ -195,8 +199,8 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
                 targetCorrectiveTerms.quantizedComponentSum(),
                 addressAndSize,
                 similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-                ? SimdVectorComputeService.SimilarityFunctionType.BBQ_IP.ordinal()
-                : SimdVectorComputeService.SimilarityFunctionType.BBQ_L2.ordinal(),
+                    ? SimdVectorComputeService.SimilarityFunctionType.BBQ_IP.ordinal()
+                    : SimdVectorComputeService.SimilarityFunctionType.BBQ_L2.ordinal(),
                 dimension,
                 centroidDp
             );

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/Faiss104ScalerQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/Faiss104ScalerQuantizedVectorScorer.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.opensearch.knn.jni.SimdVectorComputeService;
@@ -133,12 +132,8 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
         final float[] targetCopy = ArrayUtil.copyOfSubArray(target, 0, target.length);
 
         // Perform scalar quantization
-        final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms = quantizer.scalarQuantize(
-            targetCopy,
-            scratch,
-            scalarEncoding.getQueryBits(),
-            quantizedByteVectorValues.getCentroid()
-        );
+        final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms =
+            quantizer.scalarQuantize(targetCopy, scratch, scalarEncoding.getQueryBits(), quantizedByteVectorValues.getCentroid());
 
         // Transpose half-bytes (nibbles) for SIMD-friendly layout
         OptimizedScalarQuantizer.transposeHalfByte(scratch, targetQuantized);
@@ -146,7 +141,6 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
         // Return Bulk SIMD scorer
         return new BulkSimdRandomVectorScorer(
             targetQuantized,
-            quantizedByteVectorValues.size(),
             targetCorrectiveTerms,
             addressAndSize,
             quantizedByteVectorValues,
@@ -166,28 +160,23 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
      * <p>The query is preprocessed (quantized + transformed) once during construction,
      * and reused across all scoring calls.
      */
-    private static class BulkSimdRandomVectorScorer implements RandomVectorScorer {
-        private final int maxOrd;
-        private final QuantizedByteVectorValues knnVectorValues;
-
+    private static class BulkSimdRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
         /**
          * Constructs a SIMD-backed scorer and initializes the native search context.
          *
          * <p>This constructor pushes all necessary query state into native memory,
          * including quantized query values and correction terms required for accurate scoring.
          *
-         * @param targetQuantized        quantized query vector
-         * @param maxOrd                 total number of vectors
-         * @param targetCorrectiveTerms  correction terms from quantization
-         * @param addressAndSize         raw memory location of vector data
-         * @param knnVectorValues        vector storage abstraction
-         * @param similarityFunction     similarity function (IP or L2)
-         * @param dimension              vector dimensionality
-         * @param centroidDp             centroid dot-product correction
+         * @param targetQuantized       quantized query vector
+         * @param targetCorrectiveTerms correction terms from quantization
+         * @param addressAndSize        raw memory location of vector data
+         * @param knnVectorValues       vector storage abstraction
+         * @param similarityFunction    similarity function (IP or L2)
+         * @param dimension             vector dimensionality
+         * @param centroidDp            centroid dot-product correction
          */
         public BulkSimdRandomVectorScorer(
             final byte[] targetQuantized,
-            final int maxOrd,
             final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms,
             final long[] addressAndSize,
             final QuantizedByteVectorValues knnVectorValues,
@@ -195,9 +184,7 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
             final int dimension,
             final float centroidDp
         ) {
-
-            this.maxOrd = maxOrd;
-            this.knnVectorValues = knnVectorValues;
+            super(knnVectorValues);
 
             // Initialize native SIMD search context
             SimdVectorComputeService.saveBBQSearchContext(
@@ -208,8 +195,8 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
                 targetCorrectiveTerms.quantizedComponentSum(),
                 addressAndSize,
                 similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-                    ? SimdVectorComputeService.SimilarityFunctionType.BBQ_IP.ordinal()
-                    : SimdVectorComputeService.SimilarityFunctionType.BBQ_L2.ordinal(),
+                ? SimdVectorComputeService.SimilarityFunctionType.BBQ_IP.ordinal()
+                : SimdVectorComputeService.SimilarityFunctionType.BBQ_L2.ordinal(),
                 dimension,
                 centroidDp
             );
@@ -239,40 +226,8 @@ public class Faiss104ScalerQuantizedVectorScorer extends Lucene104ScalarQuantize
          * @throws IOException if the native scoring operation fails
          */
         @Override
-        public float score(final int internalVectorId) throws IOException {
+        public float score(final int internalVectorId) {
             return SimdVectorComputeService.scoreSimilarity(internalVectorId);
-        }
-
-        /**
-         * Returns the maximum vector id for scoring.
-         *
-         * @return the maximum vector id
-         */
-        @Override
-        public int maxOrd() {
-            return maxOrd;
-        }
-
-        /**
-         * Maps an internal vector ordinal to its corresponding document ID.
-         *
-         * @param ord the internal vector id
-         * @return the document ID associated with the given vector id
-         */
-        @Override
-        public int ordToDoc(int ord) {
-            return knnVectorValues.ordToDoc(ord);
-        }
-
-        /**
-         * Returns a filtered {@link Bits} view representing accepted documents.
-         *
-         * @param acceptDocs the bit set of accepted documents
-         * @return a {@link Bits} object describing acceptable vector ids for scoring
-         */
-        @Override
-        public Bits getAcceptOrds(Bits acceptDocs) {
-            return knnVectorValues.getAcceptOrds(acceptDocs);
         }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReaderTests.java
@@ -70,7 +70,7 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
             ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
@@ -91,7 +91,7 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mockSearcher);
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
             ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
@@ -145,7 +145,7 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mockSearcher);
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import org.opensearch.knn.KNNTestCase;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,27 +54,25 @@ import java.util.concurrent.ThreadLocalRandom;
  * 3. {@link Lucene104ScalarQuantizedVectorsReader} with {@link Faiss104ScalerQuantizedVectorScorer} → test subject.
  * 4. Compare scores.
  */
-public class FaissBBQBulkSimdScorerTests extends KNNTestCase {
+public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
 
     private static final String FIELD_NAME = "vector";
     private static final int NUM_VECTORS = 500;
 
     @Test
     public void testBBQEuclideanScoring() {
-        // TODO : Remove this once generic version of bulk simd is added
-        // for (int dim : Arrays.asList(1, 7, 77, 128, 512, 777, 1024, 10240, 30000, 65535)) {
-        // System.out.println("Dimension=" + dim);
-        // doTest(VectorSimilarityFunction.EUCLIDEAN, dim);
-        // }
+        for (int dim : Arrays.asList(1, 7, 77, 128, 512, 777, 1024, 10240, 30000, 65535)) {
+            System.out.println("Dimension=" + dim);
+            doTest(VectorSimilarityFunction.EUCLIDEAN, dim);
+        }
     }
 
     @Test
     public void testBBQMaxInnerProductScoring() {
-        // TODO : Remove this once generic version of bulk simd is added
-        // for (int dim : Arrays.asList(1, 7, 77, 128, 512, 777, 1024, 10240, 30000, 65535)) {
-        // System.out.println("Dimension=" + dim);
-        // doTest(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, dim);
-        // }
+        for (int dim : Arrays.asList(1, 7, 77, 128, 512, 777, 1024, 10240, 30000, 65535)) {
+            System.out.println("Dimension=" + dim);
+            doTest(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, dim);
+        }
     }
 
     @SneakyThrows
@@ -123,14 +122,8 @@ public class FaissBBQBulkSimdScorerTests extends KNNTestCase {
                 null
             );
 
-            final SegmentWriteState writeState = new SegmentWriteState(
-                InfoStream.NO_OUTPUT,
-                dir,
-                segmentInfo,
-                fieldInfos,
-                null,
-                IOContext.DEFAULT
-            );
+            final SegmentWriteState writeState =
+                new SegmentWriteState(InfoStream.NO_OUTPUT, dir, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
 
             // ---- Step 1: Write vectors using Lucene104ScalarQuantizedVectorsWriter ----
             final Lucene104ScalarQuantizedVectorScorer luceneVectorScorer = new Lucene104ScalarQuantizedVectorScorer(defaultScorer);
@@ -138,9 +131,9 @@ public class FaissBBQBulkSimdScorerTests extends KNNTestCase {
             try (
                 FlatVectorsWriter writer = new Lucene104ScalarQuantizedVectorsWriter(
                     writeState,
-                    encoding,
-                    rawVectorFormat.fieldsWriter(writeState),
-                    luceneVectorScorer
+                                                                                     encoding,
+                                                                                     rawVectorFormat.fieldsWriter(writeState),
+                                                                                     luceneVectorScorer
                 )
             ) {
                 @SuppressWarnings("unchecked")
@@ -162,8 +155,8 @@ public class FaissBBQBulkSimdScorerTests extends KNNTestCase {
             try (
                 FlatVectorsReader truthReader = new Lucene104ScalarQuantizedVectorsReader(
                     readState,
-                    rawVectorFormat.fieldsReader(readState),
-                    luceneVectorScorer
+                                                                                          rawVectorFormat.fieldsReader(readState),
+                                                                                          luceneVectorScorer
                 )
             ) {
                 truthScorer = truthReader.getRandomVectorScorer(FIELD_NAME, queryVector);
@@ -175,8 +168,8 @@ public class FaissBBQBulkSimdScorerTests extends KNNTestCase {
                 try (
                     FlatVectorsReader testReader = new Lucene104ScalarQuantizedVectorsReader(
                         readState,
-                        rawVectorFormat.fieldsReader(readState),
-                        simdFlatScorer
+                                                                                             rawVectorFormat.fieldsReader(readState),
+                                                                                             simdFlatScorer
                     )
                 ) {
                     RandomVectorScorer testScorer = testReader.getRandomVectorScorer(FIELD_NAME, queryVector);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -122,8 +122,14 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 null
             );
 
-            final SegmentWriteState writeState =
-                new SegmentWriteState(InfoStream.NO_OUTPUT, dir, segmentInfo, fieldInfos, null, IOContext.DEFAULT);
+            final SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                dir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
 
             // ---- Step 1: Write vectors using Lucene104ScalarQuantizedVectorsWriter ----
             final Lucene104ScalarQuantizedVectorScorer luceneVectorScorer = new Lucene104ScalarQuantizedVectorScorer(defaultScorer);
@@ -131,9 +137,9 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
             try (
                 FlatVectorsWriter writer = new Lucene104ScalarQuantizedVectorsWriter(
                     writeState,
-                                                                                     encoding,
-                                                                                     rawVectorFormat.fieldsWriter(writeState),
-                                                                                     luceneVectorScorer
+                    encoding,
+                    rawVectorFormat.fieldsWriter(writeState),
+                    luceneVectorScorer
                 )
             ) {
                 @SuppressWarnings("unchecked")
@@ -155,8 +161,8 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
             try (
                 FlatVectorsReader truthReader = new Lucene104ScalarQuantizedVectorsReader(
                     readState,
-                                                                                          rawVectorFormat.fieldsReader(readState),
-                                                                                          luceneVectorScorer
+                    rawVectorFormat.fieldsReader(readState),
+                    luceneVectorScorer
                 )
             ) {
                 truthScorer = truthReader.getRandomVectorScorer(FIELD_NAME, queryVector);
@@ -168,8 +174,8 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 try (
                     FlatVectorsReader testReader = new Lucene104ScalarQuantizedVectorsReader(
                         readState,
-                                                                                             rawVectorFormat.fieldsReader(readState),
-                                                                                             simdFlatScorer
+                        rawVectorFormat.fieldsReader(readState),
+                        simdFlatScorer
                     )
                 ) {
                     RandomVectorScorer testScorer = testReader.getRandomVectorScorer(FIELD_NAME, queryVector);


### PR DESCRIPTION
### Description
1. Fix: Undefined behavior in int4BitDotProduct scalar fallback
The int4BitDotProduct function in both avx512_simd_similarity_function.cpp and arm_neon_simd_similarity_function.cpp used reinterpret_cast<const uint64_t*> on pointers that may not be 8-byte aligned when binaryCodeBytes % 8 != 0. This is undefined behavior per the C++ standard.

Replaced the casts with std::memcpy into local uint64_t variables. Compilers optimize this into a single mov — zero runtime cost, no UB.

2. Feature: BBQ similarity support for the default (non-SIMD) fallback
The default similarity function (default_simd_similarity_function.cpp) only supported FP16. BBQ queries on platforms without AVX512 or NEON would fail with "Invalid native similarity function type".

Added the full BBQ scoring pipeline to the default implementation:

readDataCorrections — safe unaligned reads via std::memcpy
int4BitDotProduct — scalar weighted popcount dot product (with the alignment fix)
default4bitDotProductBatch<BATCH_SIZE> — batched version, pure C++, no SIMD intrinsics
DefaultBBQSimilarityFunction<IsMaxIP> — full scoring struct with batch-8/batch-4/scalar-tail pattern
Wired up BBQ_IP and BBQ_L2 in selectSimilarityFunction

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]


### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
