### PR TITLE
Speedup cosine similarity using AVX512-FP16 (supersedes #3181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ### Enhancements
+* Speedup cosine similarity using AVX512-FP16 [#3215](https://github.com/opensearch-project/k-NN/pull/3215)

--- a/jni/include/simd/similarity_function/similarity_function.h
+++ b/jni/include/simd/similarity_function/similarity_function.h
@@ -14,7 +14,11 @@ namespace knn_jni::simd::similarity_function {
         // L2 for FP16
         FP16_L2,
         SQ_IP,
-        SQ_L2
+        SQ_L2,
+        // FP16 Cosine Similarity. Vectors are pre-normalized so the dot product yields cosine similarity.
+        // The score transform is: max((1 + cosine) / 2, 0), matching Lucene's VectorSimilarityFunction.COSINE.
+        // Ref: https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+        FP16_COSINE
     };
 
     struct SimilarityFunction;

--- a/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
@@ -158,6 +158,23 @@ struct ArmNeonFP16L2 final : BaseSimilarityFunction<BulkScoreTransformFunc, Scor
 };
 
 //
+// FP16 Cosine Similarity — delegates to ArmNeonFP16MaxIP with cosine score transform.
+//
+template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
+struct ArmNeonFP16Cosine final : BaseSimilarityFunction<BulkScoreTransformFunc, ScoreTransformFunc> {
+    void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
+                                   int32_t* internalVectorIds,
+                                   float* scores,
+                                   const int32_t numVectors) {
+        // Reuses the IP dot product kernel; cosine score transform is injected via template parameters.
+        ipKernel.calculateSimilarityInBulk(srchContext, internalVectorIds, scores, numVectors);
+    }
+
+  private:
+    ArmNeonFP16MaxIP<BulkScoreTransformFunc, ScoreTransformFunc> ipKernel;
+};
+
+//
 // SQ (ADC: 4-bit query x 1-bit data) - NEON SIMD implementation
 //
 // The query is 4-bit quantized and transposed into 4 bit planes (via transposeHalfByte).
@@ -437,6 +454,8 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
 ArmNeonFP16MaxIP<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 ArmNeonFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> FP16_L2_SIMIL_FUNC;
+// 3. Cosine similarity
+ArmNeonFP16Cosine<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
 
 //
 // SQ
@@ -452,6 +471,8 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_L2) {
         return &FP16_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &FP16_COSINE_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_IP) {
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {

--- a/jni/src/simd/similarity_function/avx512_spr_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/avx512_spr_simd_similarity_function.cpp
@@ -10,6 +10,29 @@
 #include "faiss_score_to_lucene_transform.cpp"
 
 
+// Max FP16 accumulations before draining to FP32. Trades accuracy for speed.
+// Lower values improve precision; higher values improve performance.
+static constexpr int32_t FP16_DRAIN_INTERVAL = 4;
+
+// Drain FP16 accumulator into FP32 accumulator, then zero the FP16 accum.
+static inline void drain_ph_to_ps(__m512& acc_ps, __m512h& acc_ph) {
+    __m512i raw = _mm512_castph_si512(acc_ph);
+    acc_ps = _mm512_add_ps(acc_ps,
+                _mm512_cvtph_ps(_mm512_castsi512_si256(raw)));
+    acc_ps = _mm512_add_ps(acc_ps,
+                _mm512_cvtph_ps(_mm512_extracti64x4_epi64(raw, 1)));
+    acc_ph = _mm512_castsi512_ph(_mm512_setzero_si512());
+}
+
+// Convert 32 floats to a packed 512-bit float16 register (2x16 FP32 -> 1x32 FP16).
+static inline __m512h cvt2x16_fp32_to_ph(const float* p) {
+    __m256i lo = _mm512_cvtps_ph(_mm512_loadu_ps(p),
+                    _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    __m256i hi = _mm512_cvtps_ph(_mm512_loadu_ps(p + 16),
+                    _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    return _mm512_castsi512_ph(
+        _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1));
+}
 
 //
 // FP16
@@ -264,7 +287,7 @@ struct AVX512SPRFP16L2 final : BaseSimilarityFunction<BulkScoreTransformFunc, Sc
 
 
 //
-// FP16 Cosine Similarity — delegates to AVX512SPRFP16MaxIP with cosine score transform.
+// FP16 Cosine Similarity
 //
 template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
 struct AVX512SPRFP16Cosine final : BaseSimilarityFunction<BulkScoreTransformFunc, ScoreTransformFunc> {
@@ -272,17 +295,148 @@ struct AVX512SPRFP16Cosine final : BaseSimilarityFunction<BulkScoreTransformFunc
                                    int32_t* internalVectorIds,
                                    float* scores,
                                    const int32_t numVectors) {
-        // Reuses the IP dot product kernel; cosine score transform is injected via template parameters.
-        ipKernel.calculateSimilarityInBulk(srchContext, internalVectorIds, scores, numVectors);
-    }
+        int32_t processedCount = 0;
+        const auto* queryPtr = (const float*) srchContext->queryVectorSimdAligned;
+        const int32_t dim = srchContext->dimension;
 
-  private:
-    AVX512SPRFP16MaxIP<BulkScoreTransformFunc, ScoreTransformFunc> ipKernel;
+        constexpr int32_t vecBlock = 8;
+        constexpr int32_t elemPerLoad = 32;
+
+        // SIMD-aligned dim and tail dim
+        const int32_t simdDim = (dim / elemPerLoad) * elemPerLoad;
+        const int32_t tailDim  = dim - simdDim;
+
+        // Precompute tail mask
+        const __mmask32 tailMask = tailDim > 0 ? (__mmask32)((1ULL << tailDim) - 1) : 0;
+
+        // Do same for the tail part
+        const int32_t tailMid16 = (tailDim >= 16) ? 16 : 0;
+        const int32_t tailFinal = tailDim - tailMid16;
+        const __mmask16 tailFinalMask = tailFinal > 0 ? (__mmask16)((1U << tailFinal) - 1) : 0;
+
+        __m512h sumFp16[vecBlock]; // FP16 accumulators (32 lanes each)
+        __m512  sumFp32[vecBlock]; // FP32 accumulators (16 lanes each)
+
+        for (; processedCount <= numVectors - vecBlock; processedCount += vecBlock) {
+            const uint8_t* vectors[vecBlock];
+            srchContext->getVectorPointersInBulk((uint8_t**)vectors, &internalVectorIds[processedCount], vecBlock);
+
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                sumFp16[v] = _mm512_castsi512_ph(_mm512_setzero_si512());
+                sumFp32[v] = _mm512_setzero_ps();
+            }
+
+            int32_t drainCount = 0;
+
+            // Mask-free hot loop
+            for (int32_t i = 0; i < simdDim; i += elemPerLoad) {
+                __m512h q = cvt2x16_fp32_to_ph(queryPtr + i);
+
+                if ((i + elemPerLoad) < dim) {
+                    const int32_t nextByteOffset = (i + elemPerLoad) * 2;
+                    #pragma unroll
+                    for (int32_t v = 0; v < vecBlock; ++v) {
+                        __builtin_prefetch(vectors[v] + nextByteOffset, 0, 3);
+                    }
+                    __builtin_prefetch(queryPtr + i + elemPerLoad, 0, 3);
+                }
+
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    __m512h vec = _mm512_loadu_ph(vectors[v] + 2 * i);
+                    sumFp16[v] = _mm512_fmadd_ph(q, vec, sumFp16[v]);
+                }
+
+                if (++drainCount >= FP16_DRAIN_INTERVAL) {
+                    #pragma unroll
+                    for (int32_t v = 0; v < vecBlock; ++v)
+                        drain_ph_to_ps(sumFp32[v], sumFp16[v]);
+                    drainCount = 0;
+                }
+            }
+
+            // Single masked tail
+            if (tailDim > 0) {
+                __m256i qLoH, qHiH;
+                if (tailMid16 > 0) {
+                    qLoH = _mm512_cvtps_ph(_mm512_loadu_ps(queryPtr + simdDim),
+                                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+                    qHiH = tailFinal > 0
+                        ? _mm512_cvtps_ph(_mm512_maskz_loadu_ps(tailFinalMask, queryPtr + simdDim + 16),
+                                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)
+                        : _mm256_setzero_si256();
+                } else {
+                    qLoH = _mm512_cvtps_ph(_mm512_maskz_loadu_ps(tailFinalMask, queryPtr + simdDim),
+                                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+                    qHiH = _mm256_setzero_si256();
+                }
+                __m512h q = _mm512_castsi512_ph(
+                    _mm512_inserti64x4(_mm512_castsi256_si512(qLoH), qHiH, 1));
+
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    __m512h vec = _mm512_castsi512_ph(
+                        _mm512_maskz_loadu_epi16(tailMask, vectors[v] + 2 * simdDim));
+                    sumFp16[v] = _mm512_fmadd_ph(q, vec, sumFp16[v]);
+                }
+            }
+
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                drain_ph_to_ps(sumFp32[v], sumFp16[v]);
+                scores[processedCount + v] = _mm512_reduce_add_ps(sumFp32[v]);
+            }
+        }
+
+        // Tail loop for remaining vectors
+        for (; processedCount < numVectors; ++processedCount) {
+            const auto* vecPtr = (const uint8_t*) srchContext->getVectorPointer(internalVectorIds[processedCount]);
+            __m512h sumFp16 = _mm512_castsi512_ph(_mm512_setzero_si512());
+            __m512  sumFp32 = _mm512_setzero_ps();
+            int32_t drainCount = 0;
+
+            for (int32_t i = 0; i < simdDim; i += elemPerLoad) {
+                sumFp16 = _mm512_fmadd_ph(cvt2x16_fp32_to_ph(queryPtr + i),
+                                           _mm512_loadu_ph(vecPtr + 2 * i), sumFp16);
+                if (++drainCount >= FP16_DRAIN_INTERVAL) {
+                    drain_ph_to_ps(sumFp32, sumFp16);
+                    drainCount = 0;
+                }
+            }
+
+            if (tailDim > 0) {
+                __m256i qLoH, qHiH;
+                if (tailMid16 > 0) {
+                    qLoH = _mm512_cvtps_ph(_mm512_loadu_ps(queryPtr + simdDim),
+                                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+                    qHiH = tailFinal > 0
+                        ? _mm512_cvtps_ph(_mm512_maskz_loadu_ps(tailFinalMask, queryPtr + simdDim + 16),
+                                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)
+                        : _mm256_setzero_si256();
+                } else {
+                    qLoH = _mm512_cvtps_ph(_mm512_maskz_loadu_ps(tailFinalMask, queryPtr + simdDim),
+                                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+                    qHiH = _mm256_setzero_si256();
+                }
+                __m512h q = _mm512_castsi512_ph(
+                    _mm512_inserti64x4(_mm512_castsi256_si512(qLoH), qHiH, 1));
+                sumFp16 = _mm512_fmadd_ph(q,
+                    _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, vecPtr + 2 * simdDim)),
+                    sumFp16);
+            }
+
+            drain_ph_to_ps(sumFp32, sumFp16);
+            scores[processedCount] = _mm512_reduce_add_ps(sumFp32);
+        }
+
+        BulkScoreTransformFunc(scores, numVectors);
+    }
 };
 
 
 //
