### PR TITLE
Freeze the version of LocalStack as newer version requires an account

### DIFF
--- a/.github/workflows/remote_index_build.yml
+++ b/.github/workflows/remote_index_build.yml
@@ -82,11 +82,11 @@ jobs:
 
       - name: Pull LocalStack Docker image
         run: |
-          docker pull localstack/localstack:latest
+          docker pull localstack/localstack:4.14
 
       - name: Run LocalStack
         run: |
-          docker run --rm -d -p 4566:4566 localstack/localstack:latest
+          docker run --rm -d -p 4566:4566 localstack/localstack:4.14
 
       - name: Verify Localstack is ready
         run: |


### PR DESCRIPTION
### Description
Freeze the version of LocalStack as newer version requires an account 

Ref: https://news.ycombinator.com/item?id=47493657

### Related Issues
NA

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
