### PR TITLE
Fixing alignment issue in Faiss BBQ indexing.

### DIFF
--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -201,6 +201,7 @@ if ("${WIN32}" STREQUAL "")
                 tests/faiss_index_service_test.cpp
                 tests/nmslib_stream_support_test.cpp
                 tests/faiss_index_bq_unit_test.cpp
+                tests/faiss_bbq_distance_computer_test.cpp
         )
 
         target_link_libraries(

--- a/jni/include/bbq/faiss_bbq_flat.h
+++ b/jni/include/bbq/faiss_bbq_flat.h
@@ -8,17 +8,45 @@
 #include "memory_util.h"
 
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <iostream>
 
 namespace knn_jni {
 
-    template <bool IsMaxIP>
+    // Reads correction factors from a potentially unaligned address using std::memcpy.
+    // Layout at ptr: [lowerInterval(f32)][upperInterval(f32)][additionalCorrection(f32)][quantizedComponentSum(i32)]
+    static inline void readCorrectionFactorsSafe(const uint8_t* ptr, float& lowerInterval,
+        float& intervalLength, float& additionalCorrection, float& quantizedComponentSum) {
+        float lower, upper;
+        std::memcpy(&lower, ptr, sizeof(float));
+        std::memcpy(&upper, ptr + 4, sizeof(float));
+        std::memcpy(&additionalCorrection, ptr + 8, sizeof(float));
+        int32_t componentSum;
+        std::memcpy(&componentSum, ptr + 12, sizeof(int32_t));
+        lowerInterval = lower;
+        intervalLength = upper - lower;
+        quantizedComponentSum = static_cast<float>(componentSum);
+    }
+
+    // Reads correction factors via direct pointer cast (only safe when ptr is 4-byte aligned).
+    static inline void readCorrectionFactorsAligned(const uint8_t* ptr, float& lowerInterval,
+        float& intervalLength, float& additionalCorrection, float& quantizedComponentSum) {
+        const auto* correctionFactors = reinterpret_cast<const float*>(ptr);
+        lowerInterval = correctionFactors[0];
+        intervalLength = correctionFactors[1] - correctionFactors[0];
+        additionalCorrection = correctionFactors[2];
+        int32_t componentSum;
+        std::memcpy(&componentSum, ptr + 12, sizeof(int32_t));
+        quantizedComponentSum = static_cast<float>(componentSum);
+    }
+
+    template <bool IsMaxIP, bool IsBytesMultipleOf8>
     struct FaissBBQDistanceComputer final : faiss::DistanceComputer {
         const int64_t oneElementByteSize;
         const uint64_t quantizedVectorBytes;
         const uint8_t* data;
-        const uint64_t* query;
+        const uint8_t* query;
         const float centroidDp;
         float ay;
         float ly;
@@ -44,17 +72,22 @@ namespace knn_jni {
         }
 
         void set_query(const float* x) final {
-            query = (uint64_t*) x;
+            // The query pointer comes from FaissBBQFlat::quantizedVectorsAndCorrectionFactors
+            // which uses NBytesAlignedAllocator<uint8_t, 8> (8-byte aligned base) with a
+            // stride of oneElementByteSize that is always a multiple of 8 (quantizedVectorBytes
+            // is a multiple of 8 by formula, plus 16 bytes of correction factors).
+            // Therefore x is guaranteed 8-byte aligned when IsBytesMultipleOf8 is true.
+            query = reinterpret_cast<const uint8_t*>(x);
             setCorrectionFactors(query, ay, ly, queryAdditional, y1);
         }
 
         void setCorrectionFactors(const void* target, float& lowerInterval, float& intervalLength, float& additionalCorrection, float& quantizedComponentSum) {
-            // [Quantized Vector | lowerInterval (float) | upperInterval (float) | additionalCorrection (float) | quantizedComponentSum (int)]
-            const auto* correctionFactors = (const float*) ((const uint8_t*) target + quantizedVectorBytes);
-            lowerInterval = correctionFactors[0];
-            intervalLength = correctionFactors[1] - correctionFactors[0];
-            additionalCorrection = correctionFactors[2];
-            quantizedComponentSum = *((const int32_t*) (&correctionFactors[3]));
+            const uint8_t* ptr = static_cast<const uint8_t*>(target) + quantizedVectorBytes;
+            if constexpr (IsBytesMultipleOf8) {
+                readCorrectionFactorsAligned(ptr, lowerInterval, intervalLength, additionalCorrection, quantizedComponentSum);
+            } else {
+                readCorrectionFactorsSafe(ptr, lowerInterval, intervalLength, additionalCorrection, quantizedComponentSum);
+            }
         }
 
         float scoringSecondPart(const void* target, const float dp) {
@@ -84,23 +117,34 @@ namespace knn_jni {
 
         /// compute distance of vector i to current query
         float operator()(faiss::idx_t i) final {
-            const uint64_t* target = reinterpret_cast<const uint64_t*>(data + i * oneElementByteSize);
-
+            const uint8_t* target = data + i * oneElementByteSize;
+            // quantizedVectorBytes is always a multiple of 8 per the Java-side contract
+            // (FaissService.java: "byte length of a single 1-bit quantized vector, always
+            // 64-bit aligned"). The IsBytesMultipleOf8=false path is a safety fallback to
+            // avoid UB on unaligned pointer reads, not to handle non-multiple-of-8 sizes.
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-
             uint32_t dp = 0;
 
-            for (size_t j = 0; j < words; ++j) {
-                dp += __builtin_popcountll(query[j] & target[j]);
+            if constexpr (IsBytesMultipleOf8) {
+                const auto* q = reinterpret_cast<const uint64_t*>(query);
+                const auto* t = reinterpret_cast<const uint64_t*>(target);
+                for (size_t j = 0; j < words; ++j) {
+                    dp += __builtin_popcountll(q[j] & t[j]);
+                }
+            } else {
+                // Slower
+                for (size_t j = 0; j < words; ++j) {
+                    uint64_t queryWord, targetWord;
+                    std::memcpy(&queryWord, query + j * 8, sizeof(uint64_t));
+                    std::memcpy(&targetWord, target + j * 8, sizeof(uint64_t));
+                    dp += __builtin_popcountll(queryWord & targetWord);
+                }
             }
 
-            const float score = scoringSecondPart(target, dp);
-            return score;
+            return scoringSecondPart(target, dp);
         }
 
         /// compute distances of current query to 4 stored vectors.
-        /// certain DistanceComputer implementations may benefit
-        /// heavily from this.
         void distances_batch_4(
                 const faiss::idx_t idx0,
                 const faiss::idx_t idx1,
@@ -110,23 +154,42 @@ namespace knn_jni {
                 float& dis1,
                 float& dis2,
                 float& dis3) final {
-            const uint64_t* target1 = reinterpret_cast<const uint64_t*>(data + idx0 * oneElementByteSize);
-            const uint64_t* target2 = reinterpret_cast<const uint64_t*>(data + idx1 * oneElementByteSize);
-            const uint64_t* target3 = reinterpret_cast<const uint64_t*>(data + idx2 * oneElementByteSize);
-            const uint64_t* target4 = reinterpret_cast<const uint64_t*>(data + idx3 * oneElementByteSize);
+            const uint8_t* target1 = data + idx0 * oneElementByteSize;
+            const uint8_t* target2 = data + idx1 * oneElementByteSize;
+            const uint8_t* target3 = data + idx2 * oneElementByteSize;
+            const uint8_t* target4 = data + idx3 * oneElementByteSize;
 
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
 
-            uint32_t dp1 = 0;
-            uint32_t dp2 = 0;
-            uint32_t dp3 = 0;
-            uint32_t dp4 = 0;
+            uint32_t dp1 = 0, dp2 = 0, dp3 = 0, dp4 = 0;
 
-            for (size_t i = 0; i < words; ++i) {
-                dp1 += __builtin_popcountll(query[i] & target1[i]);
-                dp2 += __builtin_popcountll(query[i] & target2[i]);
-                dp3 += __builtin_popcountll(query[i] & target3[i]);
-                dp4 += __builtin_popcountll(query[i] & target4[i]);
+            if constexpr (IsBytesMultipleOf8) {
+                const auto* q = reinterpret_cast<const uint64_t*>(query);
+                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
+                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
+                const auto* t3 = reinterpret_cast<const uint64_t*>(target3);
+                const auto* t4 = reinterpret_cast<const uint64_t*>(target4);
+                for (size_t i = 0; i < words; ++i) {
+                    dp1 += __builtin_popcountll(q[i] & t1[i]);
+                    dp2 += __builtin_popcountll(q[i] & t2[i]);
+                    dp3 += __builtin_popcountll(q[i] & t3[i]);
+                    dp4 += __builtin_popcountll(q[i] & t4[i]);
+                }
+            } else {
+                // Slower
+                for (size_t i = 0; i < words; ++i) {
+                    uint64_t queryWord;
+                    std::memcpy(&queryWord, query + i * 8, sizeof(uint64_t));
+                    uint64_t w1, w2, w3, w4;
+                    std::memcpy(&w1, target1 + i * 8, sizeof(uint64_t));
+                    std::memcpy(&w2, target2 + i * 8, sizeof(uint64_t));
+                    std::memcpy(&w3, target3 + i * 8, sizeof(uint64_t));
+                    std::memcpy(&w4, target4 + i * 8, sizeof(uint64_t));
+                    dp1 += __builtin_popcountll(queryWord & w1);
+                    dp2 += __builtin_popcountll(queryWord & w2);
+                    dp3 += __builtin_popcountll(queryWord & w3);
+                    dp4 += __builtin_popcountll(queryWord & w4);
+                }
             }
 
             dis0 = scoringSecondPart(target1, dp1);
@@ -137,28 +200,33 @@ namespace knn_jni {
 
         /// compute distance between two stored vectors
         float symmetric_dis(faiss::idx_t i, faiss::idx_t j) {
-            const uint64_t* target1 = reinterpret_cast<const uint64_t*>(data + i * oneElementByteSize);
-            const uint64_t* target2 = reinterpret_cast<const uint64_t*>(data + j * oneElementByteSize);
+            const uint8_t* target1 = data + i * oneElementByteSize;
+            const uint8_t* target2 = data + j * oneElementByteSize;
 
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-
             uint32_t dp = 0;
 
-            for (size_t k = 0; k < words; ++k) {
-                dp += __builtin_popcountll(target1[k] & target2[k]);
+            if constexpr (IsBytesMultipleOf8) {
+                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
+                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
+                for (size_t k = 0; k < words; ++k) {
+                    dp += __builtin_popcountll(t1[k] & t2[k]);
+                }
+            } else {
+                // Slower
+                for (size_t k = 0; k < words; ++k) {
+                    uint64_t w1, w2;
+                    std::memcpy(&w1, target1 + k * 8, sizeof(uint64_t));
+                    std::memcpy(&w2, target2 + k * 8, sizeof(uint64_t));
+                    dp += __builtin_popcountll(w1 & w2);
+                }
             }
 
             // Get correction factors
-            float ax;
-            float lx;
-            float additional;
-            float x1;
+            float ax, lx, additional, x1;
             setCorrectionFactors(target1, ax, lx, additional, x1);
 
-            float az;
-            float lz;
-            float additionalz;
-            float z1;
+            float az, lz, additionalz, z1;
             setCorrectionFactors(target2, az, lz, additionalz, z1);
 
             // Scoring
@@ -182,8 +250,8 @@ namespace knn_jni {
         int32_t quantizedVectorBytes;
         float centroidDp;
         int32_t oneElementSize;
-        // For safely casting uint8_t* to float*, we should enforce 4-byte alignment for the vector.
-        std::vector<uint8_t, knn_jni::FourBytesAlignedAllocator<uint8_t>> quantizedVectorsAndCorrectionFactors;
+        // For safely casting uint8_t* to float*, we should enforce 8-byte alignment for the vector.
+        std::vector<uint8_t, knn_jni::NBytesAlignedAllocator<uint8_t, 8>> quantizedVectorsAndCorrectionFactors;
         int32_t dimension;
 
         FaissBBQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric)
@@ -207,10 +275,19 @@ namespace knn_jni {
         }
 
         faiss::DistanceComputer* get_distance_computer() const {
+            const bool aligned = (oneElementSize % 8) == 0;
             if (metric_type == faiss::MetricType::METRIC_L2) {
-                return new FaissBBQDistanceComputer<false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                if (aligned) {
+                    return new FaissBBQDistanceComputer<false, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                } else {
+                    return new FaissBBQDistanceComputer<false, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                }
             } else if (metric_type == faiss::MetricType::METRIC_INNER_PRODUCT) {
-                return new FaissBBQDistanceComputer<true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                if (aligned) {
+                    return new FaissBBQDistanceComputer<true, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                } else {
+                    return new FaissBBQDistanceComputer<true, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                }
             }
 
             throw std::runtime_error("Unsupported metric type - " + std::to_string(metric_type));

--- a/jni/include/memory_util.h
+++ b/jni/include/memory_util.h
@@ -38,18 +38,27 @@
 
 namespace knn_jni {
 
-    template <typename T>
-    struct FourBytesAlignedAllocator {
+    template <typename T, int NBytes>
+    struct NBytesAlignedAllocator {
         using value_type = T;
 
+        template <typename U>
+        struct rebind { using other = NBytesAlignedAllocator<U, NBytes>; };
+
         T* allocate(std::size_t n) {
-            void* p = ::operator new(n * sizeof(T), std::align_val_t(4));
+            void* p = ::operator new(n * sizeof(T), std::align_val_t(NBytes));
             return static_cast<T*>(p);
         }
 
         void deallocate(T* p, std::size_t) noexcept {
-            ::operator delete(p, std::align_val_t(4));
+            ::operator delete(p, std::align_val_t(NBytes));
         }
+
+        template <typename U>
+        bool operator==(const NBytesAlignedAllocator<U, NBytes>&) const noexcept { return true; }
+
+        template <typename U>
+        bool operator!=(const NBytesAlignedAllocator<U, NBytes>&) const noexcept { return false; }
     };
 
 }

--- a/jni/tests/faiss_bbq_distance_computer_test.cpp
+++ b/jni/tests/faiss_bbq_distance_computer_test.cpp
@@ -1,0 +1,421 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#include "bbq/faiss_bbq_flat.h"
+
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+using idx_t = faiss::idx_t;
+
+namespace knn_jni {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Reference scalar popcount dot-product matching FaissBBQDistanceComputer behavior.
+// Processes only full 8-byte words (quantizedVectorBytes >> 3), same as the real code.
+static uint32_t referencePopcount(const uint8_t* a, const uint8_t* b, int32_t quantizedVectorBytes) {
+    const int32_t words = quantizedVectorBytes >> 3;
+    uint32_t dp = 0;
+    for (int32_t w = 0; w < words; ++w) {
+        uint64_t wa, wb;
+        std::memcpy(&wa, a + w * 8, sizeof(uint64_t));
+        std::memcpy(&wb, b + w * 8, sizeof(uint64_t));
+        dp += __builtin_popcountll(wa & wb);
+    }
+    return dp;
+}
+
+// Reference scoring formula matching FaissBBQDistanceComputer.
+static float referenceScore(bool isMaxIP, int32_t dim, float centroidDp,
+                            float ay, float ly, float queryAdditional, float y1,
+                            float ax, float lx, float additional, float x1,
+                            float dp) {
+    float score = ax * ay * dim + ay * lx * x1 + ax * ly * y1 + lx * ly * dp;
+    if (isMaxIP) {
+        score += queryAdditional + additional - centroidDp;
+    } else {
+        score = queryAdditional + additional - 2.0f * score;
+    }
+    return score;
+}
+
+// Write correction factors into buffer at ptr.
+// Layout: [lower(f32)][upper(f32)][additional(f32)][componentSum(i32)]
+static void writeCorrectionFactors(uint8_t* ptr, float lower, float upper,
+                                   float additional, int32_t componentSum) {
+    std::memcpy(ptr,      &lower,        sizeof(float));
+    std::memcpy(ptr + 4,  &upper,        sizeof(float));
+    std::memcpy(ptr + 8,  &additional,   sizeof(float));
+    std::memcpy(ptr + 12, &componentSum, sizeof(int32_t));
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture — parameterised over (IsMaxIP, IsBytesMultipleOf8)
+// ---------------------------------------------------------------------------
+
+struct BBQTestParams {
+    bool isMaxIP;
+    bool isBytesMultipleOf8;
+    std::string name() const {
+        std::string s = isMaxIP ? "MaxIP" : "L2";
+        s += isBytesMultipleOf8 ? "_Aligned" : "_Unaligned";
+        return s;
+    }
+};
+
+class FaissBBQDistanceComputerTest : public ::testing::TestWithParam<BBQTestParams> {
+protected:
+    static constexpr float CENTROID_DP = 0.5f;
+    static constexpr float TOLERANCE  = 1e-5f;
+
+    // Deterministic RNG seeded per test for reproducibility.
+    std::mt19937 rng{42};
+
+    // Build a data buffer holding `numVecs` elements, each with
+    // `quantizedVectorBytes` of random binary data followed by correction factors.
+    // Returns (buffer, oneElementSize, quantizedVectorBytes).
+    struct TestBuffer {
+        // 8-byte aligned storage
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> data;
+        int32_t oneElementSize;
+        int32_t quantizedVectorBytes;
+    };
+
+    TestBuffer makeBuffer(int numVecs, int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        TestBuffer buf;
+        buf.oneElementSize = oneElementSize;
+        buf.quantizedVectorBytes = quantizedVectorBytes;
+        buf.data.resize(numVecs * oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int v = 0; v < numVecs; ++v) {
+            uint8_t* base = buf.data.data() + v * oneElementSize;
+            // Random quantized bytes
+            for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+                base[b] = static_cast<uint8_t>(byteDist(rng));
+            }
+            // Random correction factors
+            float lower = floatDist(rng);
+            float upper = lower + std::abs(floatDist(rng)) + 0.01f; // ensure upper > lower
+            float additional = floatDist(rng);
+            int32_t componentSum = intDist(rng);
+            writeCorrectionFactors(base + quantizedVectorBytes, lower, upper, additional, componentSum);
+        }
+        return buf;
+    }
+
+    // Create a query buffer (same layout as a single element).
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> makeQuery(int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> q(oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+            q[b] = static_cast<uint8_t>(byteDist(rng));
+        }
+        float lower = floatDist(rng);
+        float upper = lower + std::abs(floatDist(rng)) + 0.01f;
+        float additional = floatDist(rng);
+        int32_t componentSum = intDist(rng);
+        writeCorrectionFactors(q.data() + quantizedVectorBytes, lower, upper, additional, componentSum);
+        return q;
+    }
+
+    // Read correction factors back from a buffer position.
+    struct CorrFactors { float lower, interval, additional; float componentSum; };
+    static CorrFactors readCorr(const uint8_t* ptr) {
+        CorrFactors c;
+        float lower, upper;
+        std::memcpy(&lower, ptr, sizeof(float));
+        std::memcpy(&upper, ptr + 4, sizeof(float));
+        std::memcpy(&c.additional, ptr + 8, sizeof(float));
+        int32_t cs;
+        std::memcpy(&cs, ptr + 12, sizeof(int32_t));
+        c.lower = lower;
+        c.interval = upper - lower;
+        c.componentSum = static_cast<float>(cs);
+        return c;
+    }
+
+    // Dimension that produces the given quantizedVectorBytes.
+    // quantizedVectorBytes = (8 * ((dim+7)/8)) / 32  →  dim ≈ quantizedVectorBytes * 32
+    // For aligned (multiple-of-8): use quantizedVectorBytes = 8, 16, 24, ...
+    // For unaligned: we artificially test with odd quantizedVectorBytes (e.g. 5, 13).
+    int32_t dimForQVB(int32_t qvb) const {
+        // Reverse: dim = qvb * 32 (simplification; works for multiples of 8)
+        return qvb * 32;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// operator() — single vector distance
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, OperatorSingleVector) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    // quantizedVectorBytes is always a multiple of 8 in practice.
+    // For IsBytesMultipleOf8=false we still use a multiple-of-8 qvb to exercise
+    // the memcpy code path and verify it produces identical results.
+    const int32_t qvb = 16;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    // Create distance computer via template
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    // Read query correction factors
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcount(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Mismatch at vector " << i << " (isMaxIP=" << isMaxIP
+            << ", aligned=" << isBytesMultipleOf8 << ")";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// distances_batch_4
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, DistancesBatch4) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 24;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    // Batch of 4 — compare against individual operator() calls
+    float dis0, dis1, dis2, dis3;
+    dc->distances_batch_4(0, 1, 2, 3, dis0, dis1, dis2, dis3);
+
+    EXPECT_NEAR(dis0, (*dc)(0), TOLERANCE);
+    EXPECT_NEAR(dis1, (*dc)(1), TOLERANCE);
+    EXPECT_NEAR(dis2, (*dc)(2), TOLERANCE);
+    EXPECT_NEAR(dis3, (*dc)(3), TOLERANCE);
+
+    // Second batch with different indices
+    dc->distances_batch_4(4, 5, 6, 7, dis0, dis1, dis2, dis3);
+
+    EXPECT_NEAR(dis0, (*dc)(4), TOLERANCE);
+    EXPECT_NEAR(dis1, (*dc)(5), TOLERANCE);
+    EXPECT_NEAR(dis2, (*dc)(6), TOLERANCE);
+    EXPECT_NEAR(dis3, (*dc)(7), TOLERANCE);
+}
+
+// ---------------------------------------------------------------------------
+// symmetric_dis
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, SymmetricDis) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 8;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    // symmetric_dis doesn't need set_query, it works on stored vectors only
+    for (int i = 0; i < NUM_VECS; ++i) {
+        for (int j = i; j < NUM_VECS; ++j) {
+            const uint8_t* t1 = buf.data.data() + i * buf.oneElementSize;
+            const uint8_t* t2 = buf.data.data() + j * buf.oneElementSize;
+
+            uint32_t refDp = referencePopcount(t1, t2, qvb);
+            auto c1 = readCorr(t1 + qvb);
+            auto c2 = readCorr(t2 + qvb);
+
+            // symmetric scoring formula
+            float score = c1.lower * c2.lower * dim
+                        + c2.lower * c1.interval * c1.componentSum
+                        + c1.lower * c2.interval * c2.componentSum
+                        + c1.interval * c2.interval * static_cast<float>(refDp);
+
+            if (isMaxIP) {
+                score += c1.additional + c2.additional - CENTROID_DP;
+            } else {
+                score = c1.additional + c2.additional - 2 * score;
+            }
+
+            float actual = dc->symmetric_dis(static_cast<idx_t>(i), static_cast<idx_t>(j));
+            EXPECT_NEAR(actual, score, TOLERANCE)
+                << "symmetric_dis(" << i << "," << j << ") mismatch";
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// setCorrectionFactors — verify extraction matches what was written
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, CorrectionFactorsExtraction) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 16;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    // Verify correction factor extraction indirectly: set_query reads query correction
+    // factors, then operator() uses both query and target correction factors in the
+    // scoring formula. If extraction is wrong, the score won't match the reference.
+    auto queryBuf = makeQuery(qvb);
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcount(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Correction factor extraction mismatch at vector " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FaissBBQFlat::get_distance_computer — integration test
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, GetDistanceComputerIntegration) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 16;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 4;
+
+    faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
+    FaissBBQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+
+    // Populate the storage
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    flat.quantizedVectorsAndCorrectionFactors.assign(buf.data.begin(), buf.data.end());
+    flat.ntotal = NUM_VECS;
+
+    // get_distance_computer should pick the right template
+    std::unique_ptr<faiss::DistanceComputer> dc(flat.get_distance_computer());
+
+    auto queryBuf = makeQuery(qvb);
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcount(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Integration mismatch at vector " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Instantiate all 4 combinations
+// ---------------------------------------------------------------------------
+
+INSTANTIATE_TEST_SUITE_P(
+    BBQDistanceComputer,
+    FaissBBQDistanceComputerTest,
+    ::testing::Values(
+        BBQTestParams{false, true},   // L2, aligned
+        BBQTestParams{false, false},  // L2, unaligned
+        BBQTestParams{true,  true},   // MaxIP, aligned
+        BBQTestParams{true,  false}   // MaxIP, unaligned
+    ),
+    [](const ::testing::TestParamInfo<BBQTestParams>& info) {
+        return info.param.name();
+    }
+);
+
+} // namespace knn_jni

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReaderTests.java
@@ -70,7 +70,7 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
             ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
@@ -91,7 +91,7 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mockSearcher);
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
             ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
@@ -145,7 +145,7 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mockSearcher);
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {


### PR DESCRIPTION
### Description
FaissBBQDistanceComputer crashes with SIGSEGV on both Intel macOS (x86_64) and ARM macOS (aarch64) during HNSW graph construction with BBQ-quantized vectors.

The root cause is reinterpret_cast<const uint64_t*> and reinterpret_cast<const float*> on pointers that are not guaranteed to meet alignment requirements. The data buffer used FourBytesAlignedAllocator (4-byte alignment), but uint64_t* requires 8-byte alignment. This is undefined behavior per the C++ standard, and compilers may emit aligned-only load instructions that fault on misaligned addresses.

Crash sites:
- knn_jni::FaissBBQDistanceComputer<true>::operator()(long long)
- faiss::search_neighbors_to_add (calls the distance computer during HNSW construction)
Affected methods: operator(), distances_batch_4, symmetric_dis, setCorrectionFactors, set_query

Fix:
- Upgraded allocator from 4-byte to 8-byte alignment (NBytesAlignedAllocator<uint8_t, 8>)
- Added IsBytesMultipleOf8 template parameter to FaissBBQDistanceComputer with if constexpr branching: direct reinterpret_cast on the aligned fast path, std::memcpy fallback on the unaligned path
- FaissBBQFlat::get_distance_computer() selects the right template at construction time based on oneElementSize % 8

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]


### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
