### PR TITLE
Resolve FlatVectorScorer

### DIFF
--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/ADCFlatVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/ADCFlatVectorsScorer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.plugin.script.KNNScoringUtil;
+
+import java.io.IOException;
+
+/**
+ * {@link FlatVectorsScorer} implementation for Asymmetric Distance Computation (ADC).
+ * Scores float query vectors against quantized byte vectors stored in the index.
+ * Supports {@link SpaceType#L2}, {@link SpaceType#INNER_PRODUCT}, and {@link SpaceType#COSINESIMIL}.
+ */
+public class ADCFlatVectorsScorer implements FlatVectorsScorer {
+    private final SpaceType spaceType;
+
+    /**
+     * @param spaceType the space type used to determine the scoring formula
+     */
+    public ADCFlatVectorsScorer(SpaceType spaceType) {
+        this.spaceType = spaceType;
+    }
+
+    /**
+     * Not supported — ADC only operates on float query vectors against quantized byte vectors.
+     */
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        KnnVectorValues knnVectorValues,
+        byte[] target
+    ) {
+        throw new UnsupportedOperationException("ADC does not support byte vector search");
+    }
+
+    /**
+     * Returns a {@link RandomVectorScorer} that scores a float query vector against quantized byte vectors
+     * using the ADC scoring formula for the configured {@link SpaceType}.
+     *
+     * @param vectorSimilarityFunction  ignored; space type is determined at construction time
+     * @param knnVectorValues           must be an instance of {@link ByteVectorValues}
+     * @param target                    the float query vector
+     * @return a scorer computing ADC distance between {@code target} and each indexed byte vector
+     * @throws IllegalArgumentException if {@code knnVectorValues} is not a {@link ByteVectorValues}
+     */
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        KnnVectorValues knnVectorValues,
+        float[] target
+    ) {
+        if (!(knnVectorValues instanceof ByteVectorValues byteVectorValues)) {
+            throw new IllegalArgumentException(
+                "Expected " + ByteVectorValues.class.getSimpleName() + " for ADC scorer, got " + knnVectorValues.getClass().getSimpleName()
+            );
+        }
+
+        return switch (spaceType) {
+            case L2 -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                @Override
+                public float score(int internalVectorId) throws IOException {
+                    final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                    return SpaceType.L2.scoreTranslation(KNNScoringUtil.l2SquaredADC(target, quantizedByteVector));
+                }
+            };
+            case INNER_PRODUCT, COSINESIMIL -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                @Override
+                public float score(int internalVectorId) throws IOException {
+                    final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                    return SpaceType.INNER_PRODUCT.scoreTranslation(-1 * KNNScoringUtil.innerProductADC(target, quantizedByteVector));
+                }
+            };
+            default -> throw new IllegalArgumentException("Unsupported space type: " + spaceType);
+        };
+    }
+
+    /**
+     * Not supported — ADC does not support supplier-based scoring.
+     */
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction similarityFunction,
+        KnnVectorValues vectorValues
+    ) {
+        throw new UnsupportedOperationException("ADC does not support RandomVectorScorerSupplier");
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -7,44 +7,35 @@ package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.experimental.UtilityClass;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
-import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.KnnVectorValues;
-import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.util.hnsw.RandomVectorScorer;
-import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
-import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
-import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
-import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
-import java.io.IOException;
-import java.util.EnumMap;
-import java.util.Map;
+import java.util.List;
 
+/**
+ * Provides the appropriate {@link FlatVectorsScorer} for a given field by iterating a registered list of
+ * {@link FlatVectorsScorerResolver}s. The first resolver whose {@link FlatVectorsScorerResolver#canResolve}
+ * returns {@code true} is used. Falls back to {@code delegateScorer} if no resolver matches.
+ *
+ * <p>To add support for a new scorer, implement {@link FlatVectorsScorerResolver} as a static inner class
+ * in {@link FlatVectorsScorerResolver} and register it in {@link #FLAT_VECTORS_SCORER_RESOLVER_LIST}.
+ */
 @UtilityClass
 public class FlatVectorsScorerProvider {
-    private static final FlatVectorsScorer HAMMING_VECTOR_SCORER = new HammingFlatVectorsScorer();
-    private static final Map<SpaceType, FlatVectorsScorer> ADC_FLAT_SCORERS = initializeAdcFlatScorers();
 
-    private static Map<SpaceType, FlatVectorsScorer> initializeAdcFlatScorers() {
-        Map<SpaceType, FlatVectorsScorer> scorers = new EnumMap<>(SpaceType.class);
-        scorers.put(SpaceType.L2, new ADCFlatVectorsScorer(KNNVectorSimilarityFunction.EUCLIDEAN, SpaceType.L2));
-        scorers.put(SpaceType.COSINESIMIL, new ADCFlatVectorsScorer(KNNVectorSimilarityFunction.COSINE, SpaceType.COSINESIMIL));
-        scorers.put(
-            SpaceType.INNER_PRODUCT,
-            new ADCFlatVectorsScorer(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, SpaceType.INNER_PRODUCT)
-        );
-        return scorers;
-    }
+    private static final List<FlatVectorsScorerResolver> FLAT_VECTORS_SCORER_RESOLVER_LIST = List.of(
+        new FlatVectorsScorerResolver.AdcScorerResolver(),
+        new FlatVectorsScorerResolver.FaissSQScorerResolver(),
+        new FlatVectorsScorerResolver.HammingScorerResolver()
+    );
 
     /**
      * Returns the appropriate {@link FlatVectorsScorer} for the given field.
-     * Selects an ADC, Hamming, or delegate scorer based on the field's quantization config and space type.
+     * Iterates registered {@link FlatVectorsScorerResolver}s in order; falls back to {@code delegateScorer}.
      *
-     * @param fieldInfo       the field info containing space type and quantization attributes
-     * @param delegateScorer  the default scorer to fall back to when no specialized scorer applies
+     * @param fieldInfo           the field metadata containing space type and quantization attributes
+     * @param similarityFunction  the similarity function for the query
+     * @param delegateScorer      the default scorer to fall back to when no resolver matches
      * @return the resolved {@link FlatVectorsScorer}
      */
     public static FlatVectorsScorer getFlatVectorsScorer(
@@ -52,124 +43,10 @@ public class FlatVectorsScorerProvider {
         final KNNVectorSimilarityFunction similarityFunction,
         final FlatVectorsScorer delegateScorer
     ) {
-        // TODO: Refactor with a Resolver
-        // Handle Special case of ADC first.
-        if (FieldInfoExtractor.isAdc(fieldInfo)) {
-            return ADC_FLAT_SCORERS.get(FieldInfoExtractor.getSpaceType(null, fieldInfo));
-        } else if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
-                return new Faiss104ScalarQuantizedVectorScorer(delegateScorer);
-            } else if (KNNVectorSimilarityFunction.HAMMING == similarityFunction) {
-                // Since Lucene doesn't provide hamming distance scorer, we return our own hamming distance scorer
-                return HAMMING_VECTOR_SCORER;
-            } else {
-                // For all other cases just return the delegate scorer.
-                return delegateScorer;
-            }
-    }
-
-    private static class ADCFlatVectorsScorer implements FlatVectorsScorer {
-        private final KNNVectorSimilarityFunction knnSimilarityFunction;
-        private final SpaceType spaceType;
-
-        public ADCFlatVectorsScorer(KNNVectorSimilarityFunction knnSimilarityFunction, SpaceType spaceType) {
-            this.knnSimilarityFunction = knnSimilarityFunction;
-            this.spaceType = spaceType;
-        }
-
-        @Override
-        public RandomVectorScorer getRandomVectorScorer(
-            VectorSimilarityFunction vectorSimilarityFunction,
-            KnnVectorValues knnVectorValues,
-            byte[] target
-        ) {
-            throw new UnsupportedOperationException("ADC does not support byte vector search");
-        }
-
-        @Override
-        public RandomVectorScorer getRandomVectorScorer(
-            VectorSimilarityFunction vectorSimilarityFunction,
-            KnnVectorValues knnVectorValues,
-            float[] target
-        ) {
-            if (!(knnVectorValues instanceof ByteVectorValues byteVectorValues)) {
-                throw new IllegalArgumentException(
-                    "Expected "
-                        + ByteVectorValues.class.getSimpleName()
-                        + " for ADC scorer, got "
-                        + knnVectorValues.getClass().getSimpleName()
-                );
-            }
-
-            return switch (spaceType) {
-                case L2 -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
-                    @Override
-                    public float score(int internalVectorId) throws IOException {
-                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                        return SpaceType.L2.scoreTranslation(KNNScoringUtil.l2SquaredADC(target, quantizedByteVector));
-                    }
-                };
-                case INNER_PRODUCT, COSINESIMIL -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
-                    @Override
-                    public float score(int internalVectorId) throws IOException {
-                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                        return SpaceType.INNER_PRODUCT.scoreTranslation(-1 * KNNScoringUtil.innerProductADC(target, quantizedByteVector));
-                    }
-                };
-                default -> throw new IllegalArgumentException("Unsupported space type: " + spaceType);
-            };
-        }
-
-        @Override
-        public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
-            VectorSimilarityFunction similarityFunction,
-            KnnVectorValues vectorValues
-        ) {
-            throw new UnsupportedOperationException("ADC does not support RandomVectorScorerSupplier");
-        }
-    }
-
-    private static class HammingFlatVectorsScorer implements FlatVectorsScorer {
-
-        @Override
-        public RandomVectorScorer getRandomVectorScorer(
-            VectorSimilarityFunction vectorSimilarityFunction,
-            KnnVectorValues knnVectorValues,
-            byte[] target
-        ) {
-            if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
-                return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
-                    @Override
-                    public float score(int internalVectorId) throws IOException {
-                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
-                        return KNNVectorSimilarityFunction.HAMMING.compare(target, quantizedByteVector);
-                    }
-                };
-            }
-
-            throw new IllegalArgumentException(
-                "Expected "
-                    + ByteVectorValues.class.getSimpleName()
-                    + " for hamming vector scorer, got "
-                    + knnVectorValues.getClass().getSimpleName()
-            );
-        }
-
-        @Override
-        public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
-            VectorSimilarityFunction vectorSimilarityFunction,
-            KnnVectorValues knnVectorValues
-        ) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public RandomVectorScorer getRandomVectorScorer(
-            VectorSimilarityFunction vectorSimilarityFunction,
-            KnnVectorValues knnVectorValues,
-            float[] target
-        ) {
-            throw new UnsupportedOperationException();
-        }
+        return FLAT_VECTORS_SCORER_RESOLVER_LIST.stream()
+            .filter(r -> r.canResolve(fieldInfo, similarityFunction))
+            .map(r -> r.resolve(fieldInfo, similarityFunction, delegateScorer))
+            .findFirst()
+            .orElse(delegateScorer);
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerResolver.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FieldInfo;
+import org.opensearch.knn.common.FieldInfoExtractor;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Strategy interface for resolving a {@link FlatVectorsScorer} based on field metadata and similarity function.
+ * Implementations are evaluated in order by {@link FlatVectorsScorerProvider}; the first one whose
+ * {@link #canResolve} returns {@code true} wins. To add a new scorer, implement this interface as a
+ * static inner class here and register it in {@link FlatVectorsScorerProvider}.
+ */
+public interface FlatVectorsScorerResolver {
+
+    /**
+     * Returns {@code true} if this resolver can handle the given field and similarity function.
+     *
+     * @param fieldInfo           the field metadata
+     * @param similarityFunction  the similarity function for the query
+     * @return {@code true} if this resolver applies
+     */
+    boolean canResolve(FieldInfo fieldInfo, KNNVectorSimilarityFunction similarityFunction);
+
+    /**
+     * Returns the {@link FlatVectorsScorer} for the given field.
+     * Only called when {@link #canResolve} returns {@code true}.
+     *
+     * @param fieldInfo           the field metadata
+     * @param similarityFunction  the similarity function for the query
+     * @param delegateScorer      the default scorer, available for wrapping if needed
+     * @return the resolved {@link FlatVectorsScorer}
+     */
+    FlatVectorsScorer resolve(FieldInfo fieldInfo, KNNVectorSimilarityFunction similarityFunction, FlatVectorsScorer delegateScorer);
+
+    /**
+     * Resolves to an {@link ADCFlatVectorsScorer} for fields using Asymmetric Distance Computation (ADC).
+     * Selects the scorer based on the field's {@link SpaceType}.
+     */
+    class AdcScorerResolver implements FlatVectorsScorerResolver {
+        private static final Map<SpaceType, FlatVectorsScorer> ADC_FLAT_SCORERS = new EnumMap<>(SpaceType.class);
+
+        static {
+            ADC_FLAT_SCORERS.put(SpaceType.L2, new ADCFlatVectorsScorer(SpaceType.L2));
+            ADC_FLAT_SCORERS.put(SpaceType.COSINESIMIL, new ADCFlatVectorsScorer(SpaceType.COSINESIMIL));
+            ADC_FLAT_SCORERS.put(SpaceType.INNER_PRODUCT, new ADCFlatVectorsScorer(SpaceType.INNER_PRODUCT));
+        }
+
+        @Override
+        public boolean canResolve(FieldInfo fieldInfo, KNNVectorSimilarityFunction similarityFunction) {
+            return FieldInfoExtractor.isAdc(fieldInfo);
+        }
+
+        @Override
+        public FlatVectorsScorer resolve(
+            FieldInfo fieldInfo,
+            KNNVectorSimilarityFunction similarityFunction,
+            FlatVectorsScorer delegateScorer
+        ) {
+            return ADC_FLAT_SCORERS.get(FieldInfoExtractor.getSpaceType(null, fieldInfo));
+        }
+    }
+
+    /**
+     * Resolves to a {@link HammingFlatVectorsScorer} when the similarity function is
+     * {@link KNNVectorSimilarityFunction#HAMMING}. Used because Lucene does not provide a native Hamming scorer.
+     */
+    class HammingScorerResolver implements FlatVectorsScorerResolver {
+        private static final FlatVectorsScorer HAMMING_FLAT_VECTORS_SCORER = new HammingFlatVectorsScorer();
+
+        @Override
+        public boolean canResolve(FieldInfo fieldInfo, KNNVectorSimilarityFunction similarityFunction) {
+            return KNNVectorSimilarityFunction.HAMMING == similarityFunction;
+        }
+
+        @Override
+        public FlatVectorsScorer resolve(
+            FieldInfo fieldInfo,
+            KNNVectorSimilarityFunction similarityFunction,
+            FlatVectorsScorer delegateScorer
+        ) {
+            return HAMMING_FLAT_VECTORS_SCORER;
+        }
+    }
+
+    /**
+     * Resolves to a {@link Faiss104ScalarQuantizedVectorScorer} for fields using Faiss scalar quantization
+     * with 1-bit quantization ({@link FaissSQEncoder.Bits#ONE}). Wraps the delegate scorer to be used as a fallback scorer
+     * when SIMD acceleration is not applicable
+     */
+    class FaissSQScorerResolver implements FlatVectorsScorerResolver {
+
+        @Override
+        public boolean canResolve(FieldInfo fieldInfo, KNNVectorSimilarityFunction similarityFunction) {
+            return FieldInfoExtractor.isSQField(fieldInfo)
+                && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue();
+        }
+
+        @Override
+        public FlatVectorsScorer resolve(
+            FieldInfo fieldInfo,
+            KNNVectorSimilarityFunction similarityFunction,
+            FlatVectorsScorer delegateScorer
+        ) {
+            return new Faiss104ScalarQuantizedVectorScorer(delegateScorer);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/HammingFlatVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/HammingFlatVectorsScorer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+
+import java.io.IOException;
+
+/**
+ * {@link FlatVectorsScorer} implementation for Hamming distance scoring.
+ * Lucene does not provide a native Hamming distance scorer, so this class fills that gap.
+ * Operates on byte vectors only.
+ */
+public class HammingFlatVectorsScorer implements FlatVectorsScorer {
+
+    /**
+     * Returns a {@link RandomVectorScorer} that computes Hamming distance between the byte query
+     * vector and each indexed byte vector.
+     *
+     * @param vectorSimilarityFunction  ignored; Hamming distance is always used
+     * @param knnVectorValues           must be an instance of {@link ByteVectorValues}
+     * @param target                    the byte query vector
+     * @return a scorer computing Hamming distance between {@code target} and each indexed byte vector
+     * @throws IllegalArgumentException if {@code knnVectorValues} is not a {@link ByteVectorValues}
+     */
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        KnnVectorValues knnVectorValues,
+        byte[] target
+    ) {
+        if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
+            return new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                @Override
+                public float score(int internalVectorId) throws IOException {
+                    final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                    return KNNVectorSimilarityFunction.HAMMING.compare(target, quantizedByteVector);
+                }
+            };
+        }
+
+        throw new IllegalArgumentException(
+            "Expected "
+                + ByteVectorValues.class.getSimpleName()
+                + " for hamming vector scorer, got "
+                + knnVectorValues.getClass().getSimpleName()
+        );
+    }
+
+    /**
+     * Not supported — Hamming scoring does not support supplier-based scoring.
+     */
+    @Override
+    public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        KnnVectorValues knnVectorValues
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Not supported — Hamming distance operates on byte vectors only.
+     */
+    @Override
+    public RandomVectorScorer getRandomVectorScorer(
+        VectorSimilarityFunction vectorSimilarityFunction,
+        KnnVectorValues knnVectorValues,
+        float[] target
+    ) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
@@ -16,8 +16,14 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
 import org.opensearch.knn.memoryoptsearch.faiss.Faiss104ScalarQuantizedVectorScorer;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -30,6 +36,101 @@ public class FlatVectorsScorerProviderTests extends KNNTestCase {
     private static final byte[] BYTE_VECTOR = new byte[] { 1, 3, 0, 90 };
 
     private static final FlatVectorsScorer VECTOR_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+
+    @SneakyThrows
+    public void testAdcScoringL2() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final String adcConfig = QuantizationConfigParser.toCsv(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.ONE_BIT).enableADC(true).build()
+        );
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(adcConfig);
+        when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
+            KNNVectorSimilarityFunction.EUCLIDEAN,
+            VECTOR_SCORER
+        );
+
+        final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+        when(byteVectorValues.vectorValue(anyInt())).thenReturn(BYTE_VECTOR);
+        final RandomVectorScorer vectorScorer = scorer.getRandomVectorScorer(null, byteVectorValues, FLOAT_QUERY);
+        assertNotNull(vectorScorer);
+        // Verify it scores without error
+        vectorScorer.score(0);
+    }
+
+    @SneakyThrows
+    public void testAdcScoringInnerProduct() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final String adcConfig = QuantizationConfigParser.toCsv(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.ONE_BIT).enableADC(true).build()
+        );
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(adcConfig);
+        when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.INNER_PRODUCT.getValue());
+
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
+            KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            VECTOR_SCORER
+        );
+
+        final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+        when(byteVectorValues.vectorValue(anyInt())).thenReturn(BYTE_VECTOR);
+        final RandomVectorScorer vectorScorer = scorer.getRandomVectorScorer(null, byteVectorValues, FLOAT_QUERY);
+        assertNotNull(vectorScorer);
+        vectorScorer.score(0);
+    }
+
+    @SneakyThrows
+    public void testAdcScoringUnsupportedByteQuery() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final String adcConfig = QuantizationConfigParser.toCsv(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.ONE_BIT).enableADC(true).build()
+        );
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(adcConfig);
+        when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
+
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
+            KNNVectorSimilarityFunction.EUCLIDEAN,
+            VECTOR_SCORER
+        );
+
+        final ByteVectorValues byteVectorValues = mock(ByteVectorValues.class);
+        expectThrows(UnsupportedOperationException.class, () -> scorer.getRandomVectorScorer(null, byteVectorValues, BYTE_QUERY));
+    }
+
+    @SneakyThrows
+    public void testFaissSQOneBitResolverReturnsFaissSQScorer() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final String sqConfig = SQConfigParser.toCsv(SQConfig.builder().bits(FaissSQEncoder.Bits.ONE.getValue()).build());
+        when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn(sqConfig);
+
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
+            KNNVectorSimilarityFunction.EUCLIDEAN,
+            VECTOR_SCORER
+        );
+
+        assertNotSame("Expected a specialized SQ scorer, not the delegate", VECTOR_SCORER, scorer);
+    }
+
+    @SneakyThrows
+    public void testFaissSQNonOneBitFallsBackToDelegate() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        // bits=2 should NOT match the FaissSQScorerResolver
+        final String sqConfig = SQConfigParser.toCsv(SQConfig.builder().bits(2).build());
+        when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn(sqConfig);
+
+        final FlatVectorsScorer scorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
+            KNNVectorSimilarityFunction.EUCLIDEAN,
+            VECTOR_SCORER
+        );
+
+        assertSame("Expected delegate scorer for non-1-bit SQ field", VECTOR_SCORER, scorer);
+    }
 
     @SneakyThrows
     public void testHammingScoring() {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerResolverTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerResolverTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch.faiss;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.FieldInfo;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlatVectorsScorerResolverTests extends KNNTestCase {
+
+    private static final FlatVectorsScorer DELEGATE_SCORER = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+
+    // ---- AdcScorerResolver ----
+
+    public void testAdcCanResolve_returnsTrueForAdcField() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.AdcScorerResolver();
+        final FieldInfo fieldInfo = mockAdcField(SpaceType.L2);
+        assertTrue(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN));
+    }
+
+    public void testAdcCanResolve_returnsFalseForNonAdcField() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.AdcScorerResolver();
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        assertFalse(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN));
+    }
+
+    public void testAdcResolve_returnsCorrectScorerForEachSpaceType() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.AdcScorerResolver();
+
+        for (SpaceType spaceType : new SpaceType[] { SpaceType.L2, SpaceType.INNER_PRODUCT, SpaceType.COSINESIMIL }) {
+            final FieldInfo fieldInfo = mockAdcField(spaceType);
+            final FlatVectorsScorer scorer = resolver.resolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, DELEGATE_SCORER);
+            assertNotNull("Expected non-null scorer for space type: " + spaceType, scorer);
+            assertNotSame("Expected ADC scorer, not delegate, for space type: " + spaceType, DELEGATE_SCORER, scorer);
+            assertSame(
+                "Expected same cached instance for repeated resolve of space type: " + spaceType,
+                scorer,
+                resolver.resolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, DELEGATE_SCORER)
+            );
+        }
+    }
+
+    // ---- HammingScorerResolver ----
+
+    public void testHammingCanResolve_returnsTrueForHammingSimilarityFunction() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.HammingScorerResolver();
+        assertTrue(resolver.canResolve(mock(FieldInfo.class), KNNVectorSimilarityFunction.HAMMING));
+    }
+
+    public void testHammingCanResolve_returnsFalseForNonHammingSimilarityFunction() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.HammingScorerResolver();
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        assertFalse(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN));
+        assertFalse(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.COSINE));
+        assertFalse(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT));
+    }
+
+    public void testHammingResolve_returnsSameCachedInstance() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.HammingScorerResolver();
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final FlatVectorsScorer first = resolver.resolve(fieldInfo, KNNVectorSimilarityFunction.HAMMING, DELEGATE_SCORER);
+        final FlatVectorsScorer second = resolver.resolve(fieldInfo, KNNVectorSimilarityFunction.HAMMING, DELEGATE_SCORER);
+        assertNotNull(first);
+        assertSame("Expected same cached HammingFlatVectorsScorer instance", first, second);
+        assertNotSame("Expected Hamming scorer, not delegate", DELEGATE_SCORER, first);
+    }
+
+    // ---- FaissSQScorerResolver ----
+
+    public void testFaissSQCanResolve_returnsTrueForOneBitSQField() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.FaissSQScorerResolver();
+        final FieldInfo fieldInfo = mockSQField(FaissSQEncoder.Bits.ONE.getValue());
+        assertTrue(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN));
+    }
+
+    public void testFaissSQCanResolve_returnsFalseForNonOneBitSQField() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.FaissSQScorerResolver();
+        final FieldInfo fieldInfo = mockSQField(2);
+        assertFalse(resolver.canResolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN));
+    }
+
+    public void testFaissSQCanResolve_returnsFalseForNonSQField() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.FaissSQScorerResolver();
+        assertFalse(resolver.canResolve(mock(FieldInfo.class), KNNVectorSimilarityFunction.EUCLIDEAN));
+    }
+
+    public void testFaissSQResolve_wrapsDelegate() {
+        final FlatVectorsScorerResolver resolver = new FlatVectorsScorerResolver.FaissSQScorerResolver();
+        final FieldInfo fieldInfo = mockSQField(FaissSQEncoder.Bits.ONE.getValue());
+        final FlatVectorsScorer scorer = resolver.resolve(fieldInfo, KNNVectorSimilarityFunction.EUCLIDEAN, DELEGATE_SCORER);
+        assertNotNull(scorer);
+        assertNotSame("Expected a wrapping SQ scorer, not the delegate itself", DELEGATE_SCORER, scorer);
+    }
+
+    // ---- Helpers ----
+
+    private static FieldInfo mockAdcField(SpaceType spaceType) {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final String adcConfig = QuantizationConfigParser.toCsv(
+            QuantizationConfig.builder().quantizationType(ScalarQuantizationType.ONE_BIT).enableADC(true).build()
+        );
+        when(fieldInfo.getAttribute(KNNConstants.QFRAMEWORK_CONFIG)).thenReturn(adcConfig);
+        when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(spaceType.getValue());
+        return fieldInfo;
+    }
+
+    private static FieldInfo mockSQField(int bits) {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        final String sqConfig = SQConfigParser.toCsv(SQConfig.builder().bits(bits).build());
+        when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn(sqConfig);
+        return fieldInfo;
+    }
+}


### PR DESCRIPTION
### Description
Refactor `FlatVectorsScorerProvider` using a `FlatVectorsScorerResolver` interface.

#### Changes
Introduced `FlatVectorsScorerResolver` interface with `canResolve` and `resolve` methods. All resolver implementations (AdcScorerResolver, HammingScorerResolver, FaissSQScorerResolver) live as static inner classes in this file.

Extracted `ADCFlatVectorsScorer` and `HammingFlatVectorsScorer` into their own top-level classes.

`FlatVectorsScorerProvider` is now just a registry — it holds an ordered RESOLVERS list and delegates to the first matching resolver, falling back to the delegate scorer.

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
