### PR TITLE
[Bug] Fix bug when dimension <= 56 in Faiss SQ.

### DIFF
--- a/jni/include/sq/faiss_sq_flat.h
+++ b/jni/include/sq/faiss_sq_flat.h
@@ -120,10 +120,6 @@ namespace knn_jni {
         /// compute distance of vector i to current query
         float operator()(faiss::idx_t i) final {
             const uint8_t* target = data + i * oneElementByteSize;
-            // quantizedVectorBytes is always a multiple of 8 per the Java-side contract
-            // (FaissService.java: "byte length of a single 1-bit quantized vector, always
-            // 64-bit aligned"). The IsBytesMultipleOf8=false path is a safety fallback to
-            // avoid UB on unaligned pointer reads, not to handle non-multiple-of-8 sizes.
             const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
             uint32_t dp = 0;
 
@@ -134,12 +130,16 @@ namespace knn_jni {
                     dp += __builtin_popcountll(q[j] & t[j]);
                 }
             } else {
-                // Slower
                 for (size_t j = 0; j < words; ++j) {
                     uint64_t queryWord, targetWord;
                     std::memcpy(&queryWord, query + j * 8, sizeof(uint64_t));
                     std::memcpy(&targetWord, target + j * 8, sizeof(uint64_t));
                     dp += __builtin_popcountll(queryWord & targetWord);
+                }
+                // Remainder bytes that don't fill a full 8-byte word
+                const uint64_t remainStart = words * 8;
+                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
+                    dp += __builtin_popcount((query[r] & target[r]) & 0xFF);
                 }
             }
 
@@ -178,7 +178,6 @@ namespace knn_jni {
                     dp4 += __builtin_popcountll(q[i] & t4[i]);
                 }
             } else {
-                // Slower
                 for (size_t i = 0; i < words; ++i) {
                     uint64_t queryWord;
                     std::memcpy(&queryWord, query + i * 8, sizeof(uint64_t));
@@ -191,6 +190,15 @@ namespace knn_jni {
                     dp2 += __builtin_popcountll(queryWord & w2);
                     dp3 += __builtin_popcountll(queryWord & w3);
                     dp4 += __builtin_popcountll(queryWord & w4);
+                }
+                // Remainder bytes that don't fill a full 8-byte word
+                const uint64_t remainStart = words * 8;
+                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
+                    const uint8_t qb = query[r];
+                    dp1 += __builtin_popcount((qb & target1[r]) & 0xFF);
+                    dp2 += __builtin_popcount((qb & target2[r]) & 0xFF);
+                    dp3 += __builtin_popcount((qb & target3[r]) & 0xFF);
+                    dp4 += __builtin_popcount((qb & target4[r]) & 0xFF);
                 }
             }
 
@@ -215,12 +223,16 @@ namespace knn_jni {
                     dp += __builtin_popcountll(t1[k] & t2[k]);
                 }
             } else {
-                // Slower
                 for (size_t k = 0; k < words; ++k) {
                     uint64_t w1, w2;
                     std::memcpy(&w1, target1 + k * 8, sizeof(uint64_t));
                     std::memcpy(&w2, target2 + k * 8, sizeof(uint64_t));
                     dp += __builtin_popcountll(w1 & w2);
+                }
+                // Remainder bytes that don't fill a full 8-byte word
+                const uint64_t remainStart = words * 8;
+                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
+                    dp += __builtin_popcount((target1[r] & target2[r]) & 0xFF);
                 }
             }
 
