### PR TITLE
[BugFix] Block radial search on Lucene 32x compression for flat and SQ

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -489,9 +489,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             }
 
             if ((knnMappingConfig.getQuantizationConfig() != QuantizationConfig.EMPTY)
-                // If engine is Faiss and compression level is 32x, then it's using Faiss SQ which has null QuantizationConfig.
-                // In that case, we should block radial search as well.
-                || (knnEngine == FAISS && knnMappingConfig.getCompressionLevel() == CompressionLevel.x32)) {
+                // If compression level is 32x, then radial search should be blocked.
+                || (knnMappingConfig.getCompressionLevel() == CompressionLevel.x32)) {
                 throw new UnsupportedOperationException("Radial search is not supported for indices which have quantization enabled");
             }
         }

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -716,6 +716,54 @@ public class LuceneEngineIT extends KNNRestTestCase {
         validateQueryResultsWithFilters(searchVector, 5, 1, expectedDocIdsKGreaterThanFilterResult, expectedDocIdsKLimitsFilterResult);
     }
 
+    @SneakyThrows
+    public void testRadialSearch_withMaxDistance_onLuceneSQ1bit_thenBlocked() {
+        createKnnIndexMappingWithLuceneEngineWithModeAndCompression(CompressionLevel.x32, DIMENSION, Mode.NOT_CONFIGURED);
+        addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, new Float[] { 1.0f, 1.0f, 1.0f });
+        refreshIndex(INDEX_NAME);
+
+        XContentBuilder query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", new float[] { 1.0f, 1.0f, 1.0f })
+            .field(MAX_DISTANCE, 100.0f)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        org.opensearch.client.Request request = new org.opensearch.client.Request("POST", "/" + INDEX_NAME + "/_search");
+        request.setJsonEntity(query.toString());
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getMessage().contains("Radial search is not supported for indices which have quantization enabled"));
+    }
+
+    @SneakyThrows
+    public void testRadialSearch_withMinScore_onLuceneSQ1bit_thenBlocked() {
+        createKnnIndexMappingWithLuceneEngineWithModeAndCompression(CompressionLevel.x32, DIMENSION, Mode.NOT_CONFIGURED);
+        addKnnDoc(INDEX_NAME, DOC_ID, FIELD_NAME, new Float[] { 1.0f, 1.0f, 1.0f });
+        refreshIndex(INDEX_NAME);
+
+        XContentBuilder query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", new float[] { 1.0f, 1.0f, 1.0f })
+            .field(MIN_SCORE, 0.01f)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        org.opensearch.client.Request request = new org.opensearch.client.Request("POST", "/" + INDEX_NAME + "/_search");
+        request.setJsonEntity(query.toString());
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getMessage().contains("Radial search is not supported for indices which have quantization enabled"));
+    }
+
     private void createKnnIndexMappingWithLuceneEngineAndSQEncoder(
         int dimension,
         SpaceType spaceType,

--- a/src/test/java/org/opensearch/knn/index/LuceneSQFlatIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneSQFlatIT.java
@@ -468,78 +468,49 @@ public class LuceneSQFlatIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testRadialSearch_withMinScore() {
+    public void testRadialSearch_withMaxDistance_onLuceneFlat_thenBlocked() {
         createFlatIndex(SpaceType.L2);
         indexTestDocs();
 
-        // L2 scores from all-1s query: doc0(all 1s)=1.0, doc1(all 2s)=1/(1+128), doc2..doc4 even lower
-        // Only doc0 should have score >= 0.9
-        float minScore = 0.9f;
-        int[] expectedResultCounts = { 1, 1, 1 };
-        float[][] queryVectors = { generateVector(DIMENSION, 1.0f), generateVector(DIMENSION, 1.0f), generateVector(DIMENSION, 1.0f) };
+        XContentBuilder query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", generateVector(DIMENSION, 1.0f))
+            .field(MAX_DISTANCE, 100.0f)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Request request = new Request("POST", "/" + INDEX_NAME + "/_search");
+        request.setJsonEntity(query.toString());
 
-        validateRadiusSearchResults(queryVectors, null, minScore, expectedResultCounts);
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getMessage().contains("Radial search is not supported for indices which have quantization enabled"));
     }
 
     @SneakyThrows
-    public void testRadialSearch_withMaxDistance() {
+    public void testRadialSearch_withMinScore_onLuceneFlat_thenBlocked() {
         createFlatIndex(SpaceType.L2);
         indexTestDocs();
 
-        // L2 squared distances from all-1s query: doc0=0, doc1=128*(2-1)^2=128, doc2=128*(3-1)^2=512, ...
-        // Only doc0 and doc1 should be within maxDistance=200
-        float maxDistance = 200.0f;
-        int[] expectedResultCounts = { 2, 2, 2 };
-        float[][] queryVectors = { generateVector(DIMENSION, 1.0f), generateVector(DIMENSION, 1.0f), generateVector(DIMENSION, 1.0f) };
+        XContentBuilder query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", generateVector(DIMENSION, 1.0f))
+            .field(MIN_SCORE, 0.01f)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Request request = new Request("POST", "/" + INDEX_NAME + "/_search");
+        request.setJsonEntity(query.toString());
 
-        validateRadiusSearchResults(queryVectors, maxDistance, null, expectedResultCounts);
-    }
-
-    private void validateRadiusSearchResults(
-        final float[][] queryVectors,
-        final Float maxDistance,
-        final Float minScore,
-        final int[] expectedResultCounts
-    ) throws Exception {
-        for (int i = 0; i < queryVectors.length; i++) {
-            XContentBuilder builder = XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("query")
-                .startObject("knn")
-                .startObject(FIELD_NAME)
-                .field("vector", queryVectors[i]);
-            if (maxDistance != null) {
-                builder.field(MAX_DISTANCE, maxDistance);
-            } else if (minScore != null) {
-                builder.field(MIN_SCORE, minScore);
-            } else {
-                throw new IllegalArgumentException("Either maxDistance or minScore must be provided");
-            }
-            builder.endObject().endObject().endObject().endObject();
-
-            String responseBody = EntityUtils.toString(searchKNNIndex(INDEX_NAME, builder, expectedResultCounts[i]).getEntity());
-            List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
-            assertEquals(expectedResultCounts[i], results.size());
-
-            List<Float> scores = parseSearchResponseScore(responseBody, FIELD_NAME);
-            for (int j = 0; j < results.size(); j++) {
-                if (minScore != null) {
-                    assertTrue(
-                        String.format(Locale.ROOT, "Score %.4f should be >= minScore %.4f", scores.get(j), minScore),
-                        scores.get(j) >= minScore - 0.001f
-                    );
-                }
-                if (maxDistance != null) {
-                    float score = scores.get(j);
-                    // L2 score = 1 / (1 + distance), so distance = (1/score) - 1
-                    float distance = (1.0f / score) - 1.0f;
-                    assertTrue(
-                        String.format(Locale.ROOT, "Distance %.4f should be <= maxDistance %.4f", distance, maxDistance),
-                        distance <= maxDistance + 0.001f
-                    );
-                }
-            }
-        }
+        ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
+        assertTrue(ex.getMessage().contains("Radial search is not supported for indices which have quantization enabled"));
     }
 
     private void indexTestDocs() throws Exception {

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -581,6 +581,118 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals("Radial search is not supported for indices which have quantization enabled", e2.getMessage());
     }
 
+    public void testDoToQuery_whenRadialSearchOnLuceneSQ32x_thenException() {
+        float[] queryVector = { 1.0f };
+        Index dummyIndex = new Index("dummy", "dummy");
+        MethodComponentContext methodComponentContext = new MethodComponentContext(
+            org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
+            ImmutableMap.of()
+        );
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
+        KNNMappingConfig luceneSQ32xMappingConfig = new KNNMappingConfig() {
+            @Override
+            public Optional<KNNMethodContext> getKnnMethodContext() {
+                return Optional.of(knnMethodContext);
+            }
+
+            @Override
+            public int getDimension() {
+                return 1;
+            }
+
+            @Override
+            public CompressionLevel getCompressionLevel() {
+                return CompressionLevel.x32;
+            }
+        };
+
+        // Test with maxDistance
+        KNNQueryBuilder knnQueryBuilderWithDistance = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .maxDistance(MAX_DISTANCE)
+            .build();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(luceneSQ32xMappingConfig);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext));
+        assertEquals("Radial search is not supported for indices which have quantization enabled", e.getMessage());
+
+        // Test with minScore
+        KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .minScore(MIN_SCORE)
+            .build();
+        QueryShardContext mockQueryShardContext2 = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField2 = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext2.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField2.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockQueryShardContext2.fieldMapper(anyString())).thenReturn(mockKNNVectorField2);
+        when(mockKNNVectorField2.getKnnMappingConfig()).thenReturn(luceneSQ32xMappingConfig);
+        Exception e2 = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2));
+        assertEquals("Radial search is not supported for indices which have quantization enabled", e2.getMessage());
+    }
+
+    public void testDoToQuery_whenRadialSearchOnLuceneFlat32x_thenException() {
+        float[] queryVector = { 1.0f };
+        Index dummyIndex = new Index("dummy", "dummy");
+        MethodComponentContext methodComponentContext = new MethodComponentContext(
+            org.opensearch.knn.common.KNNConstants.METHOD_FLAT,
+            ImmutableMap.of()
+        );
+        KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
+        KNNMappingConfig luceneFlat32xMappingConfig = new KNNMappingConfig() {
+            @Override
+            public Optional<KNNMethodContext> getKnnMethodContext() {
+                return Optional.of(knnMethodContext);
+            }
+
+            @Override
+            public int getDimension() {
+                return 1;
+            }
+
+            @Override
+            public CompressionLevel getCompressionLevel() {
+                return CompressionLevel.x32;
+            }
+        };
+
+        // Test with maxDistance
+        KNNQueryBuilder knnQueryBuilderWithDistance = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .maxDistance(MAX_DISTANCE)
+            .build();
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
+        when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(luceneFlat32xMappingConfig);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext));
+        assertEquals("Radial search is not supported for indices which have quantization enabled", e.getMessage());
+
+        // Test with minScore
+        KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .minScore(MIN_SCORE)
+            .build();
+        QueryShardContext mockQueryShardContext2 = mock(QueryShardContext.class);
+        KNNVectorFieldType mockKNNVectorField2 = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext2.index()).thenReturn(dummyIndex);
+        when(mockKNNVectorField2.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+        when(mockQueryShardContext2.fieldMapper(anyString())).thenReturn(mockKNNVectorField2);
+        when(mockKNNVectorField2.getKnnMappingConfig()).thenReturn(luceneFlat32xMappingConfig);
+        Exception e2 = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2));
+        assertEquals("Radial search is not supported for indices which have quantization enabled", e2.getMessage());
+    }
+
     public void testDoToQuery_KnnQueryWithFilter_Lucene() {
         // Create q builder witha vector
         KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()


### PR DESCRIPTION
### Description
Blocks radial search when lucene engine is used with 32x compression.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
