### PR TITLE
Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Update Gradle wrapper to 9.4.1 and Jacoco to 0.8.14 to match core OpenSearch [#3308](https://github.com/opensearch-project/k-NN/pull/3308)
 
 ### Bug Fixes
+* Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable prefetch [#3302](https://github.com/opensearch-project/k-NN/pull/3302)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -9,10 +9,10 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import com.google.common.annotations.VisibleForTesting;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -21,7 +21,7 @@ import java.io.IOException;
 /**
  * Dedicated format for Faiss SQ vector fields.
  *
- * <p>Uses Lucene's {@link Lucene104ScalarQuantizedVectorsFormat} with 1-bit quantization
+ * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} with 1-bit quantization
  * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for flat vector storage (.vec/.veq files),
  * while HNSW graph construction is delegated to the native Faiss engine (.faiss files).
  *
@@ -37,13 +37,18 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
 
     private static final String FORMAT_NAME = "Faiss1040ScalarQuantizedKnnVectorsFormat";
 
-    // Shared across all format instances; Lucene104ScalarQuantizedVectorsFormat is stateless.
+    // Shared across all format instances; KNN1040ScalarQuantizedVectorsFormat is stateless.
     // TODO : We have to make it scalable for other encoding types, not limit this on `ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE`.
-    private static final Lucene104ScalarQuantizedVectorsFormat faissSqFlatFormat = new Lucene104ScalarQuantizedVectorsFormat(
+    private static final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat = new KNN1040ScalarQuantizedVectorsFormat(
         ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE
     );
 
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+
+    @VisibleForTesting
+    static KNN1040ScalarQuantizedVectorsFormat getFaissSqFlatFormat() {
+        return faissSqFlatFormat;
+    }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
         this(new NativeIndexBuildStrategyFactory());

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
@@ -39,6 +40,11 @@ import java.io.IOException;
 public class Faiss1040ScalarQuantizedKnnVectorsReader extends AbstractNativeEnginesKnnVectorsReader {
     Faiss1040ScalarQuantizedKnnVectorsReader(SegmentReadState state, FlatVectorsReader flatVectorsReader) {
         super(state, flatVectorsReader);
+    }
+
+    @VisibleForTesting
+    FlatVectorsReader getFlatVectorsReader() {
+        return flatVectorsReader;
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
@@ -9,6 +9,7 @@ import lombok.SneakyThrows;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
@@ -19,13 +20,16 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.util.Iterator;
@@ -177,19 +181,46 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         try (MockedStatic<CodecUtil> mockedCodecUtil = Mockito.mockStatic(CodecUtil.class)) {
             mockedCodecUtil.when(() -> CodecUtil.retrieveChecksum(any(IndexInput.class))).thenAnswer((Answer<Void>) invocation -> null);
 
-            KnnVectorsReader reader = format.fieldsReader(mockedSegmentReadState);
-            assertTrue(reader instanceof Faiss1040ScalarQuantizedKnnVectorsReader);
+            try (KnnVectorsReader rawReader = format.fieldsReader(mockedSegmentReadState)) {
+                assertTrue(rawReader instanceof Faiss1040ScalarQuantizedKnnVectorsReader);
+                Faiss1040ScalarQuantizedKnnVectorsReader reader = (Faiss1040ScalarQuantizedKnnVectorsReader) rawReader;
 
-            // Verify the internal FlatVectorsReader is wrapped with Faiss1040ScalarQuantizedFlatVectorsReader
-            java.lang.reflect.Field flatReaderField = reader.getClass().getSuperclass().getDeclaredField("flatVectorsReader");
-            flatReaderField.setAccessible(true);
-            Object flatReader = flatReaderField.get(reader);
-            assertTrue(
-                "FlatVectorsReader should be wrapped with Faiss1040ScalarQuantizedFlatVectorsReader",
-                flatReader instanceof Faiss1040ScalarQuantizedFlatVectorsReader
+                // Verify the internal FlatVectorsReader is wrapped with Faiss1040ScalarQuantizedFlatVectorsReader
+                assertTrue(
+                    "FlatVectorsReader should be wrapped with Faiss1040ScalarQuantizedFlatVectorsReader",
+                    reader.getFlatVectorsReader() instanceof Faiss1040ScalarQuantizedFlatVectorsReader
+                );
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testFieldsReader_scorerIsPrefetchable() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            SegmentReadState readState = KNN1040ScalarQuantizedTestUtils.writeQuantizedVectors(
+                dir,
+                Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+                random()
             );
 
-            reader.close();
+            try (KnnVectorsReader rawReader = new Faiss1040ScalarQuantizedKnnVectorsFormat().fieldsReader(readState)) {
+                assertTrue(
+                    "Expected Faiss1040ScalarQuantizedKnnVectorsReader but was: " + rawReader.getClass().getSimpleName(),
+                    rawReader instanceof Faiss1040ScalarQuantizedKnnVectorsReader
+                );
+                Faiss1040ScalarQuantizedKnnVectorsReader knnReader = (Faiss1040ScalarQuantizedKnnVectorsReader) rawReader;
+                FlatVectorsReader flatReader = knnReader.getFlatVectorsReader();
+                RandomVectorScorer scorer = flatReader.getRandomVectorScorer(
+                    KNN1040ScalarQuantizedTestUtils.FIELD_NAME,
+                    KNN1040ScalarQuantizedTestUtils.randomVector(KNN1040ScalarQuantizedTestUtils.DIMENSION, random())
+                );
+
+                assertNotNull("RandomVectorScorer should not be null", scorer);
+                assertTrue(
+                    "Scorer from Faiss SQ reader should be PrefetchableRandomVectorScorer, but was: " + scorer.getClass().getSimpleName(),
+                    scorer instanceof PrefetchableRandomVectorScorer
+                );
+            }
         }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedTestUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
+import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+final class KNN1040ScalarQuantizedTestUtils {
+
+    static final String FIELD_NAME = "vector";
+    static final int DIMENSION = 128;
+    static final int NUM_VECTORS = 50;
+
+    private KNN1040ScalarQuantizedTestUtils() {}
+
+    // Uses single-segment flush path (not merge). Sufficient for verifying scorer/reader types since
+    // those are determined by the flat format, not by how the segment was created.
+    // The returned SegmentReadState references the passed-in directory; caller must ensure
+    // the directory outlives any readers opened from this state.
+    static SegmentReadState writeQuantizedVectors(MMapDirectory dir, KNN1040ScalarQuantizedVectorsFormat format, Random random)
+        throws Exception {
+        final FieldInfo fieldInfo = new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            DIMENSION,
+            VectorEncoding.FLOAT32,
+            VectorSimilarityFunction.EUCLIDEAN,
+            false,
+            false
+        );
+        final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+
+        final SegmentInfo segmentInfo = new SegmentInfo(
+            dir,
+            Version.LATEST,
+            Version.LATEST,
+            "_0",
+            NUM_VECTORS,
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            StringHelper.randomId(),
+            new HashMap<>(),
+            null
+        );
+        final SegmentWriteState writeState = new SegmentWriteState(
+            InfoStream.NO_OUTPUT,
+            dir,
+            segmentInfo,
+            fieldInfos,
+            null,
+            IOContext.DEFAULT
+        );
+
+        try (FlatVectorsWriter writer = format.fieldsWriter(writeState)) {
+            @SuppressWarnings("unchecked")
+            FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+
+            for (int i = 0; i < NUM_VECTORS; i++) {
+                fieldWriter.addValue(i, randomVector(DIMENSION, random));
+            }
+
+            // null sortMap means unsorted segment — standard for non-index-time-sorted segments
+            writer.flush(NUM_VECTORS, null);
+            writer.finish();
+        }
+
+        return new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+    }
+
+    static float[] randomVector(int dimension, Random random) {
+        float[] v = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            v[i] = random.nextFloat() * 2 - 1;
+        }
+        return v;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormatTests.java
@@ -5,8 +5,14 @@
 
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
+import lombok.SneakyThrows;
+import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
@@ -34,6 +40,31 @@ public class KNN1040ScalarQuantizedVectorsFormatTests extends KNNTestCase {
     public void testGetName_returnsClassName() {
         KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat();
         assertEquals("KNN1040ScalarQuantizedVectorsFormat", format.getName());
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_returnsPrefetchableScorer() {
+        final KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat(SINGLE_BIT_QUERY_NIBBLE);
+
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            SegmentReadState readState = KNN1040ScalarQuantizedTestUtils.writeQuantizedVectors(dir, format, random());
+
+            try (FlatVectorsReader reader = format.fieldsReader(readState)) {
+                RandomVectorScorer scorer = reader.getRandomVectorScorer(
+                    KNN1040ScalarQuantizedTestUtils.FIELD_NAME,
+                    KNN1040ScalarQuantizedTestUtils.randomVector(KNN1040ScalarQuantizedTestUtils.DIMENSION, random())
+                );
+
+                assertNotNull("RandomVectorScorer should not be null", scorer);
+                assertTrue(
+                    "Scorer should be PrefetchableRandomVectorScorer (backed by KNN1040ScalarQuantizedVectorScorer), "
+                        + "but was: "
+                        + scorer.getClass().getSimpleName(),
+                    scorer instanceof PrefetchableRandomVectorScorer
+                );
+                assertEquals("maxOrd should match number of vectors", KNN1040ScalarQuantizedTestUtils.NUM_VECTORS, scorer.maxOrd());
+            }
+        }
     }
 
     public void testConstructor_allEncodings() {


### PR DESCRIPTION
### Description
The Faiss SQ format was using Lucene's `Lucene104ScalarQuantizedVectorsFormat` directly, which lacks the prefetch-enabled raw vector reader that `KNN1040ScalarQuantizedVectorsFormat` provides. This meant exact search rescoring was missing I/O prefetch during graph traversal.

### Changes
- Switch `faissSqFlatFormat` from `Lucene104ScalarQuantizedVectorsFormat` to `KNN1040ScalarQuantizedVectorsFormat` in `Faiss1040ScalarQuantizedKnnVectorsFormat`
- Add `@VisibleForTesting` package-private accessors: `getFaissSqFlatFormat()` on `Faiss1040ScalarQuantizedKnnVectorsFormat` and `getFlatVectorsReader()` on `Faiss1040ScalarQuantizedKnnVectorsReader`

### Testing
Verified the test catches the bug: when `KNN1040ScalarQuantizedVectorsFormat` is replaced with `Lucene104ScalarQuantizedVectorsFormat`, the test fails with:
```
Scorer from Faiss SQ reader should be PrefetchableRandomVectorScorer, but was: ScalarQuantizedRandomVectorScorer
```

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).