### PR TITLE
[Bug Fix] Block radial search on Faiss SQ

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -35,6 +35,7 @@ import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.model.QueryContext;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.query.parser.KNNQueryBuilderParser;
@@ -59,6 +60,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
 import static org.opensearch.knn.index.engine.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
+import static org.opensearch.knn.index.engine.KNNEngine.FAISS;
 import static org.opensearch.knn.index.engine.validation.ParameterValidator.validateParameters;
 import static org.opensearch.knn.index.query.parser.MethodParametersParser.validateMethodParameters;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_OVERSAMPLE_PARAMETER;
@@ -486,7 +488,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                 throw new UnsupportedOperationException(String.format(Locale.ROOT, "Binary data type does not support radial search"));
             }
 
-            if (knnMappingConfig.getQuantizationConfig() != QuantizationConfig.EMPTY) {
+            if ((knnMappingConfig.getQuantizationConfig() != QuantizationConfig.EMPTY)
+                // If engine is Faiss and compression level is 32x, then it's using Faiss SQ which has null QuantizationConfig.
+                // In that case, we should block radial search as well.
+                || (knnEngine == FAISS && knnMappingConfig.getCompressionLevel() == CompressionLevel.x32)) {
                 throw new UnsupportedOperationException("Radial search is not supported for indices which have quantization enabled");
             }
         }
@@ -689,7 +694,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         KNNEngine knnEngine
     ) {
 
-        if ((VectorDataType.FLOAT == vectorDataType) || (VectorDataType.BYTE == vectorDataType && KNNEngine.FAISS == knnEngine)) {
+        if ((VectorDataType.FLOAT == vectorDataType) || (VectorDataType.BYTE == vectorDataType && FAISS == knnEngine)) {
             return transformedVector;
         }
         return null;

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -37,6 +37,7 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 import org.opensearch.knn.index.mapper.Mode;
@@ -522,6 +523,62 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         });
         Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
         assertEquals("Radial search is not supported for indices which have quantization enabled", e.getMessage());
