### PR TITLE
Integrated proper ef_search functionality into MOS and Lucene with oversample_factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
 * Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)
+* Integrated proper ef_search functionality into MOS and Lucene with oversample_factor [#3331](https://github.com/opensearch-project/k-NN/pull/3331)
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
 
 ### Refactoring

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryFactory.java
@@ -148,7 +148,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
                 expandNested,
                 vectorDataType,
                 k,
-                needsRescore
+                needsRescore ? overSampledK : RescoreContext.NO_RESCORE_NEEDED
             )
         );
 
@@ -196,12 +196,12 @@ public class KNNQueryFactory extends BaseQueryFactory {
         final boolean expandNested,
         @NonNull final VectorDataType vectorDataType,
         final int k,
-        final boolean needsRescore
+        final int rescoreK
     ) {
         if (parentFilter == null) {
             assert expandNested == false : "expandNested is allowed to be true only for nested fields.";
             return vectorDataType == VectorDataType.FLOAT
-                ? new OSKnnFloatVectorQuery(fieldName, floatQueryVector, luceneK, filterQuery, k, needsRescore)
+                ? new OSKnnFloatVectorQuery(fieldName, floatQueryVector, luceneK, filterQuery, k, rescoreK)
                 : new OSKnnByteVectorQuery(fieldName, byteQueryVector, luceneK, filterQuery, k);
         }
         // If parentFilter is not null, it is a nested query. Therefore, we delegate creation of query to {@link
@@ -216,7 +216,7 @@ public class KNNQueryFactory extends BaseQueryFactory {
                 parentFilter,
                 expandNested,
                 k,
-                needsRescore
+                rescoreK
             )
             : NestedKnnVectorQueryFactory.createNestedKnnVectorQuery(
                 fieldName,

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/InternalNestedKnnFloatVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/InternalNestedKnnFloatVectorQuery.java
@@ -36,7 +36,7 @@ public class InternalNestedKnnFloatVectorQuery extends KnnFloatVectorQuery imple
         final int luceneK,
         final BitSetProducer parentFilter,
         final int k,
-        final boolean needsRescore
+        final int rescoreK
     ) {
         super(field, target, Integer.MAX_VALUE, filter);
         this.field = field;
@@ -52,7 +52,7 @@ public class InternalNestedKnnFloatVectorQuery extends KnnFloatVectorQuery imple
             luceneK,
             parentFilter,
             k,
-            needsRescore,
+            rescoreK,
             true
         );
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactory.java
@@ -58,7 +58,7 @@ public class NestedKnnVectorQueryFactory {
      * @param parentFilter has mapping data between parent doc and child doc
      * @param expandNestedDocs tells if this query is for expanding nested docs
      * @param k k nearest neighbor for search
-     * @param needsRescore tells if this query needs rescore
+     * @param rescoreK the number of candidates to retain for rescoring (0 means no rescore)
      * @return Query for k-NN nested field
      */
     public static Query createNestedKnnVectorQuery(
@@ -69,13 +69,13 @@ public class NestedKnnVectorQueryFactory {
         final BitSetProducer parentFilter,
         final boolean expandNestedDocs,
         final int k,
-        final boolean needsRescore
+        final int rescoreK
     ) {
         if (expandNestedDocs) {
             return new ExpandNestedDocsQuery.ExpandNestedDocsQueryBuilder().internalNestedKnnVectorQuery(
-                new InternalNestedKnnFloatVectorQuery(fieldName, vector, filterQuery, luceneK, parentFilter, k, needsRescore)
+                new InternalNestedKnnFloatVectorQuery(fieldName, vector, filterQuery, luceneK, parentFilter, k, rescoreK)
             ).queryUtils(QueryUtils.getInstance()).build();
         }
-        return new OSDiversifyingChildrenFloatKnnVectorQuery(fieldName, vector, filterQuery, luceneK, parentFilter, k, needsRescore);
+        return new OSDiversifyingChildrenFloatKnnVectorQuery(fieldName, vector, filterQuery, luceneK, parentFilter, k, rescoreK);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
@@ -9,6 +9,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 /**
  * OpenSearch wrapper around Lucene's DiversifyingChildrenFloatKnnVectorQuery that customizes
@@ -19,7 +20,7 @@ import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
  */
 public final class OSDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery {
     private final int k;
-    private final boolean needsRescore;
+    private final int rescoreK;
     private final boolean expandNestedDocs;
 
     public OSDiversifyingChildrenFloatKnnVectorQuery(
@@ -29,9 +30,9 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         final int luceneK,
         final BitSetProducer parentFilter,
         final int k,
-        final boolean needsRescore
+        final int rescoreK
     ) {
-        this(fieldName, vector, filterQuery, luceneK, parentFilter, k, needsRescore, false);
+        this(fieldName, vector, filterQuery, luceneK, parentFilter, k, rescoreK, false);
     }
 
     public OSDiversifyingChildrenFloatKnnVectorQuery(
@@ -41,22 +42,22 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         final int luceneK,
         final BitSetProducer parentFilter,
         final int k,
-        final boolean needsRescore,
+        final int rescoreK,
         final boolean expandNestedDocs
     ) {
         super(fieldName, vector, filterQuery, luceneK, parentFilter);
         this.k = k;
-        this.needsRescore = needsRescore;
+        this.rescoreK = rescoreK;
         this.expandNestedDocs = expandNestedDocs;
     }
 
     @Override
     protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
         // TODO: Fix this if condition after adding rescoring logic inside ExpandNestedDocsQuery when rescoring is enabled
-        if (needsRescore && !expandNestedDocs) {
-
-            // When rescoring is enabled, we need to return all the oversampled k results to rescore which are later reduced to k
-            return super.mergeLeafResults(perLeafResults);
+        if (rescoreK != RescoreContext.NO_RESCORE_NEEDED && !expandNestedDocs) {
+            // When rescoring is enabled, merge to oversampled k (rescore budget) rather than the
+            // full luceneK which may have been expanded by ef_search.
+            return TopDocs.merge(rescoreK, perLeafResults);
         }
         // Merge all segment level results and take top k from it
         return TopDocs.merge(k, perLeafResults);

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSKnnFloatVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSKnnFloatVectorQuery.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.query.lucenelib;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 /**
  * OpenSearch wrapper around Lucene's KnnByteVectorQuery that customizes
@@ -18,7 +19,7 @@ import org.apache.lucene.search.TopDocs;
  */
 public final class OSKnnFloatVectorQuery extends KnnFloatVectorQuery {
     private final int k;
-    private final boolean needsRescore;
+    private final int rescoreK;
 
     public OSKnnFloatVectorQuery(
         final String fieldName,
@@ -26,19 +27,19 @@ public final class OSKnnFloatVectorQuery extends KnnFloatVectorQuery {
         final int luceneK,
         final Query filterQuery,
         final int k,
-        final boolean needsRescore
+        final int rescoreK
     ) {
         super(fieldName, floatQueryVector, luceneK, filterQuery);
         this.k = k;
-        this.needsRescore = needsRescore;
+        this.rescoreK = rescoreK;
     }
 
     @Override
     protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
-        if (needsRescore) {
-
-            // When rescoring is enabled, we need to return all the oversampled k results to rescore which are later reduced to k
-            return super.mergeLeafResults(perLeafResults);
+        if (rescoreK != RescoreContext.NO_RESCORE_NEEDED) {
+            // When rescoring is enabled, merge to oversampled k (rescore budget) rather than the
+            // full luceneK which may have been expanded by ef_search.
+            return TopDocs.merge(rescoreK, perLeafResults);
         }
         // Merge all segment level results and take top k from it
         return TopDocs.merge(k, perLeafResults);

--- a/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/nativelib/NativeEngineKnnVectorQuery.java
@@ -38,6 +38,7 @@ import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
 import org.opensearch.knn.index.query.memoryoptsearch.MemoryOptimizedKNNWeight;
 import org.opensearch.knn.index.query.memoryoptsearch.optimistic.OptimisticSearchStrategyUtils;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.knn.index.util.IndexHyperParametersUtil;
 import org.opensearch.knn.profile.KNNProfileUtil;
 import org.opensearch.knn.profile.LongMetric;
 import org.opensearch.knn.profile.query.KNNMetrics;
@@ -92,7 +93,8 @@ public class NativeEngineKnnVectorQuery extends Query {
         // Create Weight depending on whether 2-phase search is needed
         final boolean isShardLevelRescoringDisabled = KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(knnQuery.getIndexName());
         final Integer firstPassKFor2PhaseSearch = getFirstPassK(isShardLevelRescoringDisabled);
-        final IOSupplier<KNNWeight> weightSupplier = getKNNWeightSupplier(firstPassKFor2PhaseSearch, indexSearcher, scoreMode);
+        final int effectiveK = getEffectiveK(knnQuery.getK());
+        final IOSupplier<KNNWeight> weightSupplier = getKNNWeightSupplier(firstPassKFor2PhaseSearch, indexSearcher, scoreMode, effectiveK);
 
         // Create weight
         QueryProfiler profiler = KNNProfileUtil.getProfiler(indexSearcher);
@@ -112,9 +114,12 @@ public class NativeEngineKnnVectorQuery extends Query {
         List<PerLeafResult> perLeafResults;
         final int finalK = knnQuery.getK();
         if (isRescoreRequired(firstPassKFor2PhaseSearch) == false) {
-            perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, finalK);
+            perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, effectiveK);
         } else {
-            perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, firstPassKFor2PhaseSearch);
+            // Search with max(firstPassK, effectiveK) to honor ef_search exploration,
+            // then trim to firstPassK for the rescore input.
+            final int searchK = Math.max(firstPassKFor2PhaseSearch, effectiveK);
+            perLeafResults = doSearch(indexSearcher, leafReaderContexts, knnWeight, searchK);
             if (isShardLevelRescoringDisabled == false) {
                 ResultUtil.reduceToTopK(perLeafResults, firstPassKFor2PhaseSearch);
             }
@@ -130,10 +135,9 @@ public class NativeEngineKnnVectorQuery extends Query {
             );
         }
 
-        // Since memory optimized search is using this class, we need to return the same totalHits value when it's disabled.
-        // e.g. Let's say we got 100 result per each segment where #segments=3, then 300 should be returned as total hit.
-        // Therefore, when memory optimized search is enabled, we should skip taking top-k and return whatever we got from approximate
-        // search.
+        // For non-memory-optimized search, reduce to top k across segments.
+        // For memory-optimized search, skip reduceToTopK to preserve totalHits behavior;
+        // the final trim to k is handled by TopDocs.merge via getTotalTopDoc.
         if (knnQuery.isMemoryOptimizedSearch() == false) {
             ResultUtil.reduceToTopK(perLeafResults, finalK);
         }
@@ -164,7 +168,7 @@ public class NativeEngineKnnVectorQuery extends Query {
             topDocs[i] = leafTopDocs;
         }
 
-        TopDocs topK = TopDocs.merge(getTotalTopDoc(topDocs), topDocs);
+        TopDocs topK = TopDocs.merge(getMergeTopN(topDocs, finalK, effectiveK), topDocs);
 
         if (topK.scoreDocs.length == 0) {
             return new MatchNoDocsQuery().createWeight(indexSearcher, scoreMode, boost);
@@ -181,14 +185,19 @@ public class NativeEngineKnnVectorQuery extends Query {
     private IOSupplier<KNNWeight> getKNNWeightSupplier(
         Integer firstPassKFor2PhaseSearch,
         IndexSearcher indexSearcher,
-        ScoreMode scoreMode
+        ScoreMode scoreMode,
+        int effectiveK
     ) {
-        if (isRescoreRequired(firstPassKFor2PhaseSearch) == false) {
-            return () -> (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1);
-        } else {
-            // Create weight with expanded `k`.
-            return () -> (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1, firstPassKFor2PhaseSearch);
+        if (isRescoreRequired(firstPassKFor2PhaseSearch)) {
+            // Search with max(firstPassK, effectiveK) to honor both oversample and ef_search.
+            final int searchK = Math.max(firstPassKFor2PhaseSearch, effectiveK);
+            return () -> (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1, searchK);
         }
+        if (effectiveK > knnQuery.getK()) {
+            // ef_search > k: expand the collector budget without triggering rescore.
+            return () -> (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1, effectiveK);
+        }
+        return () -> (KNNWeight) knnQuery.createWeight(indexSearcher, scoreMode, 1);
     }
 
     private Integer getFirstPassK(final boolean isShardLevelRescoringDisabled) {
@@ -204,18 +213,35 @@ public class NativeEngineKnnVectorQuery extends Query {
     }
 
     /**
-     * When expandNestedDocs is set to true, additional nested documents are retrieved.
-     * As a result, the total number of documents will exceed k.
-     * Instead of relying on the k value, we must count the total number of documents
-     * to accurately determine how many are in topDocs.
-     * The theoretical maximum value this method could return is Integer.MAX_VALUE,
-     * as a single shard cannot have more documents than Integer.MAX_VALUE.
+     * For memory-optimized search, returns max(k, ef_search) so the HNSW graph explores a wider
+     * candidate set. Results are trimmed back to k without a full-precision rescore.
+     * For non-memory-optimized search, ef_search is passed via methodParameters to the native engine
+     * directly, so no expansion is needed here.
+     *
+     * @return expanded k if ef_search > k for memory-optimized search, otherwise the original k
+     */
+    private int getEffectiveK(final int k) {
+        if (knnQuery.isMemoryOptimizedSearch() == false) {
+            return k;
+        }
+        int efSearch = IndexHyperParametersUtil.getHNSWEFSearchValue(knnQuery.getMethodParameters(), knnQuery.getIndexName());
+        return Math.max(k, efSearch);
+    }
+
+    /**
+     * Determines the topN parameter for TopDocs.merge.
+     *
+     * For expandNestedDocs or MOS without ef_search expansion: returns total doc count
+     * to preserve all results (totalHits behavior).
+     * For MOS with ef_search expansion: returns k to trim excess results from expanded search.
+     * For non-MOS without expandNestedDocs: uses k (already trimmed by reduceToTopK).
      *
      * @param topDocs the top documents
-     * @return the total number of documents in the topDocs
+     * @param k the user's requested result count
+     * @return the topN value to pass to TopDocs.merge
      */
-    private int getTotalTopDoc(TopDocs[] topDocs) {
-        if (knnQuery.isMemoryOptimizedSearch() || expandNestedDocs) {
+    private int getMergeTopN(TopDocs[] topDocs, int k, int effectiveK) {
+        if (expandNestedDocs || (knnQuery.isMemoryOptimizedSearch() && effectiveK == k)) {
             int sum = 0;
             for (TopDocs topDoc : topDocs) {
                 sum += topDoc.scoreDocs.length;
@@ -223,7 +249,7 @@ public class NativeEngineKnnVectorQuery extends Query {
             return sum;
         }
 
-        return knnQuery.getK();
+        return k;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
+++ b/src/main/java/org/opensearch/knn/index/query/rescore/RescoreContext.java
@@ -13,6 +13,8 @@ import lombok.Getter;
 @Builder
 @EqualsAndHashCode
 public final class RescoreContext {
+    public static final int NO_RESCORE_NEEDED = 0;
+
     public static final float FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR = 2.0f;
 
     public static final float DEFAULT_OVERSAMPLE_FACTOR = 1.0f;

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryFactoryTests.java
@@ -151,7 +151,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
         // efsearch > k and efSearch was set using methodParameters
         int luceneK = getLuceneK(testK, methodParameters);
         Query expectedQuery1 = new LuceneEngineKnnVectorQuery(
-            new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, false)
+            new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, RescoreContext.NO_RESCORE_NEEDED)
         );
         assertEquals(expectedQuery1, actualQuery1);
         assertEquals(luceneK, methodParameters.get(METHOD_PARAMETER_EF_SEARCH));
@@ -161,7 +161,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
         actualQuery1 = buildLuceneFloatQuery(methodParams);
         luceneK = getLuceneK(testK, methodParams);
         expectedQuery1 = new LuceneEngineKnnVectorQuery(
-            new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, false)
+            new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, RescoreContext.NO_RESCORE_NEEDED)
         );
         assertEquals(expectedQuery1, actualQuery1);
         assertEquals(luceneK, testK);
@@ -174,7 +174,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             luceneK = getLuceneK(testK, null);
             actualQuery1 = buildLuceneFloatQuery(null);
             expectedQuery1 = new LuceneEngineKnnVectorQuery(
-                new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, false)
+                new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, RescoreContext.NO_RESCORE_NEEDED)
             );
             assertEquals(expectedQuery1, actualQuery1);
             assertEquals(luceneK, efSearchIndexSettingValue);
@@ -188,7 +188,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             luceneK = getLuceneK(testK, null);
             actualQuery1 = buildLuceneFloatQuery(null);
             expectedQuery1 = new LuceneEngineKnnVectorQuery(
-                new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, false)
+                new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, RescoreContext.NO_RESCORE_NEEDED)
             );
             assertEquals(expectedQuery1, actualQuery1);
             assertEquals(luceneK, testK);
@@ -202,7 +202,7 @@ public class KNNQueryFactoryTests extends KNNTestCase {
             luceneK = getLuceneK(testK, null);
             actualQuery1 = buildLuceneFloatQuery(null);
             expectedQuery1 = new LuceneEngineKnnVectorQuery(
-                new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, false)
+                new OSKnnFloatVectorQuery(testFieldName, testQueryVector, luceneK, null, testK, RescoreContext.NO_RESCORE_NEEDED)
             );
             assertEquals(expectedQuery1, actualQuery1);
             assertEquals(luceneK, IndexHyperParametersUtil.getHNSWEFSearchValue(Version.CURRENT));

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/NestedKnnVectorQueryFactoryTests.java
@@ -10,6 +10,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import static org.mockito.Mockito.mock;
 
@@ -41,7 +42,15 @@ public class NestedKnnVectorQueryFactoryTests extends TestCase {
         );
 
         ExpandNestedDocsQuery expectedFloatQuery = new ExpandNestedDocsQuery.ExpandNestedDocsQueryBuilder().internalNestedKnnVectorQuery(
-            new InternalNestedKnnFloatVectorQuery(fieldName, floatVectors, queryFilter, luceneK, parentFilter, k, false)
+            new InternalNestedKnnFloatVectorQuery(
+                fieldName,
+                floatVectors,
+                queryFilter,
+                luceneK,
+                parentFilter,
+                k,
+                RescoreContext.NO_RESCORE_NEEDED
+            )
         ).queryUtils(null).build();
         assertEquals(
             expectedFloatQuery,
@@ -53,7 +62,7 @@ public class NestedKnnVectorQueryFactoryTests extends TestCase {
                 parentFilter,
                 expandNestedDocs,
                 k,
-                false
+                RescoreContext.NO_RESCORE_NEEDED
             )
         );
     }
@@ -88,7 +97,7 @@ public class NestedKnnVectorQueryFactoryTests extends TestCase {
             parentFilter,
             expandNestedDocs,
             k,
-            false
+            RescoreContext.NO_RESCORE_NEEDED
         );
         assertEquals(OSDiversifyingChildrenFloatKnnVectorQuery.class, floatQuery.getClass());
         assertTrue(floatQuery instanceof DiversifyingChildrenFloatKnnVectorQuery);
@@ -99,10 +108,10 @@ public class NestedKnnVectorQueryFactoryTests extends TestCase {
         float[] floatVectors = new float[3];
         int luceneK = 10;
         int k = 3;
+        int rescoreK = 6;
         Query queryFilter = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
         boolean expandNestedDocs = false;
-        boolean needsRescore = true;
 
         Query floatQuery = NestedKnnVectorQueryFactory.createNestedKnnVectorQuery(
             fieldName,
@@ -112,7 +121,7 @@ public class NestedKnnVectorQueryFactoryTests extends TestCase {
             parentFilter,
             expandNestedDocs,
             k,
-            needsRescore
+            rescoreK
         );
         assertEquals(OSDiversifyingChildrenFloatKnnVectorQuery.class, floatQuery.getClass());
         assertTrue(floatQuery instanceof DiversifyingChildrenFloatKnnVectorQuery);

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQueryTests.java
@@ -22,7 +22,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 5;
-        boolean needsRescore = false;
+        int rescoreK = 0;
         boolean expandNestedDocs = false;
         Query filterQuery = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
@@ -34,7 +34,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
             luceneK,
             parentFilter,
             k,
-            needsRescore,
+            rescoreK,
             expandNestedDocs
         );
 
@@ -46,7 +46,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 3;
-        boolean needsRescore = false;
+        int rescoreK = 0;
         boolean expandNestedDocs = false;
         Query filterQuery = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
@@ -58,7 +58,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
             luceneK,
             parentFilter,
             k,
-            needsRescore,
+            rescoreK,
             expandNestedDocs
         );
 
@@ -82,7 +82,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 5;
-        boolean needsRescore = false;
+        int rescoreK = 0;
         boolean expandNestedDocs = false;
         Query filterQuery = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
@@ -94,7 +94,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
             luceneK,
             parentFilter,
             k,
-            needsRescore,
+            rescoreK,
             expandNestedDocs
         );
 
@@ -112,7 +112,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 3;
-        boolean needsRescore = true;
+        int rescoreK = 6;
         boolean expandNestedDocs = false;
         Query filterQuery = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
@@ -124,22 +124,22 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
             luceneK,
             parentFilter,
             k,
-            needsRescore,
+            rescoreK,
             expandNestedDocs
         );
 
-        ScoreDoc[] scoreDocs1 = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f) };
-        ScoreDoc[] scoreDocs2 = { new ScoreDoc(3, 0.7f), new ScoreDoc(4, 0.6f) };
+        ScoreDoc[] scoreDocs1 = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f), new ScoreDoc(5, 0.5f) };
+        ScoreDoc[] scoreDocs2 = { new ScoreDoc(3, 0.7f), new ScoreDoc(4, 0.6f), new ScoreDoc(6, 0.4f) };
 
-        TopDocs topDocs1 = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), scoreDocs1);
-        TopDocs topDocs2 = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), scoreDocs2);
+        TopDocs topDocs1 = new TopDocs(new TotalHits(3, TotalHits.Relation.EQUAL_TO), scoreDocs1);
+        TopDocs topDocs2 = new TopDocs(new TotalHits(3, TotalHits.Relation.EQUAL_TO), scoreDocs2);
 
         TopDocs[] perLeafResults = { topDocs1, topDocs2 };
 
         TopDocs result = query.mergeLeafResults(perLeafResults);
 
