### PR TITLE
Support derived source for knn with other fields

### DIFF
--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -31,11 +31,14 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.mapper.DerivedFieldGenerator;
 import org.opensearch.index.mapper.FieldMapper;
+import org.opensearch.index.mapper.FieldValueType;
 import org.opensearch.index.mapper.Mapper;
 import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.index.mapper.ParametrizedFieldMapper;
 import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.StoredFieldFetcher;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.DerivedKnnByteVectorField;
 import org.opensearch.knn.index.DerivedKnnFloatVectorField;
@@ -921,6 +924,20 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         if (includeDefaults || ignoreMalformed.explicit()) {
             builder.field(Names.IGNORE_MALFORMED, ignoreMalformed.value());
         }
+    }
+
+    @Override
+    protected void canDeriveSourceInternal() {
+        // skipping any checks here
+    }
+
+    /**
+     * Derive source using stored field, which would always be present for derived source enabled index field
+     */
+    @Override
+    protected DerivedFieldGenerator derivedFieldGenerator() {
+        // using knn vector fetcher to fetch the vector and passing it as a doc values fetcher
+        return new DerivedFieldGenerator(mappedFieldType, new KnnVectorValuesFetcher((KNNVectorFieldType) mappedFieldType, simpleName()), null);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/mapper/KnnVectorValuesFetcher.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KnnVectorValuesFetcher.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.opensearch.index.mapper.FieldValueFetcher;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
+import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * FieldValueFetcher that retrieves KNN vector values from doc values or native KNN vector format.
+ *
+ * @opensearch.internal
+ */
+public class KnnVectorValuesFetcher extends FieldValueFetcher {
+    KNNVectorFieldType mappedFieldType;
+
+    public KnnVectorValuesFetcher(KNNVectorFieldType mappedFieldType, String simpleName) {
+        super(simpleName);
+        this.mappedFieldType = mappedFieldType;
+    }
+
+    @Override
+    public List<Object> fetch(LeafReader reader, int docId) throws IOException {
+        List<Object> values = new ArrayList<>(1);
+        try {
+            FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(mappedFieldType.name());
+            KNNVectorValues<?> vectorValues = fieldInfo != null ? KNNVectorValuesFactory.getVectorValues(fieldInfo, reader) : null;
+            if (vectorValues == null) {
+                return values;
+            }
+            if (vectorValues.advance(docId) == docId) {
+                values.add(vectorValues.getVector());
+            }
+        } catch (Exception e) {
+            throw new IOException("Failed to read doc values for document " + docId + " in field " + mappedFieldType.name(), e);
+        }
+        return values;
+    }
+
+    /**
+     * Converts the raw vector (float[] or byte[]) into a List of Numbers so that
+     * XContentBuilder serializes all vector types as numeric JSON arrays.
+     * Without this, byte[] would be serialized as Base64 binary data.
+     */
+
+    @Override
+    public Object convert(Object value) {
+        if (value instanceof float[]) {
+            float[] vector = (float[]) value;
+            List<Number> result = new ArrayList<>(vector.length);
+            for (float v : vector) {
+                result.add(v);
+            }
+            return result;
+        } else if (value instanceof byte[]) {
+            byte[] vector = (byte[]) value;
+            List<Number> result = new ArrayList<>(vector.length);
+            for (byte v : vector) {
+                result.add((int) v);
+            }
+            return result;
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -470,6 +470,11 @@ public class IndexUtil {
             return false;
         }
 
+        // if core based setting is turned on, then it takes precedence
+        if (mapperService.getIndexSettings().isDerivedSourceEnabled()) {
+            return false;
+        }
+
         if (KNNSettings.isKNNDerivedSourceEnabled(mapperService.getIndexSettings().getSettings()) == false) {
             return false;
         }

--- a/src/test/java/org/opensearch/knn/index/util/IndexUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/util/IndexUtilTests.java
@@ -457,4 +457,69 @@ public class IndexUtilTests extends KNNTestCase {
 
         assertEquals(expectedDerivedEnabled, result);
     }
+    
+    /**
+     * Helper to create a MapperService mock with the required call chain for isDerivedEnabledForIndex.
+     * Sets up: documentMapper().sourceMapper().enabled(), getIndexSettings().isDerivedSourceEnabled(),
+     * getIndexSettings().getSettings(), and getIndexSettings().isSegRepLocalEnabled().
+     */
+    private MapperService buildMockMapperServiceForDerived(
+        boolean sourceEnabled,
+        boolean coreDerivedSourceEnabled,
+        boolean knnDerivedSourceEnabled,
+        boolean segRepLocalEnabled
+    ) {
+        MapperService mapperService = mock(MapperService.class);
+
+        // Mock documentMapper().sourceMapper().enabled()
+        org.opensearch.index.mapper.DocumentMapper documentMapper = mock(org.opensearch.index.mapper.DocumentMapper.class);
+        org.opensearch.index.mapper.SourceFieldMapper sourceFieldMapper = mock(org.opensearch.index.mapper.SourceFieldMapper.class);
+        when(sourceFieldMapper.enabled()).thenReturn(sourceEnabled);
+        when(documentMapper.sourceMapper()).thenReturn(sourceFieldMapper);
+        when(mapperService.documentMapper()).thenReturn(documentMapper);
+
+        // Mock getIndexSettings()
+        org.opensearch.index.IndexSettings indexSettings = mock(org.opensearch.index.IndexSettings.class);
+        when(indexSettings.isDerivedSourceEnabled()).thenReturn(coreDerivedSourceEnabled);
+        when(indexSettings.isSegRepLocalEnabled()).thenReturn(segRepLocalEnabled);
+
+        Settings settings = Settings.builder()
+            .put(KNNSettings.KNN_DERIVED_SOURCE_ENABLED, knnDerivedSourceEnabled)
+            .build();
+        when(indexSettings.getSettings()).thenReturn(settings);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        return mapperService;
+    }
+
+    public void testIsDerivedEnabledForIndex_whenCoreDerivedSourceEnabled_thenReturnFalse() {
+        // Core derived source is ON → should return false (core takes precedence over KNN derived source)
+        MapperService mapperService = buildMockMapperServiceForDerived(true, true, true, false);
+        assertFalse(IndexUtil.isDerivedEnabledForIndex(mapperService));
+    }
+
+    public void testIsDerivedEnabledForIndex_whenCoreDerivedSourceDisabledAndKnnDerivedSourceEnabled_thenReturnTrue() {
+        // Core derived source is OFF, KNN derived source is ON, source enabled, no seg rep → should return true
+        MapperService mapperService = buildMockMapperServiceForDerived(true, false, true, false);
+        assertTrue(IndexUtil.isDerivedEnabledForIndex(mapperService));
+    }
+
+    public void testIsDerivedEnabledForIndex_whenMapperServiceNull_thenReturnFalse() {
+        assertFalse(IndexUtil.isDerivedEnabledForIndex(null));
+    }
+
+    public void testIsDerivedEnabledForIndex_whenSourceDisabled_thenReturnFalse() {
+        MapperService mapperService = buildMockMapperServiceForDerived(false, false, true, false);
+        assertFalse(IndexUtil.isDerivedEnabledForIndex(mapperService));
+    }
+
+    public void testIsDerivedEnabledForIndex_whenKnnDerivedSourceDisabled_thenReturnFalse() {
+        MapperService mapperService = buildMockMapperServiceForDerived(true, false, false, false);
+        assertFalse(IndexUtil.isDerivedEnabledForIndex(mapperService));
+    }
+
+    public void testIsDerivedEnabledForIndex_whenSegRepLocalEnabled_thenReturnFalse() {
+        MapperService mapperService = buildMockMapperServiceForDerived(true, false, true, true);
+        assertFalse(IndexUtil.isDerivedEnabledForIndex(mapperService));
+    }
 }

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -57,30 +57,23 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         testDerivedSourceE2E(indexConfigContexts);
     }
 
+    @SneakyThrows
     @ExpectRemoteBuildValidation
-    public void testMetaFields() {
+    public void testFlatFieldsWithCore() {
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("derivedit", true, false, true);
+        testDerivedSourceE2E(indexConfigContexts);
+    }
+
+    @ExpectRemoteBuildValidation
+    public void testMetaFieldsWithKnn() {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getIndexContextsWithMetaFields("derivedit", true, true);
-        List<String> metaFields = List.of(ROUTING_FIELD, "_id", "_score");
+        testMetaFields(indexConfigContexts);
+    }
 
-        assertEquals("Expected 6 index contexts for meta fields test", 6, indexConfigContexts.size());
-        prepareOriginalIndices(indexConfigContexts);
-
-        List<Object> searchResults = testSearch(indexConfigContexts);
-        assertFalse("Search results should not be empty", searchResults.isEmpty());
-
-        for (int i = 0; i < searchResults.size(); i++) {
-            Object searchResult = searchResults.get(i);
-            assertNotNull("Search result at index " + i + " should not be null", searchResult);
-
-            Map<String, Object> hits = (Map<String, Object>) searchResult;
-            for (String metaField : metaFields) {
-                assertTrue(String.format("Missing meta field '%s' in search result %d", metaField, i), hits.containsKey(metaField));
-                assertNotNull(
-                    String.format("Meta field '%s' value should not be null in search result %d", metaField, i),
-                    hits.get(metaField)
-                );
-            }
-        }
+    @ExpectRemoteBuildValidation
+    public void testMetaFieldsWithCore() {
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getIndexContextsWithMetaFields("derivedit", true, false, true);
+        testMetaFields(indexConfigContexts);
     }
 
     @SneakyThrows
@@ -95,6 +88,20 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
     public void testNestedField() {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true);
         testDerivedSourceE2E(indexConfigContexts);
+    }
+
+    @SneakyThrows
+    @ExpectRemoteBuildValidation
+    public void testNestedFieldWithCore() {
+        List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getNestedIndexContexts("derivedit", true, true);
+        expectThrows(
+                ResponseException.class,
+                () -> createKnnIndex(
+                        indexConfigContexts.get(0).indexName,
+                        indexConfigContexts.get(0).getSettings(),
+                        indexConfigContexts.get(0).getMapping()
+                )
+        );
     }
 
     @SneakyThrows
@@ -211,6 +218,30 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
                 dsDisabledException = true;
             }
             assertEquals(dsEnabledException, dsDisabledException);
+        }
+    }
+
+    private void testMetaFields(List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts) {
+        List<String> metaFields = List.of(ROUTING_FIELD, "_id", "_score");
+
+        assertEquals("Expected 6 index contexts for meta fields test", 6, indexConfigContexts.size());
+        prepareOriginalIndices(indexConfigContexts);
+
+        List<Object> searchResults = testSearch(indexConfigContexts);
+        assertFalse("Search results should not be empty", searchResults.isEmpty());
+
+        for (int i = 0; i < searchResults.size(); i++) {
+            Object searchResult = searchResults.get(i);
+            assertNotNull("Search result at index " + i + " should not be null", searchResult);
+
+            Map<String, Object> hits = (Map<String, Object>) searchResult;
+            for (String metaField : metaFields) {
+                assertTrue(String.format("Missing meta field '%s' in search result %d", metaField, i), hits.containsKey(metaField));
+                assertNotNull(
+                        String.format("Meta field '%s' value should not be null in search result %d", metaField, i),
+                        hits.get(metaField)
+                );
+            }
         }
     }
 

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -96,17 +96,22 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *     }
      * }
      */
