### PR TITLE
Add Hamming distance scorer for byte vectors in VectorScorers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,4 +43,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add VectorScorers for BinaryDocValues and nested best child scoring [#3179](https://github.com/opensearch-project/k-NN/pull/3179)
 * Introduce NativeEngines990KnnVectorsScorer to decouple native SIMD scoring selection from FaissMemoryOptimizedSearcher [#3184](https://github.com/opensearch-project/k-NN/pull/3184)
 * Add scorer-aware ByteVectorValues wrapper for FAISS Index [#3192](https://github.com/opensearch-project/k-NN/pull/3192)
+* Add Hamming distance scorer for byte vectors in VectorScorers [#3214](https://github.com/opensearch-project/k-NN/pull/3214)
 * Introduce VectorScorers to create VectorScorer instances based on the underlying vector storage format [#3183](https://github.com/opensearch-project/k-NN/pull/3183)

--- a/src/main/java/org/opensearch/knn/index/query/scorers/VectorScorers.java
+++ b/src/main/java/org/opensearch/knn/index/query/scorers/VectorScorers.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.util.BitSet;
@@ -99,6 +100,7 @@ public final class VectorScorers {
      * @param target    the byte query vector
      * @param vectorScorerMode determines whether to use scoring or rescoring
      * @param spaceType the space type defining the similarity function
+     * @param fieldInfo the field info for the vector field
      * @return a {@link VectorScorer} appropriate for the underlying vector storage format
      * @throws IOException if an I/O error occurs
      */
@@ -106,9 +108,10 @@ public final class VectorScorers {
         final KNNVectorValuesIterator.DocIdsIteratorValues docIdsIteratorValues,
         final byte[] target,
         final VectorScorerMode vectorScorerMode,
-        final SpaceType spaceType
+        final SpaceType spaceType,
+        final FieldInfo fieldInfo
     ) throws IOException {
-        return createScorer(docIdsIteratorValues, target, vectorScorerMode, spaceType, null, null);
+        return createScorer(docIdsIteratorValues, target, vectorScorerMode, spaceType, fieldInfo, null, null);
     }
 
     /**
@@ -120,6 +123,7 @@ public final class VectorScorers {
      * @param target    the byte query vector
      * @param vectorScorerMode determines whether to use scoring or rescoring
      * @param spaceType the space type defining the similarity function
+     * @param fieldInfo the field info for the vector field
      * @param acceptedChildrenIterator iterator over accepted child documents, or null if not nested
      * @param parentBitSet bit set identifying parent documents, or null if not nested
      * @return a {@link VectorScorer} appropriate for the underlying vector storage format
@@ -130,10 +134,11 @@ public final class VectorScorers {
         final byte[] target,
         final VectorScorerMode vectorScorerMode,
         final SpaceType spaceType,
+        final FieldInfo fieldInfo,
         @Nullable final DocIdSetIterator acceptedChildrenIterator,
         @Nullable final BitSet parentBitSet
     ) throws IOException {
-        final VectorScorer scorer = getBaseScorer(docIdsIteratorValues, target, vectorScorerMode, spaceType);
+        final VectorScorer scorer = getBaseScorer(docIdsIteratorValues, target, vectorScorerMode, spaceType, fieldInfo);
         return maybeWrapWithNestedScorer(scorer, acceptedChildrenIterator, parentBitSet);
     }
 
@@ -165,7 +170,8 @@ public final class VectorScorers {
         final KNNVectorValuesIterator.DocIdsIteratorValues docIdsIteratorValues,
         final byte[] target,
         final VectorScorerMode vectorScorerMode,
-        final SpaceType spaceType
+        final SpaceType spaceType,
+        final FieldInfo fieldInfo
     ) throws IOException {
         final DocIdSetIterator docIdSetIterator = docIdsIteratorValues.getDocIdSetIterator();
 
@@ -176,7 +182,9 @@ public final class VectorScorers {
 
         final KnnVectorValues knnVectorValues = docIdsIteratorValues.getKnnVectorValues();
         if (knnVectorValues instanceof ByteVectorValues byteVectorValues) {
-            return vectorScorerMode.createScorer(byteVectorValues, target);
+            return spaceType == SpaceType.HAMMING
+                ? createHammingDistanceScorer(fieldInfo, byteVectorValues, target, spaceType)
+                : vectorScorerMode.createScorer(byteVectorValues, target);
         }
         throw new IllegalArgumentException("Byte target requires ByteVectorValues but got " + knnVectorValues.getClass().getSimpleName());
     }
@@ -215,6 +223,59 @@ public final class VectorScorers {
         PrefetchableFlatVectorScorer scorer = new PrefetchableFlatVectorScorer(adcFlatVectorsScorer);
         final RandomVectorScorer randomVectorScorer = scorer.getRandomVectorScorer(
             spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction(),
+            byteVectorValues,
+            target
+        );
+        return new VectorScorer() {
+            final KnnVectorValues.DocIndexIterator iterator = byteVectorValues.iterator();
+
+            @Override
+            public float score() throws IOException {
+                return randomVectorScorer.score(iterator.docID());
+            }
+
+            @Override
+            public DocIdSetIterator iterator() {
+                return iterator;
+            }
+
+            @Override
+            public Bulk bulk(final DocIdSetIterator matchingDocs) {
+                return Bulk.fromRandomScorerSparse(randomVectorScorer, iterator, matchingDocs);
+            }
+        };
+    }
+
+    /**
+     * Creates a Hamming distance {@link VectorScorer} that scores a byte query vector
+     * against binary byte document vectors using Hamming distance.
+     *
+     * @param fieldInfo         the field info for the vector field
+     * @param byteVectorValues  the byte vector values from the segment
+     * @param target            the byte query vector
+     * @param spaceType         the space type defining the similarity function
+     * @return a {@link VectorScorer} using Hamming distance scoring
+     * @throws IOException if an I/O error occurs
+     */
+    // TODO: Remove once ByteVectorValues.scorer() is implemented to return the appropriate
+    // VectorScorer based on the distance function. At that point, VectorScorerMode.createScorer()
+    // will handle this case and this method will no longer be needed.
+    private static VectorScorer createHammingDistanceScorer(
+        final FieldInfo fieldInfo,
+        final ByteVectorValues byteVectorValues,
+        final byte[] target,
+        final SpaceType spaceType
+    ) throws IOException {
+        final FlatVectorsScorer hammingFlatVectorsScorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
+            fieldInfo,
+            spaceType.getKnnVectorSimilarityFunction(),
+            null
+        );
+        PrefetchableFlatVectorScorer scorer = new PrefetchableFlatVectorScorer(hammingFlatVectorsScorer);
+        // Hamming's KNNVectorSimilarityFunction does not map to a Lucene VectorSimilarityFunction,
+        // but HammingFlatVectorsScorer ignores this parameter, so we pass EUCLIDEAN as a placeholder.
+        final RandomVectorScorer randomVectorScorer = scorer.getRandomVectorScorer(
+            VectorSimilarityFunction.EUCLIDEAN,
             byteVectorValues,
             target
         );

--- a/src/test/java/org/opensearch/knn/index/query/scorers/VectorScorersTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/scorers/VectorScorersTests.java
@@ -138,7 +138,7 @@ public class VectorScorersTests extends KNNTestCase {
         KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
         when(iteratorValues.getDocIdSetIterator()).thenReturn(binaryDocValues);
 
-        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.HAMMING);
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.HAMMING, fieldInfo);
 
         assertNotNull(scorer);
         assertTrue(scorer instanceof KNNBinaryDocValuesScorer);
@@ -159,7 +159,7 @@ public class VectorScorersTests extends KNNTestCase {
         when(iteratorValues.getDocIdSetIterator()).thenReturn(byteVectorValues.iterator());
         when(iteratorValues.getKnnVectorValues()).thenReturn(byteVectorValues);
 
-        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.L2);
+        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.L2, fieldInfo);
 
         assertNotNull(scorer);
         assertScores(buildExpectedScores(query, docs, SpaceType.L2), scorer);
@@ -175,11 +175,37 @@ public class VectorScorersTests extends KNNTestCase {
         when(iteratorValues.getKnnVectorValues()).thenReturn(floatVectorValues);
 
         try {
-            VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.L2);
+            VectorScorers.createScorer(iteratorValues, query, VectorScorerMode.SCORE, SpaceType.L2, fieldInfo);
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Byte target requires ByteVectorValues"));
         }
+    }
+
+    @SneakyThrows
+    public void testByteTarget_withByteVectorValues_hammingSpaceType_returnsHammingScorer() {
+        byte[] query = { 0b0000_0000, (byte) 0b1111_1111 };
+        List<byte[]> docs = List.of(new byte[] { 0b0000_0000, (byte) 0b1111_1111 }, new byte[] { (byte) 0b1111_1111, 0b0000_0000 });
+        TestVectorValues.PreDefinedByteVectorValues byteVectorValues = new TestVectorValues.PreDefinedByteVectorValues(docs);
+
+        KNNVectorValuesIterator.DocIdsIteratorValues iteratorValues = mock(KNNVectorValuesIterator.DocIdsIteratorValues.class);
+        when(iteratorValues.getDocIdSetIterator()).thenReturn(byteVectorValues.iterator());
+        when(iteratorValues.getKnnVectorValues()).thenReturn(byteVectorValues);
+
+        FieldInfo hammingFieldInfo = mock(FieldInfo.class);
+        when(hammingFieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.HAMMING.getValue());
+
+        VectorScorer scorer = VectorScorers.createScorer(
+            iteratorValues,
+            query,
+            VectorScorerMode.SCORE,
+            SpaceType.HAMMING,
+            hammingFieldInfo
+        );
+
+        assertNotNull(scorer);
+        assertFalse(scorer instanceof KNNBinaryDocValuesScorer);
+        assertScores(buildExpectedScores(query, docs, SpaceType.HAMMING), scorer);
     }
 
     // ──────────────────────────────────────────────
@@ -237,7 +263,15 @@ public class VectorScorersTests extends KNNTestCase {
         BitSet parentBitSet = new FixedBitSet(4);
         parentBitSet.set(2);
 
-        VectorScorer scorer = VectorScorers.createScorer(iteratorValues, query, vectorScorerMode, SpaceType.L2, null, parentBitSet);
+        VectorScorer scorer = VectorScorers.createScorer(
+            iteratorValues,
+            query,
+            vectorScorerMode,
+            SpaceType.L2,
+            fieldInfo,
+            null,
+            parentBitSet
+        );
 
         assertTrue(scorer instanceof NestedBestChildVectorScorer);
     }


### PR DESCRIPTION
### Description
- Route SpaceType.HAMMING to a dedicated createHammingScorer via
  FlatVectorsScorerProvider for memory-optimized binary vector search
- Propagate fieldInfo to byte-target createScorer APIs for
  space-type-aware scorer resolution

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
