### PR TITLE
Skips excludes and includes for derived source codec layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable prefetch [#3302](https://github.com/opensearch-project/k-NN/pull/3302)
+* Skips excludes and includes for derived source [#3319](https://github.com/opensearch-project/k-NN/pull/3319)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -24,7 +24,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
     private final DerivedSourceReaders derivedSourceReaders;
     private final SegmentReadState segmentReadState;
     private final boolean shouldInject;
-    private boolean closed;
+    private volatile boolean closed;
 
     private final DerivedSourceVectorTransformer derivedSourceVectorTransformer;
 
@@ -98,7 +98,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         if (closed == false) {
             IOUtils.close(delegate, derivedSourceReaders);
             closed = true;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -8,8 +8,8 @@ package org.opensearch.knn.index.codec.KNN10010Codec;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.IOUtils;
-import org.opensearch.index.fieldvisitor.FieldsVisitor;
 import org.opensearch.knn.index.codec.derivedsource.DerivedFieldInfo;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceReaders;
 import org.opensearch.knn.index.codec.derivedsource.DerivedSourceStoredFieldVisitor;
@@ -24,16 +24,16 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
     private final DerivedSourceReaders derivedSourceReaders;
     private final SegmentReadState segmentReadState;
     private final boolean shouldInject;
-    private boolean transformerInitialized = false;
+    private boolean closed;
 
     private final DerivedSourceVectorTransformer derivedSourceVectorTransformer;
 
     /**
      *
-     * @param delegate delegate StoredFieldsReader
-     * @param derivedVectorFields List of fields that are derived source fields
+     * @param delegate             delegate StoredFieldsReader
+     * @param derivedVectorFields  List of fields that are derived source fields
      * @param derivedSourceReaders derived source readers
-     * @param segmentReadState SegmentReadState for the segment
+     * @param segmentReadState     SegmentReadState for the segment
      * @throws IOException in case of I/O error
      */
     public KNN10010DerivedSourceStoredFieldsReader(
@@ -52,50 +52,34 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
         SegmentReadState segmentReadState,
         boolean shouldInject
     ) throws IOException {
+        assert derivedVectorFields != null && derivedVectorFields.isEmpty() == false : "Derived vector fields should be present";
         this.delegate = delegate;
         this.derivedVectorFields = derivedVectorFields;
         this.derivedSourceReaders = derivedSourceReaders;
         this.segmentReadState = segmentReadState;
         this.shouldInject = shouldInject;
-        this.derivedSourceVectorTransformer = createDerivedSourceVectorTransformer();
-    }
-
-    private DerivedSourceVectorTransformer createDerivedSourceVectorTransformer() {
-        return new DerivedSourceVectorTransformer(derivedSourceReaders, segmentReadState, derivedVectorFields);
+        this.derivedSourceVectorTransformer = new DerivedSourceVectorTransformer(
+            this.derivedSourceReaders,
+            this.segmentReadState,
+            this.derivedVectorFields
+        );
     }
 
     @Override
     public void document(int docId, StoredFieldVisitor storedFieldVisitor) throws IOException {
         // If the visitor has explicitly indicated it does not need the fields, we should not inject them
+        // this happens on merge cases where we don't want to inject vectors
         if (shouldInject) {
-            initializeTransformerIfNeeded(storedFieldVisitor);
-            if (derivedSourceVectorTransformer.hasFieldsToInject()) {
-                delegate.document(docId, new DerivedSourceStoredFieldVisitor(storedFieldVisitor, docId, derivedSourceVectorTransformer));
-                return;
-            }
-        }
-        delegate.document(docId, storedFieldVisitor);
-    }
-
-    private void initializeTransformerIfNeeded(StoredFieldVisitor visitor) {
-        if (transformerInitialized) {
+            delegate.document(docId, new DerivedSourceStoredFieldVisitor(storedFieldVisitor, docId, derivedSourceVectorTransformer));
             return;
         }
-        String[] includes = null;
-        String[] excludes = null;
-
-        if (visitor instanceof FieldsVisitor) {
-            includes = ((FieldsVisitor) visitor).includes();
-            excludes = ((FieldsVisitor) visitor).excludes();
-        }
-
-        derivedSourceVectorTransformer.initialize(includes, excludes);
-        transformerInitialized = true;
+        delegate.document(docId, storedFieldVisitor);
     }
 
     @Override
     public StoredFieldsReader clone() {
         try {
+            ensureOpen();
             return new KNN10010DerivedSourceStoredFieldsReader(
                 delegate.clone(),
                 derivedVectorFields,
@@ -115,7 +99,10 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(delegate, derivedSourceReaders);
+        if (closed == false) {
+            IOUtils.close(delegate, derivedSourceReaders);
+            closed = true;
+        }
     }
 
     /**
@@ -127,6 +114,7 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
      */
     private StoredFieldsReader cloneForMerge() {
         try {
+            ensureOpen();
             return new KNN10010DerivedSourceStoredFieldsReader(
                 delegate.getMergeInstance(),
                 derivedVectorFields,
@@ -159,6 +147,15 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
      */
     public List<DerivedFieldInfo> getDerivedVectorFields() {
         return derivedVectorFields;
+    }
+
+    /**
+     * Throws {@link AlreadyClosedException} if this instance has been closed.
+     */
+    private void ensureOpen() {
+        if (closed) {
+            throw new AlreadyClosedException("DerivedSourceReader is closed");
+        }
     }
 
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -114,7 +114,7 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
             return null;
         }
         return XContentMapValues.transform(
-            fields.stream().collect(Collectors.toMap(k -> k, k -> (Object o) -> o == null ? o : MASK)),
+            fields.stream().collect(Collectors.toMap(Function.identity(), field -> (Object vector) -> vector == null ? null : MASK)),
             true
         );
     }

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -15,7 +15,6 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.common.regex.Regex;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -23,15 +22,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.HashSet;
-import java.util.Set;
 
 @Log4j2
 public class DerivedSourceVectorTransformer {
 
     private final DerivedSourceReaders derivedSourceReaders;
-    Function<Map<String, Object>, Map<String, Object>> derivedSourceVectorTransformer;
-    Map<String, PerFieldDerivedVectorTransformer> perFieldDerivedVectorTransformers;
+    private final Function<Map<String, Object>, Map<String, Object>> derivedSourceVectorTransformer;
+    private final Map<String, Function<Object, Object>> perFieldDerivedVectorTransformers;
     private boolean isNested;
     private final DerivedSourceLuceneHelper derivedSourceLuceneHelper;
 
@@ -57,75 +54,8 @@ public class DerivedSourceVectorTransformer {
             );
             perFieldDerivedVectorTransformers.put(derivedFieldInfo.name(), perFieldDerivedVectorTransformer);
         }
+        derivedSourceVectorTransformer = XContentMapValues.transform(perFieldDerivedVectorTransformers, true);
         derivedSourceLuceneHelper = new DerivedSourceLuceneHelper(derivedSourceReaders, segmentReadState);
-    }
-
-    /**
-     * Initialize the transformer with the fields that should be injected based on includes/excludes.
-     * This filters perFieldDerivedVectorTransformers and builds the derivedSourceVectorTransformer.
-     * Should be called once before the first call to injectVectors().
-     *
-     * @param excludes List of field patterns that should not be injected
-     */
-    public void initialize(String[] includes, String[] excludes) {
-        // Filter perFieldDerivedVectorTransformers based on includes/excludes
-        Set<String> fieldsToRemove = getFieldsToExclude(includes, excludes);
-        for (String fieldName : fieldsToRemove) {
-            perFieldDerivedVectorTransformers.remove(fieldName);
-        }
-
-        Map<String, Function<Object, Object>> transformerFunctions = new HashMap<>();
-        transformerFunctions.putAll(perFieldDerivedVectorTransformers);
-        derivedSourceVectorTransformer = XContentMapValues.transform(transformerFunctions, true);
-
-    }
-
-    private Set<String> getFieldsToExclude(String[] includes, String[] excludes) {
-        Set<String> fieldsToRemove = new HashSet<>();
-        Set<String> allFields = perFieldDerivedVectorTransformers.keySet();
-
-        // If includes are specified, start by excluding everything that doesn't match
-        if (includes != null && includes.length > 0) {
-            for (String fieldName : allFields) {
-                boolean matched = false;
-                for (String includePattern : includes) {
-                    if (Regex.simpleMatch(includePattern, fieldName)) {
-                        matched = true;
-                        break;
-                    }
-                }
-                if (!matched) {
-                    fieldsToRemove.add(fieldName);
-                }
-            }
-        }
-
-        // Then also exclude anything matching exclude patterns
-        if (excludes != null && excludes.length > 0) {
-            for (String fieldName : allFields) {
-                if (fieldsToRemove.contains(fieldName)) {
-                    continue;
-                }
-                for (String excludePattern : excludes) {
-                    if (Regex.simpleMatch(excludePattern, fieldName)) {
-                        fieldsToRemove.add(fieldName);
-                        break;
-                    }
-                }
-            }
-        }
-
-        return fieldsToRemove;
-    }
-
-    /**
-     * Check if there are any fields to inject after initialization.
-     * Must be called after initialize().
-     *
-     * @return true if there are fields to inject, false otherwise
-     */
-    public boolean hasFieldsToInject() {
-        return !perFieldDerivedVectorTransformers.isEmpty();
     }
 
     /**
@@ -156,8 +86,8 @@ public class DerivedSourceVectorTransformer {
 
         // For each vector field, add in the source. The per field injectors are responsible for skipping if
         // the field is not present.
-        for (PerFieldDerivedVectorTransformer vectorTransformer : perFieldDerivedVectorTransformers.values()) {
-            vectorTransformer.setCurrentDoc(offset, docId);
+        for (final Function<Object, Object> vectorTransformer : perFieldDerivedVectorTransformers.values()) {
+            ((PerFieldDerivedVectorTransformer) vectorTransformer).setCurrentDoc(offset, docId);
         }
 
         Map<String, Object> copy = derivedSourceVectorTransformer.apply(sourceAsMap);

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
@@ -7,190 +7,245 @@ package org.opensearch.knn.index.codec.derivedsource;
 
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentReadState;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.index.codec.KNN10010Codec.KNN10010DerivedSourceStoredFieldsWriter;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.Arrays;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DerivedSourceVectorTransformerTests extends OpenSearchTestCase {
 
     private DerivedSourceReaders mockDerivedSourceReaders;
     private SegmentReadState mockSegmentReadState;
 
-    private AutoCloseable mocks;
-
-    private static final String[] ALL_FIELDS = { "test_vector", "temp_vector", "user_vector" };
+    private static final Byte MASK = KNN10010DerivedSourceStoredFieldsWriter.MASK;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        mocks = MockitoAnnotations.openMocks(this);
-        mockDerivedSourceReaders = Mockito.mock(DerivedSourceReaders.class);
-        mockSegmentReadState = Mockito.mock(SegmentReadState.class);
+        mockDerivedSourceReaders = mock(DerivedSourceReaders.class);
+        mockSegmentReadState = mock(SegmentReadState.class);
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-        mocks.close();
-    }
+    @SuppressWarnings("unchecked")
+    public void testInjectVectors_whenNonNested_thenVectorInjected() throws IOException {
+        float[] expectedVector = new float[] { 1.5f, 2.5f, 3.5f };
+        PerFieldDerivedVectorTransformer mockTransformer = mock(PerFieldDerivedVectorTransformer.class);
+        doNothing().when(mockTransformer).setCurrentDoc(anyInt(), anyInt());
+        when(mockTransformer.apply(any())).thenReturn(expectedVector);
 
-    public void testInitialize_withVariousIncludeExcludeCombinations() {
-        // Test 1: No filtering - all fields remain
-        assertFieldFiltering(null, null, new String[] { "test_vector", "temp_vector", "user_vector" }, new String[] {});
-
-        // Test 2: Empty includes - all fields remain
-        assertFieldFiltering(new String[] {}, null, new String[] { "test_vector", "temp_vector", "user_vector" }, new String[] {});
-
-        // Test 3: Empty excludes - all fields remain
-        assertFieldFiltering(null, new String[] {}, new String[] { "test_vector", "temp_vector", "user_vector" }, new String[] {});
-
-        // Test 4: Both empty - all fields remain
-        assertFieldFiltering(
-            new String[] {},
-            new String[] {},
-            new String[] { "test_vector", "temp_vector", "user_vector" },
-            new String[] {}
-        );
-
-        // Test 5: Only includes - only matching fields remain
-        assertFieldFiltering(
-            new String[] { "test_vector", "user_vector" },
-            null,
-            new String[] { "test_vector", "user_vector" },
-            new String[] { "temp_vector" }
-        );
-
-        // Test 6: Only excludes - matching fields removed
-        assertFieldFiltering(
-            null,
-            new String[] { "test_vector" },
-            new String[] { "temp_vector", "user_vector" },
-            new String[] { "test_vector" }
-        );
-
-        // Test 7: Both includes and excludes - excludes override includes
-        assertFieldFiltering(
-            new String[] { "test_vector", "temp_vector" },
-            new String[] { "temp_vector" },
-            new String[] { "test_vector" },
-            new String[] { "temp_vector", "user_vector" }
-        );
-
-        // Test 8: Wildcard includes - only matching fields remain
-        assertFieldFiltering(new String[] { "t*" }, null, new String[] { "test_vector", "temp_vector" }, new String[] { "user_vector" });
-
-        // Test 9: Wildcard excludes - matching fields removed
-        assertFieldFiltering(null, new String[] { "t*" }, new String[] { "user_vector" }, new String[] { "test_vector", "temp_vector" });
-
-        // Test 10: Wildcard includes with specific excludes
-        assertFieldFiltering(
-            new String[] { "t*", "user_vector" },
-            new String[] { "test_vector" },
-            new String[] { "temp_vector", "user_vector" },
-            new String[] { "test_vector" }
-        );
-
-        // Test 11: All fields excluded with wildcard
-        assertFieldFiltering(null, new String[] { "*" }, new String[] {}, new String[] { "test_vector", "temp_vector", "user_vector" });
-
-        // Test 12: Includes match nothing - no fields remain
-        assertFieldFiltering(
-            new String[] { "nonexistent_*" },
-            null,
-            new String[] {},
-            new String[] { "test_vector", "temp_vector", "user_vector" }
-        );
-
-        // Test 13: Excludes match nothing - all fields remain
-        assertFieldFiltering(
-            null,
-            new String[] { "nonexistent_*" },
-            new String[] { "test_vector", "temp_vector", "user_vector" },
-            new String[] {}
-        );
-    }
-
-    private void assertFieldFiltering(String[] includes, String[] excludes, String[] expectedPresent, String[] expectedAbsent) {
-        DerivedSourceVectorTransformer transformer = createTransformerWithFields(ALL_FIELDS);
-        transformer.initialize(includes, excludes);
-
-        Set<String> remainingFields = getRemainingFields(transformer);
-
-        for (String field : expectedPresent) {
-            assertTrue(
-                String.format(
-                    "Field '%s' should be present (includes=%s, excludes=%s)",
-                    field,
-                    Arrays.toString(includes),
-                    Arrays.toString(excludes)
-                ),
-                remainingFields.contains(field)
-            );
-        }
-
-        for (String field : expectedAbsent) {
-            assertFalse(
-                String.format(
-                    "Field '%s' should be absent (includes=%s, excludes=%s)",
-                    field,
-                    Arrays.toString(includes),
-                    Arrays.toString(excludes)
-                ),
-                remainingFields.contains(field)
-            );
-        }
-
-        assertEquals(
-            String.format("Field count mismatch (includes=%s, excludes=%s)", Arrays.toString(includes), Arrays.toString(excludes)),
-            expectedPresent.length,
-            remainingFields.size()
-        );
-    }
-
-    private DerivedSourceVectorTransformer createTransformerWithFields(String... fieldNames) {
         try (
             MockedStatic<PerFieldDerivedVectorTransformerFactory> factoryMock = Mockito.mockStatic(
                 PerFieldDerivedVectorTransformerFactory.class
-            )
+            );
+            MockedConstruction<DerivedSourceLuceneHelper> helperConstruction = Mockito.mockConstruction(DerivedSourceLuceneHelper.class)
         ) {
+            factoryMock.when(() -> PerFieldDerivedVectorTransformerFactory.create(any(), anyBoolean(), any())).thenReturn(mockTransformer);
 
-            factoryMock.when(
-                () -> PerFieldDerivedVectorTransformerFactory.create(
-                    Mockito.any(FieldInfo.class),
-                    Mockito.anyBoolean(),
-                    Mockito.any(DerivedSourceReaders.class)
-                )
-            ).thenReturn(Mockito.mock(PerFieldDerivedVectorTransformer.class));
+            DerivedSourceVectorTransformer transformer = new DerivedSourceVectorTransformer(
+                mockDerivedSourceReaders,
+                mockSegmentReadState,
+                List.of(createMockDerivedFieldInfo("vec", false))
+            );
 
-            List<DerivedFieldInfo> fieldInfos = Arrays.stream(fieldNames).map(this::createMockDerivedFieldInfo).toList();
+            byte[] source = buildSourceBytes(Map.of("vec", MASK, "text", "hello"));
+            byte[] result = transformer.injectVectors(5, source);
 
-            return new DerivedSourceVectorTransformer(mockDerivedSourceReaders, mockSegmentReadState, fieldInfos);
+            verify(mockTransformer).setCurrentDoc(eq(0), eq(5));
+            DerivedSourceLuceneHelper constructedHelper = helperConstruction.constructed().get(0);
+            verify(constructedHelper, never()).getFirstChild(anyInt());
+
+            Map<String, Object> resultMap = parseSource(result);
+            assertEquals("hello", resultMap.get("text"));
+            List<Double> vectorList = (List<Double>) resultMap.get("vec");
+            assertEquals(3, vectorList.size());
+            assertEquals(1.5, vectorList.get(0), 0.001);
+            assertEquals(2.5, vectorList.get(1), 0.001);
+            assertEquals(3.5, vectorList.get(2), 0.001);
         }
     }
 
-    private DerivedFieldInfo createMockDerivedFieldInfo(String name) {
-        DerivedFieldInfo mockFieldInfo = Mockito.mock(DerivedFieldInfo.class);
-        Mockito.when(mockFieldInfo.name()).thenReturn(name);
-        Mockito.when(mockFieldInfo.isNested()).thenReturn(false);
-        Mockito.when(mockFieldInfo.fieldInfo()).thenReturn(Mockito.mock(FieldInfo.class));
+    @SuppressWarnings("unchecked")
+    public void testInjectVectors_whenNested_thenUsesLuceneHelperOffset() throws IOException {
+        float[] expectedVector = new float[] { 4.0f, 5.0f };
+        PerFieldDerivedVectorTransformer mockTransformer = mock(PerFieldDerivedVectorTransformer.class);
+        doNothing().when(mockTransformer).setCurrentDoc(anyInt(), anyInt());
+        when(mockTransformer.apply(any())).thenReturn(expectedVector);
+
+        try (
+            MockedStatic<PerFieldDerivedVectorTransformerFactory> factoryMock = Mockito.mockStatic(
+                PerFieldDerivedVectorTransformerFactory.class
+            );
+            MockedConstruction<DerivedSourceLuceneHelper> helperConstruction = Mockito.mockConstruction(
+                DerivedSourceLuceneHelper.class,
+                (mock, context) -> when(mock.getFirstChild(10)).thenReturn(7)
+            )
+        ) {
+            factoryMock.when(() -> PerFieldDerivedVectorTransformerFactory.create(any(), anyBoolean(), any())).thenReturn(mockTransformer);
+
+            DerivedSourceVectorTransformer transformer = new DerivedSourceVectorTransformer(
+                mockDerivedSourceReaders,
+                mockSegmentReadState,
+                List.of(createMockDerivedFieldInfo("nested_vec", true))
+            );
+
+            byte[] source = buildSourceBytes(Map.of("nested_vec", MASK, "id", "doc1"));
+            byte[] result = transformer.injectVectors(10, source);
+
+            verify(mockTransformer).setCurrentDoc(eq(7), eq(10));
+
+            Map<String, Object> resultMap = parseSource(result);
+            assertEquals("doc1", resultMap.get("id"));
+            List<Double> vectorList = (List<Double>) resultMap.get("nested_vec");
+            assertEquals(2, vectorList.size());
+            assertEquals(4.0, vectorList.get(0), 0.001);
+            assertEquals(5.0, vectorList.get(1), 0.001);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testInjectVectors_whenMultipleFields_thenAllVectorsInjected() throws IOException {
+        float[] vector1 = new float[] { 1.0f, 2.0f };
+        float[] vector2 = new float[] { 3.0f, 4.0f };
+
+        PerFieldDerivedVectorTransformer mockTransformer1 = mock(PerFieldDerivedVectorTransformer.class);
+        PerFieldDerivedVectorTransformer mockTransformer2 = mock(PerFieldDerivedVectorTransformer.class);
+        doNothing().when(mockTransformer1).setCurrentDoc(anyInt(), anyInt());
+        doNothing().when(mockTransformer2).setCurrentDoc(anyInt(), anyInt());
+        when(mockTransformer1.apply(any())).thenReturn(vector1);
+        when(mockTransformer2.apply(any())).thenReturn(vector2);
+
+        DerivedFieldInfo field1 = createMockDerivedFieldInfo("vec_a", false);
+        DerivedFieldInfo field2 = createMockDerivedFieldInfo("vec_b", false);
+
+        try (
+            MockedStatic<PerFieldDerivedVectorTransformerFactory> factoryMock = Mockito.mockStatic(
+                PerFieldDerivedVectorTransformerFactory.class
+            );
+            MockedConstruction<DerivedSourceLuceneHelper> ignored = Mockito.mockConstruction(DerivedSourceLuceneHelper.class)
+        ) {
+            factoryMock.when(() -> PerFieldDerivedVectorTransformerFactory.create(eq(field1.fieldInfo()), eq(false), any()))
+                .thenReturn(mockTransformer1);
+            factoryMock.when(() -> PerFieldDerivedVectorTransformerFactory.create(eq(field2.fieldInfo()), eq(false), any()))
+                .thenReturn(mockTransformer2);
+
+            DerivedSourceVectorTransformer transformer = new DerivedSourceVectorTransformer(
+                mockDerivedSourceReaders,
+                mockSegmentReadState,
+                List.of(field1, field2)
+            );
+
+            byte[] source = buildSourceBytes(Map.of("vec_a", MASK, "vec_b", MASK, "label", "test"));
+            byte[] result = transformer.injectVectors(0, source);
+
+            Map<String, Object> resultMap = parseSource(result);
+            assertEquals("test", resultMap.get("label"));
+
+            List<Double> resultVec1 = (List<Double>) resultMap.get("vec_a");
+            assertEquals(2, resultVec1.size());
+            assertEquals(1.0, resultVec1.get(0), 0.001);
+            assertEquals(2.0, resultVec1.get(1), 0.001);
+
+            List<Double> resultVec2 = (List<Double>) resultMap.get("vec_b");
+            assertEquals(2, resultVec2.size());
+            assertEquals(3.0, resultVec2.get(0), 0.001);
+            assertEquals(4.0, resultVec2.get(1), 0.001);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testInjectVectors_whenMixedNestedAndNonNested_thenAllVectorsInjected() throws IOException {
+        float[] nestedVector = new float[] { 10.0f };
+        float[] rootVector = new float[] { 20.0f };
+
+        PerFieldDerivedVectorTransformer mockNestedTransformer = mock(PerFieldDerivedVectorTransformer.class);
+        PerFieldDerivedVectorTransformer mockRootTransformer = mock(PerFieldDerivedVectorTransformer.class);
+        doNothing().when(mockNestedTransformer).setCurrentDoc(anyInt(), anyInt());
+        doNothing().when(mockRootTransformer).setCurrentDoc(anyInt(), anyInt());
+        when(mockNestedTransformer.apply(any())).thenReturn(nestedVector);
+        when(mockRootTransformer.apply(any())).thenReturn(rootVector);
+
+        DerivedFieldInfo nestedField = createMockDerivedFieldInfo("nested_vec", true);
+        DerivedFieldInfo rootField = createMockDerivedFieldInfo("root_vec", false);
+
+        try (
+            MockedStatic<PerFieldDerivedVectorTransformerFactory> factoryMock = Mockito.mockStatic(
+                PerFieldDerivedVectorTransformerFactory.class
+            );
+            MockedConstruction<DerivedSourceLuceneHelper> helperConstruction = Mockito.mockConstruction(
+                DerivedSourceLuceneHelper.class,
+                (mock, context) -> when(mock.getFirstChild(5)).thenReturn(3)
+            )
+        ) {
+            factoryMock.when(() -> PerFieldDerivedVectorTransformerFactory.create(eq(nestedField.fieldInfo()), eq(true), any()))
+                .thenReturn(mockNestedTransformer);
+            factoryMock.when(() -> PerFieldDerivedVectorTransformerFactory.create(eq(rootField.fieldInfo()), eq(false), any()))
+                .thenReturn(mockRootTransformer);
+
+            DerivedSourceVectorTransformer transformer = new DerivedSourceVectorTransformer(
+                mockDerivedSourceReaders,
+                mockSegmentReadState,
+                List.of(nestedField, rootField)
+            );
+
+            byte[] source = buildSourceBytes(Map.of("nested_vec", MASK, "root_vec", MASK));
+            byte[] result = transformer.injectVectors(5, source);
+
+            // Both get offset=3 from lucene helper since isNested is true
+            verify(mockNestedTransformer).setCurrentDoc(eq(3), eq(5));
+            verify(mockRootTransformer).setCurrentDoc(eq(3), eq(5));
+
+            Map<String, Object> resultMap = parseSource(result);
+            List<Double> nestedResult = (List<Double>) resultMap.get("nested_vec");
+            assertEquals(1, nestedResult.size());
+            assertEquals(10.0, nestedResult.get(0), 0.001);
+
+            List<Double> rootResult = (List<Double>) resultMap.get("root_vec");
+            assertEquals(1, rootResult.size());
+            assertEquals(20.0, rootResult.get(0), 0.001);
+        }
+    }
+
+    private DerivedFieldInfo createMockDerivedFieldInfo(String name, boolean isNested) {
+        DerivedFieldInfo mockFieldInfo = mock(DerivedFieldInfo.class);
+        when(mockFieldInfo.name()).thenReturn(name);
+        when(mockFieldInfo.isNested()).thenReturn(isNested);
+        when(mockFieldInfo.fieldInfo()).thenReturn(mock(FieldInfo.class));
         return mockFieldInfo;
     }
 
-    private Set<String> getRemainingFields(DerivedSourceVectorTransformer transformer) {
-        try {
-            java.lang.reflect.Field field = DerivedSourceVectorTransformer.class.getDeclaredField("perFieldDerivedVectorTransformers");
-            field.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Map<String, ?> map = (Map<String, ?>) field.get(transformer);
-            return map.keySet();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to access perFieldDerivedVectorTransformers", e);
-        }
+    private byte[] buildSourceBytes(Map<String, Object> source) throws IOException {
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.getDefaultMediaType());
+        builder.map(source);
+        builder.close();
+        return BytesReference.toBytes(BytesReference.bytes(builder));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseSource(byte[] bytes) {
+        return XContentHelper.convertToMap(
+            BytesReference.fromByteBuffer(ByteBuffer.wrap(bytes)),
+            true,
+            MediaTypeRegistry.getDefaultMediaType()
+        ).v2();
     }
 }


### PR DESCRIPTION
### Description

Honoring includes and excludes at codec layer breaks the contract in opensearch core where source is read as is on codec layer. This has unintended side effects on fetchSubporcessor layer causing source to have mask values for vectors when derived source is enabled

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/3303


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