-    protected List<DerivedSourceUtils.IndexConfigContext> getFlatIndexContexts(String testSuitePrefix, boolean addRandom, boolean addNull) {
+    protected List<DerivedSourceUtils.IndexConfigContext> getFlatIndexContexts(String testSuitePrefix, boolean addRandom, boolean addNull, boolean coreEnabled) {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = new ArrayList<>();
         long consistentRandomSeed = random().nextLong();
         for (Pair<String, Boolean> index : INDEX_PREFIX_TO_ENABLED) {
             Supplier<Integer> dimensionSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DIMENSION, MAX_DIMENSION);
             Supplier<Integer> binaryDimensionSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DIMENSION, MAX_DIMENSION, 8);
             Supplier<Integer> randomDocCountSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DOCS, MAX_DOCS);
-            DerivedSourceUtils.IndexConfigContext indexConfigContext = DerivedSourceUtils.IndexConfigContext.builder()
+            DerivedSourceUtils.IndexConfigContext.IndexConfigContextBuilder<?, ?> builder = DerivedSourceUtils.IndexConfigContext.builder();
+            if (coreEnabled) {
+                builder.coreDerivedEnabled(index.getSecond());
+            } else {
+                builder.derivedEnabled(index.getSecond());
+            }
+            DerivedSourceUtils.IndexConfigContext indexConfigContext = builder
                 .indexName(getIndexName(testSuitePrefix, index.getFirst(), addRandom))
                 .docCount(randomDocCountSupplier.get())