@@ -280,6 +292,11 @@ namespace knn_jni {
         }
 
         faiss::DistanceComputer* get_distance_computer() const {
+            // When quantizedVectorBytes is a multiple of 8, oneElementSize is also a
+            // multiple of 8 (quantizedVectorBytes + 16 bytes of correction factors),
+            // so element starts are 8-byte aligned and we can use the fast
+            // reinterpret_cast<uint64_t*> path. Otherwise we fall back to memcpy
+            // with a byte remainder loop for the trailing bytes.
             const bool aligned = (oneElementSize % 8) == 0;
             if (metric_type == faiss::MetricType::METRIC_L2) {
                 if (aligned) {

--- a/jni/tests/faiss_bbq_distance_computer_test.cpp
+++ b/jni/tests/faiss_bbq_distance_computer_test.cpp
@@ -48,10 +48,11 @@ static float referenceScore(bool isMaxIP, int32_t dim, float centroidDp,
     float score = ax * ay * dim + ay * lx * x1 + ax * ly * y1 + lx * ly * dp;
     if (isMaxIP) {
         score += queryAdditional + additional - centroidDp;
+        // Negate: Faiss HNSW always minimizes distance (CMax comparator).
+        return -score;
     } else {
-        score = queryAdditional + additional - 2.0f * score;
+        return queryAdditional + additional - 2.0f * score;
     }
-    return score;
 }
 
 // Write correction factors into buffer at ptr.
@@ -301,6 +302,7 @@ TEST_P(FaissSQDistanceComputerTest, SymmetricDis) {
 
             if (isMaxIP) {
                 score += c1.additional + c2.additional - CENTROID_DP;
+                score = -score;
             } else {
                 score = c1.additional + c2.additional - 2 * score;
             }
@@ -397,6 +399,182 @@ TEST_P(FaissSQDistanceComputerTest, GetDistanceComputerIntegration) {
         float actual = (*dc)(static_cast<idx_t>(i));
         EXPECT_NEAR(actual, expected, TOLERANCE)
             << "Integration mismatch at vector " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-multiple-of-8 quantizedVectorBytes (e.g. dim=56 → 7 bytes)
+// Verifies the byte remainder loop handles trailing bytes correctly.
+// ---------------------------------------------------------------------------
+
+// Reference popcount that handles remainder bytes (matches the fixed code).
+static uint32_t referencePopcountWithRemainder(const uint8_t* a, const uint8_t* b, int32_t quantizedVectorBytes) {
+    const int32_t words = quantizedVectorBytes >> 3;
+    uint32_t dp = 0;
+    for (int32_t w = 0; w < words; ++w) {
+        uint64_t wa, wb;
+        std::memcpy(&wa, a + w * 8, sizeof(uint64_t));
+        std::memcpy(&wb, b + w * 8, sizeof(uint64_t));
+        dp += __builtin_popcountll(wa & wb);
+    }
+    const int32_t remainStart = words * 8;
+    for (int32_t r = remainStart; r < quantizedVectorBytes; ++r) {
+        dp += __builtin_popcount((a[r] & b[r]) & 0xFF);
+    }
+    return dp;
+}
+
+TEST_P(FaissSQDistanceComputerTest, OperatorNonMultipleOf8Bytes) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    // Only the unaligned path handles remainder bytes; skip aligned tests.
+    if (isBytesMultipleOf8) return;
+
+    // dim=56 → quantizedVectorBytes=7 (the exact case that triggered the bug)
+    const int32_t qvb = 7;
+    const int32_t dim = 56;
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP)
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcountWithRemainder(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        // Verify the dot product is non-zero (the original bug produced dp=0)
+        EXPECT_NE(refDp, 0u) << "Reference dp should be non-zero for random data at vector " << i;
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Mismatch at vector " << i << " with qvb=" << qvb;
+    }
+}
+
+TEST_P(FaissSQDistanceComputerTest, DistancesBatch4NonMultipleOf8Bytes) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    if (isBytesMultipleOf8) return;
+
+    const int32_t qvb = 7;
+    const int32_t dim = 56;
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP)
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    float dis0, dis1, dis2, dis3;
+    dc->distances_batch_4(0, 1, 2, 3, dis0, dis1, dis2, dis3);
+
+    EXPECT_NEAR(dis0, (*dc)(0), TOLERANCE);
+    EXPECT_NEAR(dis1, (*dc)(1), TOLERANCE);
+    EXPECT_NEAR(dis2, (*dc)(2), TOLERANCE);
+    EXPECT_NEAR(dis3, (*dc)(3), TOLERANCE);
+}
+
+TEST_P(FaissSQDistanceComputerTest, SymmetricDisNonMultipleOf8Bytes) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    if (isBytesMultipleOf8) return;
+
+    const int32_t qvb = 7;
+    const int32_t dim = 56;
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP)
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+    else
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        for (int j = i; j < NUM_VECS; ++j) {
+            const uint8_t* t1 = buf.data.data() + i * buf.oneElementSize;
+            const uint8_t* t2 = buf.data.data() + j * buf.oneElementSize;
+
+            uint32_t refDp = referencePopcountWithRemainder(t1, t2, qvb);
+            auto c1 = readCorr(t1 + qvb);
+            auto c2 = readCorr(t2 + qvb);
+
+            float score = c1.lower * c2.lower * dim
+                        + c2.lower * c1.interval * c1.componentSum
+                        + c1.lower * c2.interval * c2.componentSum
+                        + c1.interval * c2.interval * static_cast<float>(refDp);
+
+            if (isMaxIP) {
+                score += c1.additional + c2.additional - CENTROID_DP;
+                score = -score;
+            } else {
+                score = c1.additional + c2.additional - 2 * score;
+            }
+
+            float actual = dc->symmetric_dis(static_cast<idx_t>(i), static_cast<idx_t>(j));
+            EXPECT_NEAR(actual, score, TOLERANCE)
+                << "symmetric_dis(" << i << "," << j << ") mismatch with qvb=" << qvb;
+        }
+    }
+}
+
+TEST_P(FaissSQDistanceComputerTest, GetDistanceComputerIntegrationNonMultipleOf8) {
+    auto [isMaxIP, isBytesMultipleOf8] = GetParam();
+    // This test exercises FaissSQFlat::get_distance_computer with non-aligned element size.
+    // Only run once per metric (skip the aligned param to avoid duplicate).
+    if (isBytesMultipleOf8) return;
+
+    const int32_t qvb = 7;  // dim=56
+    const int32_t dim = 56;
+    constexpr int NUM_VECS = 4;
+
+    faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
+    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    flat.quantizedVectorsAndCorrectionFactors.assign(buf.data.begin(), buf.data.end());
+    flat.ntotal = NUM_VECS;
+
+    // get_distance_computer should pick IsBytesMultipleOf8=false since oneElementSize=23
+    std::unique_ptr<faiss::DistanceComputer> dc(flat.get_distance_computer());
+
+    auto queryBuf = makeQuery(qvb);
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readCorr(queryBuf.data() + qvb);
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t refDp = referencePopcountWithRemainder(queryBuf.data(), target, qvb);
+        auto tCorr = readCorr(target + qvb);
+
+        float expected = referenceScore(isMaxIP, dim, CENTROID_DP,
+                                        qCorr.lower, qCorr.interval, qCorr.additional, qCorr.componentSum,
+                                        tCorr.lower, tCorr.interval, tCorr.additional, tCorr.componentSum,
+                                        static_cast<float>(refDp));
+
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "Integration mismatch at vector " << i << " with qvb=" << qvb;
     }
 }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss104ScalarQuantizedVectorScorer.java
