### PR TITLE
Fix derived source for mixed-case vector fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable prefetch [#3302](https://github.com/opensearch-project/k-NN/pull/3302)
+* Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
 
 ### Refactoring
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -14,6 +14,7 @@ import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.opensearch.knn.TestUtils.BWC_VERSION;
@@ -114,6 +115,85 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
         } else {
             validateDerivedSetting(indexName, true);
         }
+    }
+
+    public void testMixedCaseDerivedSourceField_indexOnOld_reconstructOnNew() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        String indexName = getIndexName("knn-bwc", "mixed-case-derived-source-", false);
+        int dimension = 3;
+
+        if (isRunningAgainstOldCluster()) {
+            Settings settings = Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put("index.knn.derived_source.enabled", true)
+                .build();
+
+            createKnnIndex(indexName, settings, createMixedCaseVectorMapping(dimension));
+            addKnnDoc(indexName, "1", createMixedCaseVectorDoc());
+            refreshIndex(indexName);
+            flushIndex(indexName);
+        } else {
+            refreshIndex(indexName);
+            List<?> retrievedVector = extractVector(getKnnDoc(indexName, "1"), "vectorSearch", "nameVector");
+
+            assertNotNull("Mixed-case vector field should be reconstructed from old lowercase segment metadata", retrievedVector);
+            assertEquals(dimension, retrievedVector.size());
+            assertEquals(1.0f, ((Number) retrievedVector.get(0)).floatValue(), 0.0f);
+            assertEquals(2.0f, ((Number) retrievedVector.get(1)).floatValue(), 0.0f);
+            assertEquals(3.0f, ((Number) retrievedVector.get(2)).floatValue(), 0.0f);
+
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    private String createMixedCaseVectorMapping(int dimension) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("vectorSearch")
+            .startObject("properties")
+            .startObject("nameVector")
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject("method")
+            .field("engine", "lucene")
+            .field("space_type", "l2")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        return builder.toString();
+    }
+
+    private String createMixedCaseVectorDoc() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("vectorSearch")
+            .array("nameVector", 1.0f, 2.0f, 3.0f)
+            .endObject()
+            .endObject();
+        return builder.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<?> extractVector(Map<String, Object> source, String... path) {
+        Object current = source;
+        for (String key : path) {
+            if (current instanceof Map) {
+                current = ((Map<String, Object>) current).get(key);
+            } else {
+                return null;
+            }
+        }
+        if (current instanceof List) {
+            return (List<?>) current;
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -104,13 +104,19 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                 continue;
             }
             if (matchedFieldInfo != null) {
-                log.warn(
-                    "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
-                    field,
-                    matchedFieldInfo.name,
-                    candidate.name
-                );
-                return null;
+                if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) {
+                    log.warn(
+                        "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
+                        field,
+                        matchedFieldInfo.name,
+                        candidate.name
+                    );
+                    return null;
+                }
+                if (candidate.hasVectorValues()) {
+                    matchedFieldInfo = candidate;
+                }
+                continue;
             }
             matchedFieldInfo = candidate;
         }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -11,6 +11,7 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
@@ -48,12 +49,10 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         List<DerivedFieldInfo> derivedVectorFields = Stream.concat(
             DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false)
                 .stream()
-                .filter(field -> fieldInfos.fieldInfo(field) != null)
-                .map(field -> new DerivedFieldInfo(fieldInfos.fieldInfo(field), false)),
+                .flatMap(field -> getDerivedFieldInfo(fieldInfos, field, false)),
             DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, true)
                 .stream()
-                .filter(field -> fieldInfos.fieldInfo(field) != null)
-                .map(field -> new DerivedFieldInfo(fieldInfos.fieldInfo(field), true))
+                .flatMap(field -> getDerivedFieldInfo(fieldInfos, field, true))
         ).toList();
 
         // If no fields have it enabled, we can just short-circuit and return the delegate's fieldReader
@@ -79,6 +78,33 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         } else {
             return delegate;
         }
