### PR TITLE
Fix derived source IT to handle field in both include and exclude

### DIFF
--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.knn.DerivedSourceUtils.DERIVED_ENABLED_WITH_SEGREP_SETTINGS;
 import static org.opensearch.knn.DerivedSourceUtils.TEST_DIMENSION;
 import static org.opensearch.knn.DerivedSourceUtils.randomVectorSupplier;
@@ -489,13 +490,14 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             new String[] { VECTOR_FIELD_1 }
         );
 
-        // Test 4: Both includes and excludes - excludes override includes
-        assertSourceFiltering(
-            indexName,
-            new String[] { VECTOR_FIELD_1, VECTOR_FIELD_2, TEXT_FIELD },
-            new String[] { VECTOR_FIELD_2 },
-            new String[] { VECTOR_FIELD_1, TEXT_FIELD },
-            new String[] { VECTOR_FIELD_2, VECTOR_FIELD_3 }
+        // Test 4: Both includes and excludes - throws IllegalArgumentException because vector field cannot be in both includes and excludes
+        ResponseException ex = expectThrows(
+            ResponseException.class,
+            () -> sourceFiltering(indexName, new String[] { VECTOR_FIELD_1, VECTOR_FIELD_2, TEXT_FIELD }, new String[] { VECTOR_FIELD_2 })
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString("The same entry [" + VECTOR_FIELD_2 + "] cannot be both included and excluded in _source.")
         );
 
         // Test 5: Wildcard includes - only matching fields returned

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -1190,13 +1190,7 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    protected void assertSourceFiltering(
-        String indexName,
-        String[] includes,
-        String[] excludes,
-        String[] expectedPresent,
-        String[] expectedAbsent
-    ) {
+    protected Response sourceFiltering(String indexName, String[] includes, String[] excludes) {
         XContentBuilder searchBuilder = XContentFactory.jsonBuilder().startObject().startObject("_source");
 
         if (includes != null) {
@@ -1210,7 +1204,18 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
 
         Request searchRequest = new Request("POST", "/" + indexName + "/_search");
         searchRequest.setJsonEntity(searchBuilder.toString());
-        Response response = client().performRequest(searchRequest);
+        return client().performRequest(searchRequest);
+    }
+
+    @SneakyThrows
+    protected void assertSourceFiltering(
+        String indexName,
+        String[] includes,
+        String[] excludes,
+        String[] expectedPresent,
+        String[] expectedAbsent
+    ) {
+        Response response = sourceFiltering(indexName, includes, excludes);
 
         Map<String, Object> responseMap = entityAsMap(response);
         Map<String, Object> hits = (Map<String, Object>) responseMap.get("hits");


### PR DESCRIPTION
### Description
With the recent change in OpenSearch Core: https://github.com/opensearch-project/OpenSearch/pull/21203, when a field is in both `includes` and `excludes`, then an exception is thrown. `DerivedSourceIT` assumed that `excludes` would take precedence over `includes`, so it needed to be fixed to align with core. 

Tested locally with `./gradlew --refresh-dependencies integTest --tests "org.opensearch.knn.integ.DerivedSourceIT"`, verified it worked. 

### Related Issues
Resolves #3279 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented. N/A
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). N/A
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
