### PR TITLE
Adding Locale.ROOT to all String.format to avoid build warnings

### DIFF
--- a/src/main/java/org/opensearch/knn/common/RobustUniqueRandomIterator.java
+++ b/src/main/java/org/opensearch/knn/common/RobustUniqueRandomIterator.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.common;
 
+import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
@@ -62,13 +63,15 @@ public final class RobustUniqueRandomIterator {
      */
     public RobustUniqueRandomIterator(int maxValExclusive, int numPopulate) {
         if (maxValExclusive <= 0) {
-            throw new IllegalArgumentException(String.format("maxValExclusive[%d] must be positive", maxValExclusive));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "maxValExclusive[%d] must be positive", maxValExclusive));
         }
         if (numPopulate < 0) {
-            throw new IllegalArgumentException(String.format("numPopulate[%d] must be non-negative", numPopulate));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "numPopulate[%d] must be non-negative", numPopulate));
         }
         if (numPopulate > maxValExclusive) {
-            throw new IllegalArgumentException(String.format("numPopulate[%d] > maxValExclusive[%d]", numPopulate, maxValExclusive));
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "numPopulate[%d] > maxValExclusive[%d]", numPopulate, maxValExclusive)
+            );
         }
 
         this.maxValExclusive = maxValExclusive;