-        // When needsRescore is true and expandNestedDocs is false, should use parent's merge (not reduce to k)
-        assertEquals(4, result.scoreDocs.length);
+        // When rescoreK > 0 and expandNestedDocs is false, should trim to rescoreK (not luceneK or k)
+        assertEquals(rescoreK, result.scoreDocs.length);
     }
 
     public void testMergeLeafResultsWithExpandNestedDocs() {
@@ -147,7 +147,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 3;
-        boolean needsRescore = false;
+        int rescoreK = 0;
         boolean expandNestedDocs = true;
         Query filterQuery = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
@@ -159,7 +159,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
             luceneK,
             parentFilter,
             k,
-            needsRescore,
+            rescoreK,
             expandNestedDocs
         );
 
@@ -173,7 +173,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
 
         TopDocs result = query.mergeLeafResults(perLeafResults);
 
-        // When expandNestedDocs is true, should reduce to k
+        // When expandNestedDocs is true, should reduce to k regardless of rescoreK
         assertEquals(k, result.scoreDocs.length);
     }
 
@@ -182,7 +182,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 3;
-        boolean needsRescore = false;
+        int rescoreK = 0;
         Query filterQuery = mock(Query.class);
         BitSetProducer parentFilter = mock(BitSetProducer.class);
 