@@ -215,8 +215,9 @@ public class Faiss104ScalarQuantizedVectorScorer extends Lucene104ScalarQuantize
                 targetCorrectiveTerms.quantizedComponentSum(),
                 addressAndSize,
                 similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-                    ? SimdVectorComputeService.SimilarityFunctionType.BBQ_IP.ordinal()
-                    : SimdVectorComputeService.SimilarityFunctionType.BBQ_L2.ordinal(),
+                    || similarityFunction == VectorSimilarityFunction.COSINE
+                        ? SimdVectorComputeService.SimilarityFunctionType.BBQ_IP.ordinal()
+                        : SimdVectorComputeService.SimilarityFunctionType.BBQ_L2.ordinal(),
                 dimension,
                 centroidDp
             );

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
@@ -57,9 +57,10 @@ import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectors
 public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestCase {
 
     // 4 -> lower dimension test
+    // 56 -> non-multiple-of-8 quantized bytes (7 bytes), regression test for remainder loop bug
     // 128 -> test dimension that's multiple of 8
     // 333 -> test odd dimension
-    private static final int[] DIMENSIONS = new int[] { 4, 128, 333 };
+    private static final int[] DIMENSIONS = new int[] { 4, 56, 128, 333 };
     private static final int NUM_VECTORS = 1234;
     private static final String FIELD_NAME = "test_field";
     private static final String SEGMENT_NAME = "_0";

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -355,10 +355,13 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     @SneakyThrows
     private void doSearchTest(final TestingSpec testingSpec, final IndexingType indexingType) {
         final List<SpaceType> spaceTypes;
-        if (testingSpec.dataType != VectorDataType.BINARY) {
-            spaceTypes = Arrays.asList(SpaceType.L2, SpaceType.INNER_PRODUCT, SpaceType.COSINESIMIL);
-        } else {
+        if (testingSpec.dataType == VectorDataType.BINARY) {
             spaceTypes = Arrays.asList(SpaceType.HAMMING);
+        } else if (testingSpec.dataType == VectorDataType.BYTE) {
+            // Byte vectors cannot be L2-normalized, so cosine similarity is not supported.
+            spaceTypes = Arrays.asList(SpaceType.L2, SpaceType.INNER_PRODUCT);
+        } else {
+            spaceTypes = Arrays.asList(SpaceType.L2, SpaceType.INNER_PRODUCT, SpaceType.COSINESIMIL);
         }
 
         for (final SpaceType spaceType : spaceTypes) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -32,6 +32,7 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.junit.Test;
@@ -39,6 +40,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNN1040Codec.Faiss104ScalarQuantizedVectorScorer;
 
 import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +61,14 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
 
     private static final String FIELD_NAME = "vector";
     private static final int NUM_VECTORS = 500;
+
+    @Test
+    public void testBBQCosineScoring() {
+        for (int dim : Arrays.asList(1, 7, 56, 57, 77, 128, 512, 777, 1024)) {
+            System.out.println("Dimension=" + dim);
+            doTest(VectorSimilarityFunction.COSINE, dim);
+        }
+    }
 
     @Test
     public void testBBQEuclideanScoring() {
@@ -105,7 +115,7 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
         );
         final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
 
-        final java.nio.file.Path tempDir = createTempDir();
+        final Path tempDir = createTempDir();
         try (MMapDirectory dir = new MMapDirectory(tempDir)) {
             // Build SegmentInfo
             final SegmentInfo segmentInfo = new SegmentInfo(
@@ -147,7 +157,13 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
 
                 for (int i = 0; i < NUM_VECTORS; i++) {
-                    fieldWriter.addValue(i, randomVector(dimension));
+                    float[] vec = similarityFunction == VectorSimilarityFunction.COSINE
+                        ? randomCosineVector(dimension)
+                        : randomVector(dimension);
+                    if (similarityFunction == VectorSimilarityFunction.COSINE) {
+                        VectorUtil.l2normalize(vec);
+                    }
+                    fieldWriter.addValue(i, vec);
                 }
 
                 writer.flush(NUM_VECTORS, null);
@@ -157,7 +173,12 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
             final SegmentReadState readState = new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
 
             // ---- Step 2: Lucene scorer (source of truth) ----
-            final float[] queryVector = randomVector(dimension);
+            float[] queryVector = similarityFunction == VectorSimilarityFunction.COSINE
+                ? randomCosineVector(dimension)
+                : randomVector(dimension);
+            if (similarityFunction == VectorSimilarityFunction.COSINE) {
+                VectorUtil.l2normalize(queryVector);
+            }
             final RandomVectorScorer truthScorer;
             try (
                 FlatVectorsReader truthReader = new Lucene104ScalarQuantizedVectorsReader(
@@ -180,11 +201,15 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 assertNotNull("Test scorer should not be null", testScorer);
 
                 // ---- Step 4: Compare scores ----
+                final boolean isCosine = similarityFunction == VectorSimilarityFunction.COSINE;
                 int maxOrd = truthScorer.maxOrd();
                 assertEquals("maxOrd mismatch", maxOrd, testScorer.maxOrd());
 
                 for (int ord = 0; ord < maxOrd; ord++) {
                     float actual = testScorer.score(ord);
+                    if (isCosine) {
+                        actual = convertMaxIpToCosineScore(actual);
+                    }
                     float expected = truthScorer.score(ord);
                     assertEquals("Score mismatch at ord=" + ord + " for " + similarityFunction, expected, actual, 1e-2);
                 }
@@ -201,11 +226,15 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                     }
                     testScorer.bulkScore(ords, bulkScores, batchSize);
                     for (int j = 0; j < batchSize; j++) {
+                        float actualBulk = bulkScores[j];
+                        if (isCosine) {
+                            actualBulk = convertMaxIpToCosineScore(actualBulk);
+                        }
                         float expected = truthScorer.score(ords[j]);
                         assertEquals(
                             "Bulk score mismatch at ord=" + ords[j] + " (batch=" + batchSize + ") for " + similarityFunction,
                             expected,
-                            bulkScores[j],
+                            actualBulk,
                             1e-2
                         );
                     }
@@ -233,5 +262,39 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
             v[i] = ThreadLocalRandom.current().nextFloat() * 2 - 1;
         }
         return v;
+    }
+
+    /**
+     * Generates a random vector with sufficient variance to avoid zero-length vectors
+     * after centroid centering during cosine quantization.
+     */
+    private static float[] randomCosineVector(int dimension) {
+        float[] v = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            v[i] = ThreadLocalRandom.current().nextFloat() * 2 - 1;
+        }
+        // Ensure the vector has meaningful magnitude by setting a component based on index
+        v[0] = ThreadLocalRandom.current().nextFloat() * 0.5f + 0.5f;
+        if (dimension > 1) {
+            v[dimension - 1] = -(ThreadLocalRandom.current().nextFloat() * 0.5f + 0.5f);
+        }
+        return v;
+    }
+
+    /**
+     * Converts a Faiss MAX_IP score (used internally for cosine) to the Lucene cosine score.
+     * Faiss uses MAX_IP under the hood for cosine similarity on normalized vectors.
+     * The MAX_IP transform maps: ip >= 0 → 1 + ip, ip < 0 → 1 / (1 - ip).
+     * This reverses that, then applies the cosine score formula: (1 + ip) / 2.
+     */
+    private static float convertMaxIpToCosineScore(float maxIpScore) {
+        float innerProductValue;
+        if (maxIpScore >= 1) {
+            innerProductValue = maxIpScore - 1;
+        } else {
+            innerProductValue = 1 - 1 / maxIpScore;
+        }
+        innerProductValue = Math.clamp(innerProductValue, -1, 1);
+        return Math.max((1 + innerProductValue) / 2.0f, 0.0f);
     }
 }


### PR DESCRIPTION
### Description
The FaissSQDistanceComputer in faiss_sq_flat.h computes the 1-bit popcount dot product using only 8-byte (uint64_t) word loops: words = quantizedVectorBytes >> 3. When quantizedVectorBytes is not a multiple of 8, the trailing bytes are silently dropped. For example, dimension 56 produces 7 quantized bytes — words = 7 >> 3 = 0 — so the popcount loop never executes and the dot product is always zero. The HNSW graph is then built with no meaningful distance discrimination, resulting in ~16% recall. At dimension 57, Lucene's getDiscreteDimensions rounds up to 64 discretized dimensions (8 bytes), so words = 1 and the loop works correctly, giving ~88% recall. This creates a sharp recall cliff rather than a gradual degradation.

Fix:

Added a byte remainder loop in the IsBytesMultipleOf8=false branch of operator(), distances_batch_4, and symmetric_dis. After the 8-byte word loop, the remaining bytes are processed individually with __builtin_popcount. The IsBytesMultipleOf8=true path is unchanged — the remainder code only exists in the unaligned template instantiation, so there is zero performance impact for the common aligned case.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