+    }
+
+    private Stream<DerivedFieldInfo> getDerivedFieldInfo(FieldInfos fieldInfos, String field, boolean isNested) {
+        FieldInfo fieldInfo = getFieldInfo(fieldInfos, field);
+        if (fieldInfo == null) {
+            return Stream.empty();
+        }
+        return Stream.of(new DerivedFieldInfo(fieldInfo, isNested));
+    }
+
+    static FieldInfo getFieldInfo(FieldInfos fieldInfos, String field) {
+        FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
+        if (fieldInfo != null) {
+            return fieldInfo;
+        }
+
+        FieldInfo matchedFieldInfo = null;
+        for (FieldInfo candidate : fieldInfos) {
+            if (candidate.name.equalsIgnoreCase(field) == false) {
+                continue;
+            }
+            if (matchedFieldInfo != null) {
+                return null;
+            }
+            matchedFieldInfo = candidate;
+        }
+        return matchedFieldInfo;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -5,7 +5,9 @@
 
 package org.opensearch.knn.index.codec.KNN10010Codec;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 @AllArgsConstructor
+@Log4j2
 public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
     // Stores the delegate codec name (in case it is different from the default one)
     static final String KNN_DELEGATE_CODEC_NAME = "knn_delegate_stored_fields_codec_key";
@@ -88,6 +91,7 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         return Stream.of(new DerivedFieldInfo(fieldInfo, isNested));
     }
 
+    @VisibleForTesting
     static FieldInfo getFieldInfo(FieldInfos fieldInfos, String field) {
         FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
         if (fieldInfo != null) {
@@ -100,6 +104,12 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                 continue;
             }
             if (matchedFieldInfo != null) {
+                log.warn(
+                    "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
+                    field,
+                    matchedFieldInfo.name,
+                    candidate.name
+                );
                 return null;
             }
             matchedFieldInfo = candidate;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -102,9 +102,14 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
             if (candidate.name.equalsIgnoreCase(field) == false) {
                 continue;
             }
-            if (matchedFieldInfo == null || candidate.hasVectorValues() && !matchedFieldInfo.hasVectorValues()) {
+            if (matchedFieldInfo == null) {
                 matchedFieldInfo = candidate;
-            } else if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) {
+                continue;
+            }
+
+            boolean matchedHasVectorValues = matchedFieldInfo.hasVectorValues();
+            boolean candidateHasVectorValues = candidate.hasVectorValues();
+            if (matchedHasVectorValues == candidateHasVectorValues) {
                 log.warn(
                     "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
                     field,
@@ -112,6 +117,9 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                     candidate.name
                 );
                 return null;
+            }
+            if (candidateHasVectorValues) {
+                matchedFieldInfo = candidate;
             }
         }
         return matchedFieldInfo;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -102,14 +102,9 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
             if (candidate.name.equalsIgnoreCase(field) == false) {
                 continue;
             }
-            if (matchedFieldInfo == null) {
+            if (matchedFieldInfo == null || candidate.hasVectorValues() && !matchedFieldInfo.hasVectorValues()) {
                 matchedFieldInfo = candidate;
-                continue;
-            }
-
-            boolean matchedHasVectorValues = matchedFieldInfo.hasVectorValues();
-            boolean candidateHasVectorValues = candidate.hasVectorValues();
-            if (matchedHasVectorValues == candidateHasVectorValues) {
+            } else if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) {
                 log.warn(
                     "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
                     field,
@@ -117,9 +112,6 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                     candidate.name
                 );
                 return null;
-            }
-            if (candidateHasVectorValues) {
-                matchedFieldInfo = candidate;
             }
         }
         return matchedFieldInfo;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -28,8 +28,8 @@ import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttribut
 import org.opensearch.knn.index.util.IndexUtil;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 @AllArgsConstructor
 @Log4j2
@@ -49,14 +49,13 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         throws IOException {
 
         final StoredFieldsFormat delegatingFormat = getStoredFieldsFormat(segmentInfo);
-        List<DerivedFieldInfo> derivedVectorFields = Stream.concat(
-            DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false)
-                .stream()
-                .flatMap(field -> getDerivedFieldInfo(fieldInfos, field, false)),
-            DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, true)
-                .stream()
-                .flatMap(field -> getDerivedFieldInfo(fieldInfos, field, true))
-        ).toList();
+        List<DerivedFieldInfo> derivedVectorFields = new ArrayList<>();
+        for (String field : DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false)) {
+            addDerivedFieldInfo(derivedVectorFields, fieldInfos, field, false);
+        }
+        for (String field : DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, true)) {
+            addDerivedFieldInfo(derivedVectorFields, fieldInfos, field, true);
+        }
 
         // If no fields have it enabled, we can just short-circuit and return the delegate's fieldReader
         if (derivedVectorFields.isEmpty()) {
@@ -83,12 +82,12 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         }
     }
 
