### PR TITLE
Add scorer-aware ByteVectorValues wrapper for FAISS Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor [#3171](https://github.com/opensearch-project/k-NN/pull/3171)
 * Add VectorScorers for BinaryDocValues and nested best child scoring [#3179](https://github.com/opensearch-project/k-NN/pull/3179)
 * Introduce NativeEngines990KnnVectorsScorer to decouple native SIMD scoring selection from FaissMemoryOptimizedSearcher [#3184](https://github.com/opensearch-project/k-NN/pull/3184)
+* Add scorer-aware ByteVectorValues wrapper for FAISS Index [#3192](https://github.com/opensearch-project/k-NN/pull/3192)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -379,7 +379,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             return null;
         }
         final VectorSearcher vectorSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
-        return vectorSearcher != null ? vectorSearcher.getByteVectorValues() : null;
+        return vectorSearcher != null ? vectorSearcher.getByteVectorValues(getFloatVectorValues(fieldInfo.getName()).iterator()) : null;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import org.apache.lucene.index.ByteVectorValues;
-import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.KnnVectorValues.DocIndexIterator;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
@@ -61,9 +61,33 @@ public interface VectorSearcher extends Closeable {
     void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
 
     /**
-     * Returns the {@link ByteVectorValues} from the searcher. The behavior is undefined if
-     * searcher doesn't have KNN vectors enabled on its {@link FieldInfo}. The return value is
-     * never {@code null}.
+     * Returns the {@link ByteVectorValues} from the searcher, using the provided iterator
+     * for the underlying scorer. When the returned values produce a {@link org.apache.lucene.search.VectorScorer},
+     * that scorer will iterate using {@code iterator} instead of the default one.
+     *
+     * <p>Why a {@link DocIndexIterator} is required</p>
+     * The FAISS-backed {@link ByteVectorValues} implementation is a random-access store: it can
+     * look up any vector by ordinal, but it does not inherently know how to iterate over
+     * documents. A {@link org.apache.lucene.search.VectorScorer}, however, needs a
+     * {@link org.apache.lucene.search.DocIdSetIterator} to drive scoring. Because the FAISS
+     * layer cannot construct one on its own, the iterator must be supplied externally.
+     *
+     * <p>Three approaches were considered:
+     * <ol>
+     *   <li><b>Pass the iterator when requesting {@code ByteVectorValues} (chosen approach)</b> –
+     *       the caller provides a {@link DocIndexIterator} here, and the
+     *       implementation wraps it into the scorer. This keeps the FAISS loading path
+     *       unchanged and gives the caller full control over which iterator is used.</li>
+     *   <li>Accept the iterator during the FAISS index load ({@code FaissIndex.load}) so it
+     *       propagates to every {@code ByteVectorValues} instance automatically.</li>
+     *   <li>Construct the iterator inside the {@code ByteVectorValues} implementation
+     *       itself.</li>
+     * </ol>
+     *
+     * <p>TODO: Clean this up by moving toward building the iterator/scorer inside the
+     * {@code ByteVectorValues} implementation so callers no longer need to supply one.
+     *
+     * @param iterator the iterator the scorer should use for document traversal
      */
-    ByteVectorValues getByteVectorValues() throws IOException;
+    ByteVectorValues getByteVectorValues(DocIndexIterator iterator) throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -10,6 +10,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.KnnVectorValues.DocIndexIterator;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
@@ -70,7 +71,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
         this.isAdc = FieldInfoExtractor.isAdc(fieldInfo);
         this.flatVectorsScorer = flatVectorsScorer;
-
         this.hnsw = extractFaissHnsw(faissIndex);
     }
 
@@ -107,14 +107,18 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     /**
-     * Returns byte vector values from the FAISS index.
-     *
-     * @return byte vector values
-     * @throws IOException if an I/O error occurs
+     * Returns a {@link FaissScorableByteVectorValues} that wraps the raw byte vectors from the
+     * FAISS index with scoring support via {@link FlatVectorsScorer}.
+     * <p>Each call creates a new instance backed by a fresh index input slice.
      */
     @Override
-    public ByteVectorValues getByteVectorValues() throws IOException {
-        return faissIndex.getByteValues(indexInput.clone());
+    public ByteVectorValues getByteVectorValues(DocIndexIterator iterator) throws IOException {
+        return new FaissScorableByteVectorValues(
+            faissIndex.getByteValues(indexInput.clone()),
+            flatVectorsScorer,
+            vectorSimilarityFunction,
+            iterator
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScorableByteVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScorableByteVectorValues.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.KnnVectorValues.DocIndexIterator;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+
+import java.io.IOException;
+
+/**
+ * Wraps raw {@link ByteVectorValues} and adds scoring capability via a {@link FlatVectorsScorer}.
+ *
+ * <p>All iteration/random-access methods delegate to the underlying values unchanged.
+ * {@link #copy()} returns a fresh wrapper via {@code delegate.copy()} so that each scorer
+ * holds an independent read cursor.
+ *
+ * <p>An optional {@link DocIndexIterator} can be supplied at construction time.
+ * When present, both {@link #iterator()} and the scorer returned by {@link #scorer(byte[])}
+ * use this iterator instead of the delegate's default one.
+ */
+public class FaissScorableByteVectorValues extends ByteVectorValues {
+
+    private final ByteVectorValues delegate;
+    private final FlatVectorsScorer flatVectorsScorer;
+    private final VectorSimilarityFunction similarityFunction;
+    private final DocIndexIterator overrideIterator;
+
+    public FaissScorableByteVectorValues(
+        final ByteVectorValues delegate,
+        final FlatVectorsScorer flatVectorsScorer,
+        final VectorSimilarityFunction similarityFunction,
+        final DocIndexIterator overrideIterator
+    ) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate must not be null");
+        }
+        this.delegate = delegate;
+        this.flatVectorsScorer = flatVectorsScorer;
+        this.similarityFunction = similarityFunction;
+        this.overrideIterator = overrideIterator;
+    }
+
+    // ---- RandomAccessVectorValues ----
+
+    @Override
+    public int dimension() {
+        return delegate.dimension();
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public byte[] vectorValue(int ord) throws IOException {
+        return delegate.vectorValue(ord);
+    }
+
+    @Override
+    public int ordToDoc(int ord) {
+        return delegate.ordToDoc(ord);
+    }
+
+    @Override
+    public Bits getAcceptOrds(Bits acceptDocs) {
+        return delegate.getAcceptOrds(acceptDocs);
+    }
+
+    @Override
+    public FaissScorableByteVectorValues copy() throws IOException {
+        return new FaissScorableByteVectorValues(delegate.copy(), flatVectorsScorer, similarityFunction, overrideIterator);
+    }
+
+    @Override
+    public DocIndexIterator iterator() {
+        if (overrideIterator != null) {
+            return overrideIterator;
+        }
+        return delegate.iterator();
+    }
+
+    // ---- Scorer ----
+
+    /**
+     * Returns a {@link VectorScorer} for {@code target}, or {@code null} for an empty index.
+     *
+     * <p>When an override iterator was supplied at construction, the scorer uses that iterator.
+     * Otherwise, a fresh copy is used so the scorer's read cursor is independent from any outer
+     * iteration. The scorer delegates to {@link RandomVectorScorer#score(int)} using the
+     * iterator's current ordinal ({@code iterator.index()}).
+     */
+    @Override
+    public VectorScorer scorer(byte[] target) throws IOException {
+        if (size() == 0) return null;
+
+        final FaissScorableByteVectorValues scorerCopy = copy();
+        final RandomVectorScorer rvs = flatVectorsScorer.getRandomVectorScorer(similarityFunction, scorerCopy, target);
+        final DocIndexIterator iterator = scorerCopy.iterator();
+
+        return new VectorScorer() {
+            @Override
+            public float score() throws IOException {
+                return rvs.score(iterator.index());
+            }
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return iterator;
+            }
+
+            @Override
+            public Bulk bulk(final DocIdSetIterator matchingDocs) {
+                return Bulk.fromRandomScorerSparse(rvs, iterator, matchingDocs);
+            }
+        };
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -10,6 +10,8 @@ import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
@@ -88,18 +90,21 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         KNNEngine mockFaiss = spy(KNNEngine.FAISS);
         VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
         VectorSearcher mockSearcher = mock(VectorSearcher.class);
-        when(mockSearcher.getByteVectorValues()).thenReturn(mock(ByteVectorValues.class));
+        when(mockSearcher.getByteVectorValues(any())).thenReturn(mock(ByteVectorValues.class));
         when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
         when(mockFactory.createVectorSearcher(any(), any(), any(), any(), any())).thenReturn(mockSearcher);
 
+        final FloatVectorValues mockFloatValues = mock(FloatVectorValues.class);
+        when(mockFloatValues.iterator()).thenReturn(mock(KnnVectorValues.DocIndexIterator.class));
         final FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+        when(flatVectorsReader.getFloatVectorValues("field1")).thenReturn(mockFloatValues);
         try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {
             mockedStatic.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
             final Set<String> filesInSegment = Set.of("_0_165_field1.faiss");
             mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
             NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, filesInSegment, flatVectorsReader);
             reader.getByteVectorValues("field1");
-            verify(mockSearcher).getByteVectorValues();
+            verify(mockSearcher).getByteVectorValues(any());
             verify(flatVectorsReader, Mockito.never()).getByteVectorValues("field1");
         }
     }

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
@@ -314,8 +314,8 @@ public class TestVectorValues {
          * @throws IOException
          */
         @Override
-        public ByteVectorValues copy() throws IOException {
-            return null;
+        public PreDefinedByteVectorValues copy() throws IOException {
+            return new PreDefinedByteVectorValues(vectors);
         }
 
         @Override

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -10,8 +10,10 @@ import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.search.AcceptDocs;
@@ -55,6 +57,8 @@ import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 import org.opensearch.knn.index.vectorvalues.VectorValueExtractorStrategy;
 import org.opensearch.knn.jni.JNIService;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSW;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIdMapIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
@@ -76,6 +80,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.ADC_ENABLED_FAISS_INDEX_INTERNAL_PARAMETER;
@@ -325,6 +330,26 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         assertThrows(FaissMemoryOptimizedSearcher.WarmupInitializationException.class, () -> {
             throw new FaissMemoryOptimizedSearcher.WarmupInitializationException("Null vector supplied for warmup");
         });
+    }
+
+    @SneakyThrows
+    public void testGetByteVectorValues_returnsDifferentInstancesPerCall() {
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+        FaissIdMapIndex faissIndex = mock(FaissIdMapIndex.class);
+        Mockito.when(faissIndex.getByteValues(any())).thenReturn(mock(ByteVectorValues.class));
+        Mockito.when(faissIndex.getVectorSimilarityFunction()).thenReturn(SpaceType.L2.getKnnVectorSimilarityFunction());
+        Mockito.when(faissIndex.getFaissHnsw()).thenReturn(mock(FaissHNSW.class));
+        final FaissMemoryOptimizedSearcher searcher = new FaissMemoryOptimizedSearcher(
+            mock(IndexInput.class),
+            faissIndex,
+            fieldInfo,
+            FlatVectorsScorerProvider.getFlatVectorsScorer(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, SCORER)
+        );
+
+        final var first = searcher.getByteVectorValues(mock(KnnVectorValues.DocIndexIterator.class));
+        final var second = searcher.getByteVectorValues(mock(KnnVectorValues.DocIndexIterator.class));
+        assertNotSame("getByteVectorValues() should return a new instance per call", first, second);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScorableByteVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScorableByteVectorValuesTests.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.vectorvalues.TestVectorValues.PreDefinedByteVectorValues;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FaissScorableByteVectorValuesTests extends KNNTestCase {
+
+    private static final int DIMENSION = 4;
+    private static final List<byte[]> VECTORS = List.of(new byte[] { 1, 2, 3, 4 }, new byte[] { 5, 6, 7, 8 }, new byte[] { 9, 10, 11, 12 });
+
+    public void testNullDelegateThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new FaissScorableByteVectorValues(null, mock(FlatVectorsScorer.class), VectorSimilarityFunction.EUCLIDEAN, null)
+        );
+    }
+
+    @SneakyThrows
+    public void testDelegatesDimension() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        assertEquals(DIMENSION, wrapper.dimension());
+    }
+
+    @SneakyThrows
+    public void testDelegatesSize() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        assertEquals(VECTORS.size(), wrapper.size());
+    }
+
+    @SneakyThrows
+    public void testDelegatesVectorValue() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        for (int i = 0; i < VECTORS.size(); i++) {
+            assertArrayEquals(VECTORS.get(i), wrapper.vectorValue(i));
+        }
+    }
+
+    @SneakyThrows
+    public void testDelegatesOrdToDoc() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        for (int i = 0; i < VECTORS.size(); i++) {
+            assertEquals(i, wrapper.ordToDoc(i));
+        }
+    }
+
+    @SneakyThrows
+    public void testDelegatesGetAcceptOrds() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        assertNull(wrapper.getAcceptOrds(null));
+    }
+
+    @SneakyThrows
+    public void testDelegatesIterator() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        final KnnVectorValues.DocIndexIterator iterator = wrapper.iterator();
+        assertNotNull(iterator);
+        assertEquals(0, iterator.nextDoc());
+        assertEquals(0, iterator.index());
+        assertEquals(1, iterator.nextDoc());
+        assertEquals(1, iterator.index());
+        assertEquals(2, iterator.nextDoc());
+        assertEquals(2, iterator.index());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iterator.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testCopyReturnsIndependentInstance() {
+        final FaissScorableByteVectorValues wrapper = createWrapper();
+        final FaissScorableByteVectorValues copy = wrapper.copy();
+
+        assertNotSame(wrapper, copy);
+        assertEquals(wrapper.dimension(), copy.dimension());
+        assertEquals(wrapper.size(), copy.size());
+
+        // Iterators should be independent
+        final KnnVectorValues.DocIndexIterator origIter = wrapper.iterator();
+        final KnnVectorValues.DocIndexIterator copyIter = copy.iterator();
+        origIter.nextDoc();
+        origIter.nextDoc();
+        assertEquals(0, copyIter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testScorerReturnsNullForEmptyIndex() {
+        final FaissScorableByteVectorValues wrapper = new FaissScorableByteVectorValues(
+            ByteVectorValues.fromBytes(List.of(), 1),
+            mock(FlatVectorsScorer.class),
+            VectorSimilarityFunction.EUCLIDEAN,
+            null
+        );
+
+        assertNull(wrapper.scorer(new byte[] { 1, 2, 3, 4 }));
+    }
+
+    @SneakyThrows
+    public void testScorerReturnsScorerWithIterator() {
+        final float expectedScore = 0.75f;
+        final byte[] target = new byte[] { 1, 2, 3, 4 };
+
+        final RandomVectorScorer rvs = mock(RandomVectorScorer.class);
+        when(rvs.score(0)).thenReturn(expectedScore);
+
+        final FlatVectorsScorer flatVectorsScorer = mock(FlatVectorsScorer.class);
+        when(flatVectorsScorer.getRandomVectorScorer(eq(VectorSimilarityFunction.EUCLIDEAN), any(ByteVectorValues.class), eq(target)))
+            .thenReturn(rvs);
+
+        final FaissScorableByteVectorValues wrapper = new FaissScorableByteVectorValues(
+            new PreDefinedByteVectorValues(VECTORS),
+            flatVectorsScorer,
+            VectorSimilarityFunction.EUCLIDEAN,
+            null
+        );
+
+        final VectorScorer scorer = wrapper.scorer(target);
+        assertNotNull(scorer);
+
+        final DocIdSetIterator iterator = scorer.iterator();
+        assertNotNull(iterator);
+
+        // Advance to first doc and verify score
+        assertEquals(0, iterator.nextDoc());
+        assertEquals(expectedScore, scorer.score(), 0.0f);
+    }
+
+    @SneakyThrows
+    public void testScorerBulkDelegatesBulkScore() {
+        final byte[] target = new byte[] { 1, 2, 3, 4 };
+
+        final RandomVectorScorer rvs = mock(RandomVectorScorer.class);
+        when(rvs.bulkScore(any(int[].class), any(float[].class), eq(2))).thenReturn(0.9f);
+
+        final FlatVectorsScorer flatVectorsScorer = mock(FlatVectorsScorer.class);
+        when(flatVectorsScorer.getRandomVectorScorer(eq(VectorSimilarityFunction.EUCLIDEAN), any(ByteVectorValues.class), eq(target)))
+            .thenReturn(rvs);
+
+        final FaissScorableByteVectorValues wrapper = new FaissScorableByteVectorValues(
+            new PreDefinedByteVectorValues(VECTORS),
+            flatVectorsScorer,
+            VectorSimilarityFunction.EUCLIDEAN,
+            null
+        );
+
+        final VectorScorer scorer = wrapper.scorer(target);
+        final VectorScorer.Bulk bulk = scorer.bulk(null);
+        assertNotNull(bulk);
+
+        final DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
+        bulk.nextDocsAndScores(Integer.MAX_VALUE, null, buffer);
+
+        verify(rvs).bulkScore(any(int[].class), any(float[].class), eq(VECTORS.size()));
+    }
+
+    @SneakyThrows
+    public void testScorerUsesIndependentCopy() {
+        final byte[] target = new byte[] { 1, 2, 3, 4 };
+
+        final RandomVectorScorer rvs = mock(RandomVectorScorer.class);
+        when(rvs.score(0)).thenReturn(1.0f);
+        when(rvs.score(1)).thenReturn(0.5f);
+
+        final FlatVectorsScorer flatVectorsScorer = mock(FlatVectorsScorer.class);
+        when(flatVectorsScorer.getRandomVectorScorer(eq(VectorSimilarityFunction.EUCLIDEAN), any(ByteVectorValues.class), eq(target)))
+            .thenReturn(rvs);
+
+        final FaissScorableByteVectorValues wrapper = new FaissScorableByteVectorValues(
+            new PreDefinedByteVectorValues(VECTORS),
+            flatVectorsScorer,
+            VectorSimilarityFunction.EUCLIDEAN,
+            null
+        );
+
+        // Advance the wrapper's own iterator
+        final KnnVectorValues.DocIndexIterator wrapperIter = wrapper.iterator();
+        wrapperIter.nextDoc();
+        wrapperIter.nextDoc(); // now at doc 1
+
+        // Scorer should start from the beginning (independent copy)
+        final VectorScorer scorer = wrapper.scorer(target);
+        final DocIdSetIterator scorerIter = scorer.iterator();
+        assertEquals(0, scorerIter.nextDoc());
+        assertEquals(1.0f, scorer.score(), 0.0f);
+
+        assertEquals(1, scorerIter.nextDoc());
+        assertEquals(0.5f, scorer.score(), 0.0f);
+    }
+
+    @SneakyThrows
+    public void testScorerUsesOverrideIterator() {
+        final byte[] target = new byte[] { 1, 2, 3, 4 };
+
+        final RandomVectorScorer rvs = mock(RandomVectorScorer.class);
+        when(rvs.score(0)).thenReturn(0.9f);
+
+        final FlatVectorsScorer flatVectorsScorer = mock(FlatVectorsScorer.class);
+        when(flatVectorsScorer.getRandomVectorScorer(eq(VectorSimilarityFunction.EUCLIDEAN), any(ByteVectorValues.class), eq(target)))
+            .thenReturn(rvs);
+
+        final KnnVectorValues.DocIndexIterator overrideIterator = mock(KnnVectorValues.DocIndexIterator.class);
+
+        final FaissScorableByteVectorValues wrapper = new FaissScorableByteVectorValues(
+            new PreDefinedByteVectorValues(VECTORS),
+            flatVectorsScorer,
+            VectorSimilarityFunction.EUCLIDEAN,
+            overrideIterator
+        );
+
+        // iterator() should return the override iterator, not the delegate's
+        assertSame(overrideIterator, wrapper.iterator());
+
+        // scorer's iterator should be the same override instance
+        final VectorScorer scorer = wrapper.scorer(target);
+        assertSame(overrideIterator, scorer.iterator());
+    }
+
+    private static FaissScorableByteVectorValues createWrapper() {
+        return new FaissScorableByteVectorValues(
+            new PreDefinedByteVectorValues(VECTORS),
+            mock(FlatVectorsScorer.class),
+            VectorSimilarityFunction.EUCLIDEAN,
+            null
+        );
+    }
+}


### PR DESCRIPTION
### Description
The FAISS-backed ByteVectorValues is a random-access store that cannot produce a DocIndexIterator on its own, which is required by VectorScorer to drive scoring. Introduce FaissScorableByteVectorValues to wrap raw byte vectors with scoring capability via FlatVectorsScorer, and update VectorSearcher.getByteVectorValues to accept a DocIndexIterator that the scorer uses for document traversal.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
