### PR TITLE
Faiss scalar quantization search options : Use MOS, Use 2 as overample factor

### DIFF
--- a/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
@@ -10,6 +10,7 @@ import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
@@ -20,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_BINARY;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FAISS_BBQ;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
@@ -33,7 +35,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
  */
 public class MemoryOptimizedSearchSupportSpec {
     private static final Version MIN_VERSION_SUPPORTS_MEM_OPT_SEARCH = Version.V_2_17_0;
-    private static final Set<String> SUPPORTED_HNSW_ENCODING = Set.of(ENCODER_FLAT, ENCODER_SQ, ENCODER_BINARY);
+    private static final Set<String> SUPPORTED_HNSW_ENCODING = Set.of(ENCODER_FLAT, ENCODER_SQ, ENCODER_BINARY, ENCODER_FAISS_BBQ);
 
     /**
      * Determines whether a memory optimized searching should be applied during search.
@@ -45,6 +47,11 @@ public class MemoryOptimizedSearchSupportSpec {
      * @return True if memory optimized search should be used otherwise False.
      */
     public static boolean isSupportedFieldType(final KNNVectorFieldType fieldType, final String indexName) {
+        // If the field is configured to always use memory optimized search, return true
+        if (fieldType.isAlwaysUseMemoryOptimizedSearch()) {
+            return true;
+        }
+
         if (fieldType.isMemoryOptimizedSearchAvailable()) {
             if (KNNSettings.isMemoryOptimizedKnnSearchModeEnabled(indexName)) {
                 final boolean shouldBlockMemoryOptimizedSearch = fieldType.getIndexCreatedVersion() == null
@@ -81,7 +88,7 @@ public class MemoryOptimizedSearchSupportSpec {
      *
      * @param methodContextOpt   Optional method context.
      * @param quantizationConfig Quantization configuration.
-     * @param modelId Model id.
+     * @param modelId            Model id.
      * @return True if memory-optimized-search is supported, otherwise false.
      */
     public static boolean isSupportedFieldType(
@@ -140,5 +147,18 @@ public class MemoryOptimizedSearchSupportSpec {
         return quantizationType == ScalarQuantizationType.ONE_BIT
             || quantizationType == ScalarQuantizationType.TWO_BIT
             || quantizationType == ScalarQuantizationType.FOUR_BIT;
+    }
+
+    /**
+     * Determines whether memory-optimized search must always be used for the given KNN method context,
+     * regardless of the cluster-level memory-optimized search setting. Currently, this returns {@code true}
+     * only when the encoder is {@code ENCODER_FAISS_BBQ}, as BBQ-encoded indices always require
+     * memory-optimized search for correctness.
+     *
+     * @param knnMethodContext Optional method context containing engine, space type, and encoder information.
+     * @return {@code true} if memory-optimized search should always be enabled, {@code false} otherwise.
+     */
+    public static boolean isAlwaysUseMemoryOptimizedSearch(final Optional<KNNMethodContext> knnMethodContext) {
+        return knnMethodContext.isPresent() && ENCODER_FAISS_BBQ.equals(KNNVectorFieldMapperUtil.getEncoderName(knnMethodContext.get()));
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FAISS_BBQ;
+
 /**
  * Enum representing the compression level for float vectors. Compression in this sense refers to compressing a
  * full precision value into a smaller number of bits. For instance. "16x" compression would mean that 2 bits would
@@ -26,11 +28,11 @@ public enum CompressionLevel {
     NOT_CONFIGURED(-1, "", null, Collections.emptySet()),
     x1(1, "1x", null, Collections.emptySet()),
     x2(2, "2x", null, Collections.emptySet()),
-    x4(4, "4x", new RescoreContext(1.0f, false, true), Set.of(Mode.ON_DISK)),
-    x8(8, "8x", new RescoreContext(2.0f, false, true), Set.of(Mode.ON_DISK)),
-    x16(16, "16x", new RescoreContext(3.0f, false, true), Set.of(Mode.ON_DISK)),
-    x32(32, "32x", new RescoreContext(3.0f, false, true), Set.of(Mode.ON_DISK)),
-    x64(64, "64x", new RescoreContext(5.0f, false, true), Set.of(Mode.ON_DISK));
+    x4(4, "4x", RescoreContext.builder().oversampleFactor(1.0f).userProvided(false).build(), Set.of(Mode.ON_DISK)),
+    x8(8, "8x", RescoreContext.builder().oversampleFactor(2.0f).userProvided(false).build(), Set.of(Mode.ON_DISK)),
+    x16(16, "16x", RescoreContext.builder().oversampleFactor(3.0f).userProvided(false).build(), Set.of(Mode.ON_DISK)),
+    x32(32, "32x", RescoreContext.builder().oversampleFactor(3.0f).userProvided(false).build(), Set.of(Mode.ON_DISK)),
+    x64(64, "64x", RescoreContext.builder().oversampleFactor(5.0f).userProvided(false).build(), Set.of(Mode.ON_DISK));
 
     public static final CompressionLevel MAX_COMPRESSION_LEVEL = CompressionLevel.x64;
 
@@ -104,15 +106,39 @@ public enum CompressionLevel {
      *
      * @param mode      The {@link Mode} for which to retrieve the {@link RescoreContext}.
      * @param dimension The dimensional value that determines the {@link RescoreContext} behavior.
-     * @return          A {@link RescoreContext} with an oversample factor of 5.0f if {@code dimension} is less than
-     *                  or equal to 1000, the default {@link RescoreContext} if greater, or {@code null} if the mode
-     *                  is invalid.
+     * @return A {@link RescoreContext} with an oversample factor of 5.0f if {@code dimension} is less than
+     * or equal to 1000, the default {@link RescoreContext} if greater, or {@code null} if the mode
+     * is invalid.
      */
     public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version) {
         return getDefaultRescoreContext(mode, dimension, version, false);
     }
 
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod) {
+    public RescoreContext getDefaultRescoreContext(
+        final Mode mode,
+        final int dimension,
+        final Version version,
+        final boolean isFlatMethod
+    ) {
+        return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, null);
+    }
+
+    public RescoreContext getDefaultRescoreContext(
+        final Mode mode,
+        final int dimension,
+        final Version version,
+        final boolean isFlatMethod,
+        final String encoderName
+    ) {
+        // For scalar quantized index, it just uses FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR.
+        if (encoderName != null && encoderName.equals(ENCODER_FAISS_BBQ)) {
+            return RescoreContext.builder()
+                .oversampleFactor(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR)
+                .allowOverrideOversampleFactor(false)
+                .userProvided(false)
+                .build();
+        }
+
         // TODO move this to separate class called resolver to resolve rescore context
         if (this == x32 && isFlatMethod) {
             return RescoreContext.builder().oversampleFactor(FLAT_OVERSAMPLE_FACTOR).userProvided(false).build();

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtil.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
@@ -170,5 +171,23 @@ public class KNNVectorFieldMapperUtil {
                 )
             )
         );
+    }
+
+    public static String getEncoderName(final KNNMethodContext methodContext) {
+        if (methodContext == null) {
+            return null;
+        }
+
+        final MethodComponentContext methodComponentContext = methodContext.getMethodComponentContext();
+
+        // We only support Flat and SQ encoder for HNSW.
+        final Map<String, Object> parameters = methodComponentContext.getParameters();
+        final Object methodComponentContextObj = parameters.get(METHOD_ENCODER_PARAMETER);
+        if ((methodComponentContextObj instanceof MethodComponentContext) == false) {
+            return null;
+        }
+
+        // Check whether HNSW encoding is supported.
+        return ((MethodComponentContext) methodComponentContextObj).getName();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -49,7 +49,23 @@ public class KNNVectorFieldType extends MappedFieldType {
     private static final Logger logger = LogManager.getLogger(KNNVectorFieldType.class);
     KNNMappingConfig knnMappingConfig;
     VectorDataType vectorDataType;
-    // Whether this field type can be benefit from memory optimized search?
+    /**
+     * When {@code true}, memory-optimized search is always applied for this field regardless of the
+     * cluster-level setting. This is determined at mapping time based on the encoder type
+     * (e.g., FAISS BBQ encoder always requires memory-optimized search).
+     *
+     * @see MemoryOptimizedSearchSupportSpec#isAlwaysUseMemoryOptimizedSearch(java.util.Optional)
+     */
+    boolean alwaysUseMemoryOptimizedSearch;
+    /**
+     * Whether this field type can benefit from memory-optimized search. This is determined at mapping time
+     * based on the engine, method, encoder, and quantization configuration. A field may be eligible for
+     * memory-optimized search but still require the cluster-level setting to be enabled, unless
+     * {@link #alwaysUseMemoryOptimizedSearch} is {@code true}.
+     *
+     * @see MemoryOptimizedSearchSupportSpec#isSupportedFieldType(java.util.Optional,
+     *      org.opensearch.knn.index.engine.qframe.QuantizationConfig, java.util.Optional)
+     */
     boolean memoryOptimizedSearchAvailable;
     Version indexCreatedVersion;
 
@@ -70,6 +86,9 @@ public class KNNVectorFieldType extends MappedFieldType {
         Version indexCreatedVersion
     ) {
         this(name, metadata, vectorDataType, annConfig);
+        this.alwaysUseMemoryOptimizedSearch = MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(
+            knnMappingConfig.getKnnMethodContext()
+        );
         this.memoryOptimizedSearchAvailable = MemoryOptimizedSearchSupportSpec.isSupportedFieldType(
             knnMappingConfig.getKnnMethodContext(),
             annConfig.getQuantizationConfig(),
@@ -146,13 +165,21 @@ public class KNNVectorFieldType extends MappedFieldType {
         if (userProvidedContext != null) {
             return userProvidedContext;
         }
-        KNNMappingConfig knnMappingConfig = getKnnMappingConfig();
-        Optional<KNNMethodContext> methodContext = knnMappingConfig.getKnnMethodContext();
-        boolean isFlatMethod = methodContext.isPresent() && METHOD_FLAT.equals(methodContext.get().getMethodComponentContext().getName());
-        int dimension = knnMappingConfig.getDimension();
-        CompressionLevel compressionLevel = knnMappingConfig.getCompressionLevel();
-        Mode mode = knnMappingConfig.getMode();
-        return compressionLevel.getDefaultRescoreContext(mode, dimension, knnMappingConfig.getIndexCreatedVersion(), isFlatMethod);
+        final KNNMappingConfig knnMappingConfig = getKnnMappingConfig();
+        final Optional<KNNMethodContext> methodContext = knnMappingConfig.getKnnMethodContext();
+        final boolean isFlatMethod = methodContext.isPresent()
+            && METHOD_FLAT.equals(methodContext.get().getMethodComponentContext().getName());
+        final String encoderName = methodContext.map(KNNVectorFieldMapperUtil::getEncoderName).orElse(null);
+        final int dimension = knnMappingConfig.getDimension();
+        final CompressionLevel compressionLevel = knnMappingConfig.getCompressionLevel();
+        final Mode mode = knnMappingConfig.getMode();
+        return compressionLevel.getDefaultRescoreContext(
+            mode,
+            dimension,
+            knnMappingConfig.getIndexCreatedVersion(),
+            isFlatMethod,
+            encoderName
+        );
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -5,16 +5,15 @@
 
 package org.opensearch.knn.index.query.rescore;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 @Builder
 @EqualsAndHashCode
 public final class RescoreContext {
+    public static final float FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR = 2.0f;
 
     public static final float DEFAULT_OVERSAMPLE_FACTOR = 1.0f;
     public static final float MAX_OVERSAMPLE_FACTOR = 100.0f;
@@ -53,6 +52,15 @@ public final class RescoreContext {
     @Builder.Default
     private boolean rescoreEnabled = true;
 
+    /**
+     * Flag to control whether the dimension-based oversampling logic in {@link #getFirstPassK(int, boolean, int)}
+     * is allowed to override the configured oversample factor. When set to {@code false}, the oversample factor
+     * remains fixed regardless of vector dimension. This is used for encoders like FAISS BBQ where the oversample
+     * factor should not be adjusted based on dimension.
+     */
+    @Builder.Default
+    private boolean allowOverrideOversampleFactor = true;
+
     public static final RescoreContext EXPLICITLY_DISABLED_RESCORE_CONTEXT = RescoreContext.builder()
         .oversampleFactor(DEFAULT_OVERSAMPLE_FACTOR)
         .rescoreEnabled(false)
@@ -82,7 +90,7 @@ public final class RescoreContext {
         // Only apply default dimension-based oversampling logic when:
         // 1. Shard-level rescoring is disabled
         // 2. The oversample factor was not provided by the user
-        if (isShardLevelRescoringDisabled && !userProvided) {
+        if (isShardLevelRescoringDisabled && !userProvided && allowOverrideOversampleFactor) {
             // Apply new dimension-based oversampling logic when shard-level rescoring is disabled
             if (dimension >= DIMENSION_THRESHOLD_1000) {
                 oversampleFactor = OVERSAMPLE_FACTOR_1000;  // No oversampling for dimensions >= 1000

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -10,6 +10,8 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.Version;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FAISS_BBQ;
+
 public class CompressionLevelTests extends KNNTestCase {
 
     public void testFromName() {
@@ -134,5 +136,47 @@ public class CompressionLevelTests extends KNNTestCase {
         // isFlatMethod=false on x32 with NOT_CONFIGURED mode should return null (no mode for rescore)
         rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(Mode.NOT_CONFIGURED, 500, Version.CURRENT, false);
         assertNull(rescoreContext);
+    }
+
+    public void testGetDefaultRescoreContext_whenBBQEncoder_thenReturnFixedOversampleFactor() {
+        // BBQ encoder should return fixed oversample factor regardless of compression level, mode, or dimension
+        for (CompressionLevel level : CompressionLevel.values()) {
+            RescoreContext rescoreContext = level.getDefaultRescoreContext(
+                Mode.NOT_CONFIGURED,
+                500,
+                Version.CURRENT,
+                false,
+                ENCODER_FAISS_BBQ
+            );
+            assertNotNull("BBQ rescore context should not be null for " + level, rescoreContext);
+            assertEquals(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR, rescoreContext.getOversampleFactor(), 0.0f);
+            assertFalse(rescoreContext.isUserProvided());
+            assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
+        }
+
+        // BBQ should also work with ON_DISK mode and high dimension
+        RescoreContext rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(
+            Mode.ON_DISK,
+            1500,
+            Version.CURRENT,
+            false,
+            ENCODER_FAISS_BBQ
+        );
+        assertNotNull(rescoreContext);
+        assertEquals(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR, rescoreContext.getOversampleFactor(), 0.0f);
+        assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
+    }
+
+    public void testGetDefaultRescoreContext_whenNonBBQEncoder_thenFallsBackToNormalLogic() {
+        // Non-BBQ encoder should fall through to normal compression level logic
+        RescoreContext rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(Mode.ON_DISK, 500, Version.CURRENT, false, "sq");
+        assertNotNull(rescoreContext);
+        // x8 with dimension <= 1000 should use 5.0f oversample (normal logic)
+        assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
+
+        // null encoder should also fall through
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(Mode.ON_DISK, 500, Version.CURRENT, false, null);
+        assertNotNull(rescoreContext);
+        assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperUtilTests.java
@@ -16,13 +16,24 @@ import org.apache.lucene.util.BytesRef;
 import org.junit.Assert;
 import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.util.KNNVectorAsCollectionOfFloatsSerializer;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FAISS_BBQ;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
 
@@ -96,5 +107,41 @@ public class KNNVectorFieldMapperUtilTests extends KNNTestCase {
         Assert.assertFalse(KNNVectorFieldMapperUtil.useFullFieldNameValidation(Version.V_2_16_0));
         Assert.assertTrue(KNNVectorFieldMapperUtil.useFullFieldNameValidation(Version.V_2_17_0));
         Assert.assertTrue(KNNVectorFieldMapperUtil.useFullFieldNameValidation(Version.V_2_18_0));
+    }
+
+    public void testGetEncoderName_whenNullMethodContext_thenReturnsNull() {
+        assertNull(KNNVectorFieldMapperUtil.getEncoderName(null));
+    }
+
+    public void testGetEncoderName_whenEncoderPresent_thenReturnsName() {
+        for (String encoder : Arrays.asList(ENCODER_FLAT, ENCODER_SQ, ENCODER_FAISS_BBQ)) {
+            KNNMethodContext methodContext = new KNNMethodContext(
+                KNNEngine.FAISS,
+                SpaceType.L2,
+                new MethodComponentContext(
+                    METHOD_HNSW,
+                    Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(encoder, Collections.emptyMap()))
+                )
+            );
+            assertEquals(encoder, KNNVectorFieldMapperUtil.getEncoderName(methodContext));
+        }
+    }
+
+    public void testGetEncoderName_whenNoEncoderParameter_thenReturnsNull() {
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
+        );
+        assertNull(KNNVectorFieldMapperUtil.getEncoderName(methodContext));
+    }
+
+    public void testGetEncoderName_whenEncoderParameterIsNotMethodComponentContext_thenReturnsNull() {
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, "not_a_method_component_context"))
+        );
+        assertNull(KNNVectorFieldMapperUtil.getEncoderName(methodContext));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.mapper;
 
+import org.opensearch.Version;
 import org.opensearch.index.mapper.ArraySourceValueFetcher;
 import org.opensearch.index.mapper.ValueFetcher;
 import org.opensearch.index.query.QueryShardContext;
@@ -21,7 +22,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FAISS_BBQ;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 public class KNNVectorFieldTypeTests extends KNNTestCase {
     private static final String FIELD_NAME = "test-field";
@@ -75,5 +80,66 @@ public class KNNVectorFieldTypeTests extends KNNTestCase {
             }
         };
         return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig);
+    }
+
+    public void testKNNVectorFieldType_whenBBQEncoder_thenAlwaysUseMemoryOptimizedSearchIsTrue() {
+        KNNVectorFieldType fieldType = buildBBQFieldType();
+        assertTrue(fieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertTrue(fieldType.isMemoryOptimizedSearchAvailable());
+    }
+
+    public void testResolveRescoreContext_whenBBQEncoder_thenReturnFixedOversampleFactor() {
+        KNNVectorFieldType fieldType = buildBBQFieldType();
+        RescoreContext rescoreContext = fieldType.resolveRescoreContext(null);
+        assertNotNull(rescoreContext);
+        assertEquals(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR, rescoreContext.getOversampleFactor(), 0.001f);
+        assertFalse(rescoreContext.isUserProvided());
+        assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
+        assertTrue(rescoreContext.isRescoreEnabled());
+    }
+
+    public void testResolveRescoreContext_whenBBQEncoderWithUserProvidedContext_thenReturnUserContext() {
+        RescoreContext userContext = RescoreContext.builder().oversampleFactor(5.0f).userProvided(true).build();
+        assertSame(userContext, buildBBQFieldType().resolveRescoreContext(userContext));
+    }
+
+    public void testResolveRescoreContext_whenNoMethodContext_thenReturnsNull() {
+        KNNMappingConfig mappingConfig = getMappingConfigForFlatMapping(128);
+        KNNVectorFieldType fieldType = new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig);
+        assertNull(fieldType.resolveRescoreContext(null));
+    }
+
+    private KNNVectorFieldType buildBBQFieldType() {
+        KNNMethodContext bbqMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_FAISS_BBQ, Collections.emptyMap()))
+            )
+        );
+        KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(bbqMethodContext, 128);
+        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT);
+    }
+
+    public void testKNNVectorFieldType_whenNonBBQEncoder_thenAlwaysUseMemoryOptimizedSearchIsFalse() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_FLAT, Collections.emptyMap()))
+            )
+        );
+        KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(flatMethodContext, 128);
+        KNNVectorFieldType fieldType = new KNNVectorFieldType(
+            FIELD_NAME,
+            Collections.emptyMap(),
+            VectorDataType.FLOAT,
+            mappingConfig,
+            Version.CURRENT
+        );
+        assertFalse(fieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertTrue(fieldType.isMemoryOptimizedSearchAvailable());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/rescore/RescoreContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/rescore/RescoreContextTests.java
@@ -82,4 +82,37 @@ public class RescoreContextTests extends KNNTestCase {
         rescoreContext = RescoreContext.builder().oversampleFactor(oversample).userProvided(true).build();  // User provided
         assertEquals(MIN_FIRST_PASS_RESULTS, rescoreContext.getFirstPassK(finalK, isShardLevelRescoringDisabled, dimension));
     }
+
+    public void testGetFirstPassK_whenAllowOverrideOversampleFactorIsFalse_thenDimensionBasedOverrideIsSkipped() {
+        // Simulates BBQ encoder behavior: oversampleFactor is fixed and should NOT be overridden by dimension-based logic
+        float oversample = RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR; // 2.0f
+        int finalK = 100;
+
+        // Even though shard-level rescoring is disabled and userProvided is false,
+        // allowOverrideOversampleFactor=false should prevent dimension-based override
+        RescoreContext rescoreContext = RescoreContext.builder()
+            .oversampleFactor(oversample)
+            .userProvided(false)
+            .allowOverrideOversampleFactor(false)
+            .build();
+
+        // dimension < 768 would normally trigger 3x oversampling, but allowOverrideOversampleFactor=false keeps it at 2x
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, 500));
+
+        // dimension >= 768 && < 1000 would normally trigger 2x, stays at 2x (same value but for different reason)
+        rescoreContext = RescoreContext.builder()
+            .oversampleFactor(oversample)
+            .userProvided(false)
+            .allowOverrideOversampleFactor(false)
+            .build();
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, 800));
+
+        // dimension >= 1000 would normally trigger 1x (no oversampling), but stays at 2x
+        rescoreContext = RescoreContext.builder()
+            .oversampleFactor(oversample)
+            .userProvided(false)
+            .allowOverrideOversampleFactor(false)
+            .build();
+        assertEquals(200, rescoreContext.getFirstPassK(finalK, true, 1200));
+    }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchSupportSpecTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchSupportSpecTests.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_BINARY;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FAISS_BBQ;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
@@ -286,7 +287,52 @@ public class MemoryOptimizedSearchSupportSpecTests extends KNNTestCase {
         );
     }
 
