### PR TITLE
Enhance unit test coverage for 32x defaults

### DIFF
--- a/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/BasePerFieldKnnVectorsFormatTests.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
@@ -589,6 +590,39 @@ public class BasePerFieldKnnVectorsFormatTests extends KNNTestCase {
         return mapperService;
     }
 
+    public void testGetKnnVectorsFormatForField_whenLuceneSQOneBit_thenReturnSQFormat() {
+        KNNMethodContext sqMethodContext = createSQMethodContext(16, 100, Map.of(LUCENE_SQ_BITS, 1));
+
+        MapperService mapperService = mockMapperService(TEST_FIELD, sqMethodContext);
+
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.SCALAR_QUANTIZED,
+            ctx -> SQ_FORMAT,
+            LuceneVectorsFormatType.HNSW,
+            ctx -> HNSW_FORMAT
+        );
+
+        TestPerFieldKnnVectorsFormat format = new TestPerFieldKnnVectorsFormat(Optional.of(mapperService), resolvers);
+        KnnVectorsFormat result = format.getKnnVectorsFormatForField(TEST_FIELD);
+        assertSame("SQ with bits=1 should route to SCALAR_QUANTIZED resolver", SQ_FORMAT, result);
+    }
+
+    public void testGetKnnVectorsFormatForField_whenFaissSQNoBits_thenReturnNativeFormat() {
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of());
+        MethodComponentContext hnswContext = new MethodComponentContext("hnsw", Map.of(METHOD_ENCODER_PARAMETER, encoderContext));
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+        when(methodContext.getMethodComponentContext()).thenReturn(hnswContext);
+
+        MapperService mapperService = mockMapperService(TEST_FIELD, methodContext);
+        KNN1040PerFieldKnnVectorsFormat perFieldFormat = new KNN1040PerFieldKnnVectorsFormat(Optional.of(mapperService));
+        KnnVectorsFormat format = perFieldFormat.getKnnVectorsFormatForField(TEST_FIELD);
+        assertTrue(
+            "FAISS SQ without bits should return NativeEngines990KnnVectorsFormat, got " + format.getClass().getSimpleName(),
+            format instanceof NativeEngines990KnnVectorsFormat
+        );
+    }
+
     // --- SQ with bits=1 (1-bit quantization) format routing ---
 
     public void testGetKnnVectorsFormatForField_whenSQOneBit_thenReturnSQOneBitFormat() {
@@ -615,5 +649,35 @@ public class BasePerFieldKnnVectorsFormatTests extends KNNTestCase {
         KNN1040PerFieldKnnVectorsFormat perFieldFormat = new KNN1040PerFieldKnnVectorsFormat(Optional.of(mapperService));
         KnnVectorsFormat format = perFieldFormat.getKnnVectorsFormatForField(TEST_FIELD);
         assertTrue(format instanceof NativeEngines990KnnVectorsFormat);
+    }
+
+    public void testGetKnnVectorsFormatForField_legacySQWithOneBit_thenReturnSQFormat() {
+        KNNMethodContext sqMethodContext = createSQMethodContext(16, 100, Map.of(LUCENE_SQ_BITS, 1));
+
+        MapperService mapperService = mockMapperService(TEST_FIELD, sqMethodContext);
+
+        final KNNScalarQuantizedVectorsFormatParams[] capturedSQParams = new KNNScalarQuantizedVectorsFormatParams[1];
+        Function<KNNScalarQuantizedVectorsFormatParams, KnnVectorsFormat> sqSupplier = sqParams -> {
+            capturedSQParams[0] = sqParams;
+            return SQ_FORMAT;
+        };
+
+        Function<KNNVectorsFormatParams, KnnVectorsFormat> hnswSupplier = hnswParams -> {
+            fail("HNSW supplier should not be called when SQ encoder with bits=1 is present");
+            return HNSW_FORMAT;
+        };
+
+        LegacySQTestPerFieldKnnVectorsFormat format = new LegacySQTestPerFieldKnnVectorsFormat(
+            Optional.of(mapperService),
+            hnswSupplier,
+            sqSupplier
+        );
+        KnnVectorsFormat result = format.getKnnVectorsFormatForField(TEST_FIELD);
+
+        assertSame("SQ with bits=1 should route to SQ supplier", SQ_FORMAT, result);
+        assertNotNull(capturedSQParams[0]);
+        assertEquals(1, capturedSQParams[0].getBits());
+        assertEquals(16, capturedSQParams[0].getMaxConnections());
+        assertEquals(100, capturedSQParams[0].getBeamWidth());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040CodecTest.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040CodecTest.java
@@ -6,11 +6,14 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.backward_codecs.lucene99.Lucene99RWHnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.CustomCodec;
 import org.opensearch.knn.index.codec.CustomCodecNoStoredFields;
 import org.opensearch.knn.index.codec.KNNCodecTestCase;
@@ -20,13 +23,23 @@ import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.index.engine.KNNEngine.LUCENE;
 
 public class KNN1040CodecTest extends KNNCodecTestCase {
@@ -63,22 +76,17 @@ public class KNN1040CodecTest extends KNNCodecTestCase {
             SpaceType.L2,
             new MethodComponentContext(METHOD_FLAT, Collections.emptyMap())
         );
+        assertThat(resolveFormat(flatMethodContext), instanceOf(KNN1040ScalarQuantizedVectorsFormat.class));
+    }
 
-        MapperService mapperService = mock(MapperService.class);
-        KNNVectorFieldType fieldType = new KNNVectorFieldType(
-            "test_field",
-            Collections.emptyMap(),
-            org.opensearch.knn.index.VectorDataType.FLOAT,
-            getMappingConfigForMethodMapping(flatMethodContext, 3)
-        );
-        when(mapperService.fieldType(eq("test_field"))).thenReturn(fieldType);
+    public void testSQOneBitFormatResolver_returnsKNN1040HnswScalarQuantizedVectorsFormat() {
+        KNNMethodContext sqMethodContext = buildHnswMethodContext(Map.of(LUCENE_SQ_BITS, 1));
+        assertThat(resolveFormat(sqMethodContext), instanceOf(KNN1040HnswScalarQuantizedVectorsFormat.class));
+    }
 
-        KNN1040PerFieldKnnVectorsFormat format = new KNN1040PerFieldKnnVectorsFormat(Optional.of(mapperService));
-        KnnVectorsFormat result = format.getKnnVectorsFormatForField("test_field");
-        assertTrue(
-            "Expected KNN1040ScalarQuantizedVectorsFormat but got " + result.getClass().getSimpleName(),
-            result instanceof KNN1040ScalarQuantizedVectorsFormat
-        );
+    public void testSQDefaultBitsFormatResolver_returnsLuceneRWHnswSQFormat() {
+        KNNMethodContext sqMethodContext = buildHnswMethodContext(Collections.emptyMap());
+        assertThat(resolveFormat(sqMethodContext), instanceOf(Lucene99RWHnswScalarQuantizedVectorsFormat.class));
     }
 
     // IMPORTANT: When this Codec is moved to a backwards Codec, this test needs to be removed, because it attempts to
@@ -96,4 +104,53 @@ public class KNN1040CodecTest extends KNNCodecTestCase {
         testKnnVectorIndex(knnCodecProvider, perFieldKnnVectorsFormatProvider);
     }
 
+    public void testHnswWithoutEncoderFormatResolver_returnsLucene99HnswFormat() {
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_PARAMETER_M, 32);
+        params.put(METHOD_PARAMETER_EF_CONSTRUCTION, 256);
+
+        KNNMethodContext hnswMethodContext = new KNNMethodContext(LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, params));
+        assertThat(resolveFormat(hnswMethodContext), instanceOf(Lucene99HnswVectorsFormat.class));
+    }
+
+    public void testFaissSQOneBitFormatResolver_returnsFaiss1040ScalarQuantizedFormat() {
+        // Faiss uses SQ_BITS while Lucene uses LUCENE_SQ_BITS for the encoder parameter key
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1));
+        MethodComponentContext hnswContext = new MethodComponentContext("hnsw", Map.of(METHOD_ENCODER_PARAMETER, encoderContext));
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getKnnEngine()).thenReturn(org.opensearch.knn.index.engine.KNNEngine.FAISS);
+        when(methodContext.getMethodComponentContext()).thenReturn(hnswContext);
+
+        assertThat(resolveFormat(methodContext), instanceOf(Faiss1040ScalarQuantizedKnnVectorsFormat.class));
+    }
+
+    public void testLuceneSQOneBitFormatResolver_returnsKNN1040HnswSQFormat() {
+        KNNMethodContext sqMethodContext = buildHnswMethodContext(Map.of(LUCENE_SQ_BITS, 1));
+        assertThat(resolveFormat(sqMethodContext), instanceOf(KNN1040HnswScalarQuantizedVectorsFormat.class));
+    }
+
+    private KNNMethodContext buildHnswMethodContext(Map<String, Object> encoderParams) {
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        params.put(METHOD_PARAMETER_M, 16);
+        params.put(METHOD_PARAMETER_EF_CONSTRUCTION, 100);
+
+        return new KNNMethodContext(LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, params));
+    }
+
+    private KnnVectorsFormat resolveFormat(KNNMethodContext methodContext) {
+        MapperService mapperService = mock(MapperService.class);
+        KNNVectorFieldType fieldType = new KNNVectorFieldType(
+            "test_field",
+            Collections.emptyMap(),
+            VectorDataType.FLOAT,
+            getMappingConfigForMethodMapping(methodContext, 3)
+        );
+        when(mapperService.fieldType(eq("test_field"))).thenReturn(fieldType);
+
+        KNN1040PerFieldKnnVectorsFormat format = new KNN1040PerFieldKnnVectorsFormat(Optional.of(mapperService));
+        return format.getKnnVectorsFormatForField("test_field");
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParamsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParamsTests.java
@@ -74,7 +74,7 @@ public class KNNScalarQuantizedVectorsFormatParamsTests extends TestCase {
         assertEquals(ScalarEncoding.fromNumBits((LUCENE_SQ_DEFAULT_BITS)), knnScalarQuantizedVectorsFormatParams.getBitEncoding());
     }
 
-    public void testInitParams_whenBitsIs1_thenReturnParams() {
+    public void testInitParams_whenBitsIs1_thenCompressFlagAndBitEncodingAreCorrect() {
         Map<String, Object> encoderParams = new HashMap<>();
         encoderParams.put(LUCENE_SQ_BITS, 1);
         MethodComponentContext encoderComponentContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
@@ -89,7 +89,8 @@ public class KNNScalarQuantizedVectorsFormatParamsTests extends TestCase {
         );
 
         assertEquals(1, knnScalarQuantizedVectorsFormatParams.getBits());
-        assertEquals(ScalarEncoding.fromNumBits(1), knnScalarQuantizedVectorsFormatParams.getBitEncoding());
+        assertTrue(knnScalarQuantizedVectorsFormatParams.isCompressFlag());
+        assertEquals(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, knnScalarQuantizedVectorsFormatParams.getBitEncoding());
         assertTrue(knnScalarQuantizedVectorsFormatParams.validate(params));
     }
 

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -300,6 +300,30 @@ public class EngineResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveEngine_whenOnDiskWith32xCompression_thenFaiss() {
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x32).build(),
+                null,
+                null,
+                false
+            )
+        );
+    }
+
+    public void testResolveEngine_whenInMemoryWith1xCompression_thenFaiss() {
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x1).build(),
+                null,
+                null,
+                false
+            )
+        );
+    }
+
     public void testValidateTopLevelEngine() throws IOException {
         // only top-level defined; set to faiss with compression 4x
         expectThrows(
@@ -324,5 +348,65 @@ public class EngineResolverTests extends KNNTestCase {
                 Version.CURRENT
             )
         );
+    }
+
+    public void testResolveEngine_whenNoModeNoCompressionAcrossVersions_thenDefault() {
+        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_7_0 → assert DEFAULT,
+        // indexVersionCreated >= V_3_7_0 → assert x32 default triggers engine resolution
+        Version[] versions = new Version[] { Version.V_2_18_0, Version.V_3_0_0, Version.V_3_5_0, Version.V_3_6_0, Version.CURRENT };
+
+        for (Version version : versions) {
+            assertEquals(
+                "Expected DEFAULT engine for version " + version + " with no mode/compression",
+                KNNEngine.DEFAULT,
+                ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().build(), null, null, false, version)
+            );
+        }
+    }
+
+    public void testResolveEngine_whenInMemoryModeAcrossVersions_thenVersionDeterminesEngine() {
+        assertEquals(
+            KNNEngine.NMSLIB,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).build(),
+                new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                null,
+                false,
+                Version.V_2_18_0
+            )
+        );
+
+        Version[] postV219Versions = new Version[] { Version.V_3_0_0, Version.V_3_5_0, Version.V_3_6_0, Version.CURRENT };
+        for (Version version : postV219Versions) {
+            assertEquals(
+                "Expected FAISS for version " + version + " with IN_MEMORY mode",
+                KNNEngine.FAISS,
+                ENGINE_RESOLVER.resolveEngine(
+                    KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).build(),
+                    new KNNMethodContext(KNNEngine.DEFAULT, SpaceType.UNDEFINED, MethodComponentContext.EMPTY, false),
+                    null,
+                    false,
+                    version
+                )
+            );
+        }
+    }
+
+    public void testResolveEngine_when32xCompressionAcrossVersions_thenAlwaysFaiss() {
+        Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.CURRENT };
+
+        for (Version version : versions) {
+            assertEquals(
+                "Expected FAISS for version " + version + " with x32 compression",
+                KNNEngine.FAISS,
+                ENGINE_RESOLVER.resolveEngine(
+                    KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x32).build(),
+                    null,
+                    null,
+                    false,
+                    version
+                )
+            );
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
@@ -175,4 +175,25 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
             result instanceof NativeEngines990KnnVectorsFormat
         );
     }
