### PR TITLE
Fix flaky RelocationIT

### DIFF
--- a/src/test/java/org/opensearch/knn/index/RelocationIT.java
+++ b/src/test/java/org/opensearch/knn/index/RelocationIT.java
@@ -34,6 +34,9 @@ public class RelocationIT extends KNNRestTestCase {
 
         int dimension = 768;
         int numNodes = 2;
+
+        // Wait for all nodes to join the cluster and ensure cluster health is green
+        waitForClusterHealthGreen(Integer.toString(numNodes));
         Request nodesNamesRequest = new Request("GET", "_cat/nodes?h=name");
         Response response = client().performRequest(nodesNamesRequest);
         assertOK(response);
@@ -62,7 +65,6 @@ public class RelocationIT extends KNNRestTestCase {
                 VectorDataType.FLOAT
             )
         );
-        waitForClusterHealthGreen(Integer.toString(numNodes));
 
         logger.info("bulk Write docs");
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
### Description
Fix the flaky test blocking 3.6 build, which is failing the cat nodes check on a multinode cluster
https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/10988/pipeline/160/

```
 2> REPRODUCE WITH: ./gradlew ':integTestMultiNode' --tests 'org.opensearch.knn.index.RelocationIT.testForcemerge_whenRelocation_and_abortSuccess' -Dtests.seed=9AAAAB31B529BAB4 -Dtests.security.manager=false -Dtests.locale=ce-RU -Dtests.timezone=Europe/San_Marino -Druntime.java=25

  2> java.lang.AssertionError: expected:<2> but was:<1>

        at __randomizedtesting.SeedInfo.seed([9AAAAB31B529BAB4:643BA395DA31358A]:0)

        at org.junit.Assert.fail(Assert.java:89)

        at org.junit.Assert.failNotEquals(Assert.java:835)

        at org.junit.Assert.assertEquals(Assert.java:647)

        at org.junit.Assert.assertEquals(Assert.java:633)

        at org.opensearch.knn.index.RelocationIT.testForcemerge_whenRelocation_and_abortSuccess(RelocationIT.java:42)

  2> NOTE: leaving temporary files on disk at: /tmp/tmp43qwmnjw/k-NN/build/testrun/integTestMultiNode/temp/org.opensearch.knn.index.RelocationIT_9AAAAB31B529BAB4-001

  2> NOTE: test params are: codec=Asserting(Lucene104): {}, docValues:{}, maxPointsInLeafNode=421, maxMBSortInHeap=6.0114818495097335, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=ce-RU, timezone=Europe/San_Marino

  2> NOTE: Linux 6.1.140-154.222.amzn2023.x86_64 amd64/Eclipse Adoptium 25 (64-bit)/cpus=4,threads=2,free=388609152,total=536870912

  2> NOTE: All tests run in this JVM: [RelocationIT]

1 test completed, 1 failed

=== Standard output of node `node{::integTestMultiNode-0}` ===

=== Standard error of node `node{::integTestMultiNode-0}` ===

=== Standard output of node `node{::integTestMultiNode-1}` ===

=== Standard error of node `node{::integTestMultiNode-1}` ===

FAILURE: Build failed with an exception.
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
