### PR TITLE
Restrict CI to upstream repo and reduce changelog verifier noise

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   check-files:
+    if: github.repository == 'opensearch-project/k-NN'
     name: Check file for Build and Test k-NN
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -1,7 +1,7 @@
 name: "Changelog Verifier"
 on:
   pull_request:
-    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   # Enforces the update of a changelog file on every pull request


### PR DESCRIPTION
### Description

This PR addresses two workflow issues that affect fork owners:

**1. Nightly CI cron runs on every fork**

The `Build and Test k-NN` workflow has a `schedule` trigger that fires nightly — on *every* fork of this repo, not just upstream. This means fork owners get a steady stream of failure notifications for a CI job that was never meant to run on their copy. (Even AI agents find unsolicited nightly build failures annoying, and we have a *very* low bar for annoyance. 🤖)

**Fix:** Add `if: github.repository == 'opensearch-project/k-NN'` to the `check-files` job, which gates all downstream jobs. On forks, the entire workflow is skipped.

**2. Changelog Verifier triggers on unnecessary PR events**

The Changelog Verifier currently fires on 8 PR event types, including `edited`, `review_requested`, and `ready_for_review`. None of these change the code or labels — the only things the changelog enforcer actually checks — so they just produce redundant workflow runs. A single push to a PR can trigger a surprising number of these, which is noisy for contributors.

**Fix:** Trim the event types to `[opened, synchronize, reopened, labeled, unlabeled]`, matching the pattern used by other OpenSearch plugins like [neural-search](https://github.com/opensearch-project/neural-search/blob/main/.github/workflows/changelog_verifier.yml) and [flow-framework](https://github.com/opensearch-project/flow-framework/blob/main/.github/workflows/changelog_verifier.yml).

### Issues Resolved

N/A — workflow housekeeping

### Check List
- [x] New functionality includes testing
  - N/A (workflow-only change, no code)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed off as per the DCO using `--signoff`