### PR TITLE
[Backport main] [BugFix] Fix Scorer, and max dimension for Lucene SQ 1 bit  (#3203)

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReader.java
@@ -13,35 +13,37 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import java.io.IOException;
 
 /**
- * A {@link FlatVectorsReader} wrapper that adds prefetch support for Faiss SQ (1-bit) vector fields.
+ * A {@link FlatVectorsReader} wrapper for Faiss SQ (1-bit) vector fields that ensures the
+ * {@link FloatVectorValues} returned by {@link #getFloatVectorValues(String)} implement
+ * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}.
  *
  * <p>Lucene's {@code Lucene104ScalarQuantizedVectorsReader} returns a {@code ScalarQuantizedVectorValues}
  * from {@link #getFloatVectorValues(String)}, which does not implement
- * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}. However, Lucene's prefetch-enabled HNSW
+ * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}. However, Lucene's HNSW
  * graph traversal requires all {@link FloatVectorValues} to implement {@code HasIndexSlice} so that
  * the underlying {@link org.apache.lucene.store.IndexInput} can be accessed for I/O prefetching.
  *
  * <p>This reader solves the problem by wrapping the delegate's {@link FloatVectorValues} with
- * {@link ScalarQuantizedFloatVectorValuesWithIndexInputSlice}, which implements {@code HasIndexSlice}
+ * {@link ScalarQuantizedFloatVectorValues}, which implements {@code HasIndexSlice}
  * by exposing the {@link org.apache.lucene.store.IndexInput} from the quantized byte vector values.
  *
  * <p>The resulting reader hierarchy is:
  * <pre>
  *   Faiss1040ScalarQuantizedKnnVectorsReader
- *     └─ Faiss1040PrefetchSupportKnnVectorReader  (this class)
+ *     └─ Faiss1040ScalarQuantizedFlatVectorsReader  (this class)
  *          └─ Lucene104ScalarQuantizedVectorsReader  (delegate)
  * </pre>
  *
  * <p>All other operations are delegated directly to the underlying reader.
  */
-public class Faiss1040PrefetchSupportKnnVectorReader extends FlatVectorsReader {
+public class Faiss1040ScalarQuantizedFlatVectorsReader extends FlatVectorsReader {
     private final FlatVectorsReader delegateFlatVectorsReader;
 
     /**
      * @param lucene104ScalarQuantizedVectorsReader the delegate reader whose {@link FloatVectorValues}
-     *                                              will be wrapped to support prefetch via {@code HasIndexSlice}
+     *                                              will be wrapped to implement {@code HasIndexSlice}
      */
-    protected Faiss1040PrefetchSupportKnnVectorReader(final FlatVectorsReader lucene104ScalarQuantizedVectorsReader) {
+    protected Faiss1040ScalarQuantizedFlatVectorsReader(final FlatVectorsReader lucene104ScalarQuantizedVectorsReader) {
         super(lucene104ScalarQuantizedVectorsReader.getFlatVectorScorer());
         this.delegateFlatVectorsReader = lucene104ScalarQuantizedVectorsReader;
     }
@@ -62,16 +64,15 @@ public class Faiss1040PrefetchSupportKnnVectorReader extends FlatVectorsReader {
     }
 
     /**
-     * Returns {@link FloatVectorValues} wrapped with {@link ScalarQuantizedFloatVectorValuesWithIndexInputSlice}
-     * so that the result implements {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}, enabling
-     * prefetch during HNSW graph traversal.
+     * Returns {@link FloatVectorValues} wrapped with {@link ScalarQuantizedFloatVectorValues}
+     * so that the result implements {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}.
      */
     @Override
     public FloatVectorValues getFloatVectorValues(String field) throws IOException {
         final FloatVectorValues floatVectorValues = delegateFlatVectorsReader.getFloatVectorValues(field);
-        return new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(
+        return new ScalarQuantizedFloatVectorValues(
             floatVectorValues,
-            Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(floatVectorValues)
+            KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(floatVectorValues)
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -52,17 +52,17 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     /**
-     * Wraps the Lucene flat vectors reader with {@link Faiss1040PrefetchSupportKnnVectorReader} so that
+     * Wraps the Lucene flat vectors reader with {@link Faiss1040ScalarQuantizedFlatVectorsReader} so that
      * the {@link org.apache.lucene.index.FloatVectorValues} returned by the reader implement
      * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}. This is required because Lucene's
-     * prefetch-enabled HNSW traversal expects all vector values to expose an {@link org.apache.lucene.store.IndexInput}
-     * for I/O prefetching, but Lucene's {@code ScalarQuantizedVectorValues} does not implement that interface.
+     * HNSW traversal expects all vector values to expose an {@link org.apache.lucene.store.IndexInput},
+     * but Lucene's {@code ScalarQuantizedVectorValues} does not implement that interface.
      */
     @Override
     public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
         return new Faiss1040ScalarQuantizedKnnVectorsReader(
             state,
-            new Faiss1040PrefetchSupportKnnVectorReader(faissSqFlatFormat.fieldsReader(state))
+            new Faiss1040ScalarQuantizedFlatVectorsReader(faissSqFlatFormat.fieldsReader(state))
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -107,7 +107,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // and pass it to the build strategy. The writer owns the reader lifecycle.
         final FlatVectorsReader flatVectorsReader = openFlatVectorsReader();
         try {
-            final QuantizedByteVectorValues quantizedValues = Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
+            final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
                 flatVectorsReader.getFloatVectorValues(fieldInfo.getName())
             );
             doFlush(
@@ -142,7 +142,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // and pass it to the build strategy. The writer owns the reader lifecycle.
         final FlatVectorsReader flatVectorsReader = openFlatVectorsReader();
         try {
-            final QuantizedByteVectorValues quantizedValues = Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
+            final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
                 flatVectorsReader.getFloatVectorValues(fieldInfo.getName())
             );
             doMergeOneField(fieldInfo, mergeState, null, null, segmentWriteState, new NativeIndexBuildStrategyFactory(), quantizedValues);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.search.TaskExecutor;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAULT_NUM_MERGE_WORKER;
+import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.HNSW_GRAPH_THRESHOLD;
+
+/**
+ * HNSW + scalar quantization format that extends {@link Lucene104HnswScalarQuantizedVectorsFormat}
+ * and overrides flat vector operations to use {@link KNN1040ScalarQuantizedVectorsFormat},
+ * inheriting its SIMD-accelerated {@link KNN1040ScalarQuantizedVectorScorer} for graph traversal scoring.
+ */
+public class KNN1040HnswScalarQuantizedVectorsFormat extends Lucene104HnswScalarQuantizedVectorsFormat {
+
+    private final int maxConn;
+    private final int beamWidth;
+    private final int tinySegmentsThreshold;
+    private final int numMergeWorkers;
+    private final TaskExecutor mergeExec;
+    private final KNN1040ScalarQuantizedVectorsFormat flatVectorsFormat;
+
+    public KNN1040HnswScalarQuantizedVectorsFormat() {
+        this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, DEFAULT_NUM_MERGE_WORKER, null);
+    }
+
+    public KNN1040HnswScalarQuantizedVectorsFormat(
+        ScalarEncoding encoding,
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec
+    ) {
+        this(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, HNSW_GRAPH_THRESHOLD);
+    }
+
+    public KNN1040HnswScalarQuantizedVectorsFormat(
+        ScalarEncoding encoding,
+        int maxConn,
+        int beamWidth,
+        int numMergeWorkers,
+        ExecutorService mergeExec,
+        int tinySegmentsThreshold
+    ) {
+        super(encoding, maxConn, beamWidth, numMergeWorkers, mergeExec, tinySegmentsThreshold);
+        this.maxConn = maxConn;
+        this.beamWidth = beamWidth;
+        this.tinySegmentsThreshold = tinySegmentsThreshold;
+        this.numMergeWorkers = numMergeWorkers;
+        this.mergeExec = mergeExec != null ? new TaskExecutor(mergeExec) : null;
+        this.flatVectorsFormat = new KNN1040ScalarQuantizedVectorsFormat(encoding);
+    }
+
+    @Override
+    public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new Lucene99HnswVectorsWriter(
+            state,
+            maxConn,
+            beamWidth,
+            flatVectorsFormat.fieldsWriter(state),
+            numMergeWorkers,
+            mergeExec,
+            tinySegmentsThreshold
+        );
+    }
+
+    @Override
+    public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return new Lucene99HnswVectorsReader(state, flatVectorsFormat.fieldsReader(state));
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "%s(maxConn=%d, beamWidth=%d, tinySegmentsThreshold=%d, flatVectorFormat=%s)",
+            getClass().getSimpleName(),
+            maxConn,
+            beamWidth,
+            tinySegmentsThreshold,
+            flatVectorsFormat
+        );
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -6,10 +6,10 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import org.apache.lucene.backward_codecs.lucene99.Lucene99RWHnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
+
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
@@ -83,7 +83,7 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             );
             final Tuple<Integer, ExecutorService> merge = getMergeThreadCountAndExecutorService();
             if (p.getBits() == LuceneSQEncoder.Bits.ONE.getValue()) {
-                return new Lucene104HnswScalarQuantizedVectorsFormat(
+                return new KNN1040HnswScalarQuantizedVectorsFormat(
                     p.getBitEncoding(),
                     p.getMaxConnections(),
                     p.getBeamWidth(),
@@ -102,7 +102,7 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
             );
         },
             LuceneVectorsFormatType.FLAT,
-            ctx -> new Lucene104ScalarQuantizedVectorsFormat(Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
+            ctx -> new KNN1040ScalarQuantizedVectorsFormat(Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
@@ -23,10 +23,10 @@ import java.util.Locale;
  *
  * <p>This is used by both the write path ({@link Faiss1040ScalarQuantizedKnnVectorsWriter}) to extract
  * quantized vectors for native HNSW graph construction, and the search path
- * ({@link Faiss104ScalarQuantizedVectorScorer}) to obtain quantized vectors for SIMD-accelerated scoring.
+ * ({@link KNN1040ScalarQuantizedVectorScorer}) to obtain quantized vectors for SIMD-accelerated scoring.
  */
 @UtilityClass
-class Faiss1040ScalarQuantizedUtils {
+class KNN1040ScalarQuantizedUtils {
     private static final String QUANTIZED_VECTOR_VALUES_FIELD_NAME = "quantizedVectorValues";
 
     /**
@@ -44,6 +44,7 @@ class Faiss1040ScalarQuantizedUtils {
      * and {@code throwExceptionIfNotFound} is {@code false}
      * @throws IOException if extraction fails and {@code throwExceptionIfNotFound} is {@code true}
      */
+
     public static QuantizedByteVectorValues extractQuantizedByteVectorValues(final KnnVectorValues floatVectorValues) throws IOException {
         try {
             final Field f = floatVectorValues.getClass().getDeclaredField(QUANTIZED_VECTOR_VALUES_FIELD_NAME);

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -42,25 +42,30 @@ import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectors
  * (e.g., AVX-512), significantly improving throughput for large-scale vector search.
  */
 @Log4j2
-public class Faiss104ScalarQuantizedVectorScorer extends Lucene104ScalarQuantizedVectorScorer {
+public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantizedVectorScorer {
     /**
      * Creates a new scorer that wraps a non-quantized delegate scorer.
      *
      * @param delegate fallback scorer used when SIMD acceleration is not applicable
      */
-    public Faiss104ScalarQuantizedVectorScorer(final FlatVectorsScorer delegate) {
+    public KNN1040ScalarQuantizedVectorScorer(final FlatVectorsScorer delegate) {
         super(delegate);
     }
 
     /**
      * Returns a {@link RandomVectorScorer} for the given query vector.
      *
+     * <p><b>Important:</b> This method only supports {@link QuantizedByteVectorValues}. It will fail
+     * with an exception if called with raw (non-quantized) vector values such as
+     * {@code OffHeapFloatVectorValues}. Callers must ensure that this scorer is not used as the
+     * scorer for raw vector formats (e.g., {@link org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat}).
+     *
      * <p>This method attempts to construct a SIMD-accelerated scorer when the input vectors
      * are quantized and backed by memory that can be accessed directly (e.g., via a memory segment).
-     * Otherwise, it falls back to the default implementation.
+     * Otherwise, it falls back to the parent's quantized scoring implementation.
      *
      * @param similarityFunction the similarity function (e.g., inner product or L2)
-     * @param vectorValues       the vector storage
+     * @param vectorValues       the quantized vector storage (must be {@link QuantizedByteVectorValues})
      * @param target             the query vector (float32)
      * @return a scorer capable of computing similarity scores
      * @throws IOException if an error occurs while accessing vector data
@@ -78,11 +83,14 @@ public class Faiss104ScalarQuantizedVectorScorer extends Lucene104ScalarQuantize
             vectorValues = WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues);
         }
 
-        // Extract QuantizedByteVectorValues from `vectorValues`.
-        // This should not be null, otherwise it can't get entroid + correction factors.
-        final QuantizedByteVectorValues quantizedByteVectorValues = Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
-            vectorValues
-        );
+        final QuantizedByteVectorValues quantizedByteVectorValues;
+        if (vectorValues instanceof QuantizedByteVectorValues) {
+            quantizedByteVectorValues = (QuantizedByteVectorValues) vectorValues;
+        } else {
+            // Extract QuantizedByteVectorValues from `vectorValues`.
+            // This should not be null, otherwise it can't get entroid + correction factors.
+            quantizedByteVectorValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(vectorValues);
+        }
 
         // Try bulk SIMD
         final IndexInput indexInput = quantizedByteVectorValues.getSlice();
@@ -92,7 +100,7 @@ public class Faiss104ScalarQuantizedVectorScorer extends Lucene104ScalarQuantize
         }
 
         // Fallback
-        log.warn("Bulk SIMD for Faiss SQ is not supported, falling back to Lucene's random vector scorer");
+        log.warn("Bulk SIMD for SQ is not supported, falling back to Lucene's random vector scorer");
         return super.getRandomVectorScorer(similarityFunction, quantizedByteVectorValues, target);
     }
 
@@ -127,7 +135,7 @@ public class Faiss104ScalarQuantizedVectorScorer extends Lucene104ScalarQuantize
 
         // We only support 32x quantization with 4 bit query quantization for search.
         if (scalarEncoding != SINGLE_BIT_QUERY_NIBBLE) {
-            throw new IllegalStateException("SQ only supports SINGLE_BIT_QUERY_NIBBLE encoding.");
+            throw new IllegalStateException(String.format("SQ only supports %s encoding.", SINGLE_BIT_QUERY_NIBBLE));
         }
 
         // Validate dimensionality
@@ -146,6 +154,10 @@ public class Faiss104ScalarQuantizedVectorScorer extends Lucene104ScalarQuantize
 
         // We make a copy as the quantization process mutates the input
         final float[] targetCopy = ArrayUtil.copyOfSubArray(target, 0, target.length);
+
+        // For cosine similarity, the query vector is expected to already be normalized.
+        // Normalization is performed upfront in KNNQueryBuilder via VectorTransformerFactory
+        // for Lucene cosine with SQ 1-bit and flat methods and for Faiss.
 
         // Perform scalar quantization
         final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms = quantizer.scalarQuantize(

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatVectorScorerUtil;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsReader;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsWriter;
+import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
+
+import java.io.IOException;
+
+/**
+ * A {@link Lucene104ScalarQuantizedVectorsFormat} that uses a {@link KNN1040ScalarQuantizedVectorScorer}
+ * to take advantage of SIMD-accelerated scoring during search.
+ */
+public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantizedVectorsFormat {
+
+    private static final KNN1040ScalarQuantizedVectorScorer KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER = FlatVectorsScorerProvider
+        .getKNN1040ScalarQuantizedVectorScorer(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+
+    // Must use the default Lucene scorer here, not KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER.
+    // KNN1040ScalarQuantizedVectorScorer.getRandomVectorScorer(float[]) always assumes quantized
+    // vectors and will fail (NPE/exception) when called with raw OffHeapFloatVectorValues.
+    private static final Lucene99FlatVectorsFormat RAW_VECTOR_FORMAT = new Lucene99FlatVectorsFormat(
+        FlatVectorScorerUtil.getLucene99FlatVectorsScorer()
+    );
+
+    private final ScalarEncoding encoding;
+
+    public KNN1040ScalarQuantizedVectorsFormat() {
+        this(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
+    }
+
+    public KNN1040ScalarQuantizedVectorsFormat(final ScalarEncoding encoding) {
+        super(encoding);
+        this.encoding = encoding;
+    }
+
+    @Override
+    public FlatVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new Lucene104ScalarQuantizedVectorsWriter(
+            state,
+            encoding,
+            RAW_VECTOR_FORMAT.fieldsWriter(state),
+            KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER
+        );
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "%s(encoding=%s, scorer=%s, rawVectorFormat=%s)",
+            getClass().getSimpleName(),
+            encoding,
+            KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER,
+            RAW_VECTOR_FORMAT
+        );
+    }
+
+    @Override
+    public FlatVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return new Lucene104ScalarQuantizedVectorsReader(
+            state,
+            RAW_VECTOR_FORMAT.fieldsReader(state),
+            KNN_1040_SCALAR_QUANTIZED_VECTOR_SCORER
+        );
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE);
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValues.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * slice that contains the quantized vector data and correction factors used during scoring.
  */
 @RequiredArgsConstructor
-class ScalarQuantizedFloatVectorValuesWithIndexInputSlice extends FloatVectorValues implements HasIndexSlice {
+class ScalarQuantizedFloatVectorValues extends FloatVectorValues implements HasIndexSlice {
     private final FloatVectorValues floatVectorValues;
     private final QuantizedByteVectorValues quantizedVectorValues;
 
@@ -52,7 +52,7 @@ class ScalarQuantizedFloatVectorValuesWithIndexInputSlice extends FloatVectorVal
 
     @Override
     public FloatVectorValues copy() throws IOException {
-        return new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(floatVectorValues.copy(), quantizedVectorValues.copy());
+        return new ScalarQuantizedFloatVectorValues(floatVectorValues.copy(), quantizedVectorValues.copy());
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissMethod.java
@@ -169,6 +169,6 @@ public abstract class AbstractFaissMethod extends AbstractKNNMethod {
 
     @Override
     protected VectorTransformer getVectorTransformer(SpaceType spaceType) {
-        return VectorTransformerFactory.getVectorTransformer(KNNEngine.FAISS, spaceType);
+        return VectorTransformerFactory.getVectorTransformer(KNNEngine.FAISS, spaceType, null);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -210,13 +210,18 @@ public class KNNVectorFieldType extends MappedFieldType {
         final Optional<KNNMethodContext> knnMethodContext = knnMappingConfig.getKnnMethodContext();
         if (knnMethodContext.isPresent()) {
             KNNMethodContext context = knnMethodContext.get();
-            return VectorTransformerFactory.getVectorTransformer(context.getKnnEngine(), context.getSpaceType()).transform(vector, false);
+            return VectorTransformerFactory.getVectorTransformer(
+                context.getKnnEngine(),
+                context.getSpaceType(),
+                context.getMethodComponentContext()
+            ).transform(vector, false);
         }
         final Optional<String> modelId = knnMappingConfig.getModelId();
         if (modelId.isPresent()) {
             ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
             final ModelMetadata metadata = modelDao.getMetadata(modelId.get());
-            return VectorTransformerFactory.getVectorTransformer(metadata.getKnnEngine(), metadata.getSpaceType()).transform(vector, false);
+            return VectorTransformerFactory.getVectorTransformer(metadata.getKnnEngine(), metadata.getSpaceType(), null)
+                .transform(vector, false);
         }
         throw new IllegalStateException("Either KNN method context or Model Id should be configured");
     }

--- a/src/main/java/org/opensearch/knn/index/mapper/VectorTransformerFactory.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/VectorTransformerFactory.java
@@ -9,6 +9,14 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 
 /**
  * Factory class responsible for creating appropriate vector transformers.
@@ -26,20 +34,71 @@ public final class VectorTransformerFactory {
     private final static NormalizeVectorTransformer DEFAULT_VECTOR_TRANSFORMER = new NormalizeVectorTransformer();
 
     /**
-     * Returns a vector transformer based on the provided KNN engine and space type.
-     * For FAISS engine with cosine similarity space type, returns a NormalizeVectorTransformer
-     * since FAISS doesn't natively support cosine space type. For all other cases,
-     * returns a no-operation transformer.
+     * Returns a vector transformer based on the provided KNN engine, space type, and method component context.
+     * Returns a NormalizeVectorTransformer for:
+     * <ul>
+     *   <li>Faiss engine with cosine similarity (Faiss doesn't natively support cosine)</li>
+     *   <li>Lucene engine with cosine similarity when using SQ 1-bit encoding or flat method
+     *       (these paths use {@code KNN1040ScalarQuantizedVectorScorer} which requires a unit vector)</li>
+     * </ul>
      *
      * @param knnEngine The KNN engine type
      * @param spaceType The space type
+     * @param methodComponentContext The method component context containing method name and parameters, may be null
      * @return VectorTransformer An appropriate vector transformer instance
      */
-    public static VectorTransformer getVectorTransformer(final KNNEngine knnEngine, final SpaceType spaceType) {
-        return shouldNormalizeVector(knnEngine, spaceType) ? DEFAULT_VECTOR_TRANSFORMER : NOOP_VECTOR_TRANSFORMER;
+    public static VectorTransformer getVectorTransformer(
+        final KNNEngine knnEngine,
+        final SpaceType spaceType,
+        final MethodComponentContext methodComponentContext
+    ) {
+        return shouldNormalizeVector(knnEngine, spaceType, methodComponentContext) ? DEFAULT_VECTOR_TRANSFORMER : NOOP_VECTOR_TRANSFORMER;
     }
 
-    private static boolean shouldNormalizeVector(final KNNEngine knnEngine, final SpaceType spaceType) {
-        return knnEngine == KNNEngine.FAISS && spaceType == SpaceType.COSINESIMIL;
+    private static boolean shouldNormalizeVector(
+        final KNNEngine knnEngine,
+        final SpaceType spaceType,
+        final MethodComponentContext methodComponentContext
+    ) {
+        if (spaceType != SpaceType.COSINESIMIL) {
+            return false;
+        }
+        if (knnEngine == KNNEngine.FAISS) {
+            return true;
+        }
+        if (knnEngine == KNNEngine.LUCENE) {
+            return shouldNormalizeForLuceneEngine(methodComponentContext);
+        }
+        return false;
+    }
+
+    private static boolean shouldNormalizeForLuceneEngine(final MethodComponentContext methodComponentContext) {
+        if (methodComponentContext == null) {
+            return false;
+        }
+
+        if (METHOD_FLAT.equals(methodComponentContext.getName())) {
+            return true;
+        }
+        if (isLuceneSQOneBit(methodComponentContext.getParameters())) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isLuceneSQOneBit(final Map<String, Object> params) {
+        if (params == null) {
+            return false;
+        }
+        Object encoderObj = params.get(METHOD_ENCODER_PARAMETER);
+        if (encoderObj instanceof MethodComponentContext == false) {
+            return false;
+        }
+        MethodComponentContext encoderCtx = (MethodComponentContext) encoderObj;
+        if (ENCODER_SQ.equals(encoderCtx.getName()) == false) {
+            return false;
+        }
+        Object bits = encoderCtx.getParameters().get(LUCENE_SQ_BITS);
+        return bits instanceof Integer && (Integer) bits == 1;
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -16,7 +16,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.codec.KNN1040Codec.Faiss104ScalarQuantizedVectorScorer;
+import org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorScorer;
 import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
@@ -64,12 +64,24 @@ public class FlatVectorsScorerProvider {
             return HAMMING_VECTOR_SCORER;
         } else if (FieldInfoExtractor.isSQField(fieldInfo)
             && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
-                return new Faiss104ScalarQuantizedVectorScorer(delegateScorer);
+                return getKNN1040ScalarQuantizedVectorScorer(delegateScorer);
             } else if (delegateScorer != null) {
                 // For all other cases, return the delegate scorer
                 return delegateScorer;
             }
         throw new IllegalArgumentException("delegateScorer must not be null");
+    }
+
+    /**
+     * Returns a {@link KNN1040ScalarQuantizedVectorScorer} that wraps the given delegate scorer.
+     * This is the single entry point for creating the SIMD-accelerated SQ scorer, making it easy
+     * to globally wrap or replace the scorer (e.g., with a prefetch-enabled variant).
+     *
+     * @param delegateScorer the fallback scorer used for non-quantized vectors
+     * @return a SIMD-accelerated scalar quantized vector scorer
+     */
+    public static KNN1040ScalarQuantizedVectorScorer getKNN1040ScalarQuantizedVectorScorer(final FlatVectorsScorer delegateScorer) {
+        return new KNN1040ScalarQuantizedVectorScorer(delegateScorer);
     }
 
     private static class ADCFlatVectorsScorer implements FlatVectorsScorer {

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -12,3 +12,5 @@
 org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat
 org.opensearch.knn.index.codec.KNN1040Codec.Faiss1040ScalarQuantizedKnnVectorsFormat
 org.opensearch.knn.index.codec.KNN9120Codec.KNN9120HnswBinaryVectorsFormat
+org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorsFormat
+org.opensearch.knn.index.codec.KNN1040Codec.KNN1040HnswScalarQuantizedVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReaderTests.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
+public class Faiss1040ScalarQuantizedFlatVectorsReaderTests extends KNNTestCase {
 
     @SneakyThrows
     public void testConstructor_thenUsesScorerFromDelegate() {
@@ -30,7 +30,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
         FlatVectorsScorer expectedScorer = mock(FlatVectorsScorer.class);
         when(delegate.getFlatVectorScorer()).thenReturn(expectedScorer);
 
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         assertSame(expectedScorer, reader.getFlatVectorScorer());
     }
 
@@ -41,7 +41,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
         float[] target = { 1.0f, 2.0f };
         when(delegate.getRandomVectorScorer("field", target)).thenReturn(expectedScorer);
 
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         assertSame(expectedScorer, reader.getRandomVectorScorer("field", target));
         verify(delegate).getRandomVectorScorer("field", target);
     }
@@ -53,7 +53,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
         byte[] target = { 1, 2 };
         when(delegate.getRandomVectorScorer("field", target)).thenReturn(expectedScorer);
 
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         assertSame(expectedScorer, reader.getRandomVectorScorer("field", target));
         verify(delegate).getRandomVectorScorer("field", target);
     }
@@ -61,7 +61,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testCheckIntegrity_thenDelegatesToReader() {
         FlatVectorsReader delegate = mock(FlatVectorsReader.class);
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         reader.checkIntegrity();
         verify(delegate).checkIntegrity();
     }
@@ -73,19 +73,16 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
         QuantizedByteVectorValues mockQbvv = mock(QuantizedByteVectorValues.class);
         when(delegate.getFloatVectorValues("field")).thenReturn(mockFvv);
 
-        try (MockedStatic<Faiss1040ScalarQuantizedUtils> mockedUtils = mockStatic(Faiss1040ScalarQuantizedUtils.class)) {
-            mockedUtils.when(() -> Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(any())).thenReturn(mockQbvv);
+        try (MockedStatic<KNN1040ScalarQuantizedUtils> mockedUtils = mockStatic(KNN1040ScalarQuantizedUtils.class)) {
+            mockedUtils.when(() -> KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(any())).thenReturn(mockQbvv);
 
-            Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+            Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
             FloatVectorValues result = reader.getFloatVectorValues("field");
 
             assertTrue("Result should implement HasIndexSlice", result instanceof HasIndexSlice);
-            assertTrue(
-                "Result should be ScalarQuantizedFloatVectorValuesWithIndexInputSlice",
-                result instanceof ScalarQuantizedFloatVectorValuesWithIndexInputSlice
-            );
+            assertTrue("Result should be ScalarQuantizedFloatVectorValues", result instanceof ScalarQuantizedFloatVectorValues);
             verify(delegate).getFloatVectorValues("field");
-            mockedUtils.verify(() -> Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(mockFvv));
+            mockedUtils.verify(() -> KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(mockFvv));
         }
     }
 
@@ -95,7 +92,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
         ByteVectorValues expectedValues = mock(ByteVectorValues.class);
         when(delegate.getByteVectorValues("field")).thenReturn(expectedValues);
 
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         assertSame(expectedValues, reader.getByteVectorValues("field"));
         verify(delegate).getByteVectorValues("field");
     }
@@ -103,7 +100,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
     @SneakyThrows
     public void testClose_thenDelegatesToReader() {
         FlatVectorsReader delegate = mock(FlatVectorsReader.class);
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         reader.close();
         verify(delegate).close();
     }
@@ -113,7 +110,7 @@ public class Faiss1040PrefetchSupportKnnVectorReaderTests extends KNNTestCase {
         FlatVectorsReader delegate = mock(FlatVectorsReader.class);
         when(delegate.ramBytesUsed()).thenReturn(12345L);
 
-        Faiss1040PrefetchSupportKnnVectorReader reader = new Faiss1040PrefetchSupportKnnVectorReader(delegate);
+        Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
         assertEquals(12345L, reader.ramBytesUsed());
         verify(delegate).ramBytesUsed();
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
@@ -180,13 +180,13 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
             KnnVectorsReader reader = format.fieldsReader(mockedSegmentReadState);
             assertTrue(reader instanceof Faiss1040ScalarQuantizedKnnVectorsReader);
 
-            // Verify the internal FlatVectorsReader is wrapped with Faiss1040PrefetchSupportKnnVectorReader
+            // Verify the internal FlatVectorsReader is wrapped with Faiss1040ScalarQuantizedFlatVectorsReader
             java.lang.reflect.Field flatReaderField = reader.getClass().getSuperclass().getDeclaredField("flatVectorsReader");
             flatReaderField.setAccessible(true);
             Object flatReader = flatReaderField.get(reader);
             assertTrue(
-                "FlatVectorsReader should be wrapped with Faiss1040PrefetchSupportKnnVectorReader for prefetch support",
-                flatReader instanceof Faiss1040PrefetchSupportKnnVectorReader
+                "FlatVectorsReader should be wrapped with Faiss1040ScalarQuantizedFlatVectorsReader",
+                flatReader instanceof Faiss1040ScalarQuantizedFlatVectorsReader
             );
 
             reader.close();

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040CodecTest.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040CodecTest.java
@@ -7,15 +7,27 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.CustomCodec;
 import org.opensearch.knn.index.codec.CustomCodecNoStoredFields;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.index.engine.KNNEngine.LUCENE;
 
 public class KNN1040CodecTest extends KNNCodecTestCase {
 
@@ -43,6 +55,30 @@ public class KNN1040CodecTest extends KNNCodecTestCase {
     public void testCodecSetsCustomPerFieldKnnVectorsFormat() {
         final Codec codec = new KNN1040Codec();
         assertTrue(codec.knnVectorsFormat() instanceof KNN1040PerFieldKnnVectorsFormat);
+    }
+
+    public void testFlatFormatResolver_returnsKNN1040ScalarQuantizedVectorsFormat() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_FLAT, Collections.emptyMap())
+        );
+
+        MapperService mapperService = mock(MapperService.class);
+        KNNVectorFieldType fieldType = new KNNVectorFieldType(
+            "test_field",
+            Collections.emptyMap(),
+            org.opensearch.knn.index.VectorDataType.FLOAT,
+            getMappingConfigForMethodMapping(flatMethodContext, 3)
+        );
+        when(mapperService.fieldType(eq("test_field"))).thenReturn(fieldType);
+
+        KNN1040PerFieldKnnVectorsFormat format = new KNN1040PerFieldKnnVectorsFormat(Optional.of(mapperService));
+        KnnVectorsFormat result = format.getKnnVectorsFormatForField("test_field");
+        assertTrue(
+            "Expected KNN1040ScalarQuantizedVectorsFormat but got " + result.getClass().getSimpleName(),
+            result instanceof KNN1040ScalarQuantizedVectorsFormat
+        );
     }
 
     // IMPORTANT: When this Codec is moved to a backwards Codec, this test needs to be removed, because it attempts to

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormatTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import java.util.concurrent.Executors;
+
+import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+
+public class KNN1040HnswScalarQuantizedVectorsFormatTests extends KNNTestCase {
+
+    public void testDefaultConstructor() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat();
+        assertNotNull(format);
+        String str = format.toString();
+        assertTrue(str.contains("KNN1040HnswScalarQuantizedVectorsFormat"));
+        assertTrue(str.contains(SINGLE_BIT_QUERY_NIBBLE.name()));
+    }
+
+    public void testCustomConstructor() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat(
+            SINGLE_BIT_QUERY_NIBBLE,
+            32,
+            200,
+            1,
+            null
+        );
+        assertNotNull(format);
+        assertEquals("KNN1040HnswScalarQuantizedVectorsFormat", format.getName());
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testGetMaxDimensions_returnsLuceneMax() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat();
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testGetName_returnsClassName() {
+        KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat();
+        assertEquals("KNN1040HnswScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    public void testConstructor_invalidMaxConn_thenThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KNN1040HnswScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE, 0, 100, 1, null)
+        );
+    }
+
+    public void testConstructor_invalidBeamWidth_thenThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KNN1040HnswScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE, 16, 0, 1, null)
+        );
+    }
+
+    public void testConstructor_singleWorkerWithExecutor_thenThrows() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new KNN1040HnswScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE, 16, 100, 1, Executors.newFixedThreadPool(1))
+        );
+    }
+
+    public void testConstructor_allEncodings() {
+        for (ScalarEncoding encoding : ScalarEncoding.values()) {
+            KNN1040HnswScalarQuantizedVectorsFormat format = new KNN1040HnswScalarQuantizedVectorsFormat(encoding, 16, 100, 1, null);
+            assertNotNull(format);
+            assertTrue(format.toString().contains(encoding.name()));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.mockito.Mockito.mock;
 
 @Log4j2
-public class Faiss1040ScalarQuantizedUtilsTests extends KNNTestCase {
+public class KNN1040ScalarQuantizedUtilsTests extends KNNTestCase {
 
     /**
      * A concrete stub extending KnnVectorValues that declares the private field
@@ -58,7 +58,7 @@ public class Faiss1040ScalarQuantizedUtilsTests extends KNNTestCase {
         field.set(stub, expected);
 
         // Act
-        QuantizedByteVectorValues result = Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(stub);
+        QuantizedByteVectorValues result = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(stub);
 
         // Assert: the returned reference is the exact same object
         assertSame(expected, result);
@@ -71,7 +71,7 @@ public class Faiss1040ScalarQuantizedUtilsTests extends KNNTestCase {
         // Act & Assert
         IOException exception = expectThrows(
             IOException.class,
-            () -> Faiss1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(mockValues)
+            () -> KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(mockValues)
         );
 
         assertTrue(exception.getMessage().contains("incompatible Lucene version"));

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Log4j2
-public class Faiss104ScalarQuantizedVectorScorerTests extends KNNTestCase {
+public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
 
     /**
      * A concrete stub extending KnnVectorValues that declares the private field
@@ -65,7 +65,7 @@ public class Faiss104ScalarQuantizedVectorScorerTests extends KNNTestCase {
         final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
 
         // Create the scorer under test
-        final Faiss104ScalarQuantizedVectorScorer scorer = new Faiss104ScalarQuantizedVectorScorer(mockDelegate);
+        final KNN1040ScalarQuantizedVectorScorer scorer = new KNN1040ScalarQuantizedVectorScorer(mockDelegate);
 
         // Set up QuantizedByteVectorValues mock with all methods needed by the parent class
         final int dimension = 8;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormatTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+
+import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+
+public class KNN1040ScalarQuantizedVectorsFormatTests extends KNNTestCase {
+
+    public void testToString_containsEncodingAndScorerInfo() {
+        KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE);
+        String str = format.toString();
+        assertTrue("toString should contain class name", str.contains("KNN1040ScalarQuantizedVectorsFormat"));
+        assertTrue("toString should contain encoding", str.contains(SINGLE_BIT_QUERY_NIBBLE.name()));
+        assertTrue("toString should contain scorer", str.contains("ScalarQuantizedVectorScorer"));
+    }
+
+    public void testDefaultConstructor_usesSingleBitQueryNibble() {
+        KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat();
+        assertTrue(format.toString().contains(SINGLE_BIT_QUERY_NIBBLE.name()));
+    }
+
+    public void testGetMaxDimensions_returnsLuceneMax() {
+        KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat();
+        assertEquals(KNNEngine.getMaxDimensionByEngine(KNNEngine.LUCENE), format.getMaxDimensions("any_field"));
+    }
+
+    public void testGetName_returnsClassName() {
+        KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat();
+        assertEquals("KNN1040ScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    public void testConstructor_allEncodings() {
+        for (Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding encoding : Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding
+            .values()) {
+            KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat(encoding);
+            assertNotNull(format);
+            assertTrue(format.toString().contains(encoding.name()));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValuesTests.java
@@ -18,13 +18,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KNNTestCase {
+public class ScalarQuantizedFloatVectorValuesTests extends KNNTestCase {
 
     @SneakyThrows
     public void testDimension_thenDelegatesToFloatVectorValues() {
         FloatVectorValues fvv = mock(FloatVectorValues.class);
         when(fvv.dimension()).thenReturn(128);
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
         assertEquals(128, wrapper.dimension());
         verify(fvv).dimension();
     }
@@ -33,7 +33,7 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
     public void testSize_thenDelegatesToFloatVectorValues() {
         FloatVectorValues fvv = mock(FloatVectorValues.class);
         when(fvv.size()).thenReturn(400);
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
         assertEquals(400, wrapper.size());
         verify(fvv).size();
     }
@@ -43,7 +43,7 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
         FloatVectorValues fvv = mock(FloatVectorValues.class);
         float[] expected = { 1.0f, 2.0f, 3.0f };
         when(fvv.vectorValue(5)).thenReturn(expected);
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
         assertSame(expected, wrapper.vectorValue(5));
         verify(fvv).vectorValue(5);
     }
@@ -57,11 +57,11 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
         when(fvv.copy()).thenReturn(fvvCopy);
         when(qbvv.copy()).thenReturn(qbvvCopy);
 
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, qbvv);
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, qbvv);
         FloatVectorValues copied = wrapper.copy();
 
         assertNotSame(wrapper, copied);
-        assertTrue(copied instanceof ScalarQuantizedFloatVectorValuesWithIndexInputSlice);
+        assertTrue(copied instanceof ScalarQuantizedFloatVectorValues);
         verify(fvv).copy();
         verify(qbvv).copy();
     }
@@ -70,7 +70,7 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
     public void testGetEncoding_thenDelegatesToFloatVectorValues() {
         FloatVectorValues fvv = mock(FloatVectorValues.class);
         when(fvv.getEncoding()).thenReturn(VectorEncoding.FLOAT32);
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
         assertEquals(VectorEncoding.FLOAT32, wrapper.getEncoding());
         verify(fvv).getEncoding();
     }
@@ -81,17 +81,14 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
         IndexInput expectedSlice = mock(IndexInput.class);
         when(qbvv.getSlice()).thenReturn(expectedSlice);
 
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(mock(FloatVectorValues.class), qbvv);
+        var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), qbvv);
         assertSame(expectedSlice, wrapper.getSlice());
         verify(qbvv).getSlice();
     }
 
     @SneakyThrows
     public void testImplementsHasIndexSlice() {
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(
-            mock(FloatVectorValues.class),
-            mock(QuantizedByteVectorValues.class)
-        );
+        var wrapper = new ScalarQuantizedFloatVectorValues(mock(FloatVectorValues.class), mock(QuantizedByteVectorValues.class));
         assertTrue(wrapper instanceof HasIndexSlice);
     }
 
@@ -101,7 +98,7 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
         FloatVectorValues.DocIndexIterator expectedIterator = mock(FloatVectorValues.DocIndexIterator.class);
         when(fvv.iterator()).thenReturn(expectedIterator);
 
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
         assertSame(expectedIterator, wrapper.iterator());
         verify(fvv).iterator();
     }
@@ -113,7 +110,7 @@ public class ScalarQuantizedFloatVectorValuesWithIndexInputSliceTests extends KN
         float[] target = { 1.0f, 2.0f };
         when(fvv.scorer(target)).thenReturn(expectedScorer);
 
-        var wrapper = new ScalarQuantizedFloatVectorValuesWithIndexInputSlice(fvv, mock(QuantizedByteVectorValues.class));
+        var wrapper = new ScalarQuantizedFloatVectorValues(fvv, mock(QuantizedByteVectorValues.class));
         assertSame(expectedScorer, wrapper.scorer(target));
         verify(fvv).scorer(target);
     }

--- a/src/test/java/org/opensearch/knn/index/mapper/VectorTransformerFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/VectorTransformerFactoryTests.java
@@ -8,21 +8,80 @@ package org.opensearch.knn.index.mapper;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 public class VectorTransformerFactoryTests extends KNNTestCase {
 
     public void testAllSpaceTypes_withFaiss() {
         for (SpaceType spaceType : SpaceType.values()) {
-            VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.FAISS, spaceType);
+            VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.FAISS, spaceType, null);
             validateTransformer(spaceType, KNNEngine.FAISS, transformer);
         }
     }
 
     public void testAllEngines_withCosine() {
         for (KNNEngine engine : KNNEngine.values()) {
-            VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(engine, SpaceType.COSINESIMIL);
+            VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(engine, SpaceType.COSINESIMIL, null);
             validateTransformer(SpaceType.COSINESIMIL, engine, transformer);
         }
+    }
+
+    public void testLuceneCosine_withFlatMethod_returnsNormalizer() {
+        MethodComponentContext flatContext = new MethodComponentContext(METHOD_FLAT, new HashMap<>());
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, SpaceType.COSINESIMIL, flatContext);
+        assertTrue(transformer instanceof NormalizeVectorTransformer);
+    }
+
+    public void testLuceneCosine_withSQOneBit_returnsNormalizer() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 1));
+        MethodComponentContext hnswCtx = new MethodComponentContext(
+            METHOD_HNSW,
+            new HashMap<>(Map.of(METHOD_ENCODER_PARAMETER, encoderCtx))
+        );
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, SpaceType.COSINESIMIL, hnswCtx);
+        assertTrue(transformer instanceof NormalizeVectorTransformer);
+    }
+
+    public void testLuceneCosine_withSQSevenBit_returnsNoop() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 7));
+        MethodComponentContext hnswCtx = new MethodComponentContext(
+            METHOD_HNSW,
+            new HashMap<>(Map.of(METHOD_ENCODER_PARAMETER, encoderCtx))
+        );
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, SpaceType.COSINESIMIL, hnswCtx);
+        assertSame(VectorTransformerFactory.NOOP_VECTOR_TRANSFORMER, transformer);
+    }
+
+    public void testLuceneCosine_withHnswNoEncoder_returnsNoop() {
+        MethodComponentContext hnswCtx = new MethodComponentContext(METHOD_HNSW, new HashMap<>());
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, SpaceType.COSINESIMIL, hnswCtx);
+        assertSame(VectorTransformerFactory.NOOP_VECTOR_TRANSFORMER, transformer);
+    }
+
+    public void testLuceneNonCosine_withFlatMethod_returnsNoop() {
+        MethodComponentContext flatContext = new MethodComponentContext(METHOD_FLAT, new HashMap<>());
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, SpaceType.L2, flatContext);
+        assertSame(VectorTransformerFactory.NOOP_VECTOR_TRANSFORMER, transformer);
+    }
+
+    public void testLuceneCosine_withNullMethodComponentContext_returnsNoop() {
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.LUCENE, SpaceType.COSINESIMIL, null);
+        assertSame(VectorTransformerFactory.NOOP_VECTOR_TRANSFORMER, transformer);
+    }
+
+    public void testFaissCosine_withMethodComponentContext_returnsNormalizer() {
+        MethodComponentContext hnswCtx = new MethodComponentContext(METHOD_HNSW, new HashMap<>());
+        VectorTransformer transformer = VectorTransformerFactory.getVectorTransformer(KNNEngine.FAISS, SpaceType.COSINESIMIL, hnswCtx);
+        assertTrue(transformer instanceof NormalizeVectorTransformer);
     }
 
     private static void validateTransformer(SpaceType spaceType, KNNEngine engine, VectorTransformer transformer) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FlatVectorsScorerProviderTests.java
@@ -16,7 +16,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.codec.KNN1040Codec.Faiss104ScalarQuantizedVectorScorer;
+import org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorScorer;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -89,7 +89,13 @@ public class FlatVectorsScorerProviderTests extends KNNTestCase {
             VECTOR_SCORER
         );
 
-        assertTrue(scorer instanceof Faiss104ScalarQuantizedVectorScorer);
+        assertTrue(scorer instanceof KNN1040ScalarQuantizedVectorScorer);
+    }
+
+    public void testGetKNN1040ScalarQuantizedVectorScorer_returnsCorrectType() {
+        KNN1040ScalarQuantizedVectorScorer scorer = FlatVectorsScorerProvider.getKNN1040ScalarQuantizedVectorScorer(VECTOR_SCORER);
+        assertNotNull(scorer);
+        assertTrue(scorer instanceof KNN1040ScalarQuantizedVectorScorer);
     }
 
     public void testNonHammingScoring() {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -37,7 +37,7 @@ import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.junit.Test;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.codec.KNN1040Codec.Faiss104ScalarQuantizedVectorScorer;
+import org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorScorer;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
@@ -48,13 +48,13 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Tests that the native SIMD SQ scorer ({@link Faiss104ScalarQuantizedVectorScorer}) produces scores
+ * Tests that the native SIMD SQ scorer ({@link KNN1040ScalarQuantizedVectorScorer}) produces scores
  * matching Lucene's {@link Lucene104ScalarQuantizedVectorScorer} (the source of truth).
  * <p>
  * Uses the Lucene codec pipeline directly:
  * 1. {@link Lucene104ScalarQuantizedVectorsFormat#fieldsWriter} to quantize and write vectors.
  * 2. {@link Lucene104ScalarQuantizedVectorsReader} with {@link Lucene104ScalarQuantizedVectorScorer} → truth.
- * 3. {@link Lucene104ScalarQuantizedVectorsReader} with {@link Faiss104ScalarQuantizedVectorScorer} → test subject.
+ * 3. {@link Lucene104ScalarQuantizedVectorsReader} with {@link KNN1040ScalarQuantizedVectorScorer} → test subject.
  * 4. Compare scores.
  */
 public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
@@ -191,7 +191,7 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 assertNotNull("Truth scorer should not be null", truthScorer);
 
                 // ---- Step 3: SIMD scorer (test subject) ----
-                final Faiss104ScalarQuantizedVectorScorer simdFlatScorer = new Faiss104ScalarQuantizedVectorScorer(defaultScorer);
+                final KNN1040ScalarQuantizedVectorScorer simdFlatScorer = new KNN1040ScalarQuantizedVectorScorer(defaultScorer);
 
                 RandomVectorScorer testScorer = simdFlatScorer.getRandomVectorScorer(
                     similarityFunction,


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/k-NN/pull/3203 to main

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
