### PR TITLE
#3182 Faiss BBQ MOS changes Mac CI Crash Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.6](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
 * Support Lucene BBQ Flat for 1 bit [#3154](https://github.com/opensearch-project/k-NN/pull/3154)
+* Faiss BBQ MOS changes [#3182](https://github.com/opensearch-project/k-NN/pull/3182)
+
 
 ### Maintenance
 * Improve unit tests by tightening asserts [#3112](https://github.com/opensearch-project/k-NN/pull/3112)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -201,6 +201,7 @@ if ("${WIN32}" STREQUAL "")
                 tests/faiss_index_service_test.cpp
                 tests/nmslib_stream_support_test.cpp
                 tests/faiss_index_bq_unit_test.cpp
+                tests/faiss_bbq_distance_computer_test.cpp
         )
 
         target_link_libraries(

--- a/jni/include/bbq/faiss_bbq_flat.h
+++ b/jni/include/bbq/faiss_bbq_flat.h
@@ -8,17 +8,45 @@
 #include "memory_util.h"
 
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <iostream>
 
 namespace knn_jni {
 
-    template <bool IsMaxIP>
+    // Reads correction factors from a potentially unaligned address using std::memcpy.
+    // Layout at ptr: [lowerInterval(f32)][upperInterval(f32)][additionalCorrection(f32)][quantizedComponentSum(i32)]
+    static inline void readCorrectionFactorsSafe(const uint8_t* ptr, float& lowerInterval,
+        float& intervalLength, float& additionalCorrection, float& quantizedComponentSum) {
+        float lower, upper;
+        std::memcpy(&lower, ptr, sizeof(float));
+        std::memcpy(&upper, ptr + 4, sizeof(float));
+        std::memcpy(&additionalCorrection, ptr + 8, sizeof(float));
+        int32_t componentSum;
+        std::memcpy(&componentSum, ptr + 12, sizeof(int32_t));
+        lowerInterval = lower;
+        intervalLength = upper - lower;
+        quantizedComponentSum = static_cast<float>(componentSum);
+    }
+
+    // Reads correction factors via direct pointer cast (only safe when ptr is 4-byte aligned).
+    static inline void readCorrectionFactorsAligned(const uint8_t* ptr, float& lowerInterval,
+        float& intervalLength, float& additionalCorrection, float& quantizedComponentSum) {
+        const auto* correctionFactors = reinterpret_cast<const float*>(ptr);
+        lowerInterval = correctionFactors[0];
+        intervalLength = correctionFactors[1] - correctionFactors[0];
+        additionalCorrection = correctionFactors[2];
+        int32_t componentSum;
+        std::memcpy(&componentSum, ptr + 12, sizeof(int32_t));
+        quantizedComponentSum = static_cast<float>(componentSum);
+    }
+
+    template <bool IsMaxIP, bool IsBytesMultipleOf8>
     struct FaissBBQDistanceComputer final : faiss::DistanceComputer {
         const int64_t oneElementByteSize;
         const uint64_t quantizedVectorBytes;
         const uint8_t* data;
-        const uint64_t* query;
+        const uint8_t* query;
         const float centroidDp;
         float ay;
         float ly;
@@ -44,17 +72,22 @@ namespace knn_jni {
         }
 
         void set_query(const float* x) final {
-            query = (uint64_t*) x;
+            // The query pointer comes from FaissBBQFlat::quantizedVectorsAndCorrectionFactors
+            // which uses NBytesAlignedAllocator<uint8_t, 8> (8-byte aligned base) with a
+            // stride of oneElementByteSize that is always a multiple of 8 (quantizedVectorBytes
+            // is a multiple of 8 by formula, plus 16 bytes of correction factors).
+            // Therefore x is guaranteed 8-byte aligned when IsBytesMultipleOf8 is true.
+            query = reinterpret_cast<const uint8_t*>(x);
             setCorrectionFactors(query, ay, ly, queryAdditional, y1);
         }
 
         void setCorrectionFactors(const void* target, float& lowerInterval, float& intervalLength, float& additionalCorrection, float& quantizedComponentSum) {
-            // [Quantized Vector | lowerInterval (float) | upperInterval (float) | additionalCorrection (float) | quantizedComponentSum (int)]
-            const auto* correctionFactors = (const float*) ((const uint8_t*) target + quantizedVectorBytes);
-            lowerInterval = correctionFactors[0];
-            intervalLength = correctionFactors[1] - correctionFactors[0];
-            additionalCorrection = correctionFactors[2];
-            quantizedComponentSum = *((const int32_t*) (&correctionFactors[3]));
+            const uint8_t* ptr = static_cast<const uint8_t*>(target) + quantizedVectorBytes;
+            if constexpr (IsBytesMultipleOf8) {
+                readCorrectionFactorsAligned(ptr, lowerInterval, intervalLength, additionalCorrection, quantizedComponentSum);
+            } else {
+                readCorrectionFactorsSafe(ptr, lowerInterval, intervalLength, additionalCorrection, quantizedComponentSum);
+            }
         }
 
         float scoringSecondPart(const void* target, const float dp) {
@@ -84,23 +117,34 @@ namespace knn_jni {
 
         /// compute distance of vector i to current query
         float operator()(faiss::idx_t i) final {
-            const uint64_t* target = reinterpret_cast<const uint64_t*>(data + i * oneElementByteSize);
-
+            const uint8_t* target = data + i * oneElementByteSize;
+            // quantizedVectorBytes is always a multiple of 8 per the Java-side contract
+            // (FaissService.java: "byte length of a single 1-bit quantized vector, always
+            // 64-bit aligned"). The IsBytesMultipleOf8=false path is a safety fallback to
+            // avoid UB on unaligned pointer reads, not to handle non-multiple-of-8 sizes.
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-
             uint32_t dp = 0;
 
-            for (size_t j = 0; j < words; ++j) {
-                dp += __builtin_popcountll(query[j] & target[j]);
+            if constexpr (IsBytesMultipleOf8) {
+                const auto* q = reinterpret_cast<const uint64_t*>(query);
+                const auto* t = reinterpret_cast<const uint64_t*>(target);
+                for (size_t j = 0; j < words; ++j) {
+                    dp += __builtin_popcountll(q[j] & t[j]);
+                }
+            } else {
+                // Slower
+                for (size_t j = 0; j < words; ++j) {
+                    uint64_t queryWord, targetWord;
+                    std::memcpy(&queryWord, query + j * 8, sizeof(uint64_t));
+                    std::memcpy(&targetWord, target + j * 8, sizeof(uint64_t));
+                    dp += __builtin_popcountll(queryWord & targetWord);
+                }
             }
 
-            const float score = scoringSecondPart(target, dp);
-            return score;
+            return scoringSecondPart(target, dp);
         }
 
         /// compute distances of current query to 4 stored vectors.
-        /// certain DistanceComputer implementations may benefit
-        /// heavily from this.
         void distances_batch_4(
                 const faiss::idx_t idx0,
                 const faiss::idx_t idx1,
@@ -110,23 +154,42 @@ namespace knn_jni {
                 float& dis1,
                 float& dis2,
                 float& dis3) final {
-            const uint64_t* target1 = reinterpret_cast<const uint64_t*>(data + idx0 * oneElementByteSize);
-            const uint64_t* target2 = reinterpret_cast<const uint64_t*>(data + idx1 * oneElementByteSize);
-            const uint64_t* target3 = reinterpret_cast<const uint64_t*>(data + idx2 * oneElementByteSize);
-            const uint64_t* target4 = reinterpret_cast<const uint64_t*>(data + idx3 * oneElementByteSize);
+            const uint8_t* target1 = data + idx0 * oneElementByteSize;
+            const uint8_t* target2 = data + idx1 * oneElementByteSize;
+            const uint8_t* target3 = data + idx2 * oneElementByteSize;
+            const uint8_t* target4 = data + idx3 * oneElementByteSize;
 
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
 
-            uint32_t dp1 = 0;
-            uint32_t dp2 = 0;
-            uint32_t dp3 = 0;
-            uint32_t dp4 = 0;
+            uint32_t dp1 = 0, dp2 = 0, dp3 = 0, dp4 = 0;
 
-            for (size_t i = 0; i < words; ++i) {
-                dp1 += __builtin_popcountll(query[i] & target1[i]);
-                dp2 += __builtin_popcountll(query[i] & target2[i]);
-                dp3 += __builtin_popcountll(query[i] & target3[i]);
-                dp4 += __builtin_popcountll(query[i] & target4[i]);
+            if constexpr (IsBytesMultipleOf8) {
+                const auto* q = reinterpret_cast<const uint64_t*>(query);
+                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
+                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
+                const auto* t3 = reinterpret_cast<const uint64_t*>(target3);
+                const auto* t4 = reinterpret_cast<const uint64_t*>(target4);
+                for (size_t i = 0; i < words; ++i) {
+                    dp1 += __builtin_popcountll(q[i] & t1[i]);
+                    dp2 += __builtin_popcountll(q[i] & t2[i]);
+                    dp3 += __builtin_popcountll(q[i] & t3[i]);
+                    dp4 += __builtin_popcountll(q[i] & t4[i]);
+                }
+            } else {
+                // Slower
+                for (size_t i = 0; i < words; ++i) {
+                    uint64_t queryWord;
+                    std::memcpy(&queryWord, query + i * 8, sizeof(uint64_t));
+                    uint64_t w1, w2, w3, w4;
+                    std::memcpy(&w1, target1 + i * 8, sizeof(uint64_t));
+                    std::memcpy(&w2, target2 + i * 8, sizeof(uint64_t));
+                    std::memcpy(&w3, target3 + i * 8, sizeof(uint64_t));
+                    std::memcpy(&w4, target4 + i * 8, sizeof(uint64_t));
+                    dp1 += __builtin_popcountll(queryWord & w1);
+                    dp2 += __builtin_popcountll(queryWord & w2);
+                    dp3 += __builtin_popcountll(queryWord & w3);
+                    dp4 += __builtin_popcountll(queryWord & w4);
+                }
             }
 
             dis0 = scoringSecondPart(target1, dp1);
@@ -137,28 +200,33 @@ namespace knn_jni {
 
         /// compute distance between two stored vectors
         float symmetric_dis(faiss::idx_t i, faiss::idx_t j) {
-            const uint64_t* target1 = reinterpret_cast<const uint64_t*>(data + i * oneElementByteSize);
-            const uint64_t* target2 = reinterpret_cast<const uint64_t*>(data + j * oneElementByteSize);
+            const uint8_t* target1 = data + i * oneElementByteSize;
+            const uint8_t* target2 = data + j * oneElementByteSize;
 
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-
             uint32_t dp = 0;
 
-            for (size_t k = 0; k < words; ++k) {
-                dp += __builtin_popcountll(target1[k] & target2[k]);
+            if constexpr (IsBytesMultipleOf8) {
+                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
+                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
+                for (size_t k = 0; k < words; ++k) {
+                    dp += __builtin_popcountll(t1[k] & t2[k]);
+                }
+            } else {
+                // Slower
+                for (size_t k = 0; k < words; ++k) {
+                    uint64_t w1, w2;
+                    std::memcpy(&w1, target1 + k * 8, sizeof(uint64_t));
+                    std::memcpy(&w2, target2 + k * 8, sizeof(uint64_t));
+                    dp += __builtin_popcountll(w1 & w2);
+                }
             }
 
             // Get correction factors
-            float ax;
-            float lx;
-            float additional;
-            float x1;
+            float ax, lx, additional, x1;
             setCorrectionFactors(target1, ax, lx, additional, x1);
 
-            float az;
-            float lz;
-            float additionalz;
-            float z1;
+            float az, lz, additionalz, z1;
             setCorrectionFactors(target2, az, lz, additionalz, z1);
 
             // Scoring
@@ -182,8 +250,8 @@ namespace knn_jni {
         int32_t quantizedVectorBytes;
         float centroidDp;
         int32_t oneElementSize;
-        // For safely casting uint8_t* to float*, we should enforce 4-byte alignment for the vector.
-        std::vector<uint8_t, knn_jni::FourBytesAlignedAllocator<uint8_t>> quantizedVectorsAndCorrectionFactors;
+        // For safely casting uint8_t* to float*, we should enforce 8-byte alignment for the vector.
+        std::vector<uint8_t, knn_jni::NBytesAlignedAllocator<uint8_t, 8>> quantizedVectorsAndCorrectionFactors;
         int32_t dimension;
 
         FaissBBQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric)
@@ -207,10 +275,19 @@ namespace knn_jni {
         }
 
         faiss::DistanceComputer* get_distance_computer() const {
+            const bool aligned = (oneElementSize % 8) == 0;
             if (metric_type == faiss::MetricType::METRIC_L2) {
-                return new FaissBBQDistanceComputer<false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                if (aligned) {
+                    return new FaissBBQDistanceComputer<false, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                } else {
+                    return new FaissBBQDistanceComputer<false, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                }
             } else if (metric_type == faiss::MetricType::METRIC_INNER_PRODUCT) {
-                return new FaissBBQDistanceComputer<true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                if (aligned) {
+                    return new FaissBBQDistanceComputer<true, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                } else {
+                    return new FaissBBQDistanceComputer<true, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                }
             }
 
             throw std::runtime_error("Unsupported metric type - " + std::to_string(metric_type));

--- a/jni/include/memory_util.h
+++ b/jni/include/memory_util.h
@@ -38,18 +38,27 @@
 
 namespace knn_jni {
 
-    template <typename T>
-    struct FourBytesAlignedAllocator {
+    template <typename T, int NBytes>
+    struct NBytesAlignedAllocator {
         using value_type = T;
 
+        template <typename U>
+        struct rebind { using other = NBytesAlignedAllocator<U, NBytes>; };
+
         T* allocate(std::size_t n) {
-            void* p = ::operator new(n * sizeof(T), std::align_val_t(4));
+            void* p = ::operator new(n * sizeof(T), std::align_val_t(NBytes));
             return static_cast<T*>(p);
         }
 
         void deallocate(T* p, std::size_t) noexcept {
-            ::operator delete(p, std::align_val_t(4));
+            ::operator delete(p, std::align_val_t(NBytes));
         }
+
+        template <typename U>
+        bool operator==(const NBytesAlignedAllocator<U, NBytes>&) const noexcept { return true; }
+
+        template <typename U>
+        bool operator!=(const NBytesAlignedAllocator<U, NBytes>&) const noexcept { return false; }
     };
 
 }

--- a/jni/tests/faiss_bbq_distance_computer_test.cpp
+++ b/jni/tests/faiss_bbq_distance_computer_test.cpp
@@ -1,0 +1,421 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#include "bbq/faiss_bbq_flat.h"
+
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+using idx_t = faiss::idx_t;
+
+namespace knn_jni {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Reference scalar popcount dot-product matching FaissBBQDistanceComputer behavior.
+// Processes only full 8-byte words (quantizedVectorBytes >> 3), same as the real code.
+static uint32_t referencePopcount(const uint8_t* a, const uint8_t* b, int32_t quantizedVectorBytes) {
+    const int32_t words = quantizedVectorBytes >> 3;
+    uint32_t dp = 0;
+    for (int32_t w = 0; w < words; ++w) {
+        uint64_t wa, wb;
+        std::memcpy(&wa, a + w * 8, sizeof(uint64_t));
+        std::memcpy(&wb, b + w * 8, sizeof(uint64_t));
+        dp += __builtin_popcountll(wa & wb);
+    }
+    return dp;
+}
+
+// Reference scoring formula matching FaissBBQDistanceComputer.
+static float referenceScore(bool isMaxIP, int32_t dim, float centroidDp,
+                            float ay, float ly, float queryAdditional, float y1,
+                            float ax, float lx, float additional, float x1,
+                            float dp) {
+    float score = ax * ay * dim + ay * lx * x1 + ax * ly * y1 + lx * ly * dp;
+    if (isMaxIP) {
+        score += queryAdditional + additional - centroidDp;
+    } else {
+        score = queryAdditional + additional - 2.0f * score;
+    }
+    return score;
+}
+
+// Write correction factors into buffer at ptr.
+// Layout: [lower(f32)][upper(f32)][additional(f32)][componentSum(i32)]
+static void writeCorrectionFactors(uint8_t* ptr, float lower, float upper,
+                                   float additional, int32_t componentSum) {
+    std::memcpy(ptr,      &lower,        sizeof(float));
+    std::memcpy(ptr + 4,  &upper,        sizeof(float));
+    std::memcpy(ptr + 8,  &additional,   sizeof(float));
+    std::memcpy(ptr + 12, &componentSum, sizeof(int32_t));
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture — parameterised over (IsMaxIP, IsBytesMultipleOf8)
+// ---------------------------------------------------------------------------
+
+struct BBQTestParams {
+    bool isMaxIP;
+    bool isBytesMultipleOf8;
+    std::string name() const {
+        std::string s = isMaxIP ? "MaxIP" : "L2";
+        s += isBytesMultipleOf8 ? "_Aligned" : "_Unaligned";
+        return s;
+    }
+};
+
+class FaissBBQDistanceComputerTest : public ::testing::TestWithParam<BBQTestParams> {
+protected:
+    static constexpr float CENTROID_DP = 0.5f;
+    static constexpr float TOLERANCE  = 1e-5f;
+
+    // Deterministic RNG seeded per test for reproducibility.
+    std::mt19937 rng{42};
+
+    // Build a data buffer holding `numVecs` elements, each with
+    // `quantizedVectorBytes` of random binary data followed by correction factors.
+    // Returns (buffer, oneElementSize, quantizedVectorBytes).
+    struct TestBuffer {
+        // 8-byte aligned storage
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> data;
+        int32_t oneElementSize;
+        int32_t quantizedVectorBytes;
+    };
+
+    TestBuffer makeBuffer(int numVecs, int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        TestBuffer buf;
+        buf.oneElementSize = oneElementSize;
+        buf.quantizedVectorBytes = quantizedVectorBytes;
+        buf.data.resize(numVecs * oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int v = 0; v < numVecs; ++v) {
+            uint8_t* base = buf.data.data() + v * oneElementSize;
+            // Random quantized bytes
+            for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+                base[b] = static_cast<uint8_t>(byteDist(rng));
+            }
+            // Random correction factors
+            float lower = floatDist(rng);
+            float upper = lower + std::abs(floatDist(rng)) + 0.01f; // ensure upper > lower
+            float additional = floatDist(rng);
+            int32_t componentSum = intDist(rng);
+            writeCorrectionFactors(base + quantizedVectorBytes, lower, upper, additional, componentSum);
+        }
+        return buf;
+    }
+
+    // Create a query buffer (same layout as a single element).
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> makeQuery(int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> q(oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+            q[b] = static_cast<uint8_t>(byteDist(rng));
+        }
+        float lower = floatDist(rng);
+        float upper = lower + std::abs(floatDist(rng)) + 0.01f;
+        float additional = floatDist(rng);
+        int32_t componentSum = intDist(rng);
+        writeCorrectionFactors(q.data() + quantizedVectorBytes, lower, upper, additional, componentSum);
+        return q;
+    }
+
+    // Read correction factors back from a buffer position.
+    struct CorrFactors { float lower, interval, additional; float componentSum; };
+    static CorrFactors readCorr(const uint8_t* ptr) {
+        CorrFactors c;
+        float lower, upper;
+        std::memcpy(&lower, ptr, sizeof(float));
+        std::memcpy(&upper, ptr + 4, sizeof(float));
+        std::memcpy(&c.additional, ptr + 8, sizeof(float));
+        int32_t cs;
+        std::memcpy(&cs, ptr + 12, sizeof(int32_t));
+        c.lower = lower;
+        c.interval = upper - lower;
+        c.componentSum = static_cast<float>(cs);
+        return c;
+    }
+
+    // Dimension that produces the given quantizedVectorBytes.
+    // quantizedVectorBytes = (8 * ((dim+7)/8)) / 32  →  dim ≈ quantizedVectorBytes * 32
+    // For aligned (multiple-of-8): use quantizedVectorBytes = 8, 16, 24, ...
+    // For unaligned: we artificially test with odd quantizedVectorBytes (e.g. 5, 13).
+    int32_t dimForQVB(int32_t qvb) const {
+        // Reverse: dim = qvb * 32 (simplification; works for multiples of 8)
+        return qvb * 32;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// operator() — single vector distance
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, OperatorSingleVector) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    // quantizedVectorBytes is always a multiple of 8 in practice.
+    // For IsBytesMultipleOf8=false we still use a multiple-of-8 qvb to exercise
+    // the memcpy code path and verify it produces identical results.
+    const int32_t qvb = 16;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    // Create distance computer via template
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    // Read query correction factors
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcount(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Mismatch at vector " << i << " (isMaxIP=" << isMaxIP
+            << ", aligned=" << isBytesMultipleOf8 << ")";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// distances_batch_4
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, DistancesBatch4) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 24;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    // Batch of 4 — compare against individual operator() calls
+    float dis0, dis1, dis2, dis3;
+    dc->distances_batch_4(0, 1, 2, 3, dis0, dis1, dis2, dis3);
+
+    EXPECT_NEAR(dis0, (*dc)(0), TOLERANCE);
+    EXPECT_NEAR(dis1, (*dc)(1), TOLERANCE);
+    EXPECT_NEAR(dis2, (*dc)(2), TOLERANCE);
+    EXPECT_NEAR(dis3, (*dc)(3), TOLERANCE);
+
+    // Second batch with different indices
+    dc->distances_batch_4(4, 5, 6, 7, dis0, dis1, dis2, dis3);
+
+    EXPECT_NEAR(dis0, (*dc)(4), TOLERANCE);
+    EXPECT_NEAR(dis1, (*dc)(5), TOLERANCE);
+    EXPECT_NEAR(dis2, (*dc)(6), TOLERANCE);
+    EXPECT_NEAR(dis3, (*dc)(7), TOLERANCE);
+}
+
+// ---------------------------------------------------------------------------
+// symmetric_dis
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, SymmetricDis) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 8;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    // symmetric_dis doesn't need set_query, it works on stored vectors only
+    for (int i = 0; i < NUM_VECS; ++i) {
+        for (int j = i; j < NUM_VECS; ++j) {
+            const uint8_t* t1 = buf.data.data() + i * buf.oneElementSize;
+            const uint8_t* t2 = buf.data.data() + j * buf.oneElementSize;
+
+            uint32_t refDp = referencePopcount(t1, t2, qvb);
+            auto c1 = readCorr(t1 + qvb);
+            auto c2 = readCorr(t2 + qvb);
+
+            // symmetric scoring formula
+            float score = c1.lower * c2.lower * dim
+                        + c2.lower * c1.interval * c1.componentSum
+                        + c1.lower * c2.interval * c2.componentSum
+                        + c1.interval * c2.interval * static_cast<float>(refDp);
+
+            if (isMaxIP) {
+                score += c1.additional + c2.additional - CENTROID_DP;
+            } else {
+                score = c1.additional + c2.additional - 2 * score;
+            }
+
+            float actual = dc->symmetric_dis(static_cast<idx_t>(i), static_cast<idx_t>(j));
+            EXPECT_NEAR(actual, score, TOLERANCE)
+                << "symmetric_dis(" << i << "," << j << ") mismatch";
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// setCorrectionFactors — verify extraction matches what was written
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, CorrectionFactorsExtraction) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 16;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (isMaxIP && !isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else if (!isMaxIP && isBytesMultipleOf8)
+        dc.reset(new FaissBBQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissBBQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    // Verify correction factor extraction indirectly: set_query reads query correction
+    // factors, then operator() uses both query and target correction factors in the
+    // scoring formula. If extraction is wrong, the score won't match the reference.
+    auto queryBuf = makeQuery(qvb);
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcount(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Correction factor extraction mismatch at vector " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FaissBBQFlat::get_distance_computer — integration test
+// ---------------------------------------------------------------------------
+
+TEST_P(FaissBBQDistanceComputerTest, GetDistanceComputerIntegration) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    const int32_t qvb = 16;
+    const int32_t dim = dimForQVB(qvb);
+    constexpr int NUM_VECS = 4;
+
+    faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
+    FaissBBQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+
+    // Populate the storage
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    flat.quantizedVectorsAndCorrectionFactors.assign(buf.data.begin(), buf.data.end());
+    flat.ntotal = NUM_VECS;
+
+    // get_distance_computer should pick the right template
+    std::unique_ptr<faiss::DistanceComputer> dc(flat.get_distance_computer());
+
+    auto queryBuf = makeQuery(qvb);
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcount(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Integration mismatch at vector " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Instantiate all 4 combinations
+// ---------------------------------------------------------------------------
+
+INSTANTIATE_TEST_SUITE_P(
+    BBQDistanceComputer,
+    FaissBBQDistanceComputerTest,
+    ::testing::Values(
+        BBQTestParams{false, true},   // L2, aligned
+        BBQTestParams{false, false},  // L2, unaligned
+        BBQTestParams{true,  true},   // MaxIP, aligned
+        BBQTestParams{true,  false}   // MaxIP, unaligned
+    ),
+    [](const ::testing::TestParamInfo<BBQTestParams>& info) {
+        return info.param.name();
+    }
+);
+
+} // namespace knn_jni

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReader.java
@@ -59,13 +59,13 @@ public class Faiss104ScalarQuantizedKnnVectorsReader extends NativeEngines990Knn
      */
     @Override
     public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(field);
+        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
+
         // Null target is the warmup signal — handle before attempting searcher load
         if (target == null) {
             throw new FaissMemoryOptimizedSearcher.WarmupInitializationException("Null vector supplied for warmup");
         }
-
-        final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(field);
-        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
 
         if (memoryOptimizedSearcher == null) {
             throw new IllegalStateException(

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -359,7 +359,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
                 fileName,
                 fieldInfo,
                 ioContext,
-                flatVectorsReader.getFlatVectorScorer()
+                flatVectorsReader
             );
         }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcherFactory.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
-import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -17,13 +17,19 @@ import java.io.IOException;
  * Provided parameters will have {@link Directory} and a file name where implementation can rely on it to open an input stream.
  */
 public interface VectorSearcherFactory {
+
     /**
      * Create a non-null {@link VectorSearcher} with given Lucene's {@link Directory}.
+     * <p>
+     * The {@code flatVectorsReader} provides access to Lucene's flat vector storage. For BBQ indices
+     * where Faiss skips flat storage via {@code IO_FLAG_SKIP_STORAGE}, the reader is used to wire in
+     * a {@code FaissBBQFlatIndex} backed by Lucene's quantized reader.
      *
      * @param directory Lucene's Directory.
      * @param fileName Logical file name to load.
      * @param fieldInfo Field info containing metadata for ADC extraction
      * @param ioContext IOContext to use when opening the file
+     * @param flatVectorsReader Reader providing flat vector scoring and storage
      * @return Null instance if it is not supported, otherwise return {@link VectorSearcher}
      * @throws IOException
      */
@@ -32,6 +38,6 @@ public interface VectorSearcherFactory {
         String fileName,
         FieldInfo fieldInfo,
         IOContext ioContext,
-        FlatVectorsScorer vectorScorer
+        FlatVectorsReader flatVectorsReader
     ) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/AbstractFaissHNSWIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/AbstractFaissHNSWIndex.java
@@ -6,10 +6,13 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.Getter;
+import lombok.Setter;
 
 public abstract class AbstractFaissHNSWIndex extends FaissIndex implements FaissHNSWProvider {
     @Getter
     protected FaissHNSW faissHnsw;
+    @Getter
+    @Setter
     protected FaissIndex flatVectors;
 
     public AbstractFaissHNSWIndex(final String indexType, final FaissHNSW faissHnsw) {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissBBQFlatIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissBBQFlatIndex.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.Getter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * A virtual FaissIndex that serves as a proxy for Lucene's BinaryQuantized vectors reader.
+ * When Faiss BBQ is used, the HNSW graph is stored in the .faiss file without storage (IO_FLAG_SKIP_STORAGE),
+ * and quantized vectors are stored separately via Lucene's format. This class bridges the two by installing
+ * itself as the flat storage under FaissHNSWIndex, providing access to the quantized vectors reader for scoring.
+ */
+public class FaissBBQFlatIndex extends FaissIndex {
+    static final String FAISS_BBQ_FLAT_INDEX = "FaissBBQFlatIndex";
+
+    @Getter
+    private final FlatVectorsReader bbqFlatReader;
+    @Getter
+    private final String fieldName;
+
+    public FaissBBQFlatIndex(final FlatVectorsReader bbqFlatReader, final String fieldName) {
+        super(FAISS_BBQ_FLAT_INDEX);
+        this.bbqFlatReader = bbqFlatReader;
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    protected void doLoad(IndexInput input) throws IOException {
+        // No-op: quantized vectors are managed by bbqFlatReader, not loaded from the faiss file.
+    }
+
+    @Override
+    public VectorEncoding getVectorEncoding() {
+        return VectorEncoding.FLOAT32;
+    }
+
+    @Override
+    public FloatVectorValues getFloatValues(IndexInput indexInput) throws IOException {
+        return bbqFlatReader.getFloatVectorValues(fieldName);
+    }
+
+    @Override
+    public ByteVectorValues getByteValues(IndexInput indexInput) throws IOException {
+        throw new UnsupportedOperationException("FaissBBQFlatIndex does not support byte vector values.");
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndex.java
@@ -25,6 +25,9 @@ import java.io.IOException;
  */
 @Getter
 public abstract class FaissIndex {
+    // Section name written by Faiss when IO_FLAG_SKIP_STORAGE is set (e.g., BBQ skips flat vector storage).
+    public static final String NULL_INDEX_TYPE = "null";
+
     // Index type name
     protected String indexType;
     // Vector dimension
@@ -44,13 +47,19 @@ public abstract class FaissIndex {
      * The first four bytes of each section represent an index type name. The index type is read first,
      * and {@link IndexTypeToFaissIndexMapping} is then used to delegate section loading to the corresponding {@link FaissIndex} subtype
      * implementation.
+     * When a "null" section name is encountered (e.g., Faiss BBQ where storage was skipped via IO_FLAG_SKIP_STORAGE),
+     * this method returns {@code null}. The caller is responsible for handling the null case
+     * (e.g., by wiring in a {@code FaissBBQFlatIndex} backed by Lucene's quantized reader).
      *
      * @param input Input stream to a FAISS index
-     * @return Top level {@link FaissIndex}.
+     * @return Top level {@link FaissIndex}, or {@code null} if a "null" section is encountered.
      * @throws IOException
      */
     public static FaissIndex load(IndexInput input) throws IOException {
         final String indexType = FaissIndexLoadUtils.readIndexType(input);
+        if (NULL_INDEX_TYPE.equals(indexType)) {
+            return null;
+        }
         final FaissIndex faissIndex = IndexTypeToFaissIndexMapping.getFaissIndex(indexType);
         faissIndex.doLoad(input);
         return faissIndex;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -60,11 +60,19 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     private boolean isAdc;
     private SimdVectorComputeService.SimilarityFunctionType nativeSimilarityFunctionType;
 
-    public FaissMemoryOptimizedSearcher(final IndexInput indexInput, final FieldInfo fieldInfo, final FlatVectorsScorer flatVectorsScorer)
-        throws IOException {
+    /**
+     * Constructor that accepts a pre-loaded {@link FaissIndex}. The factory is responsible for
+     * loading the index and applying any transformations (e.g., replacing null flat storage for BBQ).
+     */
+    public FaissMemoryOptimizedSearcher(
+        final IndexInput indexInput,
+        final FieldInfo fieldInfo,
+        final FaissIndex faissIndex,
+        final FlatVectorsScorer flatVectorsScorer
+    ) throws IOException {
         this.indexInput = indexInput;
         this.fileSize = indexInput.length();
-        this.faissIndex = FaissIndex.load(indexInput);
+        this.faissIndex = faissIndex;
         final KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
 
         if (knnVectorSimilarityFunction != KNNVectorSimilarityFunction.HAMMING) {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -5,7 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss;
 
-import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.store.Directory;
@@ -32,13 +32,15 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
         final String fileName,
         final FieldInfo fieldInfo,
         final IOContext ioContext,
-        final FlatVectorsScorer vectorScorer
+        final FlatVectorsReader flatVectorsReader
     ) throws IOException {
         final IndexInput indexInput = directory.openInput(fileName, ioContext);
 
         try {
             // Try load it. Not all FAISS index types are currently supported at the moment.
-            return new FaissMemoryOptimizedSearcher(indexInput, fieldInfo, vectorScorer);
+            FaissIndex faissIndex = FaissIndex.load(indexInput);
+            maybeSetFlatVectorsFromReader(faissIndex, flatVectorsReader, fieldInfo);
+            return new FaissMemoryOptimizedSearcher(indexInput, fieldInfo, faissIndex, flatVectorsReader.getFlatVectorScorer());
         } catch (UnsupportedFaissIndexException e) {
             // Clean up input stream.
             try {
@@ -49,4 +51,20 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
         }
     }
 
+    /**
+     * When the FAISS HNSW index has no flat vector storage (e.g., BBQ), wire in the provided
+     * {@link FlatVectorsReader} as the flat vector source.
+     */
+    private void maybeSetFlatVectorsFromReader(
+        final FaissIndex faissIndex,
+        final FlatVectorsReader flatVectorsReader,
+        final FieldInfo fieldInfo
+    ) {
+        if (faissIndex instanceof FaissIdMapIndex idMapIndex) {
+            final FaissIndex nested = idMapIndex.getNestedIndex();
+            if (nested instanceof AbstractFaissHNSWIndex hnswIndex && hnswIndex.getFlatVectors() == null) {
+                hnswIndex.setFlatVectors(new FaissBBQFlatIndex(flatVectorsReader, fieldInfo.getName()));
+            }
+        }
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedKnnVectorsReaderTests.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -70,7 +71,15 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mock(VectorSearcher.class));
+        when(
+            mockFactory.createVectorSearcher(
+                any(Directory.class),
+                anyString(),
+                any(FieldInfo.class),
+                any(IOContext.class),
+                any(FlatVectorsReader.class)
+            )
+        ).thenReturn(mock(VectorSearcher.class));
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
             ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
@@ -91,7 +100,15 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(
+            mockFactory.createVectorSearcher(
+                any(Directory.class),
+                anyString(),
+                any(FieldInfo.class),
+                any(IOContext.class),
+                any(FlatVectorsReader.class)
+            )
+        ).thenReturn(mockSearcher);
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
             ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
@@ -145,7 +162,15 @@ public class Faiss104ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
-        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+        when(
+            mockFactory.createVectorSearcher(
+                any(Directory.class),
+                anyString(),
+                any(FieldInfo.class),
+                any(IOContext.class),
+                any(FlatVectorsReader.class)
+            )
+        ).thenReturn(mockSearcher);
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
 
         try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
@@ -54,9 +54,11 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
     ) {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
+            final FaissIndex faissIndex = FaissIndex.load(input);
             final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
                 input,
                 NO_ADC_NEEDED,
+                faissIndex,
                 FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
             );
 
@@ -98,12 +100,12 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
 
             // Get answer
             input.seek(0);
-            final FaissIndex faissIndex = FaissIndex.load(input);
+            final FaissIndex answerIndex = FaissIndex.load(input);
             final Set<Integer> answerScoreDocs;
             if (vectorDataType == VectorDataType.FLOAT) {
-                answerScoreDocs = calculateFloatAnswer((float[]) query, faissIndex.getFloatValues(input), k, similarityFunction);
+                answerScoreDocs = calculateFloatAnswer((float[]) query, answerIndex.getFloatValues(input), k, similarityFunction);
             } else {
-                answerScoreDocs = calculateByteOrBinaryAnswer((byte[]) query, faissIndex.getByteValues(input), k, similarityFunction);
+                answerScoreDocs = calculateByteOrBinaryAnswer((byte[]) query, answerIndex.getByteValues(input), k, similarityFunction);
             }
 
             // Validate search result

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissBBQFlatIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissBBQFlatIndexTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.store.IndexInput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissBBQFlatIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSWIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FaissBBQFlatIndexTests extends KNNTestCase {
+
+    public void testFaissBBQFlatIndex_hasReaderReference() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        String fieldName = "test_field";
+
+        FaissBBQFlatIndex bbqFlatIndex = new FaissBBQFlatIndex(mockReader, fieldName);
+
+        assertSame(mockReader, bbqFlatIndex.getBbqFlatReader());
+        assertEquals(fieldName, bbqFlatIndex.getFieldName());
+        assertEquals("FaissBBQFlatIndex", bbqFlatIndex.getIndexType());
+        assertEquals(VectorEncoding.FLOAT32, bbqFlatIndex.getVectorEncoding());
+    }
+
+    @SneakyThrows
+    public void testFaissBBQFlatIndex_getFloatValues_delegatesToReader() {
+        FloatVectorValues mockFloatValues = mock(FloatVectorValues.class);
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        String fieldName = "test_field";
+        when(mockReader.getFloatVectorValues(fieldName)).thenReturn(mockFloatValues);
+
+        FaissBBQFlatIndex bbqFlatIndex = new FaissBBQFlatIndex(mockReader, fieldName);
+        FloatVectorValues result = bbqFlatIndex.getFloatValues(null);
+
+        assertSame(mockFloatValues, result);
+    }
+
+    public void testFaissBBQFlatIndex_getByteValues_throwsUnsupported() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        FaissBBQFlatIndex bbqFlatIndex = new FaissBBQFlatIndex(mockReader, "test_field");
+
+        assertThrows(UnsupportedOperationException.class, () -> bbqFlatIndex.getByteValues(null));
+    }
+
+    @SneakyThrows
+    public void testFaissBBQFlatIndex_doLoad_isNoOp() throws Exception {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        FaissBBQFlatIndex bbqFlatIndex = new FaissBBQFlatIndex(mockReader, "test_field");
+
+        // doLoad is protected, use reflection to verify it's a no-op
+        IndexInput mockInput = mock(IndexInput.class);
+        final Method doLoadMethod = FaissBBQFlatIndex.class.getDeclaredMethod("doLoad", IndexInput.class);
+        doLoadMethod.setAccessible(true);
+        doLoadMethod.invoke(bbqFlatIndex, mockInput);
+    }
+
+    @SneakyThrows
+    public void testFaissIndexLoad_whenNullSection_thenReturnsNull() {
+        IndexInput mockInput = mock(IndexInput.class);
+        // "null" as 4 bytes — readBytes is void, so use doAnswer
+        doAnswer(invocation -> {
+            byte[] buf = invocation.getArgument(0);
+            byte[] nullBytes = "null".getBytes();
+            System.arraycopy(nullBytes, 0, buf, 0, 4);
+            return null;
+        }).when(mockInput).readBytes(any(byte[].class), any(int.class), any(int.class));
+
+        FaissIndex result = FaissIndex.load(mockInput);
+        assertNull(result);
+    }
+
+    public void testAbstractFaissHNSWIndex_flatVectorsGetter() {
+        FaissHNSWIndex hnswIndex = mock(FaissHNSWIndex.class);
+        FaissBBQFlatIndex bbqFlatIndex = new FaissBBQFlatIndex(mock(FlatVectorsReader.class), "test_field");
+        when(hnswIndex.getFlatVectors()).thenReturn(bbqFlatIndex);
+
+        FaissIndex flatVectors = hnswIndex.getFlatVectors();
+        assertTrue(flatVectors instanceof FaissBBQFlatIndex);
+        assertSame(bbqFlatIndex, flatVectors);
+    }
+
+    @SneakyThrows
+    public void testFaissBBQFlatIndex_creation() {
+        FlatVectorsReader mockBbqFlatReader = mock(FlatVectorsReader.class);
+        FlatVectorsScorer mockScorer = mock(FlatVectorsScorer.class);
+        when(mockBbqFlatReader.getFlatVectorScorer()).thenReturn(mockScorer);
+        String fieldName = "my_vector_field";
+
+        FaissBBQFlatIndex bbqIndex = new FaissBBQFlatIndex(mockBbqFlatReader, fieldName);
+        assertSame(mockBbqFlatReader, bbqIndex.getBbqFlatReader());
+        assertEquals(fieldName, bbqIndex.getFieldName());
+        assertSame(mockScorer, bbqIndex.getBbqFlatReader().getFlatVectorScorer());
+    }
+
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissCagraHnswIndexTests.java
@@ -47,9 +47,11 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
         doTestWithIndexInput(input -> {
             // Instantiate memory optimized searcher
             // TODO: adc placeholder. isAdc false and SpaceType L2 are noops for the MemoryOptimizedSearcher here.
+            final FaissIndex faissIndex = FaissIndex.load(input);
             final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
                 input,
                 null,
+                faissIndex,
                 FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
             );
 
@@ -71,8 +73,8 @@ public class FaissCagraHnswIndexTests extends KNNTestCase {
 
             // Get answer
             input.seek(0);
-            final FaissIndex faissIndex = FaissIndex.load(input);
-            final Set<Integer> answerScoreDocs = calculateAnswer(query, faissIndex.getFloatValues(input), k);
+            final FaissIndex answerIndex = FaissIndex.load(input);
+            final Set<Integer> answerScoreDocs = calculateAnswer(query, answerIndex.getFloatValues(input), k);
 
             // Validate search result
             int matchCount = 0;

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FieldInfo;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.memoryoptsearch.faiss.AbstractFaissHNSWIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissBBQFlatIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSWIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIdMapIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcherFactory;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testMaybeSetFlatVectorsFromReader_whenNullFlatVectors_thenSetsBBQFlatIndex() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        when(mockReader.getFlatVectorScorer()).thenReturn(mock(FlatVectorsScorer.class));
+
+        AbstractFaissHNSWIndex hnswIndex = mock(FaissHNSWIndex.class);
+        when(hnswIndex.getFlatVectors()).thenReturn(null);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(hnswIndex);
+
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+
+        invokeMaybeSetFlatVectorsFromReader(idMapIndex, mockReader, fieldInfo);
+
+        verify(hnswIndex).setFlatVectors(any(FaissBBQFlatIndex.class));
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatVectorsFromReader_whenFlatVectorsAlreadySet_thenDoesNotOverwrite() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        AbstractFaissHNSWIndex hnswIndex = mock(FaissHNSWIndex.class);
+        when(hnswIndex.getFlatVectors()).thenReturn(mock(FaissIndex.class));
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(hnswIndex);
+
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+
+        invokeMaybeSetFlatVectorsFromReader(idMapIndex, mockReader, fieldInfo);
+
+        verify(hnswIndex, never()).setFlatVectors(any());
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatVectorsFromReader_whenNotIdMapIndex_thenNoOp() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        FaissIndex nonIdMapIndex = mock(FaissIndex.class);
+
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+
+        // Should not throw — just a no-op
+        invokeMaybeSetFlatVectorsFromReader(nonIdMapIndex, mockReader, fieldInfo);
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatVectorsFromReader_whenNestedIsNotHNSW_thenNoOp() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+        FaissIndex nonHnswNested = mock(FaissIndex.class);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(nonHnswNested);
+
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+
+        // Should not throw — nested is not HNSW so nothing to wire
+        invokeMaybeSetFlatVectorsFromReader(idMapIndex, mockReader, fieldInfo);
+    }
+
+    @SneakyThrows
+    private static void invokeMaybeSetFlatVectorsFromReader(FaissIndex faissIndex, FlatVectorsReader reader, FieldInfo fieldInfo) {
+        FaissMemoryOptimizedSearcherFactory factory = new FaissMemoryOptimizedSearcherFactory();
+        Method method = FaissMemoryOptimizedSearcherFactory.class.getDeclaredMethod(
+            "maybeSetFlatVectorsFromReader",
+            FaissIndex.class,
+            FlatVectorsReader.class,
+            FieldInfo.class
+        );
+        method.setAccessible(true);
+        method.invoke(factory, faissIndex, reader, fieldInfo);
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -53,6 +53,12 @@ import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 import org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy;
 import org.opensearch.knn.jni.JNIService;
+import org.opensearch.knn.memoryoptsearch.faiss.AbstractFaissHNSWIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissBBQFlatIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSW;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSWIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIdMapIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
@@ -319,6 +325,37 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         assertThrows(FaissMemoryOptimizedSearcher.WarmupInitializationException.class, () -> {
             throw new FaissMemoryOptimizedSearcher.WarmupInitializationException("Null vector supplied for warmup");
         });
+    }
+
+    @SneakyThrows
+    public void testConstructor_whenBBQFieldInfo_thenUsesBBQScorer() {
+        // Set up mocks for the BBQ flat index hierarchy
+        FlatVectorsScorer mockScorer = mock(FlatVectorsScorer.class);
+        FlatVectorsReader mockBbqReader = mock(FlatVectorsReader.class);
+        when(mockBbqReader.getFlatVectorScorer()).thenReturn(mockScorer);
+        FaissBBQFlatIndex bbqFlatIndex = new FaissBBQFlatIndex(mockBbqReader, TARGET_FIELD);
+
+        // Build the index hierarchy: FaissIdMapIndex -> FaissHNSWIndex -> FaissBBQFlatIndex
+        AbstractFaissHNSWIndex mockHnswIndex = mock(FaissHNSWIndex.class);
+        when(mockHnswIndex.getFlatVectors()).thenReturn(bbqFlatIndex);
+
+        FaissHNSW mockHnsw = mock(FaissHNSW.class);
+        FaissIdMapIndex mockIdMapIndex = mock(FaissIdMapIndex.class);
+        when(mockIdMapIndex.getVectorSimilarityFunction()).thenReturn(KNNVectorSimilarityFunction.EUCLIDEAN);
+        when(mockIdMapIndex.getNestedIndex()).thenReturn(mockHnswIndex);
+        when(mockIdMapIndex.getFaissHnsw()).thenReturn(mockHnsw);
+
+        // Build a FieldInfo — BBQ is determined by the index hierarchy, not a FieldInfo attribute
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder(TARGET_FIELD)
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .addAttribute(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
+            .build();
+
+        IndexInput mockInput = mock(IndexInput.class);
+        when(mockInput.length()).thenReturn(100L);
+
+        FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(mockInput, fieldInfo, mockIdMapIndex, mockScorer);
+        assertNotNull(searcher);
     }
 
     @SneakyThrows
@@ -912,7 +949,8 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k = 100;
 
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissIndex faissIndex = FaissIndex.load(input);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, faissIndex, SCORER);
 
         // Use a non-seeded strategy (default HNSW strategy)
         final KnnCollector knnCollector = new TopKnnCollector(k, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
@@ -943,7 +981,8 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k = 100;
 
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissIndex faissIndex = FaissIndex.load(input);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, faissIndex, SCORER);
 
         // Create a Seeded strategy with known seed entry points
         final int numSeeds = 5;
@@ -1012,7 +1051,8 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         }
 
         // First, do exhaustive search to get ground truth
-        final FaissMemoryOptimizedSearcher exhaustiveSearcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissIndex faissIndex = FaissIndex.load(input);
+        final FaissMemoryOptimizedSearcher exhaustiveSearcher = new FaissMemoryOptimizedSearcher(input, null, faissIndex, SCORER);
         final KnnCollector exhaustiveCollector = new TopKnnCollector(totalVectors, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
         final AcceptDocs acceptDocs = AcceptDocs.fromLiveDocs(null, totalVectors);
         exhaustiveSearcher.search(query, exhaustiveCollector, acceptDocs);
@@ -1025,7 +1065,8 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
 
         // Now search with a seeded collector on a fresh searcher
         input.seek(0);
-        final FaissMemoryOptimizedSearcher seededSearcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissIndex faissIndex2 = FaissIndex.load(input);
+        final FaissMemoryOptimizedSearcher seededSearcher = new FaissMemoryOptimizedSearcher(input, null, faissIndex2, SCORER);
 
         final int numSeeds = 3;
         final DocIdSetIterator seedDocs = new DocIdSetIterator() {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/CagraKnnCollectorCreationTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/CagraKnnCollectorCreationTests.java
@@ -32,7 +32,8 @@ public class CagraKnnCollectorCreationTests extends KNNTestCase {
     @SneakyThrows
     public void testCreateKnnCollector_whenNonSeeded_thenWrapsWithRandomEntryPoints() {
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissIndex faissIndex = FaissIndex.load(input);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, faissIndex, SCORER);
 
         // Create a non-seeded collector
         final KnnCollector originalCollector = new TopKnnCollector(100, Integer.MAX_VALUE, KnnSearchStrategy.Hnsw.DEFAULT);
@@ -59,7 +60,8 @@ public class CagraKnnCollectorCreationTests extends KNNTestCase {
     @SneakyThrows
     public void testCreateKnnCollector_whenSeeded_thenPreservesOriginalStrategy() {
         final IndexInput input = FaissHNSWTests.loadHnswBinary("data/memoryoptsearch/faiss_cagra_flat_float_300_vectors_768_dims.bin");
-        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, SCORER);
+        final FaissIndex faissIndex = FaissIndex.load(input);
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(input, null, faissIndex, SCORER);
 
         // Create a seeded strategy
         final DocIdSetIterator seedDocs = new DocIdSetIterator() {


### PR DESCRIPTION
### Description
#3182 keeps failing with crash in Mac.
From the seg dump, it's related to bbq indexing logic, specifically, it was related to scoring logic with unaligned pointers.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000125762680, pid=11729, tid=45363
#
# JRE version: OpenJDK Runtime Environment Temurin-25.0.2+10 (25.0.2+10) (build 25.0.2+10-LTS)
# Java VM: OpenJDK 64-Bit Server VM Temurin-25.0.2+10 (25.0.2+10-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, bsd-aarch64)
# Problematic frame:
# C  [libopensearchknn_faiss.jnilib+0x192680]  faiss::search_neighbors_to_add(faiss::HNSW&, faiss::DistanceComputer&, std::__1::priority_queue<faiss::HNSW::NodeDistCloser, std::__1::vector<faiss::HNSW::NodeDistCloser, std::__1::allocator<faiss::HNSW::NodeDistCloser>>, std::__1::less<faiss::HNSW::NodeDistCloser>>&, int, float, int, faiss::VisitedTable&, bool)+0x254
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/runner/work/k-NN/k-NN/build/testrun/test/hs_err_pid11729.log
#
# If you would like to submit a bug report, please visit:
#   https://github.com/adoptium/adoptium-support/issues
```

New failure 2 - https://github.com/opensearch-project/k-NN/actions/runs/23278017625/job/67685102279?pr=3182
Failure 1 - https://github.com/opensearch-project/k-NN/actions/runs/23275754432/job/67678337407?pr=3182

Once verified that all CIs pass, will close this issue