+
+    public void testResolve_whenCalledWithFieldContext_andSQSixteenBitEncoder_thenReturnsNativeFormat() {
+        MapperService mapperService = mock(MapperService.class);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        when(indexSettings.getValue(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_SETTING)).thenReturn(null);
+        when(mapperService.getIndexSettings()).thenReturn(indexSettings);
+
+        FaissCodecFormatResolver resolver = new FaissCodecFormatResolver(
+            Optional.of(mapperService),
+            mock(NativeIndexBuildStrategyFactory.class)
+        );
+
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);
+
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        assertTrue(
+            "SQ with bits=16 should return NativeEngines990KnnVectorsFormat, got " + result.getClass().getSimpleName(),
+            result instanceof NativeEngines990KnnVectorsFormat
+        );
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethodTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethodTests.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine.faiss;
+
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.TrainingConfigValidationInput;
+import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
+public class FaissHNSWMethodTests extends KNNTestCase {
+
+    public void testSupportedEncoders_containsFlatSqPqAndQFrame() {
+        Map<String, Encoder> encoders = FaissHNSWMethod.SUPPORTED_ENCODERS;
+        assertTrue(encoders.containsKey(ENCODER_FLAT));
+        assertTrue(encoders.containsKey(ENCODER_SQ));
+        assertTrue(encoders.containsKey(ENCODER_PQ));
+        assertTrue(encoders.containsKey(QFrameBitEncoder.NAME));
+        assertEquals(4, encoders.size());
+    }
+
+    public void testSupportedEncoders_sqEncoderIsFaissSQEncoder() {
+        Encoder sqEncoder = FaissHNSWMethod.SUPPORTED_ENCODERS.get(ENCODER_SQ);
+        assertNotNull(sqEncoder);
+        assertTrue(sqEncoder instanceof FaissSQEncoder);
+    }
+
+    public void testSupportedEncoders_flatEncoderCompressionIsX1() {
+        Encoder flatEncoder = FaissHNSWMethod.SUPPORTED_ENCODERS.get(ENCODER_FLAT);
+        assertEquals(CompressionLevel.x1, flatEncoder.calculateCompressionLevel(null, null));
+    }
+
+    public void testSupportedEncoders_sqEncoderBits1CompressionIsX32() {
+        Encoder sqEncoder = FaissHNSWMethod.SUPPORTED_ENCODERS.get(ENCODER_SQ);
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1));
+        assertEquals(CompressionLevel.x32, sqEncoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testSupportedEncoders_sqEncoderBits16CompressionIsX2() {
+        Encoder sqEncoder = FaissHNSWMethod.SUPPORTED_ENCODERS.get(ENCODER_SQ);
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
+        assertEquals(CompressionLevel.x2, sqEncoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testIsSQOneBitIndex_whenSQWithBits1Float_thenTrue() {
+        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 1), true);
+    }
+
+    public void testIsSQOneBitIndex_whenSQWithBits16Float_thenFalse() {
+        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 16), false);
+    }
+
+    public void testIsSQOneBitIndex_whenFlatEncoderFloat_thenFalse() {
+        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_FLAT, Map.of(), false);
+    }
+
+    public void testIsSQOneBitIndex_whenSQWithBits1Binary_thenFalse() {
+        assertSQOneBitIndex(VectorDataType.BINARY, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    }
+
+    public void testIsSQOneBitIndex_whenSQWithBits1Byte_thenFalse() {
+        assertSQOneBitIndex(VectorDataType.BYTE, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    }
+
+    public void testIsSQOneBitIndex_whenNoBitsParam_thenFalse() {
+        assertSQOneBitIndex(VectorDataType.FLOAT, ENCODER_SQ, Map.of(), false);
+    }
+
+    public void testIsFloat16Index_whenSQWithBits16Float_thenTrue() {
+        assertIsFloat16Index(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 16), true);
+    }
+
+    public void testIsFloat16Index_whenSQLegacyNoBitsFloat_thenTrue() {
+        assertIsFloat16Index(VectorDataType.FLOAT, ENCODER_SQ, Map.of(), true);
+    }
+
+    public void testIsFloat16Index_whenSQWithBits1Float_thenFalse() {
+        assertIsFloat16Index(VectorDataType.FLOAT, ENCODER_SQ, Map.of(SQ_BITS, 1), false);
+    }
+
+    public void testIsFloat16Index_whenFlatEncoder_thenFalse() {
+        assertIsFloat16Index(VectorDataType.FLOAT, ENCODER_FLAT, Map.of(), false);
+    }
+
+    public void testIsFloat16Index_whenBinaryDataType_thenFalse() {
+        assertIsFloat16Index(VectorDataType.BINARY, ENCODER_SQ, Map.of(SQ_BITS, 16), false);
+    }
+
+    public void testTrainingConfigValidation_whenHNSWWithSQBits1_thenValid() {
+        FaissHNSWMethod method = new FaissHNSWMethod();
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1)))
+            )
+        );
+
+        KNNLibraryIndexingContext indexingContext = method.getKNNLibraryIndexingContext(methodContext, configContext);
+        Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> validationSetup = indexingContext
+            .getTrainingConfigValidationSetup();
+
+        TrainingConfigValidationOutput output = validationSetup.apply(
+            TrainingConfigValidationInput.builder().knnMethodContext(methodContext).knnMethodConfigContext(configContext).build()
+        );
+        assertNull(output.getValid());
+    }
+
+    public void testTrainingConfigValidation_whenHNSWWithSQBits1AndX2Compression_thenInvalid() {
+        FaissHNSWMethod method = new FaissHNSWMethod();
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .compressionLevel(CompressionLevel.x2)
+            .build();
+
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1)))
+            )
+        );
+
+        KNNLibraryIndexingContext indexingContext = method.getKNNLibraryIndexingContext(methodContext, configContext);
+        Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> validationSetup = indexingContext
+            .getTrainingConfigValidationSetup();
+
+        TrainingConfigValidationOutput output = validationSetup.apply(
+            TrainingConfigValidationInput.builder().knnMethodContext(methodContext).knnMethodConfigContext(configContext).build()
+        );
+        assertNotNull(output.getValid());
+        assertFalse(output.getValid());
+        assertTrue(output.getErrorMessage().contains("incompatible"));
+    }
+
+    public void testTrainingConfigValidation_whenHNSWWithNoEncoder_thenValid() {
+        FaissHNSWMethod method = new FaissHNSWMethod();
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of())
+        );
+
+        KNNLibraryIndexingContext indexingContext = method.getKNNLibraryIndexingContext(methodContext, configContext);
+        Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> validationSetup = indexingContext
+            .getTrainingConfigValidationSetup();
+
+        TrainingConfigValidationOutput output = validationSetup.apply(
+            TrainingConfigValidationInput.builder().knnMethodContext(methodContext).knnMethodConfigContext(configContext).build()
+        );
+        assertNull(output.getValid());
+    }
+
+    public void testDefaultEncoder_isFlatEncoder() {
+        FaissHNSWMethod method = new FaissHNSWMethod();
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of())
+        );
+
+        Map<String, Object> libraryParams = method.getKNNLibraryIndexingContext(methodContext, configContext).getLibraryParameters();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> innerParams = (Map<String, Object>) libraryParams.get(PARAMETERS);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> encoderParams = (Map<String, Object>) innerParams.get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_FLAT, encoderParams.get(NAME));
+    }
+
+    private void assertSQOneBitIndex(VectorDataType dataType, String encoderName, Map<String, Object> encoderParams, boolean expected) {
+        Map<String, Object> params = buildLibraryParametersMap(dataType, encoderName, encoderParams);
+        assertEquals(expected, FaissHNSWMethod.isSQOneBitIndex(dataType, params));
+    }
+
+    private void assertIsFloat16Index(VectorDataType dataType, String encoderName, Map<String, Object> encoderParams, boolean expected) {
+        Map<String, Object> params = buildLibraryParametersMap(dataType, encoderName, encoderParams);
+        assertEquals(expected, FaissHNSWMethod.isFloat16Index(dataType, params));
+    }
+
+    private Map<String, Object> buildLibraryParametersMap(
+        VectorDataType vectorDataType,
+        String encoderName,
+        Map<String, Object> encoderParams
+    ) {
+        Map<String, Object> encoder = new java.util.HashMap<>(encoderParams);
+        encoder.put(NAME, encoderName);
+        return Map.of(
+            NAME,
+            METHOD_HNSW,
+            VECTOR_DATA_TYPE_FIELD,
+            vectorDataType.getValue(),
+            PARAMETERS,
+            Map.of(METHOD_ENCODER_PARAMETER, encoder)
+        );
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolverTests.java
@@ -285,6 +285,139 @@ public class FaissMethodResolverTests extends KNNTestCase {
 
     }
 
+    public void testResolveMethod_whenExplicitCompression32x_thenResolvesToSQOneBit() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x32)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.L2, ENCODER_SQ, true);
+        MethodComponentContext encoderCtx = (MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_SQ, encoderCtx.getName());
+        assertEquals(1, encoderCtx.getParameters().get("bits"));
+        assertFalse(encoderCtx.getParameters().containsKey("type"));
+        assertFalse(encoderCtx.getParameters().containsKey("clip"));
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x32)
+                .mode(Mode.ON_DISK)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.INNER_PRODUCT, ENCODER_SQ, true);
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x32)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.L2, ENCODER_SQ, true);
+    }
+
+    public void testResolveMethod_whenExplicitCompression1x_thenResolvesToFlat() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x1)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x1, SpaceType.L2, ENCODER_FLAT, false);
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            new KNNMethodContext(KNNEngine.FAISS, SpaceType.INNER_PRODUCT, new MethodComponentContext(METHOD_HNSW, Map.of())),
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x1)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x1, SpaceType.INNER_PRODUCT, ENCODER_FLAT, false);
+    }
+
+    public void testResolveMethod_whenNoCompressionSpecified_thenResolvesToX1() {
+        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_7_0+, keep x1 for older versions
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertEquals(
+            ENCODER_FLAT,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertEquals(
+            ENCODER_FLAT,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            new KNNMethodContext(KNNEngine.FAISS, SpaceType.HAMMING, new MethodComponentContext(METHOD_HNSW, Map.of())),
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BINARY).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.HAMMING
+        );
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenExplicit2x_thenSQEncoderHasBits16() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x2)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        MethodComponentContext encoderCtx = (MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_SQ, encoderCtx.getName());
+        assertEquals(16, encoderCtx.getParameters().get("bits"));
+    }
+
     public void testResolveMethod_whenV360WithExplicitBQ_thenUseBQ() {
         // User explicitly specifies binary (QFrameBitEncoder) on 3.6.0+ — should be honored, not overridden by sq(bits=1)
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
@@ -307,5 +440,71 @@ public class FaissMethodResolverTests extends KNNTestCase {
             SpaceType.L2
         );
         validateResolveMethodContext(resolvedMethodContext, CompressionLevel.x32, SpaceType.L2, QFrameBitEncoder.NAME, true);
+    }
+
+    public void testResolveMethod_whenNoCompressionAcrossVersions_thenAlwaysResolvesToX1() {
+        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_7_0 → assert x1,
+        // indexVersionCreated >= V_3_7_0 → assert x32
+        Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
+
+        for (Version version : versions) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x1 for version " + version + " with no compression specified",
+                CompressionLevel.x1,
+                resolvedMethodContext.getCompressionLevel()
+            );
+            assertEquals(
+                ENCODER_FLAT,
+                ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                    .getMethodComponentContext()
+                    .getParameters()
+                    .get(METHOD_ENCODER_PARAMETER)).getName()
+            );
+        }
+
+        for (Version version : versions) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x1 for version " + version + " with HNSW and no compression",
+                CompressionLevel.x1,
+                resolvedMethodContext.getCompressionLevel()
+            );
+            assertEquals(
+                ENCODER_FLAT,
+                ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                    .getMethodComponentContext()
+                    .getParameters()
+                    .get(METHOD_ENCODER_PARAMETER)).getName()
+            );
+        }
+    }
+
+    public void testResolveMethod_whenOnDiskAcrossVersions_thenAlwaysResolvesToX32() {
+        Version[] versions = new Version[] { Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
+
+        for (Version version : versions) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).mode(Mode.ON_DISK).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x32 for version " + version + " with ON_DISK mode",
+                CompressionLevel.x32,
+                resolvedMethodContext.getCompressionLevel()
+            );
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -203,6 +203,37 @@ public class FaissSQEncoderTests extends KNNTestCase {
         return TrainingConfigValidationInput.builder().knnMethodContext(methodContext).knnMethodConfigContext(configContext).build();
     }
 
