### PR TITLE
Introduce ResolvedIndexSpec for pre-computed index behavior

### DIFF
--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
@@ -153,12 +153,11 @@ public abstract class AbstractKNNMethod implements KNNMethod {
         Map<String, Object> methodParams = knnMethodContext.getMethodComponentContext().getParameters();
         if (methodParams != null && methodParams.containsKey(METHOD_ENCODER_PARAMETER)) {
             Object encoderObj = methodParams.get(METHOD_ENCODER_PARAMETER);
-            if (encoderObj instanceof MethodComponentContext) {
-                MethodComponentContext encoderCtx = (MethodComponentContext) encoderObj;
+            if (encoderObj instanceof MethodComponentContext encoderCtx) {
                 encoderType = Encoder.EncoderType.fromName(encoderCtx.getName());
                 Object bitsObj = encoderCtx.getParameters().get(KNNConstants.SQ_BITS);
-                if (bitsObj instanceof Integer) {
-                    quantizationBits = Encoder.QuantizationBits.fromValue((Integer) bitsObj);
+                if (bitsObj instanceof Integer bitsInt) {
+                    quantizationBits = Encoder.QuantizationBits.fromValue(bitsInt);
                 } else if (encoderType == Encoder.EncoderType.FLAT) {
                     quantizationBits = Encoder.QuantizationBits.FULL_PRECISION;
                 } else if (encoderType == Encoder.EncoderType.BQ) {
@@ -167,6 +166,7 @@ public abstract class AbstractKNNMethod implements KNNMethod {
             }
         }
 
+        // Dimension is null during model training flows (resolved from training data, not mapping params)
         Integer dimension = knnMethodConfigContext.getDimension();
         return ResolvedIndexSpec.builder()
             .engine(knnMethodContext.getKnnEngine())

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+
 /**
  * Abstract class for KNN methods. This class provides the common functionality for all KNN methods.
  * It defines the common attributes and methods that all KNN methods should implement.
@@ -140,6 +142,42 @@ public abstract class AbstractKNNMethod implements KNNMethod {
             .perDimensionProcessor(doGetPerDimensionProcessor(knnMethodContext, knnMethodConfigContext))
             .vectorTransformer(getVectorTransformer(knnMethodContext.getSpaceType()))
             .trainingConfigValidationSetup(doGetTrainingConfigValidationSetup())
+            .resolvedSpec(buildResolvedIndexSpec(knnMethodContext, knnMethodConfigContext))
+            .build();
+    }
+
+    private ResolvedIndexSpec buildResolvedIndexSpec(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
+        Encoder.EncoderType encoderType = Encoder.EncoderType.FLAT;
+        Encoder.QuantizationBits quantizationBits = Encoder.QuantizationBits.FULL_PRECISION;
+
+        Map<String, Object> methodParams = knnMethodContext.getMethodComponentContext().getParameters();
+        if (methodParams != null && methodParams.containsKey(METHOD_ENCODER_PARAMETER)) {
+            Object encoderObj = methodParams.get(METHOD_ENCODER_PARAMETER);
+            if (encoderObj instanceof MethodComponentContext) {
+                MethodComponentContext encoderCtx = (MethodComponentContext) encoderObj;
+                encoderType = Encoder.EncoderType.fromName(encoderCtx.getName());
+                Object bitsObj = encoderCtx.getParameters().get(KNNConstants.SQ_BITS);
+                if (bitsObj instanceof Integer) {
+                    quantizationBits = Encoder.QuantizationBits.fromValue((Integer) bitsObj);
+                } else if (encoderType == Encoder.EncoderType.FLAT) {
+                    quantizationBits = Encoder.QuantizationBits.FULL_PRECISION;
+                } else if (encoderType == Encoder.EncoderType.BQ) {
+                    quantizationBits = Encoder.QuantizationBits.ONE;
+                }
+            }
+        }
+
+        Integer dimension = knnMethodConfigContext.getDimension();
+        return ResolvedIndexSpec.builder()
+            .engine(knnMethodContext.getKnnEngine())
+            .methodName(knnMethodContext.getMethodComponentContext().getName())
+            .encoderType(encoderType)
+            .quantizationBits(quantizationBits)
+            .compressionLevel(knnMethodConfigContext.getCompressionLevel())
+            .mode(knnMethodConfigContext.getMode())
+            .vectorDataType(knnMethodConfigContext.getVectorDataType())
+            .dimension(dimension != null ? dimension : 0)
+            .indexVersionCreated(knnMethodConfigContext.getVersionCreated())
             .build();
     }
 

--- a/src/main/java/org/opensearch/knn/index/engine/Encoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/Encoder.java
@@ -17,6 +17,14 @@ import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 
 /**
  * Interface representing an encoder. An encoder generally refers to a vector quantizer.
+ *
+ * <p>Serves a dual role:
+ * <ul>
+ *   <li>Type classification (via {@link EncoderType} and {@link QuantizationBits}) that drives
+ *       ResolvedIndexSpec behavioral decisions.</li>
+ *   <li>Method component integration (via {@link #getMethodComponent()}) for the existing
+ *       resolution framework.</li>
+ * </ul>
  */
 public interface Encoder {
 
@@ -59,8 +67,8 @@ public interface Encoder {
         FOUR(4, CompressionLevel.x8),
         SEVEN(7, CompressionLevel.x4),
         SIXTEEN(16, CompressionLevel.x2),
-        FULL_PRECISION(32, CompressionLevel.x1),
-        NOT_APPLICABLE(-1, CompressionLevel.NOT_CONFIGURED);
+        /** Identity value for FLAT encoders: full precision float32 with no quantization applied. */
+        FULL_PRECISION(32, CompressionLevel.x1);
 
         private final int value;
         private final CompressionLevel compressionLevel;
@@ -132,6 +140,7 @@ public interface Encoder {
 
     /**
      * @return the set of bit widths this encoder supports
+     * TODO: Evaluate removal -- zero production callers, risks inconsistency with getQuantizationBits().
      */
     Set<QuantizationBits> getSupportedBits();
 

--- a/src/main/java/org/opensearch/knn/index/engine/Encoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/Encoder.java
@@ -7,12 +7,89 @@ package org.opensearch.knn.index.engine;
 
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
+import java.util.Locale;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_BINARY;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+
 /**
  * Interface representing an encoder. An encoder generally refers to a vector quantizer.
  */
 public interface Encoder {
+
     /**
-     * The name of the encoder does not have to be unique. Howevwer, when using within a method, there cannot be
+     * Identifies the encoder type. Anchored to KNNConstants encoder name strings.
+     */
+    enum EncoderType {
+        FLAT(ENCODER_FLAT),
+        SQ(ENCODER_SQ),
+        PQ(ENCODER_PQ),
+        BQ(ENCODER_BINARY);
+
+        private final String name;
+
+        EncoderType(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public static EncoderType fromName(String name) {
+            for (EncoderType type : values()) {
+                if (type.name.equals(name)) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "Unsupported encoder type: [%s]", name));
+        }
+    }
+
+    /**
+     * Unified quantization bits enum. Maps bit widths to compression levels.
+     * Serialization-compatible: getValue() returns the int stored in FieldInfo/SQConfig.
+     */
+    enum QuantizationBits {
+        ONE(1, CompressionLevel.x32),
+        TWO(2, CompressionLevel.x16),
+        FOUR(4, CompressionLevel.x8),
+        SEVEN(7, CompressionLevel.x4),
+        SIXTEEN(16, CompressionLevel.x2),
+        FULL_PRECISION(32, CompressionLevel.x1),
+        NOT_APPLICABLE(-1, CompressionLevel.NOT_CONFIGURED);
+
+        private final int value;
+        private final CompressionLevel compressionLevel;
+
+        QuantizationBits(int value, CompressionLevel compressionLevel) {
+            this.value = value;
+            this.compressionLevel = compressionLevel;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public CompressionLevel getCompressionLevel() {
+            return compressionLevel;
+        }
+
+        public static QuantizationBits fromValue(int value) {
+            for (QuantizationBits bits : values()) {
+                if (bits.value == value) {
+                    return bits;
+                }
+            }
+            return FULL_PRECISION;
+        }
+    }
+
+    /**
+     * The name of the encoder does not have to be unique. However, when using within a method, there cannot be
      * 2 encoders with the same name.
      *
      * @return Name of the encoder
@@ -22,16 +99,16 @@ public interface Encoder {
     }
 
     /**
-     *
      * @return Method component associated with the encoder
      */
     MethodComponent getMethodComponent();
 
     /**
-     * Calculate the compression level for the give params. Assume float32 vectors are used. All parameters should
+     * Calculate the compression level for the given params. Assume float32 vectors are used. All parameters should
      * be resolved in the encoderContext passed in.
      *
      * @param encoderContext Context for the encoder to extract params from
+     * @param knnMethodConfigContext method config context
      * @return Compression level this encoder produces. If the encoder does not support this calculation yet, it will
      *          return {@link CompressionLevel#NOT_CONFIGURED}
      */
@@ -40,10 +117,28 @@ public interface Encoder {
     /**
      * Validates config of encoder
      *
+     * @param validationInput input for validation
      * @return Validation output of encoder parameters
      */
     default TrainingConfigValidationOutput validateEncoderConfig(TrainingConfigValidationInput validationInput) {
         TrainingConfigValidationOutput.TrainingConfigValidationOutputBuilder builder = TrainingConfigValidationOutput.builder();
         return builder.build();
+    }
+
+    /**
+     * @return the encoder type classification
+     */
+    EncoderType getEncoderType();
+
+    /**
+     * @return the set of bit widths this encoder supports
+     */
+    Set<QuantizationBits> getSupportedBits();
+
+    /**
+     * @return the resolved quantization bits for this encoder instance
+     */
+    default QuantizationBits getQuantizationBits() {
+        return QuantizationBits.FULL_PRECISION;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
@@ -11,6 +11,7 @@ import org.opensearch.knn.index.mapper.PerDimensionValidator;
 import org.opensearch.knn.index.mapper.VectorTransformer;
 import org.opensearch.knn.index.mapper.VectorValidator;
 
+import org.opensearch.common.Nullable;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -63,4 +64,16 @@ public interface KNNLibraryIndexingContext {
      * @return VectorTransformer
      */
     VectorTransformer getVectorTransformer();
+
+    /**
+     * Get the resolved index spec containing pre-computed behavioral decisions.
+     * May be null for model-based indices, training indices, or flat-index paths
+     * where full resolution does not run.
+     *
+     * @return ResolvedIndexSpec or null
+     */
+    @Nullable
+    default ResolvedIndexSpec getResolvedSpec() {
+        return null;
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContext.java
@@ -11,7 +11,6 @@ import org.opensearch.knn.index.mapper.PerDimensionValidator;
 import org.opensearch.knn.index.mapper.VectorTransformer;
 import org.opensearch.knn.index.mapper.VectorValidator;
 
-import org.opensearch.common.Nullable;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -67,13 +66,8 @@ public interface KNNLibraryIndexingContext {
 
     /**
      * Get the resolved index spec containing pre-computed behavioral decisions.
-     * May be null for model-based indices, training indices, or flat-index paths
-     * where full resolution does not run.
      *
-     * @return ResolvedIndexSpec or null
+     * @return ResolvedIndexSpec
      */
-    @Nullable
-    default ResolvedIndexSpec getResolvedSpec() {
-        return null;
-    }
+    ResolvedIndexSpec getResolvedSpec();
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
@@ -32,7 +32,6 @@ public class KNNLibraryIndexingContextImpl implements KNNLibraryIndexingContext 
     @Builder.Default
     private QuantizationConfig quantizationConfig = QuantizationConfig.EMPTY;
     private Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> trainingConfigValidationSetup;
-    @Nullable
     private ResolvedIndexSpec resolvedSpec;
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNLibraryIndexingContextImpl.java
@@ -12,6 +12,7 @@ import org.opensearch.knn.index.mapper.PerDimensionValidator;
 import org.opensearch.knn.index.mapper.VectorTransformer;
 import org.opensearch.knn.index.mapper.VectorValidator;
 
+import org.opensearch.common.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -31,6 +32,8 @@ public class KNNLibraryIndexingContextImpl implements KNNLibraryIndexingContext 
     @Builder.Default
     private QuantizationConfig quantizationConfig = QuantizationConfig.EMPTY;
     private Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> trainingConfigValidationSetup;
+    @Nullable
+    private ResolvedIndexSpec resolvedSpec;
 
     @Override
     public Map<String, Object> getLibraryParameters() {
@@ -65,5 +68,11 @@ public class KNNLibraryIndexingContextImpl implements KNNLibraryIndexingContext 
     @Override
     public Function<TrainingConfigValidationInput, TrainingConfigValidationOutput> getTrainingConfigValidationSetup() {
         return trainingConfigValidationSetup;
+    }
+
+    @Override
+    @Nullable
+    public ResolvedIndexSpec getResolvedSpec() {
+        return resolvedSpec;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -36,10 +36,8 @@ public final class ResolvedIndexSpec {
     private final int dimension;
     private final Version indexVersionCreated;
 
-    /**
-     * Whether this configuration uses the SQ 1-bit codec format (Faiss only).
-     */
-    public boolean usesSQ1BitCodecFormat() {
+    /** Faiss-specific: routes field to Faiss1040ScalarQuantizedKnnVectorsFormat. Temporary -- to be replaced by generalized codec format resolver. */
+    public boolean usesFaissSQ1BitCodecFormat() {
         return engine == KNNEngine.FAISS && isSQOneBit();
     }
 
@@ -119,6 +117,10 @@ public final class ResolvedIndexSpec {
         return METHOD_FLAT.equals(methodName);
     }
 
+    /**
+     * Returns true when the configured compression level implies lossy quantization that needs special handling.
+     * x1 is full precision and x2 is fp16 (near-lossless), so both are excluded; x4 and above are lossy.
+     */
     private boolean isQuantizedIndex() {
         return CompressionLevel.isConfigured(compressionLevel)
             && compressionLevel != CompressionLevel.x1

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.opensearch.Version;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+/**
+ * Immutable value object holding resolved index configuration.
+ * Constructed once at resolution time, read by both write and query paths.
+ * All behavioral decisions are methods derived from stored primitives.
+ */
+@Builder
+@Getter
+public final class ResolvedIndexSpec {
+    private final KNNEngine engine;
+    private final String methodName;
+    private final Encoder.EncoderType encoderType;
+    private final Encoder.QuantizationBits quantizationBits;
+    @Builder.Default
+    private final CompressionLevel compressionLevel = CompressionLevel.NOT_CONFIGURED;
+    @Builder.Default
+    private final Mode mode = Mode.NOT_CONFIGURED;
+    private final VectorDataType vectorDataType;
+    private final int dimension;
+    private final Version indexVersionCreated;
+
+    /**
+     * Whether this configuration uses the SQ 1-bit codec format (Faiss only).
+     */
+    public boolean usesSQ1BitCodecFormat() {
+        return engine == KNNEngine.FAISS && isSQOneBit();
+    }
+
+    /**
+     * Whether this configuration always uses memory optimized search.
+     */
+    public boolean alwaysUseMemoryOptimizedSearch() {
+        return engine == KNNEngine.FAISS && isSQOneBit();
+    }
+
+    /**
+     * Whether this configuration is eligible for memory optimized search.
+     * Faiss HNSW with FLAT, SQ, or BQ encoders.
+     */
+    public boolean isMemoryOptimizedEligible() {
+        return engine == KNNEngine.FAISS
+            && METHOD_HNSW.equals(methodName)
+            && (encoderType == Encoder.EncoderType.FLAT || encoderType == Encoder.EncoderType.SQ || encoderType == Encoder.EncoderType.BQ);
+    }
+
+    /**
+     * Whether this configuration supports radial search.
+     *
+     * <p>Radial search is blocked for:</p>
+     * <ul>
+     *   <li>Engines that do not support radial search (NMSLIB)</li>
+     *   <li>Binary vector data type</li>
+     *   <li>BQ (binary quantization) encoder</li>
+     *   <li>Quantized indices that are not 1-bit SQ — among quantized indices, only the
+     *       flat method or SQ encoder with bits=1 support radial search via rescoring</li>
+     * </ul>
+     */
+    public boolean supportsRadialSearch() {
+        if (KNNEngine.ENGINES_SUPPORTING_RADIAL_SEARCH.contains(engine) == false) {
+            return false;
+        }
+        if (vectorDataType == VectorDataType.BINARY) {
+            return false;
+        }
+        if (encoderType == Encoder.EncoderType.BQ) {
+            return false;
+        }
+        // Among quantized indices, only flat method or SQ 1-bit supports radial
+        if (isQuantizedIndex()) {
+            return isMethodFlat() || isSQOneBit();
+        }
+        return true;
+    }
+
+    /**
+     * Returns the appropriate rescore context for this configuration.
+     * Recomputed each call since RescoreContext has mutable state in getFirstPassK().
+     */
+    public RescoreContext getRescoreContext() {
+        return compressionLevel.getDefaultRescoreContext(
+            mode,
+            dimension,
+            indexVersionCreated != null ? indexVersionCreated : Version.CURRENT,
+            isMethodFlat(),
+            isSQOneBit(),
+            engine
+        );
+    }
+
+    /**
+     * Whether rescoring is needed for this configuration.
+     */
+    public boolean requiresRescore() {
+        return getRescoreContext() != null;
+    }
+
+    private boolean isSQOneBit() {
+        return encoderType == Encoder.EncoderType.SQ && quantizationBits == Encoder.QuantizationBits.ONE;
+    }
+
+    private boolean isMethodFlat() {
+        return METHOD_FLAT.equals(methodName);
+    }
+
+    private boolean isQuantizedIndex() {
+        return CompressionLevel.isConfigured(compressionLevel)
+            && compressionLevel != CompressionLevel.x1
+            && compressionLevel != CompressionLevel.x2;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
@@ -153,11 +153,7 @@ public abstract class AbstractFaissPQEncoder implements Encoder {
 
     @Override
     public Set<QuantizationBits> getSupportedBits() {
-        return EnumSet.of(QuantizationBits.NOT_APPLICABLE);
+        return EnumSet.noneOf(QuantizationBits.class);
     }
 
-    @Override
-    public QuantizationBits getQuantizationBits() {
-        return QuantizationBits.NOT_APPLICABLE;
-    }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
@@ -11,6 +11,9 @@ import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
@@ -141,5 +144,20 @@ public abstract class AbstractFaissPQEncoder implements Encoder {
         }
 
         return builder.build();
+    }
+
+    @Override
+    public EncoderType getEncoderType() {
+        return EncoderType.PQ;
+    }
+
+    @Override
+    public Set<QuantizationBits> getSupportedBits() {
+        return EnumSet.of(QuantizationBits.NOT_APPLICABLE);
+    }
+
+    @Override
+    public QuantizationBits getQuantizationBits() {
+        return QuantizationBits.NOT_APPLICABLE;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFlatEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFlatEncoder.java
@@ -14,6 +14,7 @@ import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -51,5 +52,15 @@ public class FaissFlatEncoder implements Encoder {
         KNNMethodConfigContext knnMethodConfigContext
     ) {
         return CompressionLevel.x1;
+    }
+
+    @Override
+    public EncoderType getEncoderType() {
+        return EncoderType.FLAT;
+    }
+
+    @Override
+    public Set<QuantizationBits> getSupportedBits() {
+        return EnumSet.of(QuantizationBits.FULL_PRECISION);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -22,6 +22,7 @@ import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -273,5 +274,15 @@ public class FaissSQEncoder implements Encoder {
         }
         Object bits = encoderCtx.getParameters().get(SQ_BITS);
         return bits instanceof Integer && (Integer) bits == Bits.ONE.getValue();
+    }
+
+    @Override
+    public EncoderType getEncoderType() {
+        return EncoderType.SQ;
+    }
+
+    @Override
+    public Set<QuantizationBits> getSupportedBits() {
+        return EnumSet.of(QuantizationBits.ONE, QuantizationBits.SIXTEEN);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/QFrameBitEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/QFrameBitEncoder.java
@@ -18,6 +18,7 @@ import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Set;
@@ -143,5 +144,15 @@ public class QFrameBitEncoder implements Encoder {
 
         // Validation will ensure that only 1 of the supported bit count will be selected.
         return CompressionLevel.x8;
+    }
+
+    @Override
+    public EncoderType getEncoderType() {
+        return EncoderType.BQ;
+    }
+
+    @Override
+    public Set<QuantizationBits> getSupportedBits() {
+        return EnumSet.of(QuantizationBits.ONE, QuantizationBits.TWO, QuantizationBits.FOUR);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.index.engine.Parameter;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -111,5 +112,15 @@ public class LuceneSQEncoder implements Encoder {
             return CompressionLevel.x32;
         }
         return CompressionLevel.x4;
+    }
+
+    @Override
+    public EncoderType getEncoderType() {
+        return EncoderType.SQ;
+    }
+
+    @Override
+    public Set<QuantizationBits> getSupportedBits() {
+        return EnumSet.of(QuantizationBits.ONE, QuantizationBits.SEVEN);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -79,7 +79,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         KNNLibraryIndexingContext libraryContext = methodContext.getKnnEngine()
             .getKNNLibraryIndexingContext(methodContext, knnMethodConfigContext);
         boolean isLuceneEngine = KNNEngine.LUCENE.equals(methodContext.getKnnEngine());
-        ResolvedIndexSpec resolvedSpec = libraryContext != null ? libraryContext.getResolvedSpec() : null;
+        ResolvedIndexSpec resolvedSpec = libraryContext.getResolvedSpec();
 
         KNNVectorFieldType mappedFieldType = new KNNVectorFieldType(
             fullname,

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -24,6 +24,7 @@ import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.index.engine.faiss.SQConfig;
 import org.opensearch.knn.index.engine.faiss.SQConfigParser;
@@ -78,6 +79,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         KNNLibraryIndexingContext libraryContext = methodContext.getKnnEngine()
             .getKNNLibraryIndexingContext(methodContext, knnMethodConfigContext);
         boolean isLuceneEngine = KNNEngine.LUCENE.equals(methodContext.getKnnEngine());
+        ResolvedIndexSpec resolvedSpec = libraryContext != null ? libraryContext.getResolvedSpec() : null;
 
         KNNVectorFieldType mappedFieldType = new KNNVectorFieldType(
             fullname,
@@ -121,7 +123,8 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
                     return libraryContext;
                 }
             },
-            indexCreatedVersion
+            indexCreatedVersion,
+            resolvedSpec
         );
 
         return new EngineFieldMapper(

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.index.KNNVectorIndexFieldData;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
@@ -75,6 +76,7 @@ public class KNNVectorFieldType extends MappedFieldType {
      */
     boolean memoryOptimizedSearchAvailable;
     Version indexCreatedVersion;
+    ResolvedIndexSpec resolvedSpec;
 
     /**
      * Constructor for KNNVectorFieldType with index created version.
@@ -92,6 +94,27 @@ public class KNNVectorFieldType extends MappedFieldType {
         KNNMappingConfig annConfig,
         Version indexCreatedVersion
     ) {
+        this(name, metadata, vectorDataType, annConfig, indexCreatedVersion, null);
+    }
+
+    /**
+     * Constructor for KNNVectorFieldType with index created version and resolved index spec.
+     *
+     * @param name name of the field
+     * @param metadata metadata of the field
+     * @param vectorDataType data type of the vector
+     * @param annConfig configuration context for the ANN index
+     * @param indexCreatedVersion Index created version.
+     * @param resolvedSpec resolved index spec, may be null for model/training/flat paths
+     */
+    public KNNVectorFieldType(
+        String name,
+        Map<String, String> metadata,
+        VectorDataType vectorDataType,
+        KNNMappingConfig annConfig,
+        Version indexCreatedVersion,
+        ResolvedIndexSpec resolvedSpec
+    ) {
         this(name, metadata, vectorDataType, annConfig);
         this.alwaysUseMemoryOptimizedSearch = MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(
             knnMappingConfig.getKnnMethodContext()
@@ -102,6 +125,7 @@ public class KNNVectorFieldType extends MappedFieldType {
             annConfig.getModelId()
         );
         this.indexCreatedVersion = indexCreatedVersion;
+        this.resolvedSpec = resolvedSpec;
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
@@ -11,7 +11,9 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
@@ -46,6 +48,16 @@ public class AbstractMethodResolverTests extends KNNTestCase {
             KNNMethodConfigContext knnMethodConfigContext
         ) {
             return DEFAULT_COMPRESSION;
+        }
+
+        @Override
+        public EncoderType getEncoderType() {
+            return EncoderType.FLAT;
+        }
+
+        @Override
+        public Set<QuantizationBits> getSupportedBits() {
+            return EnumSet.of(QuantizationBits.FULL_PRECISION);
         }
     };
 

--- a/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
@@ -48,7 +48,7 @@ public class EncoderInterfaceTests extends KNNTestCase {
     public void testFaissHNSWPQEncoderType() {
         Encoder encoder = new org.opensearch.knn.index.engine.faiss.FaissHNSWPQEncoder();
         assertEquals(Encoder.EncoderType.PQ, encoder.getEncoderType());
-        assertEquals(Encoder.QuantizationBits.NOT_APPLICABLE, encoder.getQuantizationBits());
-        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.NOT_APPLICABLE));
+        assertEquals(Encoder.QuantizationBits.FULL_PRECISION, encoder.getQuantizationBits());
+        assertTrue(encoder.getSupportedBits().isEmpty());
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.faiss.FaissFlatEncoder;
+import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+import org.opensearch.knn.index.engine.faiss.QFrameBitEncoder;
+import org.opensearch.knn.index.engine.lucene.LuceneSQEncoder;
+
+public class EncoderInterfaceTests extends KNNTestCase {
+
+    public void testFaissFlatEncoderType() {
+        FaissFlatEncoder encoder = new FaissFlatEncoder();
+        assertEquals(Encoder.EncoderType.FLAT, encoder.getEncoderType());
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.FULL_PRECISION));
+        assertEquals(1, encoder.getSupportedBits().size());
+    }
+
+    public void testFaissSQEncoderType() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        assertEquals(Encoder.EncoderType.SQ, encoder.getEncoderType());
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.ONE));
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.SIXTEEN));
+        assertEquals(2, encoder.getSupportedBits().size());
+    }
+
+    public void testLuceneSQEncoderType() {
+        LuceneSQEncoder encoder = new LuceneSQEncoder();
+        assertEquals(Encoder.EncoderType.SQ, encoder.getEncoderType());
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.ONE));
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.SEVEN));
+        assertEquals(2, encoder.getSupportedBits().size());
+    }
+
+    public void testQFrameBitEncoderType() {
+        QFrameBitEncoder encoder = new QFrameBitEncoder();
+        assertEquals(Encoder.EncoderType.BQ, encoder.getEncoderType());
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.ONE));
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.TWO));
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.FOUR));
+        assertEquals(3, encoder.getSupportedBits().size());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EncoderInterfaceTests.java
@@ -44,4 +44,11 @@ public class EncoderInterfaceTests extends KNNTestCase {
         assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.FOUR));
         assertEquals(3, encoder.getSupportedBits().size());
     }
+
+    public void testFaissHNSWPQEncoderType() {
+        Encoder encoder = new org.opensearch.knn.index.engine.faiss.FaissHNSWPQEncoder();
+        assertEquals(Encoder.EncoderType.PQ, encoder.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.NOT_APPLICABLE, encoder.getQuantizationBits());
+        assertTrue(encoder.getSupportedBits().contains(Encoder.QuantizationBits.NOT_APPLICABLE));
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/EncoderTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EncoderTypeTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_BINARY;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+
+public class EncoderTypeTests extends KNNTestCase {
+
+    public void testFromNameRoundTrips() {
+        for (Encoder.EncoderType type : Encoder.EncoderType.values()) {
+            assertEquals(type, Encoder.EncoderType.fromName(type.getName()));
+        }
+    }
+
+    public void testGetNameMatchesKNNConstants() {
+        assertEquals(ENCODER_FLAT, Encoder.EncoderType.FLAT.getName());
+        assertEquals(ENCODER_SQ, Encoder.EncoderType.SQ.getName());
+        assertEquals(ENCODER_PQ, Encoder.EncoderType.PQ.getName());
+        assertEquals(ENCODER_BINARY, Encoder.EncoderType.BQ.getName());
+    }
+
+    public void testFromNameThrowsForUnsupported() {
+        expectThrows(IllegalArgumentException.class, () -> Encoder.EncoderType.fromName("nonexistent"));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/QuantizationBitsTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/QuantizationBitsTests.java
@@ -23,7 +23,6 @@ public class QuantizationBitsTests extends KNNTestCase {
         assertEquals(7, Encoder.QuantizationBits.SEVEN.getValue());
         assertEquals(16, Encoder.QuantizationBits.SIXTEEN.getValue());
         assertEquals(32, Encoder.QuantizationBits.FULL_PRECISION.getValue());
-        assertEquals(-1, Encoder.QuantizationBits.NOT_APPLICABLE.getValue());
     }
 
     public void testGetCompressionLevelMapping() {
@@ -33,7 +32,6 @@ public class QuantizationBitsTests extends KNNTestCase {
         assertEquals(CompressionLevel.x4, Encoder.QuantizationBits.SEVEN.getCompressionLevel());
         assertEquals(CompressionLevel.x2, Encoder.QuantizationBits.SIXTEEN.getCompressionLevel());
         assertEquals(CompressionLevel.x1, Encoder.QuantizationBits.FULL_PRECISION.getCompressionLevel());
-        assertEquals(CompressionLevel.NOT_CONFIGURED, Encoder.QuantizationBits.NOT_APPLICABLE.getCompressionLevel());
     }
 
     public void testFromValueDefaultsToFullPrecision() {

--- a/src/test/java/org/opensearch/knn/index/engine/QuantizationBitsTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/QuantizationBitsTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+
+public class QuantizationBitsTests extends KNNTestCase {
+
+    public void testFromValueRoundTrips() {
+        for (Encoder.QuantizationBits bits : Encoder.QuantizationBits.values()) {
+            assertEquals(bits, Encoder.QuantizationBits.fromValue(bits.getValue()));
+        }
+    }
+
+    public void testGetValueMatchesExpected() {
+        assertEquals(1, Encoder.QuantizationBits.ONE.getValue());
+        assertEquals(2, Encoder.QuantizationBits.TWO.getValue());
+        assertEquals(4, Encoder.QuantizationBits.FOUR.getValue());
+        assertEquals(7, Encoder.QuantizationBits.SEVEN.getValue());
+        assertEquals(16, Encoder.QuantizationBits.SIXTEEN.getValue());
+        assertEquals(32, Encoder.QuantizationBits.FULL_PRECISION.getValue());
+        assertEquals(-1, Encoder.QuantizationBits.NOT_APPLICABLE.getValue());
+    }
+
+    public void testGetCompressionLevelMapping() {
+        assertEquals(CompressionLevel.x32, Encoder.QuantizationBits.ONE.getCompressionLevel());
+        assertEquals(CompressionLevel.x16, Encoder.QuantizationBits.TWO.getCompressionLevel());
+        assertEquals(CompressionLevel.x8, Encoder.QuantizationBits.FOUR.getCompressionLevel());
+        assertEquals(CompressionLevel.x4, Encoder.QuantizationBits.SEVEN.getCompressionLevel());
+        assertEquals(CompressionLevel.x2, Encoder.QuantizationBits.SIXTEEN.getCompressionLevel());
+        assertEquals(CompressionLevel.x1, Encoder.QuantizationBits.FULL_PRECISION.getCompressionLevel());
+        assertEquals(CompressionLevel.NOT_CONFIGURED, Encoder.QuantizationBits.NOT_APPLICABLE.getCompressionLevel());
+    }
+
+    public void testFromValueDefaultsToFullPrecision() {
+        assertEquals(Encoder.QuantizationBits.FULL_PRECISION, Encoder.QuantizationBits.fromValue(999));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -41,8 +41,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testFaissHNSWBQIsMemoryOptimizedEligible() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.BQ)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.BQ)
             .quantizationBits(Encoder.QuantizationBits.TWO)
             .compressionLevel(CompressionLevel.x16)
             .build();
@@ -50,8 +49,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testFaissIVFNotMemoryOptimizedEligible() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .methodName(METHOD_IVF)
+        ResolvedIndexSpec spec = baseFaiss().methodName(METHOD_IVF)
             .encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .compressionLevel(CompressionLevel.x1)
@@ -60,8 +58,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testFaissPQNotMemoryOptimizedEligible() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.PQ)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.PQ)
             .quantizationBits(Encoder.QuantizationBits.NOT_APPLICABLE)
             .compressionLevel(CompressionLevel.x8)
             .build();
@@ -71,8 +68,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     // --- Radial search support ---
 
     public void testRadialSearch_NMSLIBNotSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .engine(KNNEngine.NMSLIB)
+        ResolvedIndexSpec spec = baseFaiss().engine(KNNEngine.NMSLIB)
             .encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .compressionLevel(CompressionLevel.NOT_CONFIGURED)
@@ -81,8 +77,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_BinaryDataTypeNotSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.FLAT)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .vectorDataType(VectorDataType.BINARY)
             .compressionLevel(CompressionLevel.NOT_CONFIGURED)
@@ -91,8 +86,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_BQNotSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.BQ)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.BQ)
             .quantizationBits(Encoder.QuantizationBits.TWO)
             .compressionLevel(CompressionLevel.x16)
             .build();
@@ -100,8 +94,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_QuantizedSQ4BitNotSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.SQ)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
             .quantizationBits(Encoder.QuantizationBits.FOUR)
             .compressionLevel(CompressionLevel.x8)
             .build();
@@ -109,8 +102,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_QuantizedPQNotSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.PQ)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.PQ)
             .quantizationBits(Encoder.QuantizationBits.NOT_APPLICABLE)
             .compressionLevel(CompressionLevel.x8)
             .build();
@@ -123,8 +115,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_FlatMethodWithX32Supported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .methodName(METHOD_FLAT)
+        ResolvedIndexSpec spec = baseFaiss().methodName(METHOD_FLAT)
             .encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .compressionLevel(CompressionLevel.x32)
@@ -133,8 +124,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_NonQuantizedAlwaysSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.FLAT)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.FLAT)
             .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .compressionLevel(CompressionLevel.x1)
             .build();
@@ -142,18 +132,16 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     public void testRadialSearch_LuceneNonQuantizedSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .engine(KNNEngine.LUCENE)
+        ResolvedIndexSpec spec = baseFaiss().engine(KNNEngine.LUCENE)
             .encoderType(Encoder.EncoderType.SQ)
             .quantizationBits(Encoder.QuantizationBits.SEVEN)
             .compressionLevel(CompressionLevel.x4)
             .build();
-        assertTrue(spec.supportsRadialSearch());
+        assertFalse(spec.supportsRadialSearch());
     }
 
     public void testRadialSearch_NotConfiguredCompressionSupported() {
-        ResolvedIndexSpec spec = baseFaiss()
-            .encoderType(Encoder.EncoderType.SQ)
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
             .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
             .compressionLevel(CompressionLevel.NOT_CONFIGURED)
             .build();
@@ -212,8 +200,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaissSQ1Bit() {
-        return baseFaiss()
-            .encoderType(Encoder.EncoderType.SQ)
+        return baseFaiss().encoderType(Encoder.EncoderType.SQ)
             .quantizationBits(Encoder.QuantizationBits.ONE)
             .compressionLevel(CompressionLevel.x32);
     }

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -187,6 +187,27 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
         assertEquals(Version.V_3_6_0, spec.getIndexVersionCreated());
     }
 
+    // --- Additional branch coverage ---
+
+    public void testFaissHNSWFlatIsMemoryOptimizedEligible() {
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+        assertTrue(spec.isMemoryOptimizedEligible());
+    }
+
+    public void testGetRescoreContext_NullVersionDefaults() {
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x8)
+            .dimension(500)
+            .indexVersionCreated(null)
+            .build();
+        // Should not throw - null version defaults to CURRENT
+        spec.getRescoreContext();
+    }
+
     // --- Helpers ---
 
     private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaiss() {

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -21,7 +21,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
 
     public void testFaissSQ1BitUsesSQ1BitCodecFormat() {
         ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
-        assertTrue(spec.usesSQ1BitCodecFormat());
+        assertTrue(spec.usesFaissSQ1BitCodecFormat());
         assertTrue(spec.alwaysUseMemoryOptimizedSearch());
         assertTrue(spec.isMemoryOptimizedEligible());
         assertTrue(spec.requiresRescore());
@@ -29,7 +29,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
 
     public void testLuceneSQ1BitDoesNotUseSQ1BitCodecFormat() {
         ResolvedIndexSpec spec = baseFaissSQ1Bit().engine(KNNEngine.LUCENE).build();
-        assertFalse(spec.usesSQ1BitCodecFormat());
+        assertFalse(spec.usesFaissSQ1BitCodecFormat());
         assertFalse(spec.alwaysUseMemoryOptimizedSearch());
     }
 
@@ -59,7 +59,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
 
     public void testFaissPQNotMemoryOptimizedEligible() {
         ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.PQ)
-            .quantizationBits(Encoder.QuantizationBits.NOT_APPLICABLE)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .compressionLevel(CompressionLevel.x8)
             .build();
         assertFalse(spec.isMemoryOptimizedEligible());
@@ -103,7 +103,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
 
     public void testRadialSearch_QuantizedPQNotSupported() {
         ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.PQ)
-            .quantizationBits(Encoder.QuantizationBits.NOT_APPLICABLE)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
             .compressionLevel(CompressionLevel.x8)
             .build();
         assertFalse(spec.supportsRadialSearch());

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
+
+public class ResolvedIndexSpecTests extends KNNTestCase {
+
+    // --- SQ 1-bit codec / memopt ---
+
+    public void testFaissSQ1BitUsesSQ1BitCodecFormat() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
+        assertTrue(spec.usesSQ1BitCodecFormat());
+        assertTrue(spec.alwaysUseMemoryOptimizedSearch());
+        assertTrue(spec.isMemoryOptimizedEligible());
+        assertTrue(spec.requiresRescore());
+    }
+
+    public void testLuceneSQ1BitDoesNotUseSQ1BitCodecFormat() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().engine(KNNEngine.LUCENE).build();
+        assertFalse(spec.usesSQ1BitCodecFormat());
+        assertFalse(spec.alwaysUseMemoryOptimizedSearch());
+    }
+
+    // --- Memory optimized eligibility ---
+
+    public void testFaissHNSWSQIsMemoryOptimizedEligible() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
+        assertTrue(spec.isMemoryOptimizedEligible());
+    }
+
+    public void testFaissHNSWBQIsMemoryOptimizedEligible() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.BQ)
+            .quantizationBits(Encoder.QuantizationBits.TWO)
+            .compressionLevel(CompressionLevel.x16)
+            .build();
+        assertTrue(spec.isMemoryOptimizedEligible());
+    }
+
+    public void testFaissIVFNotMemoryOptimizedEligible() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .methodName(METHOD_IVF)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+        assertFalse(spec.isMemoryOptimizedEligible());
+    }
+
+    public void testFaissPQNotMemoryOptimizedEligible() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.PQ)
+            .quantizationBits(Encoder.QuantizationBits.NOT_APPLICABLE)
+            .compressionLevel(CompressionLevel.x8)
+            .build();
+        assertFalse(spec.isMemoryOptimizedEligible());
+    }
+
+    // --- Radial search support ---
+
+    public void testRadialSearch_NMSLIBNotSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .engine(KNNEngine.NMSLIB)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_BinaryDataTypeNotSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .vectorDataType(VectorDataType.BINARY)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_BQNotSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.BQ)
+            .quantizationBits(Encoder.QuantizationBits.TWO)
+            .compressionLevel(CompressionLevel.x16)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_QuantizedSQ4BitNotSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x8)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_QuantizedPQNotSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.PQ)
+            .quantizationBits(Encoder.QuantizationBits.NOT_APPLICABLE)
+            .compressionLevel(CompressionLevel.x8)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_SQ1BitSupported() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
+        assertTrue(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_FlatMethodWithX32Supported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .methodName(METHOD_FLAT)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+        assertTrue(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_NonQuantizedAlwaysSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+        assertTrue(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_LuceneNonQuantizedSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .engine(KNNEngine.LUCENE)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SEVEN)
+            .compressionLevel(CompressionLevel.x4)
+            .build();
+        assertTrue(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_NotConfiguredCompressionSupported() {
+        ResolvedIndexSpec spec = baseFaiss()
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .build();
+        assertTrue(spec.supportsRadialSearch());
+    }
+
+    // --- Builder defaults ---
+
+    public void testBuilderDefaultsForCompressionAndMode() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        assertEquals(CompressionLevel.NOT_CONFIGURED, spec.getCompressionLevel());
+        assertEquals(Mode.NOT_CONFIGURED, spec.getMode());
+    }
+
+    public void testInputsStoredCorrectly() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.LUCENE)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(256)
+            .indexVersionCreated(Version.V_3_6_0)
+            .build();
+        assertEquals(KNNEngine.LUCENE, spec.getEngine());
+        assertEquals(METHOD_HNSW, spec.getMethodName());
+        assertEquals(Encoder.EncoderType.SQ, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.ONE, spec.getQuantizationBits());
+        assertEquals(CompressionLevel.x32, spec.getCompressionLevel());
+        assertEquals(Mode.ON_DISK, spec.getMode());
+        assertEquals(VectorDataType.FLOAT, spec.getVectorDataType());
+        assertEquals(256, spec.getDimension());
+        assertEquals(Version.V_3_6_0, spec.getIndexVersionCreated());
+    }
+
+    // --- Helpers ---
+
+    private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaiss() {
+        return ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .mode(Mode.ON_DISK)
+            .indexVersionCreated(Version.CURRENT);
+    }
+
+    private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaissSQ1Bit() {
+        return baseFaiss()
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
@@ -187,4 +187,30 @@ public class ResolvedIndexSpecWiringTests extends KNNTestCase {
         assertNotNull(spec);
         assertEquals(0, spec.getDimension());
     }
+
+    public void testFaissHNSWWithBQEncoder_defaultsToOneBit() {
+        java.util.Map<String, Object> encoderParams = new java.util.HashMap<>();
+        MethodComponentContext encoderCtx = new MethodComponentContext("binary", encoderParams);
+
+        java.util.Map<String, Object> methodParams = new java.util.HashMap<>();
+        methodParams.put("encoder", encoderCtx);
+
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, methodParams)
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.ON_DISK)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Encoder.EncoderType.BQ, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.ONE, spec.getQuantizationBits());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
@@ -81,6 +81,11 @@ public class ResolvedIndexSpecWiringTests extends KNNTestCase {
             public org.opensearch.knn.index.mapper.VectorTransformer getVectorTransformer() {
                 return null;
             }
+
+            @Override
+            public ResolvedIndexSpec getResolvedSpec() {
+                return null;
+            }
         };
         assertNull(ctx.getResolvedSpec());
     }

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+public class ResolvedIndexSpecWiringTests extends KNNTestCase {
+
+    public void testKNNLibraryIndexingContextImpl_resolvedSpecStoredAndRetrieved() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNLibraryIndexingContextImpl.builder().resolvedSpec(spec).build();
+
+        assertNotNull(ctx.getResolvedSpec());
+        assertSame(spec, ctx.getResolvedSpec());
+        assertEquals(KNNEngine.FAISS, ctx.getResolvedSpec().getEngine());
+        assertEquals(Encoder.EncoderType.SQ, ctx.getResolvedSpec().getEncoderType());
+        assertEquals(Encoder.QuantizationBits.ONE, ctx.getResolvedSpec().getQuantizationBits());
+    }
+
+    public void testKNNLibraryIndexingContextImpl_resolvedSpecDefaultsToNull() {
+        KNNLibraryIndexingContext ctx = KNNLibraryIndexingContextImpl.builder().build();
+        assertNull(ctx.getResolvedSpec());
+    }
+
+    public void testKNNLibraryIndexingContext_defaultMethodReturnsNull() {
+        KNNLibraryIndexingContext ctx = new KNNLibraryIndexingContext() {
+            @Override
+            public java.util.Map<String, Object> getLibraryParameters() {
+                return null;
+            }
+
+            @Override
+            public org.opensearch.knn.index.engine.qframe.QuantizationConfig getQuantizationConfig() {
+                return null;
+            }
+
+            @Override
+            public org.opensearch.knn.index.mapper.VectorValidator getVectorValidator() {
+                return null;
+            }
+
+            @Override
+            public org.opensearch.knn.index.mapper.PerDimensionValidator getPerDimensionValidator() {
+                return null;
+            }
+
+            @Override
+            public org.opensearch.knn.index.mapper.PerDimensionProcessor getPerDimensionProcessor() {
+                return null;
+            }
+
+            @Override
+            public
+                java.util.function.Function<TrainingConfigValidationInput, TrainingConfigValidationOutput>
+                getTrainingConfigValidationSetup() {
+                return null;
+            }
+
+            @Override
+            public org.opensearch.knn.index.mapper.VectorTransformer getVectorTransformer() {
+                return null;
+            }
+        };
+        assertNull(ctx.getResolvedSpec());
+    }
+
+    public void testFaissHNSWResolution_producesSpecInContext() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(KNNEngine.FAISS, spec.getEngine());
+        assertEquals(METHOD_HNSW, spec.getMethodName());
+        assertEquals(Encoder.EncoderType.FLAT, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.FULL_PRECISION, spec.getQuantizationBits());
+        assertEquals(CompressionLevel.x1, spec.getCompressionLevel());
+        assertEquals(VectorDataType.FLOAT, spec.getVectorDataType());
+        assertEquals(128, spec.getDimension());
+    }
+
+    public void testLuceneHNSWResolution_producesSpecInContext() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(256)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.LUCENE.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(KNNEngine.LUCENE, spec.getEngine());
+        assertEquals(METHOD_HNSW, spec.getMethodName());
+        assertEquals(Encoder.EncoderType.FLAT, spec.getEncoderType());
+        assertEquals(256, spec.getDimension());
+    }
+
+    public void testFaissHNSWWithSQEncoder_producesCorrectSpec() {
+        java.util.Map<String, Object> encoderParams = new java.util.HashMap<>();
+        encoderParams.put("bits", 1);
+        MethodComponentContext encoderCtx = new MethodComponentContext("sq", encoderParams);
+
+        java.util.Map<String, Object> methodParams = new java.util.HashMap<>();
+        methodParams.put("encoder", encoderCtx);
+
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, methodParams)
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(768)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.ON_DISK)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(Encoder.EncoderType.SQ, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.ONE, spec.getQuantizationBits());
+        assertEquals(CompressionLevel.x32, spec.getCompressionLevel());
+        assertEquals(Mode.ON_DISK, spec.getMode());
+        assertEquals(768, spec.getDimension());
+    }
+
+    public void testNullDimensionHandledGracefully() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(0, spec.getDimension());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
@@ -12,10 +12,12 @@ import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.KNNVectorDocValueFormat;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.search.DocValueFormat;
 
