### PR TITLE
Added support for 1 bit SQ with remote build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Add debug mode to MMR rerank that injects per-hit scoring details (original_score, max_similarity_to_selected, mmr_score, mmr_formula) into _source via the `debug` flag in the mmr search extension [#3254](https://github.com/opensearch-project/k-NN/pull/3254)
 * Support derived source for knn with other fields [#3260](https://github.com/opensearch-project/k-NN/pull/3260)
+* Added support for 1 bit SQ with remote build [#3270](https://github.com/opensearch-project/k-NN/pull/3270)
 
 ### Maintenance
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -372,7 +372,7 @@ There are two ways to run integration tests using the remote index builder featu
 First create an S3 bucket `<bucket_name>` in an AWS account. Then run below to setup remote index builder
 ```
 // 1. Pull GPU remote index builder docker image
-docker pull opensearchstaging/remote-vector-index-builder:api-latest
+docker pull opensearchstaging/remote-vector-index-builder:api-snapshot
 
 // 2. Set environment variables
 export AWS_ACCESS_KEY_ID=
@@ -380,7 +380,7 @@ export AWS_SECRET_ACCESS_KEY=
 export AWS_SESSION_TOKEN=
 
 // 3. Run docker image
-docker run --gpus all -p 80:1025 -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} opensearchstaging/remote-vector-index-builder:api-latest
+docker run --gpus all -p 80:1025 -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} -e AWS_DEFAULT_REGION=us-east-1  opensearchstaging/remote-vector-index-builder:api-snapshot
 
 // 4. Health ping to check service is running
 curl -XGET "http://0.0.0.0:80/_status/<job_id>"
@@ -400,10 +400,10 @@ export AWS_SESSION_TOKEN=
 First create an S3 bucket `<bucket_name>` in LocalStack. LocalStack simulates AWS locally, so the S3 bucket exists on the local machine.
 ```
 1. Pull LocalStack Docker Image
-docker pull localstack/localstack:latest
+docker pull localstack/localstack:4.14
 
 2. Run LocalStack
-docker run --rm -d -p 4566:4566 localstack/localstack:latest
+docker run --rm -d -p 4566:4566 localstack/localstack:4.14
 
 3. Create S3 Bucket in LocalStack
 aws --endpoint-url=http://localhost:4566 s3 mb s3://<bucket_name>
@@ -411,7 +411,7 @@ aws --endpoint-url=http://localhost:4566 s3 mb s3://<bucket_name>
 Then run below to setup remote index builder
 ```
 // 1. Pull GPU remote index builder docker image
-docker pull opensearchstaging/remote-vector-index-builder:api-latest
+docker pull opensearchstaging/remote-vector-index-builder:api-snapshot
 
 // 2. Set environment variables. The AWS credentials are dummy values, but need to be set for LocalStack to work
 export AWS_ACCESS_KEY_ID=test
@@ -419,7 +419,7 @@ export AWS_SECRET_ACCESS_KEY=test
 export AWS_SESSION_TOKEN=test
 
 // 3. Run docker image
-docker run --gpus all -p 80:1025 -e S3_ENDPOINT_URL=http://172.17.0.1:4566 -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} opensearchstaging/remote-vector-index-builder:api-latest
+docker run --gpus all -p 80:1025 -e S3_ENDPOINT_URL=http://172.17.0.1:4566 -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} -e AWS_DEFAULT_REGION=us-east-1 opensearchstaging/remote-vector-index-builder:api-snapshot
 
 // 4. Health ping to check service is running
 curl -XGET "http://0.0.0.0:80/_status/<job_id>"
@@ -459,6 +459,7 @@ with `@ExpectRemoteBuildValidation`, for the `@After` method `verifyRemoteIndexB
 - NestedSearchIT
 - ConcurrentSegmentSearchIT
 - MOSFaissFloatIndexIT
+- MOSFaissSQIndexIT
 - RestTrainModelHandlerIT
 - RecallTestsIT
 

--- a/remote-index-build-client/src/main/java/org/opensearch/remoteindexbuild/constants/KNNRemoteConstants.java
+++ b/remote-index-build-client/src/main/java/org/opensearch/remoteindexbuild/constants/KNNRemoteConstants.java
@@ -50,4 +50,5 @@ public class KNNRemoteConstants {
     public static final String DIMENSION = "dimension";
     public static final String VECTOR_DATA_TYPE_FIELD = "data_type";
     public static final String KNN_ENGINE = "engine";
+    public static final String SKIP_STORED_VECTORS = "skip_stored_vectors";
 }

--- a/remote-index-build-client/src/main/java/org/opensearch/remoteindexbuild/model/RemoteBuildRequest.java
+++ b/remote-index-build-client/src/main/java/org/opensearch/remoteindexbuild/model/RemoteBuildRequest.java
@@ -16,6 +16,7 @@ import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.CONTA
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DIMENSION;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DOC_COUNT;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DOC_ID_PATH;
+import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.SKIP_STORED_VECTORS;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.INDEX_PARAMETERS;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.KNN_ENGINE;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.REPOSITORY_TYPE;
@@ -40,6 +41,7 @@ public class RemoteBuildRequest implements ToXContentObject {
     protected String vectorDataType;
     protected String engine;
     protected RemoteIndexParameters indexParameters;
+    protected boolean skipStoredVectors;
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -54,6 +56,7 @@ public class RemoteBuildRequest implements ToXContentObject {
         builder.field(VECTOR_DATA_TYPE_FIELD, vectorDataType);
         builder.field(KNN_ENGINE, engine);
         builder.field(INDEX_PARAMETERS, indexParameters);
+        builder.field(SKIP_STORED_VECTORS, skipStoredVectors);
         builder.endObject();
         return builder;
     }

--- a/remote-index-build-client/src/test/java/org/opensearch/remoteindexbuild/model/RemoteBuildRequestTests.java
+++ b/remote-index-build-client/src/test/java/org/opensearch/remoteindexbuild/model/RemoteBuildRequestTests.java
@@ -30,6 +30,7 @@ import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DIMEN
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DOC_COUNT;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DOC_ID_FILE_EXTENSION;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.DOC_ID_PATH;
+import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.SKIP_STORED_VECTORS;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.INDEX_PARAMETERS;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.KNN_ENGINE;
 import static org.opensearch.remoteindexbuild.constants.KNNRemoteConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
@@ -94,6 +95,44 @@ public class RemoteBuildRequestTests extends OpenSearchSingleNodeTestCase {
         assertEquals(expectedMap, generatedMap);
     }
 
+    public void testToXContentWithSkipStoredVectors() throws IOException {
+        RemoteBuildRequest request = RemoteBuildRequest.builder()
+            .repositoryType(S3)
+            .containerName(TEST_BUCKET)
+            .vectorPath(MOCK_FULL_PATH + VECTOR_BLOB_FILE_EXTENSION)
+            .docIdPath(MOCK_FULL_PATH + DOC_ID_FILE_EXTENSION)
+            .tenantId(TEST_CLUSTER)
+            .dimension(2)
+            .docCount(2)
+            .vectorDataType(FLOAT)
+            .engine(FAISS)
+            .indexParameters(
+                RemoteFaissHNSWIndexParameters.builder()
+                    .algorithm(HNSW_ALGORITHM)
+                    .spaceType(L2_SPACE_TYPE)
+                    .efConstruction(94)
+                    .efSearch(89)
+                    .m(14)
+                    .build()
+            )
+            .skipStoredVectors(true)
+            .build();
+
+        String jsonRequest;
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            request.toXContent(builder, ToXContentObject.EMPTY_PARAMS);
+            jsonRequest = builder.toString();
+        }
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            jsonRequest
+        );
+        Map<String, Object> map = parser.map();
+        assertEquals(true, map.get(SKIP_STORED_VECTORS));
+    }
+
     /**
      * Get a mock JSON build request
      * <p>
@@ -116,7 +155,8 @@ public class RemoteBuildRequestTests extends OpenSearchSingleNodeTestCase {
      *       "ef_construction": 94,
      *       "ef_search": 89
      *     }
-     *   }
+     *   },
+     *   "skip_stored_vectors": false
      * }}</pre>
      */
     public String getMockExpectedJson() {
@@ -190,7 +230,11 @@ public class RemoteBuildRequestTests extends OpenSearchSingleNodeTestCase {
             + METHOD_PARAMETER_M
             + "\":14"
             + "}"
-            + "}"
+            + "},"
+            + "\""
+            + SKIP_STORED_VECTORS
+            + "\":"
+            + false
             + "}";
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -13,6 +13,7 @@ import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
@@ -42,13 +43,25 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
         ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE
     );
 
+    private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
+        this(new NativeIndexBuildStrategyFactory());
+    }
+
+    public Faiss1040ScalarQuantizedKnnVectorsFormat(final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory) {
         super(FORMAT_NAME);
+        this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
     }
 
     @Override
     public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
-        return new Faiss1040ScalarQuantizedKnnVectorsWriter(state, faissSqFlatFormat.fieldsWriter(state), faissSqFlatFormat::fieldsReader);
+        return new Faiss1040ScalarQuantizedKnnVectorsWriter(
+            state,
+            faissSqFlatFormat.fieldsWriter(state),
+            faissSqFlatFormat::fieldsReader,
+            nativeIndexBuildStrategyFactory
+        );
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -51,15 +51,18 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
     private FieldInfo fieldInfo;
     private boolean finished;
     private final IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier;
+    private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
 
     Faiss1040ScalarQuantizedKnnVectorsWriter(
         @NonNull SegmentWriteState segmentWriteState,
         @NonNull FlatVectorsWriter flatVectorsWriter,
-        @NonNull IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier
+        @NonNull IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier,
+        @NonNull NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
         this.segmentWriteState = segmentWriteState;
         this.flatVectorsWriter = flatVectorsWriter;
         this.quantizedFlatVectorsReaderSupplier = quantizedFlatVectorsReaderSupplier;
+        this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
     }
 
     /**
@@ -117,7 +120,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
                 null,
                 null,
                 segmentWriteState,
-                new NativeIndexBuildStrategyFactory(),
+                nativeIndexBuildStrategyFactory,
                 quantizedValues
             );
         } finally {
@@ -145,7 +148,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
                 flatVectorsReader.getFloatVectorValues(fieldInfo.getName())
             );
-            doMergeOneField(fieldInfo, mergeState, null, null, segmentWriteState, new NativeIndexBuildStrategyFactory(), quantizedValues);
+            doMergeOneField(fieldInfo, mergeState, null, null, segmentWriteState, nativeIndexBuildStrategyFactory, quantizedValues);
         } finally {
             IOUtils.close(flatVectorsReader);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -328,12 +328,26 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
 
     private static String determineVectorDataType(final VectorDataType dataType, final Map<String, Object> parameters) {
         if (dataType == VectorDataType.FLOAT) {
+            // SQ 1-bit sends fp32 vectors. Once support is added for building 1 bit SQ graphs
+            // in the Remote Vector Index Builder, then this can be modified to send 1 bit SQ vectors.
+            if (FaissHNSWMethod.isSQOneBitIndex(dataType, parameters)) {
+                return dataType.getValue();
+            }
             if (FaissHNSWMethod.isFloat16Index(dataType, parameters)) {
                 return FLOAT16_VECTOR_TYPE_STRING;
             }
         }
 
         return dataType.getValue();
+    }
+
+    /**
+     * Determines whether the Remote Vector Index Builder (RVIB) should skip writing flat vector storage (IO_FLAG_SKIP_STORAGE).
+     * When true, the RVIB writes only the HNSW graph, and the data node stitches it with locally-stored
+     * flat vectors at search time via {@link org.opensearch.knn.memoryoptsearch.faiss.FaissFlatIndexFactory}.
+     */
+    private static boolean shouldSkipStoredVectors(final VectorDataType vectorDataType, final Map<String, Object> parameters) {
+        return FaissHNSWMethod.isSQOneBitIndex(vectorDataType, parameters);
     }
 
     /**
@@ -379,6 +393,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             .vectorDataType(vectorDataType)
             .engine(indexInfo.getKnnEngine().getName())
             .indexParameters(indexInfo.getKnnEngine().createRemoteIndexingParameters(parameters))
+            .skipStoredVectors(shouldSkipStoredVectors(indexInfo.getVectorDataType(), parameters))
             .build();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -52,7 +52,7 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
         int defaultBeamWidth
     ) {
         if (isSQOneBitEncoder(params)) {
-            return new Faiss1040ScalarQuantizedKnnVectorsFormat();
+            return new Faiss1040ScalarQuantizedKnnVectorsFormat(nativeIndexBuildStrategyFactory);
         }
         return resolve();
     }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
@@ -41,6 +41,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 /**
@@ -199,6 +200,10 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
             final VectorDataType vectorDataType = extractVectorDataType(parameters);
             final Map<String, Object> encoderMap = extractEncoderMap(parameters);
 
+            if (isSQOneBitIndex(vectorDataType, parameters)) {
+                return true;
+            }
+
             if (isFloat32Index(vectorDataType, encoderMap)) {
                 return true;
             }
@@ -258,7 +263,12 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
             // Check encoding is 'sq' meaning fp32 is being scalar quantized to fp16
             final Map<String, Object> encoderMap = extractEncoderMap(parameters);
             final String encoder = getStringFromMap(encoderMap, NAME);
-            return encoder.equals(ENCODER_SQ);
+            if (encoder.equals(ENCODER_SQ) == false) {
+                return false;
+            }
+            // bits is null for legacy pre-3.6.0 indexes which default to fp16
+            Object bits = encoderMap.get(SQ_BITS);
+            return bits == null || (bits instanceof Integer && (Integer) bits == FaissSQEncoder.Bits.SIXTEEN.getValue());
         } catch (final Exception e) {
             log.debug(e.getMessage());
             // Ignore
@@ -309,6 +319,36 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
             return encoder.equals(ENCODER_FLAT);
         } catch (final Exception e) {
             log.debug(e.getMessage());
+            // Ignore
+            return false;
+        }
+    }
+
+    /**
+     * Checks whether the given parameters represent an SQ 1-bit index (encoder: sq, bits: 1).
+     *
+     * TODO: Consolidate the logic in this function with {@link FaissSQEncoder#isSQOneBit} into one function,
+     * so that there is a single source of truth. Currently, this is not possible because
+     * {@link FaissSQEncoder#isSQOneBit} assumes the encoder object is a {@link MethodComponentContext}.
+     *
+     * @param vectorDataType The data type for the vector field
+     * @param parameters KNN library indexing parameters
+     * @return true if SQ 1 bit, false otherwise
+     */
+    public static boolean isSQOneBitIndex(final VectorDataType vectorDataType, final Map<String, Object> parameters) {
+        try {
+            if (vectorDataType != VectorDataType.FLOAT) {
+                return false;
+            }
+            final Map<String, Object> encoderMap = extractEncoderMap(parameters);
+            final String encoder = getStringFromMap(encoderMap, NAME);
+            if (encoder.equals(ENCODER_SQ) == false) {
+                return false;
+            }
+            Object bits = encoderMap.get(SQ_BITS);
+            return bits instanceof Integer && (Integer) bits == FaissSQEncoder.Bits.ONE.getValue();
+        } catch (final Exception e) {
+            log.error("Failed to check if method parameters contain an sq encoder with bits=1", e);
             // Ignore
             return false;
         }

--- a/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesIterator.java
+++ b/src/main/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesIterator.java
@@ -157,6 +157,8 @@ public interface KNNVectorValuesIterator {
      */
     class FieldWriterIteratorValues<T> extends AbstractVectorValuesIterator {
         private final Function<Integer, T> vectorGetter;
+        private int index = -1;
+        private int lastDocId = Integer.MIN_VALUE;
 
         FieldWriterIteratorValues(@NonNull final DocsWithFieldSet docsWithFieldSet, @NonNull final Map<Integer, T> vectors) {
             super(docsWithFieldSet.iterator());
@@ -171,8 +173,19 @@ public interface KNNVectorValuesIterator {
             // Dense case -> Easy. doc_id == vector_ordinal and doc_id will be given as 0, 1, ..., N - 1
             // Sparse case -> doc_id will be given in increasing order 1, 4, 7, 8, 10, ...
             // but its corresponding vector ordinal is 0, 1, 2, ...
-            final int[] index = { 0 };
-            this.vectorGetter = (docId) -> vectors.get(index[0]++);
+            // The getter is idempotent — multiple getVector() calls for the same doc return the same vector
+            this.vectorGetter = (docId) -> {
+                if (docId != this.lastDocId) {
+                    if (docId < this.lastDocId) {
+                        throw new IllegalStateException(
+                            "Doc IDs must be in increasing order, but got " + docId + " after " + this.lastDocId
+                        );
+                    }
+                    this.index++;
+                    this.lastDocId = docId;
+                }
+                return vectors.get(this.index);
+            };
         }
 
         /**

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/AbstractFaissHNSWIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/AbstractFaissHNSWIndex.java
@@ -6,11 +6,13 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import lombok.Getter;
+import lombok.Setter;
 
 public abstract class AbstractFaissHNSWIndex extends FaissIndex implements FaissHNSWProvider {
     @Getter
     protected FaissHNSW faissHnsw;
     @Getter
+    @Setter
     protected FaissIndex flatVectors;
 
     public AbstractFaissHNSWIndex(final String indexType, final FaissHNSW faissHnsw) {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -13,21 +13,26 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
 
 import java.util.Arrays;
 
 /**
- * Factory that creates the appropriate {@link FaissBinaryIndex} flat storage implementation
- * based on the field's configuration, and wires it into the index tree when needed.
+ * Factory that creates the appropriate flat storage implementation based on the field's configuration,
+ * and wires it into the index tree when needed.
  */
 @UtilityClass
 public class FaissFlatIndexFactory {
 
     /**
-     * Returns a {@link FaissBinaryIndex} to use as flat storage for the given field, or {@code null}
-     * if the FAISS file's own flat storage should be used.
+     * Creates a {@link FaissIndex} flat storage backed by Lucene's {@link FlatVectorsReader} for
+     * indices where flat storage was skipped (IO_FLAG_SKIP_STORAGE). Returns {@code null} if the field
+     * does not require externally-provided flat storage.
+     *
+     * <p>Currently supports SQ 1-bit. To add support for other flat storage types (e.g., fp32 flat),
+     * add new conditions here.
      */
-    static FaissBinaryIndex createBinaryIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
+    static FaissIndex createFlatIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
         if (FieldInfoExtractor.isSQField(fieldInfo)
             && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
@@ -36,43 +41,75 @@ public class FaissFlatIndexFactory {
     }
 
     /**
+     * Convenience wrapper over {@link #createFlatIndex} for the binary HNSW graph, which requires
+     * {@link FaissBinaryIndex}. Returns {@code null} if the created flat index is not a
+     * {@link FaissBinaryIndex} or if no flat storage is needed.
+     */
+    static FaissBinaryIndex createBinaryIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
+        final FaissIndex flatIndex = createFlatIndex(fieldInfo, flatVectorsReader);
+        if (flatIndex instanceof FaissBinaryIndex binaryIndex) {
+            return binaryIndex;
+        }
+        return null;
+    }
+
+    /**
      * If the loaded FAISS index has no flat storage (e.g. SQ with 1-bit skips it via IO_FLAG_SKIP_STORAGE),
-     * wires in the appropriate flat index via {@link #createBinaryIndex}.
+     * wires in the appropriate flat index. Handles both binary HNSW (local JNI build) and float CAGRA HNSW
+     * (remote build) skip_stored_vectors indices.
      */
     static void maybeSetFlatBinaryIndex(final FaissIndex faissIndex, final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
         if (!(faissIndex instanceof FaissIdMapIndex idMapIndex)) {
             return;
         }
         final FaissIndex nested = idMapIndex.getNestedIndex();
-        if (!(nested instanceof FaissBinaryHnswIndex binaryHnswIndex) || binaryHnswIndex.getStorage() != null) {
+
+        // Binary HNSW path (local JNI build with IO_FLAG_SKIP_STORAGE)
+        if (nested instanceof FaissBinaryHnswIndex binaryHnswIndex && binaryHnswIndex.getStorage() == null) {
+            final FaissBinaryIndex flatBinaryIndex = createBinaryIndex(fieldInfo, flatVectorsReader);
+            if (flatBinaryIndex == null) {
+                throw new IllegalStateException(
+                    String.format(
+                        "%s found for field [%s] but %s returned null — cannot wire binary flat storage.",
+                        FaissEmptyIndex.class.getName(),
+                        fieldInfo.getName(),
+                        FaissFlatIndexFactory.class.getName()
+                    )
+                );
+            }
+            binaryHnswIndex.setStorage(flatBinaryIndex);
+
+            // Update the space type in FaissBinaryIndex.
+            // Faiss defaults to Hamming distance for binary indices, but with scalar quantization (ADC),
+            // we now support other space types (i.e. L2, inner product).
+            final int metricType = idMapIndex.getMetricType();
+            try {
+                final SpaceType spaceType = FaissMetricType.values()[metricType].spaceType;
+                idMapIndex.setSpaceType(spaceType);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                throw new IllegalArgumentException(
+                    "Unsupported metric type: " + metricType + ", only support " + Arrays.asList(FaissMetricType.values())
+                );
+            }
             return;
         }
 
-        final FaissBinaryIndex flatBinaryIndex = createBinaryIndex(fieldInfo, flatVectorsReader);
-        if (flatBinaryIndex == null) {
-            throw new IllegalStateException(
-                String.format(
-                    "%s found for field [%s] but %s returned null — cannot wire binary flat storage.",
-                    FaissEmptyIndex.class.getName(),
-                    fieldInfo.getName(),
-                    FaissFlatIndexFactory.class.getName()
-                )
-            );
-        }
-        binaryHnswIndex.setStorage(flatBinaryIndex);
-
-        // Update the space type in FaissBinaryIndex.
-        // Faiss defaults to Hamming distance for binary indices, but with scalar quantization (ADC),
-        // we now support other space types (i.e. L2, inner product).
-        // Update the space type accordingly.
-        final int metricType = idMapIndex.getMetricType();
-        try {
-            final SpaceType spaceType = FaissMetricType.values()[metricType].spaceType;
-            idMapIndex.setSpaceType(spaceType);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            throw new IllegalArgumentException(
-                "Unsupported metric type: " + metricType + ", only support " + Arrays.asList(FaissMetricType.values())
-            );
+        // Float CAGRA HNSW path (remote GPU build with skip_stored_vectors=true / IO_FLAG_SKIP_STORAGE)
+        if (nested instanceof FaissHNSWCagraIndex cagraIndex && FaissEmptyIndex.isEmptyIndex(cagraIndex.getFlatVectors())) {
+            final FaissIndex flatIndex = createFlatIndex(fieldInfo, flatVectorsReader);
+            if (flatIndex == null) {
+                throw new IllegalStateException(
+                    String.format(
+                        "%s found for field [%s] but %s returned null — cannot wire flat storage for CAGRA index.",
+                        FaissEmptyIndex.class.getName(),
+                        fieldInfo.getName(),
+                        FaissFlatIndexFactory.class.getName()
+                    )
+                );
+            }
+            cagraIndex.setFlatVectors(flatIndex);
+            // No space type override needed — float CAGRA reads the correct metric type
+            // from readCommonHeader() in doLoad().
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissHNSWCagraIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/cagra/FaissHNSWCagraIndex.java
@@ -75,7 +75,10 @@ public class FaissHNSWCagraIndex extends AbstractFaissHNSWIndex {
         faissHnsw.load(input, getTotalNumberOfVectors());
         ((FaissCagraHNSW) faissHnsw).setNumBaseLevelSearchEntryPoints(numBaseLevelSearchEntryPoint);
 
-        // Partial load flat vector storage
+        // Partial load flat vector storage.
+        // When IO_FLAG_SKIP_STORAGE was used (e.g., skip_stored_vectors remote build for SQ 1-bit),
+        // Faiss writes a "null" section and FaissIndex.load returns FaissEmptyIndex.
+        // FaissFlatIndexFactory will replace it with the real flat storage after loading.
         flatVectors = FaissIndex.load(input);
     }
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -83,7 +84,8 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
         objectUnderTest = new Faiss1040ScalarQuantizedKnnVectorsWriter(
             segmentWriteState,
             flatVectorsWriter,
-            quantizedFlatVectorsReaderSupplier
+            quantizedFlatVectorsReaderSupplier,
+            new NativeIndexBuildStrategyFactory()
         );
         mockedFlatFieldVectorsWriter = mock(FlatFieldVectorsWriter.class);
         Mockito.doNothing().when(mockedFlatFieldVectorsWriter).addValue(Mockito.anyInt(), Mockito.any());

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -41,6 +41,7 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX_REMOTE_VECTOR_BUILD_SETTING;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX_REMOTE_VECTOR_BUILD_SIZE_MIN_SETTING;
@@ -196,6 +197,31 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
         assertEquals(TEST_CLUSTER, request.getTenantId());
         assertEquals(3, request.getDocCount());
         assertEquals(2, request.getDimension());
+        assertFalse(request.isSkipStoredVectors());
+    }
+
+    public void testBuildRequestSQOneBit() throws IOException {
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockSQOneBitParameterMap()
+        );
+        assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
+        assertTrue(request.isSkipStoredVectors());
+    }
+
+    public void testBuildRequestFP16() throws IOException {
+        RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
+            createTestIndexSettings(),
+            buildIndexParams,
+            createTestRepositoryMetadata(),
+            MOCK_FULL_PATH,
+            getMockFP16ParameterMap()
+        );
+        assertEquals("half_float", request.getVectorDataType());
+        assertFalse(request.isSkipStoredVectors());
     }
 
     public Map<String, Object> getMockParameterMap() {
@@ -220,6 +246,58 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             METHOD_HNSW,
             VECTOR_DATA_TYPE_FIELD,
             VectorDataType.BYTE.getValue(),
+            PARAMETERS,
+            innerParams
+        );
+    }
+
+    public Map<String, Object> getMockSQOneBitParameterMap() {
+        Map<String, Object> encoderParams = Map.of(NAME, ENCODER_SQ, SQ_BITS, 1);
+        Map<String, Object> innerParams = Map.of(
+            METHOD_PARAMETER_EF_SEARCH,
+            24,
+            METHOD_PARAMETER_EF_CONSTRUCTION,
+            28,
+            METHOD_PARAMETER_M,
+            12,
+            METHOD_ENCODER_PARAMETER,
+            encoderParams
+        );
+        return Map.of(
+            INDEX_DESCRIPTION_PARAMETER,
+            "HNSW12,Flat",
+            SPACE_TYPE,
+            INNER_PRODUCT.getValue(),
+            NAME,
+            METHOD_HNSW,
+            VECTOR_DATA_TYPE_FIELD,
+            VectorDataType.FLOAT.getValue(),
+            PARAMETERS,
+            innerParams
+        );
+    }
+
+    public Map<String, Object> getMockFP16ParameterMap() {
+        Map<String, Object> encoderParams = Map.of(NAME, ENCODER_SQ);
+        Map<String, Object> innerParams = Map.of(
+            METHOD_PARAMETER_EF_SEARCH,
+            24,
+            METHOD_PARAMETER_EF_CONSTRUCTION,
+            28,
+            METHOD_PARAMETER_M,
+            12,
+            METHOD_ENCODER_PARAMETER,
+            encoderParams
+        );
+        return Map.of(
+            INDEX_DESCRIPTION_PARAMETER,
+            "HNSW12,SQfp16",
+            SPACE_TYPE,
+            INNER_PRODUCT.getValue(),
+            NAME,
+            METHOD_HNSW,
+            VECTOR_DATA_TYPE_FIELD,
+            VectorDataType.FLOAT.getValue(),
             PARAMETERS,
             innerParams
         );

--- a/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.COMPOUND_EXTENSION;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.FAISS_EXTENSION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -137,6 +138,9 @@ public class KNNEngineTests extends KNNTestCase {
 
         // Quantized case
         assertTrue(Faiss.supportsRemoteIndexBuild(createMockKnnLibraryIndexingContextParamsQuantized()));
+
+        // SQ 1-bit
+        assertTrue(Faiss.supportsRemoteIndexBuild(createMockKnnLibraryIndexingContextParamsSQOneBit()));
 
         // IVF all must fail
         assertFalse(Faiss.supportsRemoteIndexBuild(createMockKnnLibraryIndexingContextParamsByte(METHOD_IVF)));
@@ -340,6 +344,33 @@ public class KNNEngineTests extends KNNTestCase {
             .field(METHOD_PARAMETER_EF_CONSTRUCTION, 28)
             .startObject(METHOD_ENCODER_PARAMETER)
             .field(NAME, ENCODER_FLAT)
+            .endObject()
+            .endObject()
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+        return Faiss.INSTANCE.getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext);
+    }
+
+    @SneakyThrows
+    private KNNLibraryIndexingContext createMockKnnLibraryIndexingContextParamsSQOneBit() {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .field(METHOD_PARAMETER_SPACE_TYPE, L2.getValue())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_EF_SEARCH, 24)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, 28)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_SQ)
+            .startObject(PARAMETERS)
+            .field(SQ_BITS, 1)
+            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/vectorvalues/KNNVectorValuesTests.java
@@ -107,6 +107,74 @@ public class KNNVectorValuesTests extends KNNTestCase {
         return docsWithFieldSet;
     }
 
+    @SneakyThrows
+    public void testListBasedFloatVectorValues_whenGetVectorCalledTwice_thenReturnsSameVector() {
+        final List<float[]> vectors = List.of(new float[] { 1, 2 }, new float[] { 3, 4 }, new float[] { 5, 6 });
+        final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(vectors.size());
+
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+            VectorDataType.FLOAT,
+            docsWithFieldSet,
+            vectors
+        );
+
+        knnVectorValues.nextDoc();
+
+        float[] first = (float[]) knnVectorValues.getVector();
+        float[] second = (float[]) knnVectorValues.getVector();
+        assertArrayEquals(first, second, 0.0f);
+        assertArrayEquals(new float[] { 1, 2 }, first, 0.0f);
+
+        knnVectorValues.nextDoc();
+        float[] third = (float[]) knnVectorValues.getVector();
+        assertArrayEquals(new float[] { 3, 4 }, third, 0.0f);
+    }
+
+    @SneakyThrows
+    public void testListBasedFloatVectorValues_whenNormalIteration_thenReturnsCorrectVectors() {
+        final List<float[]> vectors = List.of(new float[] { 1, 2 }, new float[] { 3, 4 }, new float[] { 5, 6 });
+        final DocsWithFieldSet docsWithFieldSet = getDocIdSetIterator(vectors.size());
+
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+            VectorDataType.FLOAT,
+            docsWithFieldSet,
+            vectors
+        );
+
+        int i = 0;
+        while (knnVectorValues.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+            float[] vector = (float[]) knnVectorValues.getVector();
+            assertArrayEquals(vectors.get(i), vector, 0.0f);
+            i++;
+        }
+        assertEquals(vectors.size(), i);
+    }
+
+    @SneakyThrows
+    public void testListBasedFloatVectorValues_whenSparseDocIds_thenReturnsCorrectVectors() {
+        final List<float[]> vectors = List.of(new float[] { 1, 2 }, new float[] { 3, 4 }, new float[] { 5, 6 });
+        final DocsWithFieldSet docsWithFieldSet = new DocsWithFieldSet();
+        docsWithFieldSet.add(1);
+        docsWithFieldSet.add(4);
+        docsWithFieldSet.add(7);
+
+        final KNNVectorValues<float[]> knnVectorValues = KNNVectorValuesFactory.getVectorValues(
+            VectorDataType.FLOAT,
+            docsWithFieldSet,
+            vectors
+        );
+
+        knnVectorValues.nextDoc();
+        assertArrayEquals(new float[] { 1, 2 }, (float[]) knnVectorValues.getVector(), 0.0f);
+        assertArrayEquals(new float[] { 1, 2 }, (float[]) knnVectorValues.getVector(), 0.0f);
+
+        knnVectorValues.nextDoc();
+        assertArrayEquals(new float[] { 3, 4 }, (float[]) knnVectorValues.getVector(), 0.0f);
+
+        knnVectorValues.nextDoc();
+        assertArrayEquals(new float[] { 5, 6 }, (float[]) knnVectorValues.getVector(), 0.0f);
+    }
+
     private class CompareVectorValues<T> {
         void validateVectorValues(
             KNNVectorValues<T> vectorValues,

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -493,7 +493,11 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         // Test 4: Both includes and excludes - throws IllegalArgumentException because vector field cannot be in both includes and excludes
         ResponseException ex = expectThrows(
             ResponseException.class,
-            () -> sourceFiltering(indexName, new String[] { VECTOR_FIELD_1, VECTOR_FIELD_2, TEXT_FIELD }, new String[] { VECTOR_FIELD_2 })
+            () -> searchWithSourceIncludesExcludes(
+                indexName,
+                new String[] { VECTOR_FIELD_1, VECTOR_FIELD_2, TEXT_FIELD },
+                new String[] { VECTOR_FIELD_2 }
+            )
         );
         assertThat(
             ex.getMessage(),

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
@@ -18,6 +19,7 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     private static final String SQ_ENCODER_PARAMS = """
         {"encoder": {"name": "sq", "parameters": {"bits": 1}}}""";
 
+    @ExpectRemoteBuildValidation
     public void testNonNestedDiskBasedIndexWithIP() {
         // ANN search
         doTestNonNestedIndex(
@@ -45,6 +47,7 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
         // We don't support radial search for nested index
     }
 
+    @ExpectRemoteBuildValidation
     public void testNonNestedDiskBasedIndexWithL2() {
         // ANN search
         doTestNonNestedIndex(
@@ -72,6 +75,7 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
         // We don't support radial search for nested index
     }
 
+    @ExpectRemoteBuildValidation
     public void testNonNestedDiskBasedIndexWithCosine() {
         // ANN search
         doTestNonNestedIndex(

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
@@ -12,6 +12,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
+import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
 
 import java.lang.reflect.Field;
 
@@ -148,6 +149,66 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
             fail("Expected IllegalStateException");
         } catch (IllegalStateException e) {
             assertTrue(e.getMessage().contains(FaissEmptyIndex.class.getName()));
+        }
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenCagraWithEmptyFlatVectors_thenSetsFlatIndex() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissHNSWCagraIndex cagraIndex = new FaissHNSWCagraIndex(FaissHNSWCagraIndex.IHNC);
+        cagraIndex.setFlatVectors(FaissEmptyIndex.INSTANCE);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(cagraIndex);
+
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+        when(fieldInfo.getAttribute(SQ_CONFIG)).thenReturn("bits=1");
+
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertNotNull(cagraIndex.getFlatVectors());
+        assertFalse(FaissEmptyIndex.isEmptyIndex(cagraIndex.getFlatVectors()));
+        assertTrue(cagraIndex.getFlatVectors() instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenCagraWithExistingFlatVectors_thenNoOp() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissHNSWCagraIndex cagraIndex = new FaissHNSWCagraIndex(FaissHNSWCagraIndex.IHNC);
+        FaissIndex existingFlat = mock(FaissIndex.class);
+        cagraIndex.setFlatVectors(existingFlat);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(cagraIndex);
+
+        FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getName()).thenReturn("test_field");
+
+        FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+
+        assertSame(existingFlat, cagraIndex.getFlatVectors());
+    }
+
+    @SneakyThrows
+    public void testMaybeSetFlatIndex_whenCagraWithEmptyFlatVectorsAndNonSQField_thenThrows() {
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissHNSWCagraIndex cagraIndex = new FaissHNSWCagraIndex(FaissHNSWCagraIndex.IHNC);
+        cagraIndex.setFlatVectors(FaissEmptyIndex.INSTANCE);
+
+        FaissIdMapIndex idMapIndex = mock(FaissIdMapIndex.class);
+        when(idMapIndex.getNestedIndex()).thenReturn(cagraIndex);
+
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
+
+        try {
+            FaissFlatIndexFactory.maybeSetFlatBinaryIndex(idMapIndex, fieldInfo, mockReader);
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("CAGRA"));
         }
     }
 }

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -1190,7 +1190,7 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    protected Response sourceFiltering(String indexName, String[] includes, String[] excludes) {
+    protected Response searchWithSourceIncludesExcludes(String indexName, String[] includes, String[] excludes) {
         XContentBuilder searchBuilder = XContentFactory.jsonBuilder().startObject().startObject("_source");
 
         if (includes != null) {
@@ -1215,7 +1215,7 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
         String[] expectedPresent,
         String[] expectedAbsent
     ) {
-        Response response = sourceFiltering(indexName, includes, excludes);
+        Response response = searchWithSourceIncludesExcludes(indexName, includes, excludes);
 
         Map<String, Object> responseMap = entityAsMap(response);
         Map<String, Object> hits = (Map<String, Object>) responseMap.get("hits");


### PR DESCRIPTION
### Description
This enables support for 1 bit SQ with remote build. For this change, we transfer the FP32 vectors to the GPU worker, the GPU worker sends back the FP32 graph, and then the k-NN data node stitches together the FP32 graph with the 1 bit SQ vectors. The GPU worker now supports only transferring the FP32 graph back without the flat vectors with the new `skip_stored_vectors` parameter. See this PR for the GPU worker change: https://github.com/opensearch-project/remote-vector-index-builder/pull/127 


### Testing

- Unit tests
- Manual test:
    - Ran a single node OS cluster with `./gradlew run` and the `opensearchstaging/remote-vector-index-builder:api-snapshot` GPU worker docker image. 
    - Created a 32x compression index, with remote index build enabled. Indexed some documents and then ran search, validated search worked as expected: 
```
curl -XPUT "localhost:9200/_snapshot/my-repo" -H 'Content-Type: application/json' -d '{
  "type": "s3",
  "settings": {
    "bucket": "testbucket-rchital",
    "base_path": "test-data/more-data",
    "region": "us-west-2"
  }
}'
```

```
curl -XPUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{
  "persistent": {
    "knn.remote_index_build.enabled": true,
    "knn.remote_index_build.repository": "my-repo",
    "knn.remote_index_build.service.endpoint": "http://0.0.0.0:80"
  }
}'
```

```
curl -XPUT "localhost:9200/sq-test" -H 'Content-Type: application/json' -d '{
  "settings": {
    "index.knn": true,
    "index.knn.remote_index_build.enabled": true,
    "index.knn.remote_index_build.size.min": "0b",
    "number_of_shards": 1,
    "number_of_replicas": 0
  },
  "mappings": {
    "properties": {
      "vec": {
        "type": "knn_vector",
        "dimension": 8,
        "mode": "on_disk",
        "compression_level": "32x",
        "method": { "name": "hnsw", "engine": "faiss", "space_type": "l2" }
      }
    }
  }
}'
```

```
for i in $(seq 1 6); do
  curl -XPOST "localhost:9200/sq-test/_doc" -H 'Content-Type: application/json' \
    -d "{\"vec\": [$i.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]}"
done
```

```
curl -XPOST "localhost:9200/sq-test/_search" -H 'Content-Type: application/json' -d '{
  "query": { "knn": { "vec": { "vector": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], "k": 2 } } }
}'
```

- Integration tests: 
    - Added `ExpectRemoteBuildValidation` to MOSFaissSQIndexIT tests. 
- 1M OSB benchmark with faiss cohere
    - Setup is explained here: https://github.com/opensearch-project/k-NN/issues/3274#issuecomment-4238881163
    - Validated the recall was similar to 1 bit SQ non remote build. 

### Related Issues
Resolves #3274

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented - N/A
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md) - N/A
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