-                .derivedEnabled(index.getSecond())
                 .random(new Random(consistentRandomSeed))
                 .fields(
                     List.of(
@@ -146,8 +151,14 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                             .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .isUpdate(true)
                             .build(),
-                        DerivedSourceUtils.TextFieldType.builder().fieldPath("test-text").build(),
-                        DerivedSourceUtils.IntFieldType.builder().fieldPath("test-int").build()
+                        DerivedSourceUtils.TextFieldType.builder()
+                                .fieldPath("test-text")
+                                .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
+                                .build(),
+                        DerivedSourceUtils.IntFieldType.builder()
+                                .fieldPath("test-int")
+                                .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
+                                .build()
                     )
                 )
                 .build();
@@ -155,6 +166,10 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
             indexConfigContexts.add(indexConfigContext);
         }
         return indexConfigContexts;
+    }
+
+    protected List<DerivedSourceUtils.IndexConfigContext> getFlatIndexContexts(String testSuitePrefix, boolean addRandom, boolean addNull) {
+        return getFlatIndexContexts(testSuitePrefix, addRandom, addNull, false);
     }
 
     /**
@@ -299,7 +314,6 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                             .fieldPath("update_vector")
                             .isUpdate(true)
                             .build(),
-
                         DerivedSourceUtils.TextFieldType.builder().fieldPath("test-text").build(),
                         DerivedSourceUtils.IntFieldType.builder().fieldPath("test-int").build()
                     )
@@ -497,16 +511,22 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
      *     }
      *   }
      */