+    public void testBits1_quantizationConfigIsEmpty() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponent methodComponent = encoder.getMethodComponent();
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1));
+        KNNLibraryIndexingContext indexingContext = methodComponent.getKNNLibraryIndexingContext(mcc, context);
+
+        assertEquals(org.opensearch.knn.index.engine.qframe.QuantizationConfig.EMPTY, indexingContext.getQuantizationConfig());
+    }
+
+    public void testBits16_libraryIndexingContextUsesSQDescription() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponent methodComponent = encoder.getMethodComponent();
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
+        KNNLibraryIndexingContext indexingContext = methodComponent.getKNNLibraryIndexingContext(mcc, context);
+
+        Map<String, Object> params = indexingContext.getLibraryParameters();
+        assertNotEquals(FAISS_FLAT_DESCRIPTION, params.get(INDEX_DESCRIPTION_PARAMETER));
+    }
+
     // --- isSQOneBit utility ---
 
     public void testIsSQOneBit_whenSQWithBits1_thenTrue() {

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
@@ -34,6 +34,7 @@ import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_ENCODER_FP16;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
 import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -421,6 +422,78 @@ public class FaissTests extends KNNTestCase {
         float expectedDistance5 = -0.5f;
         float actualDistance5 = Faiss.INSTANCE.scoreToRadialThreshold(score5, org.opensearch.knn.index.SpaceType.INNER_PRODUCT);
         assertEquals("Score 0.667 should convert to distance -0.5 (inner product = -0.5)", expectedDistance5, actualDistance5, 1e-6);
+    }
+
+    @SneakyThrows
+    public void testGetKNNLibraryIndexingContext_whenMethodIsHNSWSQOneBit_thenCreateCorrectIndexDescription() {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(128)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+        int hnswMParam = 16;
+        String expectedIndexDescription = String.format(Locale.ROOT, "HNSW%d,Flat", hnswMParam);
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_M, hnswMParam)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_SQ)
+            .startObject(PARAMETERS)
+            .field(SQ_BITS, 1)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+
+        KNNLibraryIndexingContext knnLibraryIndexingContext = Faiss.INSTANCE.getKNNLibraryIndexingContext(
+            knnMethodContext,
+            knnMethodConfigContext
+        );
+        Map<String, Object> map = knnLibraryIndexingContext.getLibraryParameters();
+
+        assertTrue(map.containsKey(INDEX_DESCRIPTION_PARAMETER));
+        assertEquals(expectedIndexDescription, map.get(INDEX_DESCRIPTION_PARAMETER));
+        assertEquals(QuantizationConfig.EMPTY, knnLibraryIndexingContext.getQuantizationConfig());
+    }
+
+    @SneakyThrows
+    public void testGetKNNLibraryIndexingContext_whenMethodIsHNSWSQOneBit_thenEncoderParamsAreCorrect() {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .versionCreated(org.opensearch.Version.CURRENT)
+            .dimension(64)
+            .vectorDataType(VectorDataType.FLOAT)
+            .build();
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, FAISS_NAME)
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_M, 16)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, ENCODER_SQ)
+            .startObject(PARAMETERS)
+            .field(SQ_BITS, 1)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
+        KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
+
+        Map<String, Object> map = Faiss.INSTANCE.getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext)
+            .getLibraryParameters();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> encoderParams = (Map<String, Object>) ((Map<String, Object>) map.get(PARAMETERS)).get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_SQ, encoderParams.get(NAME));
+        assertEquals(1, encoderParams.get(SQ_BITS));
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import static org.mockito.Mockito.mock;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -176,5 +177,62 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
     public void testResolve_whenNoArgCalled_thenThrowUnsupportedOperationException() {
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(Map.of());
         expectThrows(UnsupportedOperationException.class, resolver::resolve);
+    }
+
+    public void testResolve_whenHnswWithSQOneBitEncoder_thenReturnSQFormat() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(LUCENE_SQ_BITS, 1);
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        params.put(METHOD_PARAMETER_M, 16);
+        params.put(METHOD_PARAMETER_EF_CONSTRUCTION, 100);
+
+        KNNMethodContext sqContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, params));
+
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.SCALAR_QUANTIZED,
+            ctx -> SQ_FORMAT,
+            LuceneVectorsFormatType.HNSW,
+            ctx -> HNSW_FORMAT
+        );
+
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        assertSame("SQ with bits=1 should route to SCALAR_QUANTIZED resolver", SQ_FORMAT, result);
+    }
+
+    public void testResolve_whenHnswWithSQOneBitEncoder_thenContextContainsBitsParam() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(LUCENE_SQ_BITS, 1);
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        params.put(METHOD_PARAMETER_M, 32);
+        params.put(METHOD_PARAMETER_EF_CONSTRUCTION, 200);
+
+        KNNMethodContext sqContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, params));
+
+        final KnnVectorsFormatContext[] capturedContext = new KnnVectorsFormatContext[1];
+        Map<LuceneVectorsFormatType, Function<KnnVectorsFormatContext, KnnVectorsFormat>> resolvers = Map.of(
+            LuceneVectorsFormatType.SCALAR_QUANTIZED,
+            ctx -> {
+                capturedContext[0] = ctx;
+                return SQ_FORMAT;
+            },
+            LuceneVectorsFormatType.HNSW,
+            ctx -> HNSW_FORMAT
+        );
+
+        LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
+        resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+
+        assertNotNull(capturedContext[0]);
+        assertEquals(TEST_FIELD, capturedContext[0].getField());
+        Object encoder = capturedContext[0].getParams().get(METHOD_ENCODER_PARAMETER);
+        assertTrue(encoder instanceof MethodComponentContext);
+        assertEquals(1, ((MethodComponentContext) encoder).getParameters().get(LUCENE_SQ_BITS));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
@@ -434,4 +434,234 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveMethod_whenExplicitCompression32x_thenResolvesToSQOneBit() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x32)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
+        assertEquals(KNNEngine.LUCENE, resolvedMethodContext.getKnnMethodContext().getKnnEngine());
+        assertEquals(
+            ENCODER_SQ,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+        assertEquals(
+            1,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getParameters().get(LUCENE_SQ_BITS)
+        );
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            new KNNMethodContext(KNNEngine.LUCENE, SpaceType.INNER_PRODUCT, new MethodComponentContext(METHOD_HNSW, Map.of())),
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x32)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
+        assertEquals(
+            ENCODER_SQ,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+        assertEquals(
+            1,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getParameters().get(LUCENE_SQ_BITS)
+        );
+    }
+
+    public void testResolveMethod_whenExplicitCompression4x_thenResolvesToSQSevenBit() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .compressionLevel(CompressionLevel.x4)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x4, resolvedMethodContext.getCompressionLevel());
+        assertEquals(KNNEngine.LUCENE, resolvedMethodContext.getKnnMethodContext().getKnnEngine());
+        assertEquals(
+            ENCODER_SQ,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+        assertEquals(
+            7,
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getParameters().get(LUCENE_SQ_BITS)
+        );
+    }
+
+    public void testResolveMethod_whenNoCompressionSpecified_thenResolvesToX1() {
+        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_7_0+, keep x1 for older versions
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertEquals(KNNEngine.LUCENE, resolvedMethodContext.getKnnMethodContext().getKnnEngine());
+        assertFalse(
+            resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
+        );
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertFalse(
+            resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
+        );
+
+        resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BYTE).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x1, resolvedMethodContext.getCompressionLevel());
+        assertFalse(
+            resolvedMethodContext.getKnnMethodContext().getMethodComponentContext().getParameters().containsKey(METHOD_ENCODER_PARAMETER)
+        );
+    }
+
+    public void testResolveMethod_whenOnDiskMode_thenSQEncoderHasBits1() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .mode(Mode.ON_DISK)
+                .versionCreated(Version.CURRENT)
+                .build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        assertEquals(CompressionLevel.x32, resolvedMethodContext.getCompressionLevel());
+        MethodComponentContext encoderCtx = (MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_SQ, encoderCtx.getName());
+        assertEquals(1, encoderCtx.getParameters().get(LUCENE_SQ_BITS));
+    }
+
+    public void testResolveMethod_whenNoCompressionAcrossVersions_thenAlwaysResolvesToX1() {
+        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_7_0 → assert x1,
+        // indexVersionCreated >= V_3_7_0 → assert x32
+        Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
+
+        for (Version version : versions) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x1 for version " + version + " with no compression specified",
+                CompressionLevel.x1,
+                resolvedMethodContext.getCompressionLevel()
+            );
+            assertFalse(
+                resolvedMethodContext.getKnnMethodContext()
+                    .getMethodComponentContext()
+                    .getParameters()
+                    .containsKey(METHOD_ENCODER_PARAMETER)
+            );
+        }
+
+        for (Version version : versions) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, new MethodComponentContext(METHOD_HNSW, Map.of())),
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x1 for version " + version + " with HNSW and no compression",
+                CompressionLevel.x1,
+                resolvedMethodContext.getCompressionLevel()
+            );
+            assertFalse(
+                resolvedMethodContext.getKnnMethodContext()
+                    .getMethodComponentContext()
+                    .getParameters()
+                    .containsKey(METHOD_ENCODER_PARAMETER)
+            );
+        }
+
+        for (Version version : versions) {
+            ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.BYTE).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x1 for BYTE data type at version " + version,
+                CompressionLevel.x1,
+                resolvedMethodContext.getCompressionLevel()
+            );
+        }
+    }
+
+    public void testResolveMethod_whenOnDiskAcrossVersions_thenVersionDeterminesCompression() {
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            null,
+            KNNMethodConfigContext.builder()
+                .vectorDataType(VectorDataType.FLOAT)
+                .mode(Mode.ON_DISK)
+                .versionCreated(Version.V_3_5_0)
+                .build(),
+            false,
+            SpaceType.L2
+        );
+        assertEquals(CompressionLevel.x4, resolvedMethodContext.getCompressionLevel());
+
+        Version[] postV360Versions = new Version[] { Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
+        for (Version version : postV360Versions) {
+            resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+                null,
+                KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).mode(Mode.ON_DISK).versionCreated(version).build(),
+                false,
+                SpaceType.L2
+            );
+            assertEquals(
+                "Expected x32 for version " + version + " with ON_DISK mode",
+                CompressionLevel.x32,
+                resolvedMethodContext.getCompressionLevel()
+            );
+        }
+    }
+
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
@@ -134,6 +134,34 @@ public class LuceneSQEncoderTests extends KNNTestCase {
         callValidateEncoderParams(Version.CURRENT, CompressionLevel.x4, Map.of(LUCENE_SQ_BITS, 7));
     }
 