@@ -194,7 +194,7 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
             luceneK,
             parentFilter,
             k,
-            needsRescore
+            rescoreK
         );
 
         assertTrue(query instanceof DiversifyingChildrenFloatKnnVectorQuery);
@@ -209,7 +209,83 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
         TopDocs[] perLeafResults = { topDocs1, topDocs2 };
         TopDocs result = query.mergeLeafResults(perLeafResults);
 
-        // Should reduce to k (default behavior when expandNestedDocs is false and needsRescore is false)
+        // Should reduce to k (default behavior when expandNestedDocs is false and rescoreK is 0)
         assertEquals(k, result.scoreDocs.length);
+    }
+
+    public void testMergeLeafResultsWithRescoreAndExpandNestedDocs() {
+        String fieldName = "test_field";
+        float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        int luceneK = 10;
+        int k = 3;
+        int rescoreK = 6;
+        boolean expandNestedDocs = true;
+        Query filterQuery = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+
+        OSDiversifyingChildrenFloatKnnVectorQuery query = new OSDiversifyingChildrenFloatKnnVectorQuery(
+            fieldName,
+            queryVector,
+            filterQuery,
+            luceneK,
+            parentFilter,
+            k,
+            rescoreK,
+            expandNestedDocs
+        );
+
+        ScoreDoc[] scoreDocs1 = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f) };
+        ScoreDoc[] scoreDocs2 = { new ScoreDoc(3, 0.7f), new ScoreDoc(4, 0.6f) };
+
+        TopDocs topDocs1 = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), scoreDocs1);
+        TopDocs topDocs2 = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), scoreDocs2);
+
+        TopDocs[] perLeafResults = { topDocs1, topDocs2 };
+
+        TopDocs result = query.mergeLeafResults(perLeafResults);
+
+        // When expandNestedDocs is true, should reduce to k even if rescoreK > 0
+        assertEquals(k, result.scoreDocs.length);
+    }
+
+    public void testMergeLeafResultsWithRescoreK_trimsToRescoreKNotLuceneK() {
+        String fieldName = "test_field";
+        float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        // luceneK=256 (ef_search dominated), rescoreK=200 (oversample dominated), k=100
+        int luceneK = 256;
+        int k = 100;
+        int rescoreK = 200;
+        boolean expandNestedDocs = false;
+        Query filterQuery = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+
+        OSDiversifyingChildrenFloatKnnVectorQuery query = new OSDiversifyingChildrenFloatKnnVectorQuery(
+            fieldName,
+            queryVector,
+            filterQuery,
+            luceneK,
+            parentFilter,
+            k,
+            rescoreK,
+            expandNestedDocs
+        );
+
+        // Create enough results to exceed rescoreK but be within luceneK
+        ScoreDoc[] scoreDocs1 = new ScoreDoc[128];
+        ScoreDoc[] scoreDocs2 = new ScoreDoc[128];
+        for (int i = 0; i < 128; i++) {
+            scoreDocs1[i] = new ScoreDoc(i, 1.0f - (i * 0.001f));
+            scoreDocs2[i] = new ScoreDoc(128 + i, 0.5f - (i * 0.001f));
+        }
+
+        TopDocs topDocs1 = new TopDocs(new TotalHits(128, TotalHits.Relation.EQUAL_TO), scoreDocs1);
+        TopDocs topDocs2 = new TopDocs(new TotalHits(128, TotalHits.Relation.EQUAL_TO), scoreDocs2);
+
+        TopDocs[] perLeafResults = { topDocs1, topDocs2 };
+
+        TopDocs result = query.mergeLeafResults(perLeafResults);
+
+        // Should trim to rescoreK (200), not luceneK (256) and not k (100)
+        assertEquals(rescoreK, result.scoreDocs.length);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/OSKnnFloatVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/OSKnnFloatVectorQueryTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import static org.mockito.Mockito.mock;
 
@@ -21,22 +22,35 @@ public class OSKnnFloatVectorQueryTests extends TestCase {
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 5;
-        boolean needsRescore = false;
         Query filterQuery = mock(Query.class);
 
-        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(fieldName, queryVector, luceneK, filterQuery, k, needsRescore);
+        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(
+            fieldName,
+            queryVector,
+            luceneK,
+            filterQuery,
+            k,
+            RescoreContext.NO_RESCORE_NEEDED
+        );
 
         assertTrue(query instanceof KnnFloatVectorQuery);
     }
 
-    public void testMergeLeafResultsWithRescoreFalse() {
+    public void testMergeLeafResultsNoRescore() {
         String fieldName = "test_field";
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
         int luceneK = 10;
         int k = 3;
         Query filterQuery = mock(Query.class);
 
-        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(fieldName, queryVector, luceneK, filterQuery, k, false);
+        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(
+            fieldName,
+            queryVector,
+            luceneK,
+            filterQuery,
+            k,
+            RescoreContext.NO_RESCORE_NEEDED
+        );
 
         // Create mock TopDocs with more results than k
         ScoreDoc[] scoreDocs1 = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f) };
@@ -63,7 +77,14 @@ public class OSKnnFloatVectorQueryTests extends TestCase {
         int k = 5;
         Query filterQuery = mock(Query.class);
 
-        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(fieldName, queryVector, luceneK, filterQuery, k, false);
+        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(
+            fieldName,
+            queryVector,
+            luceneK,
+            filterQuery,
+            k,
+            RescoreContext.NO_RESCORE_NEEDED
+        );
 
         // Create mock TopDocs with fewer results than k
         ScoreDoc[] scoreDocs = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f) };