-    protected List<DerivedSourceUtils.IndexConfigContext> getNestedIndexContexts(String testSuitePrefix, boolean addRandom) {
+    protected List<DerivedSourceUtils.IndexConfigContext> getNestedIndexContexts(String testSuitePrefix, boolean addRandom, boolean coreEnabled) {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = new ArrayList<>();
         long consistentRandomSeed = random().nextLong();
         for (Pair<String, Boolean> index : INDEX_PREFIX_TO_ENABLED) {
             Supplier<Integer> dimensionSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DIMENSION, MAX_DIMENSION);
             Supplier<Integer> randomDocCountSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DOCS, MAX_DOCS);
-            DerivedSourceUtils.IndexConfigContext indexConfigContext = DerivedSourceUtils.IndexConfigContext.builder()
+            DerivedSourceUtils.IndexConfigContext.IndexConfigContextBuilder<?, ?> builder = DerivedSourceUtils.IndexConfigContext.builder();
+            if (coreEnabled) {
+                builder.coreDerivedEnabled(index.getSecond());
+            } else {
+                builder.derivedEnabled(index.getSecond());
+            }
+
+            DerivedSourceUtils.IndexConfigContext indexConfigContext = builder
                 .indexName(getIndexName(testSuitePrefix, index.getFirst(), addRandom))
                 .docCount(randomDocCountSupplier.get())
-                .derivedEnabled(index.getSecond())
                 .random(new Random(consistentRandomSeed))
                 .fields(
                     List.of(
@@ -614,6 +634,10 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
         return indexConfigContexts;
     }
 
+    protected List<DerivedSourceUtils.IndexConfigContext> getNestedIndexContexts(String testSuitePrefix, boolean addRandom) {
+        return getNestedIndexContexts(testSuitePrefix, addRandom, false);
+    }
+
     /**
      * Testing meta fields like routing
      * <p>
@@ -644,17 +668,23 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
     protected List<DerivedSourceUtils.IndexConfigContext> getIndexContextsWithMetaFields(
         String testSuitePrefix,
         boolean addRandom,
-        boolean addNull
+        boolean addNull,
+        boolean coreEnabled
     ) {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = new ArrayList<>();
         long consistentRandomSeed = random().nextLong();
         for (Pair<String, Boolean> index : INDEX_PREFIX_TO_ENABLED) {
             Supplier<Integer> dimensionSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DIMENSION, MAX_DIMENSION);
             Supplier<Integer> randomDocCountSupplier = randomIntegerSupplier(consistentRandomSeed, MIN_DOCS, MAX_DOCS);
-            DerivedSourceUtils.IndexConfigContext indexConfigContext = DerivedSourceUtils.IndexConfigContext.builder()
+            DerivedSourceUtils.IndexConfigContext.IndexConfigContextBuilder<?, ?> builder = DerivedSourceUtils.IndexConfigContext.builder();
+            if (coreEnabled) {
+                builder.coreDerivedEnabled(index.getSecond());
+            } else {
+                builder.derivedEnabled(index.getSecond());
+            }
+            DerivedSourceUtils.IndexConfigContext indexConfigContext = builder
                 .indexName(getIndexName(testSuitePrefix, index.getFirst(), addRandom))
                 .docCount(randomDocCountSupplier.get())
-                .derivedEnabled(index.getSecond())
                 .random(new Random(consistentRandomSeed))
                 .fields(
                     List.of(
@@ -663,8 +693,14 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
                             .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
                             .fieldPath("test_float_vector")
                             .build(),
-                        DerivedSourceUtils.TextFieldType.builder().fieldPath("test-text").build(),
-                        DerivedSourceUtils.IntFieldType.builder().fieldPath("test-int").build()
+                        DerivedSourceUtils.TextFieldType.builder()
+                                .fieldPath("test-text")
+                                .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
+                                .build(),
+                        DerivedSourceUtils.IntFieldType.builder()
+                                .fieldPath("test-int")
+                                .nullProb(addNull ? DerivedSourceUtils.DEFAULT_NULL_PROB : 0)
+                                .build()
                     )
                 )
                 .isRoutingEnabled(true)
@@ -673,6 +709,14 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
             indexConfigContexts.add(indexConfigContext);
         }
         return indexConfigContexts;
+    }
+
+    protected List<DerivedSourceUtils.IndexConfigContext> getIndexContextsWithMetaFields(
+            String testSuitePrefix,
+            boolean addRandom,
+            boolean addNull
+    ) {
+        return getIndexContextsWithMetaFields(testSuitePrefix, addRandom, addNull, false);
     }
 
     @SneakyThrows

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
@@ -15,6 +15,7 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.replication.common.ReplicationType;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
@@ -51,6 +52,22 @@ public class DerivedSourceUtils {
         .put("index.knn", true)
         .put(KNNSettings.KNN_DERIVED_SOURCE_ENABLED, true)
         .build();
+
+    public static final Settings CORE_DERIVED_ENABLED_SETTINGS = Settings.builder()
+            .put(
+                    "number_of_shards",
+                    System.getProperty(BWC_VERSION, null) == null ? Integer.parseInt(System.getProperty("cluster.number_of_nodes", "1")) : 1
+            )
+            .put(
+                    "number_of_replicas",
+                    Integer.parseInt(System.getProperty("cluster.number_of_nodes", "1")) > 1 && System.getProperty(BWC_VERSION, null) == null
+                            ? 1
+                            : 0
+            )
+            .put("index.knn", true)
+            .put(IndexSettings.INDEX_DERIVED_SOURCE_SETTING.getKey(), true)
+            .put(IndexSettings.INDEX_DERIVED_SOURCE_TRANSLOG_ENABLED_SETTING.getKey(), true)
+            .build();
 
     public static final Settings DERIVED_ENABLED_WITH_SEGREP_SETTINGS = Settings.builder()
         .put(
@@ -94,6 +111,8 @@ public class DerivedSourceUtils {
         @Builder.Default
         public boolean derivedEnabled = false;
         @Builder.Default
+        public boolean coreDerivedEnabled = false;
+        @Builder.Default
         public int docCount = DOCS;
         @Builder.Default
         public Settings settings = null;
@@ -110,6 +129,9 @@ public class DerivedSourceUtils {
         public Settings getSettings() {
             if (settings != null) {
                 return settings;
+            }
+            if (coreDerivedEnabled) {
+                return CORE_DERIVED_ENABLED_SETTINGS;
             }
             return derivedEnabled ? DERIVED_ENABLED_SETTINGS : DERIVED_DISABLED_SETTINGS;
         }


### PR DESCRIPTION
### Description
Implement derived source for k-NN fields with core implementation, with a fallback to k-NN plugin's implementation. 

Related PR: https://github.com/opensearch-project/OpenSearch/pull/20991

Before this change, if `index.derived_source.enabled` and there is a knn field type, there will be error thrown saying that knn vector field doesnt supprt derived source feature.
After this change, if `index.derived_source.enabled` and there is a knn field type, the derived source feature will be turned on so that users can benefit out of both knn fields and other fields.

### Related Issues
Resolves #3058


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
