### PR TITLE
Overrides visits to honor filter query

### DIFF
--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.opensearch.common.ValidationException;
@@ -21,6 +22,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.mapper.MappedFieldType;
 import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.WithFieldName;
@@ -711,6 +713,25 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             return byteVector;
         }
         return null;
+    }
+
+    /**
+     * Visits this query builder and its filter clause using the provided visitor.
+     * <p>
+     * This method first accepts the visitor for the current {@link KNNQueryBuilder}, then if a filter
+     * is present, it obtains a child visitor for {@link BooleanClause.Occur#FILTER} and delegates
+     * the filter's visitation to it. This enables traversal of the full query tree including any
+     * nested filter queries.
+     *
+     * @param visitor the {@link QueryBuilderVisitor} used to traverse the query tree
+     */
+    @Override
+    public void visit(QueryBuilderVisitor visitor) {
+        visitor.accept(this);
+        if (filter != null) {
+            final QueryBuilderVisitor subVisitor = visitor.getChildVisitor(BooleanClause.Occur.FILTER);
+            filter.visit(subVisitor);
+        }
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1431,8 +1431,13 @@ public class OpenSearchIT extends KNNRestTestCase {
         float[] query = new float[dim];
         Arrays.fill(query, 2);
 
+        // Force merging to one segment since each doc gets added with refresh=true which can  create
+        // multiple segments. This fails the assertion since its expecting each metric to have 7 values intead
+        // of a total 7 values
+        forceMergeKnnIndex(INDEX_NAME);
+
         int k = 7;
-        // Create knn search, P <= k
+        // Filtered k-NN search without profiling
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .field("profile", false)

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1554,7 +1554,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         }
         results = parseProfileMetric(responseBody, KNNQueryTimingType.EXACT_SEARCH.toString(), false);
         for (Long result : results) {
-            assertNotEquals(0L, result.longValue());
+            assertEquals(0L, result.longValue());
         }
 
         deleteKNNIndex(INDEX_NAME);

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -1431,7 +1431,7 @@ public class OpenSearchIT extends KNNRestTestCase {
         float[] query = new float[dim];
         Arrays.fill(query, 2);
 
-        // Force merging to one segment since each doc gets added with refresh=true which can  create
+        // Force merging to one segment since each doc gets added with refresh=true which can create
         // multiple segments. This fails the assertion since its expecting each metric to have 7 values intead
         // of a total 7 values
         forceMergeKnnIndex(INDEX_NAME);

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -35,6 +35,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.CompressionLevel;
@@ -70,6 +71,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
 import static org.opensearch.knn.index.engine.KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH;
@@ -1541,6 +1544,34 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(knnQueryBuilder.getRescoreContext(), updatedKnnQueryBuilder.getRescoreContext());
         assertEquals(knnQueryBuilder.getExpandNested(), updatedKnnQueryBuilder.getExpandNested());
         assertEquals(TERM_QUERY, updatedKnnQueryBuilder.getFilter());
+    }
+
+    public void testVisit_whenNoFilter_thenVisitorAcceptsOnlyQueryBuilder() {
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).k(K).build();
+        QueryBuilderVisitor visitor = mock(QueryBuilderVisitor.class);
+
+        knnQueryBuilder.visit(visitor);
+
+        verify(visitor).accept(knnQueryBuilder);
+        verify(visitor, never()).getChildVisitor(any());
+    }
+
+    public void testVisit_whenFilterPresent_thenVisitorTraversesFilter() {
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(QUERY_VECTOR)
+            .k(K)
+            .filter(TERM_QUERY)
+            .build();
+        QueryBuilderVisitor visitor = mock(QueryBuilderVisitor.class);
+        QueryBuilderVisitor subVisitor = mock(QueryBuilderVisitor.class);
+        when(visitor.getChildVisitor(any())).thenReturn(subVisitor);
+
+        knnQueryBuilder.visit(visitor);
+
+        verify(visitor).accept(knnQueryBuilder);
+        verify(visitor).getChildVisitor(org.apache.lucene.search.BooleanClause.Occur.FILTER);
+        verify(subVisitor).accept(TERM_QUERY);
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description
Corrects the visitor patter for knn querybuilder to visit the underlying filter. 

Visitor pattern is intended to visit each underlying query and take action against it. By not having an inner query, the high level call to `query.visit(QueryVisitor)` won't be able to visit the filter query and stops at k-NN query which can cause silent unintended behavior. The visitor pattern relies on right implementation of `visits` to be able to avoid recursion logic in core or elsewhere to evaluate a query


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
