### PR TITLE
Add Gradle cache to setup-java steps in CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: gradle
 
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
@@ -127,6 +128,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: gradle
 
       - name: Install dependencies on macos
         run: |
@@ -170,6 +172,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: gradle
 
       - name: Install MinGW Using Chocolatey
         run: choco install mingw -y --no-progress

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -63,9 +63,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - if: startsWith(matrix.os,'ubuntu')
         name: Install dependencies on ubuntu
@@ -149,9 +151,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - if: startsWith(matrix.os,'ubuntu')
         name: Install dependencies on ubuntu

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
+          cache: gradle
       - uses: actions/checkout@v3
 
       - name: Load secret

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+          cache: gradle
 
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Added support for 1 bit SQ with remote build [#3270](https://github.com/opensearch-project/k-NN/pull/3270)
 
 ### Maintenance
+* Add Gradle cache to setup-java steps in GitHub Actions workflows [#3295](https://github.com/opensearch-project/k-NN/pull/3295)
 
 
 ### Bug Fixes


### PR DESCRIPTION
### Description

Adds `cache: gradle` to all `actions/setup-java` steps in CI and test workflows to cache Gradle dependencies between runs, reducing build times for PRs.

Also upgrades `setup-java` from v1 to v4 in `backwards_compatibility_tests_workflow.yml` — v1 is deprecated and does not support the `cache` parameter. The upgrade requires adding `distribution: temurin` (no other behavioral changes).

### Changes

- **CI.yml**: Added `cache: gradle` to all 3 `setup-java` steps (Linux, MacOS, Windows)
- **backwards_compatibility_tests_workflow.yml**: Upgraded 2 steps from `@v1` → `@v4`, added `distribution: temurin` and `cache: gradle`
- **maven-publish.yml**: Added `cache: gradle` (already on v3)
- **test_security.yml**: Added `cache: gradle` (already on v4)

**Intentionally excluded:** `remote_index_build.yml` — it explicitly uses `--refresh-dependencies --no-build-cache` for fully clean builds.

### Reference

- [actions/setup-java caching documentation](https://github.com/actions/setup-java#caching-packages-dependencies)

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
  - N/A (infrastructure-only change, CI runs will validate)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`