+    public void testIsAlwaysUseMemoryOptimizedSearch_whenBBQEncoder_thenReturnsTrue() {
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_FAISS_BBQ, Collections.emptyMap()))
+            )
+        );
+        assertTrue(MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(Optional.of(methodContext)));
+    }
+
+    public void testIsAlwaysUseMemoryOptimizedSearch_whenNonBBQEncoder_thenReturnsFalse() {
+        for (String encoder : Arrays.asList(ENCODER_FLAT, ENCODER_SQ, ENCODER_BINARY)) {
+            KNNMethodContext methodContext = new KNNMethodContext(
+                KNNEngine.FAISS,
+                SpaceType.L2,
+                new MethodComponentContext(
+                    METHOD_HNSW,
+                    Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(encoder, Collections.emptyMap()))
+                )
+            );
+            assertFalse(MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(Optional.of(methodContext)));
+        }
+    }
+
+    public void testIsAlwaysUseMemoryOptimizedSearch_whenEmptyMethodContext_thenReturnsFalse() {
+        assertFalse(MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(Optional.empty()));
+    }
+
+    public void testIsAlwaysUseMemoryOptimizedSearch_whenNoEncoderParameter_thenReturnsFalse() {
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
+        );
+        assertFalse(MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(Optional.of(methodContext)));
+    }
+
     public void testIsSupportedFieldTypeDuringSearch() {
+
+        // When alwaysUseMemoryOptimizedSearch is true, isSupportedFieldType should return true regardless of other settings
+        final KNNVectorFieldType alwaysUseFieldType = mock(KNNVectorFieldType.class);
+        when(alwaysUseFieldType.isAlwaysUseMemoryOptimizedSearch()).thenReturn(true);
+        assertTrue(MemoryOptimizedSearchSupportSpec.isSupportedFieldType(alwaysUseFieldType, "IndexName"));
+
         // @formatter:off
         /*
         |----------------------|-------------|---------------||-----------|


### PR DESCRIPTION
### Descriptions
Add BBQ encoder support for memory-optimized search and rescore context

When the FAISS BBQ encoder is used:
- Memory-optimized search is always enabled regardless of the cluster-level setting.
- The default oversample factor is set to FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR (2.0f) and dimension-based oversampling override is disabled (allowOverrideOversampleFactor = false).

Changes:
- MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch returns true for BBQ encoder.
- KNNVectorFieldType sets alwaysUseMemoryOptimizedSearch and memoryOptimizedSearchAvailable based on the encoder at mapping time.
- CompressionLevel.getDefaultRescoreContext returns a fixed rescore context for BBQ with no dimension-based override.
- Migrated RescoreContext to use Lombok @Builder pattern, removed explicit constructor.
- Added tests in MemoryOptimizedSearchSupportSpecTests, KNNVectorFieldTypeTests, and RescoreContextTests.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
