### PR TITLE
Bug fix for clip parameter, integration test coverage for Faiss SQ 1 bit

### DIFF
--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -141,6 +141,11 @@ public class FaissSQEncoder implements Encoder {
         return CompressionLevel.x2;
     }
 
+    // TODO: The Encoder interface's validateEncoderConfig uses TrainingConfigValidation* types that were
+    // designed for model training. We should add a general-purpose validation method to the Encoder interface
+    // (e.g. Encoder.validate(KNNMethodContext, KNNMethodConfigContext)) that both Faiss and Lucene resolvers
+    // can delegate to, decoupled from training concerns. See LuceneHNSWMethodResolver.validateEncoderParams()
+    // for the Lucene equivalent that avoids the training interface.
     @Override
     public TrainingConfigValidationOutput validateEncoderConfig(TrainingConfigValidationInput validationInput) {
         TrainingConfigValidationOutput.TrainingConfigValidationOutputBuilder builder = TrainingConfigValidationOutput.builder();
@@ -163,6 +168,7 @@ public class FaissSQEncoder implements Encoder {
         boolean isV360OrLater = version != null && version.onOrAfter(Version.V_3_6_0);
         Object bitsObj = encoderParams.get(SQ_BITS);
         boolean hasType = encoderParams.containsKey(FAISS_SQ_TYPE);
+        boolean hasClip = encoderParams.containsKey(FAISS_SQ_CLIP);
 
         // On 3.6.0+, bits is required when the user explicitly specifies the sq encoder for FLOAT data
         if (isV360OrLater && bitsObj == null && configContext.getVectorDataType() == VectorDataType.FLOAT) {
@@ -183,21 +189,40 @@ public class FaissSQEncoder implements Encoder {
         if (bitsObj instanceof Integer) {
             int bits = (Integer) bitsObj;
 
-            // bits=1 does not support the type parameter
-            if (bits == Bits.ONE.getValue() && hasType) {
-                return builder.valid(false)
-                    .errorMessage(
-                        String.format(
-                            Locale.ROOT,
-                            "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
-                                + "The 1-bit scalar quantization path does not use the type parameter.",
-                            FAISS_SQ_TYPE,
-                            SQ_BITS,
-                            bits,
-                            ENCODER_SQ
+            // type and clip is only applicable for fp16 (bits=16)
+            if (Bits.SIXTEEN.getValue() != bits) {
+                if (hasType) {
+                    return builder.valid(false)
+                        .errorMessage(
+                            String.format(
+                                Locale.ROOT,
+                                "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
+                                    + "The type parameter is only applicable for fp16 quantization (bits=16).",
+                                FAISS_SQ_TYPE,
+                                SQ_BITS,
+                                bits,
+                                ENCODER_SQ
+                            )
                         )
-                    )
-                    .build();
+                        .build();
+                }
+
+                if (hasClip) {
+                    return builder.valid(false)
+                        .errorMessage(
+                            String.format(
+                                Locale.ROOT,
+                                "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
+                                    + "Clipping is only applicable for fp16 quantization (bits=16).",
+                                FAISS_SQ_CLIP,
+                                SQ_BITS,
+                                bits,
+                                ENCODER_SQ
+                            )
+                        )
+                        .build();
+                }
+
             }
 
             // Validate compression level compatibility if explicitly set

--- a/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
+++ b/src/test/java/org/opensearch/knn/common/FieldInfoExtractorTests.java
@@ -13,6 +13,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
 
@@ -107,5 +108,30 @@ public class FieldInfoExtractorTests extends KNNTestCase {
         Mockito.when(fieldInfos.fieldInfo("valid")).thenReturn(fieldInfo);
         Assert.assertNull(FieldInfoExtractor.getFieldInfo(leafReader, "invalid"));
         Assert.assertEquals(fieldInfo, FieldInfoExtractor.getFieldInfo(leafReader, "valid"));
+    }
+
+    public void testIsSQField_whenAttributePresent_thenTrue() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn("bits=1");
+        Assert.assertTrue(FieldInfoExtractor.isSQField(fieldInfo));
+    }
+
+    public void testIsSQField_whenAttributeAbsent_thenFalse() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn(null);
+        Assert.assertFalse(FieldInfoExtractor.isSQField(fieldInfo));
+    }
+
+    public void testExtractSQConfig_whenPresent_thenReturnConfig() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn("bits=1");
+        SQConfig config = FieldInfoExtractor.extractSQConfig(fieldInfo);
+        Assert.assertEquals(1, config.getBits());
+    }
+
+    public void testExtractSQConfig_whenAbsent_thenReturnEmpty() {
+        FieldInfo fieldInfo = Mockito.mock(FieldInfo.class);
+        Mockito.when(fieldInfo.getAttribute(KNNConstants.SQ_CONFIG)).thenReturn(null);
+        Assert.assertSame(SQConfig.EMPTY, FieldInfoExtractor.extractSQConfig(fieldInfo));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.FAISS_FLAT_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_CLIP;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
@@ -110,6 +111,30 @@ public class FaissSQEncoderTests extends KNNTestCase {
         assertTrue(output.getErrorMessage().contains("not supported"));
     }
 
+    // --- Validation: bits=1 + clip not allowed ---
+
+    public void testValidate_whenBits1WithClip_thenError() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        TrainingConfigValidationOutput output = encoder.validateEncoderConfig(
+            buildValidationInput(Version.CURRENT, CompressionLevel.NOT_CONFIGURED, Map.of(SQ_BITS, 1, FAISS_SQ_CLIP, true))
+        );
+        assertNotNull(output.getValid());
+        assertFalse(output.getValid());
+        assertTrue(output.getErrorMessage().contains("clip"));
+    }
+
+    public void testValidate_whenBits16WithClip_thenOk() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        TrainingConfigValidationOutput output = encoder.validateEncoderConfig(
+            buildValidationInput(
+                Version.CURRENT,
+                CompressionLevel.NOT_CONFIGURED,
+                Map.of(SQ_BITS, 16, FAISS_SQ_TYPE, "fp16", FAISS_SQ_CLIP, true)
+            )
+        );
+        assertNull(output.getValid());
+    }
+
     // --- Validation: compression level compatibility ---
 
     public void testValidate_whenBits1WithX32Compression_thenOk() {
@@ -176,5 +201,37 @@ public class FaissSQEncoderTests extends KNNTestCase {
         );
 
         return TrainingConfigValidationInput.builder().knnMethodContext(methodContext).knnMethodConfigContext(configContext).build();
+    }
+
+    // --- isSQOneBit utility ---
+
+    public void testIsSQOneBit_whenSQWithBits1_thenTrue() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1));
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertTrue(FaissSQEncoder.isSQOneBit(params));
+    }
+
+    public void testIsSQOneBit_whenSQWithBits16_thenFalse() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertFalse(FaissSQEncoder.isSQOneBit(params));
+    }
+
+    public void testIsSQOneBit_whenNonSQEncoder_thenFalse() {
+        MethodComponentContext encoderCtx = new MethodComponentContext("flat", Map.of());
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertFalse(FaissSQEncoder.isSQOneBit(params));
+    }
+
+    public void testIsSQOneBit_whenNullParams_thenFalse() {
+        assertFalse(FaissSQEncoder.isSQOneBit(null));
+    }
+
+    public void testIsSQOneBit_whenNoEncoder_thenFalse() {
+        assertFalse(FaissSQEncoder.isSQOneBit(Map.of()));
+    }
+
+    public void testIsSQOneBit_whenEncoderNotMethodComponentContext_thenFalse() {
+        assertFalse(FaissSQEncoder.isSQOneBit(Map.of(METHOD_ENCODER_PARAMETER, "not_a_context")));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/SQConfigParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/SQConfigParserTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.faiss;
+
+import org.opensearch.knn.KNNTestCase;
+
+public class SQConfigParserTests extends KNNTestCase {
+
+    public void testToCsv_whenValidConfig_thenReturnCsv() {
+        SQConfig config = SQConfig.builder().bits(1).build();
+        assertEquals("bits=1", SQConfigParser.toCsv(config));
+    }
+
+    public void testToCsv_whenBits16_thenReturnCsv() {
+        SQConfig config = SQConfig.builder().bits(16).build();
+        assertEquals("bits=16", SQConfigParser.toCsv(config));
+    }
+
+    public void testToCsv_whenNull_thenReturnEmpty() {
+        assertEquals("", SQConfigParser.toCsv(null));
+    }
+
+    public void testToCsv_whenEmpty_thenReturnEmpty() {
+        assertEquals("", SQConfigParser.toCsv(SQConfig.EMPTY));
+    }
+
+    public void testFromCsv_whenValidCsv_thenReturnConfig() {
+        SQConfig config = SQConfigParser.fromCsv("bits=1");
+        assertEquals(1, config.getBits());
+    }
+
+    public void testFromCsv_whenBits16_thenReturnConfig() {
+        SQConfig config = SQConfigParser.fromCsv("bits=16");
+        assertEquals(16, config.getBits());
+    }
+
+    public void testFromCsv_whenNull_thenReturnEmpty() {
+        assertSame(SQConfig.EMPTY, SQConfigParser.fromCsv(null));
+    }
+
+    public void testFromCsv_whenEmptyString_thenReturnEmpty() {
+        assertSame(SQConfig.EMPTY, SQConfigParser.fromCsv(""));
+    }
+
+    public void testFromCsv_whenInvalidFormat_thenThrow() {
+        expectThrows(IllegalArgumentException.class, () -> SQConfigParser.fromCsv("invalid"));
+    }
+
+    public void testFromCsv_whenWrongKey_thenThrow() {
+        expectThrows(IllegalArgumentException.class, () -> SQConfigParser.fromCsv("wrong=1"));
+    }
+
+    public void testRoundTrip() {
+        SQConfig original = SQConfig.builder().bits(1).build();
+        SQConfig parsed = SQConfigParser.fromCsv(SQConfigParser.toCsv(original));
+        assertEquals(original, parsed);
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.SpaceType;
+
+import java.util.Map;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_CLIP;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_ENCODER_FP16;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NLIST;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.PROPERTIES;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
+/**
+ * Integration tests for Faiss SQ encoder mapping validation.
+ * Covers bits parameter requirements, type/bits conflicts, compression compatibility,
+ * and various mapping combinations.
+ */
+public class FaissSQMappingIT extends KNNRestTestCase {
+
+    private static final int TEST_DIMENSION = 128;
+    private static final int NUM_DOCS = 10;
+    private static final int K = 5;
+
+    /**
+     * Validates a bits=16 (fp16) index
+     */
+    private void validateFP16Index(String indexName, String mapping, Integer expectedBits, String expectedType, Boolean expectedClip)
+        throws Exception {
+        createKnnIndex(indexName, mapping);
+        validateMapping(indexName, expectedBits, expectedType, expectedClip);
+        addKNNDocs(indexName, FIELD_NAME, TEST_DIMENSION, 0, NUM_DOCS);
+        validateKNNSearch(indexName, FIELD_NAME, TEST_DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
+    /**
+     * Validates a bits=1 index at mapping level
+     */
+    private void validateMappingOnly(String indexName, String mapping, Integer expectedBits) throws Exception {
+        createKnnIndex(indexName, mapping);
+        validateMapping(indexName, expectedBits, null, null);
+        deleteKNNIndex(indexName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateMapping(String indexName, Integer expectedBits, String expectedType, Boolean expectedClip) throws Exception {
+        Map<String, Object> actualMapping = getIndexMappingAsMap(indexName);
+        assertNotNull(actualMapping);
+        Map<String, Object> actualProps = (Map<String, Object>) actualMapping.get(PROPERTIES);
+        assertNotNull("Mapping properties should not be null", actualProps);
+        Map<String, Object> actualField = (Map<String, Object>) actualProps.get(FIELD_NAME);
+        assertNotNull("Field [" + FIELD_NAME + "] should exist in mapping", actualField);
+        assertEquals(TYPE_KNN_VECTOR, actualField.get(TYPE));
+        assertEquals(TEST_DIMENSION, actualField.get(DIMENSION));
+
+        Map<String, Object> method = (Map<String, Object>) actualField.get(KNN_METHOD);
+        assertNotNull("Method should not be null", method);
+        assertEquals(FAISS_NAME, method.get(KNN_ENGINE));
+        Map<String, Object> params = (Map<String, Object>) method.get(PARAMETERS);
+        assertNotNull("Method parameters should not be null", params);
+        Map<String, Object> encoder = (Map<String, Object>) params.get(METHOD_ENCODER_PARAMETER);
+        assertNotNull("Encoder should not be null", encoder);
+        assertEquals(ENCODER_SQ, encoder.get(NAME));
+
+        Map<String, Object> encoderParams = (Map<String, Object>) encoder.get(PARAMETERS);
+        assertNotNull("Encoder parameters should not be null", encoderParams);
+        if (expectedBits != null) {
+            assertEquals(expectedBits, encoderParams.get(SQ_BITS));
+        }
+        if (expectedType != null) {
+            assertEquals(expectedType, encoderParams.get(FAISS_SQ_TYPE));
+        }
+        if (expectedClip != null) {
+            assertEquals(expectedClip, encoderParams.get(FAISS_SQ_CLIP));
+        }
+    }
+
+    /**
+     * Validates that index creation fails with a ResponseException containing the expected message.
+     */
+    private void validateMappingFails(String mapping, String expectedError) {
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, mapping));
+        assertTrue(
+            "Expected error containing [" + expectedError + "] but got: " + ex.getMessage(),
+            ex.getMessage().contains(expectedError)
+        );
+    }
+
+    // --- bits required on 3.6.0+ ---
+
+    public void testSQEncoder_whenNoBitsOnCurrentVersion_thenFail() throws Exception {
+        String mapping = buildSQMapping(null, FAISS_SQ_ENCODER_FP16, null, null, null);
+        validateMappingFails(mapping, "bits");
+    }
+
+    // --- bits=16 with type=fp16 (valid) ---
+
+    public void testSQEncoder_whenBits16WithTypeFP16_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, null);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    public void testSQEncoder_whenBits16WithTypeFP16AndCompressionX2_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, CompressionLevel.x2.getName(), null, null);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    public void testSQEncoder_whenBits16WithTypeFP16AndOnDisk_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, Mode.ON_DISK.getName(), null);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    // --- bits=1 (type not allowed) ---
+
+    public void testSQEncoder_whenBits1WithType_thenFail() throws Exception {
+        String mapping = buildSQMapping(1, FAISS_SQ_ENCODER_FP16, null, null, null);
+        validateMappingFails(mapping, "type");
+    }
+
+    public void testSQEncoder_whenBits1WithoutType_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, null, null, null);
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    public void testSQEncoder_whenBits1WithCompressionX32_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, CompressionLevel.x32.getName(), null, null);
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    // --- compression level mismatches ---
+
+    public void testSQEncoder_whenBits1WithCompressionX2_thenFail() throws Exception {
+        String mapping = buildSQMapping(1, null, CompressionLevel.x2.getName(), null, null);
+        validateMappingFails(mapping, "incompatible");
+    }
+
+    public void testSQEncoder_whenBits16WithCompressionX32_thenFail() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, CompressionLevel.x32.getName(), null, null);
+        validateMappingFails(mapping, "incompatible");
+    }
+
+    // --- invalid bits values ---
+
+    public void testSQEncoder_whenBits2_thenFail() throws Exception {
+        String mapping = buildSQMapping(2, null, null, null, null);
+        validateMappingFails(mapping, "Unsupported bits value");
+    }
+
+    public void testSQEncoder_whenBits8_thenFail() throws Exception {
+        String mapping = buildSQMapping(8, null, null, null, null);
+        validateMappingFails(mapping, "Unsupported bits value");
+    }
+
+    // --- mode + encoder combinations ---
+
+    public void testSQEncoder_whenBits16WithInMemoryMode_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, Mode.IN_MEMORY.getName(), null);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    // --- clip parameter: only valid with bits=16 (fp16) ---
+
+    public void testSQEncoder_whenBits1WithClip_thenFail() throws Exception {
+        String mapping = buildSQMapping(1, null, null, null, null, true);
+        validateMappingFails(mapping, "clip");
+    }
+
+    public void testSQEncoder_whenBits16WithClip_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, null, true);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, true);
+    }
+
+    // --- IVF + sq(bits=1) not supported ---
+    public void testSQEncoder_whenBits1WithIVF_thenFail() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES)
+            .startObject(FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, TEST_DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_IVF)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_NLIST, 4)
+            .field(METHOD_PARAMETER_NPROBES, 2)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_SQ)
+            .startObject(PARAMETERS)
+            .field(SQ_BITS, 1)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        ResponseException ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, builder.toString()));
+        assertTrue(ex.getMessage().contains("Validation Failed"));
+    }
+
+    // --- Space type variations with bits=16 ---
+
+    public void testSQEncoder_whenBits16WithL2_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, SpaceType.L2.getValue());
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    public void testSQEncoder_whenBits16WithIP_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, SpaceType.INNER_PRODUCT.getValue());
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    public void testSQEncoder_whenBits16WithCosine_thenSucceed() throws Exception {
+        // Cosine rejects zero vectors from addKNNDocs, so validate mapping only
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, SpaceType.COSINESIMIL.getValue());
+        validateMappingOnly(INDEX_NAME, mapping, 16);
+    }
+
+    // --- Space type variations with bits=1 ---
+
+    public void testSQEncoder_whenBits1WithL2_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, null, null, SpaceType.L2.getValue());
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    public void testSQEncoder_whenBits1WithIP_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, null, null, SpaceType.INNER_PRODUCT.getValue());
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    public void testSQEncoder_whenBits1WithCosine_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, null, null, SpaceType.COSINESIMIL.getValue());
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    // --- bits=16 without type (should default to fp16) ---
+
+    public void testSQEncoder_whenBits16WithoutType_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, null, null, null, null);
+        validateFP16Index(INDEX_NAME, mapping, 16, null, null);
+    }
+
+    // --- bits=1 with mode variations ---
+
+    public void testSQEncoder_whenBits1WithOnDiskMode_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, null, Mode.ON_DISK.getName(), null);
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    public void testSQEncoder_whenBits1WithInMemoryMode_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, null, Mode.IN_MEMORY.getName(), null);
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    // --- Full explicit combos ---
+
+    public void testSQEncoder_whenBits16WithOnDiskAndCompressionX2_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, CompressionLevel.x2.getName(), Mode.ON_DISK.getName(), null);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    public void testSQEncoder_whenBits1WithOnDiskAndCompressionX32_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(1, null, CompressionLevel.x32.getName(), Mode.ON_DISK.getName(), null);
+        validateMappingOnly(INDEX_NAME, mapping, 1);
+    }
+
+    // --- Data type: SQ only supports FLOAT ---
+
+    public void testSQEncoder_whenBits1WithByteDataType_thenFail() throws Exception {
+        String mapping = buildSQMappingWithDataType(1, null, VectorDataType.BYTE.getValue());
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits16WithByteDataType_thenFail() throws Exception {
+        String mapping = buildSQMappingWithDataType(16, FAISS_SQ_ENCODER_FP16, VectorDataType.BYTE.getValue());
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits1WithBinaryDataType_thenFail() throws Exception {
+        String mapping = buildSQMappingWithDataType(1, null, VectorDataType.BINARY.getValue());
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    // --- Additional compression level mismatches ---
+
+    public void testSQEncoder_whenBits1WithCompressionX4_thenFail() throws Exception {
+        String mapping = buildSQMapping(1, null, CompressionLevel.x4.getName(), null, null);
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits1WithCompressionX8_thenFail() throws Exception {
+        String mapping = buildSQMapping(1, null, CompressionLevel.x8.getName(), null, null);
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits1WithCompressionX16_thenFail() throws Exception {
+        String mapping = buildSQMapping(1, null, CompressionLevel.x16.getName(), null, null);
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits16WithCompressionX4_thenFail() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, CompressionLevel.x4.getName(), null, null);
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits16WithCompressionX8_thenFail() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, CompressionLevel.x8.getName(), null, null);
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    public void testSQEncoder_whenBits16WithCompressionX16_thenFail() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, CompressionLevel.x16.getName(), null, null);
+        validateMappingFails(mapping, "Validation Failed");
+    }
+
+    // --- bits=16 only (no type, no clip) base case ---
+
+    public void testSQEncoder_whenOnlyBits16_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, null, null, null, null);
+        validateFP16Index(INDEX_NAME, mapping, 16, null, null);
+    }
+
+    // --- bits + type + clip combinations ---
+
+    public void testSQEncoder_whenBits16WithTypeFP16AndClipTrue_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, null, true);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, true);
+    }
+
+    public void testSQEncoder_whenBits16WithTypeFP16AndClipFalse_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, FAISS_SQ_ENCODER_FP16, null, null, null, false);
+        validateFP16Index(INDEX_NAME, mapping, 16, FAISS_SQ_ENCODER_FP16, null);
+    }
+
+    public void testSQEncoder_whenBits16WithNoTypeAndClipTrue_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(16, null, null, null, null, true);
+        validateFP16Index(INDEX_NAME, mapping, 16, null, true);
+    }
+
+    public void testSQEncoder_whenBits1WithClipFalse_thenFail() throws Exception {
+        // clip parameter is not applicable for bits=1, even when false
+        String mapping = buildSQMapping(1, null, null, null, null, false);
+        validateMappingFails(mapping, "clip");
+    }
+
+    private String buildSQMappingWithDataType(Integer bits, String type, String dataType) throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES)
+            .startObject(FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, TEST_DIMENSION)
+            .field(VECTOR_DATA_TYPE_FIELD, dataType)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .startObject(PARAMETERS)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_SQ)
+            .startObject(PARAMETERS);
+        if (bits != null) {
+            builder.field(SQ_BITS, bits);
+        }
+        if (type != null) {
+            builder.field(FAISS_SQ_TYPE, type);
+        }
+        builder.endObject().endObject().endObject().endObject().endObject().endObject().endObject();
+        return builder.toString();
+    }
+
+    private String buildSQMapping(Integer bits, String type, String compressionLevel, String mode, String spaceType) throws Exception {
+        return buildSQMapping(bits, type, compressionLevel, mode, spaceType, null);
+    }
+
+    private String buildSQMapping(Integer bits, String type, String compressionLevel, String mode, String spaceType, Boolean clip)
+        throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES)
+            .startObject(FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, TEST_DIMENSION);
+
+        if (mode != null) {
+            builder.field(MODE_PARAMETER, mode);
+        }
+        if (compressionLevel != null) {
+            builder.field(COMPRESSION_LEVEL_PARAMETER, compressionLevel);
+        }
+
+        builder.startObject(KNN_METHOD).field(NAME, METHOD_HNSW).field(KNN_ENGINE, FAISS_NAME);
+        if (spaceType != null) {
+            builder.field(METHOD_PARAMETER_SPACE_TYPE, spaceType);
+        }
+        builder.startObject(PARAMETERS).startObject(METHOD_ENCODER_PARAMETER).field(NAME, ENCODER_SQ).startObject(PARAMETERS);
+
+        if (bits != null) {
+            builder.field(SQ_BITS, bits);
+        }
+        if (type != null) {
+            builder.field(FAISS_SQ_TYPE, type);
+        }
+        if (clip != null) {
+            builder.field(FAISS_SQ_CLIP, clip);
+        }
+
+        builder.endObject().endObject().endObject().endObject().endObject().endObject().endObject();
+
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
### Description
- Fixes usage of clip parameter with SQ 1 bit
- Adds comprehensive ITs and UTs for SQ encoder extensions

### Related Issues
Related #3169 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
