### PR TITLE
Integrated Prefetch with Fp16 based index for MOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade Lucene to 10.4.0 [#3135](https://github.com/opensearch-project/k-NN/pull/3135)
 * Speedup FP16 bulk similarity by precomputing the tail mask [#3172](https://github.com/opensearch-project/k-NN/pull/3172)
 * Add Prefetch functionality to prefetch vectors during ANN Search for MemoryOptimizedSearch. [#3173](https://github.com/opensearch-project/k-NN/pull/3173)
+* Add Prefetch functionality to Fp16 based indices during ANN Search for MemoryOptimizedSearch. [#3195](https://github.com/opensearch-project/k-NN/pull/3195)
 * Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor [#3171](https://github.com/opensearch-project/k-NN/pull/3171)
 * Add VectorScorers for BinaryDocValues and nested best child scoring [#3179](https://github.com/opensearch-project/k-NN/pull/3179)
 * Introduce NativeEngines990KnnVectorsScorer to decouple native SIMD scoring selection from FaissMemoryOptimizedSearcher [#3184](https://github.com/opensearch-project/k-NN/pull/3184)

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelper.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelper.java
@@ -10,9 +10,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.KnnVectorValues;
-import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexFloatFlat;
-import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
-
 import java.io.IOException;
 
 /**
@@ -22,12 +19,8 @@ import java.io.IOException;
  * during scoring operations. This is particularly beneficial for memory-optimized (off-heap) search where vector
  * data is read directly from disk-backed index inputs.
  * <p>
- * Supports prefetching for the following {@link KnnVectorValues} implementations:
- * <ul>
- *   <li>{@link FaissIndexFloatFlat.FloatVectorValuesImpl} — FAISS flat float vector storage</li>
- *   <li>{@link FaissIndexBinaryFlat.ByteVectorValuesImpl} — FAISS flat binary vector storage</li>
- *   <li>{@link HasIndexSlice} — Lucene native vector storage backed by a sliced index input</li>
- * </ul>
+ * Supports prefetching for any {@link KnnVectorValues} implementation that also implements {@link HasIndexSlice},
+ * which provides access to the underlying sliced index input for prefetch operations.
  */
 @Log4j2
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -46,20 +39,11 @@ class PrefetchableVectorValuesHelper {
      * @throws IOException if an I/O error occurs during prefetching
      */
     public static void mayBeDoPrefetch(final KnnVectorValues vectorValues, final int[] nodes, final int numNodes) throws IOException {
-        switch (vectorValues) {
-            case FaissIndexFloatFlat.FloatVectorValuesImpl floatImpl:
-                floatImpl.prefetch(nodes, numNodes);
-                break;
-            case FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl:
-                binaryImpl.prefetch(nodes, numNodes);
-                break;
-            case HasIndexSlice luceneKNNVectorValues:
-                // Since Lucene uses HasIndexSlice, we can use the slice to prefetch and for lucene base offset for
-                // sliced index input is always 0.
-                PrefetchHelper.prefetch(luceneKNNVectorValues.getSlice(), 0, vectorValues.getVectorByteLength(), nodes, numNodes);
-                break;
-            default:
-                log.warn("Not able to do prefetch on instance {}", vectorValues.getClass().getSimpleName());
+        if (vectorValues instanceof HasIndexSlice vectorValuesWithSlice) {
+            // passing base offset as 0, since the index input is a slice and its base offset is 0.
+            PrefetchHelper.prefetch(vectorValuesWithSlice.getSlice(), 0, vectorValues.getVectorByteLength(), nodes, numNodes);
+        } else {
+            log.warn("Not able to do prefetch on instance {}", vectorValues.getClass().getSimpleName());
         }
     }
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexFloatFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexFloatFlat.java
@@ -6,13 +6,12 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
-import org.opensearch.knn.index.codec.scorer.PrefetchHelper;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues;
 
 import java.io.IOException;
 import java.util.Map;
@@ -41,6 +40,7 @@ public class FaissIndexFloatFlat extends FaissIndex {
     private long oneVectorByteSize;
     @Getter
     private final KNNVectorSimilarityFunction vectorSimilarityFunction;
+    private static final String VECTOR_VALUES_SLICE_NAME = "FaissFloatVectorValuesImplSlice";
 
     public FaissIndexFloatFlat(final String indexType) {
         super(indexType);
@@ -81,44 +81,17 @@ public class FaissIndexFloatFlat extends FaissIndex {
     }
 
     @Override
-    public FloatVectorValues getFloatValues(final IndexInput indexInput) {
-        return new FloatVectorValuesImpl(indexInput);
+    public FloatVectorValues getFloatValues(final IndexInput indexInput) throws IOException {
+        return new FaissFloatVectorValues(
+            floatVectors.slice(indexInput, VECTOR_VALUES_SLICE_NAME),
+            oneVectorByteSize,
+            dimension,
+            totalNumberOfVectors
+        );
     }
 
     @Override
     public ByteVectorValues getByteValues(IndexInput indexInput) {
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support " + ByteVectorValues.class.getSimpleName());
-    }
-
-    @RequiredArgsConstructor
-    public class FloatVectorValuesImpl extends FloatVectorValues {
-        final IndexInput indexInput;
-        final float[] buffer = new float[dimension];
-
-        @Override
-        public float[] vectorValue(int internalVectorId) throws IOException {
-            indexInput.seek(floatVectors.getBaseOffset() + internalVectorId * oneVectorByteSize);
-            indexInput.readFloats(buffer, 0, buffer.length);
-            return buffer;
-        }
-
-        public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
-            PrefetchHelper.prefetch(indexInput, floatVectors.getBaseOffset(), oneVectorByteSize, ordsToPrefetch, numOrds);
-        }
-
-        @Override
-        public FloatVectorValues copy() {
-            return new FloatVectorValuesImpl(indexInput.clone());
-        }
-
-        @Override
-        public int dimension() {
-            return dimension;
-        }
-
-        @Override
-        public int size() {
-            return totalNumberOfVectors;
-        }
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexScalarQuantizedFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexScalarQuantizedFlat.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
@@ -35,7 +36,9 @@ public class FaissIndexScalarQuantizedFlat extends FaissIndex {
     );
 
     public static final String IXSQ = "IxSQ";
-
+    private static final String FLOAT_VECTOR_VALUES_SLICE = "FaissIndexScalarQuantizedFloatVectorValuesSlice";
+    private static final String MMAP_FLOAT_VECTOR_VALUES_SLICE = "FaissIndexScalarQuantizedMMapFloatVectorValuesSlice";
+    private static final String BYTE_VECTOR_VALUES_SLICE = "FaissIndexScalarQuantizedByteVectorValuesSlice";
     private FaissQuantizerType quantizerType;
     private FaissQuantizedValueReconstructor reconstructor;
     private RangeStat rangeStat;
@@ -96,37 +99,7 @@ public class FaissIndexScalarQuantizedFlat extends FaissIndex {
     }
 
     @Override
-    public FloatVectorValues getFloatValues(IndexInput indexInput) {
-        @RequiredArgsConstructor
-        final class FloatVectorValuesImpl extends FloatVectorValues {
-            final IndexInput indexInput;
-            final byte[] bytesBuffer = new byte[(int) oneVectorByteSize];
-            final float[] floatBuffer = new float[dimension];
-
-            @Override
-            public float[] vectorValue(int internalVectorId) throws IOException {
-                indexInput.seek(flatVectors.getBaseOffset() + internalVectorId * oneVectorByteSize);
-                indexInput.readBytes(bytesBuffer, 0, bytesBuffer.length);
-                reconstructor.reconstruct(bytesBuffer, floatBuffer);
-                return floatBuffer;
-            }
-
-            @Override
-            public int dimension() {
-                return dimension;
-            }
-
-            @Override
-            public int size() {
-                return totalNumberOfVectors;
-            }
-
-            @Override
-            public FloatVectorValuesImpl copy() {
-                return new FloatVectorValuesImpl(indexInput.clone());
-            }
-        }
-
+    public FloatVectorValues getFloatValues(IndexInput indexInput) throws IOException {
         if (quantizerType == FaissQuantizerType.QT_FP16) {
             // Faiss SIMD bulk only supported for FP16 for now.
             final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(
@@ -137,55 +110,21 @@ public class FaissIndexScalarQuantizedFlat extends FaissIndex {
             if (addressAndSize != null) {
                 // Return MMapByteVectorValues having pointers pointing to mmap regions.
                 return new MMapFloatVectorValues(
-                    indexInput,
-                    oneVectorByteSize,
-                    flatVectors.getBaseOffset(),
-                    dimension,
-                    totalNumberOfVectors,
-                    addressAndSize,
-                    reconstructor
+                    new FloatVectorValuesImpl(flatVectors.slice(indexInput, FLOAT_VECTOR_VALUES_SLICE)),
+                    addressAndSize
                 );
             } else {
                 log.debug("Failed to extract mapped pointers from IndexInput, falling back to FloatVectorValuesImpl.");
             }
         }
 
-        return new FloatVectorValuesImpl(indexInput);
+        return new FloatVectorValuesImpl(flatVectors.slice(indexInput, FLOAT_VECTOR_VALUES_SLICE));
     }
 
     @Override
-    public ByteVectorValues getByteValues(IndexInput indexInput) {
-        @RequiredArgsConstructor
-        final class ByteVectorValuesImpl extends ByteVectorValues {
-            final IndexInput indexInput;
-            final byte[] buffer = new byte[(int) oneVectorByteSize];
-
-            @Override
-            public byte[] vectorValue(int internalVectorId) throws IOException {
-                indexInput.seek(flatVectors.getBaseOffset() + internalVectorId * oneVectorByteSize);
-                indexInput.readBytes(buffer, 0, buffer.length);
-                reconstructor.reconstruct(buffer, buffer);
-                return buffer;
-            }
-
-            @Override
-            public int dimension() {
-                return dimension;
-            }
-
-            @Override
-            public int size() {
-                return totalNumberOfVectors;
-            }
-
-            @Override
-            public ByteVectorValues copy() {
-                return new ByteVectorValuesImpl(indexInput.clone());
-            }
-        }
-
+    public ByteVectorValues getByteValues(IndexInput indexInput) throws IOException {
         // Return default implementation
-        return new ByteVectorValuesImpl(indexInput);
+        return new ByteVectorValuesImpl(flatVectors.slice(indexInput, BYTE_VECTOR_VALUES_SLICE));
     }
 
     @Override
@@ -236,5 +175,91 @@ public class FaissIndexScalarQuantizedFlat extends FaissIndex {
         QUANTILES,
         // Alternate optimization of reconstruction error
         OPTIM
+    }
+
+    @RequiredArgsConstructor
+    public class FloatVectorValuesImpl extends FloatVectorValues implements HasIndexSlice {
+        final IndexInput indexInput;
+        final byte[] bytesBuffer = new byte[(int) oneVectorByteSize];
+        final float[] floatBuffer = new float[dimension];
+
+        @Override
+        public float[] vectorValue(int internalVectorId) throws IOException {
+            indexInput.seek(internalVectorId * oneVectorByteSize);
+            indexInput.readBytes(bytesBuffer, 0, bytesBuffer.length);
+            reconstructor.reconstruct(bytesBuffer, floatBuffer);
+            return floatBuffer;
+        }
+
+        /**
+         * Returns the vector byte length. Since this is fp16 we need to send oneVectorByteSize. This is important,
+         * otherwise Lucene will use the dimension * FP32 bytes which will cause error
+         */
+        @Override
+        public int getVectorByteLength() {
+            return (int) oneVectorByteSize;
+        }
+
+        @Override
+        public int dimension() {
+            return dimension;
+        }
+
+        @Override
+        public int size() {
+            return totalNumberOfVectors;
+        }
+
+        @Override
+        public FloatVectorValuesImpl copy() {
+            return new FloatVectorValuesImpl(indexInput.clone());
+        }
+
+        /**
+         * Returns an IndexInput from which to read this instance's values, or null if not available.
+         */
+        @Override
+        public IndexInput getSlice() {
+            return indexInput;
+        }
+    }
+
+    // TODO: implement HasIndexSlice function on this Vector Values. Currently its failing tests with
+    // MemorySegmentScorer. Will fix it in another PR.
+    @RequiredArgsConstructor
+    public class ByteVectorValuesImpl extends ByteVectorValues {
+        final IndexInput indexInput;
+        final byte[] buffer = new byte[(int) oneVectorByteSize];
+
+        @Override
+        public byte[] vectorValue(int internalVectorId) throws IOException {
+            indexInput.seek(internalVectorId * oneVectorByteSize);
+            indexInput.readBytes(buffer, 0, buffer.length);
+            reconstructor.reconstruct(buffer, buffer);
+            return buffer;
+        }
+
+        @Override
+        public int dimension() {
+            return dimension;
+        }
+
+        @Override
+        public int size() {
+            return totalNumberOfVectors;
+        }
+
+        /**
+         * Returns the vector byte length, defaults to dimension multiplied by float byte size
+         */
+        @Override
+        public int getVectorByteLength() {
+            return (int) oneVectorByteSize;
+        }
+
+        @Override
+        public ByteVectorValues copy() {
+            return new ByteVectorValuesImpl(indexInput.clone());
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -50,7 +50,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     private final FlatVectorsScorer flatVectorsScorer;
     private final FaissHNSW hnsw;
     private final VectorSimilarityFunction vectorSimilarityFunction;
-    private final long fileSize;
     private boolean isAdc;
 
     public FaissMemoryOptimizedSearcher(
@@ -60,7 +59,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         final FlatVectorsScorer flatVectorsScorer
     ) {
         this.indexInput = indexInput;
-        this.fileSize = indexInput.length();
         this.faissIndex = faissIndex;
         final KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
 
@@ -87,8 +85,8 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     @Override
     public void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         final KnnVectorValues knnVectorValues = isAdc
-            ? faissIndex.getByteValues(getSlicedIndexInput())
-            : faissIndex.getFloatValues(getSlicedIndexInput());
+            ? faissIndex.getByteValues(indexInput.clone())
+            : faissIndex.getFloatValues(indexInput.clone());
 
         search(
             VectorEncoding.FLOAT32,
@@ -102,7 +100,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     public void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         search(
             VectorEncoding.BYTE,
-            flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, faissIndex.getByteValues(getSlicedIndexInput()), target),
+            flatVectorsScorer.getRandomVectorScorer(vectorSimilarityFunction, faissIndex.getByteValues(indexInput.clone()), target),
             knnCollector,
             acceptDocs
         );
@@ -116,7 +114,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
      */
     @Override
     public ByteVectorValues getByteVectorValues() throws IOException {
-        return faissIndex.getByteValues(getSlicedIndexInput());
+        return faissIndex.getByteValues(indexInput.clone());
     }
 
     @Override
@@ -151,7 +149,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
 
         if (knnCollector.k() < scorer.maxOrd()) {
             // Do ANN search with Lucene's HNSW graph searcher.
-            HnswGraphSearcher.search(scorer, collector, new FaissHnswGraph(hnsw, getSlicedIndexInput()), acceptedOrds);
+            HnswGraphSearcher.search(scorer, collector, new FaissHnswGraph(hnsw, indexInput.clone()), acceptedOrds);
         } else {
             // If k is larger than the number of vectors, we can just iterate over all vectors
             // and collect them.
@@ -166,10 +164,6 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
                 }
             }
         }
-    }
-
-    private IndexInput getSlicedIndexInput() throws IOException {
-        return indexInput.slice("FaissMemoryOptimizedSearcher", 0, fileSize);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissSection.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissSection.java
@@ -52,4 +52,16 @@ public class FaissSection {
             throw new IOException("Failed to partial load where baseOffset=" + baseOffset + ", sectionSize=" + sectionSize, e);
         }
     }
+
+    /**
+     * Creates a bounded {@link IndexInput} slice over this section's byte range.
+     *
+     * @param input     The parent {@link IndexInput} to slice from.
+     * @param sliceName A descriptive name for the slice, used in debugging and error messages.
+     * @return A new {@link IndexInput} positioned at {@code baseOffset} with length {@code sectionSize}.
+     * @throws IOException If the slice cannot be created.
+     */
+    public IndexInput slice(IndexInput input, String sliceName) throws IOException {
+        return input.slice(sliceName, baseOffset, sectionSize);
+    }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/MMapFloatVectorValues.java
@@ -6,32 +6,24 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.Getter;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.store.IndexInput;
-import org.opensearch.common.Nullable;
-import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueReconstructor;
 
 import java.io.IOException;
 
 /**
- * Encapsulates raw pointers to memory-mapped regions associated with a given {@link IndexInput}.
+ * A {@link FloatVectorValues} wrapper that exposes memory-mapped segment addresses for direct native access.
  * <p>
- * The list of addresses and sizes can be passed to native scoring code for improved performance.
- * Native code may operate directly on these mapped pointers to perform computations efficiently.
+ * This class decorates a delegate {@link FloatVectorValues} backed by an MMap {@link IndexInput}, exposing
+ * the underlying memory segment addresses and sizes via {@link #getAddressAndSize()}. Native scoring code
+ * can use these raw pointers to read vectors directly from mapped memory, avoiding Java-level copies.
  * <p>
- * Users can still retrieve vector bytes via the {@code vectorValue} API, which lazily creates
- * an internal buffer and returns it after filling in the requested bytes.
+ * Standard Java access is still available through {@link #vectorValue(int)}, which delegates to the
+ * underlying implementation. The class also implements {@link HasIndexSlice} to provide access to the
+ * backing {@link IndexInput} for prefetching or sequential reads.
  */
-public class MMapFloatVectorValues extends FloatVectorValues implements MMapVectorValues {
-    private final IndexInput indexInput;
-    // oneVectorByteSize == Float.BYTES * Dimension. Ex: 3072 bytes for 768 dimensions.
-    private final long oneVectorByteSize;
-    // Start offset pointing to flat vectors section in Faiss index.
-    private final long baseOffset;
-    // Vector dimension
-    private final int dimension;
-    // Total number of vectors stored in Faiss index.
-    private final int totalNumberOfVectors;
+public class MMapFloatVectorValues extends FloatVectorValues implements MMapVectorValues, HasIndexSlice {
     // It has address and size per MemorySegment extracted from MemorySegmentIndexInput.
     // e.g. address_i = addressAndSize[i], mapped_size_i = addressAndSize[i + 1]
     // For example, if a given IndexInput had 2 MemorySegments, then addressAndSize[0] has the address of the first MemorySegment
@@ -39,26 +31,10 @@ public class MMapFloatVectorValues extends FloatVectorValues implements MMapVect
     // addressAndSize[3] has the size of the second mapped region.
     @Getter
     private final long[] addressAndSize;
-    // Internal buffer that lazily created.
-    private float[] floatBuffer;
-    private byte[] bytesBuffer;
-    @Nullable
-    private final FaissQuantizedValueReconstructor reconstructor;
+    private final FloatVectorValues delegate;
 
-    public MMapFloatVectorValues(
-        final IndexInput indexInput,
-        final long oneVectorByteSize,
-        final long baseOffset,
-        final int dimension,
-        final int totalNumberOfVectors,
-        final long[] addressAndSize,
-        final FaissQuantizedValueReconstructor reconstructor
-    ) {
-        this.indexInput = indexInput;
-        this.oneVectorByteSize = oneVectorByteSize;
-        this.baseOffset = baseOffset;
-        this.dimension = dimension;
-        this.totalNumberOfVectors = totalNumberOfVectors;
+    public MMapFloatVectorValues(final FloatVectorValues delegate, final long[] addressAndSize) {
+        this.delegate = delegate;
         if (addressAndSize == null || addressAndSize.length == 0) {
             throw new IllegalArgumentException(
                 "Empty `addressAndSize` was provided in "
@@ -68,54 +44,45 @@ public class MMapFloatVectorValues extends FloatVectorValues implements MMapVect
             );
         }
         this.addressAndSize = addressAndSize;
-        this.reconstructor = reconstructor;
     }
 
     @Override
     public float[] vectorValue(int internalVectorId) throws IOException {
-        // Seek to the starting offset of vector
-        indexInput.seek(baseOffset + internalVectorId * oneVectorByteSize);
-        // Lazy initialization, in general this method is not expected to be called during search.
-        // During search, distance calculation will be done in a separated C++ code.
-        if (floatBuffer == null) {
-            floatBuffer = new float[(int) dimension];
-        }
-
-        if (reconstructor != null) {
-            // We have transform logic present, first load bytes into byte[] then transform it to float[]
-            if (bytesBuffer == null) {
-                bytesBuffer = new byte[(int) oneVectorByteSize];
-            }
-            indexInput.readBytes(bytesBuffer, 0, bytesBuffer.length);
-            reconstructor.reconstruct(bytesBuffer, floatBuffer);
-        } else {
-            // No encoding logic present, directly load into float[]
-            indexInput.readFloats(floatBuffer, 0, floatBuffer.length);
-        }
-
-        return floatBuffer;
+        return delegate.vectorValue(internalVectorId);
     }
 
     @Override
     public int dimension() {
-        return dimension;
+        return delegate.dimension();
     }
 
     @Override
     public int size() {
-        return totalNumberOfVectors;
+        return delegate.size();
+    }
+
+    /**
+     * Returns the vector byte length, defaults to dimension multiplied by float byte size. Hence, we are changing it to
+     * oneVectorByteSize
+     */
+    @Override
+    public int getVectorByteLength() {
+        return delegate.getVectorByteLength();
     }
 
     @Override
     public FloatVectorValues copy() throws IOException {
-        return new MMapFloatVectorValues(
-            indexInput.clone(),
-            oneVectorByteSize,
-            baseOffset,
-            dimension,
-            totalNumberOfVectors,
-            addressAndSize,
-            reconstructor
-        );
+        return new MMapFloatVectorValues(delegate.copy(), addressAndSize);
+    }
+
+    /**
+     * Returns an IndexInput from which to read this instance's values, or null if not available.
+     */
+    @Override
+    public IndexInput getSlice() {
+        if (delegate instanceof HasIndexSlice hasIndexSlice) {
+            return hasIndexSlice.getSlice();
+        }
+        throw new UnsupportedOperationException("HasIndexSlice interface is not supported with the delegate class " + delegate.getClass());
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
@@ -6,11 +6,11 @@
 package org.opensearch.knn.memoryoptsearch.faiss.binary;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
-import org.opensearch.knn.index.codec.scorer.PrefetchHelper;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissSection;
 
 import java.io.IOException;
@@ -28,6 +28,7 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
     public static final String IBXF = "IBxF";
 
     private FaissSection binaryFlatVectorSection;
+    private static final String VECTOR_VALUES_SLICE_NAME = "FaissByteVectorValuesImplSlice";
 
     public FaissIndexBinaryFlat() {
         super(IBXF);
@@ -58,30 +59,29 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
 
     @Override
     public ByteVectorValues getByteValues(final IndexInput indexInput) throws IOException {
-
-        return new ByteVectorValuesImpl(indexInput);
+        return new ByteVectorValuesImpl(binaryFlatVectorSection.slice(indexInput, VECTOR_VALUES_SLICE_NAME));
     }
 
     @RequiredArgsConstructor
-    public class ByteVectorValuesImpl extends ByteVectorValues {
+    public class ByteVectorValuesImpl extends ByteVectorValues implements HasIndexSlice {
         final IndexInput indexInput;
         final byte[] buffer = new byte[codeSize];
 
         @Override
         public byte[] vectorValue(int internalVectorId) throws IOException {
-            final long offset = binaryFlatVectorSection.getBaseOffset() + (long) internalVectorId * codeSize;
+            final long offset = (long) internalVectorId * codeSize;
             indexInput.seek(offset);
             indexInput.readBytes(buffer, 0, codeSize);
             return buffer;
         }
 
-        public void prefetch(final int[] ordsToPrefetch, int numOrds) throws IOException {
-            PrefetchHelper.prefetch(indexInput, binaryFlatVectorSection.getBaseOffset(), codeSize, ordsToPrefetch, numOrds);
-        }
-
         @Override
         public int dimension() {
             return dimension;
+        }
+
+        public int getVectorByteLength() {
+            return codeSize;
         }
 
         @Override
@@ -92,6 +92,14 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
         @Override
         public ByteVectorValues copy() {
             return new ByteVectorValuesImpl(indexInput.clone());
+        }
+
+        /**
+         * Returns an IndexInput from which to read this instance's values, or null if not available.
+         */
+        @Override
+        public IndexInput getSlice() {
+            return indexInput;
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValues.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.vectorvalues;
+
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * A {@link FloatVectorValues} implementation that reads float vectors directly from a FAISS index
+ * section via an {@link IndexInput}.
+ * <p>
+ * Each vector is located by seeking to {@code internalVectorId * oneVectorByteSize} within the
+ * backing {@link IndexInput} and reading {@code dimension} floats. A single reusable buffer is
+ * used across calls to {@link #vectorValue(int)}, so callers must consume or copy the returned
+ * array before the next call.
+ * <p>
+ * Implements {@link HasIndexSlice} to expose the underlying {@link IndexInput} for prefetching
+ * or direct access by native code.
+ */
+public class FaissFloatVectorValues extends FloatVectorValues implements HasIndexSlice {
+    private final IndexInput indexInput;
+    private final long oneVectorByteSize;
+    private final int dimension;
+    private final float[] buffer;
+    private final int totalNumberOfVectors;
+
+    public FaissFloatVectorValues(IndexInput indexInput, long oneVectorByteSize, int dimension, int totalNumberOfVectors) {
+        this.indexInput = indexInput;
+        this.oneVectorByteSize = oneVectorByteSize;
+        this.dimension = dimension;
+        this.buffer = new float[dimension];
+        this.totalNumberOfVectors = totalNumberOfVectors;
+    }
+
+    @Override
+    public float[] vectorValue(int internalVectorId) throws IOException {
+        indexInput.seek(internalVectorId * oneVectorByteSize);
+        indexInput.readFloats(buffer, 0, buffer.length);
+        return buffer;
+    }
+
+    @Override
+    public FloatVectorValues copy() {
+        return new FaissFloatVectorValues(indexInput.clone(), oneVectorByteSize, dimension, totalNumberOfVectors);
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public int size() {
+        return totalNumberOfVectors;
+    }
+
+    /**
+     * Returns an IndexInput from which to read this instance's values, or null if not available.
+     */
+    @Override
+    public IndexInput getSlice() {
+        return indexInput;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelperTests.java
@@ -11,14 +11,14 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.store.IndexInput;
 import org.mockito.MockedStatic;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexFloatFlat;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexScalarQuantizedFlat;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues;
 
 import java.io.IOException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PrefetchableVectorValuesHelperTests extends KNNTestCase {
@@ -26,23 +26,55 @@ public class PrefetchableVectorValuesHelperTests extends KNNTestCase {
     private final int[] nodes = { 0, 1, 2 };
     private final int numNodes = 3;
 
-    public void testMayBeDoPrefetch_whenFloatVectorValuesImpl_thenDelegates() throws IOException {
-        FaissIndexFloatFlat.FloatVectorValuesImpl floatImpl = mock(FaissIndexFloatFlat.FloatVectorValuesImpl.class);
+    public void testMayBeDoPrefetch_whenFloatVectorValuesImpl_thenPrefetchesViaHasIndexSlice() throws IOException {
+        IndexInput mockSlice = mock(IndexInput.class);
+        when(mockSlice.length()).thenReturn(200L * 1024);
+        int vectorByteLength = 512;
 
-        PrefetchableVectorValuesHelper.mayBeDoPrefetch(floatImpl, nodes, numNodes);
+        FaissFloatVectorValues floatImpl = mock(FaissFloatVectorValues.class);
+        when(floatImpl.getSlice()).thenReturn(mockSlice);
+        when(floatImpl.getVectorByteLength()).thenReturn(vectorByteLength);
 
-        verify(floatImpl).prefetch(nodes, numNodes);
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(floatImpl, nodes, numNodes);
+
+            mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, numNodes));
+        }
     }
 
-    public void testMayBeDoPrefetch_whenByteVectorValuesImpl_thenDelegates() throws IOException {
+    public void testMayBeDoPrefetch_whenQuantizedFloatVectorValuesImpl_thenPrefetchesViaHasIndexSlice() throws IOException {
+        IndexInput mockSlice = mock(IndexInput.class);
+        when(mockSlice.length()).thenReturn(200L * 1024);
+        int vectorByteLength = 512;
+
+        FaissIndexScalarQuantizedFlat.FloatVectorValuesImpl floatImpl = mock(FaissIndexScalarQuantizedFlat.FloatVectorValuesImpl.class);
+        when(floatImpl.getSlice()).thenReturn(mockSlice);
+        when(floatImpl.getVectorByteLength()).thenReturn(vectorByteLength);
+
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(floatImpl, nodes, numNodes);
+
+            mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, numNodes));
+        }
+    }
+
+    public void testMayBeDoPrefetch_whenByteVectorValuesImpl_thenPrefetchesViaHasIndexSlice() throws IOException {
+        IndexInput mockSlice = mock(IndexInput.class);
+        when(mockSlice.length()).thenReturn(200L * 1024);
+        int vectorByteLength = 64;
+
         FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl = mock(FaissIndexBinaryFlat.ByteVectorValuesImpl.class);
+        when(binaryImpl.getSlice()).thenReturn(mockSlice);
+        when(binaryImpl.getVectorByteLength()).thenReturn(vectorByteLength);
 
-        PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, numNodes);
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, numNodes);
 
-        verify(binaryImpl).prefetch(nodes, numNodes);
+            mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, numNodes));
+        }
     }
 
-    public void testMayBeDoPrefetch_whenHasIndexSlice_thenCallsPrefetchHelper() throws IOException {
+    public void testMayBeDoPrefetch_whenOffHeapFloatVectorValues_thenCallsPrefetchHelper() throws IOException {
         IndexInput mockSlice = mock(IndexInput.class);
         when(mockSlice.length()).thenReturn(200L * 1024);
         int vectorByteLength = 16;
@@ -61,23 +93,26 @@ public class PrefetchableVectorValuesHelperTests extends KNNTestCase {
     public void testMayBeDoPrefetch_whenUnsupportedType_thenNoException() throws IOException {
         KnnVectorValues unsupported = mock(FloatVectorValues.class);
 
-        // Should not throw, just logs
-        PrefetchableVectorValuesHelper.mayBeDoPrefetch(unsupported, nodes, numNodes);
-    }
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(unsupported, nodes, numNodes);
 
-    public void testMayBeDoPrefetch_whenNullNodes_thenDelegatesAsIs() throws IOException {
-        FaissIndexFloatFlat.FloatVectorValuesImpl floatImpl = mock(FaissIndexFloatFlat.FloatVectorValuesImpl.class);
-
-        PrefetchableVectorValuesHelper.mayBeDoPrefetch(floatImpl, null, 0);
-
-        verify(floatImpl).prefetch(null, 0);
+            mockedPrefetchHelper.verifyNoInteractions();
+        }
     }
 
     public void testMayBeDoPrefetch_whenZeroNumNodes_thenDelegatesAsIs() throws IOException {
+        IndexInput mockSlice = mock(IndexInput.class);
+        when(mockSlice.length()).thenReturn(200L * 1024);
+        int vectorByteLength = 64;
+
         FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl = mock(FaissIndexBinaryFlat.ByteVectorValuesImpl.class);
+        when(binaryImpl.getSlice()).thenReturn(mockSlice);
+        when(binaryImpl.getVectorByteLength()).thenReturn(vectorByteLength);
 
-        PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, 0);
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, 0);
 
-        verify(binaryImpl).prefetch(nodes, 0);
+            mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, 0));
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractFaissCagraHnswIndexTests.java
@@ -27,6 +27,7 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
@@ -75,7 +76,7 @@ public abstract class AbstractFaissCagraHnswIndexTests extends KNNTestCase {
                 FlatVectorsScorerProvider.getFlatVectorsScorer(
                     noADC,
                     similarityFunction,
-                    FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+                    new NativeEngines990KnnVectorsScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer())
                 )
             );
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -40,6 +40,7 @@ import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsRead
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.codec.nativeindex.MemoryOptimizedSearchIndexingSupport;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
+import org.opensearch.knn.index.codec.scorer.NativeEngines990KnnVectorsScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
@@ -118,7 +119,9 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     private static final int TOTAL_NUM_DOCS_IN_SEGMENT = 300;
     private static final int TOP_K = 30;
     private static final float NO_FILTERING = Float.NaN;
-    private static final FlatVectorsScorer SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+    private static final FlatVectorsScorer SCORER = new NativeEngines990KnnVectorsScorer(
+        FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+    );
 
     public void test32xQuantizedBinaryIndexType() {
         final TestingSpec testingSpec = new TestingSpec(

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MMapFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MMapFloatVectorValuesTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.knn.generate.SearchTestHelper;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapFloatVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
@@ -57,15 +58,10 @@ public class MMapFloatVectorValuesTests extends LuceneTestCase {
                     numVectors * dimension * Float.BYTES
                 );
                 assertNotNull(addressAndSize);
-                final MMapFloatVectorValues values = new MMapFloatVectorValues(
-                    input,
-                    oneVectorByteSize,
-                    0,
-                    dimension,
-                    numVectors,
-                    addressAndSize,
-                    null
-                );
+
+                FaissFloatVectorValues faissFloatVectorValues = new FaissFloatVectorValues(input, oneVectorByteSize, dimension, numVectors);
+
+                final MMapFloatVectorValues values = new MMapFloatVectorValues(faissFloatVectorValues, addressAndSize);
 
                 // Ensure properties are correct.
                 assertEquals(oneVectorByteSize, values.getVectorByteLength());


### PR DESCRIPTION
### Description
Integrated Prefetch with Fp16 based index for MOS. The current prefetch works when we are using BulkSIMD too.

Next Steps:
1. Integrate Prefetch with SparseVectorvalues for faiss indices.

### Related Issues
https://github.com/opensearch-project/k-NN/issues/2577
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
