### PR TITLE
Add support for pre-quantized vector exact search (#3095)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.2](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+### Features
+
+### Enhancements
+* Use pre-quantized vectors from native engines for exact search [#3095](https://github.com/opensearch-project/k-NN/pull/3095)
+
+### Bug Fixes
+
+### Infrastructure
+
+### Documentation
+
+### Maintenance
+
+### Refactoring

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -21,7 +21,6 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -199,7 +198,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
      *                     if they are all allowed to match.
      */
     @Override
-    public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+    public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
         final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(field);
         // searching with byte vector is not supported by ADC.
         if (trySearchWithMemoryOptimizedSearch(fieldInfo, target, knnCollector, acceptDocs, false)) {
@@ -254,7 +253,7 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         final FieldInfo fieldInfo,
         final Object target,
         final KnnCollector knnCollector,
-        final AcceptDocs acceptDocs,
+        final Bits acceptDocs,
         final boolean isFloatVector
     ) throws IOException {
         // Try with memory optimized searcher

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReader.java
@@ -20,6 +20,8 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
@@ -36,6 +38,7 @@ import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
+import org.opensearch.knn.memoryoptsearch.faiss.FaissMemoryOptimizedSearcher;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationStateCacheManager;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationStateReadConfig;
@@ -47,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.KNN_FIELD;
 
 /**
@@ -98,14 +102,23 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
     }
 
     /**
-     * Returns the {@link ByteVectorValues} for the given {@code field}. The behavior is undefined if
-     * the given field doesn't have KNN vectors enabled on its {@link FieldInfo}. The return value is
-     * never {@code null}.
+     * Returns the {@link ByteVectorValues} for the given field.
+     * Attempts flat vectors reader first, then falls back to quantized vectors if available.
      *
-     * @param field {@link String}
+     * @param field the vector field name
+     * @return {@link ByteVectorValues} for the field, never {@code null}
+     * @throws IOException if an I/O error occurs or no byte vectors are available for the field
      */
     @Override
     public ByteVectorValues getByteVectorValues(final String field) throws IOException {
+        final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(field);
+        if (fieldInfo.getVectorEncoding() == VectorEncoding.FLOAT32) {
+            final ByteVectorValues quantizedVectorValues = getQuantizedVectorValues(fieldInfo);
+            if (quantizedVectorValues != null) {
+                return quantizedVectorValues;
+            }
+            log.warn("No quantized vectors found for field [{}]", field);
+        }
         return flatVectorsReader.getByteVectorValues(field);
     }
 
@@ -152,8 +165,8 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             ((QuantizationConfigKNNCollector) knnCollector).setQuantizationState(quantizationState);
             return;
         }
-
-        if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, true)) {
+        final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(field);
+        if (trySearchWithMemoryOptimizedSearch(fieldInfo, target, knnCollector, acceptDocs, true)) {
             return;
         }
 
@@ -186,8 +199,10 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
      *                     if they are all allowed to match.
      */
     @Override
-    public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
-        if (trySearchWithMemoryOptimizedSearch(field, target, knnCollector, acceptDocs, false)) {
+    public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+        final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(field);
+        // searching with byte vector is not supported by ADC.
+        if (trySearchWithMemoryOptimizedSearch(fieldInfo, target, knnCollector, acceptDocs, false)) {
             return;
         }
 
@@ -236,14 +251,18 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
     }
 
     private boolean trySearchWithMemoryOptimizedSearch(
-        final String field,
+        final FieldInfo fieldInfo,
         final Object target,
         final KnnCollector knnCollector,
-        final Bits acceptDocs,
+        final AcceptDocs acceptDocs,
         final boolean isFloatVector
     ) throws IOException {
         // Try with memory optimized searcher
-        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(field);
+        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
+
+        if (target == null) {
+            throw new FaissMemoryOptimizedSearcher.WarmupInitializationException("Null vector supplied for warmup");
+        }
 
         if (memoryOptimizedSearcher != null) {
             if (isFloatVector) {
@@ -293,8 +312,8 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
         return cacheKeys;
     }
 
-    private VectorSearcher loadMemoryOptimizedSearcherIfRequired(final String fieldName) {
-        final VectorSearcherHolder searcherHolder = vectorSearchers.get(fieldName);
+    private VectorSearcher loadMemoryOptimizedSearcherIfRequired(final FieldInfo fieldInfo) {
+        final VectorSearcherHolder searcherHolder = vectorSearchers.get(fieldInfo.getName());
         if (searcherHolder == null) {
             // This is not KNN field or unsupported field.
             return null;
@@ -308,34 +327,19 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
             if (searcherHolder.isSet()) {
                 return searcherHolder.getVectorSearcher();
             }
-
-            VectorSearcher searcher = null;
-
-            try {
-                final FieldInfo fieldInfo = segmentReadState.fieldInfos.fieldInfo(fieldName);
-                if (fieldInfo != null) {
-                    final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
-                    if (searcherSupplier != null) {
-                        searcher = searcherSupplier.get();
-                        if (searcher != null) {
-                            // It's supported. There can be a case where a certain index type underlying is not yet supported while
-                            // KNNEngine
-                            // itself supports memory optimized searching.
-                            searcherHolder.setVectorSearcher(searcher);
-                        }
-                    }
-                }
-
-                return searcher;
-            } catch (Exception e) {
-                // Close opened searchers first, then suppress
+            final IOSupplier<VectorSearcher> searcherSupplier = getVectorSearcherSupplier(fieldInfo);
+            // It's supported. There can be a case where a certain index type underlying is not yet supported while
+            // KNNEngine itself supports memory optimized searching.
+            if (searcherSupplier != null) {
                 try {
-                    IOUtils.closeWhileHandlingException(searcher);
-                } catch (Exception closeException) {
-                    log.error(closeException.getMessage(), closeException);
+                    searcherHolder.setVectorSearcher(searcherSupplier.get());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
-                throw new RuntimeException(e);
+            } else {
+                log.error("Failed to load memory optimized searcher for field [{}]", fieldInfo.getName());
             }
+            return searcherHolder.getVectorSearcher();
         }
     }
 
@@ -369,6 +373,21 @@ public class NativeEngines990KnnVectorsReader extends KnnVectorsReader {
 
         // Not supported
         return null;
+    }
+
+    /**
+     * Retrieves quantized byte vectors from Faiss memory-optimized searcher.
+     *
+     * @param fieldInfo the field to retrieve vectors for
+     * @return quantized byte vectors, or null if not available
+     * @throws IOException if an I/O error occurs
+     */
+    private ByteVectorValues getQuantizedVectorValues(@NonNull final FieldInfo fieldInfo) throws IOException {
+        if (fieldInfo.getAttribute(QFRAMEWORK_CONFIG) == null) {
+            return null;
+        }
+        final VectorSearcher vectorSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
+        return vectorSearcher != null ? vectorSearcher.getByteVectorValues() : null;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/ExactSearcher.java
@@ -227,7 +227,26 @@ public class ExactSearcher {
             segmentLevelQuantizationInfo = null;
             quantizedQueryVector = null;
         }
-
+        // Quantized search path: retrieve quantized byte vectors from reader as KNNBinaryVectorValues and perform exact search
+        // using Hamming distance.
+        if (quantizedQueryVector != null) {
+            final KNNVectorValues<byte[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader, true);
+            if (isNestedRequired) {
+                return new NestedBinaryVectorIdsExactKNNIterator(
+                    matchedDocs,
+                    quantizedQueryVector,
+                    (KNNBinaryVectorValues) vectorValues,
+                    SpaceType.HAMMING,
+                    exactSearcherContext.getParentsFilter().getBitSet(leafReaderContext)
+                );
+            }
+            return new BinaryVectorIdsExactKNNIterator(
+                matchedDocs,
+                quantizedQueryVector,
+                (KNNBinaryVectorValues) vectorValues,
+                SpaceType.HAMMING
+            );
+        }
         final KNNVectorValues<float[]> vectorValues = KNNVectorValuesFactory.getVectorValues(fieldInfo, reader);
         if (isNestedRequired) {
             return new NestedVectorIdsKNNIterator(

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesIterator.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesIterator.java
@@ -106,14 +106,13 @@ public interface KNNVectorValuesIterator {
      * A DocIdsIteratorValues provides a common iteration logic for all Values that implements
      * {@link DocIdSetIterator} interface. Example: {@link BinaryDocValues}, {@link FloatVectorValues} etc.
      */
+    @Getter
     class DocIdsIteratorValues extends AbstractVectorValuesIterator {
 
         private final KnnVectorValues knnVectorValues;
 
-        @Getter
         @Setter
         private int lastOrd = -1;
-        @Getter
         @Setter
         private Object lastAccessedVector = null;
 
@@ -127,8 +126,9 @@ public interface KNNVectorValuesIterator {
             this.knnVectorValues = null;
         }
 
-        public KnnVectorValues getKnnVectorValues() {
-            return knnVectorValues;
+        DocIdsIteratorValues(@NonNull final DocIdSetIterator docIdSetIterator, @NonNull final KnnVectorValues knnVectorValues) {
+            super(docIdSetIterator);
+            this.knnVectorValues = knnVectorValues;
         }
 
         @Override

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
@@ -5,6 +5,9 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
 
@@ -16,6 +19,11 @@ import java.io.IOException;
  * Two search APIs will be compatible with Lucene, taking {@link KnnCollector} and {@link Bits}.
  * In its implementation, it must collect top vectors that is similar to the given query. Make sure to transform the result to similarity
  * value if internally calculates distance between.
+ *
+ * <p>TODO: Refactor to eliminate this interface in favor of extending KnnVectorReader directly.
+ * VectorSearcher duplicates functionality already present in KnnVectorReader (search methods and getByteVectorValues),
+ * creating maintenance overhead and potential inconsistencies. Remove this interface and have all implementing classes
+ * extend KnnVectorReader instead.
  */
 public interface VectorSearcher extends Closeable {
     /**
@@ -33,7 +41,7 @@ public interface VectorSearcher extends Closeable {
      * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
      *     if they are all allowed to match.
      */
-    void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException;
+    void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
 
     /**
      * Return the k nearest neighbor documents as determined by comparison of their vector values for
@@ -50,5 +58,12 @@ public interface VectorSearcher extends Closeable {
      * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
      *     if they are all allowed to match.
      */
-    void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException;
+    void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
+
+    /**
+     * Returns the {@link ByteVectorValues} from the searcher. The behavior is undefined if
+     * searcher doesn't have KNN vectors enabled on its {@link FieldInfo}. The return value is
+     * never {@code null}.
+     */
+    ByteVectorValues getByteVectorValues() throws IOException;
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/VectorSearcher.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.memoryoptsearch;
 
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.util.Bits;
 
@@ -41,7 +40,7 @@ public interface VectorSearcher extends Closeable {
      * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
      *     if they are all allowed to match.
      */
-    void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
+    void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException;
 
     /**
      * Return the k nearest neighbor documents as determined by comparison of their vector values for
@@ -58,7 +57,7 @@ public interface VectorSearcher extends Closeable {
      * @param acceptDocs {@link Bits} that represents the allowed documents to match, or {@code null}
      *     if they are all allowed to match.
      */
-    void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException;
+    void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException;
 
     /**
      * Returns the {@link ByteVectorValues} from the searcher. The behavior is undefined if

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -16,7 +16,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
@@ -63,7 +62,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     @Override
-    public void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+    public void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
         search(
             VectorEncoding.FLOAT32,
             () -> flatVectorsScorer.getRandomVectorScorer(
@@ -77,7 +76,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     @Override
-    public void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
+    public void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
         search(
             VectorEncoding.BYTE,
             () -> flatVectorsScorer.getRandomVectorScorer(
@@ -110,7 +109,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         final VectorEncoding vectorEncoding,
         final IOSupplier<RandomVectorScorer> scorerSupplier,
         final KnnCollector knnCollector,
-        final AcceptDocs acceptDocs
+        final Bits acceptDocs
     ) throws IOException {
         if (faissIndex.getTotalNumberOfVectors() == 0 || knnCollector.k() == 0) {
             return;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -6,12 +6,17 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
+import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOSupplier;
 import org.apache.lucene.util.hnsw.HnswGraphSearcher;
@@ -58,7 +63,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     @Override
-    public void search(float[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+    public void search(float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         search(
             VectorEncoding.FLOAT32,
             () -> flatVectorsScorer.getRandomVectorScorer(
@@ -72,7 +77,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     }
 
     @Override
-    public void search(byte[] target, KnnCollector knnCollector, Bits acceptDocs) throws IOException {
+    public void search(byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
         search(
             VectorEncoding.BYTE,
             () -> flatVectorsScorer.getRandomVectorScorer(
@@ -85,6 +90,17 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         );
     }
 
+    /**
+     * Returns byte vector values from the FAISS index.
+     *
+     * @return byte vector values
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public ByteVectorValues getByteVectorValues() throws IOException {
+        return faissIndex.getByteValues(getSlicedIndexInput());
+    }
+
     @Override
     public void close() throws IOException {
         indexInput.close();
@@ -94,7 +110,7 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         final VectorEncoding vectorEncoding,
         final IOSupplier<RandomVectorScorer> scorerSupplier,
         final KnnCollector knnCollector,
-        final Bits acceptDocs
+        final AcceptDocs acceptDocs
     ) throws IOException {
         if (faissIndex.getTotalNumberOfVectors() == 0 || knnCollector.k() == 0) {
             return;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
@@ -229,9 +230,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    private static NativeEngines990KnnVectorsReader createReader(final FieldInfos fieldInfos, final Set<String> filesInSegment) {
-        return createReader(fieldInfos, filesInSegment, null);
-    }
+    private static NativeEngines990KnnVectorsReader createReader(
         final FieldInfos fieldInfos,
         final Set<String> filesInSegment,
         final FlatVectorsReader flatVectorsReader

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -7,20 +7,25 @@ package org.opensearch.knn.index.codec.KNN990Codec;
 
 import com.google.common.collect.ImmutableSet;
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,8 +36,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
 import static org.opensearch.knn.index.mapper.KNNVectorFieldMapper.KNN_FIELD;
 
 public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
@@ -43,10 +50,74 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
 
         // Load vector searchers
-        final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, Collections.emptySet());
+        final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, Collections.emptySet(), null);
 
         final Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder> vectorSearchers = getVectorSearcherHolders(reader);
         assertTrue(vectorSearchers.isEmpty());
+    }
+
+    public void testFlatVectorReaderIsCalled_whenNoQuantization() throws IOException {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("field1")
+            .fieldNumber(0)
+            .addAttribute(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .vectorEncoding(VectorEncoding.FLOAT32)
+            .build();
+
+        FieldInfo[] fieldInfoArray = new FieldInfo[] { fieldInfo };
+        final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
+
+        final FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+        NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, Set.of(), flatVectorsReader);
+        reader.getByteVectorValues("field1");
+        verify(flatVectorsReader).getByteVectorValues("field1");
+    }
+
+    public void testBinaryVectorValuesIsCalled_whenQuantizationIsAvailable_thenSuccess() throws IOException {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("field1")
+            .fieldNumber(0)
+            .addAttribute(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .addAttribute(QFRAMEWORK_CONFIG, "some-value")
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .build();
+
+        FieldInfo[] fieldInfoArray = new FieldInfo[] { fieldInfo };
+        final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
+
+        KNNEngine mockFaiss = spy(KNNEngine.FAISS);
+        VectorSearcherFactory mockFactory = mock(VectorSearcherFactory.class);
+        VectorSearcher mockSearcher = mock(VectorSearcher.class);
+        when(mockSearcher.getByteVectorValues()).thenReturn(mock(ByteVectorValues.class));
+        when(mockFaiss.getVectorSearcherFactory()).thenReturn(mockFactory);
+        when(mockFactory.createVectorSearcher(any(), any(), any(), any())).thenReturn(mockSearcher);
+
+        final FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+        try (MockedStatic<KNNEngine> mockedStatic = mockStatic(KNNEngine.class)) {
+            mockedStatic.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
+            final Set<String> filesInSegment = Set.of("_0_165_field1.faiss");
+            mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
+            NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, filesInSegment, flatVectorsReader);
+            reader.getByteVectorValues("field1");
+            verify(mockSearcher).getByteVectorValues();
+            verify(flatVectorsReader, Mockito.never()).getByteVectorValues("field1");
+        }
+    }
+
+    public void testFlatVectorReaderIsCalled_whenEncodingIsByte_thenSuccess() throws IOException {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("field1")
+            .fieldNumber(0)
+            .addAttribute(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .vectorEncoding(VectorEncoding.BYTE)
+            .build();
+
+        FieldInfo[] fieldInfoArray = new FieldInfo[] { fieldInfo };
+        final FieldInfos fieldInfos = new FieldInfos(fieldInfoArray);
+
+        final FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
+        NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, Set.of(), flatVectorsReader);
+        reader.getByteVectorValues("field1");
+        verify(flatVectorsReader).getByteVectorValues("field1");
     }
 
     @SneakyThrows
@@ -90,7 +161,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
             mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
 
             // Load reader
-            final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, filesInSegment);
+            final NativeEngines990KnnVectorsReader reader = createReader(fieldInfos, filesInSegment, null);
 
             // Check the size of `vectorSearcher`
             final Map<String, NativeEngines990KnnVectorsReader.VectorSearcherHolder> vectorSearchers = getVectorSearcherHolders(reader);
@@ -154,6 +225,17 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
 
     @SneakyThrows
     private static NativeEngines990KnnVectorsReader createReader(final FieldInfos fieldInfos, final Set<String> filesInSegment) {
+        return createReader(fieldInfos, filesInSegment, null);
+    }
+
+    @SneakyThrows
+    private static NativeEngines990KnnVectorsReader createReader(final FieldInfos fieldInfos, final Set<String> filesInSegment) {
+        return createReader(fieldInfos, filesInSegment, null);
+    }
+        final FieldInfos fieldInfos,
+        final Set<String> filesInSegment,
+        final FlatVectorsReader flatVectorsReader
+    ) {
         // Prepare infra
         final IndexInput mockIndexInput = mock(IndexInput.class);
         final Directory mockDirectory = mock(Directory.class);
@@ -164,7 +246,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         final SegmentReadState readState = new SegmentReadState(mockDirectory, segmentInfo, fieldInfos, IOContext.DEFAULT);
 
         // Create reader
-        final NativeEngines990KnnVectorsReader reader = new NativeEngines990KnnVectorsReader(readState, null);
+        final NativeEngines990KnnVectorsReader reader = new NativeEngines990KnnVectorsReader(readState, flatVectorsReader);
         return reader;
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestUtil.java
@@ -58,6 +58,7 @@ public class KNNCodecTestUtil {
         private VectorSimilarityFunction vectorSimilarityFunction;
         private boolean softDeletes;
         private boolean isParentField;
+        private VectorEncoding vectorEncoding;
 
         public static FieldInfoBuilder builder(String fieldName) {
             return new FieldInfoBuilder(fieldName);
@@ -80,6 +81,7 @@ public class KNNCodecTestUtil {
             this.vectorSimilarityFunction = VectorSimilarityFunction.EUCLIDEAN;
             this.softDeletes = false;
             this.isParentField = false;
+            this.vectorEncoding = VectorEncoding.FLOAT32;
         }
 
         public FieldInfoBuilder fieldNumber(int fieldNumber) {
@@ -157,6 +159,11 @@ public class KNNCodecTestUtil {
             return this;
         }
 
+        public FieldInfoBuilder vectorEncoding(VectorEncoding vectorEncoding) {
+            this.vectorEncoding = vectorEncoding;
+            return this;
+        }
+
         public FieldInfo build() {
             return new FieldInfo(
                 fieldName,
@@ -174,7 +181,7 @@ public class KNNCodecTestUtil {
                 pointIndexDimensionCount,
                 pointNumBytes,
                 vectorDimension,
-                VectorEncoding.FLOAT32,
+                vectorEncoding,
                 vectorSimilarityFunction,
                 softDeletes,
                 isParentField

--- a/src/test/java/org/opensearch/knn/index/query/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ExactSearcherTests.java
@@ -111,6 +111,86 @@ public class ExactSearcherTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testExactSearch_whenQuantizationWithoutADC_thenSuccess() {
+        try (
+            MockedStatic<KNNVectorValuesFactory> valuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<org.opensearch.knn.index.query.SegmentLevelQuantizationInfo> quantizationInfoMockedStatic = Mockito.mockStatic(
+                org.opensearch.knn.index.query.SegmentLevelQuantizationInfo.class
+            );
+            MockedStatic<org.opensearch.knn.index.query.SegmentLevelQuantizationUtil> quantizationUtilMockedStatic = Mockito.mockStatic(
+                org.opensearch.knn.index.query.SegmentLevelQuantizationUtil.class
+            )
+        ) {
+            final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+            final byte[] quantizedQueryVector = new byte[] { 1, 2, 3 };
+            final List<float[]> floatVectors = List.of(
+                new float[] { 1, 2, 3 },
+                new float[] { 4, 5, 6 },
+                new float[] { 2, 3, 4 },
+                new float[] { 7, 8, 9 },
+                new float[] { 0, 1, 2 }
+            );
+            final List<byte[]> quantizedDataVectors = List.of(
+                new byte[] { 1, 2, 3 },
+                new byte[] { 4, 5, 6 },
+                new byte[] { 2, 3, 4 },
+                new byte[] { 7, 8, 9 },
+                new byte[] { 0, 1, 2 }
+            );
+            final SpaceType spaceType = SpaceType.L2;
+            final int k = 10;
+
+            final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+                .field(FIELD_NAME)
+                .floatQueryVector(queryVector)
+                .useQuantizedVectorsForSearch(true)
+                .k(k)
+                .build();
+
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+
+            final org.opensearch.knn.index.query.SegmentLevelQuantizationInfo quantizationInfo = mock(
+                org.opensearch.knn.index.query.SegmentLevelQuantizationInfo.class
+            );
+            quantizationInfoMockedStatic.when(
+                () -> org.opensearch.knn.index.query.SegmentLevelQuantizationInfo.build(reader, fieldInfo, FIELD_NAME)
+            ).thenReturn(quantizationInfo);
+            quantizationUtilMockedStatic.when(
+                () -> org.opensearch.knn.index.query.SegmentLevelQuantizationUtil.isAdcEnabled(quantizationInfo)
+            ).thenReturn(false);
+            quantizationUtilMockedStatic.when(
+                () -> org.opensearch.knn.index.query.SegmentLevelQuantizationUtil.quantizeVector(queryVector, quantizationInfo)
+            ).thenReturn(quantizedQueryVector);
+
+            final KNNVectorValues knnFloatVectorValues = TestVectorValues.createKNNFloatVectorValues(floatVectors);
+            final KNNVectorValues knnByteVectorValues = TestVectorValues.createKNNBinaryVectorValues(quantizedDataVectors);
+            valuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnFloatVectorValues);
+            valuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader, true))
+                .thenReturn(knnByteVectorValues);
+
+            TopDocs docs = exactSearcher.searchLeaf(leafReaderContext, exactSearcherContext);
+            assertEquals(quantizedDataVectors.size(), docs.scoreDocs.length);
+
+            final List<Float> expectedScores = quantizedDataVectors.stream()
+                .map(quantizedVector -> SpaceType.HAMMING.getKnnVectorSimilarityFunction().compare(quantizedQueryVector, quantizedVector))
+                .sorted(Comparator.reverseOrder())
+                .toList();
+            final List<Float> actualScores = Arrays.stream(docs.scoreDocs).map(scoreDoc -> scoreDoc.score).toList();
+            assertEquals(expectedScores, actualScores);
+        }
+    }
+
+    @SneakyThrows
     private void doTestRadialSearch_whenNoEngineFiles_thenSuccess(final boolean memoryOptimizedSearchEnabled) {
         try (MockedStatic<KNNVectorValuesFactory> valuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
             // Prepare data

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/TestVectorValues.java
@@ -416,4 +416,18 @@ public class TestVectorValues {
         }
         return data;
     }
+
+    public static KNNVectorValues createKNNBinaryVectorValues(final BinaryDocValues binaryDocValues) {
+        return new KNNBinaryVectorValues(new KNNVectorValuesIterator.DocIdsIteratorValues(binaryDocValues));
+    }
+
+    public static KNNVectorValues createKNNBinaryVectorValues(final List<byte[]> vectors) {
+        return new KNNBinaryVectorValues(new KNNVectorValuesIterator.DocIdsIteratorValues(new PreDefinedBinaryVectorValues(vectors)));
+    }
+
+    public static KNNVectorValues createKNNFloatVectorValues(final List<float[]> vectors) {
+        return new KNNFloatVectorValues(
+            new KNNVectorValuesIterator.DocIdsIteratorValues(new PredefinedFloatVectorBinaryDocValues(vectors))
+        );
+    }
 }

--- a/src/test/java/org/opensearch/knn/integ/DiskBasedFilteredExactSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DiskBasedFilteredExactSearchIT.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNJsonQueryBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.NestedKnnDocBuilder;
+import org.opensearch.knn.index.KNNSettings;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
+
+/**
+ * Integration test for disk-based filtered exact search.
+ */
+@Log4j2
+public class DiskBasedFilteredExactSearchIT extends KNNRestTestCase {
+
+    @SneakyThrows
+    public void testDiskBasedFilteredExactSearch_whenFiltersMatchAllDocs_thenReturnCorrectResults() {
+        for (CompressionLevel compressionLevel : List.of(
+            CompressionLevel.x4,
+            CompressionLevel.x8,
+            CompressionLevel.x16,
+            CompressionLevel.x32
+        )) {
+            testDiskBasedFilteredExactSearchWhenFiltersMatchAllDocs(compressionLevel);
+        }
+    }
+
+    private void testDiskBasedFilteredExactSearchWhenFiltersMatchAllDocs(CompressionLevel compressionLevel) throws Exception {
+        String indexName = INDEX_NAME + "_" + compressionLevel.getName();
+        String filterFieldName = "color";
+        final int expectResultSize = randomIntBetween(1, 3);
+        final String filterValue = "red";
+
+        createDiskBasedIndex(indexName, FIELD_NAME, 8, compressionLevel);
+
+        for (int i = 0; i < 5; i++) {
+            addKnnDocWithAttributes(
+                indexName,
+                String.valueOf(i),
+                FIELD_NAME,
+                new float[] { i, i, i, i, i, i, i, i },
+                ImmutableMap.of(filterFieldName, filterValue)
+            );
+        }
+
+        refreshIndex(indexName);
+        forceMergeKnnIndex(indexName);
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 100));
+
+        Float[] queryVector = { 3f, 3f, 3f, 3f, 3f, 3f, 3f, 3f };
+        String query = KNNJsonQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(expectResultSize)
+            .filterFieldName(filterFieldName)
+            .filterValue(filterValue)
+            .rescoreEnabled(false)
+            .build()
+            .getQueryString();
+
+        Response response = searchKNNIndex(indexName, query, expectResultSize);
+        String entity = EntityUtils.toString(response.getEntity());
+        List<String> docIds = parseIds(entity);
+        assertEquals(expectResultSize, docIds.size());
+        assertEquals(expectResultSize, parseTotalSearchHits(entity));
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testDiskBasedFilteredExactSearch_whenNonVectorFields_thenSucceed() {
+        for (CompressionLevel compressionLevel : List.of(
+            CompressionLevel.x4,
+            CompressionLevel.x8,
+            CompressionLevel.x16,
+            CompressionLevel.x32
+        )) {
+            testDiskBasedFilteredExactSearchWithNonVectorFields(compressionLevel);
+        }
+    }
+
+    private void testDiskBasedFilteredExactSearchWithNonVectorFields(CompressionLevel compressionLevel) throws Exception {
+        String filterFieldName = "category";
+        String filterValue = "electronics";
+        String indexName = INDEX_NAME + "_" + compressionLevel.getName();
+        createDiskBasedIndex(indexName, FIELD_NAME, 8, compressionLevel);
+
+        for (int i = 0; i < 5; i++) {
+            addKnnDocWithAttributes(
+                indexName,
+                String.valueOf(i),
+                FIELD_NAME,
+                new float[] { i, i, i, i, i, i, i, i },
+                ImmutableMap.of(filterFieldName, filterValue)
+            );
+        }
+        addKnnDocWithAttributes(
+            indexName,
+            String.valueOf(6),
+            FIELD_NAME,
+            new float[] { 6, 6, 6, 6, 6, 6, 6, 6 },
+            ImmutableMap.of(filterFieldName, "books")
+        );
+        addNonKNNDoc(indexName, String.valueOf(7), filterFieldName, "clothes");
+
+        flush(indexName, true);
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 100));
+
+        Float[] queryVector = { 2f, 2f, 2f, 2f, 2f, 2f, 2f, 2f };
+        String query = KNNJsonQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(10)
+            .filterFieldName(filterFieldName)
+            .filterValue(filterValue)
+            .rescoreEnabled(false)
+            .build()
+            .getQueryString();
+
+        Response response = searchKNNIndex(indexName, query, 10);
+        assertOK(response);
+        String entity = EntityUtils.toString(response.getEntity());
+        List<String> docIds = parseIds(entity);
+        assertEquals(5, docIds.size());
+        assertFalse(docIds.contains("6"));
+        assertFalse(docIds.contains("7"));
+
+        List<Double> scores = parseScores(entity);
+        for (Double score : scores) {
+            assertTrue("Score should be non-negative: " + score, score >= 0);
+        }
+
+        query = KNNJsonQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(10)
+            .filterFieldName(filterFieldName)
+            .filterValue("nonexistent")
+            .rescoreEnabled(false)
+            .build()
+            .getQueryString();
+        response = searchKNNIndex(indexName, query, 10);
+        assertOK(response);
+        entity = EntityUtils.toString(response.getEntity());
+        assertEquals(0, parseIds(entity).size());
+
+        query = KNNJsonQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(10)
+            .filterFieldName(filterFieldName)
+            .filterValue("clothes")
+            .rescoreEnabled(false)
+            .build()
+            .getQueryString();
+        response = searchKNNIndex(indexName, query, 10);
+        assertOK(response);
+        entity = EntityUtils.toString(response.getEntity());
+        assertEquals(0, parseIds(entity).size());
+
+        deleteKNNIndex(indexName);
+    }
+
+    /**
+     * Test nested field with disk-based exact search.
+     */
+    @SneakyThrows
+    public void testDiskBasedFilteredExactSearch_whenNestedField_thenSucceed() {
+        for (CompressionLevel compressionLevel : List.of(
+            CompressionLevel.x4,
+            CompressionLevel.x8,
+            CompressionLevel.x16,
+            CompressionLevel.x32
+        )) {
+            testDiskBasedFilteredExactSearchWithCompressionLevel(compressionLevel);
+        }
+    }
+
+    private void testDiskBasedFilteredExactSearchWithCompressionLevel(CompressionLevel compressionLevel) throws Exception {
+        String indexName = INDEX_NAME + "_" + compressionLevel.getName();
+        String nestedFieldName = "test_nested";
+        String filterFieldName = "parking";
+        String filterValue = "true";
+
+        createNestedDiskBasedKnnIndex(indexName, 8, compressionLevel);
+
+        for (int i = 1; i < 4; i++) {
+            float value = (float) i;
+            String doc = NestedKnnDocBuilder.create(nestedFieldName)
+                .addVectors(
+                    FIELD_NAME,
+                    new Float[] { value, value, value, value, value, value, value, value },
+                    new Float[] { value, value, value, value, value, value, value, value }
+                )
+                .addTopLevelField(filterFieldName, i % 2 == 1 ? "true" : "false")
+                .build();
+            addKnnDoc(indexName, String.valueOf(i), doc);
+        }
+        refreshIndex(indexName);
+        forceMergeKnnIndex(indexName);
+
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 100));
+
+        Float[] queryVector = { 3f, 3f, 3f, 3f, 3f, 3f, 3f, 3f };
+        String query = KNNJsonQueryBuilder.builder()
+            .nestedFieldName(nestedFieldName)
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(10)
+            .filterFieldName(filterFieldName)
+            .filterValue(filterValue)
+            .rescoreEnabled(false)
+            .build()
+            .getQueryString();
+
+        Response response = searchKNNIndex(indexName, query, 10);
+        assertOK(response);
+        String entity = EntityUtils.toString(response.getEntity());
+        List<String> docIds = parseIds(entity);
+        assertEquals(2, docIds.size());
+        assertEquals("3", docIds.get(0));
+        assertEquals("1", docIds.get(1));
+
+        deleteKNNIndex(indexName);
+    }
+
+    private void createDiskBasedIndex(String indexName, String fieldName, int dimension, CompressionLevel compressionLevel)
+        throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel.getName())
+            .startObject("method")
+            .field("name", METHOD_HNSW)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void createNestedDiskBasedKnnIndex(String indexName, int dimension, CompressionLevel compressionLevel) throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("test_nested")
+            .field("type", "nested")
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, compressionLevel.getName())
+            .startObject("method")
+            .field("name", METHOD_HNSW)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, builder.toString());
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNJsonQueryBuilder.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNJsonQueryBuilder.java
@@ -27,6 +27,7 @@ public class KNNJsonQueryBuilder {
     private String nestedFieldName;
     private String filterFieldName;
     private String filterValue;
+    private Boolean rescoreEnabled;
 
     public String getQueryString() throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("query");
@@ -55,6 +56,10 @@ public class KNNJsonQueryBuilder {
             builder.field(filterFieldName, filterValue);
             builder.endObject();
             builder.endObject();
+        }
+
+        if (rescoreEnabled != null) {
+            builder.field("rescore", rescoreEnabled);
         }
 
         builder.endObject().endObject().endObject().endObject();


### PR DESCRIPTION
* Add support for pre-quantized vector exact search

Implement exact KNN search using pre-quantized vectors from native engines to avoid redundant quantization during query execution. This optimization retrieves quantized vectors directly from FAISS memory-optimized indexes and uses them for Hamming distance calculations.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