-    private Stream<DerivedFieldInfo> getDerivedFieldInfo(FieldInfos fieldInfos, String field, boolean isNested) {
+    private void addDerivedFieldInfo(List<DerivedFieldInfo> derivedFieldInfos, FieldInfos fieldInfos, String field, boolean isNested) {
         FieldInfo fieldInfo = getFieldInfo(fieldInfos, field);
         if (fieldInfo == null) {
-            return Stream.empty();
+            return;
         }
-        return Stream.of(new DerivedFieldInfo(fieldInfo, isNested));
+        derivedFieldInfos.add(new DerivedFieldInfo(fieldInfo, isNested));
     }
 
     @VisibleForTesting

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -102,10 +102,9 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
             if (candidate.name.equalsIgnoreCase(field) == false) {
                 continue;
             }
-            if (matchedFieldInfo != null) {
-                boolean matchedHasVectorValues = matchedFieldInfo.hasVectorValues();
-                boolean candidateHasVectorValues = candidate.hasVectorValues();
-                if (matchedHasVectorValues == candidateHasVectorValues) {
+            if (matchedFieldInfo == null || candidate.hasVectorValues() && !matchedFieldInfo.hasVectorValues()) {
+                matchedFieldInfo = candidate;
+             } else if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) { 
                     log.warn(
                         "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
                         field,
@@ -113,13 +112,7 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                         candidate.name
                     );
                     return null;
-                }
-                if (candidateHasVectorValues) {
-                    matchedFieldInfo = candidate;
-                }
-                continue;
             }
-            matchedFieldInfo = candidate;
         }
         return matchedFieldInfo;
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -103,7 +103,9 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                 continue;
             }
             if (matchedFieldInfo != null) {
-                if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) {
+                boolean matchedHasVectorValues = matchedFieldInfo.hasVectorValues();
+                boolean candidateHasVectorValues = candidate.hasVectorValues();
+                if (matchedHasVectorValues == candidateHasVectorValues) {
                     log.warn(
                         "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
                         field,
@@ -112,7 +114,7 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
                     );
                     return null;
                 }
-                if (candidate.hasVectorValues()) {
+                if (candidateHasVectorValues) {
                     matchedFieldInfo = candidate;
                 }
                 continue;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -104,14 +104,14 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
             }
             if (matchedFieldInfo == null || candidate.hasVectorValues() && !matchedFieldInfo.hasVectorValues()) {
                 matchedFieldInfo = candidate;
-             } else if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) { 
-                    log.warn(
-                        "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
-                        field,
-                        matchedFieldInfo.name,
-                        candidate.name
-                    );
-                    return null;
+            } else if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) {
+                log.warn(
+                    "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
+                    field,
+                    matchedFieldInfo.name,
+                    candidate.name
+                );
+                return null;
             }
         }
         return matchedFieldInfo;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -140,7 +140,7 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
         for (MappedFieldType fieldType : mapperService.fieldTypes()) {
             if (fieldType instanceof KNNVectorFieldType knnVectorFieldType) {
                 if (IndexUtil.isDerivedEnabledForField(knnVectorFieldType, mapperService)) {
-                    String fieldName = fieldType.name().toLowerCase();
+                    String fieldName = fieldType.name();
                     boolean isNested = mapperService.documentMapper().mappers().getNestedScope(fieldType.name()) != null;
 
                     if (isNested) {

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
@@ -8,9 +8,18 @@ package org.opensearch.knn.index.codec.KNN10010Codec;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
+    private static final String NMSLIB_ENGINE_NAME = "nmslib";
 
     public void testGetFieldInfoReturnsExactMatch() {
         FieldInfo exactFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
@@ -57,5 +66,33 @@ public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
         FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { nonVectorFieldInfo, vectorFieldInfo });
 
         assertSame(vectorFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoPrefersNativeFaissVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
+        assertNativeVectorFieldPreferred(FAISS_NAME);
+    }
+
+    public void testGetFieldInfoPrefersNativeNmslibVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
+        assertNativeVectorFieldPreferred(NMSLIB_ENGINE_NAME);
+    }
+
+    private void assertNativeVectorFieldPreferred(String engineName) {
+        FieldInfo nonVectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(1).build();
+        FieldInfo nativeVectorFieldInfo = nativeVectorFieldInfo(engineName);
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { nonVectorFieldInfo, nativeVectorFieldInfo });
+
+        assertTrue(nativeVectorFieldInfo.hasVectorValues());
+        assertSame(nativeVectorFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    private FieldInfo nativeVectorFieldInfo(String engineName) {
+        return KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")
+            .fieldNumber(2)
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .addAttribute(KNN_METHOD, METHOD_HNSW)
+            .addAttribute(KNN_ENGINE, engineName)
+            .addAttribute(VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue())
+            .vectorDimension(16)
+            .build();
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN10010Codec;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+
+public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
+
+    public void testGetFieldInfoReturnsExactMatch() {
+        FieldInfo exactFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { exactFieldInfo });
+
+        assertSame(exactFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorSearch.nameVector"));
+    }
+
+    public void testGetFieldInfoFallsBackToUnambiguousCaseInsensitiveMatch() {
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo });
+
+        assertSame(mixedCaseFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoDoesNotGuessWhenCaseInsensitiveMatchIsAmbiguous() {
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(2).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo, lowerCaseFieldInfo });
+
+        assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
@@ -40,6 +40,14 @@ public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
         assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
     }
 
+    public void testGetFieldInfoDoesNotGuessWhenCaseInsensitiveMatchHasNoVectorHints() {
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(2).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo, lowerCaseFieldInfo });
+
+        assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
     public void testGetFieldInfoPrefersVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
         FieldInfo nonVectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(1).build();
         FieldInfo vectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
@@ -27,10 +27,27 @@ public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
     }
 
     public void testGetFieldInfoDoesNotGuessWhenCaseInsensitiveMatchIsAmbiguous() {
-        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
-        FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(2).build();
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")
+            .fieldNumber(1)
+            .vectorDimension(16)
+            .build();
+        FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector")
+            .fieldNumber(2)
+            .vectorDimension(16)
+            .build();
         FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo, lowerCaseFieldInfo });
 
         assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoPrefersVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