-// SQ (ADC: 4-bit query x 1-bit data) - AVX512 SIMD implementation
+// BBQ (ADC: 4-bit query x 1-bit data) - AVX512 SIMD implementation
 //
 // The query is 4-bit quantized and transposed into 4 bit planes (via transposeHalfByte).
 // Each bit plane has `binaryCodeBytes` bytes. The int4BitDotProduct computes:
@@ -479,7 +633,7 @@ static FORCE_INLINE void avx512_4bitDotProductBatch(
 }
 
 template <bool IsMaxIP>
-struct AVX512SQSimilarityFunction final : SimilarityFunction {
+struct AVX512BBQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
                                             float* scores,
@@ -631,12 +785,12 @@ AVX512SPRFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToL
 AVX512SPRFP16Cosine<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
 
 //
-// SQ
+// BBQ
 //
 // 1. Max IP
-AVX512SQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+AVX512BBQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
 // 2. L2
-AVX512SQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+AVX512BBQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {

--- a/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
@@ -38,12 +38,31 @@ struct DefaultFP16SimilarityFunction final : BaseSimilarityFunction<BulkScoreTra
 };
 
 //
+// FP16 Cosine Similarity - Default (non-SIMD) implementation
+//
+template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
+struct DefaultFP16CosineSimilarityFunction final : BaseSimilarityFunction<BulkScoreTransformFunc, ScoreTransformFunc> {
+    void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
+                                   int32_t* internalVectorIds,
+                                   float* scores,
+                                   const int32_t numVectors) {
+        // Reuses the IP dot product kernel; cosine score transform is injected via template parameters.
+        ipKernel.calculateSimilarityInBulk(srchContext, internalVectorIds, scores, numVectors);
+    }
+
+  private:
+    DefaultFP16SimilarityFunction<BulkScoreTransformFunc, ScoreTransformFunc> ipKernel;
+};
+
+//
 // FP16
 //
 // 1. Max IP
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> DEFAULT_FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> DEFAULT_FP16_L2_SIMIL_FUNC;
+// 3. Cosine similarity
+DefaultFP16CosineSimilarityFunction<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> DEFAULT_FP16_COSINE_SIMIL_FUNC;
 
 
 //
