### PR TITLE
[Bug] Fix FaissIdMap honor the given acceptOrds for sparse case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixed generating random entry points for CagraIndex in MOS when numVectors < entryPoints [#3161](https://github.com/opensearch-project/k-NN/pull/3161)
 * Fix integer overflow for memory optimized search [#3130](https://github.com/opensearch-project/k-NN/pull/3130)
 * Fix derived source returning incorrect vector value during indexing with dynamic templates [#3035](https://github.com/opensearch-project/k-NN/pull/3035)
+* Fix FaissIdMap honor the given acceptOrds for sparse case. [#3196](https://github.com/opensearch-project/k-NN/pull/3196)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIdMapIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIdMapIndex.java
@@ -138,18 +138,16 @@ public class FaissIdMapIndex extends FaissBinaryIndex implements FaissHNSWProvid
             @Override
             public Bits getAcceptOrds(final Bits acceptDocs) {
                 if (acceptDocs != null) {
-                    final Bits internalBits = vectorValues.getAcceptOrds(acceptDocs);
-
                     return new Bits() {
                         @Override
                         public boolean get(int internalVectorId) {
-                            // Apply filtering with a converted Lucene document id.
-                            return internalBits.get((int) idMappingReader.get(internalVectorId));
+                            // Convert internal vector ordinal to Lucene document id, then check acceptDocs directly.
+                            return acceptDocs.get((int) idMappingReader.get(internalVectorId));
                         }
 
                         @Override
                         public int length() {
-                            return internalBits.length();
+                            return vectorValues.size();
                         }
                     };
                 }
@@ -205,18 +203,16 @@ public class FaissIdMapIndex extends FaissBinaryIndex implements FaissHNSWProvid
             @Override
             public Bits getAcceptOrds(final Bits acceptDocs) {
                 if (acceptDocs != null) {
-                    final Bits internalBits = floatVectorValues.getAcceptOrds(acceptDocs);
-
                     return new Bits() {
                         @Override
                         public boolean get(int internalVectorId) {
-                            // Apply filtering with a converted Lucene document id.
-                            return internalBits.get((int) idMappingReader.get(internalVectorId));
+                            // Convert internal vector ordinal to Lucene document id, then check acceptDocs directly.
+                            return acceptDocs.get((int) idMappingReader.get(internalVectorId));
                         }
 
                         @Override
                         public int length() {
-                            return internalBits.length();
+                            return floatVectorValues.size();
                         }
                     };
                 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIdMapIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIdMapIndexTests.java
@@ -104,22 +104,43 @@ public class FaissIdMapIndexTests extends KNNTestCase {
         Bits bitsFromByteVectors = byteVectorValues.getAcceptOrds(null);
         assertNull(bitsFromByteVectors);
 
-        bitsFromByteVectors = byteVectorValues.getAcceptOrds(mock(Bits.class));
+        // Verify that getAcceptOrds correctly maps vector ordinal -> doc ID via acceptDocs
+        final Bits mockAcceptDocsForBytes = mock(Bits.class);
+        final AtomicInteger byteIdx = new AtomicInteger(0);
+        doAnswer((Answer<Boolean>) invocation -> {
+            final int docId = invocation.getArgument(0);
+            assertEquals(mappingTable[byteIdx.getAndIncrement()], docId);
+            return true;
+        }).when(mockAcceptDocsForBytes).get(anyInt());
+
+        bitsFromByteVectors = byteVectorValues.getAcceptOrds(mockAcceptDocsForBytes);
+        assertEquals(totalNumberOfVectors, bitsFromByteVectors.length());
         for (int i = 0; i < totalNumberOfVectors; ++i) {
-            // Internally, it will intercept the argument then compare the converted doc id to the expected one.
             bitsFromByteVectors.get(i);
+            assertEquals(mappingTable[i], byteVectorValues.ordToDoc(i));
         }
+        assertEquals(totalNumberOfVectors, byteIdx.get());
 
         // Sparse float vectors
         final FloatVectorValues floatVectorValues = index.getFloatValues(null);
         Bits bitsFromFloatVectors = floatVectorValues.getAcceptOrds(null);
         assertNull(bitsFromFloatVectors);
 
-        bitsFromFloatVectors = floatVectorValues.getAcceptOrds(mock(Bits.class));
+        final Bits mockAcceptDocsForFloats = mock(Bits.class);
+        final AtomicInteger floatIdx = new AtomicInteger(0);
+        doAnswer((Answer<Boolean>) invocation -> {
+            final int docId = invocation.getArgument(0);
+            assertEquals(mappingTable[floatIdx.getAndIncrement()], docId);
+            return true;
+        }).when(mockAcceptDocsForFloats).get(anyInt());
+
+        bitsFromFloatVectors = floatVectorValues.getAcceptOrds(mockAcceptDocsForFloats);
+        assertEquals(totalNumberOfVectors, bitsFromFloatVectors.length());
         for (int i = 0; i < totalNumberOfVectors; ++i) {
-            // Internally, it will intercept the argument then compare the converted doc id to the expected one.
             bitsFromFloatVectors.get(i);
+            assertEquals(mappingTable[i], floatVectorValues.ordToDoc(i));
         }
+        assertEquals(totalNumberOfVectors, floatIdx.get());
     }
 
     public void testParentChildNestedCase() {
@@ -157,22 +178,42 @@ public class FaissIdMapIndexTests extends KNNTestCase {
         Bits bitsFromByteVectors = byteVectorValues.getAcceptOrds(null);
         assertNull(bitsFromByteVectors);
 
-        bitsFromByteVectors = byteVectorValues.getAcceptOrds(mock(Bits.class));
+        final Bits mockAcceptDocsForBytes = mock(Bits.class);
+        final AtomicInteger byteIdx = new AtomicInteger(0);
+        doAnswer((Answer<Boolean>) invocation -> {
+            final int docId = invocation.getArgument(0);
+            assertEquals(mappingTable[byteIdx.getAndIncrement()], docId);
+            return true;
+        }).when(mockAcceptDocsForBytes).get(anyInt());
+
+        bitsFromByteVectors = byteVectorValues.getAcceptOrds(mockAcceptDocsForBytes);
+        assertEquals(totalNumberOfVectors, bitsFromByteVectors.length());
         for (int i = 0; i < totalNumberOfVectors; ++i) {
-            // Internally, it will intercept the argument then compare the converted doc id to the expected one.
             bitsFromByteVectors.get(i);
+            assertEquals(mappingTable[i], byteVectorValues.ordToDoc(i));
         }
+        assertEquals(totalNumberOfVectors, byteIdx.get());
 
         // Sparse float vectors
         final FloatVectorValues floatVectorValues = index.getFloatValues(null);
         Bits bitsFromFloatVectors = floatVectorValues.getAcceptOrds(null);
         assertNull(bitsFromFloatVectors);
 
-        bitsFromFloatVectors = floatVectorValues.getAcceptOrds(mock(Bits.class));
+        final Bits mockAcceptDocsForFloats = mock(Bits.class);
+        final AtomicInteger floatIdx = new AtomicInteger(0);
+        doAnswer((Answer<Boolean>) invocation -> {
+            final int docId = invocation.getArgument(0);
+            assertEquals(mappingTable[floatIdx.getAndIncrement()], docId);
+            return true;
+        }).when(mockAcceptDocsForFloats).get(anyInt());
+
+        bitsFromFloatVectors = floatVectorValues.getAcceptOrds(mockAcceptDocsForFloats);
+        assertEquals(totalNumberOfVectors, bitsFromFloatVectors.length());
         for (int i = 0; i < totalNumberOfVectors; ++i) {
-            // Internally, it will intercept the argument then compare the converted doc id to the expected one.
             bitsFromFloatVectors.get(i);
+            assertEquals(mappingTable[i], floatVectorValues.ordToDoc(i));
         }
+        assertEquals(totalNumberOfVectors, floatIdx.get());
     }
 
     @SneakyThrows
@@ -221,28 +262,14 @@ public class FaissIdMapIndexTests extends KNNTestCase {
             mockStaticFaissIndex.when(() -> FaissIndex.load(any())).thenReturn(nestedIndex);
 
             // Byte vectors
-            final Bits mockBitsFromByteVectors = mock(Bits.class);
-            final AtomicInteger idx1 = new AtomicInteger(0);
-            doAnswer((Answer<Void>) invocation -> {
-                final int convertedDocId = invocation.getArgument(0);
-                assertEquals(mappingTable[idx1.getAndIncrement()], convertedDocId);
-                return null;
-            }).when(mockBitsFromByteVectors).get(anyInt());
             final ByteVectorValues mockByteValues = mock(ByteVectorValues.class);
             when(nestedIndex.getByteValues(any())).thenReturn(mockByteValues);
-            when(mockByteValues.getAcceptOrds(any())).thenReturn(mockBitsFromByteVectors);
+            when(mockByteValues.size()).thenReturn(Math.toIntExact(totalNumberOfVectors));
 
             // Float vectors
-            final Bits mockBitsFromFloatVectors = mock(Bits.class);
-            final AtomicInteger idx2 = new AtomicInteger(0);
-            doAnswer((Answer<Void>) invocation -> {
-                final int convertedDocId = invocation.getArgument(0);
-                assertEquals(mappingTable[idx2.getAndIncrement()], convertedDocId);
-                return null;
-            }).when(mockBitsFromFloatVectors).get(anyInt());
             final FloatVectorValues mockFloatValues = mock(FloatVectorValues.class);
             when(nestedIndex.getFloatValues(any())).thenReturn(mockFloatValues);
-            when(mockFloatValues.getAcceptOrds(any())).thenReturn(mockBitsFromFloatVectors);
+            when(mockFloatValues.size()).thenReturn(Math.toIntExact(totalNumberOfVectors));
 
             // Trigger load
             final IndexInput input = prepareBytes(dimension, totalNumberOfVectors, useL2Metric, mappingTable, indexType);


### PR DESCRIPTION
### Description

### Bug
In FaissIdMapIndex, the getAcceptOrds method in both SparseByteVectorValuesImpl and SparseFloatVectorValuesImpl applied the ordinal→docID mapping twice.

The old code:
```
final Bits internalBits = vectorValues.getAcceptOrds(acceptDocs);
return internalBits.get((int) idMappingReader.get(internalVectorId));
```

vectorValues.getAcceptOrds(acceptDocs) already returns a Bits indexed by vector ordinal — per the Lucene KnnVectorValues.getAcceptOrds contract, it internally translates ordinal→docID via ordToDoc() before checking acceptDocs. Then the wrapper applied idMappingReader.get() (another ordinal→docID mapping) on top, passing a docID into internalBits.get() which expects an ordinal.

With the current nested HNSW flat index (where ordToDoc is identity), the double mapping was masked. But it would produce incorrect filtering results with any nested index that has a non-identity ordToDoc, such as Lucene104ScalarQuantizedVectorsReader's sparse OffHeapScalarQuantizedFloatVectorValues.

### Fix
Skip the nested index's getAcceptOrds and map directly:
```
return acceptDocs.get((int) idMappingReader.get(internalVectorId));
```

This matches Lucene's own SparseOffHeapVectorValues.getAcceptOrds pattern: take the vector ordinal, convert to docID via the mapping, check acceptDocs at that docID. One translation, no delegation.

Test changes
- Moved the ordinal→docID assertions from the shared triggerLoadAndGetIndex setup (where they were on the now-unused vectorValues.getAcceptOrds mock) into each test method, asserting directly on the acceptDocs mock.
- Added length() assertions to verify the returned Bits reports the correct size.
- Added ordToDoc() assertions to verify consistency between ordToDoc and getAcceptOrds.
- Removed dead mock setup (mockBitsFromByteVectors, mockBitsFromFloatVectors and their getAcceptOrds stubs).
- Stubbed mockByteValues.size() and mockFloatValues.size() since length() now delegates to vectorValues.size().


### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