@@ -76,26 +97,27 @@ public class OSKnnFloatVectorQueryTests extends TestCase {
         assertEquals(2, result.scoreDocs.length);
     }
 
-    public void testMergeLeafResultsWithRescoreTrue() {
+    public void testMergeLeafResultsWithRescore() {
         String fieldName = "test_field";
         float[] queryVector = { 1.0f, 2.0f, 3.0f };
-        int luceneK = 4;
+        int luceneK = 6;
         int k = 2;
+        int rescoreK = 4;
         Query filterQuery = mock(Query.class);
 
-        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(fieldName, queryVector, luceneK, filterQuery, k, true);
+        OSKnnFloatVectorQuery query = new OSKnnFloatVectorQuery(fieldName, queryVector, luceneK, filterQuery, k, rescoreK);
 
-        ScoreDoc[] scoreDocs1 = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f) };
-        ScoreDoc[] scoreDocs2 = { new ScoreDoc(3, 0.7f), new ScoreDoc(4, 0.6f) };
+        ScoreDoc[] scoreDocs1 = { new ScoreDoc(1, 0.9f), new ScoreDoc(2, 0.8f), new ScoreDoc(5, 0.5f) };
+        ScoreDoc[] scoreDocs2 = { new ScoreDoc(3, 0.7f), new ScoreDoc(4, 0.6f), new ScoreDoc(6, 0.4f) };
 
