### PR TITLE
Deprecate mode

### DIFF
--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModeDeprecationIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ModeDeprecationIT.java
@@ -1,0 +1,280 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.Version;
+import org.opensearch.common.xcontent.XContentFactory;
+
+/**
+ * Restart-upgrade BwC tests for mode parameter deprecation (V_3_7_0+).
+ *
+ * <p>Covers the following backward-compatibility scenarios:
+ * <ol>
+ *   <li>An index created with {@code mode=on_disk} on the old cluster must survive a full
+ *       cluster restart-upgrade and remain searchable on the new cluster.</li>
+ *   <li>An index created with {@code mode=in_memory} on the old cluster must survive
+ *       restart-upgrade and remain searchable.</li>
+ *   <li>An index created with {@code mode=on_disk} only (no explicit compression) on the old
+ *       cluster must survive restart-upgrade; the upgraded cluster re-derives compression from
+ *       the stored mode value and produces the same result.</li>
+ *   <li>On the upgraded cluster, an index created with only {@code compression_level} (no
+ *       explicit {@code mode}) must resolve correctly via the new derivation logic.</li>
+ *   <li>On the upgraded cluster, providing both {@code compression_level} and {@code mode}
+ *       must still work (deprecated but honoured) and produce a deprecation warning in logs.</li>
+ * </ol>
+ *
+ * <p>Tests that require the old cluster to support mode/compression (>= 2.17.0) are guarded
+ * by {@link #isModeSupported(java.util.Optional)}.
+ */
+public class ModeDeprecationIT extends AbstractRestartUpgradeTestCase {
+
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 16;
+    private static final int K = 5;
+    private static final int NUM_DOCS = 100;
+
+    // -------------------------------------------------------------------------
+    // Scenario 1: mode=on_disk + compression_level=32x created on old cluster
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an index with explicit {@code mode=on_disk, compression_level=32x} on the old
+     * cluster. After restart-upgrade the index must still be searchable and accept new docs.
+     * The mapping stores the user-provided {@code mode}; the upgraded cluster must honour it
+     * without re-deriving or rejecting it (BwC guarantee).
+     */
+    public void testOnDiskModeIndex_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        if (isModeSupported(getBWCVersion()) == false) {
+            logger.info("Skipping: mode parameter not supported in BWC version {}", getBWCVersion());
+            return;
+        }
+        String indexName = testIndex + "-ondisk-32x";
+        if (isRunningAgainstOldCluster()) {
+            createOnDiskIndex(indexName, "32x");
+            addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        } else {
+            // Upgraded cluster: existing index must be searchable
+            validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            // New docs must be indexable
+            addKNNDocs(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+            forceMergeKnnIndex(indexName);
+            validateKNNSearch(indexName, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2: mode=in_memory + compression_level=1x created on old cluster
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an index with explicit {@code mode=in_memory, compression_level=1x} on the old
+     * cluster. After restart-upgrade the index must still be searchable.
+     */
+    public void testInMemoryModeIndex_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        if (isModeSupported(getBWCVersion()) == false) {
+            logger.info("Skipping: mode parameter not supported in BWC version {}", getBWCVersion());
+            return;
+        }
+        String indexName = testIndex + "-inmemory-1x";
+        if (isRunningAgainstOldCluster()) {
+            createInMemoryIndex(indexName, "1x");
+            addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        } else {
+            validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            addKNNDocs(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+            forceMergeKnnIndex(indexName);
+            validateKNNSearch(indexName, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3: mode=on_disk only (no compression) created on old cluster
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an index with only {@code mode=on_disk} (no explicit compression) on the old
+     * cluster. The old cluster resolves this to {@code compression_level=32x} internally.
+     * After restart-upgrade the upgraded cluster must re-derive the same configuration from
+     * the stored mapping and the index must remain searchable.
+     */
+    public void testOnDiskModeOnlyIndex_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        if (isModeSupported(getBWCVersion()) == false) {
+            logger.info("Skipping: mode parameter not supported in BWC version {}", getBWCVersion());
+            return;
+        }
+        String indexName = testIndex + "-ondisk-only";
+        if (isRunningAgainstOldCluster()) {
+            createModeOnlyIndex(indexName, "on_disk");
+            addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        } else {
+            validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            addKNNDocs(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, NUM_DOCS);
+            forceMergeKnnIndex(indexName);
+            validateKNNSearch(indexName, TEST_FIELD, DIMENSION, 2 * NUM_DOCS, K);
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 4: compression_level only (no mode) on upgraded cluster
+    // -------------------------------------------------------------------------
+
+    /**
+     * On the upgraded cluster only, creates an index with {@code compression_level=32x} and
+     * no explicit {@code mode}. The resolver must derive {@code mode=on_disk} automatically
+     * and the index must be searchable.
+     */
+    public void testCompressionOnly32x_onUpgradedCluster_thenSucceed() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            return;
+        }
+        String indexName = testIndex + "-compression-32x";
+        createCompressionOnlyIndex(indexName, "32x");
+        addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        forceMergeKnnIndex(indexName);
+        validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
+    /**
+     * On the upgraded cluster only, creates an index with {@code compression_level=2x} and
+     * no explicit {@code mode}. The resolver must derive {@code mode=in_memory} automatically.
+     */
+    public void testCompressionOnly2x_onUpgradedCluster_thenSucceed() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            return;
+        }
+        String indexName = testIndex + "-compression-2x";
+        createCompressionOnlyIndex(indexName, "2x");
+        addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        forceMergeKnnIndex(indexName);
+        validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
+    /**
+     * On the upgraded cluster only, creates an index with {@code compression_level=1x} and
+     * no explicit {@code mode}. The resolver must derive {@code mode=in_memory} automatically.
+     */
+    public void testCompressionOnly1x_onUpgradedCluster_thenSucceed() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            return;
+        }
+        String indexName = testIndex + "-compression-1x";
+        createCompressionOnlyIndex(indexName, "1x");
+        addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        forceMergeKnnIndex(indexName);
+        validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 5: both compression_level and mode on upgraded cluster (deprecated but honoured)
+    // -------------------------------------------------------------------------
+
+    /**
+     * On the upgraded cluster, providing both {@code compression_level=32x} and
+     * {@code mode=on_disk} must still succeed (deprecated but honoured for BwC).
+     * A deprecation warning is expected in the server logs but the index must be functional.
+     */
+    public void testExplicitModeAndCompression_onUpgradedCluster_thenSucceed() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            return;
+        }
+        String indexName = testIndex + "-explicit-both";
+        createOnDiskIndex(indexName, "32x");
+        addKNNDocs(indexName, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+        forceMergeKnnIndex(indexName);
+        validateKNNSearch(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void createOnDiskIndex(String indexName, String compressionLevel) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("mode", "on_disk")
+            .field("compression_level", compressionLevel)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void createInMemoryIndex(String indexName, String compressionLevel) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("mode", "in_memory")
+            .field("compression_level", compressionLevel)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void createModeOnlyIndex(String indexName, String mode) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("mode", mode)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void createCompressionOnlyIndex(String indexName, String compressionLevel) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("compression_level", compressionLevel)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    /**
+     * Returns true if the old cluster version supports the mode/compression parameters
+     * (introduced in 2.17.0).
+     */
+    private boolean isModeSupported(java.util.Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get().replace("-SNAPSHOT", "");
+        return Version.fromString(versionString).onOrAfter(Version.V_2_17_0);
+    }
+}

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/ModeDeprecationIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/ModeDeprecationIT.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.opensearch.Version;
+import org.opensearch.common.xcontent.XContentFactory;
+
+import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
+
+/**
+ * Rolling-upgrade BwC tests for mode parameter deprecation (V_3_7_0+).
+ *
+ * <p>Covers three backward-compatibility scenarios:
+ * <ol>
+ *   <li>An index created with {@code mode=on_disk} on the old cluster must survive rolling
+ *       upgrade and remain searchable on mixed and fully-upgraded clusters.</li>
+ *   <li>An index created with {@code mode=in_memory} on the old cluster must survive rolling
+ *       upgrade and remain searchable.</li>
+ *   <li>On the fully-upgraded cluster, an index created with only {@code compression_level}
+ *       (no explicit {@code mode}) must resolve correctly via the new derivation logic and
+ *       be searchable.</li>
+ * </ol>
+ *
+ * <p>These tests do NOT run on old clusters that pre-date mode/compression support (< 2.17.0).
+ */
+public class ModeDeprecationIT extends AbstractRollingUpgradeTestCase {
+
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 16;
+    private static final int K = 5;
+    private static final int NUM_DOCS = 10;
+
+    // -------------------------------------------------------------------------
+    // Scenario 1: mode=on_disk index created on old cluster survives upgrade
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an index with {@code mode=on_disk, compression_level=32x} on the old cluster,
+     * continues indexing through mixed rounds, and verifies search on the upgraded cluster.
+     * The mapping stores the explicit {@code mode} value; the upgraded cluster must honour it
+     * without re-deriving or rejecting it.
+     */
+    public void testOnDiskModeIndex_rollingUpgrade_thenSucceed() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        if (isModeSupported(getBWCVersion()) == false) {
+            return;
+        }
+        String onDiskIndex = testIndex + "-ondisk";
+        switch (getClusterType()) {
+            case OLD:
+                createOnDiskIndex(onDiskIndex);
+                addKNNDocs(onDiskIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+                break;
+            case MIXED:
+                int totalDocs = isFirstMixedRound() ? 2 * NUM_DOCS : 3 * NUM_DOCS;
+                int docId = isFirstMixedRound() ? NUM_DOCS : 2 * NUM_DOCS;
+                addKNNDocs(onDiskIndex, TEST_FIELD, DIMENSION, docId, NUM_DOCS);
+                validateKNNSearch(onDiskIndex, TEST_FIELD, DIMENSION, totalDocs, K);
+                break;
+            case UPGRADED:
+                addKNNDocs(onDiskIndex, TEST_FIELD, DIMENSION, 3 * NUM_DOCS, NUM_DOCS);
+                forceMergeKnnIndex(onDiskIndex);
+                validateKNNSearch(onDiskIndex, TEST_FIELD, DIMENSION, 4 * NUM_DOCS, K);
+                deleteKNNIndex(onDiskIndex);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2: mode=in_memory index created on old cluster survives upgrade
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates an index with {@code mode=in_memory, compression_level=1x} on the old cluster
+     * and verifies it remains searchable through rolling upgrade.
+     */
+    public void testInMemoryModeIndex_rollingUpgrade_thenSucceed() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        if (isModeSupported(getBWCVersion()) == false) {
+            return;
+        }
+        String inMemoryIndex = testIndex + "-inmemory";
+        switch (getClusterType()) {
+            case OLD:
+                createInMemoryIndex(inMemoryIndex);
+                addKNNDocs(inMemoryIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+                break;
+            case MIXED:
+                int totalDocs = isFirstMixedRound() ? 2 * NUM_DOCS : 3 * NUM_DOCS;
+                int docId = isFirstMixedRound() ? NUM_DOCS : 2 * NUM_DOCS;
+                addKNNDocs(inMemoryIndex, TEST_FIELD, DIMENSION, docId, NUM_DOCS);
+                validateKNNSearch(inMemoryIndex, TEST_FIELD, DIMENSION, totalDocs, K);
+                break;
+            case UPGRADED:
+                addKNNDocs(inMemoryIndex, TEST_FIELD, DIMENSION, 3 * NUM_DOCS, NUM_DOCS);
+                forceMergeKnnIndex(inMemoryIndex);
+                validateKNNSearch(inMemoryIndex, TEST_FIELD, DIMENSION, 4 * NUM_DOCS, K);
+                deleteKNNIndex(inMemoryIndex);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3: compression_level only (no mode) on upgraded cluster
+    // -------------------------------------------------------------------------
+
+    /**
+     * On the fully-upgraded cluster, creates an index with only {@code compression_level=32x}
+     * (no explicit {@code mode}). The resolver must derive {@code mode=on_disk} automatically
+     * and the index must be searchable.
+     */
+    public void testCompressionOnlyIndex_onUpgradedCluster_thenSucceed() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        switch (getClusterType()) {
+            case OLD:
+            case MIXED:
+                break;
+            case UPGRADED:
+                String compressionOnlyIndex = testIndex + "-compressiononly";
+                createCompressionOnlyIndex(compressionOnlyIndex, "32x");
+                addKNNDocs(compressionOnlyIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+                forceMergeKnnIndex(compressionOnlyIndex);
+                validateKNNSearch(compressionOnlyIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+                deleteKNNIndex(compressionOnlyIndex);
+        }
+    }
+
+    /**
+     * On the fully-upgraded cluster, creates an index with only {@code compression_level=2x}
+     * (no explicit {@code mode}). The resolver must derive {@code mode=in_memory} automatically.
+     */
+    public void testCompressionOnly2x_onUpgradedCluster_thenSucceed() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        switch (getClusterType()) {
+            case OLD:
+            case MIXED:
+                break;
+            case UPGRADED:
+                String compressionOnly2xIndex = testIndex + "-compressiononly2x";
+                createCompressionOnlyIndex(compressionOnly2xIndex, "2x");
+                addKNNDocs(compressionOnly2xIndex, TEST_FIELD, DIMENSION, 0, NUM_DOCS);
+                forceMergeKnnIndex(compressionOnly2xIndex);
+                validateKNNSearch(compressionOnly2xIndex, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+                deleteKNNIndex(compressionOnly2xIndex);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void createOnDiskIndex(String indexName) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("mode", "on_disk")
+            .field("compression_level", "32x")
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void createInMemoryIndex(String indexName) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("mode", "in_memory")
+            .field("compression_level", "1x")
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    private void createCompressionOnlyIndex(String indexName, String compressionLevel) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(TEST_FIELD)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("compression_level", compressionLevel)
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName, getKNNDefaultIndexSettings(), mapping);
+    }
+
+    /**
+     * Returns true if the old cluster version supports the mode/compression parameters
+     * (introduced in 2.17.0).
+     */
+    private boolean isModeSupported(java.util.Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get().replace("-SNAPSHOT", "");
+        return Version.fromString(versionString).onOrAfter(Version.V_2_17_0);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -561,14 +561,32 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             ParserContext parserContext,
             SpaceType resolvedSpaceType
         ) {
+            Mode userMode = Mode.fromName(builder.originalParameters.getMode());
+            CompressionLevel userCompression = CompressionLevel.fromName(builder.originalParameters.getCompressionLevel());
+
+            // Deprecation warning: mode is deprecated starting V_3_7_0. Users should use compression_level instead.
+            if (Mode.isConfigured(userMode) && parserContext.indexVersionCreated().onOrAfter(Version.V_3_7_0)) {
+                log.warn(
+                    "[Deprecation] The \"mode\" parameter is deprecated as of OpenSearch 3.7.0 and will be removed in 4.0. "
+                        + "Use \"compression_level\" instead. \"mode\" will be derived automatically from \"compression_level\"."
+                );
+            }
+
+            // Derive mode from compression_level when compression is provided but mode is not.
+            // 1x/2x -> in_memory; 4x and above -> on_disk.
+            Mode resolvedMode = userMode;
+            if (Mode.isConfigured(userMode) == false && CompressionLevel.isConfigured(userCompression)) {
+                resolvedMode = Mode.deriveMode(userCompression);
+            }
+
             // Setup the initial configuration that is used to help resolve parameters.
             builder.setKnnMethodConfigContext(
                 KNNMethodConfigContext.builder()
                     .vectorDataType(builder.originalParameters.getVectorDataType())
                     .versionCreated(parserContext.indexVersionCreated())
                     .dimension(builder.originalParameters.getDimension())
-                    .mode(Mode.fromName(builder.originalParameters.getMode()))
-                    .compressionLevel(CompressionLevel.fromName(builder.originalParameters.getCompressionLevel()))
+                    .mode(resolvedMode)
+                    .compressionLevel(userCompression)
                     .build()
             );
 

--- a/src/main/java/org/opensearch/knn/index/mapper/Mode.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/Mode.java
@@ -16,7 +16,11 @@ import java.util.stream.Collectors;
 /**
  * Enum representing the intended workload optimization a user wants their k-NN system to have. Based on this value,
  * default parameter resolution will be determined.
+ *
+ * @deprecated since 3.7.0. Storage mode is now derived automatically from {@link CompressionLevel}.
+ *             Use {@code compression_level} in the mapping instead. This parameter will be removed in 4.0.
  */
+@Deprecated(since = "3.7.0", forRemoval = true)
 @Getter
 @AllArgsConstructor
 public enum Mode {
@@ -62,5 +66,31 @@ public enum Mode {
      */
     public static boolean isConfigured(Mode mode) {
         return mode != null && mode != NOT_CONFIGURED;
+    }
+
+    /**
+     * Derives the storage mode from a compression level. This is the canonical mapping used when
+     * {@code mode} is not explicitly provided by the user.
+     *
+     * <ul>
+     *   <li>1x and 2x → {@link #IN_MEMORY} (low/no compression; full-precision vectors fit in memory)</li>
+     *   <li>4x, 8x, 16x, 32x, 64x → {@link #ON_DISK} (quantized graph stored on disk; FP32 rescore from doc values)</li>
+     *   <li>{@link CompressionLevel#NOT_CONFIGURED} → {@link #NOT_CONFIGURED}</li>
+     * </ul>
+     *
+     * @param compressionLevel the compression level to derive mode from
+     * @return the derived {@link Mode}
+     */
+    public static Mode deriveMode(CompressionLevel compressionLevel) {
+        if (CompressionLevel.isConfigured(compressionLevel) == false) {
+            return NOT_CONFIGURED;
+        }
+        switch (compressionLevel) {
+            case x1:
+            case x2:
+                return IN_MEMORY;
+            default:
+                return ON_DISK;
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -2167,7 +2167,8 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             VectorDataType.FLOAT,
             CompressionLevel.x2,
             CompressionLevel.x2,
-            Mode.NOT_CONFIGURED,
+            Mode.NOT_CONFIGURED, // original: user did not provide mode
+            Mode.IN_MEMORY,      // resolved: derived from x2 compression
             false
         );
 
@@ -2560,14 +2561,38 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         Mode expectedMode,
         boolean shouldUsesBinaryQFramework
     ) {
+        validateBuilderAfterParsing(
+            builder,
+            expectedEngine,
+            expectedSpaceType,
+            expectedVectorDataType,
+            expectedResolvedCompressionLevel,
+            expectedOriginalCompressionLevel,
+            expectedMode,
+            expectedMode,
+            shouldUsesBinaryQFramework
+        );
+    }
+
+    private void validateBuilderAfterParsing(
+        KNNVectorFieldMapper.Builder builder,
+        KNNEngine expectedEngine,
+        SpaceType expectedSpaceType,
+        VectorDataType expectedVectorDataType,
+        CompressionLevel expectedResolvedCompressionLevel,
+        CompressionLevel expectedOriginalCompressionLevel,
+        Mode expectedOriginalMode,
+        Mode expectedResolvedMode,
+        boolean shouldUsesBinaryQFramework
+    ) {
         assertEquals(expectedEngine, builder.getOriginalParameters().getResolvedKnnMethodContext().getKnnEngine());
         assertEquals(expectedSpaceType, builder.getOriginalParameters().getResolvedKnnMethodContext().getSpaceType());
         assertEquals(expectedVectorDataType, builder.getKnnMethodConfigContext().getVectorDataType());
 
         assertEquals(expectedResolvedCompressionLevel, builder.getKnnMethodConfigContext().getCompressionLevel());
         assertEquals(expectedOriginalCompressionLevel, CompressionLevel.fromName(builder.getOriginalParameters().getCompressionLevel()));
-        assertEquals(expectedMode, Mode.fromName(builder.getOriginalParameters().getMode()));
-        assertEquals(expectedMode, builder.getKnnMethodConfigContext().getMode());
+        assertEquals(expectedOriginalMode, Mode.fromName(builder.getOriginalParameters().getMode()));
+        assertEquals(expectedResolvedMode, builder.getKnnMethodConfigContext().getMode());
         assertFalse(builder.getOriginalParameters().getResolvedKnnMethodContext().getMethodComponentContext().getParameters().isEmpty());
 
         if (shouldUsesBinaryQFramework) {


### PR DESCRIPTION
## Note: running for bwc tests. Not ready yet

### Description
Deprecates the `mode` parameter (`in_memory`, `on_disk`) for `knn_vector` field mappings, starting in OpenSearch 3.7.0. Storage mode is now derived automatically from `compression_level`, making `mode` redundant as a user-facing input.

Changes:
- `Mode` enum marked `@Deprecated(since = "3.7.0", forRemoval = true)` — will be removed in 4.0
- When `mode` is explicitly provided on an index created at version 3.7.0+, a deprecation warning is logged
- When only `compression_level` is provided (no `mode`), mode is derived automatically: `1x`/`2x` -> `in_memory`, `4x` and above -> `on_disk`
- `Mode.deriveMode(CompressionLevel)` added as the canonical derivation method
- Existing indices that stored an explicit `mode` value continue to work unchanged (BwC)
- BwC tests added for both rolling-upgrade and restart-upgrade scenarios covering: explicit `mode` indices surviving upgrade, and compression-only indices resolving correctly on the upgraded cluster

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.