--- a/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorScriptDocValues.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -44,6 +45,7 @@ public abstract class KNNVectorScriptDocValues<T> extends ScriptDocValues<T> {
     public T getValue() {
         if (!docExists) {
             String errorMessage = String.format(
+                Locale.ROOT,
                 "One of the document doesn't have a value for field '%s'. "
                     + "This can be avoided by checking if a document has a value for the field or not "
                     + "by doc['%s'].size() == 0 ? 0 : {your script}",

--- a/src/main/java/org/opensearch/knn/index/SpaceType.java
+++ b/src/main/java/org/opensearch/knn/index/SpaceType.java
@@ -308,6 +308,8 @@ public enum SpaceType {
      * @return translated distance
      */
     public float scoreToDistanceTranslation(float score) {
-        throw new UnsupportedOperationException(String.format("Space [%s] does not have a score to distance translation", getValue()));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "Space [%s] does not have a score to distance translation", getValue())
+        );
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040BasePerFieldKnnVectorsFormat.java
@@ -16,6 +16,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -76,7 +77,7 @@ public abstract class KNN1040BasePerFieldKnnVectorsFormat extends PerFieldKnnVec
         }
         KNNVectorFieldType mappedFieldType = (KNNVectorFieldType) mapperService.orElseThrow(
             () -> new IllegalStateException(
-                String.format("Cannot read field type for field [%s] because mapper service is not available", field)
+                String.format(Locale.ROOT, "Cannot read field type for field [%s] because mapper service is not available", field)
             )
         ).fieldType(field);
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.TaskExecutor;
 import org.opensearch.knn.index.engine.KNNEngine;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
@@ -100,6 +101,7 @@ public class KNN1040HnswScalarQuantizedVectorsFormat extends Lucene104HnswScalar
     @Override
     public String toString() {
         return String.format(
+            Locale.ROOT,
             "%s(maxConn=%d, beamWidth=%d, tinySegmentsThreshold=%d, flatVectorFormat=%s)",
             getClass().getSimpleName(),
             maxConn,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.jni.SimdVectorComputeService;
 import org.opensearch.knn.memoryoptsearch.MemorySegmentAddressExtractorUtil;
 import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
 
+import java.util.Locale;
 import java.io.IOException;
 
 import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
@@ -152,7 +153,7 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
 
         // We only support 32x quantization with 4 bit query quantization for search.
         if (scalarEncoding != SINGLE_BIT_QUERY_NIBBLE) {
-            throw new IllegalStateException(String.format("SQ only supports %s encoding.", SINGLE_BIT_QUERY_NIBBLE));
+            throw new IllegalStateException(String.format(Locale.ROOT, "SQ only supports %s encoding.", SINGLE_BIT_QUERY_NIBBLE));
         }
 
         // Validate dimensionality

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.memoryoptsearch.faiss.FlatVectorsScorerProvider;
 
+import java.util.Locale;
 import java.io.IOException;
 
 /**
@@ -58,6 +59,7 @@ public class KNN1040ScalarQuantizedVectorsFormat extends Lucene104ScalarQuantize
     @Override
     public String toString() {
         return String.format(
+            Locale.ROOT,
             "%s(encoding=%s, scorer=%s, rawVectorFormat=%s)",
             getClass().getSimpleName(),
             encoding,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.plugin.stats.KNNGraphValue;
 
+import java.util.Locale;
 import java.io.IOException;
 
 import static org.opensearch.knn.common.FieldInfoExtractor.extractKNNEngine;
@@ -60,7 +61,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
 
     private boolean isKNNBinaryFieldRequired(FieldInfo field) {
         final KNNEngine knnEngine = extractKNNEngine(field);
-        log.debug(String.format("Read engine [%s] for field [%s]", knnEngine.getName(), field.getName()));
+        log.debug(String.format(Locale.ROOT, "Read engine [%s] for field [%s]", knnEngine.getName(), field.getName()));
         return field.attributes().containsKey(KNNVectorFieldMapper.KNN_FIELD)
             && KNNEngine.getEnginesThatCreateCustomSegmentFiles().stream().anyMatch(engine -> engine == knnEngine);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -23,7 +23,6 @@ import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.plugin.stats.KNNGraphValue;
 
-import java.util.Locale;
 import java.io.IOException;
 
 import static org.opensearch.knn.common.FieldInfoExtractor.extractKNNEngine;
@@ -61,7 +60,7 @@ class KNN80DocValuesConsumer extends DocValuesConsumer {
 
     private boolean isKNNBinaryFieldRequired(FieldInfo field) {
         final KNNEngine knnEngine = extractKNNEngine(field);
-        log.debug(String.format(Locale.ROOT, "Read engine [%s] for field [%s]", knnEngine.getName(), field.getName()));
+        log.debug("Read engine [{}] for field [{}]", knnEngine.getName(), field.getName());
         return field.attributes().containsKey(KNNVectorFieldMapper.KNN_FIELD)
             && KNNEngine.getEnginesThatCreateCustomSegmentFiles().stream().anyMatch(engine -> engine == knnEngine);
     }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/KNN990QuantizationStateReader.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.quantization.models.quantizationState.OneBitScalarQuan
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationStateReadConfig;
 
+import java.util.Locale;
 import java.io.IOException;
 
 /**
@@ -75,7 +76,7 @@ public final class KNN990QuantizationStateReader {
             }
 
             if (position == -1 || length == 0) {
-                throw new IllegalArgumentException(String.format("Field %s not found", field));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Field %s not found", field));
             }
 
             byte[] stateBytes = readStateBytes(input, position, length);
@@ -89,7 +90,9 @@ public final class KNN990QuantizationStateReader {
                 case FOUR_BIT:
                     return MultiBitScalarQuantizationState.fromByteArray(stateBytes);
                 default:
-                    throw new IllegalArgumentException(String.format("Unexpected scalar quantization type: %s", scalarQuantizationType));
+                    throw new IllegalArgumentException(
+                        String.format(Locale.ROOT, "Unexpected scalar quantization type: %s", scalarQuantizationType)
+                    );
             }
         }
     }

--- a/src/main/java/org/opensearch/knn/index/codec/backward_codecs/BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/backward_codecs/BasePerFieldKnnVectorsFormat.java
@@ -22,6 +22,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -99,7 +100,7 @@ public abstract class BasePerFieldKnnVectorsFormat extends PerFieldKnnVectorsFor
         }
         KNNVectorFieldType mappedFieldType = (KNNVectorFieldType) mapperService.orElseThrow(
             () -> new IllegalStateException(
-                String.format("Cannot read field type for field [%s] because mapper service is not available", field)
+                String.format(Locale.ROOT, "Cannot read field type for field [%s] because mapper service is not available", field)
             )
         ).fieldType(field);
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -36,6 +36,7 @@ import org.opensearch.knn.indices.ModelCache;
 import org.opensearch.knn.plugin.stats.KNNGraphValue;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -318,7 +319,7 @@ public class NativeIndexWriter {
         String modelId = fieldInfo.attributes().get(MODEL_ID);
         Model model = ModelCache.getInstance().get(modelId);
         if (model.getModelBlob() == null) {
-            throw new RuntimeException(String.format("There is no trained model with id \"%s\"", modelId));
+            throw new RuntimeException(String.format(Locale.ROOT, "There is no trained model with id \"%s\"", modelId));
         }
         return model;
     }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -36,6 +36,7 @@ import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.repositories.blobstore.BlobStoreRepository;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -196,7 +197,10 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             );
             success = true;
         } catch (InterruptedException | IOException e) {
-            throw new RuntimeException(String.format("Repository write failed for vector field [%s]", indexInfo.getField()), e);
+            throw new RuntimeException(
+                String.format(Locale.ROOT, "Repository write failed for vector field [%s]", indexInfo.getField()),
+                e
+            );
         } finally {
             metrics.endRepositoryWriteMetrics(success);
         }
@@ -230,7 +234,10 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             success = true;
             return remoteBuildResponse;
         } catch (IOException e) {
-            throw new RuntimeException(String.format("Submit vector build failed for vector field [%s]", indexInfo.getField()), e);
+            throw new RuntimeException(
+                String.format(Locale.ROOT, "Submit vector build failed for vector field [%s]", indexInfo.getField()),
+                e
+            );
         } finally {
             metrics.endBuildRequestMetrics(success);
         }
@@ -256,7 +263,10 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             remoteBuildStatusResponse = waiter.awaitVectorBuild(remoteBuildStatusRequest);
             return remoteBuildStatusResponse;
         } catch (InterruptedException | IOException e) {
-            throw new RuntimeException(String.format("Await index build failed for vector field [%s]", indexInfo.getField()), e);
+            throw new RuntimeException(
+                String.format(Locale.ROOT, "Await index build failed for vector field [%s]", indexInfo.getField()),
+                e
+            );
         } finally {
             metrics.endWaitingMetrics();
         }
@@ -281,7 +291,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         } catch (TerminalIOException e) {
             throw e;
         } catch (Exception e) {
-            throw new RuntimeException(String.format("Repository read failed for vector field [%s]", indexInfo.getField()), e);
+            throw new RuntimeException(String.format(Locale.ROOT, "Repository read failed for vector field [%s]", indexInfo.getField()), e);
         } finally {
             metrics.endRepositoryReadMetrics(success);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.index.codec.KNN80Codec.KNN80BinaryDocValues;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
@@ -48,15 +49,21 @@ public class KNNCodecUtil {
     }
 
     public static String buildEngineFileName(String segmentName, String latestBuildVersion, String fieldName, String extension) {
-        return String.format("%s%s%s", buildEngineFilePrefix(segmentName), latestBuildVersion, buildEngineFileSuffix(fieldName, extension));
+        return String.format(
+            Locale.ROOT,
+            "%s%s%s",
+            buildEngineFilePrefix(segmentName),
+            latestBuildVersion,
+            buildEngineFileSuffix(fieldName, extension)
+        );
     }
 
     public static String buildEngineFilePrefix(String segmentName) {
-        return String.format("%s_", segmentName);
+        return String.format(Locale.ROOT, "%s_", segmentName);
     }
 
     public static String buildEngineFileSuffix(String fieldName, String extension) {
-        return String.format("_%s%s", fieldName, extension);
+        return String.format(Locale.ROOT, "_%s%s", fieldName, extension);
     }
 
     public static long getTotalLiveDocsCount(final BinaryDocValues binaryDocValues) {

--- a/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
+++ b/src/main/java/org/opensearch/knn/index/codec/util/KNNCodecUtil.java
@@ -59,11 +59,11 @@ public class KNNCodecUtil {
     }
 
     public static String buildEngineFilePrefix(String segmentName) {
-        return String.format(Locale.ROOT, "%s_", segmentName);
+        return segmentName + "_";
     }
 
     public static String buildEngineFileSuffix(String fieldName, String extension) {
-        return String.format(Locale.ROOT, "_%s%s", fieldName, extension);
+        return "_" + fieldName + extension;
     }
 
     public static long getTotalLiveDocsCount(final BinaryDocValues binaryDocValues) {

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNLibrary.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNLibrary.java
@@ -106,7 +106,7 @@ public abstract class AbstractKNNLibrary implements KNNLibrary {
     private String validateMethodExists(String methodName) {
         KNNMethod method = methods.get(methodName);
         if (method == null) {
-            return String.format("Invalid method name: %s", methodName);
+            return String.format(Locale.ROOT, "Invalid method name: %s", methodName);
         }
         return null;
     }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -15,6 +15,7 @@ import org.opensearch.knn.index.engine.lucene.Lucene;
 import org.opensearch.knn.index.engine.nmslib.Nmslib;
 import org.opensearch.remoteindexbuild.model.RemoteIndexParameters;
 
+import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,7 +109,7 @@ public enum KNNEngine implements KNNLibrary {
             return UNDEFINED;
         }
 
-        throw new IllegalArgumentException(String.format("Invalid engine type: %s", name));
+        throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid engine type: %s", name));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/Parameter.java
+++ b/src/main/java/org/opensearch/knn/index/engine/Parameter.java
@@ -62,14 +62,16 @@ public abstract class Parameter<T> {
             if (!(value instanceof Boolean)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of Boolean for Boolean parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of Boolean for Boolean parameter [%s].", getName())
                 );
                 return validationException;
             }
 
             if (!validator.apply((Boolean) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format("parameter validation failed for Boolean parameter [%s].", getName()));
+                validationException.addValidationError(
+                    String.format(Locale.ROOT, "parameter validation failed for Boolean parameter [%s].", getName())
+                );
             }
             return validationException;
         }
@@ -89,14 +91,16 @@ public abstract class Parameter<T> {
             if (!(value instanceof Integer)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of Integer for Integer parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of Integer for Integer parameter [%s].", getName())
                 );
                 return validationException;
             }
 
             if (!validator.apply((Integer) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format("parameter validation failed for Integer parameter [%s].", getName()));
+                validationException.addValidationError(
+                    String.format(Locale.ROOT, "parameter validation failed for Integer parameter [%s].", getName())
+                );
             }
 
             return validationException;
@@ -165,14 +169,16 @@ public abstract class Parameter<T> {
             if (!(value instanceof String)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of String for String parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of String for String parameter [%s].", getName())
                 );
                 return validationException;
             }
 
             if (!validator.apply((String) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
-                validationException.addValidationError(String.format("parameter validation failed for String parameter [%s].", getName()));
+                validationException.addValidationError(
+                    String.format(Locale.ROOT, "parameter validation failed for String parameter [%s].", getName())
+                );
             }
 
             return validationException;
@@ -216,7 +222,7 @@ public abstract class Parameter<T> {
             if (!(value instanceof MethodComponentContext)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("value is not an instance of for MethodComponentContext parameter [%s].", getName())
+                    String.format(Locale.ROOT, "value is not an instance of for MethodComponentContext parameter [%s].", getName())
                 );
                 return validationException;
             }
@@ -224,7 +230,7 @@ public abstract class Parameter<T> {
             if (!validator.apply((MethodComponentContext) value, knnMethodConfigContext)) {
                 validationException = new ValidationException();
                 validationException.addValidationError(
-                    String.format("parameter validation failed for MethodComponentContext parameter [%s].", getName())
+                    String.format(Locale.ROOT, "parameter validation failed for MethodComponentContext parameter [%s].", getName())
                 );
             }
 

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
@@ -10,6 +10,7 @@ import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
+import java.util.Locale;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
@@ -133,7 +134,9 @@ public abstract class AbstractFaissPQEncoder implements Encoder {
 
             if (trainingVectors < minTrainingVectorCount) {
                 builder.valid(false).minTrainingVectorCount(minTrainingVectorCount);
-                builder.errorMessage(String.format("Number of training points should be greater than %d", minTrainingVectorCount));
+                builder.errorMessage(
+                    String.format(Locale.ROOT, "Number of training points should be greater than %d", minTrainingVectorCount)
+                );
                 return builder.build();
             } else {
                 builder.valid(true);

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFMethod.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.TrainingConfigValidationInput;
 import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
 
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -130,7 +131,7 @@ public class FaissIVFMethod extends AbstractFaissMethod {
                     Parameter<?> nlistParameter = methodComponent.getParameters().get(METHOD_PARAMETER_NLIST);
                     if (nlistParameter == null) {
                         throw new IllegalStateException(
-                            String.format("%s  is not a valid parameter. This is a bug.", METHOD_PARAMETER_NLIST)
+                            String.format(Locale.ROOT, "%s  is not a valid parameter. This is a bug.", METHOD_PARAMETER_NLIST)
                         );
                     }
 
@@ -138,7 +139,7 @@ public class FaissIVFMethod extends AbstractFaissMethod {
                 }
 
                 if (!(nlistObject instanceof Integer)) {
-                    throw new IllegalStateException(String.format("%s must be an integer.", METHOD_PARAMETER_NLIST));
+                    throw new IllegalStateException(String.format(Locale.ROOT, "%s must be an integer.", METHOD_PARAMETER_NLIST));
                 }
 
                 int centroids = (Integer) nlistObject;

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissIVFPQEncoder.java
@@ -12,6 +12,7 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.Parameter;
 
+import java.util.Locale;
 import java.util.Set;
 
 import static org.opensearch.knn.common.KNNConstants.BYTES_PER_KILOBYTES;
@@ -71,7 +72,7 @@ public class FaissIVFPQEncoder extends AbstractFaissPQEncoder {
                 Parameter<?> codeSizeParameter = methodComponent.getParameters().get(ENCODER_PARAMETER_PQ_CODE_SIZE);
                 if (codeSizeParameter == null) {
                     throw new IllegalStateException(
-                        String.format("%s  is not a valid parameter. This is a bug.", ENCODER_PARAMETER_PQ_CODE_SIZE)
+                        String.format(Locale.ROOT, "%s  is not a valid parameter. This is a bug.", ENCODER_PARAMETER_PQ_CODE_SIZE)
                     );
                 }
 
@@ -79,7 +80,7 @@ public class FaissIVFPQEncoder extends AbstractFaissPQEncoder {
             }
 
             if (!(codeSizeObject instanceof Integer)) {
-                throw new IllegalStateException(String.format("%s must be an integer.", ENCODER_PARAMETER_PQ_CODE_SIZE));
+                throw new IllegalStateException(String.format(Locale.ROOT, "%s must be an integer.", ENCODER_PARAMETER_PQ_CODE_SIZE));
             }
 
             int codeSize = (Integer) codeSizeObject;

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -13,6 +13,7 @@ import org.opensearch.knn.index.codec.params.KNNScalarQuantizedVectorsFormatPara
 import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -43,7 +44,7 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
     @Override
     public KnnVectorsFormat resolve() {
         throw new UnsupportedOperationException(
-            String.format("%s requires field context, use resolve(field, ...) instead", getClass().getSimpleName())
+            String.format(Locale.ROOT, "%s requires field context, use resolve(field, ...) instead", getClass().getSimpleName())
         );
     }
 
@@ -58,7 +59,7 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
         LuceneVectorsFormatType formatType = determineFormatType(field, methodContext, params, defaultMaxConnections, defaultBeamWidth);
         Function<KnnVectorsFormatContext, KnnVectorsFormat> factory = formatResolvers.get(formatType);
         if (factory == null) {
-            throw new IllegalStateException(String.format("No Lucene vectors format registered for type [%s]", formatType));
+            throw new IllegalStateException(String.format(Locale.ROOT, "No Lucene vectors format registered for type [%s]", formatType));
         }
         return factory.apply(new KnnVectorsFormatContext(field, methodContext, params, defaultMaxConnections, defaultBeamWidth));
     }

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -30,6 +30,7 @@ import org.opensearch.knn.index.engine.faiss.SQConfigParser;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -213,7 +214,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
                     XContentFactory.jsonBuilder().map(knnLibraryIndexingContext.getLibraryParameters()).toString()
                 );
             } catch (IOException ioe) {
-                throw new RuntimeException(String.format("Unable to create KNNVectorFieldMapper: %s", ioe), ioe);
+                throw new RuntimeException(String.format(Locale.ROOT, "Unable to create KNNVectorFieldMapper: %s", ioe), ioe);
             }
 
             if (useLuceneBasedVectorField) {

--- a/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/ModelFieldMapper.java
@@ -24,6 +24,7 @@ import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
@@ -357,7 +358,7 @@ public class ModelFieldMapper extends KNNVectorFieldMapper {
     private static ModelMetadata getModelMetadata(ModelDao modelDao, String modelId) {
         ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
         if (!ModelUtil.isModelCreated(modelMetadata)) {
-            throw new IllegalStateException(String.format("Model ID '%s' is not created.", modelId));
+            throw new IllegalStateException(String.format(Locale.ROOT, "Model ID '%s' is not created.", modelId));
         }
         return modelMetadata;
     }

--- a/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/BaseQueryFactory.java
@@ -24,6 +24,7 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -92,6 +93,7 @@ public abstract class BaseQueryFactory {
             .orElseThrow(() -> new RuntimeException("Shard context cannot be null"));
         log.debug(
             String.format(
+                Locale.ROOT,
                 "Creating query with filter for index [%s], field [%s]",
                 createQueryRequest.getIndexName(),
                 createQueryRequest.getFieldName()

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -126,13 +126,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     @Deprecated
     public KNNQueryBuilder(String fieldName, float[] vector) {
         if (Strings.isNullOrEmpty(fieldName)) {
-            throw new IllegalArgumentException(String.format("[%s] requires fieldName", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", NAME));
         }
         if (vector == null) {
-            throw new IllegalArgumentException(String.format("[%s] requires query vector", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", NAME));
         }
         if (vector.length == 0) {
-            throw new IllegalArgumentException(String.format("[%s] query vector is empty", NAME));
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", NAME));
         }
         this.fieldName = fieldName;
         this.vector = vector;
@@ -501,7 +501,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         if (this.maxDistance != null) {
             if (this.maxDistance < 0 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException(
-                    String.format("[" + NAME + "] requires distance to be non-negative for space type: %s", spaceType)
+                    String.format(Locale.ROOT, "[" + NAME + "] requires distance to be non-negative for space type: %s", spaceType)
                 );
             }
             if (memoryOptimizedSearchEnabled) {
@@ -514,7 +514,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         if (this.minScore != null) {
             if (this.minScore > 1 && SpaceType.INNER_PRODUCT.equals(spaceType) == false) {
                 throw new IllegalArgumentException(
-                    String.format("[" + NAME + "] requires score to be in the range [0, 1] for space type: %s", spaceType)
+                    String.format(Locale.ROOT, "[" + NAME + "] requires score to be in the range [0, 1] for space type: %s", spaceType)
                 );
             }
             if (memoryOptimizedSearchEnabled) {
@@ -528,6 +528,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         if (knnMappingConfig.getDimension() != vectorLength) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "Query vector has invalid dimension: %d. Dimension should be: %d",
                     vectorLength,
                     knnMappingConfig.getDimension()

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -42,6 +42,7 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelUtil;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -136,7 +137,10 @@ public abstract class KNNWeight extends Weight {
                 score = getKnnScore(knnScorer, doc);
             }
         } catch (IOException e) {
-            throw new RuntimeException(String.format("Error while explaining KNN score for doc [%d], score [%f]", doc, score), e);
+            throw new RuntimeException(
+                String.format(Locale.ROOT, "Error while explaining KNN score for doc [%d], score [%f]", doc, score),
+                e
+            );
         }
         final String highLevelExplanation = getHighLevelExplanation();
         final StringBuilder leafLevelExplanation = getLeafLevelExplanation(context);

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -100,7 +100,9 @@ public class RNNQueryFactory extends BaseQueryFactory {
                 .build();
         }
 
-        log.debug(String.format("Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", indexName, fieldName, radius));
+        log.debug(
+            String.format(Locale.ROOT, "Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", indexName, fieldName, radius)
+        );
 
         switch (vectorDataType) {
             case BYTE:

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -100,9 +100,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
                 .build();
         }
 
-        log.debug(
-            String.format(Locale.ROOT, "Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", indexName, fieldName, radius)
-        );
+        log.debug("Creating Lucene r-NN query for index: {} \"\", field: {} \"\", k: {}", indexName, fieldName, radius);
 
         switch (vectorDataType) {
             case BYTE:

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -280,7 +280,9 @@ public final class KNNQueryBuilderParser {
 
     private static float[] floatListToFloatArray(List<Float> floats) {
         if (Objects.isNull(floats) || floats.isEmpty()) {
-            throw new IllegalArgumentException(String.format("[%s] field 'vector' requires to be non-null and non-empty", NAME));
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "[%s] field 'vector' requires to be non-null and non-empty", NAME)
+            );
         }
         float[] vec = new float[floats.size()];
         for (int i = 0; i < floats.size(); i++) {

--- a/src/main/java/org/opensearch/knn/index/remote/RemoteIndexPoller.java
+++ b/src/main/java/org/opensearch/knn/index/remote/RemoteIndexPoller.java
@@ -11,6 +11,7 @@ import org.opensearch.remoteindexbuild.client.RemoteIndexClient;
 import org.opensearch.remoteindexbuild.model.RemoteBuildStatusRequest;
 import org.opensearch.remoteindexbuild.model.RemoteBuildStatusResponse;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Random;
@@ -75,12 +76,14 @@ public class RemoteIndexPoller implements RemoteIndexWaiter {
             STATUS_REQUEST_SUCCESS_COUNT.increment();
             String taskStatus = remoteBuildStatusResponse.getTaskStatus();
             if (StringUtils.isBlank(taskStatus)) {
-                throw new IOException(String.format("Invalid response format, missing %s", TASK_STATUS));
+                throw new IOException(String.format(Locale.ROOT, "Invalid response format, missing %s", TASK_STATUS));
             }
             switch (taskStatus) {
                 case COMPLETED_INDEX_BUILD -> {
                     if (StringUtils.isBlank(remoteBuildStatusResponse.getFileName())) {
-                        throw new IOException(String.format("Invalid response format, missing %s for %s status", FILE_NAME, taskStatus));
+                        throw new IOException(
+                            String.format(Locale.ROOT, "Invalid response format, missing %s for %s status", FILE_NAME, taskStatus)
+                        );
                     }
                     return remoteBuildStatusResponse;
                 }
@@ -88,17 +91,18 @@ public class RemoteIndexPoller implements RemoteIndexWaiter {
                     String errorMessage = remoteBuildStatusResponse.getErrorMessage();
                     Duration d = Duration.ofNanos(System.nanoTime() - startTime);
                     throw new InterruptedException(
-                        String.format("Remote index build failed after %d minutes. %s", d.toMinutesPart(), errorMessage)
+                        String.format(Locale.ROOT, "Remote index build failed after %d minutes. %s", d.toMinutesPart(), errorMessage)
                     );
                 }
                 case RUNNING_INDEX_BUILD -> sleepWithJitter(pollInterval);
-                default -> throw new IOException(String.format("Server returned invalid task status %s", taskStatus));
+                default -> throw new IOException(String.format(Locale.ROOT, "Server returned invalid task status %s", taskStatus));
             }
         }
         Duration waitedDuration = Duration.ofNanos(System.nanoTime() - startTime);
         Duration timeoutDuration = Duration.ofNanos(timeout);
         throw new InterruptedException(
             String.format(
+                Locale.ROOT,
                 "Remote index build timed out after %d minutes, timeout is set to %d minutes. Falling back to CPU build",
                 waitedDuration.toMinutesPart(),
                 timeoutDuration.toMinutesPart()

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -146,13 +146,13 @@ public class IndexUtil {
 
         // Check field existence
         if (fieldMapping == null) {
-            exception.addValidationError(String.format("Field \"%s\" does not exist.", field));
+            exception.addValidationError(String.format(Locale.ROOT, "Field \"%s\" does not exist.", field));
             return exception;
         }
 
         // Check if field is a map. If not, that is a problem
         if (!(fieldMapping instanceof Map)) {
-            exception.addValidationError(String.format("Field info for \"%s\" is not a map.", field));
+            exception.addValidationError(String.format(Locale.ROOT, "Field info for \"%s\" is not a map.", field));
             return exception;
         }
 
@@ -162,7 +162,9 @@ public class IndexUtil {
         Object type = fieldMap.get("type");
 
         if (!(type instanceof String) || !KNNVectorFieldMapper.CONTENT_TYPE.equals(type)) {
-            exception.addValidationError(String.format("Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE));
+            exception.addValidationError(
+                String.format(Locale.ROOT, "Field \"%s\" is not of type %s.", field, KNNVectorFieldMapper.CONTENT_TYPE)
+            );
             return exception;
         }
 
@@ -220,17 +222,17 @@ public class IndexUtil {
             String modelId = (String) fieldMap.get(KNNConstants.MODEL_ID);
 
             if (modelId == null) {
-                exception.addValidationError(String.format("Field \"%s\" does not have a dimension set.", field));
+                exception.addValidationError(String.format(Locale.ROOT, "Field \"%s\" does not have a dimension set.", field));
                 return exception;
             }
 
             if (modelDao == null) {
-                throw new IllegalArgumentException(String.format("Field \"%s\" uses model. modelDao cannot be null.", field));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Field \"%s\" uses model. modelDao cannot be null.", field));
             }
 
             ModelMetadata modelMetadata = modelDao.getMetadata(modelId);
             if (!ModelUtil.isModelCreated(modelMetadata)) {
-                exception.addValidationError(String.format("Model \"%s\" for field \"%s\" is not created.", modelId, field));
+                exception.addValidationError(String.format(Locale.ROOT, "Model \"%s\" for field \"%s\" is not created.", modelId, field));
                 return exception;
             }
 
@@ -238,6 +240,7 @@ public class IndexUtil {
             if ((Integer) dimension != expectedDimension) {
                 exception.addValidationError(
                     String.format(
+                        Locale.ROOT,
                         "Field \"%s\" has dimension %d, which is different from " + "dimension specified in the training request: %d",
                         field,
                         dimension,
@@ -254,6 +257,7 @@ public class IndexUtil {
         if ((Integer) dimension != expectedDimension) {
             exception.addValidationError(
                 String.format(
+                    Locale.ROOT,
                     "Field \"%s\" has dimension %d, which is different from " + "dimension specified in the training request: %d",
                     field,
                     dimension,

--- a/src/main/java/org/opensearch/knn/index/util/KNNClusterUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/KNNClusterUtil.java
@@ -18,6 +18,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.index.Index;
 import org.opensearch.search.pipeline.SearchPipelineService;
 
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -65,7 +66,11 @@ public class KNNClusterUtil {
             return this.clusterService.state().getNodes().getMinNodeVersion();
         } catch (Exception exception) {
             log.error(
-                String.format("Failed to get cluster minimum node version, returning current node version %s instead.", Version.CURRENT),
+                String.format(
+                    Locale.ROOT,
+                    "Failed to get cluster minimum node version, returning current node version %s instead.",
+                    Version.CURRENT
+                ),
                 exception
             );
             return Version.CURRENT;

--- a/src/main/java/org/opensearch/knn/indices/ModelDao.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelDao.java
@@ -63,6 +63,7 @@ import org.opensearch.knn.plugin.transport.UpdateModelGraveyardRequest;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataAction;
 import org.opensearch.knn.plugin.transport.UpdateModelMetadataRequest;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Base64;
@@ -426,7 +427,7 @@ public interface ModelDao {
 
                 getRequestBuilder.execute(ActionListener.wrap(response -> {
                     if (response.isSourceEmpty()) {
-                        String errorMessage = String.format("Model \" %s \" does not exist", modelId);
+                        String errorMessage = String.format(Locale.ROOT, "Model \" %s \" does not exist", modelId);
                         actionListener.onFailure(new ResourceNotFoundException(modelId, errorMessage));
                         return;
                     }
@@ -509,7 +510,12 @@ public interface ModelDao {
         public void delete(String modelId, ActionListener<DeleteModelResponse> listener) {
             // If the index is not created, there is no need to delete the model
             if (!isCreated()) {
-                String errorMessage = String.format("Cannot delete model [%s]. Model index [%s] does not exist", modelId, MODEL_INDEX_NAME);
+                String errorMessage = String.format(
+                    Locale.ROOT,
+                    "Cannot delete model [%s]. Model index [%s] does not exist",
+                    modelId,
+                    MODEL_INDEX_NAME
+                );
                 listener.onFailure(new ResourceNotFoundException(errorMessage));
                 return;
             }
@@ -524,7 +530,7 @@ public interface ModelDao {
             // Get Model to check if model is in TRAINING
             get(modelId, ActionListener.wrap(getModelStep::onResponse, exception -> {
                 if (exception instanceof ResourceNotFoundException) {
-                    String errorMessage = String.format("Unable to delete model [%s]. Model does not exist", modelId);
+                    String errorMessage = String.format(Locale.ROOT, "Unable to delete model [%s]. Model does not exist", modelId);
                     ResourceNotFoundException resourceNotFoundException = new ResourceNotFoundException(errorMessage);
                     removeModelIdFromGraveyardOnFailure(modelId, resourceNotFoundException, getModelStep);
                 } else {
@@ -535,7 +541,7 @@ public interface ModelDao {
             getModelStep.whenComplete(getModelResponse -> {
                 // If model is in Training state, fail delete model request
                 if (ModelState.TRAINING == getModelResponse.getModel().getModelMetadata().getState()) {
-                    String errorMessage = String.format("Cannot delete model [%s]. Model is still in training", modelId);
+                    String errorMessage = String.format(Locale.ROOT, "Cannot delete model [%s]. Model is still in training", modelId);
                     listener.onFailure(new DeleteModelException(errorMessage));
                     return;
                 }
@@ -562,7 +568,7 @@ public interface ModelDao {
                 // If model is not deleted, remove modelId from model graveyard and return with error message
                 if (deleteResponse.getResult() != DocWriteResponse.Result.DELETED) {
                     updateModelGraveyardToDelete(modelId, true, unblockModelIdStep, Optional.empty());
-                    String errorMessage = String.format("Model [%s] does not exist", modelId);
+                    String errorMessage = String.format(Locale.ROOT, "Model [%s] does not exist", modelId);
                     listener.onFailure(new ResourceNotFoundException(errorMessage));
                     return;
                 }
@@ -641,8 +647,8 @@ public interface ModelDao {
 
                 }, e -> {
                     // If it fails to remove the modelId from Model Graveyard, then log the error message
-                    String errorMessage = String.format("Failed to remove \" %s \" from Model Graveyard", modelId);
-                    String failureMessage = String.format("%s%s%s", errorMessage, "\n", e.getMessage());
+                    String errorMessage = String.format(Locale.ROOT, "Failed to remove \" %s \" from Model Graveyard", modelId);
+                    String failureMessage = String.format(Locale.ROOT, "%s%s%s", errorMessage, "\n", e.getMessage());
                     logger.error(failureMessage);
 
                     if (exception.isEmpty()) {
@@ -677,8 +683,14 @@ public interface ModelDao {
                 }, unblockingFailedException -> {
                     // If it fails to remove the modelId from Model Graveyard, then log the error message and
                     // throw the exception that was passed as a parameter from previous step
-                    String errorMessage = String.format("Failed to remove \" %s \" from Model Graveyard", modelId);
-                    String failureMessage = String.format("%s%s%s", errorMessage, "\n", unblockingFailedException.getMessage());
+                    String errorMessage = String.format(Locale.ROOT, "Failed to remove \" %s \" from Model Graveyard", modelId);
+                    String failureMessage = String.format(
+                        Locale.ROOT,
+                        "%s%s%s",
+                        errorMessage,
+                        "\n",
+                        unblockingFailedException.getMessage()
+                    );
                     logger.error(failureMessage);
                     step.onFailure(exceptionFromPreviousStep);
                 })

--- a/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
+++ b/src/main/java/org/opensearch/knn/indices/ModelMetadata.java
@@ -33,6 +33,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -147,6 +148,7 @@ public class ModelMetadata implements Writeable, ToXContentObject {
         if (dimension <= 0 || dimension > maxDimensions) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "Dimension \"%s\" is invalid. Value must be greater than 0 and less than or equal to %d",
                     dimension,
                     maxDimensions

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissEmptyIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissEmptyIndex.java
@@ -9,6 +9,7 @@ import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
+import java.util.Locale;
 
 /**
  * Sentinel {@link FaissIndex} returned when a "null" section is encountered during loading
@@ -27,17 +28,23 @@ public class FaissEmptyIndex extends FaissIndex {
 
     @Override
     public VectorEncoding getVectorEncoding() {
-        throw new UnsupportedOperationException(String.format("%s does not support this operation.", getClass().getSimpleName()));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "%s does not support this operation.", getClass().getSimpleName())
+        );
     }
 
     @Override
     public FloatVectorValues getFloatValues(IndexInput indexInput) {
-        throw new UnsupportedOperationException(String.format("%s does not support this operation.", getClass().getSimpleName()));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "%s does not support this operation.", getClass().getSimpleName())
+        );
     }
 
     @Override
     public ByteVectorValues getByteValues(IndexInput indexInput) {
-        throw new UnsupportedOperationException(String.format("%s does not support this operation.", getClass().getSimpleName()));
+        throw new UnsupportedOperationException(
+            String.format(Locale.ROOT, "%s does not support this operation.", getClass().getSimpleName())
+        );
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -15,6 +15,7 @@ import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
 
+import java.util.Locale;
 import java.util.Arrays;
 
 /**
@@ -70,6 +71,7 @@ public class FaissFlatIndexFactory {
             if (flatBinaryIndex == null) {
                 throw new IllegalStateException(
                     String.format(
+                        Locale.ROOT,
                         "%s found for field [%s] but %s returned null — cannot wire binary flat storage.",
                         FaissEmptyIndex.class.getName(),
                         fieldInfo.getName(),
@@ -100,6 +102,7 @@ public class FaissFlatIndexFactory {
             if (flatIndex == null) {
                 throw new IllegalStateException(
                     String.format(
+                        Locale.ROOT,
                         "%s found for field [%s] but %s returned null — cannot wire flat storage for CAGRA index.",
                         FaissEmptyIndex.class.getName(),
                         fieldInfo.getName(),

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedFlatIndex.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedFlatIndex.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
 
+import java.util.Locale;
 import java.io.IOException;
 
 /**
@@ -58,7 +59,7 @@ public class FaissScalarQuantizedFlatIndex extends FaissBinaryIndex {
     @Override
     public ByteVectorValues getByteValues(IndexInput indexInput) throws IOException {
         throw new UnsupportedOperationException(
-            String.format("%s does not support byte vector values.", FAISS_SCALAR_QUANTIZED_FLAT_INDEX)
+            String.format(Locale.ROOT, "%s does not support byte vector values.", FAISS_SCALAR_QUANTIZED_FLAT_INDEX)
         );
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/rest/RestSearchModelHandler.java
+++ b/src/main/java/org/opensearch/knn/plugin/rest/RestSearchModelHandler.java
@@ -80,7 +80,7 @@ public class RestSearchModelHandler extends BaseRestHandler {
             return;
         }
         throw new IllegalArgumentException(
-            String.format("%s must be between %d and %d inclusive", PARAM_SIZE, SEARCH_MODEL_MIN_SIZE, SEARCH_MODEL_MAX_SIZE)
+            String.format(Locale.ROOT, "%s must be between %d and %d inclusive", PARAM_SIZE, SEARCH_MODEL_MIN_SIZE, SEARCH_MODEL_MAX_SIZE)
         );
     }
 

--- a/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
+++ b/src/main/java/org/opensearch/knn/plugin/script/KNNScoringUtil.java
@@ -33,6 +33,7 @@ public class KNNScoringUtil {
         Objects.requireNonNull(inputVector);
         if (queryVector.length != inputVector.length) {
             String errorMessage = String.format(
+                Locale.ROOT,
                 "query vector dimension mismatch. Expected: %d, Given: %d",
                 inputVector.length,
                 queryVector.length
@@ -53,6 +54,7 @@ public class KNNScoringUtil {
         Objects.requireNonNull(inputVector);
         if (queryVector.length != inputVector.length) {
             String errorMessage = String.format(
+                Locale.ROOT,
                 "query vector dimension mismatch. Expected: %d, Given: %d",
                 inputVector.length,
                 queryVector.length

--- a/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/TrainingModelRequest.java
@@ -32,6 +32,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.indices.ModelDao;
 
+import java.util.Locale;
 import java.io.IOException;
 
 /**
@@ -200,7 +201,11 @@ public class TrainingModelRequest extends ActionRequest {
     public void setMaximumVectorCount(int maximumVectorCount) {
         if (maximumVectorCount <= 0) {
             throw new IllegalArgumentException(
-                String.format("Maximum vector count %d is invalid. Maximum vector " + "count must be greater than 0", maximumVectorCount)
+                String.format(
+                    Locale.ROOT,
+                    "Maximum vector count %d is invalid. Maximum vector " + "count must be greater than 0",
+                    maximumVectorCount
+                )
             );
         }
         this.maximumVectorCount = maximumVectorCount;
@@ -214,7 +219,7 @@ public class TrainingModelRequest extends ActionRequest {
     public void setSearchSize(int searchSize) {
         if (searchSize <= 0 || searchSize > 10000) {
             throw new IllegalArgumentException(
-                String.format("Search size %d is invalid. Search size must be " + "between 0 and 10,000", searchSize)
+                String.format(Locale.ROOT, "Search size %d is invalid. Search size must be " + "between 0 and 10,000", searchSize)
             );
         }
         this.searchSize = searchSize;
@@ -228,7 +233,11 @@ public class TrainingModelRequest extends ActionRequest {
     void setTrainingDataSizeInKB(int trainingDataSizeInKB) {
         if (trainingDataSizeInKB <= 0) {
             throw new IllegalArgumentException(
-                String.format("Training data size %d is invalid. Training data size " + "must be greater than 0", trainingDataSizeInKB)
+                String.format(
+                    Locale.ROOT,
+                    "Training data size %d is invalid. Training data size " + "must be greater than 0",
+                    trainingDataSizeInKB
+                )
             );
         }
         this.trainingDataSizeInKB = trainingDataSizeInKB;
@@ -252,6 +261,7 @@ public class TrainingModelRequest extends ActionRequest {
         if (modelDao.isModelInGraveyard(modelId)) {
             exception = new ActionRequestValidationException();
             String errorMessage = String.format(
+                Locale.ROOT,
                 "Model with id = \"%s\" is being deleted. Cannot create a model with same modelID until that model is deleted",
                 modelId
             );

--- a/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportAction.java
+++ b/src/main/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportAction.java
@@ -29,6 +29,7 @@ import org.opensearch.knn.indices.ModelGraveyard;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -163,6 +164,7 @@ public class UpdateModelGraveyardTransportAction extends TransportClusterManager
                 if (!indicesUsingModel.isEmpty()) {
                     throw new DeleteModelException(
                         String.format(
+                            Locale.ROOT,
                             "Cannot delete model [%s].  Model is in use by the following indices %s, which must be deleted first.",
                             task.getModelId(),
                             indicesUsingModel

--- a/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
+++ b/src/main/java/org/opensearch/knn/search/processor/mmr/MMRUtil.java
@@ -144,6 +144,7 @@ public class MMRUtil {
         if (!nonKnnFields.isEmpty()) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "MMR query extension cannot support non knn_vector field [%s].",
                     nonKnnFields.stream()
                         .map(info -> String.format(Locale.ROOT, "%s:%s", info.getIndexName(), info.getFieldPath()))
@@ -171,6 +172,7 @@ public class MMRUtil {
         if (!current.equals(next)) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "MMR query extension cannot support different %s [%s, %s] for the knn_vector field at path %s.",
                     fieldDescription,
                     valueFormatter.apply(current),
@@ -217,6 +219,7 @@ public class MMRUtil {
         if (userProvided != null && resolved != null && !userProvided.equals(resolved)) {
             throw new IllegalArgumentException(
                 String.format(
+                    Locale.ROOT,
                     "The %s [%s] provided in the MMR query extension does not match the %s [%s] in target indices.",
                     fieldDescription,
                     valueFormatter.apply(userProvided),
@@ -253,6 +256,7 @@ public class MMRUtil {
                 if (infoFromModel == null) {
                     throw new IllegalStateException(
                         String.format(
+                            Locale.ROOT,
                             "Unexpected null when try to resolve the info of the vector field at path [%s] based on its model [%s].",
                             info.getModelId(),
                             info.getFieldPath()
@@ -441,14 +445,14 @@ public class MMRUtil {
             String part = pathParts[i];
             if (!(current instanceof Map<?, ?> map)) {
                 throw new IllegalArgumentException(
-                    String.format("%s: expected object at [%s], but found [%s]", baseError, part, current.getClass().getName())
+                    String.format(Locale.ROOT, "%s: expected object at [%s], but found [%s]", baseError, part, current.getClass().getName())
                 );
             }
 
             current = map.get(part);
             if (current == null) {
                 throw new IllegalArgumentException(
-                    String.format("%s: field path [%s] not found in document source.", baseError, fieldPath)
+                    String.format(Locale.ROOT, "%s: field path [%s] not found in document source.", baseError, fieldPath)
                 );
             }
 
@@ -472,7 +476,13 @@ public class MMRUtil {
                         }
                     } catch (Exception e) {
                         throw new IllegalArgumentException(
-                            String.format("%s: unexpected value at the vector field [%s]. error: %s", baseError, fieldPath, e.getMessage()),
+                            String.format(
+                                Locale.ROOT,
+                                "%s: unexpected value at the vector field [%s]. error: %s",
+                                baseError,
+                                fieldPath,
+                                e.getMessage()
+                            ),
                             e
                         );
                     }
@@ -482,6 +492,7 @@ public class MMRUtil {
                 }
                 throw new IllegalArgumentException(
                     String.format(
+                        Locale.ROOT,
                         "%s: expected vector (list of numbers) at field path [%s], but found type [%s]",
                         baseError,
                         fieldPath,
@@ -492,7 +503,9 @@ public class MMRUtil {
         }
 
         // Should never reach here
-        throw new IllegalStateException(String.format("%s: unexpected error resolving field path [%s].", baseError, fieldPath));
+        throw new IllegalStateException(
+            String.format(Locale.ROOT, "%s: unexpected error resolving field path [%s].", baseError, fieldPath)
+        );
     }
 
     /**
@@ -541,7 +554,12 @@ public class MMRUtil {
             String fieldType = (String) current.get(TYPE);
             if (ObjectMapper.NESTED_CONTENT_TYPE.equals(fieldType)) {
                 throw new IllegalArgumentException(
-                    String.format("MMR search extension cannot support the field %s because it is in the nested field %s.", fieldPath, part)
+                    String.format(
+                        Locale.ROOT,
+                        "MMR search extension cannot support the field %s because it is in the nested field %s.",
+                        fieldPath,
+                        part
+                    )
                 );
             }
         }

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -308,7 +308,10 @@ public class FaissIT extends KNNRestTestCase {
         );
 
         for (KNNResult result : results.get(0)) {
-            assertTrue(String.format("Score %.4f below threshold %.3f", result.getScore(), minScore), result.getScore() >= minScore);
+            assertTrue(
+                String.format(Locale.ROOT, "Score %.4f below threshold %.3f", result.getScore(), minScore),
+                result.getScore() >= minScore
+            );
         }
 
         deleteKNNIndex(indexName);

--- a/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNESSettingsTestIT.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.stats.StatNames;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -154,7 +155,7 @@ public class KNNESSettingsTestIT extends KNNRestTestCase {
             ResponseException.class,
             () -> updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.KNN_INDEX, false))
         );
-        assertThat(ex.getMessage(), containsString(String.format("final %s setting [index.knn], not updateable", INDEX_NAME)));
+        assertThat(ex.getMessage(), containsString(String.format(Locale.ROOT, "final %s setting [index.knn], not updateable", INDEX_NAME)));
 
     }
 

--- a/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNIndexShardTests.java
@@ -21,6 +21,7 @@ import org.opensearch.index.shard.IndexShard;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.memory.NativeMemoryCacheManager;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -125,15 +126,15 @@ public class KNNIndexShardTests extends KNNSingleNodeTestCase {
         VectorDataType vectorDataType = VectorDataType.FLOAT;
 
         Set<String> includedFileNames = ImmutableSet.of(
-            String.format("%s_111_%s%s", segmentName, fieldName, fileExt),
-            String.format("%s_7_%s%s", segmentName, fieldName, fileExt),
-            String.format("%s_53_%s%s", segmentName, fieldName, fileExt)
+            String.format(Locale.ROOT, "%s_111_%s%s", segmentName, fieldName, fileExt),
+            String.format(Locale.ROOT, "%s_7_%s%s", segmentName, fieldName, fileExt),
+            String.format(Locale.ROOT, "%s_53_%s%s", segmentName, fieldName, fileExt)
         );
 
         List<String> excludedFileNames = ImmutableList.of(
-            String.format("_111_%s%s", fieldName, fileExt), // missing segment name
-            String.format("%s_111_%s", segmentName, fileExt), // missing field name
-            String.format("%s_111_%s.invalid", segmentName, fieldName) // missing extension
+            String.format(Locale.ROOT, "_111_%s%s", fieldName, fileExt), // missing segment name
+            String.format(Locale.ROOT, "%s_111_%s", segmentName, fileExt), // missing field name
+            String.format(Locale.ROOT, "%s_111_%s.invalid", segmentName, fieldName) // missing extension
         );
 
         List<String> files = Stream.concat(includedFileNames.stream(), excludedFileNames.stream()).collect(Collectors.toList());

--- a/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
@@ -16,6 +16,7 @@ import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
+import java.util.Locale;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -300,7 +301,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
     public void testStoredFields_whenByteDataType_thenSucceed() {
         // Create index with stored field and confirm that we can properly retrieve it
         int[] testVector = new int[] { -128, 0, 1, 127 };
-        String expectedResponse = String.format("\"fields\":{\"%s\":[[-128,0,1,127]]}}", FIELD_NAME);
+        String expectedResponse = String.format(Locale.ROOT, "\"fields\":{\"%s\":[[-128,0,1,127]]}}", FIELD_NAME);
         createKnnIndex(
             INDEX_NAME,
             createVectorMapping(testVector.length, KNNEngine.LUCENE.getName(), VectorDataType.BYTE.getValue(), true)
@@ -362,7 +363,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
     public void testStoredFields_whenFloatDataType_thenSucceed() {
         List<KNNEngine> enginesToTest = List.of(KNNEngine.FAISS, KNNEngine.LUCENE);
         float[] testVector = new float[] { -100.0f, 100.0f, 0f, 1f };
-        String expectedResponse = String.format("\"fields\":{\"%s\":[[-100.0,100.0,0.0,1.0]]}}", FIELD_NAME);
+        String expectedResponse = String.format(Locale.ROOT, "\"fields\":{\"%s\":[[-100.0,100.0,0.0,1.0]]}}", FIELD_NAME);
         for (KNNEngine knnEngine : enginesToTest) {
             createKnnIndex(INDEX_NAME, createVectorMapping(testVector.length, knnEngine.getName(), VectorDataType.FLOAT.getValue(), true));
             addKnnDoc(INDEX_NAME, "1", FIELD_NAME, testVector);

--- a/src/test/java/org/opensearch/knn/index/MinScoreIT.java
+++ b/src/test/java/org/opensearch/knn/index/MinScoreIT.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
 
+import java.util.Locale;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -276,6 +277,7 @@ public class MinScoreIT extends KNNRestTestCase {
 
             assertEquals(
                 String.format(
+                    Locale.ROOT,
                     "[%s, %s, memOpt=%s] Expected %d results with min_score=%.2f",
                     knnEngine.getName(),
                     spaceType.getValue(),
@@ -291,6 +293,7 @@ public class MinScoreIT extends KNNRestTestCase {
             for (KNNResult result : results) {
                 assertTrue(
                     String.format(
+                        Locale.ROOT,
                         "[%s, %s, memOpt=%s] Score %.3f should be >= %.2f",
                         knnEngine.getName(),
                         spaceType.getValue(),

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -311,7 +311,7 @@ public class VectorDataTypeIT extends KNNRestTestCase {
         createKnnIndexMappingForScripting(2, VectorDataType.BYTE.getValue());
         ingestL2ByteTestData();
 
-        String source = String.format("1/(1 + l2Squared([1, 1], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l2Squared([1, 1], doc['%s']))", FIELD_NAME);
         Request request = constructScriptScoreContextSearchRequest(
             INDEX_NAME,
             MATCH_ALL_QUERY_BUILDER,
@@ -332,7 +332,7 @@ public class VectorDataTypeIT extends KNNRestTestCase {
         createKnnIndexMappingForScripting(2, VectorDataType.FLOAT.getValue());
         ingestL2FloatTestData();
 
-        String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = constructScriptScoreContextSearchRequest(
             INDEX_NAME,
             MATCH_ALL_QUERY_BUILDER,
@@ -397,7 +397,7 @@ public class VectorDataTypeIT extends KNNRestTestCase {
     public void testSearchWithInvalidSearchVectorType() {
         createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
         ingestL2FloatTestData();
-        Request request = new Request("POST", String.format("/%s/_search", INDEX_NAME));
+        Request request = new Request("POST", String.format(Locale.ROOT, "/%s/_search", INDEX_NAME));
         List<Object> invalidTypeQueryVector = new ArrayList<>();
         invalidTypeQueryVector.add(1.5);
         invalidTypeQueryVector.add(2.5);
@@ -425,7 +425,7 @@ public class VectorDataTypeIT extends KNNRestTestCase {
     public void testSearchWithMissingQueryVector() {
         createKnnIndexMappingWithLuceneEngine(2, SpaceType.L2, VectorDataType.FLOAT.getValue());
         ingestL2FloatTestData();
-        Request request = new Request("POST", String.format("/%s/_search", INDEX_NAME));
+        Request request = new Request("POST", String.format(Locale.ROOT, "/%s/_search", INDEX_NAME));
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("query")

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
@@ -31,6 +31,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -257,7 +258,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         when(dir.openInput(any(), any())).thenReturn(mock(IndexInput.class));
         SegmentInfo si = mock(SegmentInfo.class);
         when(si.files()).thenReturn(files);
-        when(si.getId()).thenReturn((si.hashCode() + "").getBytes());
+        when(si.getId()).thenReturn((si.hashCode() + "").getBytes(StandardCharsets.UTF_8));
         return new Faiss1040ScalarQuantizedKnnVectorsReader(new SegmentReadState(dir, si, fieldInfos, IOContext.DEFAULT), fvr);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80CompoundFormatTests.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.knn.index.codec.KNNCodecVersion;
 import org.opensearch.knn.index.engine.KNNEngine;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
@@ -59,12 +60,12 @@ public class KNN80CompoundFormatTests extends KNNTestCase {
         String segmentName = "_test";
 
         Set<String> segmentFiles = Sets.newHashSet(
-            String.format("%s_nmslib1%s", segmentName, KNNEngine.NMSLIB.getExtension()),
-            String.format("%s_nmslib2%s", segmentName, KNNEngine.NMSLIB.getExtension()),
-            String.format("%s_nmslib3%s", segmentName, KNNEngine.NMSLIB.getExtension()),
-            String.format("%s_faiss1%s", segmentName, KNNEngine.FAISS.getExtension()),
-            String.format("%s_faiss2%s", segmentName, KNNEngine.FAISS.getExtension()),
-            String.format("%s_faiss3%s", segmentName, KNNEngine.FAISS.getExtension())
+            String.format(Locale.ROOT, "%s_nmslib1%s", segmentName, KNNEngine.NMSLIB.getExtension()),
+            String.format(Locale.ROOT, "%s_nmslib2%s", segmentName, KNNEngine.NMSLIB.getExtension()),
+            String.format(Locale.ROOT, "%s_nmslib3%s", segmentName, KNNEngine.NMSLIB.getExtension()),
+            String.format(Locale.ROOT, "%s_faiss1%s", segmentName, KNNEngine.FAISS.getExtension()),
+            String.format(Locale.ROOT, "%s_faiss2%s", segmentName, KNNEngine.FAISS.getExtension()),
+            String.format(Locale.ROOT, "%s_faiss3%s", segmentName, KNNEngine.FAISS.getExtension())
         );
 
         SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
@@ -92,7 +93,7 @@ public class KNN80CompoundFormatTests extends KNNTestCase {
             try {
                 directory.deleteFile(filename);
             } catch (IOException e) {
-                fail(String.format("Failed to delete: %s", filename));
+                fail(String.format(Locale.ROOT, "Failed to delete: %s", filename));
             }
         });
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumerTests.java
@@ -52,6 +52,7 @@ import org.opensearch.knn.jni.JNIService;
 import org.opensearch.knn.plugin.stats.KNNCounter;
 import org.opensearch.knn.plugin.stats.KNNGraphValue;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -133,7 +134,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         DocValuesConsumer delegate = mock(DocValuesConsumer.class);
         doNothing().when(delegate).addBinaryField(fieldInfo, docValuesProducer);
 
-        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
         int docsInSegment = 100;
 
         SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
@@ -171,7 +172,7 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
         Long initialMergeOperations = KNNGraphValue.MERGE_TOTAL_OPERATIONS.getValue();
         Long initialMergeSize = KNNGraphValue.MERGE_TOTAL_SIZE_IN_BYTES.getValue();
         Long initialMergeDocs = KNNGraphValue.MERGE_TOTAL_DOCS.getValue();
-        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
         int docsInSegment = 100;
 
         SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
@@ -194,9 +195,9 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
 
     public void testAddKNNBinaryField_fromScratch_nmslibCurrent() throws IOException {
         // Set information about the segment and the fields
-        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
         int docsInSegment = 100;
-        String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+        String fieldName = String.format(Locale.ROOT, "test_field%s", randomAlphaOfLength(4));
 
         KNNEngine knnEngine = KNNEngine.NMSLIB;
         SpaceType spaceType = SpaceType.COSINESIMIL;
@@ -262,9 +263,9 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
 
     public void testAddKNNBinaryField_fromScratch_nmslibLegacy() throws IOException {
         // Set information about the segment and the fields
-        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
         int docsInSegment = 100;
-        String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+        String fieldName = String.format(Locale.ROOT, "test_field%s", randomAlphaOfLength(4));
 
         KNNEngine knnEngine = KNNEngine.NMSLIB;
         SpaceType spaceType = SpaceType.COSINESIMIL;
@@ -316,9 +317,9 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
     }
 
     public void testAddKNNBinaryField_fromScratch_faissCurrent() throws IOException {
-        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
         int docsInSegment = 100;
-        String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+        String fieldName = String.format(Locale.ROOT, "test_field%s", randomAlphaOfLength(4));
 
         KNNEngine knnEngine = KNNEngine.FAISS;
         SpaceType spaceType = SpaceType.INNER_PRODUCT;
@@ -381,9 +382,9 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
     }
 
     public void testAddKNNBinaryField_whenFaissBinary_thenAdded() throws IOException {
-        String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+        String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
         int docsInSegment = 100;
-        String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+        String fieldName = String.format(Locale.ROOT, "test_field%s", randomAlphaOfLength(4));
 
         KNNEngine knnEngine = KNNEngine.FAISS;
         SpaceType spaceType = SpaceType.HAMMING;
@@ -505,9 +506,9 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
             ModelCache.initialize(modelDao, clusterService);
 
             // Build the segment and field info
-            String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+            String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
             int docsInSegment = 100;
-            String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+            String fieldName = String.format(Locale.ROOT, "test_field%s", randomAlphaOfLength(4));
 
             SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
                 .directory(directory)
@@ -685,9 +686,9 @@ public class KNN80DocValuesConsumerTests extends KNNTestCase {
             ModelCache.initialize(modelDao, clusterService);
 
             // Build the segment and field info
-            String segmentName = String.format("test_segment%s", randomAlphaOfLength(4));
+            String segmentName = String.format(Locale.ROOT, "test_segment%s", randomAlphaOfLength(4));
             int docsInSegment = 100;
-            String fieldName = String.format("test_field%s", randomAlphaOfLength(4));
+            String fieldName = String.format(Locale.ROOT, "test_field%s", randomAlphaOfLength(4));
 
             SegmentInfo segmentInfo = KNNCodecTestUtil.segmentInfoBuilder()
                 .directory(directory)

--- a/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesProducerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN80Codec/KNN80DocValuesProducerTests.java
@@ -33,6 +33,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -73,11 +74,11 @@ public class KNN80DocValuesProducerTests extends KNNTestCase {
 
         String segmentName = "_test";
         int docsInSegment = 100;
-        String fieldName1 = String.format("test_field1%s", randomAlphaOfLength(4));
-        String fieldName2 = String.format("test_field2%s", randomAlphaOfLength(4));
+        String fieldName1 = String.format(Locale.ROOT, "test_field1%s", randomAlphaOfLength(4));
+        String fieldName2 = String.format(Locale.ROOT, "test_field2%s", randomAlphaOfLength(4));
         List<String> segmentFiles = Arrays.asList(
-            String.format("%s_2011_%s%s", segmentName, fieldName1, KNNEngine.NMSLIB.getExtension()),
-            String.format("%s_165_%s%s", segmentName, fieldName2, KNNEngine.FAISS.getExtension())
+            String.format(Locale.ROOT, "%s_2011_%s%s", segmentName, fieldName1, KNNEngine.NMSLIB.getExtension()),
+            String.format(Locale.ROOT, "%s_165_%s%s", segmentName, fieldName2, KNNEngine.FAISS.getExtension())
         );
 
         KNNEngine knnEngine = KNNEngine.NMSLIB;
@@ -142,11 +143,11 @@ public class KNN80DocValuesProducerTests extends KNNTestCase {
 
         String segmentName = "_test";
         int docsInSegment = 100;
-        String fieldName1 = String.format("test_field1%s", randomAlphaOfLength(4));
-        String fieldName2 = String.format("test_field2%s", randomAlphaOfLength(4));
+        String fieldName1 = String.format(Locale.ROOT, "test_field1%s", randomAlphaOfLength(4));
+        String fieldName2 = String.format(Locale.ROOT, "test_field2%s", randomAlphaOfLength(4));
         List<String> segmentFiles = Arrays.asList(
-            String.format("%s_2011_%s%s", segmentName, fieldName1, KNNEngine.NMSLIB.getExtension()),
-            String.format("%s_165_%s%s", segmentName, fieldName2, KNNEngine.FAISS.getExtension())
+            String.format(Locale.ROOT, "%s_2011_%s%s", segmentName, fieldName1, KNNEngine.NMSLIB.getExtension()),
+            String.format(Locale.ROOT, "%s_165_%s%s", segmentName, fieldName2, KNNEngine.FAISS.getExtension())
         );
 
         KNNEngine knnEngine = KNNEngine.NMSLIB;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -32,6 +32,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -207,7 +208,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
         when(mockDirectory.openInput(any(), any())).thenReturn(mockIndexInput);
         final SegmentInfo segmentInfo = mock(SegmentInfo.class);
         when(segmentInfo.files()).thenReturn(filesInSegment);
-        when(segmentInfo.getId()).thenReturn((segmentInfo.hashCode() + "").getBytes());
+        when(segmentInfo.getId()).thenReturn((segmentInfo.hashCode() + "").getBytes(StandardCharsets.UTF_8));
         final SegmentReadState readState = new SegmentReadState(mockDirectory, segmentInfo, fieldInfos, IOContext.DEFAULT);
 
         // Create reader

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitorTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceStoredFieldVisitorTests.java
@@ -11,6 +11,7 @@ import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 
 import static org.mockito.Mockito.mock;
@@ -33,8 +34,8 @@ public class DerivedSourceStoredFieldVisitorTests extends OpenSearchTestCase {
         DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder(SourceFieldMapper.NAME).build();
 
-        byte[] originalValue = TEST_ORIGINAL_VALUE.getBytes();
-        byte[] transformedValue = TEST_TRANSFORMED_VALUE.getBytes();
+        byte[] originalValue = TEST_ORIGINAL_VALUE.getBytes(StandardCharsets.UTF_8);
+        byte[] transformedValue = TEST_TRANSFORMED_VALUE.getBytes(StandardCharsets.UTF_8);
         int documentId = TEST_DOC_ID;
 
         when(transformer.injectVectors(documentId, originalValue)).thenReturn(transformedValue);
@@ -52,7 +53,7 @@ public class DerivedSourceStoredFieldVisitorTests extends OpenSearchTestCase {
         DerivedSourceVectorTransformer transformer = mock(DerivedSourceVectorTransformer.class);
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("other-field").build();
 
-        byte[] value = TEST_VALUE.getBytes();
+        byte[] value = TEST_VALUE.getBytes(StandardCharsets.UTF_8);
         int documentId = TEST_DOC_ID;
 
         DerivedSourceStoredFieldVisitor visitor = new DerivedSourceStoredFieldVisitor(delegate, documentId, transformer);

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -125,6 +126,7 @@ public class DerivedSourceVectorTransformerTests extends OpenSearchTestCase {
         for (String field : expectedPresent) {
             assertTrue(
                 String.format(
+                    Locale.ROOT,
                     "Field '%s' should be present (includes=%s, excludes=%s)",
                     field,
                     Arrays.toString(includes),
@@ -137,6 +139,7 @@ public class DerivedSourceVectorTransformerTests extends OpenSearchTestCase {
         for (String field : expectedAbsent) {
             assertFalse(
                 String.format(
+                    Locale.ROOT,
                     "Field '%s' should be absent (includes=%s, excludes=%s)",
                     field,
                     Arrays.toString(includes),
@@ -147,7 +150,12 @@ public class DerivedSourceVectorTransformerTests extends OpenSearchTestCase {
         }
 
         assertEquals(
-            String.format("Field count mismatch (includes=%s, excludes=%s)", Arrays.toString(includes), Arrays.toString(excludes)),
+            String.format(
+                Locale.ROOT,
+                "Field count mismatch (includes=%s, excludes=%s)",
+                Arrays.toString(includes),
+                Arrays.toString(excludes)
+            ),
             expectedPresent.length,
             remainingFields.size()
         );

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsReaderTests.java
@@ -29,6 +29,7 @@ import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
@@ -235,7 +236,7 @@ public class AbstractNativeEnginesKnnVectorsReaderTests extends KNNTestCase {
         when(dir.openInput(any(), any())).thenReturn(mock(IndexInput.class));
         final SegmentInfo si = mock(SegmentInfo.class);
         when(si.files()).thenReturn(files);
-        when(si.getId()).thenReturn((si.hashCode() + "").getBytes());
+        when(si.getId()).thenReturn((si.hashCode() + "").getBytes(StandardCharsets.UTF_8));
         return new TestReader(new SegmentReadState(dir, si, fieldInfos, IOContext.DEFAULT), fvr);
     }
 

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissTests.java
@@ -442,7 +442,12 @@ public class FaissTests extends KNNTestCase {
             float convertedDistance = Faiss.INSTANCE.scoreToRadialThreshold(luceneScore, org.opensearch.knn.index.SpaceType.INNER_PRODUCT);
 
             assertEquals(
-                String.format("Round-trip conversion failed for distance %.2f (score was %.4f)", originalDistance, luceneScore),
+                String.format(
+                    Locale.ROOT,
+                    "Round-trip conversion failed for distance %.2f (score was %.4f)",
+                    originalDistance,
+                    luceneScore
+                ),
                 originalDistance,
                 convertedDistance,
                 1e-5

--- a/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNWeightTests.java
@@ -254,7 +254,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         when(fieldInfo.getAttribute(eq(MODEL_ID))).thenReturn(modelId);
 
         RuntimeException ex = expectThrows(RuntimeException.class, () -> knnWeight.scorer(leafReaderContext));
-        assertEquals(String.format("Model \"%s\" is not created.", modelId), ex.getMessage());
+        assertEquals(String.format(Locale.ROOT, "Model \"%s\" is not created.", modelId), ex.getMessage());
     }
 
     @SneakyThrows
@@ -1726,7 +1726,7 @@ public class KNNWeightTests extends KNNWeightTestCase {
         String engineName = fieldInfo.attributes().getOrDefault(KNN_ENGINE, KNNEngine.NMSLIB.getName());
         KNNEngine knnEngine = KNNEngine.getEngine(engineName);
         List<String> engineFiles = KNNCodecUtil.getEngineFiles(knnEngine.getExtension(), query.getField(), reader.getSegmentInfo().info);
-        String expectIndexPath = String.format("%s_%s_%s%s%s", SEGMENT_NAME, 2011, FIELD_NAME, knnEngine.getExtension(), "c");
+        String expectIndexPath = String.format(Locale.ROOT, "%s_%s_%s%s%s", SEGMENT_NAME, 2011, FIELD_NAME, knnEngine.getExtension(), "c");
         assertEquals(engineFiles.get(0), expectIndexPath);
 
         final KNNScorer knnScorer = (KNNScorer) knnWeight.scorer(leafReaderContext);

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
+import java.util.Locale;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.concurrent.ExecutionException;
@@ -523,7 +524,7 @@ public class ModelCacheTests extends KNNTestCase {
         int maxDocuments = 10;
         ModelDao modelDao = mock(ModelDao.class);
         for (int i = 0; i < maxDocuments; i++) {
-            String modelId = String.format(modelIdPattern, i);
+            String modelId = String.format(Locale.ROOT, modelIdPattern, i);
             Model mockModel = new Model(
                 new ModelMetadata(
                     KNNEngine.DEFAULT,
@@ -557,7 +558,7 @@ public class ModelCacheTests extends KNNTestCase {
         ModelCache modelCache = new ModelCache();
         assertNull(modelCache.getEvictedDueToSizeAt());
         for (int i = 0; i < maxDocuments; i++) {
-            modelCache.get(String.format(modelIdPattern, i));
+            modelCache.get(String.format(Locale.ROOT, modelIdPattern, i));
         }
         assertNotNull(modelCache.getEvictedDueToSizeAt());
     }

--- a/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelCacheTests.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -56,7 +57,7 @@ public class ModelCacheTests extends KNNTestCase {
                 CompressionLevel.NOT_CONFIGURED,
                 Version.V_EMPTY
             ),
-            "hello".getBytes(),
+            "hello".getBytes(StandardCharsets.UTF_8),
             modelId
         );
         String cacheSize = "10%";
@@ -300,7 +301,7 @@ public class ModelCacheTests extends KNNTestCase {
                 CompressionLevel.NOT_CONFIGURED,
                 Version.V_EMPTY
             ),
-            "hello".getBytes(),
+            "hello".getBytes(StandardCharsets.UTF_8),
             modelId
         );
 

--- a/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelDaoTests.java
@@ -51,6 +51,7 @@ import org.opensearch.knn.plugin.transport.UpdateModelGraveyardAction;
 import org.opensearch.knn.plugin.transport.UpdateModelGraveyardRequest;
 import org.opensearch.knn.training.TrainingJobClusterStateListener;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -130,7 +131,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         // insert model
         String modelId = "created-1";
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
 
         Model model = new Model(
@@ -186,7 +187,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
         String modelId = "efbsdhcvbsd"; // User provided model id
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
 
         Model model = new Model(
@@ -358,7 +359,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
 
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
         String modelId = "efbsdhcvbsd"; // User provided model id
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
 
         Model model = new Model(
@@ -448,7 +449,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
     public void testGet() throws IOException, InterruptedException, ExecutionException {
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
         String modelId = "efbsdhcvbsd";
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
 
         // model index doesnt exist
@@ -519,7 +520,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         assertNull(modelDao.getMetadata(modelId));
 
         // Model exists
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
 
         KNNEngine knnEngine = KNNEngine.FAISS;
         SpaceType spaceType = SpaceType.INNER_PRODUCT;
@@ -562,7 +563,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
         String modelId = "testDeleteModelID";
         String modelId1 = "testDeleteModelID1";
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
 
         final CountDownLatch inProgressLatch = new CountDownLatch(1);
@@ -710,7 +711,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
     public void testDeleteModelInTrainingWithStepListeners() throws IOException, ExecutionException, InterruptedException {
         String modelId = "test-model-id-training";
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
-        byte[] modelBlob = "deleteModel".getBytes();
+        byte[] modelBlob = "deleteModel".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
         createIndex(MODEL_INDEX_NAME);
 
@@ -756,7 +757,7 @@ public class ModelDaoTests extends KNNSingleNodeTestCase {
     public void testDeleteWithStepListeners() throws IOException, InterruptedException, ExecutionException {
         String modelId = "test-model-id-delete";
         ModelDao modelDao = ModelDao.OpenSearchKNNModelDao.getInstance();
-        byte[] modelBlob = "deleteModel".getBytes();
+        byte[] modelBlob = "deleteModel".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
         createIndex(MODEL_INDEX_NAME);
 

--- a/src/test/java/org/opensearch/knn/indices/ModelTests.java
+++ b/src/test/java/org/opensearch/knn/indices/ModelTests.java
@@ -21,6 +21,7 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -148,7 +149,7 @@ public class ModelTests extends KNNTestCase {
     }
 
     public void testGetModelBlob() {
-        byte[] modelBlob = "hello".getBytes();
+        byte[] modelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         Model model = new Model(
             new ModelMetadata(
                 KNNEngine.DEFAULT,
@@ -217,7 +218,7 @@ public class ModelTests extends KNNTestCase {
     }
 
     public void testSetModelBlob() {
-        byte[] blob1 = "Hello blob 1".getBytes();
+        byte[] blob1 = "Hello blob 1".getBytes(StandardCharsets.UTF_8);
         Model model = new Model(
             new ModelMetadata(
                 KNNEngine.DEFAULT,
@@ -238,7 +239,7 @@ public class ModelTests extends KNNTestCase {
             "test-model"
         );
         assertEquals(blob1, model.getModelBlob());
-        byte[] blob2 = "Hello blob 2".getBytes();
+        byte[] blob2 = "Hello blob 2".getBytes(StandardCharsets.UTF_8);
 
         model.setModelBlob(blob2);
         assertEquals(blob2, model.getModelBlob());
@@ -418,7 +419,7 @@ public class ModelTests extends KNNTestCase {
         modelAsMap.put(KNNConstants.MODE_PARAMETER, Mode.NOT_CONFIGURED.getName());
         modelAsMap.put(KNNConstants.COMPRESSION_LEVEL_PARAMETER, CompressionLevel.NOT_CONFIGURED.getName());
 
-        byte[] blob1 = "hello".getBytes();
+        byte[] blob1 = "hello".getBytes(StandardCharsets.UTF_8);
         Model expected = new Model(metadata, blob1, modelID);
 
         Model fromMap = Model.getModelFromSourceMap(modelAsMap);

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -237,9 +237,12 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
             Map<String, Object> hits = (Map<String, Object>) searchResult;
             for (String metaField : metaFields) {
-                assertTrue(String.format("Missing meta field '%s' in search result %d", metaField, i), hits.containsKey(metaField));
+                assertTrue(
+                    String.format(Locale.ROOT, "Missing meta field '%s' in search result %d", metaField, i),
+                    hits.containsKey(metaField)
+                );
                 assertNotNull(
-                    String.format("Meta field '%s' value should not be null in search result %d", metaField, i),
+                    String.format(Locale.ROOT, "Meta field '%s' value should not be null in search result %d", metaField, i),
                     hits.get(metaField)
                 );
             }

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -123,7 +123,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL2ScriptScoreFails() throws Exception {
-        String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -185,7 +185,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testL2ScriptScore() throws Exception {
 
-        String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
 
         Response response = client().performRequest(request);
@@ -203,7 +203,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testGetValueReturnsDocValues() throws Exception {
 
-        String source = String.format("doc['%s'].value[0]", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "doc['%s'].value[0]", FIELD_NAME);
         Map<String, Float[]> testData = getKnnVectorTestData();
         Request request = buildPainlessScoreScriptRequest(source, testData.size(), testData);
 
@@ -221,7 +221,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testGetValueScriptFailsWithMissingField() throws Exception {
-        String source = String.format("doc['%s']", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "doc['%s']", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getKnnVectorTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -230,7 +230,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testGetValueScriptFailsWithOutOfBoundException() throws Exception {
         Map<String, Float[]> testData = getKnnVectorTestData();
-        String source = String.format("doc['%s'].value[%d]", FIELD_NAME, testData.get("1").length);
+        String source = String.format(Locale.ROOT, "doc['%s'].value[%d]", FIELD_NAME, testData.get("1").length);
         Request request = buildPainlessScoreScriptRequest(source, testData.size(), testData);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
         deleteKNNIndex(INDEX_NAME);
@@ -238,7 +238,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testGetValueScriptScoreWithNumericField() throws Exception {
 
-        String source = String.format("doc['%s'].size() == 0 ? 0 : doc['%s'].value[0]", FIELD_NAME, FIELD_NAME);
+        String source = String.format(Locale.ROOT, "doc['%s'].size() == 0 ? 0 : doc['%s'].value[0]", FIELD_NAME, FIELD_NAME);
         Map<String, Float[]> testData = getKnnVectorTestData();
         Request request = buildPainlessScoreScriptRequest(source, testData.size(), testData);
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -257,7 +257,12 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testL2ScriptScoreWithNumericField() throws Exception {
 
-        String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
+        String source = String.format(
+            Locale.ROOT,
+            "doc['%s'].size() == 0 ? 0 : 1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))",
+            FIELD_NAME,
+            FIELD_NAME
+        );
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         Response response = client().performRequest(request);
@@ -274,7 +279,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityScriptScoreFails() throws Exception {
-        String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -282,7 +287,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityScriptScore() throws Exception {
-        String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
@@ -298,7 +303,12 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityScriptScoreWithNumericField() throws Exception {
-        String source = String.format("doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME, FIELD_NAME);
+        String source = String.format(
+            Locale.ROOT,
+            "doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])",
+            FIELD_NAME,
+            FIELD_NAME
+        );
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         Response response = client().performRequest(request);
@@ -316,7 +326,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     // test fails without size check before executing method
     public void testCosineSimilarityNormalizedScriptScoreFails() throws Exception {
-        String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -324,7 +334,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityNormalizedScriptScore() throws Exception {
-        String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
@@ -341,6 +351,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testCosineSimilarityNormalizedScriptScoreWithNumericField() throws Exception {
         String source = String.format(
+            Locale.ROOT,
             "doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)",
             FIELD_NAME,
             FIELD_NAME
@@ -362,7 +373,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     // L1 tests
     public void testL1ScriptScoreFails() throws Exception {
-        String source = String.format("1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -371,7 +382,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testL1ScriptScore() throws Exception {
 
-        String source = String.format("1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
 
         Response response = client().performRequest(request);
@@ -389,7 +400,12 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testL1ScriptScoreWithNumericField() throws Exception {
 
-        String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
+        String source = String.format(
+            Locale.ROOT,
+            "doc['%s'].size() == 0 ? 0 : 1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))",
+            FIELD_NAME,
+            FIELD_NAME
+        );
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         Response response = client().performRequest(request);
@@ -407,7 +423,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     // L-inf tests
     public void testLInfScriptScoreFails() throws Exception {
-        String source = String.format("1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -416,7 +432,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testLInfScriptScore() throws Exception {
 
-        String source = String.format("1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
 
         Response response = client().performRequest(request);
@@ -434,7 +450,12 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testLInfScriptScoreWithNumericField() throws Exception {
 
-        String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
+        String source = String.format(
+            Locale.ROOT,
+            "doc['%s'].size() == 0 ? 0 : 1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))",
+            FIELD_NAME,
+            FIELD_NAME
+        );
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         Response response = client().performRequest(request);
@@ -451,7 +472,11 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testInnerProdScriptScoreFails() throws Exception {
-        String source = String.format("float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
+        String source = String.format(
+            Locale.ROOT,
+            "float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);",
+            FIELD_NAME
+        );
         Request request = buildPainlessScoreScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
         expectThrows(ResponseException.class, () -> client().performRequest(request));
@@ -460,7 +485,11 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     public void testInnerProdScriptScore() throws Exception {
 
-        String source = String.format("float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
+        String source = String.format(
+            Locale.ROOT,
+            "float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);",
+            FIELD_NAME
+        );
         Request request = buildPainlessScoreScriptRequest(source, 3, getInnerProdTestData());
 
         Response response = client().performRequest(request);
@@ -479,6 +508,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     public void testInnerProdScriptScoreWithNumericField() throws Exception {
 
         String source = String.format(
+            Locale.ROOT,
             "if (doc['%s'].size() == 0) "
                 + "{ return 0; } "
                 + "else "
@@ -505,7 +535,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
         Map<String, Float[]> testData = getKnnVectorTestData();
         // sum of first value from each vector
         String initScriptSource = "state.x = []";
-        String mapScriptSource = String.format("state.x.add(doc['%s'].value[0])", FIELD_NAME);
+        String mapScriptSource = String.format(Locale.ROOT, "state.x.add(doc['%s'].value[0])", FIELD_NAME);
         String combineScriptSource = "double sum = 0; for (t in state.x) { sum += t } return sum";
         String reduceScriptSource = "double sum = 0; for (v in states) { sum += v } return sum";
         String aggName = randomAlphaOfLengthBetween(AGGREGATION_FIELD_NAME_MIN_LENGTH, AGGREGATION_FIELD_NAME_MAX_LENGTH); // random agg
@@ -546,7 +576,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
                 .build()
         );
 
-        String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData(), properties);
 
         Response response = client().performRequest(request);
@@ -568,7 +598,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
         String mappingForKnnDisabled = createKnnIndexMapping(FIELD_NAME, dimensions, VectorDataType.BINARY);
 
         // 0b00000001, 0b00000001
-        String source = String.format("1/(1 + hamming([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + hamming([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
 
         Map<String, Float[]> data = new HashMap<>();
         data.put("1", new Float[] { (float) 0b00000001, (float) 0b00000001 });// Hamming distance 0
@@ -590,7 +620,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     public void testPainlessScript_whenNonBinary_thenException() {
         int dimensions = 2;
         String mapping = createKnnIndexMapping(FIELD_NAME, dimensions);
-        String source = String.format("1/(1 + hamming([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        String source = String.format(Locale.ROOT, "1/(1 + hamming([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Exception e = expectThrows(
             ResponseException.class,
             () -> buildIndexAndRunPainlessScript(source, 3, getKnnVectorTestData(), mapping, false)

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissByteIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissByteIndexTests.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueR
 import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizedValueReconstructorFactory;
 import org.opensearch.knn.memoryoptsearch.faiss.reconstruct.FaissQuantizerType;
 
+import java.nio.charset.StandardCharsets;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -78,7 +79,7 @@ public class FaissByteIndexTests extends KNNTestCase {
     private static IndexInput loadFlatByteVectors() {
         final String relativePath = "data/memoryoptsearch/faiss_flat_byte_100_vectors_8_dim.bin";
         final URL flatByteVectors = FaissHNSWTests.class.getClassLoader().getResource(relativePath);
-        final byte[] indexTypeFourBytes = FaissIndexScalarQuantizedFlat.IXSQ.getBytes();
+        final byte[] indexTypeFourBytes = FaissIndexScalarQuantizedFlat.IXSQ.getBytes(StandardCharsets.UTF_8);
         final byte[] bytes = Files.readAllBytes(Path.of(flatByteVectors.toURI()));
         final byte[] combinedBytes = ByteBuffer.allocate(bytes.length + indexTypeFourBytes.length)
             .put(indexTypeFourBytes)

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexFloatFlatTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissIndexFloatFlatTests.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.memoryoptsearch.faiss.FaissIndexFloatFlat;
 import org.opensearch.knn.memoryoptsearch.faiss.FaissSection;
 import org.opensearch.knn.memoryoptsearch.faiss.UnsupportedFaissIndexException;
 
+import java.nio.charset.StandardCharsets;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.ByteBuffer;
@@ -125,7 +126,7 @@ public class FaissIndexFloatFlatTests extends KNNTestCase {
         final String relativePath = "data/memoryoptsearch/faiss_flat_float_50_vectors_128_dim.bin";
         final URL floatFloatVectors = FaissHNSWTests.class.getClassLoader().getResource(relativePath);
         final byte[] bytes = Files.readAllBytes(Path.of(floatFloatVectors.toURI()));
-        final byte[] indexTypeFourBytes = indexType.getBytes();
+        final byte[] indexTypeFourBytes = indexType.getBytes(StandardCharsets.UTF_8);
         final byte[] combinedBytes = ByteBuffer.allocate(bytes.length + indexTypeFourBytes.length)
             .put(indexTypeFourBytes)
             .put(bytes)

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
@@ -27,6 +27,7 @@ import org.opensearch.knn.memoryoptsearch.faiss.FaissScalarQuantizedFlatIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.UnsupportedFaissIndexException;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
@@ -143,7 +144,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
                 // Write an invalid FAISS index type header to trigger UnsupportedFaissIndexException
                 // FAISS index format: first 4 bytes are a uint32 representing the index type string length,
                 // followed by the index type string. We write a valid-looking but unsupported type.
-                byte[] unsupportedType = "IxUNSUPPORTED".getBytes();
+                byte[] unsupportedType = "IxUNSUPPORTED".getBytes(StandardCharsets.UTF_8);
                 output.writeInt(unsupportedType.length);
                 output.writeBytes(unsupportedType, unsupportedType.length);
                 // Pad with zeros to avoid EOF
@@ -189,7 +190,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
 
         try (Directory directory = newFSDirectory(tempDir)) {
             try (IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
-                byte[] unsupportedType = "IxUNSUPPORTED".getBytes();
+                byte[] unsupportedType = "IxUNSUPPORTED".getBytes(StandardCharsets.UTF_8);
                 output.writeInt(unsupportedType.length);
                 output.writeBytes(unsupportedType, unsupportedType.length);
                 output.writeBytes(new byte[1024], 1024);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -82,6 +82,7 @@ import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 import org.opensearch.knn.quantization.models.quantizationParams.ScalarQuantizationParams;
 import org.opensearch.knn.quantization.models.quantizationState.QuantizationState;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
@@ -644,7 +645,7 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final SegmentInfo segmentInfo = mock(SegmentInfo.class);
         when(segmentInfo.getUseCompoundFile()).thenReturn(false);
         when(segmentInfo.files()).thenReturn(Set.of(buildInfo.faissIndexFile));
-        when(segmentInfo.getId()).thenReturn("LuceneOnFaiss".getBytes());
+        when(segmentInfo.getId()).thenReturn("LuceneOnFaiss".getBytes(StandardCharsets.UTF_8));
         when(segmentInfo.getVersion()).thenReturn(org.apache.lucene.util.Version.LATEST);
 
         // Prepare collector and bits

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/NestedMappingSchema.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/NestedMappingSchema.java
@@ -11,6 +11,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
+import java.util.Locale;
 
 import static org.opensearch.knn.memoryoptsearch.NonNestedNMappingSchema.createModeCompressionLevelPartInMapping;
 
@@ -29,38 +30,39 @@ public class NestedMappingSchema {
     private CompressionLevel compressionLevel;
 
     public String createString() {
-        final String mapping = """
-            {
-              "properties": {
-                "%s": {
-                  "type": "nested",
+        final String mapping = String.format(
+            Locale.ROOT,
+            """
+                {
                   "properties": {
                     "%s": {
-                      "type": "knn_vector",
-                      "dimension": %s,
-                      "data_type": "%s",
-                      %s
-                      "space_type": "%s",
-                      "method": {
-                        "engine": "faiss",
-                        "name": "hnsw",
-                        "parameters": %s
+                      "type": "nested",
+                      "properties": {
+                        "%s": {
+                          "type": "knn_vector",
+                          "dimension": %s,
+                          "data_type": "%s",
+                          %s
+                          "space_type": "%s",
+                          "method": {
+                            "engine": "faiss",
+                            "name": "hnsw",
+                            "parameters": %s
+                          }
+                        }
                       }
+                    },
+                    "%s": {
+                      "type": "keyword",
+                      "index": true
+                    },
+                    "%s": {
+                      "type": "keyword",
+                      "index": true
                     }
-                  }
-                },
-                "%s": {
-                  "type": "keyword",
-                  "index": true
-                },
-                "%s": {
-                  "type": "keyword",
-                  "index": true
-                }
-              },
-              "dynamic": false
-            }
-            """.formatted(
+                  },
+                  "dynamic": false
+                }""",
             nestedFieldName,
             knnFieldName,
             Integer.toString(dimension),

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/NonNestedNMappingSchema.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/NonNestedNMappingSchema.java
@@ -11,6 +11,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
+import java.util.Locale;
 
 @Accessors(fluent = true, chain = true)
 @Setter
@@ -30,39 +31,41 @@ class NonNestedNMappingSchema {
             return "";
         }
 
-        return """
+        return String.format(Locale.ROOT, """
               "mode": "%s",
               "compression_level": "%s",
-            """.formatted(mode == Mode.NOT_CONFIGURED ? "null" : mode.getName(), compressionLevel.getName());
+            """, mode == Mode.NOT_CONFIGURED ? "null" : mode.getName(), compressionLevel.getName());
     }
 
     public String createString() {
-        final String mapping = """
-            {
-              "properties": {
-                "%s": {
-                  "type": "knn_vector",
-                  "dimension": %s,
-                  "data_type": "%s",
-                  %s
-                  "space_type": "%s",
-                  "method": {
-                    "engine": "faiss",
-                    "name": "hnsw",
-                    "parameters": %s
-                  }
-                },
-                "%s": {
-                  "type": "keyword",
-                  "index": true
-                },
-                "%s": {
-                  "type": "keyword",
-                  "index": true
-                }
-              },
-              "dynamic": false
-            }""".formatted(
+        final String mapping = String.format(
+            Locale.ROOT,
+            """
+                {
+                  "properties": {
+                    "%s": {
+                      "type": "knn_vector",
+                      "dimension": %s,
+                      "data_type": "%s",
+                      %s
+                      "space_type": "%s",
+                      "method": {
+                        "engine": "faiss",
+                        "name": "hnsw",
+                        "parameters": %s
+                      }
+                    },
+                    "%s": {
+                      "type": "keyword",
+                      "index": true
+                    },
+                    "%s": {
+                      "type": "keyword",
+                      "index": true
+                    }
+                  },
+                  "dynamic": false
+                }""",
             knnFieldName,
             Integer.toString(dimension),
             dataType.getValue(),

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissIndexTests.java
@@ -9,6 +9,8 @@ import lombok.SneakyThrows;
 import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.KNNTestCase;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -20,7 +22,7 @@ public class FaissIndexTests extends KNNTestCase {
         IndexInput mockInput = mock(IndexInput.class);
         doAnswer(invocation -> {
             byte[] buf = invocation.getArgument(0);
-            byte[] nullBytes = "null".getBytes();
+            byte[] nullBytes = "null".getBytes(StandardCharsets.UTF_8);
             System.arraycopy(nullBytes, 0, buf, 0, 4);
             return null;
         }).when(mockInput).readBytes(any(byte[].class), any(int.class), any(int.class));

--- a/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
+++ b/src/test/java/org/opensearch/knn/plugin/action/RestSearchModelHandlerIT.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.plugin.KNNPlugin;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchHit;
 
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -84,13 +85,14 @@ public class RestSearchModelHandlerIT extends KNNRestTestCase {
 
             ResponseException ex = expectThrows(ResponseException.class, () -> client().performRequest(request));
             String messageExpected = String.format(
+                Locale.ROOT,
                 "%s must be between %s and %s inclusive",
                 PARAM_SIZE,
                 SEARCH_MODEL_MIN_SIZE,
                 SEARCH_MODEL_MAX_SIZE
             );
             assertTrue(
-                String.format("FAILED - Expected  \"%s\" to have \"%s\"", ex.getMessage(), messageExpected),
+                String.format(Locale.ROOT, "FAILED - Expected  \"%s\" to have \"%s\"", ex.getMessage(), messageExpected),
                 ex.getMessage().contains(messageExpected)
             );
         }

--- a/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/script/KNNScoringSpaceTests.java
@@ -50,7 +50,7 @@ public class KNNScoringSpaceTests extends KNNTestCase {
         assertTrue(e.getCause() instanceof IllegalArgumentException);
         assertTrue(
             e.getCause().getMessage(),
-            e.getCause().getMessage().contains(String.format("The data type should be %s", DATA_TYPES_DEFAULT))
+            e.getCause().getMessage().contains(String.format(Locale.ROOT, "The data type should be %s", DATA_TYPES_DEFAULT))
         );
     }
 

--- a/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/GetModelResponseTests.java
@@ -28,6 +28,7 @@ import org.opensearch.knn.indices.Model;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.util.Locale;
 
@@ -57,7 +58,7 @@ public class GetModelResponseTests extends KNNTestCase {
 
     public void testStreams() throws IOException {
         String modelId = "test-model";
-        byte[] testModelBlob = "hello".getBytes();
+        byte[] testModelBlob = "hello".getBytes(StandardCharsets.UTF_8);
         Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
         GetModelResponse getModelResponse = new GetModelResponse(model);
         BytesStreamOutput streamOutput = new BytesStreamOutput();
@@ -72,7 +73,7 @@ public class GetModelResponseTests extends KNNTestCase {
             when(knnClusterUtil.getClusterMinVersion()).thenReturn(Version.CURRENT);
             knnClusterUtilMockedStatic.when(KNNClusterUtil::instance).thenReturn(knnClusterUtil);
             String modelId = "test-model";
-            byte[] testModelBlob = "hello".getBytes();
+            byte[] testModelBlob = "hello".getBytes(StandardCharsets.UTF_8);
             Model model = new Model(getModelMetadata(ModelState.CREATED), testModelBlob, modelId);
             GetModelResponse getModelResponse = new GetModelResponse(model);
             String expectedResponseString = String.format(

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
@@ -28,6 +28,7 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.Locale;
 import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -380,6 +381,7 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
                     assertTrue(e instanceof DeleteModelException);
                     assertEquals(
                         String.format(
+                            Locale.ROOT,
                             "Cannot delete model [%s].  Model is in use by the following indices %s, which must be deleted first.",
                             updateModelGraveyardRequest.getModelId(),
                             indicesPresentInException

--- a/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
+++ b/src/test/java/org/opensearch/knn/plugin/transport/UpdateModelGraveyardTransportActionTests.java
@@ -28,6 +28,7 @@ import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -200,7 +201,7 @@ public class UpdateModelGraveyardTransportActionTests extends KNNSingleNodeTestC
             .getInstance(UpdateModelGraveyardTransportAction.class);
 
         String modelId = "test-model-id";
-        byte[] modelBlob = "testModel".getBytes();
+        byte[] modelBlob = "testModel".getBytes(StandardCharsets.UTF_8);
         int dimension = 2;
 
         createIndex(MODEL_INDEX_NAME);

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -23,6 +23,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.faiss.QFrameBitEncoder;
 
+import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -502,7 +503,7 @@ public class RecallTestsIT extends KNNRestTestCase {
                 TRAIN_FIELD_NAME,
                 TEST_DIMENSION,
                 xContentBuilderToMap(trainingBuilder),
-                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+                String.format(Locale.ROOT, "%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
             );
             assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
 
@@ -579,7 +580,7 @@ public class RecallTestsIT extends KNNRestTestCase {
                 TRAIN_FIELD_NAME,
                 TEST_DIMENSION,
                 xContentBuilderToMap(trainingBuilder),
-                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+                String.format(Locale.ROOT, "%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
             );
             assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
 
@@ -657,7 +658,7 @@ public class RecallTestsIT extends KNNRestTestCase {
                 TRAIN_FIELD_NAME,
                 TEST_DIMENSION,
                 xContentBuilderToMap(trainingBuilder),
-                String.format("%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
+                String.format(Locale.ROOT, "%s-%s", KNNEngine.FAISS.getName(), spaceType.getValue())
             );
             assertTrainingSucceeds(TEST_MODEL_ID, 100, 1000 * 5);
 
@@ -779,7 +780,7 @@ public class RecallTestsIT extends KNNRestTestCase {
     }
 
     private String createIndexName(KNNEngine knnEngine, SpaceType spaceType) {
-        return String.format("%s_%s_%s", TEST_INDEX_PREFIX_NAME, knnEngine.getName(), spaceType.getValue());
+        return String.format(Locale.ROOT, "%s_%s_%s", TEST_INDEX_PREFIX_NAME, knnEngine.getName(), spaceType.getValue());
     }
 
     @SneakyThrows

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -257,6 +257,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         List<Map<String, Object>> nodesStats = parseNodeStatsResponse(responseBody);
         Map<String, Object> node = nodesStats.getFirst();
         String path = String.format(
+            Locale.ROOT,
             "%s.%s.%s",
             StatNames.REMOTE_VECTOR_INDEX_BUILD_STATS.getName(),
             StatNames.CLIENT_STATS.getName(),
@@ -1594,7 +1595,7 @@ public class KNNRestTestCase extends ODFERestTestCase {
         scriptedMetricAggregationBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         builder.endObject();
-        String endpoint = String.format(Locale.getDefault(), "/%s/_search?size=0&filter_path=aggregations", INDEX_NAME);
+        String endpoint = String.format(Locale.ROOT, "/%s/_search?size=0&filter_path=aggregations", INDEX_NAME);
         Request request = new Request("POST", endpoint);
         request.setJsonEntity(builder.toString());
         return request;
@@ -2423,14 +2424,14 @@ public class KNNRestTestCase extends ODFERestTestCase {
     protected String createL2PainlessScriptSource(String testField, int dimension, int numDocs) {
         IDVectorProducer idVectorProducer = new IDVectorProducer(dimension, numDocs);
         float[] queryVector = idVectorProducer.getVector(numDocs);
-        return String.format("1/(1 + l2Squared(" + Arrays.toString(queryVector) + ", doc['%s']))", testField);
+        return String.format(Locale.ROOT, "1/(1 + l2Squared(" + Arrays.toString(queryVector) + ", doc['%s']))", testField);
     }
 
     // create painless script source for space_type "l1" by creating query vector based on number of documents
     protected String createL1PainlessScriptSource(String testField, int dimension, int numDocs) {
         IDVectorProducer idVectorProducer = new IDVectorProducer(dimension, numDocs);
         float[] queryVector = idVectorProducer.getVector(numDocs);
-        return String.format("1/(1 + l1Norm(" + Arrays.toString(queryVector) + ", doc['%s']))", testField);
+        return String.format(Locale.ROOT, "1/(1 + l1Norm(" + Arrays.toString(queryVector) + ", doc['%s']))", testField);
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -17,6 +17,7 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -210,7 +211,7 @@ public class TestUtils {
     }
 
     public static String createFakeNativeMamoryCacheKey(final String fileName) {
-        return fileName + "@" + Base64.getEncoder().encodeToString(fileName.getBytes());
+        return fileName + "@" + Base64.getEncoder().encodeToString(fileName.getBytes(StandardCharsets.UTF_8));
     }
 
     /*

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -17,6 +17,7 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
+import java.util.Locale;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -256,7 +257,7 @@ public class TestUtils {
         float dist;
         if (spaceType != null) {
             dist = KNN_SCORING_SPACE_TYPE.getOrDefault(spaceType, (defaultQueryVector, defaultIndexVector) -> {
-                throw new IllegalArgumentException(String.format("Invalid SpaceType function: \"%s\"", spaceType));
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Invalid SpaceType function: \"%s\"", spaceType));
             }).apply(queryVector, indexVector);
         } else {
             throw new NullPointerException("SpaceType is null. Provide a valid SpaceType.");


### PR DESCRIPTION
### Description
Current build has become extremenly verbose with these warnings, making it extremely hard to detect failures. Addressing string.format changes to start with

Changes:
1. Added Locale.ROOT for most string format
2. Adds StandardCharset.UTF8 in string.getBytes: Only tests
3. Replaced String.format for live code paths as its expensive 

```
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.index.mapper.ModelFieldMapper (ModelFieldMapper.java:360)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.memoryoptsearch.faiss.FaissEmptyIndex (FaissEmptyIndex.java:30)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.memoryoptsearch.faiss.FaissEmptyIndex (FaissEmptyIndex.java:35)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.memoryoptsearch.faiss.FaissEmptyIndex (FaissEmptyIndex.java:40)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.memoryoptsearch.faiss.FaissScalarQuantizedFlatIndex (FaissScalarQuantizedFlatIndex.java:61)
Forbidden class/interface use: java.security.AccessController [Deprecated in Java 21]
  in org.opensearch.knn.index.codec.nativeindex.MemOptimizedScalarQuantizedIndexBuildStrategy (MemOptimizedScalarQuantizedIndexBuildStrategy.java:132)
Forbidden class/interface use: java.security.AccessController [Deprecated in Java 21]
  in org.opensearch.knn.index.codec.nativeindex.MemOptimizedScalarQuantizedIndexBuildStrategy (MemOptimizedScalarQuantizedIndexBuildStrategy.java:232)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.index.query.BaseQueryFactory (BaseQueryFactory.java:94)
Forbidden class/interface use: org.apache.lucene.util.IOUtils [use @org.opensearch.core.internal.io instead]
  in org.opensearch.knn.index.codec.backward_codecs.KNN9120Codec.KNN9120DerivedSourceReaders (KNN9120DerivedSourceReaders.java:79)
Forbidden method invocation: java.util.Random#<init>() [Use org.opensearch.common.Randomness#get for reproducible sources of randomness]
  in org.opensearch.knn.index.remote.RemoteIndexPoller (RemoteIndexPoller.java:46)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.index.remote.RemoteIndexPoller (RemoteIndexPoller.java:78)
Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  in org.opensearch.knn.index.remote.RemoteIndexPoller (RemoteIndexPoller.java:83)
Forbidden method invocation: java.lang.String#format(java
```

### Related Issues


### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
