### PR TITLE
Moved the creation of Scorer out of FaissMemoryOptimizedSearcher

### DIFF
--- a/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
+++ b/src/main/java/org/opensearch/knn/common/FieldInfoExtractor.java
@@ -85,6 +85,16 @@ public class FieldInfoExtractor {
     }
 
     /**
+     * Check for a field to be ADC or not
+     * @param fieldInfo {@link FieldInfo}
+     * @return true if the field is ADC, false otherwise
+     */
+    public static boolean isAdc(final FieldInfo fieldInfo) {
+        final QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo);
+        return quantizationConfig.isEnableADC();
+    }
+
+    /**
      * Get the space type for the given field info.
      *
      * @param modelDao ModelDao instance to retrieve model metadata

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -359,7 +359,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
                 fileName,
                 fieldInfo,
                 ioContext,
-                flatVectorsReader.getFlatVectorScorer()
+                flatVectorsReader
             );
         }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
-import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -32,6 +32,6 @@ public interface VectorSearcherFactory {
         String fileName,
         FieldInfo fieldInfo,
         IOContext ioContext,
-        FlatVectorsScorer vectorScorer
+        FlatVectorsReader flatVectorsReader
     ) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -18,16 +18,12 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
 import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.common.FieldInfoExtractor;
-import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.common.RobustUniqueRandomIterator;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
-import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
 
@@ -57,11 +53,15 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     private final long fileSize;
     private boolean isAdc;
 
-    public FaissMemoryOptimizedSearcher(final IndexInput indexInput, final FieldInfo fieldInfo, final FlatVectorsScorer flatVectorsScorer)
-        throws IOException {
+    public FaissMemoryOptimizedSearcher(
+        final IndexInput indexInput,
+        final FaissIndex faissIndex,
+        final FieldInfo fieldInfo,
+        final FlatVectorsScorer flatVectorsScorer
+    ) {
         this.indexInput = indexInput;
         this.fileSize = indexInput.length();
-        this.faissIndex = FaissIndex.load(indexInput);
+        this.faissIndex = faissIndex;
         final KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
 
         if (knnVectorSimilarityFunction != KNNVectorSimilarityFunction.HAMMING) {
@@ -70,21 +70,8 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
             vectorSimilarityFunction = null;
         }
 
-        this.isAdc = false;
-        SpaceType spaceType = null;
-        if (fieldInfo != null) {
-            // Extract ADC info from fieldInfo to determine scorer.
-            final QuantizationConfig quantizationConfig = FieldInfoExtractor.extractQuantizationConfig(fieldInfo);
-            this.isAdc = quantizationConfig.isEnableADC();
-            spaceType = isAdc ? SpaceType.getSpace(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)) : null;
-        }
-
-        this.flatVectorsScorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
-            knnVectorSimilarityFunction,
-            isAdc,
-            spaceType,
-            flatVectorsScorer
-        );
+        this.isAdc = FieldInfoExtractor.isAdc(fieldInfo);
+        this.flatVectorsScorer = flatVectorsScorer;
 
         this.hnsw = extractFaissHnsw(faissIndex);
     }
@@ -105,7 +92,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
         search(
             VectorEncoding.FLOAT32,
-            () -> flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, knnVectorValues, target),
+            flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, knnVectorValues, target),
             knnCollector,
             acceptDocs
         );
@@ -115,11 +102,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     public void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         search(
             VectorEncoding.BYTE,
-            () -> flatVectorsScorer.getRandomVectorScorer(
-                vectorSimilarityFunction,
-                faissIndex.getByteValues(getSlicedIndexInput()),
-                target
-            ),
+            flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, faissIndex.getByteValues(getSlicedIndexInput()), target),
             knnCollector,
             acceptDocs
         );
@@ -143,7 +126,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
     private void search(
         final VectorEncoding vectorEncoding,
-        final IOSupplier<RandomVectorScorer> scorerSupplier,
+        final RandomVectorScorer scorer,
         final KnnCollector knnCollector,
         final AcceptDocs acceptDocs
     ) throws IOException {
@@ -163,7 +146,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         }
 
         // Set up required components for vector search
-        final RandomVectorScorer scorer = scorerSupplier.get();
         final KnnCollector collector = createKnnCollector(knnCollector, scorer);
         final Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss;
 
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.FieldInfo;
 import lombok.extern.log4j.Log4j2;
@@ -32,13 +33,18 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
         final String fileName,
         final FieldInfo fieldInfo,
         final IOContext ioContext,
-        final FlatVectorsScorer vectorScorer
+        final FlatVectorsReader flatVectorsReader
     ) throws IOException {
         final IndexInput indexInput = directory.openInput(fileName, ioContext);
-
         try {
             // Try load it. Not all FAISS index types are currently supported at the moment.
-            return new FaissMemoryOptimizedSearcher(indexInput, fieldInfo, vectorScorer);
+            final FaissIndex faissIndex = FaissIndex.load(indexInput);
+            final FlatVectorsScorer vectorScorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+                fieldInfo,
+                faissIndex.getVectorSimilarityFunction(),
+                flatVectorsReader.getFlatVectorScorer()
+            );
+            return new FaissMemoryOptimizedSearcher(indexInput, faissIndex, fieldInfo, vectorScorer);
         } catch (UnsupportedFaissIndexException e) {
             // Clean up input stream.
             try {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -8,10 +8,12 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import lombok.experimental.UtilityClass;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
@@ -37,27 +39,28 @@ public class FlatVectorsScorerProvider {
     }
 
     /**
-     * Returns the FlatVectorsScorer based on the similarity function, or if adc is enabled based on the SpaceType.
-     * @param similarityFunction the vector similarity function to use
-     * @param isAdc whether ADC (Asymmetric Distance Computation) is enabled
-     * @param spaceType the space type for vector comparison
-     * @return FlatVectorsScorer instance
+     * Returns the appropriate {@link FlatVectorsScorer} for the given field.
+     * Selects an ADC, Hamming, or delegate scorer based on the field's quantization config and space type.
+     *
+     * @param fieldInfo       the field info containing space type and quantization attributes
+     * @param delegateScorer  the default scorer to fall back to when no specialized scorer applies
+     * @return the resolved {@link FlatVectorsScorer}
      */
     public static FlatVectorsScorer getFlatVectorsScorer(
+        final FieldInfo fieldInfo,
         final KNNVectorSimilarityFunction similarityFunction,
-        final boolean isAdc,
-        final SpaceType spaceType,
         final FlatVectorsScorer delegateScorer
     ) {
-        if (isAdc) {
-            // Note: we cannot leverage KNNVectorSimilarityFunction here as it is HAMMING for ADC, so we must use SpaceType.
-            return ADC_FLAT_SCORERS.get(spaceType);
-        }
-        if (similarityFunction == KNNVectorSimilarityFunction.HAMMING) {
+        // Handle Special case of ADC first.
+        if (FieldInfoExtractor.isAdc(fieldInfo)) {
+            return ADC_FLAT_SCORERS.get(FieldInfoExtractor.getSpaceType(null, fieldInfo));
+        } else if (KNNVectorSimilarityFunction.HAMMING == similarityFunction) {
+            // Since Lucene doesn't provide hamming distance scorer, we return our own hamming distance scorer
             return HAMMING_VECTOR_SCORER;
+        } else {
+            // For all other cases just return the delegate scorer.
+            return delegateScorer;
         }
-
-        return delegateScorer;
     }
 
     private static class ADCFlatVectorsScorer implements FlatVectorsScorer {

--- a/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
+++ b/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
@@ -66,6 +66,38 @@ public class FieldInfoExtractorTests extends KNNTestCase {
         assertEquals(VectorDataType.DEFAULT, FieldInfoExtractor.extractVectorDataType(fieldInfo));
     }
 
+    public void testIsAdc_whenNoQFrameworkConfig_thenReturnsFalse() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(null);
+        Assert.assertFalse(FieldInfoExtractor.isAdc(fieldInfo));
+    }
+
+    public void testIsAdc_whenEmptyQFrameworkConfig_thenReturnsFalse() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn("");
+        Assert.assertFalse(FieldInfoExtractor.isAdc(fieldInfo));
+    }
+
+    public void testIsAdc_whenAdcEnabled_thenReturnsTrue() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn("type=binary,bits=2,random_rotation=false,enable_adc=true");
+        Assert.assertTrue(FieldInfoExtractor.isAdc(fieldInfo));
+    }
+
+    public void testIsAdc_whenAdcDisabled_thenReturnsFalse() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(
+            "type=binary,bits=2,random_rotation=false,enable_adc=false"
+        );
+        Assert.assertFalse(FieldInfoExtractor.isAdc(fieldInfo));
+    }
+
+    public void testIsAdc_whenOldFormatWithoutAdcField_thenReturnsFalse() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn("type=binary,bits=2");
+        Assert.assertFalse(FieldInfoExtractor.isAdc(fieldInfo));
+    }
+
     public void testGetFieldInfo_whenDifferentInput_thenSuccess() {
         LeafReader leafReader = Mockito.mock(LeafReader.class);
         FieldInfos fieldInfos = Mockito.mock(FieldInfos.class);

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -78,7 +78,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("field1")
             .fieldNumber(0)
             .addAttribute(KNN_ENGINE, KNNEngine.FAISS.getName())
-            .addAttribute(QFRAMEWORK_CONFIG, "some-value")
+            .addAttribute(QFRAMEWORK_CONFIG, "type=binary,bits=2")
             .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
             .build();
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
@@ -21,11 +21,15 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.IOConsumer;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,11 +40,10 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 import static org.opensearch.knn.memoryoptsearch.FaissHNSWTests.loadHnswBinary;
 
 public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
-    private static final FieldInfo NO_ADC_NEEDED = null;
-
     private static final int EF_SEARCH = 100;
     private static final int DIMENSION = 768;
     // Applying 32x quantization, one float will be quantized to 1 bit. As a result, one vector have 768 bits, which becomes 96 bytes.
@@ -52,12 +55,28 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
         final VectorDataType vectorDataType,
         final KNNVectorSimilarityFunction similarityFunction
     ) {
+        FieldInfo noADC = Mockito.mock(FieldInfo.class);
+        Mockito.when(noADC.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(null);
+        if (similarityFunction == KNNVectorSimilarityFunction.HAMMING) {
+            Mockito.when(noADC.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.HAMMING.getValue());
+        } else if (similarityFunction == KNNVectorSimilarityFunction.EUCLIDEAN) {
+            Mockito.when(noADC.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+        } else if (similarityFunction == KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT) {
+            Mockito.when(noADC.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.INNER_PRODUCT.getValue());
+        } else {
+            throw new IllegalArgumentException("Unsupported similarity function: " + similarityFunction);
+        }
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
             final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
                 input,
-                NO_ADC_NEEDED,
-                FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+                FaissIndex.load(input),
+                noADC,
+                FlatVectorsScorerProvider.getFlatVectorsScorer(
+                    noADC,
+                    similarityFunction,
+                    FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+                )
             );
 
             // Make collector

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
@@ -18,6 +19,7 @@ import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOConsumer;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
@@ -49,7 +51,8 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
             // TODO: adc placeholder. isAdc false and SpaceType L2 are noops for the MemoryOptimizedSearcher here.
             final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
                 input,
-                null,
+                FaissIndex.load(input),
+                Mockito.mock(FieldInfo.class),
                 FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
             );
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcherFactory;
+import org.opensearch.knn.memoryoptsearch.faiss.UnsupportedFaissIndexException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
+
+    private static final FlatVectorsScorer SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+
+    @SneakyThrows
+    public void testCreateVectorSearcher_whenValidFaissIndex_thenReturnsSearcher() {
+        final FaissMemoryOptimizedSearcherFactory factory = new FaissMemoryOptimizedSearcherFactory();
+        final Path tempDir = createTempDir(UUID.randomUUID().toString());
+        final String fileName = "test_index.faiss";
+
+        // Use a valid FAISS HNSW index binary (flat index types are not supported by the searcher)
+        final byte[] indexBytes = loadResourceBytes("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
+
+        try (Directory directory = newFSDirectory(tempDir)) {
+            try (IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                output.writeBytes(indexBytes, indexBytes.length);
+            }
+
+            FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+
+            FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+
+            VectorSearcher searcher = factory.createVectorSearcher(directory, fileName, fieldInfo, IOContext.DEFAULT, flatVectorsReader);
+            assertNotNull(searcher);
+            searcher.close();
+        }
+    }
+
+    @SneakyThrows
+    public void testCreateVectorSearcher_whenUnsupportedIndex_thenThrowsAndClosesInput() {
+        final FaissMemoryOptimizedSearcherFactory factory = new FaissMemoryOptimizedSearcherFactory();
+        final Path tempDir = createTempDir(UUID.randomUUID().toString());
+        final String fileName = "invalid_index.faiss";
+
+        // Write garbage bytes that will fail FaissIndex.load with UnsupportedFaissIndexException
+        try (Directory directory = newFSDirectory(tempDir)) {
+            try (IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                // Write an invalid FAISS index type header to trigger UnsupportedFaissIndexException
+                // FAISS index format: first 4 bytes are a uint32 representing the index type string length,
+                // followed by the index type string. We write a valid-looking but unsupported type.
+                byte[] unsupportedType = "IxUNSUPPORTED".getBytes();
+                output.writeInt(unsupportedType.length);
+                output.writeBytes(unsupportedType, unsupportedType.length);
+                // Pad with zeros to avoid EOF
+                output.writeBytes(new byte[1024], 1024);
+            }
+
+            FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+
+            FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+
+            expectThrows(
+                UnsupportedFaissIndexException.class,
+                () -> factory.createVectorSearcher(directory, fileName, fieldInfo, IOContext.DEFAULT, flatVectorsReader)
+            );
+        }
+    }
+
+    @SneakyThrows
+    public void testCreateVectorSearcher_whenIOExceptionOnOpen_thenThrowsIOException() {
+        final FaissMemoryOptimizedSearcherFactory factory = new FaissMemoryOptimizedSearcherFactory();
+        final Path tempDir = createTempDir(UUID.randomUUID().toString());
+
+        try (Directory directory = newFSDirectory(tempDir)) {
+            FieldInfo fieldInfo = mock(FieldInfo.class);
+            FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+
+            // File doesn't exist, should throw IOException
+            expectThrows(
+                IOException.class,
+                () -> factory.createVectorSearcher(directory, "nonexistent.faiss", fieldInfo, IOContext.DEFAULT, flatVectorsReader)
+            );
+        }
+    }
+
+    @SneakyThrows
+    public void testCreateVectorSearcher_whenUnsupportedIndex_thenIndexInputIsClosed() {
+        final FaissMemoryOptimizedSearcherFactory factory = new FaissMemoryOptimizedSearcherFactory();
+        final Path tempDir = createTempDir(UUID.randomUUID().toString());
+        final String fileName = "invalid_index2.faiss";
+
+        try (Directory directory = newFSDirectory(tempDir)) {
+            try (IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
+                byte[] unsupportedType = "IxUNSUPPORTED".getBytes();
+                output.writeInt(unsupportedType.length);
+                output.writeBytes(unsupportedType, unsupportedType.length);
+                output.writeBytes(new byte[1024], 1024);
+            }
+
+            FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+
+            FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+
+            // Verify that after the exception, the IndexInput was properly closed
+            // by confirming we can open the file again (no resource leak)
+            try {
+                factory.createVectorSearcher(directory, fileName, fieldInfo, IOContext.DEFAULT, flatVectorsReader);
+                fail("Expected UnsupportedFaissIndexException");
+            } catch (UnsupportedFaissIndexException e) {
+                // Expected - now verify we can still open the file (no leaked handles)
+                IndexInput input = directory.openInput(fileName, IOContext.DEFAULT);
+                assertNotNull(input);
+                input.close();
+            }
+        }
+    }
+
+    @SneakyThrows
+    private byte[] loadResourceBytes(String resourcePath) {
+        return FaissHNSWTests.class.getClassLoader().getResourceAsStream(resourcePath).readAllBytes();
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.generate.IndexingType;
@@ -53,7 +54,9 @@ import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 import org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy;
 import org.opensearch.knn.jni.JNIService;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
@@ -910,7 +913,14 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k = 100;
 
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+            input,
+            FaissIndex.load(input),
+            fieldInfo,
+            FlatVectorsScorerProvider.getFlatVectorsScorer(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, SCORER)
+        );
 
         // Use a non-seeded strategy (default HNSW strategy)
         final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
@@ -941,7 +951,14 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k = 100;
 
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        FieldInfo mockedFieldInfo = mock(FieldInfo.class);
+        Mockito.when(mockedFieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+            input,
+            FaissIndex.load(input),
+            mockedFieldInfo,
+            FlatVectorsScorerProvider.getFlatVectorsScorer(mockedFieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, SCORER)
+        );
 
         // Create a Seeded strategy with known seed entry points
         final int numSeeds = 5;
@@ -1010,7 +1027,14 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         }
 
         // First, do exhaustive search to get ground truth
-        final FaissMemoryOptimizedSearcher exhaustiveSearcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        FieldInfo mockedFieldInfo = mock(FieldInfo.class);
+        Mockito.when(mockedFieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+        final FaissMemoryOptimizedSearcher exhaustiveSearcher = new FaissMemoryOptimizedSearcher(
+            input,
+            FaissIndex.load(input),
+            mockedFieldInfo,
+            FlatVectorsScorerProvider.getFlatVectorsScorer(mockedFieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, SCORER)
+        );
         final KnnCollector exhaustiveCollector = new TopKnnCollector(totalVectors, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
         final AcceptDocs acceptDocs = AcceptDocs.fromLiveDocs(null, totalVectors);
         exhaustiveSearcher.search(query, exhaustiveCollector, acceptDocs);
@@ -1023,7 +1047,12 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
 
         // Now search with a seeded collector on a fresh searcher
         input.seek(0);
-        final FaissMemoryOptimizedSearcher seededSearcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissMemoryOptimizedSearcher seededSearcher = new FaissMemoryOptimizedSearcher(
+            input,
+            FaissIndex.load(input),
+            mockedFieldInfo,
+            FlatVectorsScorerProvider.getFlatVectorsScorer(mockedFieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, SCORER)
+        );
 
         final int numSeeds = 3;
         final DocIdSetIterator seedDocs = new DocIdSetIterator() {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
@@ -9,10 +9,13 @@ import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -25,14 +28,17 @@ public class FlatVectorsScorerProviderTests extends KNNTestCase {
     private static final byte[] BYTE_QUERY = new byte[] { 12, 77, 100, 4 };
     private static final byte[] BYTE_VECTOR = new byte[] { 1, 3, 0, 90 };
 
+    private static final FlatVectorsScorer VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+
     @SneakyThrows
     public void testHammingScoring() {
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.HAMMING.getValue());
         // Get hamming scorer
         final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
             KNNVectorSimilarityFunction.HAMMING,
-            false,
-            null,
-            null
+            VECTOR_SCORER
         );
 
         // Test byte[] vector and query
@@ -64,30 +70,31 @@ public class FlatVectorsScorerProviderTests extends KNNTestCase {
     }
 
     public void testNonHammingScoring() {
+        FieldInfo fieldInfo = mock(FieldInfo.class);
         // Test L2
-        doTest(KNNVectorSimilarityFunction.EUCLIDEAN, true);
-        doTest(KNNVectorSimilarityFunction.EUCLIDEAN, false);
+        when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+        doTest(KNNVectorSimilarityFunction.EUCLIDEAN, true, fieldInfo);
+        doTest(KNNVectorSimilarityFunction.EUCLIDEAN, false, fieldInfo);
 
         // Test DotProduct
-        doTest(KNNVectorSimilarityFunction.DOT_PRODUCT, true);
-        doTest(KNNVectorSimilarityFunction.DOT_PRODUCT, false);
+        doTest(KNNVectorSimilarityFunction.DOT_PRODUCT, true, fieldInfo);
+        doTest(KNNVectorSimilarityFunction.DOT_PRODUCT, false, fieldInfo);
 
         // Test Cosine
-        doTest(KNNVectorSimilarityFunction.COSINE, true);
-        doTest(KNNVectorSimilarityFunction.COSINE, false);
+        doTest(KNNVectorSimilarityFunction.COSINE, true, fieldInfo);
+        doTest(KNNVectorSimilarityFunction.COSINE, false, fieldInfo);
 
         // Test Maximum Inner Product
-        doTest(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, true);
-        doTest(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, false);
+        doTest(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, true, fieldInfo);
+        doTest(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, false, fieldInfo);
     }
 
     @SneakyThrows
-    private void doTest(final KNNVectorSimilarityFunction knnVectorSimilarityFunction, final boolean isFloat) {
+    private void doTest(final KNNVectorSimilarityFunction knnVectorSimilarityFunction, final boolean isFloat, final FieldInfo fieldInfo) {
         final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
             knnVectorSimilarityFunction,
-            false,
-            null,
-            FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+            VECTOR_SCORER
         );
 
         if (isFloat) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/CagraKnnCollectorCreationTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/CagraKnnCollectorCreationTests.java
@@ -8,12 +8,14 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.memoryoptsearch.FaissHNSWTests;
 
@@ -32,7 +34,12 @@ public class CagraKnnCollectorCreationTests extends KNNTestCase {
     @SneakyThrows
     public void testCreateKnnCollector_whenNonSeeded_thenWrapsWithRandomEntryPoints() {
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+            input,
+            FaissIndex.load(input),
+            Mockito.mock(FieldInfo.class),
+            SCORER
+        );
 
         // Create a non-seeded collector
         final KnnCollector originalCollector = new TopKnnCollector(100, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
@@ -59,7 +66,12 @@ public class CagraKnnCollectorCreationTests extends KNNTestCase {
     @SneakyThrows
     public void testCreateKnnCollector_whenSeeded_thenPreservesOriginalStrategy() {
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+            input,
+            FaissIndex.load(input),
+            Mockito.mock(FieldInfo.class),
+            SCORER
+        );
 
         // Create a seeded strategy
         final DocIdSetIterator seedDocs = new DocIdSetIterator() {


### PR DESCRIPTION
### Description
Moved the creation of Scorer out of FaissMemoryOptimizedSearcher. There is no impact on performance. But this refactoring cleans up class and moves the creation of Scorer at one single place. This is complimentary to https://github.com/opensearch-project/k-NN/pull/3184/changes . Plus it will help in integration of PrefetchableScorer to different parts of the search.

### Related Issues
https://github.com/opensearch-project/k-NN/issues/2577

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
