### PR TITLE
Integrated prefetch for SparseFloatVectorValues with Faiss Indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Speedup FP16 bulk similarity by precomputing the tail mask [#3172](https://github.com/opensearch-project/k-NN/pull/3172)
 * Add Prefetch functionality to prefetch vectors during ANN Search for MemoryOptimizedSearch. [#3173](https://github.com/opensearch-project/k-NN/pull/3173)
 * Add Prefetch functionality to Fp16 based indices during ANN Search for MemoryOptimizedSearch. [#3195](https://github.com/opensearch-project/k-NN/pull/3195)
+* Add Prefetch functionality to SparseFloatVectorValues with Faiss Indices [#]()
 * Optimize ByteVectorIdsExactKNNIterator by moving array conversion to constructor [#3171](https://github.com/opensearch-project/k-NN/pull/3171)
 * Add VectorScorers for BinaryDocValues and nested best child scoring [#3179](https://github.com/opensearch-project/k-NN/pull/3179)
 * Introduce NativeEngines990KnnVectorsScorer to decouple native SIMD scoring selection from FaissMemoryOptimizedSearcher [#3184](https://github.com/opensearch-project/k-NN/pull/3184)

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIdMapIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIdMapIndex.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues;
 
 import java.io.IOException;
 
@@ -170,69 +171,9 @@ public class FaissIdMapIndex extends FaissBinaryIndex implements FaissHNSWProvid
         return new SparseByteVectorValuesImpl(vectorValues);
     }
 
-    /**
-     * For sparse or nested cases, {@link ByteVectorValues} needs to be wrapped to correctly map an internal vector ID to a
-     * Lucene document ID.
-     *
-     * @param indexInput A read stream to FAISS index file.
-     * @return {@link FloatVectorValues} which is a float vector random accessor.
-     * @throws IOException
-     */
     private FloatVectorValues sparseFloatValues(IndexInput indexInput) throws IOException {
-        final class SparseFloatVectorValuesImpl extends WrappedFloatVectorValues {
-            public SparseFloatVectorValuesImpl(final FloatVectorValues vectorValues) {
-                super(vectorValues);
-            }
-
-            @Override
-            public float[] vectorValue(int internalVectorId) throws IOException {
-                return floatVectorValues.vectorValue(internalVectorId);
-            }
-
-            @Override
-            public int dimension() {
-                return floatVectorValues.dimension();
-            }
-
-            @Override
-            public int ordToDoc(int internalVectorId) {
-                // Convert an internal vector id to Lucene document id.
-                return (int) idMappingReader.get(internalVectorId);
-            }
-
-            @Override
-            public Bits getAcceptOrds(final Bits acceptDocs) {
-                if (acceptDocs != null) {
-                    return new Bits() {
-                        @Override
-                        public boolean get(int internalVectorId) {
-                            // Convert internal vector ordinal to Lucene document id, then check acceptDocs directly.
-                            return acceptDocs.get((int) idMappingReader.get(internalVectorId));
-                        }
-
-                        @Override
-                        public int length() {
-                            return floatVectorValues.size();
-                        }
-                    };
-                }
-
-                return null;
-            }
-
-            @Override
-            public int size() {
-                return floatVectorValues.size();
-            }
-
-            @Override
-            public FloatVectorValues copy() throws IOException {
-                return new SparseFloatVectorValuesImpl(floatVectorValues.copy());
-            }
-        }
-
         final FloatVectorValues vectorValues = nestedIndex.getFloatValues(indexInput);
-        return new SparseFloatVectorValuesImpl(vectorValues);
+        return new FaissFloatVectorValues.SparseFloatVectorValuesImpl(vectorValues, idMappingReader);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/binary/FaissIndexBinaryFlat.java
@@ -5,13 +5,12 @@
 
 package org.opensearch.knn.memoryoptsearch.faiss.binary;
 
-import lombok.RequiredArgsConstructor;
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissSection;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissByteVectorValues;
 
 import java.io.IOException;
 
@@ -59,47 +58,11 @@ public class FaissIndexBinaryFlat extends FaissBinaryIndex {
 
     @Override
     public ByteVectorValues getByteValues(final IndexInput indexInput) throws IOException {
-        return new ByteVectorValuesImpl(binaryFlatVectorSection.slice(indexInput, VECTOR_VALUES_SLICE_NAME));
-    }
-
-    @RequiredArgsConstructor
-    public class ByteVectorValuesImpl extends ByteVectorValues implements HasIndexSlice {
-        final IndexInput indexInput;
-        final byte[] buffer = new byte[codeSize];
-
-        @Override
-        public byte[] vectorValue(int internalVectorId) throws IOException {
-            final long offset = (long) internalVectorId * codeSize;
-            indexInput.seek(offset);
-            indexInput.readBytes(buffer, 0, codeSize);
-            return buffer;
-        }
-
-        @Override
-        public int dimension() {
-            return dimension;
-        }
-
-        public int getVectorByteLength() {
-            return codeSize;
-        }
-
-        @Override
-        public int size() {
-            return totalNumberOfVectors;
-        }
-
-        @Override
-        public ByteVectorValues copy() {
-            return new ByteVectorValuesImpl(indexInput.clone());
-        }
-
-        /**
-         * Returns an IndexInput from which to read this instance's values, or null if not available.
-         */
-        @Override
-        public IndexInput getSlice() {
-            return indexInput;
-        }
+        return new FaissByteVectorValues(
+            binaryFlatVectorSection.slice(indexInput, VECTOR_VALUES_SLICE_NAME),
+            codeSize,
+            dimension,
+            totalNumberOfVectors
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissByteVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissByteVectorValues.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.vectorvalues;
+
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.store.IndexInput;
+
+import java.io.IOException;
+
+/**
+ * A {@link ByteVectorValues} implementation that reads byte-encoded vectors directly from a FAISS
+ * index section via an {@link IndexInput}.
+ * <p>
+ * Each vector is located by seeking to {@code internalVectorId * codeSize} within the backing
+ * {@link IndexInput} and reading {@code codeSize} bytes. This is used for scalar-quantized vectors
+ * where {@code codeSize} may differ from {@code dimension} (e.g., SQ8 uses 1 byte per dimension,
+ * while SQfp16 uses 2 bytes per dimension).
+ * <p>
+ * A single reusable buffer is used across calls to {@link #vectorValue(int)}, so callers must
+ * consume or copy the returned array before the next call.
+ * <p>
+ * Implements {@link HasIndexSlice} to expose the underlying {@link IndexInput} for prefetching
+ * or direct access by native code.
+ */
+public class FaissByteVectorValues extends ByteVectorValues implements HasIndexSlice {
+    private final IndexInput indexInput;
+    private final byte[] buffer;
+    private final int codeSize;
+    private final int dimension;
+    private final int totalNumberOfVectors;
+
+    /**
+     * @param indexInput           The {@link IndexInput} positioned at the start of the vector data section.
+     * @param codeSize             The byte size of a single encoded vector (may differ from dimension for quantized vectors).
+     * @param dimension            The logical vector dimension.
+     * @param totalNumberOfVectors The total number of vectors in this section.
+     */
+    public FaissByteVectorValues(final IndexInput indexInput, int codeSize, int dimension, int totalNumberOfVectors) {
+        this.indexInput = indexInput;
+        this.codeSize = codeSize;
+        this.dimension = dimension;
+        this.totalNumberOfVectors = totalNumberOfVectors;
+        this.buffer = new byte[codeSize];
+    }
+
+    /**
+     * Return the vector value for the given vector ordinal which must be in [0, size() - 1],
+     * otherwise IndexOutOfBoundsException is thrown. The returned array may be shared across calls.
+     *
+     * @return the vector value
+     */
+    @Override
+    public byte[] vectorValue(int internalVectorId) throws IOException {
+        final long offset = (long) internalVectorId * codeSize;
+        indexInput.seek(offset);
+        indexInput.readBytes(buffer, 0, codeSize);
+        return buffer;
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    /**
+     * Returns the byte length of a single vector, which equals {@code codeSize}. Default lucene returns
+     * dimension multiplied by float byte size, hence we need to override this method
+     */
+    @Override
+    public int getVectorByteLength() {
+        return codeSize;
+    }
+
+    @Override
+    public int size() {
+        return totalNumberOfVectors;
+    }
+
+    @Override
+    public ByteVectorValues copy() {
+        return new FaissByteVectorValues(indexInput.clone(), codeSize, dimension, totalNumberOfVectors);
+    }
+
+    /**
+     * Returns an IndexInput from which to read this instance's values, or null if not available.
+     */
+    @Override
+    public IndexInput getSlice() {
+        return indexInput;
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValues.java
@@ -8,6 +8,9 @@ package org.opensearch.knn.memoryoptsearch.faiss.vectorvalues;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
 
 import java.io.IOException;
 
@@ -66,5 +69,85 @@ public class FaissFloatVectorValues extends FloatVectorValues implements HasInde
     @Override
     public IndexInput getSlice() {
         return indexInput;
+    }
+
+    /**
+     * A {@link FloatVectorValues} wrapper for sparse or nested cases that maps internal vector IDs
+     * to Lucene document IDs via a {@link DirectMonotonicReader}.
+     * <p>
+     * Delegates vector reads to the wrapped {@link FloatVectorValues} and translates ordinals
+     * in {@link #ordToDoc(int)} and {@link #getAcceptOrds(Bits)}.
+     */
+    public static class SparseFloatVectorValuesImpl extends WrappedFloatVectorValues implements HasIndexSlice {
+        private final DirectMonotonicReader idMappingReader;
+
+        public SparseFloatVectorValuesImpl(final FloatVectorValues vectorValues, final DirectMonotonicReader idMappingReader) {
+            super(vectorValues);
+            this.idMappingReader = idMappingReader;
+            if ((vectorValues instanceof HasIndexSlice) == false) {
+                throw new IllegalArgumentException(
+                    "SparseFloatVectorValuesImpl needs an instance of "
+                        + "FloatVectorValues which implements HasIndexSlice interface. "
+                        + vectorValues.getClass().getCanonicalName()
+                        + " doesn't implement "
+                        + HasIndexSlice.class
+                        + "interface"
+                );
+            }
+        }
+
+        @Override
+        public float[] vectorValue(int internalVectorId) throws IOException {
+            return floatVectorValues.vectorValue(internalVectorId);
+        }
+
+        @Override
+        public int dimension() {
+            return floatVectorValues.dimension();
+        }
+
+        @Override
+        public int ordToDoc(int internalVectorId) {
+            return (int) idMappingReader.get(internalVectorId);
+        }
+
+        @Override
+        public int getVectorByteLength() {
+            return floatVectorValues.getVectorByteLength();
+        }
+
+        @Override
+        public Bits getAcceptOrds(final Bits acceptDocs) {
+            if (acceptDocs != null) {
+                return new Bits() {
+                    @Override
+                    public boolean get(int internalVectorId) {
+                        return acceptDocs.get((int) idMappingReader.get(internalVectorId));
+                    }
+
+                    @Override
+                    public int length() {
+                        return floatVectorValues.size();
+                    }
+                };
+            }
+            return null;
+        }
+
+        @Override
+        public int size() {
+            return floatVectorValues.size();
+        }
+
+        @Override
+        public FloatVectorValues copy() throws IOException {
+            return new SparseFloatVectorValuesImpl(floatVectorValues.copy(), idMappingReader);
+        }
+
+        @Override
+        public IndexInput getSlice() {
+            // Since in constructor we are already validating the instance type we don't need another validation here
+            return ((HasIndexSlice) floatVectorValues).getSlice();
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelperTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/PrefetchableVectorValuesHelperTests.java
@@ -12,8 +12,9 @@ import org.apache.lucene.store.IndexInput;
 import org.mockito.MockedStatic;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexScalarQuantizedFlat;
-import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissIndexBinaryFlat;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissByteVectorValues;
 import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues.SparseFloatVectorValuesImpl;
 
 import java.io.IOException;
 
@@ -63,12 +64,28 @@ public class PrefetchableVectorValuesHelperTests extends KNNTestCase {
         when(mockSlice.length()).thenReturn(200L * 1024);
         int vectorByteLength = 64;
 
-        FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl = mock(FaissIndexBinaryFlat.ByteVectorValuesImpl.class);
+        FaissByteVectorValues binaryImpl = mock(FaissByteVectorValues.class);
         when(binaryImpl.getSlice()).thenReturn(mockSlice);
         when(binaryImpl.getVectorByteLength()).thenReturn(vectorByteLength);
 
         try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
             PrefetchableVectorValuesHelper.mayBeDoPrefetch(binaryImpl, nodes, numNodes);
+
+            mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, numNodes));
+        }
+    }
+
+    public void testMayBeDoPrefetch_whenSparseFloatVectorValuesImpl_thenPrefetchesViaHasIndexSlice() throws IOException {
+        IndexInput mockSlice = mock(IndexInput.class);
+        when(mockSlice.length()).thenReturn(200L * 1024);
+        int vectorByteLength = 512;
+
+        SparseFloatVectorValuesImpl sparseImpl = mock(SparseFloatVectorValuesImpl.class);
+        when(sparseImpl.getSlice()).thenReturn(mockSlice);
+        when(sparseImpl.getVectorByteLength()).thenReturn(vectorByteLength);
+
+        try (MockedStatic<PrefetchHelper> mockedPrefetchHelper = mockStatic(PrefetchHelper.class)) {
+            PrefetchableVectorValuesHelper.mayBeDoPrefetch(sparseImpl, nodes, numNodes);
 
             mockedPrefetchHelper.verify(() -> PrefetchHelper.prefetch(mockSlice, 0, vectorByteLength, nodes, numNodes));
         }
@@ -105,7 +122,7 @@ public class PrefetchableVectorValuesHelperTests extends KNNTestCase {
         when(mockSlice.length()).thenReturn(200L * 1024);
         int vectorByteLength = 64;
 
-        FaissIndexBinaryFlat.ByteVectorValuesImpl binaryImpl = mock(FaissIndexBinaryFlat.ByteVectorValuesImpl.class);
+        FaissByteVectorValues binaryImpl = mock(FaissByteVectorValues.class);
         when(binaryImpl.getSlice()).thenReturn(mockSlice);
         when(binaryImpl.getVectorByteLength()).thenReturn(vectorByteLength);
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIdMapIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIdMapIndexTests.java
@@ -21,6 +21,8 @@ import org.opensearch.knn.memoryoptsearch.faiss.FaissHNSWIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIdMapIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissByteVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.vectorvalues.FaissFloatVectorValues;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -262,12 +264,28 @@ public class FaissIdMapIndexTests extends KNNTestCase {
             mockStaticFaissIndex.when(() -> FaissIndex.load(any())).thenReturn(nestedIndex);
 
             // Byte vectors
-            final ByteVectorValues mockByteValues = mock(ByteVectorValues.class);
+            final Bits mockBitsFromByteVectors = mock(Bits.class);
+            final AtomicInteger idx1 = new AtomicInteger(0);
+            doAnswer((Answer<Void>) invocation -> {
+                final int convertedDocId = invocation.getArgument(0);
+                assertEquals(mappingTable[idx1.getAndIncrement()], convertedDocId);
+                return null;
+            }).when(mockBitsFromByteVectors).get(anyInt());
+
+            final ByteVectorValues mockByteValues = mock(FaissByteVectorValues.class);
+
             when(nestedIndex.getByteValues(any())).thenReturn(mockByteValues);
             when(mockByteValues.size()).thenReturn(Math.toIntExact(totalNumberOfVectors));
 
             // Float vectors
-            final FloatVectorValues mockFloatValues = mock(FloatVectorValues.class);
+            final Bits mockBitsFromFloatVectors = mock(Bits.class);
+            final AtomicInteger idx2 = new AtomicInteger(0);
+            doAnswer((Answer<Void>) invocation -> {
+                final int convertedDocId = invocation.getArgument(0);
+                assertEquals(mappingTable[idx2.getAndIncrement()], convertedDocId);
+                return null;
+            }).when(mockBitsFromFloatVectors).get(anyInt());
+            final FloatVectorValues mockFloatValues = mock(FaissFloatVectorValues.class);
             when(nestedIndex.getFloatValues(any())).thenReturn(mockFloatValues);
             when(mockFloatValues.size()).thenReturn(Math.toIntExact(totalNumberOfVectors));
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexBinaryFlatTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexBinaryFlatTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.memoryoptsearch;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
@@ -80,6 +81,27 @@ public class FaissIndexBinaryFlatTests extends KNNTestCase {
         // Validate the last vector values
         vector = values.vectorValue(values.size() - 1);
         assertArrayEquals(LAST_VECTOR, vector);
+        assertEquals(CODE_SIZE, values.getVectorByteLength());
+        assertTrue(values instanceof HasIndexSlice);
+        assertNotNull(((HasIndexSlice) values).getSlice());
+
+        // validate copy instance is correct is or not
+        final ByteVectorValues copiedInstance = values.copy();
+        assertEquals(BINARY_DIMENSION, copiedInstance.dimension());
+        assertEquals(NUM_VECTORS, copiedInstance.size());
+
+        // Validate the first vector values
+        vector = copiedInstance.vectorValue(0);
+        assertArrayEquals(FIRST_VECTOR, vector);
+
+        // Validate the last vector values
+        vector = copiedInstance.vectorValue(copiedInstance.size() - 1);
+        assertArrayEquals(LAST_VECTOR, vector);
+
+        assertEquals(CODE_SIZE, copiedInstance.getVectorByteLength());
+        assertTrue(copiedInstance instanceof HasIndexSlice);
+        assertNotNull(((HasIndexSlice) copiedInstance).getSlice());
+
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexFloatFlatTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexFloatFlatTests.java
@@ -66,6 +66,22 @@ public class FaissIndexFloatFlatTests extends KNNTestCase {
         for (int i = 0; i < DIMENSION; ++i) {
             assertEquals(ANSWER_LAST_VECTORS[i], vector[i], 1e-3);
         }
+
+        // Do Validation on the copy instance
+        FloatVectorValues copiedVectorValues = values.copy();
+        assertEquals(DIMENSION, copiedVectorValues.dimension());
+        assertEquals(NUM_VECTORS, copiedVectorValues.size());
+
+        vector = copiedVectorValues.vectorValue(0);
+        assertEquals(DIMENSION, vector.length);
+        for (int i = 0; i < DIMENSION; ++i) {
+            assertEquals(ANSWER_FIRST_VECTORS[i], vector[i], 1e-3);
+        }
+
+        vector = copiedVectorValues.vectorValue(NUM_VECTORS - 1);
+        for (int i = 0; i < DIMENSION; ++i) {
+            assertEquals(ANSWER_LAST_VECTORS[i], vector[i], 1e-3);
+        }
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/vectorvalues/FaissFloatVectorValuesTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss.vectorvalues;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.opensearch.common.lucene.store.ByteArrayIndexInput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.vectorvalues.TestVectorValues;
+import org.opensearch.knn.memoryoptsearch.faiss.MonotonicIntegerSequenceEncoder;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+
+public class FaissFloatVectorValuesTests extends KNNTestCase {
+
+    private static final int DIMENSION = 4;
+    private static final int NUM_VECTORS = 5;
+    // Sparse mapping: internalId 0->0, 1->2, 2->5, 3->7, 4->10
+    private static final int[] DOC_ID_MAPPING = { 0, 2, 5, 7, 10 };
+
+    @SneakyThrows
+    public void testSparseVectorsValues_whenValidInput_thenSuccess() {
+        final FaissFloatVectorValues baseValues = createFaissFloatVectorValues();
+        final DirectMonotonicReader idReader = createIdMappingReader(DOC_ID_MAPPING);
+        final FaissFloatVectorValues.SparseFloatVectorValuesImpl sparse = new FaissFloatVectorValues.SparseFloatVectorValuesImpl(
+            baseValues,
+            idReader
+        );
+
+        // Verify dimension and size delegation
+        assertEquals(DIMENSION, sparse.dimension());
+        assertEquals(NUM_VECTORS, sparse.size());
+        assertEquals(DIMENSION * Float.BYTES, sparse.getVectorByteLength());
+
+        // Verify vectorValue delegation
+        for (int i = 0; i < NUM_VECTORS; i++) {
+            float[] expected = baseValues.vectorValue(i);
+            float[] actual = sparse.vectorValue(i);
+            assertArrayEquals(expected, actual, 0f);
+        }
+
+        // Verify ordToDoc mapping
+        for (int i = 0; i < NUM_VECTORS; i++) {
+            assertEquals(DOC_ID_MAPPING[i], sparse.ordToDoc(i));
+        }
+
+        // Verify getSlice returns the underlying IndexInput
+        assertNotNull(sparse.getSlice());
+        assertEquals(baseValues.getSlice(), sparse.getSlice());
+    }
+
+    @SneakyThrows
+    public void testSparseVectorsValues_getAcceptOrds_whenAcceptDocsProvided_thenFiltersCorrectly() {
+        final FaissFloatVectorValues baseValues = createFaissFloatVectorValues();
+        final DirectMonotonicReader idReader = createIdMappingReader(DOC_ID_MAPPING);
+        final FaissFloatVectorValues.SparseFloatVectorValuesImpl sparse = new FaissFloatVectorValues.SparseFloatVectorValuesImpl(
+            baseValues,
+            idReader
+        );
+
+        // acceptDocs accepts only even doc IDs
+        Bits acceptDocs = new Bits() {
+            @Override
+            public boolean get(int index) {
+                return index % 2 == 0;
+            }
+
+            @Override
+            public int length() {
+                return 11;
+            }
+        };
+
+        Bits acceptOrds = sparse.getAcceptOrds(acceptDocs);
+        assertNotNull(acceptOrds);
+        assertEquals(NUM_VECTORS, acceptOrds.length());
+
+        // internalId 0 -> docId 0 (even) -> true
+        assertTrue(acceptOrds.get(0));
+        // internalId 1 -> docId 2 (even) -> true
+        assertTrue(acceptOrds.get(1));
+        // internalId 2 -> docId 5 (odd) -> false
+        assertFalse(acceptOrds.get(2));
+        // internalId 3 -> docId 7 (odd) -> false
+        assertFalse(acceptOrds.get(3));
+        // internalId 4 -> docId 10 (even) -> true
+        assertTrue(acceptOrds.get(4));
+    }
+
+    @SneakyThrows
+    public void testSparseVectorsValues_getAcceptOrds_whenNull_thenReturnsNull() {
+        final FaissFloatVectorValues baseValues = createFaissFloatVectorValues();
+        final DirectMonotonicReader idReader = createIdMappingReader(DOC_ID_MAPPING);
+        final FaissFloatVectorValues.SparseFloatVectorValuesImpl sparse = new FaissFloatVectorValues.SparseFloatVectorValuesImpl(
+            baseValues,
+            idReader
+        );
+
+        assertNull(sparse.getAcceptOrds(null));
+    }
+
+    @SneakyThrows
+    public void testSparseVectorsValues_copy_thenReturnsCopy() {
+        final FaissFloatVectorValues baseValues = createFaissFloatVectorValues();
+        final DirectMonotonicReader idReader = createIdMappingReader(DOC_ID_MAPPING);
+        final FaissFloatVectorValues.SparseFloatVectorValuesImpl sparse = new FaissFloatVectorValues.SparseFloatVectorValuesImpl(
+            baseValues,
+            idReader
+        );
+
+        var copy = sparse.copy();
+        assertNotNull(copy);
+        assertTrue(copy instanceof FaissFloatVectorValues.SparseFloatVectorValuesImpl);
+        assertEquals(sparse.dimension(), copy.dimension());
+        assertEquals(sparse.size(), copy.size());
+    }
+
+    public void testSparseVectorsValues_whenNonHasIndexSlice_thenThrows() {
+        final List<float[]> vectors = List.of(new float[] { 1.0f, 2.0f, 3.0f, 4.0f });
+        final TestVectorValues.PreDefinedFloatVectorValues nonSliceValues = new TestVectorValues.PreDefinedFloatVectorValues(vectors);
+
+        expectThrows(IllegalArgumentException.class, () -> new FaissFloatVectorValues.SparseFloatVectorValuesImpl(nonSliceValues, null));
+    }
+
+    private FaissFloatVectorValues createFaissFloatVectorValues() {
+        int oneVectorByteSize = DIMENSION * Float.BYTES;
+        ByteBuffer buf = ByteBuffer.allocate(NUM_VECTORS * oneVectorByteSize).order(ByteOrder.BIG_ENDIAN);
+        for (int i = 0; i < NUM_VECTORS; i++) {
+            for (int j = 0; j < DIMENSION; j++) {
+                buf.putFloat(i * 10.0f + j);
+            }
+        }
+        IndexInput indexInput = new ByteArrayIndexInput("test", buf.array());
+        return new FaissFloatVectorValues(indexInput, oneVectorByteSize, DIMENSION, NUM_VECTORS);
+    }
+
+    @SneakyThrows
+    private DirectMonotonicReader createIdMappingReader(int[] mapping) {
+        ByteBuffersDataOutput dataOutput = new ByteBuffersDataOutput();
+        ByteBuffersIndexOutput indexOutput = new ByteBuffersIndexOutput(dataOutput, "test", "test");
+        for (int docId : mapping) {
+            indexOutput.writeLong(docId);
+        }
+        indexOutput.close();
+        IndexInput input = new ByteArrayIndexInput("test", dataOutput.toArrayCopy());
+        return MonotonicIntegerSequenceEncoder.encode(mapping.length, input);
+    }
+}


### PR DESCRIPTION
### Description
Integrated prefetch for SparseFloatVectorValues with Faiss Indices. In the earlier PRs, the prefetch was only working when Vectorvalues were dense. With this change prefetch will work with sparse float vector values too of Faiss(fp32, fp16, binary). 

### Next Step
1. Integrate Prefetch with SparseByteVectorValues. I am facing some issues in distance computation with Lucene when MemorySegment based distance computation happens. Since Lucene and Faiss stores data in different fashion for byte. Will take it in next PR. 

### Related Issues
https://github.com/opensearch-project/k-NN/issues/2577

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