@@ -303,6 +322,8 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &DEFAULT_FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_L2) {
         return &DEFAULT_FP16_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &DEFAULT_FP16_COSINE_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_IP) {
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {

--- a/jni/src/simd/similarity_function/faiss_score_to_lucene_transform.cpp
+++ b/jni/src/simd/similarity_function/faiss_score_to_lucene_transform.cpp
@@ -71,6 +71,41 @@ struct FaissScoreToLuceneScoreTransform final {
         }
     }
 
+    // Convert dot product value (on pre-normalized vectors) to Lucene cosine score.
+    // Lucene cosine score = max((1 + cosine) / 2, 0), mapping [-1,1] to [0,1].
+    static float cosineTransform(const float dotProductValue) noexcept {
+        return std::max((1.0f + dotProductValue) / 2.0f, 0.0f);
+    }
+
+    // Bulk version of cosineTransform.
+    // `scores` contain raw dot product values; after this transform they will have Lucene cosine scores.
+    static void cosineTransformBulk(float* scores, const int32_t numScores) noexcept {
+        int32_t i = 0;
+        for (; (i + 8) <= numScores ; i += 8, scores += 8) {
+            scores[0] = std::max((1.0f + scores[0]) / 2.0f, 0.0f);
+            scores[1] = std::max((1.0f + scores[1]) / 2.0f, 0.0f);
+            scores[2] = std::max((1.0f + scores[2]) / 2.0f, 0.0f);
+            scores[3] = std::max((1.0f + scores[3]) / 2.0f, 0.0f);
+            scores[4] = std::max((1.0f + scores[4]) / 2.0f, 0.0f);
+            scores[5] = std::max((1.0f + scores[5]) / 2.0f, 0.0f);
+            scores[6] = std::max((1.0f + scores[6]) / 2.0f, 0.0f);
+            scores[7] = std::max((1.0f + scores[7]) / 2.0f, 0.0f);
+        }
+
+        for (; (i + 4) <= numScores ; i += 4, scores += 4) {
+            scores[0] = std::max((1.0f + scores[0]) / 2.0f, 0.0f);
+            scores[1] = std::max((1.0f + scores[1]) / 2.0f, 0.0f);
+            scores[2] = std::max((1.0f + scores[2]) / 2.0f, 0.0f);
+            scores[3] = std::max((1.0f + scores[3]) / 2.0f, 0.0f);
+        }
+
+        while (i < numScores) {
+            *scores = cosineTransform(*scores);
+            ++i;
+            ++scores;
+        }
+    }
+
 private:
     FaissScoreToLuceneScoreTransform() = delete;
 };