+    public void testCalculateCompressionLevel_whenBits1InMethodComponentContext_thenX32() {
+        LuceneSQEncoder encoder = new LuceneSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 1));
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build();
+        assertEquals(CompressionLevel.x32, encoder.calculateCompressionLevel(mcc, context));
+    }
+
+    public void testCalculateCompressionLevel_whenBits7InMethodComponentContext_thenX4() {
+        LuceneSQEncoder encoder = new LuceneSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 7));
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).build();
+        assertEquals(CompressionLevel.x4, encoder.calculateCompressionLevel(mcc, context));
+    }
+
+    public void testCalculateCompressionLevel_whenBits1AndExplicitCompressionX32_thenX32() {
+        LuceneSQEncoder encoder = new LuceneSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 1));
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+        assertEquals(CompressionLevel.x32, encoder.calculateCompressionLevel(mcc, context));
+    }
+
+    public void testValidate_whenBits1WithX32Compression_explicitOnDisk_thenOk() {
+        callValidateEncoderParams(Version.CURRENT, CompressionLevel.x32, Map.of(LUCENE_SQ_BITS, 1));
+    }
+
     private void callValidateEncoderParams(Version version, CompressionLevel compressionLevel, Map<String, Object> encoderParams) {
         KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
             .versionCreated(version)

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -8,7 +8,10 @@ package org.opensearch.knn.index.mapper;
 import org.opensearch.core.common.Strings;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+import org.opensearch.knn.index.engine.lucene.LuceneSQEncoder;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 import org.opensearch.Version;
 
 public class CompressionLevelTests extends KNNTestCase {
@@ -212,5 +215,75 @@ public class CompressionLevelTests extends KNNTestCase {
         rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(Mode.ON_DISK, 500, Version.CURRENT, false, false);
         assertNotNull(rescoreContext);
         assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
+    }
+
+    public void testX32MapsToOneBitQuantization() {
+        assertEquals(1, CompressionLevel.x32.numBitsForFloat32());
+
+        assertEquals(CompressionLevel.x32, FaissSQEncoder.Bits.ONE.getCompressionLevel());
+        assertEquals(1, FaissSQEncoder.Bits.ONE.getValue());
+
+        assertEquals(CompressionLevel.x32, LuceneSQEncoder.Bits.ONE.getCompressionLevel());
+        assertEquals(1, LuceneSQEncoder.Bits.ONE.getValue());
+
+        assertEquals(1, ScalarQuantizationType.ONE_BIT.getId());
+    }
+
+    public void testCompressionLevelEnumMappings() {
+        assertEquals(1, CompressionLevel.x32.numBitsForFloat32());
+        assertEquals("32x", CompressionLevel.x32.getName());
+
+        assertEquals(2, CompressionLevel.x16.numBitsForFloat32());
+        assertEquals("16x", CompressionLevel.x16.getName());
+
+        assertEquals(4, CompressionLevel.x8.numBitsForFloat32());
+        assertEquals("8x", CompressionLevel.x8.getName());
+
+        assertEquals(8, CompressionLevel.x4.numBitsForFloat32());
+        assertEquals("4x", CompressionLevel.x4.getName());
+
+        assertEquals(16, CompressionLevel.x2.numBitsForFloat32());
+        assertEquals("2x", CompressionLevel.x2.getName());
+
+        assertEquals(32, CompressionLevel.x1.numBitsForFloat32());
+        assertEquals("1x", CompressionLevel.x1.getName());
+    }
+
+    public void testFromNameAllValidLevels() {
+        assertEquals(CompressionLevel.x1, CompressionLevel.fromName("1x"));
+        assertEquals(CompressionLevel.x2, CompressionLevel.fromName("2x"));
+        assertEquals(CompressionLevel.x4, CompressionLevel.fromName("4x"));
+        assertEquals(CompressionLevel.x8, CompressionLevel.fromName("8x"));
+        assertEquals(CompressionLevel.x16, CompressionLevel.fromName("16x"));
+        assertEquals(CompressionLevel.x32, CompressionLevel.fromName("32x"));
+        assertEquals(CompressionLevel.x64, CompressionLevel.fromName("64x"));
+    }
+
+    public void testDefaultCompressionIsX1() {
+        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 (SQ 1-bit) instead
+        assertEquals(32, CompressionLevel.NOT_CONFIGURED.numBitsForFloat32());
+        assertEquals(CompressionLevel.x1.numBitsForFloat32(), CompressionLevel.NOT_CONFIGURED.numBitsForFloat32());
+    }
+
+    public void testMaxCompressionLevelConstant() {
+        assertEquals(CompressionLevel.x64, CompressionLevel.MAX_COMPRESSION_LEVEL);
+    }
+
+    public void testFromName_whenInvalid_thenThrows() {
+        expectThrows(IllegalArgumentException.class, () -> CompressionLevel.fromName("99x"));
+        expectThrows(IllegalArgumentException.class, () -> CompressionLevel.fromName("0x"));
+        expectThrows(IllegalArgumentException.class, () -> CompressionLevel.fromName("x32"));
+        expectThrows(IllegalArgumentException.class, () -> CompressionLevel.fromName("3x"));
+        expectThrows(IllegalArgumentException.class, () -> CompressionLevel.fromName("abc"));
+        expectThrows(IllegalArgumentException.class, () -> CompressionLevel.fromName("-1x"));
+    }
+
+    public void testX32ConsistentAcrossEngineEncoders() {
+        FaissSQEncoder.Bits faissBits1 = FaissSQEncoder.Bits.fromValue(1);
+        LuceneSQEncoder.Bits luceneBits1 = LuceneSQEncoder.Bits.fromValue(1);
+
+        assertEquals(faissBits1.getCompressionLevel(), luceneBits1.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, faissBits1.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, luceneBits1.getCompressionLevel());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.tests.util.LuceneTestCase.AwaitsFix;
 import org.junit.Assert;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -2548,6 +2549,204 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
             buildParserContext(indexName, settings)
         );
         assertNotNull(builder3);
+    }
+
+    @SneakyThrows
+    public void testTypeParser_whenInvalidCompressionLevel_thenReject() {
+        int dimension = 16;
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder invalidCompressionBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "99x")
+            .endObject();
+        expectThrows(
+            MapperParsingException.class,
+            () -> typeParser.parse(
+                TEST_FIELD_NAME,
+                xContentBuilderToMap(invalidCompressionBuilder),
+                buildParserContext(TEST_INDEX_NAME, settings)
+            )
+        );
+
+        XContentBuilder numericCompressionBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, 32)
+            .endObject();
+        expectThrows(
+            MapperParsingException.class,
+            () -> typeParser.parse(
+                TEST_FIELD_NAME,
+                xContentBuilderToMap(numericCompressionBuilder),
+                buildParserContext(TEST_INDEX_NAME, settings)
+            )
+        );
+
+        XContentBuilder emptyCompressionBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "")
+            .endObject();
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            TEST_FIELD_NAME,
+            xContentBuilderToMap(emptyCompressionBuilder),
+            buildParserContext(TEST_INDEX_NAME, settings)
+        );
+        assertEquals(CompressionLevel.NOT_CONFIGURED, CompressionLevel.fromName(builder.getOriginalParameters().getCompressionLevel()));
+    }
+
+    @SneakyThrows
+    public void testTypeParser_whenCompression1x_thenFP32NoQuantization() {
+        int dimension = 16;
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder x1Builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x1.getName())
+            .endObject();
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            TEST_FIELD_NAME,
+            xContentBuilderToMap(x1Builder),
+            buildParserContext(TEST_INDEX_NAME, settings)
+        );
+        assertEquals(CompressionLevel.x1, CompressionLevel.fromName(builder.getOriginalParameters().getCompressionLevel()));
+        assertEquals(CompressionLevel.x1, builder.getKnnMethodConfigContext().getCompressionLevel());
+
+        XContentBuilder x1InMemoryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x1.getName())
+            .field(MODE_PARAMETER, Mode.IN_MEMORY.getName())
+            .endObject();
+        builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            TEST_FIELD_NAME,
+            xContentBuilderToMap(x1InMemoryBuilder),
+            buildParserContext(TEST_INDEX_NAME, settings)
+        );
+        validateBuilderAfterParsing(
+            builder,
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            VectorDataType.FLOAT,
+            CompressionLevel.x1,
+            CompressionLevel.x1,
+            Mode.IN_MEMORY,
+            false
+        );
+    }
+
+    @SneakyThrows
+    public void testTypeParser_whenEncoderFlat_thenFP32NoQuantization() {
+        int dimension = 16;
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder flatEncoderBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, KNNEngine.FAISS.getName())
+            .startObject(PARAMETERS)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "flat")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            TEST_FIELD_NAME,
+            xContentBuilderToMap(flatEncoderBuilder),
+            buildParserContext(TEST_INDEX_NAME, settings)
+        );
+        assertEquals(CompressionLevel.x1, builder.getKnnMethodConfigContext().getCompressionLevel());
+        assertFalse(builder.getOriginalParameters().isLegacyMapping());
+    }
+
+    @SneakyThrows
+    public void testTypeParser_whenOnDiskWith32xCompression_thenSuccess() {
+        int dimension = 16;
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder onDisk32xBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x32.getName())
+            .endObject();
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            TEST_FIELD_NAME,
+            xContentBuilderToMap(onDisk32xBuilder),
+            buildParserContext(TEST_INDEX_NAME, settings)
+        );
+        validateBuilderAfterParsing(
+            builder,
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            VectorDataType.FLOAT,
+            CompressionLevel.x32,
+            CompressionLevel.x32,
+            Mode.ON_DISK,
+            true
+        );
+    }
+
+    @SneakyThrows
+    public void testTypeParser_whenInMemoryWith1xCompression_thenSuccess() {
+        int dimension = 16;
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        XContentBuilder inMemory1xBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(MODE_PARAMETER, Mode.IN_MEMORY.getName())
+            .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x1.getName())
+            .endObject();
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            TEST_FIELD_NAME,
+            xContentBuilderToMap(inMemory1xBuilder),
+            buildParserContext(TEST_INDEX_NAME, settings)
+        );
+        validateBuilderAfterParsing(
+            builder,
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            VectorDataType.FLOAT,
+            CompressionLevel.x1,
+            CompressionLevel.x1,
+            Mode.IN_MEMORY,
+            false
+        );
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/3290")
+    public void testModeDeprecationWarning_placeholder() {
+        // TODO: [DEFAULT_FLIP] After Step 4, mode parameter is deprecated and derived from compression_level.
+        // Add warning assertions here to verify that:
+        // - Using mode=on_disk emits a deprecation warning after 3.7.0
+        // - Using mode=in_memory emits a deprecation warning after 3.7.0
+        // - compression_level alone (without mode) does not emit a deprecation warning
+        // - mode is correctly inferred from compression_level: x32 → on_disk behavior, x1 → in_memory behavior
     }
 
     private void validateBuilderAfterParsing(

--- a/src/test/java/org/opensearch/knn/quantization/quantizer/OneBitScalarQuantizerTests.java
+++ b/src/test/java/org/opensearch/knn/quantization/quantizer/OneBitScalarQuantizerTests.java
@@ -397,6 +397,200 @@ public class OneBitScalarQuantizerTests extends KNNTestCase {
         assertSame(firstByteArray, thirdByteArray);
     }
 
+    public void testOneBitConfig_producesOneBitPerDimension() {
+        ScalarQuantizationParams params = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
+        assertEquals(1, params.getSqType().getId());
+
+        float[] thresholds8D = new float[8];
+        OneBitScalarQuantizationState state8D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds8D)
+            .build();
+        assertEquals(1, state8D.getBytesPerVector());
+        assertEquals(8, state8D.getDimensions());
+
+        float[] thresholds16D = new float[16];
+        OneBitScalarQuantizationState state16D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds16D)
+            .build();
+        assertEquals(2, state16D.getBytesPerVector());
+        assertEquals(16, state16D.getDimensions());
+
+        float[] thresholds128D = new float[128];
+        OneBitScalarQuantizationState state128D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds128D)
+            .build();
+        assertEquals(16, state128D.getBytesPerVector());
+        assertEquals(128, state128D.getDimensions());
+        // FP32 uses 4 bytes per dimension; 1-bit uses 1 bit per dimension → 32x compression
+        int fp32Bytes = 128 * Float.BYTES;
+        assertEquals(32, fp32Bytes / state128D.getBytesPerVector());
+    }
+
+    public void testOneBitConfig_unalignedDimensions_bytesPerVector() {
+        ScalarQuantizationParams params = ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build();
+
+        float[] thresholds3D = new float[3];
+        OneBitScalarQuantizationState state3D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds3D)
+            .build();
+        assertEquals(1, state3D.getBytesPerVector());
+        assertEquals(8, state3D.getDimensions());
+
+        float[] thresholds9D = new float[9];
+        OneBitScalarQuantizationState state9D = OneBitScalarQuantizationState.builder()
+            .quantizationParams(params)
+            .meanThresholds(thresholds9D)
+            .build();
+        assertEquals(2, state9D.getBytesPerVector());
+        assertEquals(16, state9D.getDimensions());
+    }
+
+    public void testOneBitQuantize_roundTripErrorIsBounded() throws IOException {
+        float[][] vectors = {
+            { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f },
+            { 8.0f, 7.0f, 6.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f },
+            { 4.0f, 4.0f, 4.0f, 4.0f, 5.0f, 5.0f, 5.0f, 5.0f },
+            { 1.5f, 3.5f, 5.5f, 7.5f, 2.5f, 4.5f, 6.5f, 8.5f } };
+
+        TrainingRequest<float[]> trainingRequest = new TrainingRequest<float[]>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+
+            @Override
+            public void resetVectorValues() {
+                // No-op
+            }
+        };
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        OneBitScalarQuantizationState state = (OneBitScalarQuantizationState) quantizer.train(trainingRequest);
+        float[] thresholds = state.getMeanThresholds();
+
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+        for (float[] vector : vectors) {
+            quantizer.quantize(vector, state, output);
+            byte[] quantized = output.getQuantizedVector();
+
+            // Reconstruct: bit=1 → aboveThresholdMean, bit=0 → belowThresholdMean
+            float[] aboveMeans = state.getAboveThresholdMeans();
+            float[] belowMeans = state.getBelowThresholdMeans();
+            float[] reconstructed = new float[vector.length];
+            for (int d = 0; d < vector.length; d++) {
+                int byteIndex = d >> 3;
+                int bitIndex = 7 - (d & 7);
+                boolean bitSet = (quantized[byteIndex] & (1 << bitIndex)) != 0;
+                reconstructed[d] = bitSet ? aboveMeans[d] : belowMeans[d];
+            }
+
+            for (int d = 0; d < vector.length; d++) {
+                float error = Math.abs(vector[d] - reconstructed[d]);
+                float spread = Math.abs(aboveMeans[d] - belowMeans[d]);
+                assertTrue(
+                    "Reconstruction error " + error + " exceeds data spread " + spread + " at dimension " + d,
+                    error <= spread + 1e-6f
+                );
+            }
+        }
+    }
+
+    public void testOneBitQuantize_consistentBitAssignment() throws IOException {
+        float[] thresholds = { 4.0f, 5.0f, 6.0f, 7.0f, 3.0f, 4.0f, 5.0f, 6.0f };
+        OneBitScalarQuantizationState state = OneBitScalarQuantizationState.builder()
+            .quantizationParams(ScalarQuantizationParams.builder().sqType(ScalarQuantizationType.ONE_BIT).build())
+            .meanThresholds(thresholds)
+            .build();
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        BinaryQuantizationOutput output = new BinaryQuantizationOutput(1);
+
+        float[] allAbove = { 5.0f, 6.0f, 7.0f, 8.0f, 4.0f, 5.0f, 6.0f, 7.0f };
+        quantizer.quantize(allAbove, state, output);
+        byte[] result = output.getQuantizedVector();
+        assertEquals("All bits should be 1 → 0xFF", (byte) 0xFF, result[0]);
+
+        float[] allBelow = { 3.0f, 4.0f, 5.0f, 6.0f, 2.0f, 3.0f, 4.0f, 5.0f };
+        output.prepareQuantizedVector(allBelow.length);
+        quantizer.quantize(allBelow, state, output);
+        result = output.getQuantizedVector();
+        assertEquals("All bits should be 0 → 0x00", (byte) 0x00, result[0]);
+    }
+
+    public void testTrain_withSingleVector() throws IOException {
+        float[][] vectors = { { 5.0f, 10.0f, 15.0f } };
+        TrainingRequest<float[]> trainingRequest = new TrainingRequest<float[]>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+
+            @Override
+            public void resetVectorValues() {
+                // No-op
+            }
+        };
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        OneBitScalarQuantizationState state = (OneBitScalarQuantizationState) quantizer.train(trainingRequest);
+        assertNotNull(state);
+        assertNotNull(state.getMeanThresholds());
+        assertEquals(3, state.getMeanThresholds().length);
+        assertArrayEquals(new float[] { 5.0f, 10.0f, 15.0f }, state.getMeanThresholds(), 0.001f);
+    }
+
+    public void testTrain_withLargeNumberOfVectors() throws IOException {
+        int numVectors = 1000;
+        int dimensions = 64;
+        float[][] vectors = new float[numVectors][dimensions];
+        for (int i = 0; i < numVectors; i++) {
+            for (int d = 0; d < dimensions; d++) {
+                vectors[i][d] = (float) (i * dimensions + d) / (numVectors * dimensions);
+            }
+        }
+
+        TrainingRequest<float[]> trainingRequest = new TrainingRequest<float[]>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+
+            @Override
+            public void resetVectorValues() {
+                // No-op
+            }
+        };
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        OneBitScalarQuantizationState state = (OneBitScalarQuantizationState) quantizer.train(trainingRequest);
+        assertNotNull(state);
+        float[] thresholds = state.getMeanThresholds();
+        assertEquals(dimensions, thresholds.length);
+        assertEquals(8, state.getBytesPerVector());
+    }
+
+    public void testTrain_withEmptyVectorSet_throwsException() {
+        float[][] vectors = {};
+        TrainingRequest<float[]> trainingRequest = new TrainingRequest<float[]>(vectors.length) {
+            @Override
+            public float[] getVectorAtThePosition(int position) {
+                return vectors[position];
+            }
+
+            @Override
+            public void resetVectorValues() {
+                // No-op
+            }
+        };
+
+        OneBitScalarQuantizer quantizer = new OneBitScalarQuantizer();
+        expectThrows(IllegalArgumentException.class, () -> quantizer.train(trainingRequest));
+    }
+
     public void testQuantize_withMultipleVectors_inLoop() throws IOException {
         OneBitScalarQuantizer oneBitQuantizer = new OneBitScalarQuantizer();
         float[][] vectors = { { 1.0f, 2.0f, 3.0f, 4.0f }, { 2.0f, 3.0f, 4.0f, 5.0f }, { 1.5f, 2.5f, 3.5f, 4.5f } };


### PR DESCRIPTION
### Description
Enhances unit test coverage for the 32x default compression behavior and one-bit scalar quantization paths across k-NN engines, method resolvers, codec format selection, and quantization utilities.

#### Engine and method resolution

Adds coverage for engine and method resolver behavior around 32x compression defaults, including:

- `ON_DISK + 32x` resolving to Faiss where applicable.
- `IN_MEMORY + 1x` resolving to Faiss for newer index versions.
- Version-gated behavior for default engine resolution.
- Lucene HNSW resolution for:
  - explicit `32x` compression
  - explicit `4x` compression
  - `ON_DISK` mode defaults
  - older index-version compatibility
  - invalid compression / SQ bit combinations.

#### Faiss SQ encoder behavior

Adds tests for Faiss scalar quantization encoder behavior, including:

- `bits=1` mapping to `32x` compression.
- `bits=16` mapping to `2x` compression.
- Validation of supported and unsupported SQ bit values.
- Validation that one-bit SQ is only supported for compatible vector data types.
- Validation of incompatible parameter combinations such as `bits=1` with `type` or `clip`.
- Backward-compatible behavior for legacy SQ configurations without explicit bits.

#### Lucene SQ encoder behavior

Adds tests for Lucene scalar quantization encoder behavior, including:

- `bits=1` mapping to `32x` compression.
- `bits=7` mapping to `4x` compression.
- Validation of version-gated SQ behavior.
- Validation of invalid bit values and unsupported parameter combinations.
- Validation that explicitly provided compression levels take precedence where expected.

#### Codec format selection

Adds coverage for codec format routing to ensure the correct vector format is selected for:

- Lucene HNSW with one-bit SQ.
- Lucene HNSW with default SQ bits.
- Lucene HNSW without an encoder.
- Faiss SQ with one-bit quantization.
- Faiss SQ with non-one-bit quantization.
- Flat scalar-quantized vector formats.

#### Compression and quantization utilities

Adds coverage for:

- Parsing and handling of `32x` compression level.
- `32x` mapping to one bit for float32 vectors.
- Default rescore behavior for higher compression levels.


### Related Issues
Related #3290 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
