### PR TITLE
[Bug] Fix bug when taking dimension < 8 for Faiss SQ.

### DIFF
--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -25,6 +25,7 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0007-Modify-minor-Faiss-structures-to-support-Faiss-SQ.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0008-Added-skipping-flat-storage-availability-in-write_in.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0009-Fixing-radial-search-for-IndexHNSWCagra.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/faiss/0010-Make-selective-FAISS_THROW_IF_NOT-d-8-0-in-IndexBina.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/faiss)

--- a/jni/include/sq/faiss_sq_flat.h
+++ b/jni/include/sq/faiss_sq_flat.h
@@ -259,7 +259,7 @@ namespace knn_jni {
         int32_t dimension;
 
         FaissSQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric)
-          : faiss::IndexBinary(_dimension, _metric),
+          : faiss::IndexBinary(_dimension, _metric, true),
             numVectors(_numVectors),
             quantizedVectorBytes(_quantizedVectorBytes),
             centroidDp(_centroidDp),

--- a/jni/include/sq/faiss_sq_hnsw.h
+++ b/jni/include/sq/faiss_sq_hnsw.h
@@ -10,7 +10,7 @@ namespace knn_jni {
         FaissSQFlat* faiss_sq_flat;
 
         FaissSQHnsw(int32_t _m, FaissSQFlat* _faiss_sq_flat)
-          : faiss::IndexBinaryHNSW(_faiss_sq_flat, _m),
+          : faiss::IndexBinaryHNSW(_faiss_sq_flat, _m, true),
             faiss_sq_flat(_faiss_sq_flat) {
             // This has the ownership of FaissSQFlat, setting this true to make it free'd when this class is freed
             own_fields = true;

--- a/jni/patches/faiss/0010-Make-selective-FAISS_THROW_IF_NOT-d-8-0-in-IndexBina.patch
+++ b/jni/patches/faiss/0010-Make-selective-FAISS_THROW_IF_NOT-d-8-0-in-IndexBina.patch
@@ -1,0 +1,101 @@
+From ef445296a0f48f3a0eb69b7436a60125f4a951e9 Mon Sep 17 00:00:00 2001
+From: Dooyong Kim <kdooyong@amazon.com>
+Date: Thu, 26 Mar 2026 17:05:44 -0700
+Subject: [PATCH] Make selective FAISS_THROW_IF_NOT(d % 8 == 0) in IndexBinary.
+
+Signed-off-by: Dooyong Kim <kdooyong@amazon.com>
+---
+ faiss/IndexBinary.cpp     | 7 +++++--
+ faiss/IndexBinary.h       | 5 +++--
+ faiss/IndexBinaryHNSW.cpp | 4 ++--
+ faiss/IndexBinaryHNSW.h   | 2 +-
+ faiss/IndexIDMap.cpp      | 3 ++-
+ 5 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/faiss/IndexBinary.cpp b/faiss/IndexBinary.cpp
+index 3c8165b76..7764ffbea 100644
+--- a/faiss/IndexBinary.cpp
++++ b/faiss/IndexBinary.cpp
+@@ -15,9 +15,12 @@
+ 
+ namespace faiss {
+ 
+-IndexBinary::IndexBinary(idx_t d, MetricType metric)
++IndexBinary::IndexBinary(idx_t d, MetricType metric, bool isExtendedIndex)
+         : d(d), code_size(d / 8), metric_type(metric) {
+-    FAISS_THROW_IF_NOT(d % 8 == 0);
++    if (isExtendedIndex == false) {
++        // If this is not extended, then it's required for dimension to be multiple of 8.
++        FAISS_THROW_IF_NOT(d % 8 == 0);
++    }
+ }
+ 
+ IndexBinary::~IndexBinary() = default;
+diff --git a/faiss/IndexBinary.h b/faiss/IndexBinary.h
+index 41ae6522a..0f99ebe0f 100644
+--- a/faiss/IndexBinary.h
++++ b/faiss/IndexBinary.h
+@@ -31,7 +31,7 @@ struct IndexBinary {
+     using distance_t = int32_t;
+ 
+     int d = 0;            ///< vector dimension
+-    int code_size = 0;    ///< number of bytes per vector ( = d / 8 )
++    int code_size = 0;    ///< number of bytes per vector ( = d / 8 if not isExtendedIndex, otherwise, it can be an arbitrary code_size)
+     idx_t ntotal = 0;     ///< total nb of indexed vectors
+     bool verbose = false; ///< verbosity level
+ 
+@@ -42,7 +42,8 @@ struct IndexBinary {
+     /// type of metric this index uses for search
+     MetricType metric_type = METRIC_L2;
+ 
+-    explicit IndexBinary(idx_t d = 0, MetricType metric = METRIC_L2);
++    // If this is extended index,
++    explicit IndexBinary(idx_t d = 0, MetricType metric = METRIC_L2, bool isExtendedIndex = false);
+ 
+     virtual ~IndexBinary();
+ 
+diff --git a/faiss/IndexBinaryHNSW.cpp b/faiss/IndexBinaryHNSW.cpp
+index a1db923b9..c5d221e44 100644
+--- a/faiss/IndexBinaryHNSW.cpp
++++ b/faiss/IndexBinaryHNSW.cpp
+@@ -180,8 +180,8 @@ IndexBinaryHNSW::IndexBinaryHNSW(int d, int M)
+     is_trained = true;
+ }
+ 
+-IndexBinaryHNSW::IndexBinaryHNSW(IndexBinary* storage, int M)
+-        : IndexBinary(storage->d),
++IndexBinaryHNSW::IndexBinaryHNSW(IndexBinary* storage, int M, bool isExtendedBinaryIndex)
++        : IndexBinary(storage->d, storage->metric_type, isExtendedBinaryIndex),
+           hnsw(M),
+           own_fields(false),
+           storage(storage) {
+diff --git a/faiss/IndexBinaryHNSW.h b/faiss/IndexBinaryHNSW.h
+index a72f06bc6..7ff1aaae2 100644
+--- a/faiss/IndexBinaryHNSW.h
++++ b/faiss/IndexBinaryHNSW.h
+@@ -42,7 +42,7 @@ struct IndexBinaryHNSW : IndexBinary {
+ 
+     explicit IndexBinaryHNSW();
+     explicit IndexBinaryHNSW(int d, int M = 32);
+-    explicit IndexBinaryHNSW(IndexBinary* storage, int M = 32);
++    explicit IndexBinaryHNSW(IndexBinary* storage, int M = 32, bool isExtendedBinaryIndex = false);
+ 
+     ~IndexBinaryHNSW() override;
+ 
+diff --git a/faiss/IndexIDMap.cpp b/faiss/IndexIDMap.cpp
+index 8c7a893e3..d9a27d30e 100644
+--- a/faiss/IndexIDMap.cpp
++++ b/faiss/IndexIDMap.cpp
+@@ -28,7 +28,8 @@ namespace {
+ void sync_d(Index* index) {}
+ 
+ void sync_d(IndexBinary* index) {
+-    FAISS_THROW_IF_NOT(index->d % 8 == 0);
++    // We don't need this check in here, it's already tested in its constructor.
++    // FAISS_THROW_IF_NOT(index->d % 8 == 0);
+     index->code_size = index->d / 8;
+ }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
@@ -56,7 +56,10 @@ import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectors
  */
 public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestCase {
 
-    private static final int DIMENSION = 128;
+    // 4 -> lower dimension test
+    // 128 -> test dimension that's multiple of 8
+    // 333 -> test odd dimension
+    private static final int[] DIMENSIONS = new int[] { 4, 128, 333 };
     private static final int NUM_VECTORS = 1234;
     private static final String FIELD_NAME = "test_field";
     private static final String SEGMENT_NAME = "_0";
@@ -64,60 +67,98 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
     @SneakyThrows
     public void testBuildDenseInnerProduct() {
         int[] docIds = sequentialDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, SpaceType.INNER_PRODUCT.getValue(), 1);
+        doBuildAndVerifyForMultipleDimensions(
+            docIds,
+            VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            SpaceType.INNER_PRODUCT.getValue(),
+            1
+        );
     }
 
     @SneakyThrows
     public void testBuildSparseInnerProduct() {
         int[] docIds = sparseDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, SpaceType.INNER_PRODUCT.getValue(), 1);
+        doBuildAndVerifyForMultipleDimensions(
+            docIds,
+            VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            SpaceType.INNER_PRODUCT.getValue(),
+            1
+        );
     }
 
     @SneakyThrows
     public void testBuildDenseL2() {
         int[] docIds = sequentialDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 1);
+        doBuildAndVerifyForMultipleDimensions(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 1);
     }
 
     @SneakyThrows
     public void testBuildSparseL2() {
         int[] docIds = sparseDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 1);
+        doBuildAndVerifyForMultipleDimensions(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 1);
     }
 
     @SneakyThrows
     public void testBuildDenseInnerProductMultiThreaded() {
         int[] docIds = sequentialDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, SpaceType.INNER_PRODUCT.getValue(), 4);
+        doBuildAndVerifyForMultipleDimensions(
+            docIds,
+            VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            SpaceType.INNER_PRODUCT.getValue(),
+            4
+        );
     }
 
     @SneakyThrows
     public void testBuildSparseInnerProductMultiThreaded() {
         int[] docIds = sparseDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, SpaceType.INNER_PRODUCT.getValue(), 4);
+        doBuildAndVerifyForMultipleDimensions(
+            docIds,
+            VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            SpaceType.INNER_PRODUCT.getValue(),
+            4
+        );
     }
 
     @SneakyThrows
     public void testBuildDenseL2MultiThreaded() {
         int[] docIds = sequentialDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 4);
+        doBuildAndVerifyForMultipleDimensions(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 4);
     }
 
     @SneakyThrows
     public void testBuildSparseL2MultiThreaded() {
         int[] docIds = sparseDocIds(NUM_VECTORS);
-        doBuildAndVerify(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 4);
+        doBuildAndVerifyForMultipleDimensions(docIds, VectorSimilarityFunction.EUCLIDEAN, SpaceType.L2.getValue(), 4);
     }
 
     @SneakyThrows
-    private void doBuildAndVerify(int[] docIds, VectorSimilarityFunction similarityFunction, String spaceType, int indexThreadQty) {
+    private void doBuildAndVerifyForMultipleDimensions(
+        int[] docIds,
+        VectorSimilarityFunction similarityFunction,
+        String spaceType,
+        int indexThreadQty
+    ) {
+        for (int dimension : DIMENSIONS) {
+            doBuildAndVerify(dimension, docIds, similarityFunction, spaceType, indexThreadQty);
+        }
+    }
+
+    @SneakyThrows
+    private void doBuildAndVerify(
+        int dimension,
+        int[] docIds,
+        VectorSimilarityFunction similarityFunction,
+        String spaceType,
+        int indexThreadQty
+    ) {
         final int maxDoc = docIds[docIds.length - 1] + 1;
-        final float[][] vectors = generateRandomVectors(NUM_VECTORS, DIMENSION);
+        final float[][] vectors = generateRandomVectors(NUM_VECTORS, dimension);
         final byte[] segmentId = StringHelper.randomId();
 
         try (Directory directory = newDirectory()) {
             // Step 1: Build .vec + .veb files via Lucene102 binary quantized format
-            final FieldInfo fieldInfo = createFieldInfo(similarityFunction);
+            final FieldInfo fieldInfo = createFieldInfo(similarityFunction, dimension);
             final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
             final SegmentInfo segmentInfo = new SegmentInfo(
                 directory,
@@ -204,7 +245,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
         }
     }
 
-    private static FieldInfo createFieldInfo(VectorSimilarityFunction similarityFunction) {
+    private static FieldInfo createFieldInfo(VectorSimilarityFunction similarityFunction, int dimension) {
         return new FieldInfo(
             FIELD_NAME,
             0,
@@ -219,7 +260,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
             0,
             0,
             0,
-            DIMENSION,
+            dimension,
             VectorEncoding.FLOAT32,
             similarityFunction,
             false,


### PR DESCRIPTION
### Description
Patches Faiss IndexBinary to make the d % 8 == 0 dimension constraint optional via a new isExtendedIndex flag, allowing scalar quantized indexes (FaissSQFlat, FaissSQHnsw) to use non-byte-aligned dimensions. Expands test coverage in MemOptimizedScalarQuantizedIndexBuildStrategyTests to verify builds across multiple dimensions (4, 128, 333).

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