--- a/jni/src/simd/similarity_function/simd_similarity_function_common.cpp
+++ b/jni/src/simd/similarity_function/simd_similarity_function_common.cpp
@@ -234,6 +234,24 @@ SimdVectorSearchContext* SimilarityFunction::saveSearchContext(
         // Assign query to Faiss function
         THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction->set_query(
             reinterpret_cast<float*>(THREAD_LOCAL_SIMD_VEC_SRCH_CTX.queryVectorSimdAligned));
+    } else if (nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::FP16_COSINE)) {
+        // Set similarity function for cosine similarity.
+        // The bulk SIMD kernel computes the same dot product as IP, but applies a cosine-specific
+        // score transform: max((1 + dot) / 2, 0).
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.similarityFunction = selectSimilarityFunction(
+            NativeSimilarityFunctionType::FP16_COSINE);
+
+        // FP16 vector bytes = 2bytes * dimension
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.oneVectorByteSize = 2 * dimension;
+
+        // Use inner product distance computer since the underlying math is the same for normalized vectors
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction.reset(
+             faiss::ScalarQuantizer {static_cast<size_t>(dimension), faiss::ScalarQuantizer::QuantizerType::QT_fp16}
+                                    .get_distance_computer(faiss::MetricType::METRIC_INNER_PRODUCT));
+
+        // Assign query to Faiss function
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction->set_query(
+            reinterpret_cast<float*>(THREAD_LOCAL_SIMD_VEC_SRCH_CTX.queryVectorSimdAligned));
     } else if (nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_IP)
                || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_L2)) {
          // Set similarity function to offload similarity calculation

--- a/jni/src/simd/similarity_function/similarity_function.cpp
+++ b/jni/src/simd/similarity_function/similarity_function.cpp
@@ -9,14 +9,14 @@
  * GitHub history for details.
  */
 
-#ifdef KNN_HAVE_AVX512
+#if defined(KNN_HAVE_AVX512_SPR)
+    // Convert FP32 query vector to FP16 and do bulk
+    // similarity with native AVX512-FP16 instructions.
+    #include "avx512_spr_simd_similarity_function.cpp"
+#elif defined(KNN_HAVE_AVX512)
+    // Convert FP16 vectors to FP32 and do bulk similarity.
     #include "avx512_simd_similarity_function.cpp"
-#elif KNN_HAVE_AVX512_SPR
-    // Since we convert FP16 to FP32 then do bulk operation,
-    // we're not really using SPR instruction set.
-    // Therefore, both AVX512 and AVX512_SPR are sharing the same code piece.
-    #include "avx512_simd_similarity_function.cpp"
-#elif KNN_HAVE_ARM_FP16
+#elif defined(KNN_HAVE_ARM_FP16)
     #include "arm_neon_simd_similarity_function.cpp"
 #else
     #include "default_simd_similarity_function.cpp"

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -948,21 +948,41 @@ public class KNNSettings {
     }
 
     public static boolean isFaissAVX512Disabled() {
-        return parseBoolean(
-            Objects.requireNonNullElse(
-                KNNSettings.state().getSettingValue(KNNSettings.KNN_FAISS_AVX512_DISABLED),
-                KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE
-            ).toString()
-        );
+        try {
+            return parseBoolean(
+                Objects.requireNonNullElse(
+                    KNNSettings.state().getSettingValue(KNNSettings.KNN_FAISS_AVX512_DISABLED),
+                    KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE
+                ).toString()
+            );
+        } catch (Exception e) {
+            log.warn(
+                "Unable to get setting value {} from cluster settings. Using default value as {}",
+                KNN_FAISS_AVX512_DISABLED,
+                KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE,
+                e
+            );
+            return KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE;
+        }
     }
 
     public static boolean isFaissAVX512SPRDisabled() {
-        return parseBoolean(
-            Objects.requireNonNullElse(
-                KNNSettings.state().getSettingValue(KNNSettings.KNN_FAISS_AVX512_SPR_DISABLED),
-                KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE
-            ).toString()
-        );
+        try {
+            return parseBoolean(
+                Objects.requireNonNullElse(
+                    KNNSettings.state().getSettingValue(KNNSettings.KNN_FAISS_AVX512_SPR_DISABLED),
+                    KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE
+                ).toString()
+            );
+        } catch (Exception e) {
+            log.warn(
+                "Unable to get setting value {} from cluster settings. Using default value as {}",
+                KNN_FAISS_AVX512_SPR_DISABLED,
+                KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE,
+                e
+            );
+            return KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE;
+        }
     }
 
     public static Integer getFilteredExactSearchThreshold(final String indexName) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -210,6 +210,8 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
      * and reused across all scoring calls.
      */
     private static class BulkSimdRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+        private final boolean isCosine;
+
         /**
          * Constructs a SIMD-backed scorer and initializes the native search context.
          *
@@ -220,7 +222,7 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
          * @param targetCorrectiveTerms correction terms from quantization
          * @param addressAndSize        raw memory location of vector data
          * @param knnVectorValues       vector storage abstraction
-         * @param similarityFunction    similarity function (IP or L2)
+         * @param similarityFunction    similarity function (IP, COSINE, or L2)
          * @param dimension             vector dimensionality
          * @param centroidDp            centroid dot-product correction
          */
@@ -234,8 +236,11 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
             final float centroidDp
         ) {
             super(knnVectorValues);
+            this.isCosine = similarityFunction == VectorSimilarityFunction.COSINE;
 
-            // Initialize native SIMD search context
+            // Initialize native SIMD search context.
+            // COSINE uses the same SQ_IP SIMD kernel (dot product on normalized vectors),
+            // then scores are post-processed in Java to apply the Lucene cosine transform.
             SimdVectorComputeService.saveSQSearchContext(
                 targetQuantized,
                 targetCorrectiveTerms.lowerInterval(),
@@ -265,7 +270,13 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
          */
         @Override
         public float bulkScore(final int[] internalVectorIds, final float[] scores, final int numVectors) {
-            return SimdVectorComputeService.scoreSimilarityInBulk(internalVectorIds, scores, numVectors);
+            final float result = SimdVectorComputeService.scoreSimilarityInBulk(internalVectorIds, scores, numVectors);
+            if (isCosine) {
+                for (int i = 0; i < numVectors; i++) {
+                    scores[i] = maxIpToCosine(scores[i]);
+                }
+            }
+            return result;
         }
 
         /**
@@ -277,7 +288,19 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
          */
         @Override
         public float score(final int internalVectorId) {
-            return SimdVectorComputeService.scoreSimilarity(internalVectorId);
+            final float score = SimdVectorComputeService.scoreSimilarity(internalVectorId);
+            return isCosine ? maxIpToCosine(score) : score;
+        }
+
+        /**
+         * Converts a Max Inner Product score to a Lucene cosine score.
+         * Reverses the Max-IP transform to recover the raw dot product,
+         * clamps to [-1, 1] (BBQ quantization can produce values slightly outside this range),
+         * then applies the Lucene cosine formula: max((1 + dot) / 2, 0).
+         */
+        private static float maxIpToCosine(final float maxIpScore) {
+            final float dot = maxIpScore >= 1.0f ? maxIpScore - 1.0f : 1.0f - 1.0f / maxIpScore;
+            return Math.max((1.0f + Math.min(dot, 1.0f)) / 2.0f, 0.0f);
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
@@ -70,6 +70,7 @@ public class NativeEngines990KnnVectorsScorer implements FlatVectorsScorer {
         return switch (similarityFunction) {
             case MAXIMUM_INNER_PRODUCT -> SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT;
             case EUCLIDEAN -> SimdVectorComputeService.SimilarityFunctionType.FP16_L2;
+            case COSINE -> SimdVectorComputeService.SimilarityFunctionType.FP16_COSINE;
             default -> null;
         };
     }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissMethod.java
@@ -158,12 +158,10 @@ public abstract class AbstractFaissMethod extends AbstractKNNMethod {
 
     @Override
     protected SpaceType convertUserToMethodSpaceType(SpaceType spaceType) {
-        // While FAISS doesn't directly support cosine similarity, we can leverage the mathematical
-        // relationship between cosine similarity and inner product for normalized vectors to add support.
-        // When ||a|| = ||b|| = 1, cos(θ) = a · b
-        if (spaceType == SpaceType.COSINESIMIL) {
-            return SpaceType.INNER_PRODUCT;
-        }
+        // Cosine similarity now has its own dedicated SIMD scoring path (FP16_COSINE).
+        // We no longer silently convert it to INNER_PRODUCT.
+        // The underlying FAISS index still uses METRIC_INNER_PRODUCT (since FAISS has no native cosine metric), but the space type
+        // identity is preserved so the correct score transform is applied during search.
         return super.convertUserToMethodSpaceType(spaceType);
     }
 

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
@@ -164,7 +164,8 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
     public RemoteIndexParameters createRemoteIndexingParameters(Map<String, Object> parameters) {
         RemoteFaissHNSWIndexParameters.RemoteFaissHNSWIndexParametersBuilder<?, ?> builder = RemoteFaissHNSWIndexParameters.builder();
         builder.algorithm(METHOD_HNSW);
-        builder.spaceType(getStringFromMap(parameters, SPACE_TYPE));
+        SpaceType spaceType = SpaceType.getSpace(getStringFromMap(parameters, SPACE_TYPE));
+        builder.spaceType((spaceType == SpaceType.COSINESIMIL ? SpaceType.INNER_PRODUCT : spaceType).getValue());
 
         Map<String, Object> innerParameters = (Map<String, Object>) parameters.get(PARAMETERS);
         builder.efConstruction(getIntegerFromMap(innerParameters, METHOD_PARAMETER_EF_CONSTRUCTION));

--- a/src/main/java/org/opensearch/knn/index/query/MemoryOptimizedSearchScoreConverter.java
+++ b/src/main/java/org/opensearch/knn/index/query/MemoryOptimizedSearchScoreConverter.java
@@ -47,12 +47,12 @@ public final class MemoryOptimizedSearchScoreConverter {
             return KNNEngine.LUCENE.distanceToRadialThreshold(distance, spaceType);
         }
 
-        // For cosine similarity, `distance = 1 - inner_product_value`.
-        // therefore, we should extract it then convert it to max_inner_product_value
-        final float innerProductValue = KNNEngine.FAISS.distanceToRadialThreshold(distance, SpaceType.COSINESIMIL);
+        // For cosine similarity, Faiss distance = 1 - cosine_similarity.
+        // Extract cosine similarity value.
+        final float cosineSimilarity = KNNEngine.FAISS.distanceToRadialThreshold(distance, SpaceType.COSINESIMIL);
 
-        // Convert inner product value to max inner product value.
-        return SpaceType.INNER_PRODUCT.scoreTranslation(-innerProductValue);
+        // Convert to Lucene cosine score: max((1 + cosine) / 2, 0)
+        return Math.max((1.0f + cosineSimilarity) / 2.0f, 0.0f);
     }
 
     /**
@@ -67,12 +67,12 @@ public final class MemoryOptimizedSearchScoreConverter {
             return KNNEngine.LUCENE.scoreToRadialThreshold(score, spaceType);
         }
 
-        // Since `score = (2 - (1 - inner_product_value)) / 2 = (1 + inner_product_value) / 2`,
-        // we should extract it then convert it to max inner product value.
-        final float innerProductValue = KNNEngine.FAISS.scoreToRadialThreshold(score, SpaceType.COSINESIMIL);
+        // For cosine similarity, Faiss score = max((2 - (1 - cosine)) / 2, 0) = max((1 + cosine) / 2, 0).
+        // Extract cosine similarity value from Faiss score.
+        final float cosineSimilarity = KNNEngine.FAISS.scoreToRadialThreshold(score, SpaceType.COSINESIMIL);
 
-        // Convert inner product value to max inner product value.
-        return SpaceType.INNER_PRODUCT.scoreTranslation(-innerProductValue);
+        // Convert to Lucene cosine score: max((1 + cosine) / 2, 0)
+        return Math.max((1.0f + cosineSimilarity) / 2.0f, 0.0f);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -30,7 +30,6 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
-import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
 import org.opensearch.lucene.OptimisticKnnCollectorManager;
 import org.opensearch.lucene.ReentrantKnnCollectorManager;
 
@@ -212,9 +211,6 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         if (topDocs.scoreDocs.length == 0) {
             log.debug("[KNN] Query yielded 0 results");
             return EMPTY_TOPDOCS;
-        }
-        if (spaceType == SpaceType.COSINESIMIL) {
-            MemoryOptimizedSearchScoreConverter.convertToCosineScore(topDocs.scoreDocs);
         }
         addExplainIfRequired(topDocs, knnEngine, spaceType);
         return topDocs;

--- a/src/main/java/org/opensearch/knn/index/query/scorers/VectorScorers.java
+++ b/src/main/java/org/opensearch/knn/index/query/scorers/VectorScorers.java
@@ -18,16 +18,15 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
-import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
 import java.io.IOException;
-
-import static org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter.convertInnerProductScoreToCosineScore;
 
 /**
  * Static factory for creating {@link VectorScorer} instances from {@link KNNVectorValuesIterator.DocIdsIteratorValues}.
@@ -222,13 +221,10 @@ public final class VectorScorers {
             spaceType.getKnnVectorSimilarityFunction(),
             null
         );
-        // For COSINESIMIL, the ADCFlatVectorsScorer produces scores in INNER_PRODUCT format
-        // (used by MemoryOptimizedKNNWeight which post-converts via convertToCosineScore).
-        // In the exact search path there is no post-conversion, so we wrap the scorer to convert here.
-        if (spaceType == SpaceType.COSINESIMIL) {
-            adcFlatVectorsScorer = new CosineADCFlatVectorsScorer(adcFlatVectorsScorer);
-        }
-        final RandomVectorScorer randomVectorScorer = adcFlatVectorsScorer.getRandomVectorScorer(
+        // ADCFlatVectorsScorer now directly produces the correct score format for each space type,
+        // including COSINESIMIL (Lucene cosine transform). No wrapper needed.
+        PrefetchableFlatVectorScorer scorer = new PrefetchableFlatVectorScorer(adcFlatVectorsScorer);
+        final RandomVectorScorer randomVectorScorer = scorer.getRandomVectorScorer(
             spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction(),
             byteVectorValues,
             target
@@ -251,51 +247,6 @@ public final class VectorScorers {
                 return Bulk.fromRandomScorerSparse(randomVectorScorer, iterator, matchingDocs);
             }
         };
-    }
-
-    /**
-     * Wraps an ADC {@link FlatVectorsScorer} to convert INNER_PRODUCT-format scores to
-     * COSINESIMIL-format. The ADCFlatVectorsScorer uses INNER_PRODUCT.scoreTranslation for
-     * cosine, which the MemoryOptimized path post-converts. In the exact search path there
-     * is no post-conversion, so this wrapper applies it at the scorer level.
-     */
-    // TODO: Move this cosine score conversion into ADCFlatVectorsScorer itself so that it directly
-    // produces COSINESIMIL-format scores. This would eliminate the need for both this wrapper and
-    // the post-conversion in MemoryOptimizedKNNWeight (convertToCosineScore), keeping the
-    // conversion logic in a single place.
-    private record CosineADCFlatVectorsScorer(FlatVectorsScorer delegate) implements FlatVectorsScorer {
-
-        @Override
-        public RandomVectorScorerSupplier getRandomVectorScorerSupplier(
-            VectorSimilarityFunction similarityFunction,
-            KnnVectorValues vectorValues
-        ) throws IOException {
-            return delegate.getRandomVectorScorerSupplier(similarityFunction, vectorValues);
-        }
-
-        @Override
-        public RandomVectorScorer getRandomVectorScorer(
-            VectorSimilarityFunction similarityFunction,
-            KnnVectorValues vectorValues,
-            float[] target
-        ) throws IOException {
-            final RandomVectorScorer inner = delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
-            return new RandomVectorScorer.AbstractRandomVectorScorer(vectorValues) {
-                @Override
-                public float score(int node) throws IOException {
-                    return convertInnerProductScoreToCosineScore(inner.score(node));
-                }
-            };
-        }
-
-        @Override
-        public RandomVectorScorer getRandomVectorScorer(
-            VectorSimilarityFunction similarityFunction,
-            KnnVectorValues vectorValues,
-            byte[] target
-        ) throws IOException {
-            return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
-        }
     }
 
     /**
@@ -323,9 +274,10 @@ public final class VectorScorers {
             spaceType.getKnnVectorSimilarityFunction(),
             null
         );
+        PrefetchableFlatVectorScorer scorer = new PrefetchableFlatVectorScorer(hammingFlatVectorsScorer);
         // Hamming's KNNVectorSimilarityFunction does not map to a Lucene VectorSimilarityFunction,
         // but HammingFlatVectorsScorer ignores this parameter, so we pass EUCLIDEAN as a placeholder.
-        final RandomVectorScorer randomVectorScorer = hammingFlatVectorsScorer.getRandomVectorScorer(
+        final RandomVectorScorer randomVectorScorer = scorer.getRandomVectorScorer(
             VectorSimilarityFunction.EUCLIDEAN,
             byteVectorValues,
             target

--- a/src/main/java/org/opensearch/knn/jni/SimdVectorComputeService.java
+++ b/src/main/java/org/opensearch/knn/jni/SimdVectorComputeService.java
@@ -25,7 +25,10 @@ public class SimdVectorComputeService {
         // FP16 Maximum Inner Product. The result will be the same as we acquired from VectorSimilarityFunction.EUCLIDEAN.
         FP16_L2,
         SQ_IP,
-        SQ_L2
+        SQ_L2,
+        // FP16 Cosine Similarity. Vectors are pre-normalized so the dot product yields cosine similarity.
+        // The score transform is: max((1 + cosine) / 2, 0), matching Lucene's VectorSimilarityFunction.COSINE.
+        FP16_COSINE
     }
 
     public static native void saveSQSearchContext(

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.common.RobustUniqueRandomIterator;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.WarmupUtil;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
@@ -54,7 +55,18 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     ) {
         this.indexInput = indexInput;
         this.faissIndex = faissIndex;
-        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
+        KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
+
+        // FAISS stores cosine as METRIC_INNER_PRODUCT, so the index-level metric alone can't
+        // distinguish them. Check the field's space type attribute to resolve the ambiguity.
+        // Only override for float vectors — cosine requires normalization which is only done for floats.
+        if (knnVectorSimilarityFunction == KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
+            && faissIndex.getVectorEncoding() == VectorEncoding.FLOAT32) {
+            final SpaceType fieldSpaceType = FieldInfoExtractor.getSpaceType(null, fieldInfo);
+            if (fieldSpaceType == SpaceType.COSINESIMIL) {
+                knnVectorSimilarityFunction = KNNVectorSimilarityFunction.COSINE;
+            }
+        }
 
         if (knnVectorSimilarityFunction != KNNVectorSimilarityFunction.HAMMING) {
             vectorSimilarityFunction = knnVectorSimilarityFunction.getVectorSimilarityFunction();

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -148,7 +148,16 @@ public class FlatVectorsScorerProvider {
                         return SpaceType.L2.scoreTranslation(KNNScoringUtil.l2SquaredADC(target, quantizedByteVector));
                     }
                 };
-                case INNER_PRODUCT, COSINESIMIL -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                case COSINESIMIL -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
+                    @Override
+                    public float score(int internalVectorId) throws IOException {
+                        final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);
+                        // For cosine, the dot product of normalized vectors equals cosine similarity.
+                        // COSINESIMIL.scoreTranslation expects rawScore = 1 - cosine, which equals 1 - dot.
+                        return SpaceType.COSINESIMIL.scoreTranslation(1 - KNNScoringUtil.innerProductADC(target, quantizedByteVector));
+                    }
+                };
+                case INNER_PRODUCT -> new RandomVectorScorer.AbstractRandomVectorScorer(knnVectorValues) {
                     @Override
                     public float score(int internalVectorId) throws IOException {
                         final byte[] quantizedByteVector = byteVectorValues.vectorValue(internalVectorId);

--- a/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNSettingsTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.knn.index;
 
 import lombok.SneakyThrows;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -311,5 +313,54 @@ public class KNNSettingsTests extends KNNTestCase {
         int availableProcessors = Runtime.getRuntime().availableProcessors();
         int expected = (availableProcessors >= 32) ? 4 : 1;
         assertEquals(expected, threadQtyWithEmpty);
+    }
+
+    public void testIsFaissAVX512Disabled_whenClusterServiceUnavailable_thenReturnsDefault() {
+        // Mock KNNSettings.state() to return a mock whose getSettingValue throws,
+        // simulating the cluster service being unavailable.
+        KNNSettings mockSettings = Mockito.mock(KNNSettings.class);
+        Mockito.when(mockSettings.getSettingValue(KNNSettings.KNN_FAISS_AVX512_DISABLED)).thenThrow(new NullPointerException("no cluster"));
+
+        try (MockedStatic<KNNSettings> knnSettingsStaticMock = Mockito.mockStatic(KNNSettings.class, Mockito.CALLS_REAL_METHODS)) {
+            knnSettingsStaticMock.when(KNNSettings::state).thenReturn(mockSettings);
+            boolean result = KNNSettings.isFaissAVX512Disabled();
+            assertEquals(KNNSettings.KNN_DEFAULT_FAISS_AVX512_DISABLED_VALUE, result);
+        }
+    }
+
+    public void testIsFaissAVX512SPRDisabled_whenClusterServiceUnavailable_thenReturnsDefault() {
+        // Mock KNNSettings.state() to return a mock whose getSettingValue throws,
+        // simulating the cluster service being unavailable.
+        KNNSettings mockSettings = Mockito.mock(KNNSettings.class);
+        Mockito.when(mockSettings.getSettingValue(KNNSettings.KNN_FAISS_AVX512_SPR_DISABLED))
+            .thenThrow(new NullPointerException("no cluster"));
+
+        try (MockedStatic<KNNSettings> knnSettingsStaticMock = Mockito.mockStatic(KNNSettings.class, Mockito.CALLS_REAL_METHODS)) {
+            knnSettingsStaticMock.when(KNNSettings::state).thenReturn(mockSettings);
+            boolean result = KNNSettings.isFaissAVX512SPRDisabled();
+            assertEquals(KNNSettings.KNN_DEFAULT_FAISS_AVX512_SPR_DISABLED_VALUE, result);
+        }
+    }
+
+    @SneakyThrows
+    public void testIsFaissAVX512Disabled_whenSettingAvailable_thenReturnsSettingValue() {
+        Node mockNode = createMockNode(Map.of(KNNSettings.KNN_FAISS_AVX512_DISABLED, true));
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        boolean result = KNNSettings.isFaissAVX512Disabled();
+        mockNode.close();
+        assertTrue(result);
+    }
+
+    @SneakyThrows
+    public void testIsFaissAVX512SPRDisabled_whenSettingAvailable_thenReturnsSettingValue() {
+        Node mockNode = createMockNode(Map.of(KNNSettings.KNN_FAISS_AVX512_SPR_DISABLED, true));
+        mockNode.start();
+        ClusterService clusterService = mockNode.injector().getInstance(ClusterService.class);
+        KNNSettings.state().setClusterService(clusterService);
+        boolean result = KNNSettings.isFaissAVX512SPRDisabled();
+        mockNode.close();
+        assertTrue(result);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorerTests.java
@@ -72,6 +72,26 @@ public class NativeEngines990KnnVectorsScorerTests extends TestCase {
         }
     }
 
+    public void testFloatVector_mmapValues_cosine_returnsNativeScorer() throws IOException {
+        KnnVectorValues vectorValues = mock(KnnVectorValues.class);
+        FloatVectorValues mmapValues = mock(FloatVectorValues.class, withSettings().extraInterfaces(MMapVectorValues.class));
+        when(((MMapVectorValues) mmapValues).getAddressAndSize()).thenReturn(new long[] { 100L, 200L });
+        float[] target = new float[] { 1.0f, 2.0f };
+
+        try (
+            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class);
+            MockedStatic<SimdVectorComputeService> ignored = mockStatic(SimdVectorComputeService.class)
+        ) {
+            wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(mmapValues);
+
+            RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.COSINE, vectorValues, target);
+
+            assertNotNull(result);
+            assertTrue(result instanceof NativeRandomVectorScorer);
+            verifyNoInteractions(delegate);
+        }
+    }
+
     public void testFloatVector_nonMmapValues_delegatesToWrapped() throws IOException {
         KnnVectorValues vectorValues = mock(KnnVectorValues.class);
         FloatVectorValues plainValues = mock(FloatVectorValues.class);
@@ -93,9 +113,9 @@ public class NativeEngines990KnnVectorsScorerTests extends TestCase {
         float[] target = new float[] { 1.0f, 2.0f };
         RandomVectorScorer expectedScorer = mock(RandomVectorScorer.class);
 
-        when(delegate.getRandomVectorScorer(VectorSimilarityFunction.COSINE, vectorValues, target)).thenReturn(expectedScorer);
+        when(delegate.getRandomVectorScorer(VectorSimilarityFunction.DOT_PRODUCT, vectorValues, target)).thenReturn(expectedScorer);
 
-        RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.COSINE, vectorValues, target);
+        RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.DOT_PRODUCT, vectorValues, target);
 
         assertSame(expectedScorer, result);
     }

--- a/src/test/java/org/opensearch/knn/index/query/scorers/VectorScorersTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/scorers/VectorScorersTests.java
@@ -21,7 +21,6 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
-import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesIterator;
 import org.opensearch.knn.index.vectorvalues.TestVectorValues;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
@@ -282,7 +281,7 @@ public class VectorScorersTests extends KNNTestCase {
     }
 
     // ──────────────────────────────────────────────
-    // CosineADCFlatVectorsScorer
+    // Cosine ADC scoring (direct cosine-format scores)
     // ──────────────────────────────────────────────
 
     @SneakyThrows
@@ -299,13 +298,16 @@ public class VectorScorersTests extends KNNTestCase {
         when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.COSINESIMIL.getValue());
         QuantizationConfig adcConfig = QuantizationConfig.builder().enableADC(true).build();
 
-        // Known IP-format scores the inner ADC scorer will return for each doc
-        float[] ipScores = { 1.5f, 0.5f };
+        // FlatVectorsScorerProvider now directly produces cosine-format scores
+        float[] cosineScores = { 0.85f, 0.65f };
 
-        // Build a mock FlatVectorsScorer that returns known IP-format scores
-        RandomVectorScorer mockRandomScorer = mock(RandomVectorScorer.class);
-        when(mockRandomScorer.score(0)).thenReturn(ipScores[0]);
-        when(mockRandomScorer.score(1)).thenReturn(ipScores[1]);
+        // Build a mock FlatVectorsScorer that returns cosine-format scores directly.
+        // Must mock AbstractRandomVectorScorer (not RandomVectorScorer) because
+        // PrefetchableFlatVectorScorer casts the result to AbstractRandomVectorScorer.
+        RandomVectorScorer.AbstractRandomVectorScorer mockRandomScorer = mock(RandomVectorScorer.AbstractRandomVectorScorer.class);
+        when(mockRandomScorer.score(0)).thenReturn(cosineScores[0]);
+        when(mockRandomScorer.score(1)).thenReturn(cosineScores[1]);
+        when(mockRandomScorer.values()).thenReturn(byteVectorValues);
 
         FlatVectorsScorer mockFlatScorer = mock(FlatVectorsScorer.class);
         when(mockFlatScorer.getRandomVectorScorer(any(VectorSimilarityFunction.class), any(KnnVectorValues.class), any(float[].class)))
@@ -328,10 +330,10 @@ public class VectorScorersTests extends KNNTestCase {
 
             assertNotNull(scorer);
 
-            // Verify scores are converted from IP format to cosine format
+            // Scores are already in cosine format — no post-conversion needed
             Map<Integer, Float> expectedScores = new HashMap<>();
-            for (int i = 0; i < ipScores.length; i++) {
-                expectedScores.put(i, MemoryOptimizedSearchScoreConverter.convertInnerProductScoreToCosineScore(ipScores[i]));
+            for (int i = 0; i < cosineScores.length; i++) {
+                expectedScores.put(i, cosineScores[i]);
             }
             assertScores(expectedScores, scorer);
         }
@@ -351,10 +353,11 @@ public class VectorScorersTests extends KNNTestCase {
         when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.COSINESIMIL.getValue());
         QuantizationConfig adcConfig = QuantizationConfig.builder().enableADC(true).build();
 
-        // IP score < 1 exercises the other branch: ip = 1 - 1/ipScore
-        float ipScore = 0.25f;
-        RandomVectorScorer mockRandomScorer = mock(RandomVectorScorer.class);
-        when(mockRandomScorer.score(0)).thenReturn(ipScore);
+        // FlatVectorsScorerProvider now directly produces cosine-format scores
+        float cosineScore = 0.25f;
+        RandomVectorScorer.AbstractRandomVectorScorer mockRandomScorer = mock(RandomVectorScorer.AbstractRandomVectorScorer.class);
+        when(mockRandomScorer.score(0)).thenReturn(cosineScore);
+        when(mockRandomScorer.values()).thenReturn(byteVectorValues);
 
         FlatVectorsScorer mockFlatScorer = mock(FlatVectorsScorer.class);
         when(mockFlatScorer.getRandomVectorScorer(any(VectorSimilarityFunction.class), any(KnnVectorValues.class), any(float[].class)))
@@ -375,9 +378,8 @@ public class VectorScorersTests extends KNNTestCase {
                 fieldInfo
             );
 
-            // Reverse INNER_PRODUCT.scoreTranslation for ipScore < 1
-            float expected = MemoryOptimizedSearchScoreConverter.convertInnerProductScoreToCosineScore(ipScore);
-            assertScores(Map.of(0, expected), scorer);
+            // Score is already in cosine format — used as-is
+            assertScores(Map.of(0, cosineScore), scorer);
         }
     }
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -64,7 +64,6 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.index.quantizationservice.QuantizationService;
 import org.opensearch.knn.index.query.FilterIdsSelector;
 import org.opensearch.knn.index.query.KNNQueryResult;
-import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
 import org.opensearch.knn.index.store.IndexInputWithBuffer;
 import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.index.vectorvalues.KNNByteVectorValues;
@@ -738,9 +737,6 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         // Make results
         final TopDocs topDocs = knnCollector.topDocs();
         final ScoreDoc[] scoreDocs = topDocs.scoreDocs;
-        if (spaceType == SpaceType.COSINESIMIL) {
-            MemoryOptimizedSearchScoreConverter.convertToCosineScore(scoreDocs);
-        }
         assertTrue(scoreDocs.length >= k);
         final List<KNNQueryResult> results = new ArrayList<>();
         for (int i = 0; i < k; ++i) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchScoreConverterTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchScoreConverterTests.java
@@ -34,19 +34,17 @@ public class MemoryOptimizedSearchScoreConverterTests {
             1e-6
         );
 
-        // For cosine though, score function between Faiss and Lucene is different
-        // Faiss's score = (1 + inner_product_value) / 2
-        // Since MAXIMUM_INNER_PRODUCT is being used in Lucene, we should get max_inner_product value which is 1.54.
-        // inner_product_value = 2 * score - 1
-        // max_inner_product_value = inner_product_value + 1 if inner_product_value >= 0 else 1 / -inner_product_value
+        // For cosine, the score function now directly produces Lucene cosine scores: max((1 + cosine) / 2, 0).
+        // FAISS cosine score = (1 + cosine) / 2, extracting cosine = 2 * score - 1.
+        // Lucene cosine score = max((1 + cosine) / 2, 0) = same as FAISS score for cosine.
         final float faissCosine1 = 0.77F;
         final float luceneRadius1 = MemoryOptimizedSearchScoreConverter.scoreToRadialThreshold(faissCosine1, SpaceType.COSINESIMIL);
-        assertEquals(luceneRadius1, 1.54F, 1e-6);
+        assertEquals(luceneRadius1, 0.77F, 1e-6);
 
-        // When two vectors are perpendicular to each other.
+        // When two vectors are perpendicular to each other (cosine = 0, FAISS score = 0.5).
         final float faissCosine2 = 0.5F;
         final float luceneRadius2 = MemoryOptimizedSearchScoreConverter.scoreToRadialThreshold(faissCosine2, SpaceType.COSINESIMIL);
-        assertEquals(luceneRadius2, 1F, 1e-6);
+        assertEquals(luceneRadius2, 0.5F, 1e-6);
     }
 
     @Test
@@ -79,38 +77,39 @@ public class MemoryOptimizedSearchScoreConverterTests {
         );
         assertEquals(1 + faissIpDistance3, luceneIpRadius3, 1e-6);
 
-        // For cosine, the input distance is actually `1 - inner product value (whose range is in [-1, 1])`
+        // For cosine, the input distance is `1 - cosine_similarity` (cosine in [-1, 1]).
+        // New transform: extract cosine = 1 - distance, then Lucene score = max((1 + cosine) / 2, 0).
         final float faissCosineDistance1 = 0;
         final float luceneCosineRadius1 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance1,
             SpaceType.COSINESIMIL
         );
-        // inner product value is 1 from distance `0`, hence it should be 1 + the value.
-        assertEquals(1 + 1, luceneCosineRadius1, 1e-6);
+        // cosine = 1 - 0 = 1, score = (1 + 1) / 2 = 1.0
+        assertEquals(1.0F, luceneCosineRadius1, 1e-6);
 
         final float faissCosineDistance2 = 2;
         final float luceneCosineRadius2 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance2,
             SpaceType.COSINESIMIL
         );
-        // inner product value is -1, hence max inner product value should be 1 / (1 + 1)
-        assertEquals(1F / (1 + 1), luceneCosineRadius2, 1e-6);
+        // cosine = 1 - 2 = -1, score = (1 + (-1)) / 2 = 0
+        assertEquals(0F, luceneCosineRadius2, 1e-6);
 
         final float faissCosineDistance3 = 1.44F;
         final float luceneCosineRadius3 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance3,
             SpaceType.COSINESIMIL
         );
-        // inner product value is -0.44, hence max inner product value should be 1 / (1 + 0.44)
-        assertEquals(1 / (1 + 0.44F), luceneCosineRadius3, 1e-6);
+        // cosine = 1 - 1.44 = -0.44, score = (1 + (-0.44)) / 2 = 0.28
+        assertEquals((1 + (1 - 1.44F)) / 2, luceneCosineRadius3, 1e-6);
 
         final float faissCosineDistance4 = 0.77F;
         final float luceneCosineRadius4 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance4,
             SpaceType.COSINESIMIL
         );
-        // inner product value is 0.23, hence max inner product value should be 1 / (1 + 0.44)
-        assertEquals(1.23F, luceneCosineRadius4, 1e-6);
+        // cosine = 1 - 0.77 = 0.23, score = (1 + 0.23) / 2 = 0.615
+        assertEquals((1 + (1 - 0.77F)) / 2, luceneCosineRadius4, 1e-6);
     }
 
     @Test

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -201,15 +201,11 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 assertNotNull("Test scorer should not be null", testScorer);
 
                 // ---- Step 4: Compare scores ----
-                final boolean isCosine = similarityFunction == VectorSimilarityFunction.COSINE;
                 int maxOrd = truthScorer.maxOrd();
                 assertEquals("maxOrd mismatch", maxOrd, testScorer.maxOrd());
 
                 for (int ord = 0; ord < maxOrd; ord++) {
                     float actual = testScorer.score(ord);
-                    if (isCosine) {
-                        actual = convertMaxIpToCosineScore(actual);
-                    }
                     float expected = truthScorer.score(ord);
                     assertEquals("Score mismatch at ord=" + ord + " for " + similarityFunction, expected, actual, 1e-2);
                 }
@@ -227,9 +223,6 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                     testScorer.bulkScore(ords, bulkScores, batchSize);
                     for (int j = 0; j < batchSize; j++) {
                         float actualBulk = bulkScores[j];
-                        if (isCosine) {
-                            actualBulk = convertMaxIpToCosineScore(actualBulk);
-                        }
                         float expected = truthScorer.score(ords[j]);
                         assertEquals(
                             "Bulk score mismatch at ord=" + ords[j] + " (batch=" + batchSize + ") for " + similarityFunction,
@@ -279,22 +272,5 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
             v[dimension - 1] = -(ThreadLocalRandom.current().nextFloat() * 0.5f + 0.5f);
         }
         return v;
-    }
-
-    /**
-     * Converts a Faiss MAX_IP score (used internally for cosine) to the Lucene cosine score.
-     * Faiss uses MAX_IP under the hood for cosine similarity on normalized vectors.
-     * The MAX_IP transform maps: ip >= 0 → 1 + ip, ip < 0 → 1 / (1 - ip).
-     * This reverses that, then applies the cosine score formula: (1 + ip) / 2.
-     */
-    private static float convertMaxIpToCosineScore(float maxIpScore) {
-        float innerProductValue;
-        if (maxIpScore >= 1) {
-            innerProductValue = maxIpScore - 1;
-        } else {
-            innerProductValue = 1 - 1 / maxIpScore;
-        }
-        innerProductValue = Math.clamp(innerProductValue, -1, 1);
-        return Math.max((1 + innerProductValue) / 2.0f, 0.0f);
     }
 }


### PR DESCRIPTION
### Description
This PR speeds up bulk cosine similarity using AVX512-FP16 by introducing a dedicated `FP16_COSINE` SIMD path for `cosinesimil`, rather than routing cosine through the inner product pipeline. Because cosine operates on L2-normalized vectors, the computation stays within a safe numeric range, allowing us to leverage AVX512-FP16 without the overflow concerns that typically come with FP16 arithmetic. This optimization is available under -`Dknn.faiss_opt_level=avx512_spr`.

FAISS does not expose cosine similarity as a first-class metric. Instead, cosine is implemented via `METRIC_INNER_PRODUCT` over L2-normalized vectors. In the current k-NN stack, this abstraction leaks through multiple layers: the space type is implicitly rewritten to `innerproduct`, the Max IP scorer and transform are applied, and `convertToCosineScore()` is used as a post-processing step to recover cosine semantics.

This PR preserves FAISS’s underlying `METRIC_INNER_PRODUCT` representation, but elevates cosine to a distinct similarity type at the API and execution layers. It applies Lucene’s cosine transform, `max((1 + dot) / 2, 0)`, directly during scoring (via native SIMD for FP16, via Java for ADC and BBQ)and eliminates the need for the Max IP–based workaround.

Performance:

Using `AVX512-FP16` for cosine, instead of the current IP path that converts `FP16` to `FP32`, can speedup performance by up to **52%**.

Source: https://gist.github.com/mulugetam/c3577f14ba0c3038669b3c90334563a2

```text
--------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations bytes_per_second items_per_second  score_avg  score_max  score_min
--------------------------------------------------------------------------------------------------------------------------------------------
BM_MaxIP/dim:384/numVecs:64         0.845 us        0.844 us       825898      54.2599Gi/s       29.1305G/s   2.68031m   0.137055  -0.116485
BM_MaxIP/dim:384/numVecs:256         3.39 us         3.38 us       207821       54.107Gi/s       29.0485G/s  -364.183u    0.18728  -0.127211
BM_MaxIP/dim:768/numVecs:64          1.60 us         1.59 us       440820      57.4398Gi/s       30.8378G/s -0.0126963  0.0622617  -0.103194
BM_MaxIP/dim:768/numVecs:256         6.33 us         6.32 us       105129      57.9845Gi/s       31.1302G/s  -7.00176m  0.0738014  -0.103194
BM_MaxIP/dim:1536/numVecs:64         3.07 us         3.06 us       223932      59.8104Gi/s       32.1104G/s   2.26699m  0.0600814 -0.0593108
BM_MaxIP/dim:1536/numVecs:256        12.3 us         12.3 us        57238      59.6056Gi/s       32.0005G/s  -779.642u  0.0600814 -0.0819004
BM_Cosine/dim:384/numVecs:64        0.623 us        0.622 us      1128178      73.5419Gi/s       39.4825G/s   2.68135m   0.137057  -0.116507
BM_Cosine/dim:384/numVecs:256        2.54 us         2.54 us       278328      72.2249Gi/s       38.7755G/s  -362.642u   0.187291  -0.127225
BM_Cosine/dim:768/numVecs:64         1.09 us         1.09 us       644787      83.7552Gi/s       44.9657G/s -0.0126957  0.0622705  -0.103185
BM_Cosine/dim:768/numVecs:256        4.35 us         4.34 us       161948      84.4021Gi/s        45.313G/s  -7.00271m  0.0738189  -0.103185
BM_Cosine/dim:1536/numVecs:64        2.01 us         2.00 us       347231      91.3607Gi/s       49.0489G/s   2.26844m  0.0600681 -0.0592989
BM_Cosine/dim:1536/numVecs:256       8.07 us         8.06 us        87360      90.9186Gi/s       48.8115G/s  -778.649u  0.0600681 -0.0818998
```
### Related Issues
Supersedes #3181 

### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