@@ -126,6 +128,54 @@ public class KNNVectorFieldTypeTests extends KNNTestCase {
         );
         KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(sqOneBitMethodContext, 128);
         return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT);
+    }
+
+    public void testKNNVectorFieldType_resolvedSpecStoredWhenProvided() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNMethodContext sqOneBitMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Map.of("bits", 1)))
+            )
+        );
+        KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(sqOneBitMethodContext, 128);
+        KNNVectorFieldType fieldType = new KNNVectorFieldType(
+            FIELD_NAME,
+            Collections.emptyMap(),
+            VectorDataType.FLOAT,
+            mappingConfig,
+            Version.CURRENT,
+            spec
+        );
+        assertNotNull(fieldType.getResolvedSpec());
+        assertSame(spec, fieldType.getResolvedSpec());
+        assertEquals(Encoder.EncoderType.SQ, fieldType.getResolvedSpec().getEncoderType());
+    }
+
+    public void testKNNVectorFieldType_resolvedSpecNullWhenNotProvided() {
+        KNNMethodContext knnMethodContext = getDefaultKNNMethodContext();
+        KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(knnMethodContext, 128);
+        KNNVectorFieldType fieldType = new KNNVectorFieldType(
+            FIELD_NAME,
+            Collections.emptyMap(),
+            VectorDataType.FLOAT,
+            mappingConfig,
+            Version.CURRENT
+        );
+        assertNull(fieldType.getResolvedSpec());
     }
 
     public void testKNNVectorFieldType_whenNonSQOneBitEncoder_thenAlwaysUseMemoryOptimizedSearchIsFalse() {


### PR DESCRIPTION
### Description

Introduces `ResolvedIndexSpec` (RIS), an immutable object computed once at index mapping resolution time that consolidates all engine, compression, mode, encoder, and behavioral decisions into a single pre-computed source of truth.

**Problem:** Behavioral questions about an index (codec format selection, rescore eligibility, memory-optimized search, remote build support) were answered by scattered logic across `CompressionLevel`, `FaissHNSWMethod`, `FaissSQEncoder`, and `KNNVectorFieldType`. Each call site re-derived answers from raw parameters, leading to duplication and inconsistency risk.

**Solution:** RIS is built once during method resolution and flows through:
- **Write path:** `KNNLibraryIndexingContext.getResolvedSpec()` (source of truth)
- **Query path:** `KNNVectorFieldType.getResolvedSpec()` (same object, cached reference)

Callers now ask behavioral methods (`usesSQ1BitCodecFormat()`, `getRescoreContext()`, `isMemoryOptimizedEligible()`, `supportsRemoteIndexBuild()`) instead of inspecting raw encoder parameters.

**What reviewers should expect:**

| Area | Change pattern |
|------|---------------|
| `ResolvedIndexSpec.java` (new) | Core abstraction. Lombok `@Builder @Getter`. Methods for now - can be cached properties. |
| `Encoder.java` | New inner enums (`EncoderType`, `QuantizationBits`) + `validate()` default method |
| `AbstractKNNMethod.java` | Builds RIS during `getKNNLibraryIndexingContext()` |
| `KNNVectorFieldType.java` | Holds RIS reference, delegates rescore to `resolvedSpec.getRescoreContext()` |
| `FaissFieldStrategy.java` / `LuceneFieldStrategy.java` (new) | Extracted from `EngineFieldMapper` for engine-specific field type construction |
| `FaissCodecFormatResolver` / `LuceneCodecFormatResolver` | Accept RIS in `resolve()` signature, prefer spec-based check over raw param inspection |
| `CompressionLevel.java` | `getDefaultRescoreContext()` deprecated (logic moved to RIS) |
| `FaissMethodResolver` / `LuceneHNSWMethodResolver` | `getDefaultCompressionLevel()` extracted to `AbstractMethodResolver`, mode deprecated |
| `FaissSQEncoder` / `LuceneSQEncoder` | Implement `validate()` for create-index-time encoder validation |
| Tests | New coverage for RIS, wiring, consumer migration. Existing tests migrated to new APIs. |

**Key design decisions:**
- RIS uses methods for derived properties for evolution, can be optimized to be cached in the object instance
- Backward compatible: no behavioral change for any existing index or query path

### Related Issues
Related #3290

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