+        FieldInfo nonVectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(1).build();
+        FieldInfo vectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")
+            .fieldNumber(2)
+            .vectorDimension(16)
+            .build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { nonVectorFieldInfo, vectorFieldInfo });
+
+        assertSame(vectorFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
@@ -40,12 +40,12 @@ public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
         assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
     }
 
-    public void testGetFieldInfoDoesNotGuessWhenCaseInsensitiveMatchHasNoVectorHints() {
+    public void testGetFieldInfoFallsBackToFirstCaseInsensitiveMatchWhenNoVectorHints() {
         FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
         FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(2).build();
         FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo, lowerCaseFieldInfo });
 
-        assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+        assertSame(mixedCaseFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
     }
 
     public void testGetFieldInfoPrefersVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttributeParser;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.util.IndexUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,6 +85,8 @@ public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
         when(mappingLookup.getNestedScope(fieldName)).thenReturn(null);
         when(segmentInfo.putAttribute(any(), any())).thenAnswer(t -> fakeAttributes.put(t.getArgument(0), t.getArgument(1)));
         when(segmentInfo.getAttribute(any())).thenAnswer(t -> fakeAttributes.get(t.getArgument(0)));
+
+        assertTrue(IndexUtil.isDerivedEnabledForField(vectorFieldType, mapperService));
 
         KNN10010DerivedSourceStoredFieldsWriter derivedSourceStoredFieldsWriter = new KNN10010DerivedSourceStoredFieldsWriter(
             "mock-codec",

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -13,14 +13,23 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttributeParser;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
@@ -53,5 +62,39 @@ public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
         byte[] shiftedBytes = new byte[originalBytes.length + 2];
         System.arraycopy(originalBytes, 0, shiftedBytes, 1, originalBytes.length);
         derivedSourceStoredFieldsWriter.writeField(fieldInfo, new BytesRef(shiftedBytes, 1, originalBytes.length));
+    }
+
+    @SneakyThrows
+    public void testFinishPreservesMixedCaseVectorFieldNamesInSegmentAttributes() {
+        StoredFieldsWriter delegate = mock(StoredFieldsWriter.class);
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        MapperService mapperService = mock(MapperService.class);
+        DocumentMapper documentMapper = mock(DocumentMapper.class);
+        MappingLookup mappingLookup = mock(MappingLookup.class);
+        KNNVectorFieldType vectorFieldType = mock(KNNVectorFieldType.class);
+        Map<String, String> fakeAttributes = new HashMap<>();
+
+        String fieldName = "vectorSearch.nameVector";
+        when(vectorFieldType.name()).thenReturn(fieldName);
+        when(mapperService.fieldTypes()).thenReturn(List.of(vectorFieldType));
+        when(mapperService.documentMapper()).thenReturn(documentMapper);
+        when(documentMapper.metadataMapper(SourceFieldMapper.class)).thenReturn(null);
+        when(documentMapper.mappers()).thenReturn(mappingLookup);
+        when(mappingLookup.getMapper(fieldName)).thenReturn(null);
+        when(mappingLookup.getNestedScope(fieldName)).thenReturn(null);
+        when(segmentInfo.putAttribute(any(), any())).thenAnswer(t -> fakeAttributes.put(t.getArgument(0), t.getArgument(1)));
+        when(segmentInfo.getAttribute(any())).thenAnswer(t -> fakeAttributes.get(t.getArgument(0)));
+
+        KNN10010DerivedSourceStoredFieldsWriter derivedSourceStoredFieldsWriter = new KNN10010DerivedSourceStoredFieldsWriter(
+            "mock-codec",
+            delegate,
+            segmentInfo,
+            mapperService
+        );
+
+        derivedSourceStoredFieldsWriter.finish(1);
+
+        assertEquals(List.of(fieldName), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false));
+        verify(delegate).finish(1);
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -330,6 +330,60 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         deleteKNNIndex(indexName);
     }
 
