### PR TITLE
Add debug mode to MMR rerank that injects per-hit scoring details 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 3.6](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
+* Add debug mode to MMR rerank that injects per-hit scoring details (original_score, max_similarity_to_selected, mmr_score, mmr_formula) into _source via the `debug` flag in the mmr search extension [#3254](https://github.com/opensearch-project/k-NN/pull/3254)
 * Support Lucene SQ Flat for 1 bit [#3154](https://github.com/opensearch-project/k-NN/pull/3154)
 * Add 32x support for SQ encoder on Faiss [#3193](https://github.com/opensearch-project/k-NN/pull/3193)
 * Faiss SQ 1bit MOS changes [#3182](https://github.com/opensearch-project/k-NN/pull/3182)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -207,6 +207,8 @@ public class KNNConstants {
 
     // mmr
     public static final String MMR = "mmr";
+    public static final String MMR_EXPLAIN = "mmr_explain";
+    public static final String EXPLAIN = "explain";
     public static final String DIVERSITY = "diversity";
     public static final String CANDIDATES = "candidates";
     public static final String VECTOR_FIELD_PATH = "vector_field_path";

--- a/src/main/java/org/opensearch/knn/search/extension/MMRSearchExtBuilder.java
+++ b/src/main/java/org/opensearch/knn/search/extension/MMRSearchExtBuilder.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.opensearch.Version;
 import org.opensearch.core.ParseField;
 import org.opensearch.core.common.ParsingException;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -29,6 +30,7 @@ import java.util.Objects;
 
 import static org.opensearch.knn.common.KNNConstants.CANDIDATES;
 import static org.opensearch.knn.common.KNNConstants.DIVERSITY;
+import static org.opensearch.knn.common.KNNConstants.EXPLAIN;
 import static org.opensearch.knn.common.KNNConstants.MMR;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_FIELD_DATA_TYPE;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_FIELD_PATH;
@@ -45,6 +47,11 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
 
     public static final String NAME = MMR;
 
+    // TODO: Change to Version.V_3_7_0 once it's available. Using V_3_6_0 as a placeholder for backward compatibility
+    // during rolling upgrades. The explain field was introduced after 3.6.0 and should only be serialized to nodes
+    // that support it.
+    private static final Version MMR_EXPLAIN_MIN_VERSION = Version.V_3_6_0;
+
     // Used to control the weight of the diversity, range is from [0,1]. (diversity = 1) prioritizes maximum diversity
     // which means the documents are selected just based on how different they are from already chosen documents.
     public static final ParseField DIVERSITY_FIELD = new ParseField(DIVERSITY);
@@ -59,12 +66,15 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
     // Space type of the vector field which is used to decide the similarity function. Optional. If not provided we
     // should auto resolve it from the index mapping.
     public static final ParseField VECTOR_FIELD_SPACE_TYPE_FIELD = new ParseField(VECTOR_FIELD_SPACE_TYPE);
+    // Flag to enable MMR explain info in the response. Optional. Defaults to false.
+    public static final ParseField EXPLAIN_FIELD = new ParseField(EXPLAIN);
 
     private Float diversity;
     private Integer candidates;
     private String vectorFieldPath;
     private VectorDataType vectorFieldDataType;
     private SpaceType spaceType;
+    private Boolean explain;
 
     public static class Builder {
         private Float diversity;
@@ -72,6 +82,7 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
         private String vectorFieldPath;
         private VectorDataType vectorFieldDataType;
         private SpaceType spaceType;
+        private Boolean explain;
 
         public Builder() {}
 
@@ -121,10 +132,15 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
             return this;
         }
 
+        public Builder explain(Boolean explain) {
+            this.explain = explain;
+            return this;
+        }
+
         public MMRSearchExtBuilder build() {
             setDefault();
             validate();
-            return new MMRSearchExtBuilder(diversity, candidates, vectorFieldPath, vectorFieldDataType, spaceType);
+            return new MMRSearchExtBuilder(diversity, candidates, vectorFieldPath, vectorFieldDataType, spaceType, explain);
         }
 
         private void setDefault() {
@@ -170,6 +186,9 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
         if (spaceTypeStr != null) {
             spaceType = SpaceType.getSpace(spaceTypeStr);
         }
+        if (in.getVersion().onOrAfter(MMR_EXPLAIN_MIN_VERSION)) {
+            explain = in.readOptionalBoolean();
+        }
     }
 
     @Override
@@ -179,6 +198,9 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
         out.writeOptionalString(vectorFieldPath);
         out.writeOptionalString(vectorFieldDataType == null ? null : vectorFieldDataType.getValue());
         out.writeOptionalString(spaceType == null ? null : spaceType.getValue());
+        if (out.getVersion().onOrAfter(MMR_EXPLAIN_MIN_VERSION)) {
+            out.writeOptionalBoolean(explain);
+        }
     }
 
     @Override
@@ -204,13 +226,16 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
         if (spaceType != null) {
             builder.field(VECTOR_FIELD_SPACE_TYPE_FIELD.getPreferredName(), spaceType.getValue());
         }
+        if (explain != null) {
+            builder.field(EXPLAIN_FIELD.getPreferredName(), explain);
+        }
         builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(diversity, candidates, vectorFieldPath, vectorFieldDataType, spaceType);
+        return Objects.hash(diversity, candidates, vectorFieldPath, vectorFieldDataType, spaceType, explain);
     }
 
     @Override
@@ -224,6 +249,7 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
         equalsBuilder.append(vectorFieldPath, other.vectorFieldPath);
         equalsBuilder.append(vectorFieldDataType, other.vectorFieldDataType);
         equalsBuilder.append(spaceType, other.spaceType);
+        equalsBuilder.append(explain, other.explain);
         return equalsBuilder.isEquals();
     }
 
@@ -246,6 +272,8 @@ public class MMRSearchExtBuilder extends SearchExtBuilder {
                     builder.vectorFieldDataType(parser.text());
                 } else if (VECTOR_FIELD_SPACE_TYPE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     builder.spaceType(parser.text());
+                } else if (EXPLAIN_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    builder.explain(parser.booleanValue());
                 } else {
                     throw unsupportedField(parser, currentFieldName);
                 }

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRExplainInfo.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRExplainInfo.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.search.processor.mmr;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A DTO to hold the explain info for a single hit selected by the MMR algorithm.
+ * This captures the scoring details at the moment the document was chosen.
+ * Note: the selection order and previously-selected documents can be inferred from
+ * the position of each hit in the result list.
+ */
+@Value
+@Builder
+public class MMRExplainInfo {
+
+    public static final String ORIGINAL_SCORE_FIELD = "original_score";
+    public static final String MAX_SIMILARITY_TO_SELECTED_FIELD = "max_similarity_to_selected";
+    public static final String MMR_SCORE_FIELD = "mmr_score";
+    public static final String MMR_FORMULA_FIELD = "mmr_formula";
+
+    /**
+     * The original relevance score from the KNN/neural search.
+     */
+    float originalScore;
+
+    /**
+     * The maximum vector similarity between this document and any already-selected document.
+     * For the first selected document, this is 0.0.
+     */
+    float maxSimilarityToSelected;
+
+    /**
+     * The computed MMR score at selection time: (1 - diversity) * originalScore - diversity * maxSimilarityToSelected.
+     */
+    double mmrScore;
+
+    /**
+     * The diversity parameter (lambda) used in the MMR formula.
+     */
+    float diversity;
+
+    /**
+     * Converts this explain info to a map suitable for injection into a search hit's _source.
+     *
+     * @return a map representing the mmr_explain payload
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(ORIGINAL_SCORE_FIELD, originalScore);
+        map.put(MAX_SIMILARITY_TO_SELECTED_FIELD, maxSimilarityToSelected);
+        map.put(MMR_SCORE_FIELD, mmrScore);
+        map.put(
+            MMR_FORMULA_FIELD,
+            String.format(
+                Locale.ROOT,
+                "(1 - %.4f) * %.4f - %.4f * %.4f = %.4f",
+                diversity,
+                originalScore,
+                diversity,
+                maxSimilarityToSelected,
+                mmrScore
+            )
+        );
+        return map;
+    }
+}

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMROverSampleProcessor.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMROverSampleProcessor.java
@@ -99,6 +99,7 @@ public class MMROverSampleProcessor implements SearchRequestProcessor, SystemGen
 
             MMRRerankContext mmrRerankContext = new MMRRerankContext();
             mmrRerankContext.setDiversity(mmrSearchExtBuilder.getDiversity());
+            mmrRerankContext.setExplain(mmrSearchExtBuilder.getExplain());
 
             validateForRemoteIndices(mmrSearchExtBuilder, remoteIndices);
 

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRRerankContext.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRRerankContext.java
@@ -28,4 +28,6 @@ public class MMRRerankContext {
     private VectorDataType vectorDataType;
     // To support the case that we have different vector field paths in different indices
     private Map<String, String> indexToVectorFieldPathMap;
+    // Flag to enable MMR explain info in the response
+    private Boolean explain;
 }

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRRerankProcessor.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRRerankProcessor.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static org.opensearch.knn.common.KNNConstants.MMR_EXPLAIN;
 import static org.opensearch.knn.common.KNNConstants.MMR_RERANK_CONTEXT;
 import static org.opensearch.knn.search.processor.mmr.MMRUtil.extractVectorFromHit;
 import static org.opensearch.knn.search.processor.mmr.MMRUtil.shouldGenerateMMRProcessor;
@@ -81,14 +83,22 @@ public class MMRRerankProcessor implements SearchResponseProcessor, SystemGenera
             isFloatVector
         );
 
+        final boolean explainEnabled = Boolean.TRUE.equals(mmrContext.getExplain());
+        final Map<String, MMRExplainInfo> explainInfoMap = explainEnabled ? new LinkedHashMap<>() : null;
+
         final List<SearchHit> selected = selectHitsWithMMR(
             candidates,
             docVectors,
             similarityFunction,
             diversity,
             originalQuerySize,
-            isFloatVector
+            isFloatVector,
+            explainInfoMap
         );
+
+        if (explainEnabled) {
+            injectExplainInfo(selected, explainInfoMap);
+        }
 
         applyFetchSourceFilterIfNeeded(selected, mmrContext);
 
@@ -193,15 +203,18 @@ public class MMRRerankProcessor implements SearchResponseProcessor, SystemGenera
         KNNVectorSimilarityFunction similarityFunction,
         float diversity,
         int targetSize,
-        boolean isFloatVector
+        boolean isFloatVector,
+        Map<String, MMRExplainInfo> explainInfoMap
     ) {
         List<SearchHit> selected = new ArrayList<>();
         Map<String, Float> simCache = new HashMap<>();
+        final boolean collectExplain = explainInfoMap != null;
 
         while (selected.size() < targetSize && !candidates.isEmpty()) {
 
             Pair<SearchHit, Double> bestCandidate = null;
             double bestScore = Double.NEGATIVE_INFINITY;
+            float bestMaxSimToSelected = 0.0f;
 
             for (SearchHit candidate : candidates) {
                 String candidateId = candidate.getId();
@@ -227,18 +240,51 @@ public class MMRRerankProcessor implements SearchResponseProcessor, SystemGenera
                 double score = (1 - diversity) * candidate.getScore() - diversity * maxSimToSelected;
                 if (score > bestScore) {
                     bestScore = score;
+                    bestMaxSimToSelected = maxSimToSelected;
                     bestCandidate = Pair.of(candidate, score);
                 }
             }
 
             if (bestCandidate != null) {
                 SearchHit bestHit = bestCandidate.getLeft();
+
+                if (collectExplain) {
+                    MMRExplainInfo explainInfo = MMRExplainInfo.builder()
+                        .originalScore(bestHit.getScore())
+                        .maxSimilarityToSelected(bestMaxSimToSelected)
+                        .mmrScore(bestCandidate.getRight())
+                        .diversity(diversity)
+                        .build();
+                    explainInfoMap.put(bestHit.getId(), explainInfo);
+                }
+
                 selected.add(bestHit);
                 candidates.remove(bestHit);
             }
         }
 
         return selected;
+    }
+
+    /**
+     * Injects MMR explain info into each selected hit's _source as an "mmr_explain" field.
+     */
+    private void injectExplainInfo(List<SearchHit> selected, Map<String, MMRExplainInfo> explainInfoMap) throws IOException {
+        for (SearchHit hit : selected) {
+            MMRExplainInfo explainInfo = explainInfoMap.get(hit.getId());
+            if (explainInfo == null) {
+                throw new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "MMR explain info not found for selected hit [%s]. This indicates an internal inconsistency in the MMR selection process.",
+                        hit.getId()
+                    )
+                );
+            }
+            Map<String, Object> source = hit.getSourceAsMap();
+            source.put(MMR_EXPLAIN, explainInfo.toMap());
+            hit.sourceRef(BytesReference.bytes(XContentFactory.jsonBuilder().map(source)));
+        }
     }
 
     private void applyFetchSourceFilterIfNeeded(List<SearchHit> hits, MMRRerankContext mmrContext) throws IOException {

--- a/src/test/java/org/opensearch/knn/search/extension/MMRSearchExtBuilderIT.java
+++ b/src/test/java/org/opensearch/knn/search/extension/MMRSearchExtBuilderIT.java
@@ -19,10 +19,33 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.search.processor.mmr.MMROverSampleProcessor;
 import org.opensearch.knn.search.processor.mmr.MMRRerankProcessor;
 
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
-import static org.opensearch.knn.common.KNNConstants.*;
+import org.opensearch.knn.search.processor.mmr.MMRExplainInfo;
+
+import static org.opensearch.knn.KNNRestTestCase.PROPERTIES_FIELD;
+import static org.opensearch.knn.common.KNNConstants.CANDIDATES;
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.DIVERSITY;
+import static org.opensearch.knn.common.KNNConstants.EXPLAIN;
+import static org.opensearch.knn.common.KNNConstants.K;
+import static org.opensearch.knn.common.KNNConstants.KNN;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MMR;
+import static org.opensearch.knn.common.KNNConstants.MMR_EXPLAIN;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.TYPE;
+import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.common.KNNConstants.VECTOR;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_FIELD_PATH;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_FIELD_SPACE_TYPE;
 import static org.opensearch.search.pipeline.SearchPipelineService.ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING;
 
 public class MMRSearchExtBuilderIT extends KNNRestTestCase {
@@ -95,6 +118,91 @@ public class MMRSearchExtBuilderIT extends KNNRestTestCase {
         List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
 
         verifyResults(results, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    @SneakyThrows
+    public void testMMR_whenExplainEnabled_thenExplainInfoInResponse() {
+        XContentBuilder queryBuilder = buildMMRQueryWithExplain(SIMILAR_VECTOR, QUERY_SIZE, true);
+
+        Response response = searchKNNIndex(INDEX_NAME, queryBuilder.toString(), QUERY_SIZE);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(QUERY_SIZE, results.size());
+
+        // Parse the raw response to check for mmr_explain in _source
+        Map<String, Object> responseMap = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        Map<String, Object> hitsOuter = (Map<String, Object>) responseMap.get("hits");
+        List<Map<String, Object>> hitsList = (List<Map<String, Object>>) hitsOuter.get("hits");
+
+        for (int i = 0; i < hitsList.size(); i++) {
+            Map<String, Object> hit = hitsList.get(i);
+            Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+            assertNotNull("Hit " + i + " should have _source", source);
+
+            Map<String, Object> mmrExplain = (Map<String, Object>) source.get(MMR_EXPLAIN);
+            assertNotNull("Hit " + i + " should have mmr_explain in _source", mmrExplain);
+            assertNotNull("original_score should be present", mmrExplain.get(MMRExplainInfo.ORIGINAL_SCORE_FIELD));
+            assertNotNull("max_similarity_to_selected should be present", mmrExplain.get(MMRExplainInfo.MAX_SIMILARITY_TO_SELECTED_FIELD));
+            assertNotNull("mmr_score should be present", mmrExplain.get(MMRExplainInfo.MMR_SCORE_FIELD));
+            assertNotNull("mmr_formula should be present", mmrExplain.get(MMRExplainInfo.MMR_FORMULA_FIELD));
+            // selection_round and selected_so_far are intentionally absent - inferred from result position
+            assertNull("selection_round should NOT be present", mmrExplain.get("selection_round"));
+            assertNull("selected_so_far should NOT be present", mmrExplain.get("selected_so_far"));
+        }
+
+        // Verify first hit has max_similarity_to_selected = 0 (no prior selections)
+        Map<String, Object> firstSource = (Map<String, Object>) hitsList.get(0).get("_source");
+        Map<String, Object> firstExplain = (Map<String, Object>) firstSource.get(MMR_EXPLAIN);
+        assertEquals(0.0, ((Number) firstExplain.get(MMRExplainInfo.MAX_SIMILARITY_TO_SELECTED_FIELD)).doubleValue(), 1e-6);
+    }
+
+    @SuppressWarnings("unchecked")
+    @SneakyThrows
+    public void testMMR_whenExplainDisabled_thenNoExplainInfoInResponse() {
+        XContentBuilder queryBuilder = buildMMRQueryWithExplain(SIMILAR_VECTOR, QUERY_SIZE, false);
+
+        Response response = searchKNNIndex(INDEX_NAME, queryBuilder.toString(), QUERY_SIZE);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(QUERY_SIZE, results.size());
+
+        Map<String, Object> responseMap = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        Map<String, Object> hitsOuter = (Map<String, Object>) responseMap.get("hits");
+        List<Map<String, Object>> hitsList = (List<Map<String, Object>>) hitsOuter.get("hits");
+
+        for (int i = 0; i < hitsList.size(); i++) {
+            Map<String, Object> hit = hitsList.get(i);
+            Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+            assertNotNull("Hit " + i + " should have _source", source);
+            assertNull("Hit " + i + " should NOT have mmr_explain when explain is disabled", source.get(MMR_EXPLAIN));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @SneakyThrows
+    public void testMMR_whenExplainNotSpecified_thenNoExplainInfoInResponse() {
+        // Use the standard query builder without explain field
+        XContentBuilder queryBuilder = buildMMRQuery(SIMILAR_VECTOR, QUERY_SIZE, false, false);
+
+        Response response = searchKNNIndex(INDEX_NAME, queryBuilder.toString(), QUERY_SIZE);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        assertEquals(QUERY_SIZE, results.size());
+
+        Map<String, Object> responseMap = createParser(MediaTypeRegistry.getDefaultMediaType().xContent(), responseBody).map();
+        Map<String, Object> hitsOuter = (Map<String, Object>) responseMap.get("hits");
+        List<Map<String, Object>> hitsList = (List<Map<String, Object>>) hitsOuter.get("hits");
+
+        for (int i = 0; i < hitsList.size(); i++) {
+            Map<String, Object> hit = hitsList.get(i);
+            Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+            assertNotNull("Hit " + i + " should have _source", source);
+            assertNull("Hit " + i + " should NOT have mmr_explain when explain is not specified", source.get(MMR_EXPLAIN));
+        }
     }
 
     @SneakyThrows
@@ -175,6 +283,31 @@ public class MMRSearchExtBuilderIT extends KNNRestTestCase {
             builder.field(VECTOR_FIELD_PATH, FIELD_NAME).field(VECTOR_FIELD_SPACE_TYPE, SpaceType.L2.getValue());
         }
         builder.endObject().endObject().endObject();
+
+        return builder;
+    }
+
+    @SneakyThrows
+    private XContentBuilder buildMMRQueryWithExplain(float[] queryVector, int k, boolean explain) {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+
+        builder.startObject("query")
+            .startObject(KNN)
+            .startObject(FIELD_NAME)
+            .array(VECTOR, queryVector)
+            .field(K, k)
+            .endObject()
+            .endObject()
+            .endObject();
+
+        builder.startObject("ext")
+            .startObject(MMR)
+            .field(CANDIDATES, 9)
+            .field(DIVERSITY, 0.9)
+            .field(EXPLAIN, explain)
+            .endObject()
+            .endObject()
+            .endObject();
 
         return builder;
     }

--- a/src/test/java/org/opensearch/knn/search/extension/MMRSearchExtBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/search/extension/MMRSearchExtBuilderTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.search.extension;
 
 import org.junit.Before;
+import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -172,6 +173,90 @@ public class MMRSearchExtBuilderTests extends MMRTestCase {
             String expectedError = "[mmr] query extension does not support [unsupported_field]";
             assertEquals(expectedError, ex.getMessage());
         }
+    }
+
+    public void testSerializationRoundTrip_whenExplainEnabled_thenPreserved() throws IOException {
+        MMRSearchExtBuilder original = new MMRSearchExtBuilder.Builder().diversity(0.6f)
+            .candidates(20)
+            .vectorFieldPath("vec")
+            .spaceType("l2")
+            .vectorFieldDataType("byte")
+            .explain(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        MMRSearchExtBuilder deserialized = new MMRSearchExtBuilder(out.bytes().streamInput());
+
+        assertEquals(original, deserialized);
+        assertEquals(true, deserialized.getExplain());
+    }
+
+    public void testSerializationRoundTrip_whenExplainDisabled_thenPreserved() throws IOException {
+        MMRSearchExtBuilder original = new MMRSearchExtBuilder.Builder().diversity(0.6f).explain(false).build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        MMRSearchExtBuilder deserialized = new MMRSearchExtBuilder(out.bytes().streamInput());
+
+        assertEquals(original, deserialized);
+        assertEquals(false, deserialized.getExplain());
+    }
+
+    public void testSerialization_whenOlderVersion_thenExplainNotSerialized() throws IOException {
+        MMRSearchExtBuilder original = new MMRSearchExtBuilder.Builder().diversity(0.6f)
+            .candidates(20)
+            .vectorFieldPath("vec")
+            .spaceType("l2")
+            .explain(true)
+            .build();
+
+        // Simulate writing to an older node that doesn't support explain
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_3_5_0);
+        original.writeTo(out);
+
+        // Simulate reading from an older node stream
+        var streamInput = out.bytes().streamInput();
+        streamInput.setVersion(Version.V_3_5_0);
+        MMRSearchExtBuilder deserialized = new MMRSearchExtBuilder(streamInput);
+
+        // Explain should be null since older version doesn't support it
+        assertNull("Explain should be null when deserialized from older version stream", deserialized.getExplain());
+        // Other fields should still be preserved
+        assertEquals(0.6f, deserialized.getDiversity(), DELTA);
+        assertEquals(20, (int) deserialized.getCandidates());
+        assertEquals("vec", deserialized.getVectorFieldPath());
+        assertEquals(SpaceType.L2, deserialized.getSpaceType());
+    }
+
+    public void testToXContentAndParse_whenExplainEnabled_thenPreserved() throws IOException {
+        MMRSearchExtBuilder original = new MMRSearchExtBuilder.Builder().diversity(0.9f).candidates(15).explain(true).build();
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        original.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+        xContentBuilder.endObject();
+
+        try (XContentParser parser = createParser(xContentBuilder)) {
+            parser.nextToken(); // start object
+            parser.nextToken(); // field name "mmr"
+            parser.nextToken(); // start object
+            MMRSearchExtBuilder parsed = MMRSearchExtBuilder.parse(parser);
+
+            assertEquals(original, parsed);
+            assertEquals(true, parsed.getExplain());
+        }
+    }
+
+    public void testEqualsAndHashCode_whenExplainDiffers_thenNotEqual() {
+        MMRSearchExtBuilder withExplain = new MMRSearchExtBuilder.Builder().diversity(0.7f).explain(true).build();
+        MMRSearchExtBuilder withoutExplain = new MMRSearchExtBuilder.Builder().diversity(0.7f).build();
+
+        assertNotEquals(withExplain, withoutExplain);
+        assertNotEquals(withExplain.hashCode(), withoutExplain.hashCode());
     }
 
     public void testParse_whenMMRProcessorsNotEnabled_thenException() throws IOException {

--- a/src/test/java/org/opensearch/knn/search/processor/mmr/MMRRerankProcessorTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/mmr/MMRRerankProcessorTests.java
@@ -25,8 +25,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.mockito.Mockito.mock;
+import static org.opensearch.knn.common.KNNConstants.MMR_EXPLAIN;
 import static org.opensearch.knn.common.KNNConstants.MMR_RERANK_CONTEXT;
+import static org.mockito.Mockito.mock;
 
 public class MMRRerankProcessorTests extends KNNTestCase {
     private MMRRerankProcessor processor;
@@ -141,6 +142,118 @@ public class MMRRerankProcessorTests extends KNNTestCase {
         );
         String expectedMessage = "Original query size in MMR rerank context cannot be null";
         assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testProcessResponse_whenExplainEnabled_thenExplainInfoInSource() throws IOException {
+        SearchResponse searchResponse = createSearchResponse();
+
+        MMRRerankContext mmrRerankContext = new MMRRerankContext();
+        mmrRerankContext.setDiversity(0.5f);
+        mmrRerankContext.setOriginalQuerySize(3);
+        mmrRerankContext.setSpaceType(SpaceType.L2);
+        mmrRerankContext.setVectorDataType(VectorDataType.FLOAT);
+        mmrRerankContext.setVectorFieldPath("knn_vector");
+        mmrRerankContext.setExplain(true);
+        PipelineProcessingContext ctx = new PipelineProcessingContext();
+        ctx.setAttribute(MMR_RERANK_CONTEXT, mmrRerankContext);
+
+        SearchResponse result = processor.processResponse(searchRequest, searchResponse, ctx);
+
+        assertEquals(3, result.getInternalResponse().hits().getHits().length);
+
+        for (SearchHit hit : result.getInternalResponse().hits().getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            assertNotNull("mmr_explain should be present when explain is enabled", source.get(MMR_EXPLAIN));
+            Map<String, Object> explainInfo = (Map<String, Object>) source.get(MMR_EXPLAIN);
+            assertNotNull("original_score should be present", explainInfo.get(MMRExplainInfo.ORIGINAL_SCORE_FIELD));
+            assertNotNull("max_similarity_to_selected should be present", explainInfo.get(MMRExplainInfo.MAX_SIMILARITY_TO_SELECTED_FIELD));
+            assertNotNull("mmr_score should be present", explainInfo.get(MMRExplainInfo.MMR_SCORE_FIELD));
+            assertNotNull("mmr_formula should be present", explainInfo.get(MMRExplainInfo.MMR_FORMULA_FIELD));
+            // selection_round and selected_so_far are intentionally omitted - they can be inferred from result position
+            assertNull("selection_round should NOT be present (redundant with result position)", explainInfo.get("selection_round"));
+            assertNull("selected_so_far should NOT be present (redundant with preceding hits)", explainInfo.get("selected_so_far"));
+        }
+
+        // Verify first hit has max_similarity_to_selected = 0 (no prior selections)
+        Map<String, Object> firstExplain = (Map<String, Object>) result.getInternalResponse().hits().getHits()[0].getSourceAsMap()
+            .get(MMR_EXPLAIN);
+        assertEquals(0.0f, ((Number) firstExplain.get(MMRExplainInfo.MAX_SIMILARITY_TO_SELECTED_FIELD)).floatValue(), 1e-6);
+    }
+
+    public void testProcessResponse_whenExplainDisabled_thenNoExplainInfoInSource() throws IOException {
+        SearchResponse searchResponse = createSearchResponse();
+
+        MMRRerankContext mmrRerankContext = new MMRRerankContext();
+        mmrRerankContext.setDiversity(0.5f);
+        mmrRerankContext.setOriginalQuerySize(3);
+        mmrRerankContext.setSpaceType(SpaceType.L2);
+        mmrRerankContext.setVectorDataType(VectorDataType.FLOAT);
+        mmrRerankContext.setVectorFieldPath("knn_vector");
+        mmrRerankContext.setExplain(false);
+        PipelineProcessingContext ctx = new PipelineProcessingContext();
+        ctx.setAttribute(MMR_RERANK_CONTEXT, mmrRerankContext);
+
+        SearchResponse result = processor.processResponse(searchRequest, searchResponse, ctx);
+
+        assertEquals(3, result.getInternalResponse().hits().getHits().length);
+
+        for (SearchHit hit : result.getInternalResponse().hits().getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            assertNull("mmr_explain should NOT be present when explain is disabled", source.get(MMR_EXPLAIN));
+        }
+    }
+
+    public void testProcessResponse_whenExplainNull_thenNoExplainInfoInSource() throws IOException {
+        SearchResponse searchResponse = createSearchResponse();
+
+        MMRRerankContext mmrRerankContext = new MMRRerankContext();
+        mmrRerankContext.setDiversity(0.5f);
+        mmrRerankContext.setOriginalQuerySize(3);
+        mmrRerankContext.setSpaceType(SpaceType.L2);
+        mmrRerankContext.setVectorDataType(VectorDataType.FLOAT);
+        mmrRerankContext.setVectorFieldPath("knn_vector");
+        // explain is not set (null)
+        PipelineProcessingContext ctx = new PipelineProcessingContext();
+        ctx.setAttribute(MMR_RERANK_CONTEXT, mmrRerankContext);
+
+        SearchResponse result = processor.processResponse(searchRequest, searchResponse, ctx);
+
+        assertEquals(3, result.getInternalResponse().hits().getHits().length);
+
+        for (SearchHit hit : result.getInternalResponse().hits().getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            assertNull("mmr_explain should NOT be present when explain is null", source.get(MMR_EXPLAIN));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testProcessResponse_whenExplainEnabledWithFetchSourceFilter_thenExplainInfoFilteredCorrectly() throws IOException {
+        SearchResponse searchResponse = createSearchResponse();
+
+        MMRRerankContext mmrRerankContext = new MMRRerankContext();
+        mmrRerankContext.setDiversity(0.5f);
+        mmrRerankContext.setOriginalQuerySize(3);
+        mmrRerankContext.setSpaceType(SpaceType.L2);
+        mmrRerankContext.setVectorDataType(VectorDataType.FLOAT);
+        mmrRerankContext.setVectorFieldPath("knn_vector");
+        mmrRerankContext.setExplain(true);
+        // Exclude knn_vector but include mmr_explain
+        mmrRerankContext.setOriginalFetchSourceContext(new FetchSourceContext(true, new String[] {}, new String[] { "knn_vector" }));
+        PipelineProcessingContext ctx = new PipelineProcessingContext();
+        ctx.setAttribute(MMR_RERANK_CONTEXT, mmrRerankContext);
+
+        SearchResponse result = processor.processResponse(searchRequest, searchResponse, ctx);
+
+        assertEquals(3, result.getInternalResponse().hits().getHits().length);
+
+        for (SearchHit hit : result.getInternalResponse().hits().getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            // mmr_explain should still be present since it's not excluded
+            assertNotNull("mmr_explain should be present", source.get(MMR_EXPLAIN));
+            // knn_vector should be excluded
+            assertNull("knn_vector should be excluded", source.get("knn_vector"));
+        }
     }
 
     public void testProcessResponse_whenMissingDiversity_thenException() throws IOException {


### PR DESCRIPTION
### Description

### What this PR does

Adds an `explain` flag to the MMR (Maximal Marginal Relevance) search extension that enables per-hit explainability for the MMR reranking algorithm, consistent with OpenSearch's existing `explain` convention. When `"explain": true` is set in the `ext.mmr` block, each selected hit's `_source` will contain an `mmr_explain` object showing exactly why that document was chosen.

**Example usage:**
```json
{
  "ext": {
    "mmr": {
      "diversity": 0.5,
      "candidates": 100,
      "explain": true
    }
  }
}
```

**Example output per hit:**
```json
"mmr_explain": {
  "original_score": 1.0,
  "max_similarity_to_selected": 0.95,
  "mmr_score": 0.525,
  "mmr_formula": "(1 - 0.5000) * 1.0000 - 0.5000 * 0.9500 = 0.5250"
}
```

The selection order and previously-selected documents are intentionally omitted from the explain payload — they are redundant since they can be inferred from each hit's position in the result list.

---

### Changes

**New file:**
- `MMRDebugInfo.java` — DTO holding the 4 explain fields and a `toMap()` method for `_source` injection

**Modified files:**
- `KNNConstants.java` — Added `MMR_EXPLAIN = "mmr_explain"` and `EXPLAIN = "explain"` constants
- `MMRSearchExtBuilder.java` — Added `explain` field with full parse/serialize/toXContent/equals/hashCode support. Added a version guard (`MMR_EXPLAIN_MIN_VERSION = V_3_6_0`, TODO to update to `V_3_7_0`) in `writeTo()` and the `StreamInput` constructor to ensure backward compatibility during rolling upgrades — older nodes will not receive the `explain` field in the stream.
- `MMRRerankContext.java` — Added `explain` field to carry the flag through the pipeline
- `MMROverSampleProcessor.java` — Propagates `explain` from the search extension to the rerank context
- `MMRRerankProcessor.java` — Collects explain info during the greedy MMR selection loop and injects `mmr_explain` into each hit's `_source` when explain is enabled
- `CHANGELOG.md` — Added entry under `[Unreleased 3.6] ### Features`

**Tests:**
- `MMRRerankProcessorTests.java` — 4 new unit tests covering explain enabled/disabled/null and explain with fetch source filter
- `MMRSearchExtBuilderTests.java` — 5 new unit tests covering serialization round-trip with explain, older-version stream guard, XContent parse, and equals/hashCode
- `MMRSearchExtBuilderIT.java` — 3 new integration tests covering explain enabled/disabled/not-specified

---

### Backward Compatibility

The `explain` field is guarded by a minimum version check (`V_3_6_0`, TODO to update to `V_3_7_0`) in the stream serialization. During a rolling upgrade from an older cluster:
- **New → Old node**: `explain` is not written to the stream, so old nodes can deserialize safely
- **Old → New node**: `explain` is not read (defaults to `null`/disabled), so new nodes handle old streams gracefully


### Related Issues
Resolves #3107 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