-        TopDocs topDocs1 = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), scoreDocs1);
-        TopDocs topDocs2 = new TopDocs(new TotalHits(2, TotalHits.Relation.EQUAL_TO), scoreDocs2);
+        TopDocs topDocs1 = new TopDocs(new TotalHits(3, TotalHits.Relation.EQUAL_TO), scoreDocs1);
+        TopDocs topDocs2 = new TopDocs(new TotalHits(3, TotalHits.Relation.EQUAL_TO), scoreDocs2);
 
         TopDocs[] perLeafResults = { topDocs1, topDocs2 };
 
         TopDocs result = query.mergeLeafResults(perLeafResults);
 
-        // When needsRescore is true, results are not reduced to k and instead reduced to luceneK
-        assertEquals(luceneK, result.scoreDocs.length);
+        // When rescore is enabled, results are trimmed to rescoreK (not k, not luceneK)
+        assertEquals(rescoreK, result.scoreDocs.length);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/nativelib/NativeEngineKNNVectorQueryTests.java
@@ -59,6 +59,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.utils.TopDocsTestUtils.buildTopDocs;
 import static org.opensearch.knn.utils.TopDocsTestUtils.convertTopDocsToMap;
 
@@ -667,6 +668,208 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
         doTestMemoryOptimizedSearchUsingExpandK(100, true, false);
     }
 