+    @SneakyThrows
+    public void testDerivedSource_withMixedCaseObjectVectorField() {
+        String indexName = getIndexName("derived-source", "mixed-case", false);
+        int dimension = 3;
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.knn.derived_source.enabled", true)
+            .build();
+
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject("vectorSearch")
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject("nameVector")
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .startObject("method")
+            .field("engine", "lucene")
+            .field("space_type", "l2")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, settings, mappingBuilder.toString());
+
+        XContentBuilder docBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("vectorSearch")
+            .array("nameVector", 1.0f, 2.0f, 3.0f)
+            .endObject()
+            .endObject();
+
+        addKnnDoc(indexName, "1", docBuilder.toString());
+        refreshIndex(indexName);
+
+        List<?> retrievedVector = extractVector(getKnnDoc(indexName, "1"), "vectorSearch", "nameVector");
+
+        assertNotNull("Mixed-case vector field should be reconstructed instead of returning the mask value", retrievedVector);
+        assertEquals(dimension, retrievedVector.size());
+        assertEquals(1.0f, ((Number) retrievedVector.get(0)).floatValue(), 0.0f);
+        assertEquals(2.0f, ((Number) retrievedVector.get(1)).floatValue(), 0.0f);
+        assertEquals(3.0f, ((Number) retrievedVector.get(2)).floatValue(), 0.0f);
+
+        deleteKNNIndex(indexName);
+    }
+
     /**
      * Single method for running end to end tests for different index configurations for derived source. In general,
      * flow of operations are


### PR DESCRIPTION
## Summary

- Preserve exact k-NN vector field names when writing derived-source segment attributes.
- Resolve previously-written lowercase segment attributes through an unambiguous case-insensitive `FieldInfo` fallback.
- Add unit and integration regression coverage for mixed-case object vector fields.

## Issue

Fixes #3312

## Testing

- `./gradlew :spotlessCheck`
- `./gradlew :test -x buildJniTest -x buildJniLib -x cmakeJniLib --tests org.opensearch.knn.index.codec.KNN10010Codec.DerivedSourceStoredFieldsWriterTests --tests org.opensearch.knn.index.codec.KNN10010Codec.DerivedSourceStoredFieldsFormatTests`
- `./gradlew :integTest -x buildJniLib -x cmakeJniLib -x integTestMultiNode --tests org.opensearch.knn.integ.DerivedSourceIT.testDerivedSource_withMixedCaseObjectVectorField`