+    }
+
+    public void testDoToQuery_whenRadialSearchOnFaissSQ32x_thenException() {
+        float[] queryVector = { 1.0f };
+        Index dummyIndex = new Index("dummy", "dummy");
+        MethodComponentContext methodComponentContext = new MethodComponentContext(
+            org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
+            ImmutableMap.of()
+        );
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, methodComponentContext);
+        KNNMappingConfig faissSQ32xMappingConfig = new KNNMappingConfig() {
+            @Override
+            public Optional<KNNMethodContext> getKnnMethodContext() {
+                return Optional.of(knnMethodContext);
+            }
+
+            @Override
+            public int getDimension() {
+                return 1;
+            }
+
+            @Override
+            public CompressionLevel getCompressionLevel() {
+                return CompressionLevel.x32;
+            }
+        };
+
+        // Test with maxDistance
+        KNNQueryBuilder knnQueryBuilderWithDistance = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .maxDistance(MAX_DISTANCE)
+            .build();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(faissSQ32xMappingConfig);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext));
+        assertEquals("Radial search is not supported for indices which have quantization enabled", e.getMessage());
+
+        // Test with minScore
+        KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .minScore(MIN_SCORE)
+            .build();
+        QueryShardContext mockQueryShardContext2 = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField2 = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext2.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField2.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockQueryShardContext2.fieldMapper(anyString())).thenReturn(mockKNNVectorField2);
+        when(mockKNNVectorField2.getKnnMappingConfig()).thenReturn(faissSQ32xMappingConfig);
+        Exception e2 = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2));
+        assertEquals("Radial search is not supported for indices which have quantization enabled", e2.getMessage());
     }
 
     public void testDoToQuery_KnnQueryWithFilter_Lucene() {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissSQRadialSearchBlockedIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissSQRadialSearchBlockedIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import lombok.SneakyThrows;
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.SpaceType;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+/**
+ * Integration test to verify that radial search (max_distance / min_score) is blocked
+ * for Faiss SQ (scalar quantized, 32x compression) indices.
+ */
+public class FaissSQRadialSearchBlockedIT extends KNNRestTestCase {
+
+    private static final String INDEX_NAME = "faiss_sq_radial_test";
+    private static final String FIELD_NAME = "vec_field";
+    private static final int DIMENSION = 128;
+    private static final int NUM_DOCS = 100;
+
+    @SneakyThrows
+    public void testRadialSearch_withMaxDistance_onFaissSQ32x_thenBlocked() {
+        // Create Faiss SQ index
+        createFaissSQIndex();
+
+        // Index vectors + refresh
+        indexDocuments();
+        refreshIndex(INDEX_NAME);
+
+        // Radial search with max_distance should fail
+        final float[] queryVector = generateRandomVector();
+        final String query = buildRadialSearchQuery(FIELD_NAME, queryVector, "max_distance", 100.0f);
+        final Request request = new Request("POST", "/" + INDEX_NAME + "/_search");
+        request.setJsonEntity(query);
+
+        // Exception should be thrown, radial search is blocked on Faiss SQ
+        final ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getMessage().contains("Radial search is not supported for indices which have quantization enabled"));
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    @SneakyThrows
+    public void testRadialSearch_withMinScore_onFaissSQ32x_thenBlocked() {
+        // Create Faiss SQ index
+        createFaissSQIndex();
+
+        // Index vectors + refresh
+        indexDocuments();
+        refreshIndex(INDEX_NAME);
+
+        // Radial search with min_score should fail
+        float[] queryVector = generateRandomVector();
+        final String query = buildRadialSearchQuery(FIELD_NAME, queryVector, "min_score", 0.01f);
+        final Request request = new Request("POST", "/" + INDEX_NAME + "/_search");
+        request.setJsonEntity(query);
+
+        // Exception should be thrown, radial search is blocked on Faiss SQ
+        final ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getMessage().contains("Radial search is not supported for indices which have quantization enabled"));
+
+        // Delete index
+        deleteKNNIndex(INDEX_NAME);
+    }
+
+    private void createFaissSQIndex() throws Exception {
+        // Faiss SQ is default for 32x
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("data_type", "float")
+            .field("mode", "on_disk")
+            .field("compression_level", "32x")
+            .field("space_type", SpaceType.L2.getValue())
+            .startObject("method")
+            .field("engine", "faiss")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        // Index setting
+        Settings settings = Settings.builder().put("number_of_shards", 1).put("number_of_replicas", 0).put(KNN_INDEX, true).build();
+
+        // Create index
+        createKnnIndex(INDEX_NAME, settings, mapping);
+    }
+
+    private void indexDocuments() throws Exception {
+        for (int i = 0; i < NUM_DOCS; i++) {
+            final float[] vector = new float[DIMENSION];
+            for (int j = 0; j < DIMENSION; j++) {
+                vector[j] = ThreadLocalRandom.current().nextFloat() * 4 - 2;
+            }
+            addKnnDoc(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector);
+        }
+    }
+
+    private float[] generateRandomVector() {
+        final float[] vector = new float[DIMENSION];
+        for (int i = 0; i < DIMENSION; i++) {
+            vector[i] = ThreadLocalRandom.current().nextFloat() * 4 - 2;
+        }
+        return vector;
+    }
+
+    private String buildRadialSearchQuery(
+        final String fieldName,
+        final float[] vector,
+        final String thresholdType,
+        final float thresholdValue
+    ) throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+        builder.startObject("query");
+        builder.startObject("knn");
+        builder.startObject(fieldName);
+        builder.field("vector", vector);
+        builder.field(thresholdType, thresholdValue);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
### Description
Radial search should not allowed on Faiss SQ.
This PR is explicitly blocking radial search on Faiss SQ.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