+    public void testMemoryOptimizedSearch_efSearchFromMethodParameters_greaterThanK() {
+        // ef_search=256 > k=50, no rescore: search should use ef_search, results trimmed to k
+        doTestMemoryOptimizedSearchWithEfSearch(50, 256, false, false);
+    }
+
+    public void testMemoryOptimizedSearch_efSearchFromMethodParameters_lessThanK() {
+        // ef_search=10 < k=50, no rescore: search should use k (ef_search is a no-op)
+        doTestMemoryOptimizedSearchWithEfSearch(50, 10, false, false);
+    }
+
+    public void testMemoryOptimizedSearch_efSearchWithRescore_efSearchDominates() {
+        // k=100, ef_search=256, oversample=2.0 -> firstPassK=200, search should use max(200,256)=256
+        // rescore input should be 200, final result should be k=100
+        doTestMemoryOptimizedSearchWithEfSearch(100, 256, true, false);
+    }
+
+    public void testMemoryOptimizedSearch_efSearchWithRescore_oversampleDominates() {
+        // k=100, ef_search=150, oversample=2.0 -> firstPassK=200, search should use max(200,150)=200
+        doTestMemoryOptimizedSearchWithEfSearch(100, 150, true, false);
+    }
+
+    public void testMemoryOptimizedSearch_efSearchFromIndexSetting() {
+        // ef_search not in method params, falls back to index setting (mocked to 200), k=50
+        doTestMemoryOptimizedSearchWithEfSearchFromIndexSetting(50, 200);
+    }
+
+    @SneakyThrows
+    private void doTestMemoryOptimizedSearchWithEfSearch(
+        final int k,
+        final int efSearch,
+        final boolean rescoreEnabled,
+        final boolean isShardLevelRescoringDisabled
+    ) {
+        try (MockedStatic<KNNSettings> mockedKnnSettings = mockStatic(KNNSettings.class)) {
+            mockedKnnSettings.when(() -> KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(any()))
+                .thenReturn(isShardLevelRescoringDisabled);
+
+            final IndexSearcher indexSearcher = mock(IndexSearcher.class);
+            final IndexReader indexReader = mock(CompositeReader.class);
+            when(indexSearcher.getIndexReader()).thenReturn(indexReader);
+            when(indexSearcher.getTaskExecutor()).thenReturn(taskExecutor);
+
+            Constructor<LeafReaderContext> ctor = LeafReaderContext.class.getDeclaredConstructor(
+                CompositeReaderContext.class,
+                LeafReader.class,
+                int.class,
+                int.class,
+                int.class,
+                int.class
+            );
+            ctor.setAccessible(true);
+            final LeafReader leafReader = mock(LeafReader.class);
+            when(indexReader.leaves()).thenReturn(
+                Arrays.asList(ctor.newInstance(null, leafReader, 0, 0, 0, 0), ctor.newInstance(null, leafReader, 1, 10000, 1, 10000))
+            );
+            when(indexReader.getContext()).thenReturn(indexReaderContext);
+
+            final int dimension = 128;
+            final KNNQuery knnQuery = mock(KNNQuery.class);
+            when(knnQuery.getField()).thenReturn("field");
+            when(knnQuery.getOriginalQueryVector()).thenReturn(new float[dimension]);
+            when(knnQuery.getQueryVector()).thenReturn(new float[dimension]);
+            when(knnQuery.getK()).thenReturn(k);
+            doReturn(Map.of(METHOD_PARAMETER_EF_SEARCH, efSearch)).when(knnQuery).getMethodParameters();
+            when(knnQuery.getIndexName()).thenReturn("test-index");
+            when(knnQuery.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+            when(knnQuery.isMemoryOptimizedSearch()).thenReturn(true);
+
+            final float oversampleFactor = 2.0f;
+            final int firstPassK;
+            if (rescoreEnabled) {
+                RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(oversampleFactor).build();
+                when(knnQuery.getRescoreContext()).thenReturn(rescoreContext);
+                firstPassK = rescoreContext.getFirstPassK(k, isShardLevelRescoringDisabled, dimension);
+            } else {
+                firstPassK = k;
+            }
+
+            final int expectedSearchK = Math.max(firstPassK, Math.max(k, efSearch));
+
+            final MemoryOptimizedKNNWeight weight = mock(MemoryOptimizedKNNWeight.class);
+
+            when(weight.searchLeaf(any(), anyInt())).thenAnswer(invocation -> {
+                final int passedK = invocation.getArgument(1);
+                assertEquals("searchLeaf should receive expectedSearchK", expectedSearchK, passedK);
+                final TotalHits totalHits = new TotalHits(passedK, TotalHits.Relation.EQUAL_TO);
+                final ScoreDoc[] scoreDocs = new ScoreDoc[passedK];
+                for (int i = 0; i < passedK; ++i) {
+                    scoreDocs[i] = new ScoreDoc(i, passedK - i);
+                }
+                return new PerLeafResult(null, 0, new TopDocs(totalHits, scoreDocs), PerLeafResult.SearchMode.APPROXIMATE_SEARCH);
+            });
+
+            when(weight.exactSearch(any(), any())).thenAnswer(invocation -> {
+                ExactSearcher.ExactSearcherContext context = invocation.getArgument(1);
+                final int passedK = context.getK();
+                final TotalHits totalHits = new TotalHits(passedK, TotalHits.Relation.EQUAL_TO);
+                final ScoreDoc[] scoreDocs = new ScoreDoc[passedK];
+                for (int i = 0; i < passedK; ++i) {
+                    scoreDocs[i] = new ScoreDoc(i, passedK - i);
+                }
+                return new TopDocs(totalHits, scoreDocs);
+            });
+
+            when(weight.approximateSearch(any(), any(), anyInt(), anyInt())).thenAnswer(invocation -> {
+                final int passedK = invocation.getArgument(3);
+                final TotalHits totalHits = new TotalHits(passedK, TotalHits.Relation.EQUAL_TO);
+                final ScoreDoc[] scoreDocs = new ScoreDoc[passedK];
+                for (int i = 0; i < passedK; ++i) {
+                    scoreDocs[i] = new ScoreDoc(i, passedK - i);
+                }
+                return new TopDocs(totalHits, scoreDocs);
+            });
+
+            when(knnQuery.createWeight(eq(indexSearcher), eq(ScoreMode.TOP_DOCS), eq(1f), anyInt())).thenAnswer(invocation -> {
+                final int expandedK = invocation.getArgument(3);
+                assertEquals("createWeight kOverride should be expectedSearchK", expectedSearchK, expandedK);
+                return weight;
+            });
+
+            if (rescoreEnabled == false && efSearch <= k) {
+                when(knnQuery.createWeight(indexSearcher, ScoreMode.TOP_DOCS, 1)).thenReturn(weight);
+            }
+
+            final NativeEngineKnnVectorQuery query = new NativeEngineKnnVectorQuery(knnQuery, QueryUtils.getInstance(), false);
+            query.createWeight(indexSearcher, ScoreMode.TOP_DOCS, 1);
+        }
+    }
+
+    @SneakyThrows
+    private void doTestMemoryOptimizedSearchWithEfSearchFromIndexSetting(final int k, final int indexSettingEfSearch) {
+        try (MockedStatic<KNNSettings> mockedKnnSettings = mockStatic(KNNSettings.class)) {
+            mockedKnnSettings.when(() -> KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(any())).thenReturn(false);
+            mockedKnnSettings.when(() -> KNNSettings.getEfSearchParam("test-index")).thenReturn(indexSettingEfSearch);
+
+            final IndexSearcher indexSearcher = mock(IndexSearcher.class);
+            final IndexReader indexReader = mock(CompositeReader.class);
+            when(indexSearcher.getIndexReader()).thenReturn(indexReader);
+            when(indexSearcher.getTaskExecutor()).thenReturn(taskExecutor);
+
+            Constructor<LeafReaderContext> ctor = LeafReaderContext.class.getDeclaredConstructor(
+                CompositeReaderContext.class,
+                LeafReader.class,
+                int.class,
+                int.class,
+                int.class,
+                int.class
+            );
+            ctor.setAccessible(true);
+            final LeafReader leafReader = mock(LeafReader.class);
+            when(indexReader.leaves()).thenReturn(
+                Arrays.asList(ctor.newInstance(null, leafReader, 0, 0, 0, 0), ctor.newInstance(null, leafReader, 1, 10000, 1, 10000))
+            );
+            when(indexReader.getContext()).thenReturn(indexReaderContext);
+
+            final int dimension = 128;
+            final KNNQuery knnQuery = mock(KNNQuery.class);
+            when(knnQuery.getField()).thenReturn("field");
+            when(knnQuery.getOriginalQueryVector()).thenReturn(new float[dimension]);
+            when(knnQuery.getQueryVector()).thenReturn(new float[dimension]);
+            when(knnQuery.getK()).thenReturn(k);
+            when(knnQuery.getMethodParameters()).thenReturn(null);
+            when(knnQuery.getIndexName()).thenReturn("test-index");
+            when(knnQuery.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
+            when(knnQuery.isMemoryOptimizedSearch()).thenReturn(true);
+
+            final int expectedSearchK = Math.max(k, indexSettingEfSearch);
+
+            final MemoryOptimizedKNNWeight weight = mock(MemoryOptimizedKNNWeight.class);
+
+            when(weight.searchLeaf(any(), anyInt())).thenAnswer(invocation -> {
+                final int passedK = invocation.getArgument(1);
+                assertEquals("searchLeaf should receive expectedSearchK", expectedSearchK, passedK);
+                final TotalHits totalHits = new TotalHits(passedK, TotalHits.Relation.EQUAL_TO);
+                final ScoreDoc[] scoreDocs = new ScoreDoc[passedK];
+                for (int i = 0; i < passedK; ++i) {
+                    scoreDocs[i] = new ScoreDoc(i, passedK - i);
+                }
+                return new PerLeafResult(null, 0, new TopDocs(totalHits, scoreDocs), PerLeafResult.SearchMode.APPROXIMATE_SEARCH);
+            });
+
+            when(weight.approximateSearch(any(), any(), anyInt(), anyInt())).thenAnswer(invocation -> {
+                final int passedK = invocation.getArgument(3);
+                final TotalHits totalHits = new TotalHits(passedK, TotalHits.Relation.EQUAL_TO);
+                final ScoreDoc[] scoreDocs = new ScoreDoc[passedK];
+                for (int i = 0; i < passedK; ++i) {
+                    scoreDocs[i] = new ScoreDoc(i, passedK - i);
+                }
+                return new TopDocs(totalHits, scoreDocs);
+            });
+
+            when(knnQuery.createWeight(eq(indexSearcher), eq(ScoreMode.TOP_DOCS), eq(1f), anyInt())).thenAnswer(invocation -> {
+                final int expandedK = invocation.getArgument(3);
+                assertEquals("createWeight kOverride should be expectedSearchK", expectedSearchK, expandedK);
+                return weight;
+            });
+
+            final NativeEngineKnnVectorQuery query = new NativeEngineKnnVectorQuery(knnQuery, QueryUtils.getInstance(), false);
+            query.createWeight(indexSearcher, ScoreMode.TOP_DOCS, 1);
+        }
+    }
+
     @SneakyThrows
     private void doTestMemoryOptimizedSearchUsingExpandK(
         final int dimension,
@@ -679,6 +882,8 @@ public class NativeEngineKNNVectorQueryTests extends OpenSearchTestCase {
 
             mockedKnnSettings.when(() -> KNNSettings.isShardLevelRescoringDisabledForDiskBasedVector(any()))
                 .thenReturn(isShardLevelRescoringDisabled);
+            // Return ef_search < k so ef_search expansion is not triggered in these tests
+            mockedKnnSettings.when(() -> KNNSettings.getEfSearchParam(any())).thenReturn(1);
 
             // Prepare index searcher + reader
             final IndexSearcher indexSearcher = mock(IndexSearcher.class);


### PR DESCRIPTION
### Description
Implementation of MOS does not honor ef_search, and implementation of lucene engine rescores on all ef_search docs if ef_search > oversampledK. Fixes both issues.

1. Lucene : k=100, ef_search=10000 on quantized index
From the 1st phase ANN search, result size would be 10000. Then the 10k vectors will be passed to exact searcher. Ideally, we should cut down the result to 200 (assuming over sampling factor is 2, hence 100 * 2 = 200), then only running exact search on 200 vectors. 

2. MOS with Faiss : k=100, ef_search=1000, but we're using 100 as a ANN heap size.
We're not honoring ef_search that was given. We should 1000 as a heap size during ANN search instead of 100.

### Related Issues
Resolves #3272 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
