### PR TITLE
Rescore radial search quantized complete

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -87,6 +87,7 @@ public class KNNConstants {
     public static final String TOP_LEVEL_ENGINE_FEATURE = "top_level_engine_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
+    public static final int MAX_RESULTS_RADIAL_RESCORING = 10000;
     public static final String NULL_K = "null_k";
     public static final String MODEL_VERSION = "model_version";
     public static final String QUANTIZATION_STATE_FILE_SUFFIX = "osknnqstate";

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.query;
 
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
+import static org.opensearch.knn.common.KNNConstants.MAX_RESULTS_RADIAL_RESCORING;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
 
@@ -74,7 +75,22 @@ public class RNNQueryFactory extends BaseQueryFactory {
         }
 
         if (createQueryRequest.getVectorFieldType() != null && createQueryRequest.getVectorFieldType().isRescoringRequiredForRadial()) {
-            return new RescoreRadialSearchQuery(innerQuery, fieldName, vector, radius, createQueryRequest.isMemoryOptimizedSearchEnabled());
+            // Honor the index-level max_result_window setting to cap the number of results retained
+            // after rescoring. Falls back to MAX_RESULTS_RADIAL_RESCORING if context is unavailable.
+            final int maxResultsSize;
+            if (createQueryRequest.getContext().isPresent()) {
+                maxResultsSize = createQueryRequest.getContext().get().getIndexSettings().getMaxResultWindow();
+            } else {
+                maxResultsSize = MAX_RESULTS_RADIAL_RESCORING;
+            }
+            return new RescoreRadialSearchQuery(
+                innerQuery,
+                fieldName,
+                vector,
+                radius,
+                createQueryRequest.isMemoryOptimizedSearchEnabled(),
+                maxResultsSize
+            );
         }
         return innerQuery;
     }

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -74,7 +74,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
         }
 
         if (createQueryRequest.getVectorFieldType() != null && createQueryRequest.getVectorFieldType().isRescoringRequiredForRadial()) {
-            return new RescoreRadialSearchQuery(innerQuery, fieldName, vector, radius);
+            return new RescoreRadialSearchQuery(innerQuery, fieldName, vector, radius, createQueryRequest.isMemoryOptimizedSearchEnabled());
         }
         return innerQuery;
     }

--- a/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.lucene.index.LeafReaderContext;
@@ -14,19 +15,15 @@ import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.TopKnnCollector;
 import org.apache.lucene.search.Weight;
 import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
-import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -52,6 +49,7 @@ import java.util.Objects;
 @Getter
 @EqualsAndHashCode(callSuper = false)
 public class RescoreRadialSearchQuery extends Query {
+    private static ExactSearcher EXACT_SEARCHER_SINGLETON;
 
     /** The inner radial search query that operates on quantized vectors. */
     private final Query innerQuery;
@@ -78,6 +76,14 @@ public class RescoreRadialSearchQuery extends Query {
     private final boolean memoryOptimizedSearchEnabled;
 
     /**
+     * Maximum number of results to retain after rescoring.
+     * Derived from the index-level {@code max_result_window} setting when available,
+     * otherwise defaults to {@code MAX_RESULTS_RADIAL_RESCORING}.
+     * All first-pass candidates are still scored, but only the top results up to this cap are kept.
+     */
+    private final int maxResultsSize;
+
+    /**
      * Constructs a new rescoring wrapper for radial search on a quantized index.
      *
      * @param innerQuery                   the inner radial search query (must not be null)
@@ -91,13 +97,21 @@ public class RescoreRadialSearchQuery extends Query {
         final String field,
         final float[] queryVector,
         float radius,
-        boolean memoryOptimizedSearchEnabled
+        final boolean memoryOptimizedSearchEnabled,
+        final int maxResultsSize
     ) {
         this.innerQuery = Objects.requireNonNull(innerQuery);
         this.field = Objects.requireNonNull(field);
         this.queryVector = Objects.requireNonNull(queryVector);
         this.radius = radius;
         this.memoryOptimizedSearchEnabled = memoryOptimizedSearchEnabled;
+        this.maxResultsSize = maxResultsSize;
+        Objects.requireNonNull(EXACT_SEARCHER_SINGLETON, "Exact searcher was not initialized.");
+    }
+
+    @VisibleForTesting
+    public static void initialize(final ExactSearcher exactSearcher) {
+        EXACT_SEARCHER_SINGLETON = exactSearcher;
     }
 
     /**
@@ -121,13 +135,7 @@ public class RescoreRadialSearchQuery extends Query {
     public Query rewrite(final IndexSearcher indexSearcher) throws IOException {
         final Query rewritten = innerQuery.rewrite(indexSearcher);
         if (rewritten != innerQuery) {
-            return new RescoreRadialSearchQuery(
-                innerQuery.rewrite(indexSearcher),
-                field,
-                queryVector,
-                radius,
-                memoryOptimizedSearchEnabled
-            );
+            return new RescoreRadialSearchQuery(rewritten, field, queryVector, radius, memoryOptimizedSearchEnabled, maxResultsSize);
         } else {
             return this;
         }
@@ -173,6 +181,7 @@ public class RescoreRadialSearchQuery extends Query {
         private final float[] queryVector;
         private final float radius;
         private final boolean memoryOptimizedSearchEnabled;
+        private final int maxResultsSize;
 
         /**
          * @param query       the parent query (for Lucene's Weight contract)
@@ -188,6 +197,7 @@ public class RescoreRadialSearchQuery extends Query {
             this.queryVector = rescoreQuery.queryVector;
             this.radius = rescoreQuery.radius;
             this.memoryOptimizedSearchEnabled = rescoreQuery.memoryOptimizedSearchEnabled;
+            this.maxResultsSize = rescoreQuery.maxResultsSize;
         }
 
         @Override
@@ -222,31 +232,41 @@ public class RescoreRadialSearchQuery extends Query {
                         return KNNScorer.emptyScorer();
                     }
 
-                    // 2. Collect first-pass results into TopDocs
-                    final TopDocs firstPassResults = collectTopDocs(innerScorer);
-                    if (firstPassResults.scoreDocs.length == 0) {
+                    // 2. Get matched docs from inner scorer
+                    final DocIdSetIterator matchedDocs = innerScorer.iterator();
+                    if (matchedDocs.cost() == 0) {
                         return KNNScorer.emptyScorer();
                     }
 
-                    // 3. Build ExactSearcherContext — rescore with full-precision vectors
-                    final DocIdSetIterator matchedDocs = new TopDocsDISI(firstPassResults);
+                    // 3. If more candidates than maxResultsSize, pull only top-maxResultsSize
+                    // from the inner scorer; otherwise use the iterator directly.
+                    final DocIdSetIterator docsToRescore;
+                    final long numDocsToRescore;
+                    if (matchedDocs.cost() > maxResultsSize) {
+                        final TopDocs topCandidates = collectTopDocs(innerScorer);
+                        docsToRescore = new TopDocsDISI(topCandidates);
+                        numDocsToRescore = topCandidates.scoreDocs.length;
+                    } else {
+                        docsToRescore = matchedDocs;
+                        numDocsToRescore = matchedDocs.cost();
+                    }
+
+                    // 4. Build ExactSearcherContext — rescore with full-precision vectors
                     final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
-                        .matchedDocsIterator(matchedDocs)
-                        .numberOfMatchedDocs(matchedDocs.cost())
+                        .matchedDocsIterator(docsToRescore)
+                        .numberOfMatchedDocs(numDocsToRescore)
                         .useQuantizedVectorsForSearch(false)
-                        .k(0)
-                        .maxResultWindow((int) matchedDocs.cost())
+                        .maxResultWindow((int) Math.min(maxResultsSize, numDocsToRescore))
                         .radius(radius)
                         .field(field)
                         .floatQueryVector(queryVector)
                         .isMemoryOptimizedSearchEnabled(memoryOptimizedSearchEnabled)
                         .build();
 
-                    // 4. Rescore — ExactSearcher handles radius→minScore conversion internally
-                    final ExactSearcher exactSearcher = new ExactSearcher(ModelDao.OpenSearchKNNModelDao.getInstance());
-                    final TopDocs rescored = exactSearcher.searchLeaf(context, exactSearcherContext);
+                    // 5. Rescore — ExactSearcher handles radius → minScore conversion internally
+                    final TopDocs rescored = EXACT_SEARCHER_SINGLETON.searchLeaf(context, exactSearcherContext);
 
-                    // 5. Return scorer over rescored results
+                    // 6. Return scorer over rescored results
                     return new KNNScorer(rescored, boost);
                 }
 
@@ -270,16 +290,17 @@ public class RescoreRadialSearchQuery extends Query {
         }
 
         /**
-         * Collects all documents from the scorer into a {@link TopDocs}.
+         * Collects the top-maxResultsSize documents by score from the scorer.
          */
         private TopDocs collectTopDocs(final Scorer scorer) throws IOException {
-            final List<ScoreDoc> scoreDocs = new ArrayList<>();
+            final TopKnnCollector collector = new TopKnnCollector(maxResultsSize, Integer.MAX_VALUE);
             final DocIdSetIterator iterator = scorer.iterator();
+            assert (iterator.cost() > maxResultsSize);
             int docId;
             while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-                scoreDocs.add(new ScoreDoc(docId, scorer.score()));
+                collector.collect(docId, scorer.score());
             }
-            return new TopDocs(new TotalHits(scoreDocs.size(), TotalHits.Relation.EQUAL_TO), scoreDocs.toArray(new ScoreDoc[0]));
+            return collector.topDocs();
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
@@ -9,16 +9,24 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
+import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
+import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -62,18 +70,34 @@ public class RescoreRadialSearchQuery extends Query {
     private final float radius;
 
     /**
+     * Whether memory-optimized search is enabled for this field.
+     * Determines how {@code radius} is interpreted during rescoring:
+     * when true, radius is already a Lucene-normalized score;
+     * when false, radius is a raw distance requiring conversion via {@code KNNEngine.score()}.
+     */
+    private final boolean memoryOptimizedSearchEnabled;
+
+    /**
      * Constructs a new rescoring wrapper for radial search on a quantized index.
      *
-     * @param innerQuery  the inner radial search query (must not be null)
-     * @param field       the knn_vector field name (must not be null)
-     * @param queryVector the query vector (must not be null)
-     * @param radius      the radius threshold for the search
+     * @param innerQuery                   the inner radial search query (must not be null)
+     * @param field                        the knn_vector field name (must not be null)
+     * @param queryVector                  the query vector (must not be null)
+     * @param radius                       the radius threshold for the search
+     * @param memoryOptimizedSearchEnabled whether memory-optimized search is enabled
      */
-    public RescoreRadialSearchQuery(final Query innerQuery, final String field, final float[] queryVector, float radius) {
+    public RescoreRadialSearchQuery(
+        final Query innerQuery,
+        final String field,
+        final float[] queryVector,
+        float radius,
+        boolean memoryOptimizedSearchEnabled
+    ) {
         this.innerQuery = Objects.requireNonNull(innerQuery);
         this.field = Objects.requireNonNull(field);
         this.queryVector = Objects.requireNonNull(queryVector);
         this.radius = radius;
+        this.memoryOptimizedSearchEnabled = memoryOptimizedSearchEnabled;
     }
 
     /**
@@ -97,7 +121,13 @@ public class RescoreRadialSearchQuery extends Query {
     public Query rewrite(final IndexSearcher indexSearcher) throws IOException {
         final Query rewritten = innerQuery.rewrite(indexSearcher);
         if (rewritten != innerQuery) {
-            return new RescoreRadialSearchQuery(innerQuery.rewrite(indexSearcher), field, queryVector, radius);
+            return new RescoreRadialSearchQuery(
+                innerQuery.rewrite(indexSearcher),
+                field,
+                queryVector,
+                radius,
+                memoryOptimizedSearchEnabled
+            );
         } else {
             return this;
         }
@@ -139,6 +169,10 @@ public class RescoreRadialSearchQuery extends Query {
     private static class RescoreWeight extends Weight {
         private final Weight innerWeight;
         private final float boost;
+        private final String field;
+        private final float[] queryVector;
+        private final float radius;
+        private final boolean memoryOptimizedSearchEnabled;
 
         /**
          * @param query       the parent query (for Lucene's Weight contract)
@@ -149,6 +183,11 @@ public class RescoreRadialSearchQuery extends Query {
             super(query);
             this.innerWeight = innerWeight;
             this.boost = boost;
+            RescoreRadialSearchQuery rescoreQuery = (RescoreRadialSearchQuery) query;
+            this.field = rescoreQuery.field;
+            this.queryVector = rescoreQuery.queryVector;
+            this.radius = rescoreQuery.radius;
+            this.memoryOptimizedSearchEnabled = rescoreQuery.memoryOptimizedSearchEnabled;
         }
 
         @Override
@@ -177,11 +216,38 @@ public class RescoreRadialSearchQuery extends Query {
 
                 @Override
                 public Scorer get(long leadCost) throws IOException {
-                    // Run radial search
+                    // 1. Run inner scorer (quantized radial search on this leaf)
                     final Scorer innerScorer = innerScorerSupplier.get(leadCost);
-                    // TODO: Add rescoring with ExactSearcher using full-precision vectors.
-                    // This will be dealt with in next PR.
-                    return Objects.requireNonNullElseGet(innerScorer, KNNScorer::emptyScorer);
+                    if (innerScorer == null) {
+                        return KNNScorer.emptyScorer();
+                    }
+
+                    // 2. Collect first-pass results into TopDocs
+                    final TopDocs firstPassResults = collectTopDocs(innerScorer);
+                    if (firstPassResults.scoreDocs.length == 0) {
+                        return KNNScorer.emptyScorer();
+                    }
+
+                    // 3. Build ExactSearcherContext — rescore with full-precision vectors
+                    final DocIdSetIterator matchedDocs = new TopDocsDISI(firstPassResults);
+                    final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+                        .matchedDocsIterator(matchedDocs)
+                        .numberOfMatchedDocs(matchedDocs.cost())
+                        .useQuantizedVectorsForSearch(false)
+                        .k(0)
+                        .maxResultWindow((int) matchedDocs.cost())
+                        .radius(radius)
+                        .field(field)
+                        .floatQueryVector(queryVector)
+                        .isMemoryOptimizedSearchEnabled(memoryOptimizedSearchEnabled)
+                        .build();
+
+                    // 4. Rescore — ExactSearcher handles radius→minScore conversion internally
+                    final ExactSearcher exactSearcher = new ExactSearcher(ModelDao.OpenSearchKNNModelDao.getInstance());
+                    final TopDocs rescored = exactSearcher.searchLeaf(context, exactSearcherContext);
+
+                    // 5. Return scorer over rescored results
+                    return new KNNScorer(rescored, boost);
                 }
 
                 @Override
@@ -201,6 +267,19 @@ public class RescoreRadialSearchQuery extends Query {
         @Override
         public boolean isCacheable(final LeafReaderContext ctx) {
             return true;
+        }
+
+        /**
+         * Collects all documents from the scorer into a {@link TopDocs}.
+         */
+        private TopDocs collectTopDocs(final Scorer scorer) throws IOException {
+            final List<ScoreDoc> scoreDocs = new ArrayList<>();
+            final DocIdSetIterator iterator = scorer.iterator();
+            int docId;
+            while ((docId = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                scoreDocs.add(new ScoreDoc(docId, scorer.score()));
+            }
+            return new TopDocs(new TotalHits(scoreDocs.size(), TotalHits.Relation.EQUAL_TO), scoreDocs.toArray(new ScoreDoc[0]));
         }
     }
 }

--- a/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
+++ b/src/main/java/org/opensearch/knn/plugin/KNNPlugin.java
@@ -48,6 +48,8 @@ import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.query.RescoreKNNVectorQuery;
+import org.opensearch.knn.index.query.RescoreRadialSearchQuery;
+import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.parser.KNNQueryBuilderParser;
 import org.opensearch.knn.index.util.KNNClusterUtil;
@@ -263,6 +265,7 @@ public class KNNPlugin extends Plugin
         KNNCircuitBreaker.getInstance().initialize(threadPool, clusterService, client);
         KNNQueryBuilder.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
         KNNWeight.initialize(ModelDao.OpenSearchKNNModelDao.getInstance());
+        RescoreRadialSearchQuery.initialize(new ExactSearcher(ModelDao.OpenSearchKNNModelDao.getInstance()));
         TrainingModelRequest.initialize(ModelDao.OpenSearchKNNModelDao.getInstance(), clusterService);
 
         clusterService.addListener(TrainingJobClusterStateListener.getInstance());

--- a/src/test/java/org/opensearch/knn/index/query/AbstractRadialSearchOnQuantizedIndexIT.java
+++ b/src/test/java/org/opensearch/knn/index/query/AbstractRadialSearchOnQuantizedIndexIT.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNRestTestCase;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Abstract base for radial search integration tests on quantized indices.
+ * Subclasses provide the index creation logic; the test methods are shared.
+ */
+public abstract class AbstractRadialSearchOnQuantizedIndexIT extends KNNRestTestCase {
+
+    protected static final String FIELD_NAME = "vec_field";
+    protected static final int DIMENSION = 128;
+    protected static final int NUM_DOCS = 100;
+    protected static final float LARGE_MAX_DISTANCE = 10000.0f;
+    protected static final float SMALL_MIN_SCORE = 0.0001f;
+
+    protected abstract String getIndexName();
+
+    /**
+     * Creates the quantized index with default settings (no custom max_result_window).
+     */
+    protected abstract void createQuantizedIndex() throws Exception;
+
+    /**
+     * Creates the quantized index with a custom max_result_window setting.
+     */
+    protected abstract void createQuantizedIndexWithMaxResultWindow(int maxResultWindow) throws Exception;
+
+    @SneakyThrows
+    public void testRadialSearch_withMaxDistance() {
+        createQuantizedIndex();
+        indexDocuments();
+        refreshIndex(getIndexName());
+
+        Response response = executeRadialSearch("max_distance", LARGE_MAX_DISTANCE);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertTrue(getHitCount(response) > 0);
+
+        deleteKNNIndex(getIndexName());
+    }
+
+    @SneakyThrows
+    public void testRadialSearch_withMinScore() {
+        createQuantizedIndex();
+        indexDocuments();
+        refreshIndex(getIndexName());
+
+        Response response = executeRadialSearch("min_score", SMALL_MIN_SCORE);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertTrue(getHitCount(response) > 0);
+
+        deleteKNNIndex(getIndexName());
+    }
+
+    // Given: index with max_result_window=100 and 200 docs all within radius
+    // When: radial search is executed with size=100
+    // Then: hits.hits size is <= 100 (honoring the index setting)
+    @SneakyThrows
+    public void testRadialSearch_whenMaxResultWindowIs100_thenResultsCappedAt100() {
+        int maxResultWindow = 100;
+        int numDocs = 200;
+
+        createQuantizedIndexWithMaxResultWindow(maxResultWindow);
+
+        // Index 200 docs — all identical vectors so all are within any radius
+        float[] identicalVector = new float[DIMENSION];
+        for (int j = 0; j < DIMENSION; j++) {
+            identicalVector[j] = 1.0f;
+        }
+        for (int i = 0; i < numDocs; i++) {
+            addKnnDoc(getIndexName(), Integer.toString(i), FIELD_NAME, identicalVector);
+        }
+        refreshIndex(getIndexName());
+
+        // When: radial search with very large distance (all docs within radius)
+        String query = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("size", maxResultWindow)
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", identicalVector)
+            .field("max_distance", LARGE_MAX_DISTANCE)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        Request request = new Request("POST", "/" + getIndexName() + "/_search");
+        request.setJsonEntity(query);
+        Response response = client().performRequest(request);
+
+        // Then: parse hits.hits — results should be capped at max_result_window (100) by the rescore layer
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        String responseBody = EntityUtils.toString(response.getEntity());
+        int resultSize = parseSearchResponse(responseBody, FIELD_NAME).size();
+        assertTrue("Results size should be <= max_result_window (100), got " + resultSize, resultSize <= maxResultWindow);
+
+        deleteKNNIndex(getIndexName());
+    }
+
+    protected void indexDocuments() throws Exception {
+        for (int i = 0; i < NUM_DOCS; i++) {
+            float[] vector = new float[DIMENSION];
+            for (int j = 0; j < DIMENSION; j++) {
+                vector[j] = ThreadLocalRandom.current().nextFloat() * 4 - 2;
+            }
+            addKnnDoc(getIndexName(), Integer.toString(i), FIELD_NAME, vector);
+        }
+    }
+
+    protected Response executeRadialSearch(String thresholdType, float thresholdValue) throws Exception {
+        float[] queryVector = new float[DIMENSION];
+        for (int i = 0; i < DIMENSION; i++) {
+            queryVector[i] = ThreadLocalRandom.current().nextFloat() * 4 - 2;
+        }
+
+        String query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(FIELD_NAME)
+            .field("vector", queryVector)
+            .field(thresholdType, thresholdValue)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        Request request = new Request("POST", "/" + getIndexName() + "/_search");
+        request.setJsonEntity(query);
+        return client().performRequest(request);
+    }
+
+    protected int getHitCount(Response response) throws Exception {
+        String responseBody = EntityUtils.toString(response.getEntity());
+        return parseSearchResponse(responseBody, FIELD_NAME).size();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/FaissSQRadialSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/query/FaissSQRadialSearchIT.java
@@ -5,67 +5,26 @@
 
 package org.opensearch.knn.index.query;
 
-import lombok.SneakyThrows;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.index.SpaceType;
-
-import java.util.concurrent.ThreadLocalRandom;
 
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
 
 /**
- * Integration tests verifying that radial search (max_distance / min_score) works on
- * Faiss 32x SQ quantized indices with HNSW method.
- *
- * These tests validate that the query pipeline executes without error and returns results.
- * Recall/precision validation will be added once ExactSearcher rescoring is implemented.
+ * Integration tests for radial search on Faiss 32x SQ quantized indices with HNSW method.
  */
-public class FaissSQRadialSearchIT extends KNNRestTestCase {
+public class FaissSQRadialSearchIT extends AbstractRadialSearchOnQuantizedIndexIT {
 
     private static final String INDEX_NAME = "faiss_sq_radial_search_test";
-    private static final String FIELD_NAME = "vec_field";
-    private static final int DIMENSION = 128;
-    private static final int NUM_DOCS = 100;
 
-    // max_distance for L2 is squared Euclidean distance.
-    // With dim=128, vectors in [-2,2], typical distance between random vectors is ~340.
-    // Use 10000.0 to ensure all docs are within radius.
-    private static final float LARGE_MAX_DISTANCE = 10000.0f;
-    // min_score for L2 is 1/(1+distance). A very small value accepts nearly all docs.
-    private static final float SMALL_MIN_SCORE = 0.0001f;
-
-    @SneakyThrows
-    public void testRadialSearch_withMaxDistance_onFaissSQHnsw() {
-        createFaissSQHnswIndex();
-        indexDocuments();
-        refreshIndex(INDEX_NAME);
-
-        Response response = executeRadialSearch("max_distance", LARGE_MAX_DISTANCE);
-        assertEquals(200, response.getStatusLine().getStatusCode());
-        assertTrue(getHitCount(response) > 0);
-
-        deleteKNNIndex(INDEX_NAME);
+    @Override
+    protected String getIndexName() {
+        return INDEX_NAME;
     }
 
-    @SneakyThrows
-    public void testRadialSearch_withMinScore_onFaissSQHnsw() {
-        createFaissSQHnswIndex();
-        indexDocuments();
-        refreshIndex(INDEX_NAME);
-
-        Response response = executeRadialSearch("min_score", SMALL_MIN_SCORE);
-        assertEquals(200, response.getStatusLine().getStatusCode());
-        assertTrue(getHitCount(response) > 0);
-
-        deleteKNNIndex(INDEX_NAME);
-    }
-
-    private void createFaissSQHnswIndex() throws Exception {
+    @Override
+    protected void createQuantizedIndex() throws Exception {
         String mapping = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -89,42 +48,33 @@ public class FaissSQRadialSearchIT extends KNNRestTestCase {
         createKnnIndex(INDEX_NAME, settings, mapping);
     }
 
-    private void indexDocuments() throws Exception {
-        for (int i = 0; i < NUM_DOCS; i++) {
-            float[] vector = new float[DIMENSION];
-            for (int j = 0; j < DIMENSION; j++) {
-                vector[j] = ThreadLocalRandom.current().nextFloat() * 4 - 2;
-            }
-            addKnnDoc(INDEX_NAME, Integer.toString(i), FIELD_NAME, vector);
-        }
-    }
-
-    private Response executeRadialSearch(String thresholdType, float thresholdValue) throws Exception {
-        float[] queryVector = new float[DIMENSION];
-        for (int i = 0; i < DIMENSION; i++) {
-            queryVector[i] = ThreadLocalRandom.current().nextFloat() * 4 - 2;
-        }
-
-        String query = XContentFactory.jsonBuilder()
+    @Override
+    protected void createQuantizedIndexWithMaxResultWindow(int maxResultWindow) throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("query")
-            .startObject("knn")
+            .startObject("properties")
             .startObject(FIELD_NAME)
-            .field("vector", queryVector)
-            .field(thresholdType, thresholdValue)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("data_type", "float")
+            .field("mode", "on_disk")
+            .field("compression_level", "32x")
+            .field("space_type", SpaceType.L2.getValue())
+            .startObject("method")
+            .field("engine", "faiss")
+            .field("name", "hnsw")
             .endObject()
             .endObject()
             .endObject()
             .endObject()
             .toString();
 
-        Request request = new Request("POST", "/" + INDEX_NAME + "/_search");
-        request.setJsonEntity(query);
-        return client().performRequest(request);
-    }
-
-    private int getHitCount(Response response) throws Exception {
-        String responseBody = EntityUtils.toString(response.getEntity());
-        return parseSearchResponse(responseBody, FIELD_NAME).size();
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put(KNN_INDEX, true)
+            .put("index.max_result_window", maxResultWindow)
+            .build();
+        createKnnIndex(INDEX_NAME, settings, mapping);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/FlatSQRadialSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/query/FlatSQRadialSearchIT.java
@@ -7,15 +7,17 @@ package org.opensearch.knn.index.query;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.index.SpaceType;
 
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
 
 /**
- * Integration tests for radial search on Lucene 32x SQ quantized indices with HNSW method.
+ * Integration tests for radial search on flat quantized indices (method: flat, 1-bit SQ by default).
+ * The flat method is engine-agnostic — it does not specify an engine explicitly.
  */
-public class LuceneSQRadialSearchIT extends AbstractRadialSearchOnQuantizedIndexIT {
+public class FlatSQRadialSearchIT extends AbstractRadialSearchOnQuantizedIndexIT {
 
-    private static final String INDEX_NAME = "lucene_sq_radial_search_test";
+    private static final String INDEX_NAME = "flat_sq_radial_search_test";
 
     @Override
     protected String getIndexName() {
@@ -30,11 +32,9 @@ public class LuceneSQRadialSearchIT extends AbstractRadialSearchOnQuantizedIndex
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", DIMENSION)
-            .field("compression_level", "32x")
-            .field("mode", "on_disk")
+            .field("space_type", SpaceType.L2.getValue())
             .startObject("method")
-            .field("name", "hnsw")
-            .field("engine", "lucene")
+            .field("name", "flat")
             .endObject()
             .endObject()
             .endObject()
@@ -53,11 +53,9 @@ public class LuceneSQRadialSearchIT extends AbstractRadialSearchOnQuantizedIndex
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", DIMENSION)
-            .field("compression_level", "32x")
-            .field("mode", "on_disk")
+            .field("space_type", SpaceType.L2.getValue())
             .startObject("method")
-            .field("name", "hnsw")
-            .field("engine", "lucene")
+            .field("name", "flat")
             .endObject()
             .endObject()
             .endObject()

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -52,6 +52,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorQueryType;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
 import org.opensearch.knn.indices.ModelDao;
 import org.opensearch.knn.indices.ModelMetadata;
 import org.opensearch.knn.indices.ModelState;
@@ -102,6 +103,9 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(metadata.index(anyString())).thenReturn(indexMetadata);
         when(indexMetadata.getSettings()).thenReturn(settings);
         when(indexMetadata.getCreationVersion()).thenReturn(Version.CURRENT);
+
+        // Initialize RescoreRadialSearchQuery singleton for tests that trigger radial search on quantized indices
+        RescoreRadialSearchQuery.initialize(new ExactSearcher(mock(ModelDao.OpenSearchKNNModelDao.class)));
     }
 
     public void testInvalidK() {

--- a/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FIELD;
+import static org.opensearch.knn.common.KNNConstants.MAX_RESULTS_RADIAL_RESCORING;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 
 import java.util.Arrays;
@@ -29,11 +30,20 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
+import org.opensearch.knn.indices.ModelDao;
 
 public class RNNQueryFactoryTests extends KNNTestCase {
     private static final String FILTER_FILED_NAME = "foo";
     private static final String FILTER_FILED_VALUE = "fooval";
     private static final QueryBuilder FILTER_QUERY_BUILDER = new TermQueryBuilder(FILTER_FILED_NAME, FILTER_FILED_VALUE);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RescoreRadialSearchQuery.initialize(new ExactSearcher(mock(ModelDao.OpenSearchKNNModelDao.class)));
+    }
+
     private final int testQueryDimension = 17;
     private final float[] testQueryVector = new float[testQueryDimension];
     private final byte[] testByteQueryVector = new byte[testQueryDimension];
@@ -174,6 +184,64 @@ public class RNNQueryFactoryTests extends KNNTestCase {
         assertTrue(rescoreQuery.getInnerQuery() instanceof KNNQuery);
         assertEquals(testFieldName, rescoreQuery.getField());
         assertEquals(testRadius, rescoreQuery.getRadius(), 0.0f);
+        // maxResultsSize should come from IndexSettings.getMaxResultWindow()
+        assertEquals(maxResultWindow, rescoreQuery.getMaxResultsSize());
+    }
+
+    // Given: rescoring is required but no QueryShardContext is present
+    // When: RNNQueryFactory creates the query
+    // Then: maxResultsSize falls back to MAX_RESULTS_RADIAL_RESCORING
+    public void testCreate_whenRescoringRequired_andNoContext_thenUsesDefaultMaxResultsSize() {
+        KNNVectorFieldType mockFieldType = mock(KNNVectorFieldType.class);
+        when(mockFieldType.isRescoringRequiredForRadial()).thenReturn(true);
+
+        final RNNQueryFactory.CreateQueryRequest createQueryRequest = RNNQueryFactory.CreateQueryRequest.builder()
+            .knnEngine(KNNEngine.LUCENE)
+            .indexName(testIndexName)
+            .fieldName(testFieldName)
+            .vector(testQueryVector)
+            .radius(testRadius)
+            .vectorDataType(DEFAULT_VECTOR_DATA_TYPE_FIELD)
+            .vectorFieldType(mockFieldType)
+            .build();
+
+        Query query = RNNQueryFactory.create(createQueryRequest);
+
+        assertTrue(query instanceof RescoreRadialSearchQuery);
+        RescoreRadialSearchQuery rescoreQuery = (RescoreRadialSearchQuery) query;
+        assertEquals(MAX_RESULTS_RADIAL_RESCORING, rescoreQuery.getMaxResultsSize());
+    }
+
+    // Given: rescoring is required and IndexSettings has a custom maxResultWindow (e.g. 500)
+    // When: RNNQueryFactory creates the query
+    // Then: maxResultsSize is set to that custom value
+    public void testCreate_whenRescoringRequired_andCustomMaxResultWindow_thenUsesCustomValue() {
+        int customMaxResultWindow = 500;
+        QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
+        IndexSettings indexSettings = mock(IndexSettings.class);
+        MappedFieldType testMapper = mock(MappedFieldType.class);
+        KNNVectorFieldType mockFieldType = mock(KNNVectorFieldType.class);
+        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
+        when(mockQueryShardContext.fieldMapper(any())).thenReturn(testMapper);
+        when(indexSettings.getMaxResultWindow()).thenReturn(customMaxResultWindow);
+        when(mockFieldType.isRescoringRequiredForRadial()).thenReturn(true);
+
+        final RNNQueryFactory.CreateQueryRequest createQueryRequest = RNNQueryFactory.CreateQueryRequest.builder()
+            .knnEngine(KNNEngine.LUCENE)
+            .indexName(testIndexName)
+            .fieldName(testFieldName)
+            .vector(testQueryVector)
+            .radius(testRadius)
+            .vectorDataType(DEFAULT_VECTOR_DATA_TYPE_FIELD)
+            .context(mockQueryShardContext)
+            .vectorFieldType(mockFieldType)
+            .build();
+
+        Query query = RNNQueryFactory.create(createQueryRequest);
+
+        assertTrue(query instanceof RescoreRadialSearchQuery);
+        RescoreRadialSearchQuery rescoreQuery = (RescoreRadialSearchQuery) query;
+        assertEquals(customMaxResultWindow, rescoreQuery.getMaxResultsSize());
     }
 
     // Verify that Lucene radial search with 32x SQ wraps the inner FloatVectorSimilarityQuery

--- a/src/test/java/org/opensearch/knn/index/query/RescoreRadialSearchQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RescoreRadialSearchQueryTests.java
@@ -5,7 +5,14 @@
 
 package org.opensearch.knn.index.query;
 
+import lombok.SneakyThrows;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
@@ -17,9 +24,12 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
 
@@ -37,46 +47,10 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     private static final float[] QUERY_VECTOR = { 1.0f, 2.0f, 3.0f };
     private static final float RADIUS = 0.5f;
 
-    // Verify scorerSupplier delegates to inner weight and returns the same results
-    public void testScorerSupplier_passThrough() throws IOException {
-        // Set up inner query results: 3 docs with known scores
-        TopDocs innerTopDocs = new TopDocs(
-            new TotalHits(3, TotalHits.Relation.EQUAL_TO),
-            new ScoreDoc[] { new ScoreDoc(0, 0.9f), new ScoreDoc(1, 0.7f), new ScoreDoc(2, 0.5f) }
-        );
-        Scorer innerScorer = new KNNScorer(innerTopDocs, 1.0f);
-
-        ScorerSupplier innerScorerSupplier = mock(ScorerSupplier.class);
-        when(innerScorerSupplier.get(any(Long.class))).thenReturn(innerScorer);
-        when(innerScorerSupplier.cost()).thenReturn(3L);
-
-        Weight innerWeight = mock(Weight.class);
-        LeafReaderContext leafContext = mock(LeafReaderContext.class);
-        when(innerWeight.scorerSupplier(leafContext)).thenReturn(innerScorerSupplier);
-
-        Query innerQuery = mock(Query.class);
-        when(innerQuery.rewrite(any(IndexSearcher.class))).thenReturn(innerQuery);
-        IndexSearcher searcher = mock(IndexSearcher.class);
-        when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
-        when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
-
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
-        Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
-        ScorerSupplier supplier = weight.scorerSupplier(leafContext);
-
-        assertNotNull(supplier);
-        assertEquals(3L, supplier.cost());
-
-        Scorer scorer = supplier.get(0);
-        assertNotNull(scorer);
-
-        // Iterate and verify all 3 docs are returned in doc ID order (TopDocsDISI sorts by docId)
-        int count = 0;
-        while (scorer.iterator().nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            count++;
-        }
-        assertEquals(3, count);
-    }
+    // Note: the full rescoring flow (inner scorer → collectTopDocs → ExactSearcher → KNNScorer)
+    // requires a real SegmentReader and cannot be unit-tested with mocks alone.
+    // The rescoring correctness is validated by integration tests in FaissSQRadialSearchIT
+    // and LuceneSQRadialSearchIT.
 
     // Verify that when inner scorer supplier is null, our supplier returns null
     public void testScorerSupplier_whenInnerReturnsNull_thenReturnsNull() throws IOException {
@@ -89,7 +63,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
         ScorerSupplier supplier = weight.scorerSupplier(leafContext);
 
@@ -113,7 +87,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
         ScorerSupplier supplier = weight.scorerSupplier(leafContext);
 
@@ -126,29 +100,29 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Verify equals/hashCode contract
     public void testEqualsAndHashCode() {
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery q1 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
-        RescoreRadialSearchQuery q2 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery q1 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery q2 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
 
         assertEquals(q1, q2);
         assertEquals(q1.hashCode(), q2.hashCode());
 
         // Different radius
-        RescoreRadialSearchQuery q3 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, 0.9f);
+        RescoreRadialSearchQuery q3 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, 0.9f, false);
         assertNotEquals(q1, q3);
 
         // Different field
-        RescoreRadialSearchQuery q4 = new RescoreRadialSearchQuery(innerQuery, "other-field", QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery q4 = new RescoreRadialSearchQuery(innerQuery, "other-field", QUERY_VECTOR, RADIUS, false);
         assertNotEquals(q1, q4);
 
         // Different vector
-        RescoreRadialSearchQuery q5 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, new float[] { 9.0f }, RADIUS);
+        RescoreRadialSearchQuery q5 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, new float[] { 9.0f }, RADIUS, false);
         assertNotEquals(q1, q5);
     }
 
     // Verify toString contains useful information
     public void testToString() {
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         String str = query.toString(FIELD_NAME);
 
         assertTrue(str.contains("RescoreRadialSearchQuery"));
@@ -159,7 +133,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Verify getters expose the fields correctly
     public void testGetters() {
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
 
         assertSame(innerQuery, query.getInnerQuery());
         assertEquals(FIELD_NAME, query.getField());
@@ -179,7 +153,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         IndexSearcher searcher = mock(IndexSearcher.class);
         when(originalInner.rewrite(searcher)).thenReturn(rewrittenInner);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(originalInner, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(originalInner, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
 
         // When: first rewrite — inner query changes, so a new wrapper is created
         Query firstRewrite = query.rewrite(searcher);
@@ -206,7 +180,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         Query innerQuery = new MatchAllDocsQuery();
         IndexSearcher searcher = mock(IndexSearcher.class);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         Query rewritten = query.rewrite(searcher);
 
         // Returns this — same instance, not just equal
@@ -220,7 +194,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     public void testVisit() {
         // Given: a RescoreRadialSearchQuery wrapping a MatchAllDocsQuery
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         final boolean[] innerVisited = { false };
 
         // When: visit() is called — it propagates to the inner query via getSubVisitor(MUST)
@@ -254,7 +228,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
         // When: explain is called on the RescoreWeight for doc 42
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
         Explanation explanation = weight.explain(leafContext, 42);
 
@@ -274,10 +248,300 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
 
         // When/Then: isCacheable returns true for any leaf context
         assertTrue("RescoreWeight should be cacheable", weight.isCacheable(leafContext));
+    }
+
+    // --- Full rescoring flow tests using real Lucene index ---
+    // These tests use MatchAllDocsQuery as the inner query so that ALL vectors pass the first phase
+    // (simulating a quantized first pass that returns false positives). The rescore phase must then
+    // filter out vectors whose true full-precision score falls outside the radius.
+
+    // Given: 5 vectors indexed, all returned by inner query (first phase includes false positives)
+    // When: RescoreRadialSearchQuery rescores with full precision
+    // Then: only vectors within the true radius are kept, false positives are excluded
+    @SneakyThrows
+    public void testRescore_withLuceneIndex_filtersOutsideRadius() {
+        int dimension = 3;
+        float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        float[][] vectors = {
+            { 1.0f, 0.0f, 0.0f },   // identical to query, distance=0, similarity=1.0
+            { 0.9f, 0.1f, 0.0f },   // very close, similarity ≈ 0.98
+            { 0.8f, 0.2f, 0.0f },   // close, similarity ≈ 0.93
+            { 0.0f, 1.0f, 0.0f },   // far (orthogonal), similarity ≈ 0.33 — FALSE POSITIVE
+            { -1.0f, 0.0f, 0.0f },  // very far (opposite), similarity = 0.2 — FALSE POSITIVE
+        };
+
+        // Tight radius: only first 3 vectors should survive rescoring
+        float radiusThreshold = 0.9f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
+                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+
+                    // Inner query returns ALL docs — simulates quantized first pass with false positives
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    // Rescore with tight radius — should filter out the false positives
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, 10);
+
+                    // Then: false positives (orthogonal, opposite) are excluded by rescoring
+                    assertTrue("Expected some results within radius", results.scoreDocs.length > 0);
+                    assertTrue(
+                        "Expected fewer results than total docs (false positives filtered)",
+                        results.scoreDocs.length < vectors.length
+                    );
+                    for (ScoreDoc scoreDoc : results.scoreDocs) {
+                        assertTrue(
+                            "All returned docs should have score >= radiusThreshold, but got " + scoreDoc.score,
+                            scoreDoc.score >= radiusThreshold
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Given: all vectors are outside the radius, but inner query returns all of them (all are false positives)
+    // When: RescoreRadialSearchQuery rescores with full precision
+    // Then: all are filtered out, empty result
+    @SneakyThrows
+    public void testRescore_withLuceneIndex_whenAllAreFalsePositives_thenEmpty() {
+        int dimension = 3;
+        float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        float[][] vectors = {
+            { 0.0f, 1.0f, 0.0f },   // orthogonal, similarity ≈ 0.33
+            { -1.0f, 0.0f, 0.0f },  // opposite, similarity = 0.2
+            { 0.0f, 0.0f, 1.0f },   // orthogonal, similarity ≈ 0.33
+        };
+
+        // Very tight radius — none should survive
+        float radiusThreshold = 0.99f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
+                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+
+                    // Inner query returns ALL docs — all are false positives
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, 10);
+
+                    // Then: all filtered out since none are within radius
+                    assertEquals("All false positives should be filtered out", 0, results.scoreDocs.length);
+                }
+            }
+        }
+    }
+
+    // Given: all vectors are within the radius, inner query returns all (no false positives)
+    // When: RescoreRadialSearchQuery rescores with full precision
+    // Then: all docs kept — rescoring confirms they are all true positives
+    @SneakyThrows
+    public void testRescore_withLuceneIndex_whenAllWithinRadius_thenAllKept() {
+        int dimension = 3;
+        float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        float[][] vectors = {
+            { 1.0f, 0.0f, 0.0f },   // identical, similarity = 1.0
+            { 0.99f, 0.01f, 0.0f }, // very close, similarity ≈ 0.9998
+            { 0.95f, 0.05f, 0.0f }, // close, similarity ≈ 0.995
+        };
+
+        // Loose radius — all should survive
+        float radiusThreshold = 0.5f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
+                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+
+                    // Inner query returns ALL docs — none are false positives
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, 10);
+
+                    // Then: all docs kept since all are true positives
+                    assertEquals("All true positives should be kept", vectors.length, results.scoreDocs.length);
+                }
+            }
+        }
+    }
+
+    // Given: vectors indexed with COSINE similarity, inner query returns all (includes false positives)
+    // When: RescoreRadialSearchQuery rescores with full precision
+    // Then: only vectors with cosine similarity >= radius are kept
+    @SneakyThrows
+    public void testRescore_withCosine_filtersOutsideRadius() {
+        int dimension = 3;
+        // Normalized query vector for cosine
+        float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        float[][] vectors = {
+            { 1.0f, 0.0f, 0.0f },   // cos=1.0, Lucene score = (1+1)/2 = 1.0
+            { 0.9f, 0.1f, 0.0f },   // cos≈0.994, score ≈ 0.997
+            { 0.0f, 1.0f, 0.0f },   // cos=0, score = 0.5 — FALSE POSITIVE
+            { -1.0f, 0.0f, 0.0f },  // cos=-1, score = 0.0 — FALSE POSITIVE
+        };
+
+        // Lucene cosine score = (1 + cosine) / 2
+        // Threshold 0.9 → only vectors with cosine > 0.8 pass
+        float radiusThreshold = 0.9f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.COSINE));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
+                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, 10);
+
+                    // Then: false positives (orthogonal, opposite) are filtered
+                    assertTrue("Expected some results", results.scoreDocs.length > 0);
+                    assertTrue("Expected fewer than total (false positives removed)", results.scoreDocs.length < vectors.length);
+                    for (ScoreDoc scoreDoc : results.scoreDocs) {
+                        assertTrue("Score should be >= threshold, got " + scoreDoc.score, scoreDoc.score >= radiusThreshold);
+                    }
+                }
+            }
+        }
+    }
+
+    // Given: vectors indexed with MAXIMUM_INNER_PRODUCT, inner query returns all (includes false positives)
+    // When: RescoreRadialSearchQuery rescores with full precision
+    // Then: only vectors with inner product score >= radius are kept
+    @SneakyThrows
+    public void testRescore_withMaxInnerProduct_filtersOutsideRadius() {
+        int dimension = 3;
+        float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        float[][] vectors = {
+            { 3.0f, 0.0f, 0.0f },   // ip=3.0, Lucene score = 3.0+1 = 4.0
+            { 1.0f, 0.0f, 0.0f },   // ip=1.0, Lucene score = 1.0+1 = 2.0
+            { 0.1f, 0.0f, 0.0f },   // ip=0.1, Lucene score = 0.1+1 = 1.1
+            { -1.0f, 0.0f, 0.0f },  // ip=-1.0, Lucene score = 1/(1-(-1)) = 0.5 — FALSE POSITIVE
+            { -3.0f, 0.0f, 0.0f },  // ip=-3.0, Lucene score = 1/(1-(-3)) = 0.25 — FALSE POSITIVE
+        };
+
+        // Lucene MAX_INNER_PRODUCT score:
+        // if ip >= 0: score = ip + 1
+        // if ip < 0: score = 1 / (1 - ip)
+        // Threshold 1.0 → only vectors with ip >= 0 pass (score >= 1.0)
+        float radiusThreshold = 1.0f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
+                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, 10);
+
+                    // Then: negative inner product vectors are filtered out
+                    assertTrue("Expected some results", results.scoreDocs.length > 0);
+                    assertTrue("Expected fewer than total (false positives removed)", results.scoreDocs.length < vectors.length);
+                    for (ScoreDoc scoreDoc : results.scoreDocs) {
+                        assertTrue("Score should be >= threshold, got " + scoreDoc.score, scoreDoc.score >= radiusThreshold);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/RescoreRadialSearchQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RescoreRadialSearchQueryTests.java
@@ -26,9 +26,8 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.query.exactsearch.ExactSearcher;
 import org.opensearch.knn.indices.ModelDao;
 
 import java.io.IOException;
@@ -38,6 +37,7 @@ import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.MAX_RESULTS_RADIAL_RESCORING;
 
 // Tests for RescoreRadialSearchQuery — the pass-through skeleton.
 // At this stage the wrapper delegates entirely to the inner query without rescoring.
@@ -47,10 +47,42 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     private static final float[] QUERY_VECTOR = { 1.0f, 2.0f, 3.0f };
     private static final float RADIUS = 0.5f;
 
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // Initialize the singleton ExactSearcher used by RescoreRadialSearchQuery
+        RescoreRadialSearchQuery.initialize(new ExactSearcher(mock(ModelDao.OpenSearchKNNModelDao.class)));
+    }
+
     // Note: the full rescoring flow (inner scorer → collectTopDocs → ExactSearcher → KNNScorer)
     // requires a real SegmentReader and cannot be unit-tested with mocks alone.
     // The rescoring correctness is validated by integration tests in FaissSQRadialSearchIT
     // and LuceneSQRadialSearchIT.
+
+    // Given: ExactSearcher singleton is not initialized (null)
+    // When: RescoreRadialSearchQuery is constructed
+    // Then: NullPointerException is thrown with message about initialization
+    public void testConstructor_whenExactSearcherNotInitialized_thenThrows() {
+        // Temporarily set singleton to null
+        RescoreRadialSearchQuery.initialize(null);
+        try {
+            NullPointerException e = expectThrows(
+                NullPointerException.class,
+                () -> new RescoreRadialSearchQuery(
+                    new MatchAllDocsQuery(),
+                    FIELD_NAME,
+                    QUERY_VECTOR,
+                    RADIUS,
+                    false,
+                    MAX_RESULTS_RADIAL_RESCORING
+                )
+            );
+            assertTrue(e.getMessage().contains("Exact searcher was not initialized"));
+        } finally {
+            // Restore for other tests
+            RescoreRadialSearchQuery.initialize(new ExactSearcher(mock(ModelDao.OpenSearchKNNModelDao.class)));
+        }
+    }
 
     // Verify that when inner scorer supplier is null, our supplier returns null
     public void testScorerSupplier_whenInnerReturnsNull_thenReturnsNull() throws IOException {
@@ -63,7 +95,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
         ScorerSupplier supplier = weight.scorerSupplier(leafContext);
 
@@ -72,25 +111,37 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
 
     // Verify that when inner scorer returns empty TopDocs, we get an empty scorer
     public void testScorerSupplier_whenInnerReturnsEmpty_thenEmptyScorer() throws IOException {
+        // Inner query returns an empty scorer
         Scorer innerScorer = KNNScorer.emptyScorer();
 
         ScorerSupplier innerScorerSupplier = mock(ScorerSupplier.class);
         when(innerScorerSupplier.get(any(Long.class))).thenReturn(innerScorer);
         when(innerScorerSupplier.cost()).thenReturn(0L);
 
+        // Mocking inner weight
         Weight innerWeight = mock(Weight.class);
         LeafReaderContext leafContext = mock(LeafReaderContext.class);
         when(innerWeight.scorerSupplier(leafContext)).thenReturn(innerScorerSupplier);
 
+        // IndexSearcher
         Query innerQuery = mock(Query.class);
         IndexSearcher searcher = mock(IndexSearcher.class);
         when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        // Set up RescoreRadialSearchQuery
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
         ScorerSupplier supplier = weight.scorerSupplier(leafContext);
 
+        // Validate empty iterator
         assertNotNull(supplier);
         Scorer scorer = supplier.get(0);
         assertNotNull(scorer);
@@ -100,29 +151,71 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Verify equals/hashCode contract
     public void testEqualsAndHashCode() {
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery q1 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
-        RescoreRadialSearchQuery q2 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery q1 = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
+        RescoreRadialSearchQuery q2 = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
 
         assertEquals(q1, q2);
         assertEquals(q1.hashCode(), q2.hashCode());
 
         // Different radius
-        RescoreRadialSearchQuery q3 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, 0.9f, false);
+        RescoreRadialSearchQuery q3 = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            0.9f,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         assertNotEquals(q1, q3);
 
         // Different field
-        RescoreRadialSearchQuery q4 = new RescoreRadialSearchQuery(innerQuery, "other-field", QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery q4 = new RescoreRadialSearchQuery(
+            innerQuery,
+            "other-field",
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         assertNotEquals(q1, q4);
 
         // Different vector
-        RescoreRadialSearchQuery q5 = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, new float[] { 9.0f }, RADIUS, false);
+        RescoreRadialSearchQuery q5 = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            new float[] { 9.0f },
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         assertNotEquals(q1, q5);
     }
 
     // Verify toString contains useful information
     public void testToString() {
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         String str = query.toString(FIELD_NAME);
 
         assertTrue(str.contains("RescoreRadialSearchQuery"));
@@ -133,7 +226,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Verify getters expose the fields correctly
     public void testGetters() {
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
 
         assertSame(innerQuery, query.getInnerQuery());
         assertEquals(FIELD_NAME, query.getField());
@@ -153,7 +253,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         IndexSearcher searcher = mock(IndexSearcher.class);
         when(originalInner.rewrite(searcher)).thenReturn(rewrittenInner);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(originalInner, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            originalInner,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
 
         // When: first rewrite — inner query changes, so a new wrapper is created
         Query firstRewrite = query.rewrite(searcher);
@@ -180,7 +287,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         Query innerQuery = new MatchAllDocsQuery();
         IndexSearcher searcher = mock(IndexSearcher.class);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         Query rewritten = query.rewrite(searcher);
 
         // Returns this — same instance, not just equal
@@ -194,7 +308,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     public void testVisit() {
         // Given: a RescoreRadialSearchQuery wrapping a MatchAllDocsQuery
         Query innerQuery = new MatchAllDocsQuery();
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         final boolean[] innerVisited = { false };
 
         // When: visit() is called — it propagates to the inner query via getSubVisitor(MUST)
@@ -228,7 +349,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
         // When: explain is called on the RescoreWeight for doc 42
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
         Explanation explanation = weight.explain(leafContext, 42);
 
@@ -248,7 +376,14 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         when(searcher.rewrite(innerQuery)).thenReturn(innerQuery);
         when(searcher.createWeight(eq(innerQuery), any(ScoreMode.class), anyFloat())).thenReturn(innerWeight);
 
-        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(innerQuery, FIELD_NAME, QUERY_VECTOR, RADIUS, false);
+        RescoreRadialSearchQuery query = new RescoreRadialSearchQuery(
+            innerQuery,
+            FIELD_NAME,
+            QUERY_VECTOR,
+            RADIUS,
+            false,
+            MAX_RESULTS_RADIAL_RESCORING
+        );
         Weight weight = query.createWeight(searcher, ScoreMode.COMPLETE, 1.0f);
 
         // When/Then: isCacheable returns true for any leaf context
@@ -265,9 +400,8 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Then: only vectors within the true radius are kept, false positives are excluded
     @SneakyThrows
     public void testRescore_withLuceneIndex_filtersOutsideRadius() {
-        int dimension = 3;
-        float[] queryVector = { 1.0f, 0.0f, 0.0f };
-        float[][] vectors = {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final float[][] vectors = {
             { 1.0f, 0.0f, 0.0f },   // identical to query, distance=0, similarity=1.0
             { 0.9f, 0.1f, 0.0f },   // very close, similarity ≈ 0.98
             { 0.8f, 0.2f, 0.0f },   // close, similarity ≈ 0.93
@@ -276,7 +410,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         };
 
         // Tight radius: only first 3 vectors should survive rescoring
-        float radiusThreshold = 0.9f;
+        final float radiusThreshold = 0.9f;
 
         try (Directory directory = newDirectory()) {
             try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
@@ -289,8 +423,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
             }
 
             try (IndexReader reader = DirectoryReader.open(directory)) {
-                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
-                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+                {
 
                     IndexSearcher searcher = new IndexSearcher(reader);
 
@@ -303,7 +436,8 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
                         FIELD_NAME,
                         queryVector,
                         radiusThreshold,
-                        false
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
                     );
 
                     TopDocs results = searcher.search(rescoreQuery, 10);
@@ -330,16 +464,15 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Then: all are filtered out, empty result
     @SneakyThrows
     public void testRescore_withLuceneIndex_whenAllAreFalsePositives_thenEmpty() {
-        int dimension = 3;
-        float[] queryVector = { 1.0f, 0.0f, 0.0f };
-        float[][] vectors = {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final float[][] vectors = {
             { 0.0f, 1.0f, 0.0f },   // orthogonal, similarity ≈ 0.33
             { -1.0f, 0.0f, 0.0f },  // opposite, similarity = 0.2
             { 0.0f, 0.0f, 1.0f },   // orthogonal, similarity ≈ 0.33
         };
 
         // Very tight radius — none should survive
-        float radiusThreshold = 0.99f;
+        final float radiusThreshold = 0.99f;
 
         try (Directory directory = newDirectory()) {
             try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
@@ -352,8 +485,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
             }
 
             try (IndexReader reader = DirectoryReader.open(directory)) {
-                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
-                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+                {
 
                     IndexSearcher searcher = new IndexSearcher(reader);
 
@@ -365,7 +497,8 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
                         FIELD_NAME,
                         queryVector,
                         radiusThreshold,
-                        false
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
                     );
 
                     TopDocs results = searcher.search(rescoreQuery, 10);
@@ -382,16 +515,15 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Then: all docs kept — rescoring confirms they are all true positives
     @SneakyThrows
     public void testRescore_withLuceneIndex_whenAllWithinRadius_thenAllKept() {
-        int dimension = 3;
-        float[] queryVector = { 1.0f, 0.0f, 0.0f };
-        float[][] vectors = {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final float[][] vectors = {
             { 1.0f, 0.0f, 0.0f },   // identical, similarity = 1.0
             { 0.99f, 0.01f, 0.0f }, // very close, similarity ≈ 0.9998
             { 0.95f, 0.05f, 0.0f }, // close, similarity ≈ 0.995
         };
 
         // Loose radius — all should survive
-        float radiusThreshold = 0.5f;
+        final float radiusThreshold = 0.5f;
 
         try (Directory directory = newDirectory()) {
             try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
@@ -404,8 +536,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
             }
 
             try (IndexReader reader = DirectoryReader.open(directory)) {
-                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
-                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+                {
 
                     IndexSearcher searcher = new IndexSearcher(reader);
 
@@ -417,7 +548,8 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
                         FIELD_NAME,
                         queryVector,
                         radiusThreshold,
-                        false
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
                     );
 
                     TopDocs results = searcher.search(rescoreQuery, 10);
@@ -434,10 +566,9 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
     // Then: only vectors with cosine similarity >= radius are kept
     @SneakyThrows
     public void testRescore_withCosine_filtersOutsideRadius() {
-        int dimension = 3;
         // Normalized query vector for cosine
-        float[] queryVector = { 1.0f, 0.0f, 0.0f };
-        float[][] vectors = {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final float[][] vectors = {
             { 1.0f, 0.0f, 0.0f },   // cos=1.0, Lucene score = (1+1)/2 = 1.0
             { 0.9f, 0.1f, 0.0f },   // cos≈0.994, score ≈ 0.997
             { 0.0f, 1.0f, 0.0f },   // cos=0, score = 0.5 — FALSE POSITIVE
@@ -446,7 +577,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
 
         // Lucene cosine score = (1 + cosine) / 2
         // Threshold 0.9 → only vectors with cosine > 0.8 pass
-        float radiusThreshold = 0.9f;
+        final float radiusThreshold = 0.9f;
 
         try (Directory directory = newDirectory()) {
             try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
@@ -459,8 +590,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
             }
 
             try (IndexReader reader = DirectoryReader.open(directory)) {
-                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
-                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+                {
 
                     IndexSearcher searcher = new IndexSearcher(reader);
                     Query innerQuery = new MatchAllDocsQuery();
@@ -470,7 +600,8 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
                         FIELD_NAME,
                         queryVector,
                         radiusThreshold,
-                        false
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
                     );
 
                     TopDocs results = searcher.search(rescoreQuery, 10);
@@ -486,14 +617,292 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         }
     }
 
+    // Given: inner query returns fewer docs than maxResultsSize
+    // When: RescoreRadialSearchQuery rescores
+    // Then: iterator is used directly (no collectTopDocs), all valid results returned
+    @SneakyThrows
+    public void testRescore_whenCostBelowMaxResultsSize_thenUsesIteratorDirectly() {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final float[][] vectors = {
+            { 1.0f, 0.0f, 0.0f },   // identical, similarity = 1.0
+            { 0.9f, 0.1f, 0.0f },   // close, passes radius
+            { 0.0f, 1.0f, 0.0f },   // orthogonal, fails radius — FALSE POSITIVE
+        };
+        final float radiusThreshold = 0.9f;
+        // maxResultsSize = 10 > 3 docs, so direct iterator path is taken
+        final int maxResultsSize = 10;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                Query innerQuery = new MatchAllDocsQuery();
+
+                RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                    innerQuery,
+                    FIELD_NAME,
+                    queryVector,
+                    radiusThreshold,
+                    false,
+                    maxResultsSize
+                );
+
+                TopDocs results = searcher.search(rescoreQuery, 10);
+
+                // Only vectors within radius survive rescoring
+                assertTrue("Expected some results within radius", results.scoreDocs.length > 0);
+                assertTrue("False positive should be filtered", results.scoreDocs.length < vectors.length);
+                for (ScoreDoc scoreDoc : results.scoreDocs) {
+                    assertTrue("Score should be >= threshold, got " + scoreDoc.score, scoreDoc.score >= radiusThreshold);
+                }
+            }
+        }
+    }
+
+    // Given: inner query returns more docs than maxResultsSize
+    // When: RescoreRadialSearchQuery rescores
+    // Then: only top-maxResultsSize candidates (by score) are collected before rescoring,
+    // meaning the highest-scoring vectors are retained and low-scoring ones are dropped
+    @SneakyThrows
+    public void testRescore_whenCostExceedsMaxResultsSize_thenCollectsTopCandidatesByScore() {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        // 6 vectors with clearly different similarities to query.
+        // Euclidean similarity = 1/(1+dist^2).
+        // doc0: identical → score=1.0
+        // doc1: very close → score≈0.99
+        // doc2: close → score≈0.96
+        // doc3-5: progressively farther → lower scores
+        final float[][] vectors = {
+            { 1.0f, 0.0f, 0.0f },    // doc0: score=1.0
+            { 0.99f, 0.01f, 0.0f },  // doc1: very high score
+            { 0.95f, 0.05f, 0.0f },  // doc2: high score
+            { 0.7f, 0.3f, 0.0f },    // doc3: medium score
+            { 0.5f, 0.5f, 0.0f },    // doc4: lower score
+            { 0.3f, 0.7f, 0.0f },    // doc5: lowest score
+        };
+        // Loose radius so all vectors pass the rescore filter
+        final float radiusThreshold = 0.1f;
+        // Only top 3 by score should be collected for rescoring
+        final int maxResultsSize = 3;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (float[] vector : vectors) {
+                    Document doc = new Document();
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                Query innerQuery = new MatchAllDocsQuery();
+
+                RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                    innerQuery,
+                    FIELD_NAME,
+                    queryVector,
+                    radiusThreshold,
+                    false,
+                    maxResultsSize
+                );
+
+                TopDocs results = searcher.search(rescoreQuery, vectors.length);
+
+                // Exactly maxResultsSize results since all pass the radius filter
+                assertEquals("Should return exactly maxResultsSize results", maxResultsSize, results.scoreDocs.length);
+
+                // The returned docs should be the top-3 by score (doc0, doc1, doc2)
+                // Verify that the minimum score in the result set is higher than
+                // the maximum score of the excluded docs (doc3-5)
+                float minReturnedScore = Float.MAX_VALUE;
+                for (ScoreDoc scoreDoc : results.scoreDocs) {
+                    minReturnedScore = Math.min(minReturnedScore, scoreDoc.score);
+                }
+
+                // Compute the max score of vectors that should NOT be in the result
+                // doc3 ({0.7, 0.3, 0}) has dist^2 = (0.3)^2 + (0.3)^2 = 0.18, score = 1/(1+0.18) ≈ 0.847
+                // The minimum returned score (from doc2) should be higher than doc3's score
+                float doc3Score = 1.0f / (1.0f + (0.3f * 0.3f + 0.3f * 0.3f));
+                assertTrue(
+                    "Top-k by score: min returned score (" + minReturnedScore + ") should exceed excluded doc score (" + doc3Score + ")",
+                    minReturnedScore > doc3Score
+                );
+            }
+        }
+    }
+
+    // Given: more than MAX_RESULTS_RADIAL_RESCORING (10k) vectors, all within radius
+    // When: RescoreRadialSearchQuery rescores
+    // Then: results are capped at MAX_RESULTS_RADIAL_RESCORING
+    @SneakyThrows
+    public void testRescore_whenResultsExceedMaxResultWindow_thenCappedAt10k() {
+        // Given: index 10,050 vectors all very close to query (all within radius)
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final int totalDocs = 10_050;
+        final float radiusThreshold = 0.01f; // Very loose — all docs should be within radius
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (int i = 0; i < totalDocs; i++) {
+                    Document doc = new Document();
+                    // All vectors identical to query — guaranteed similarity=1.0, always within any radius
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, queryVector.clone(), VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.forceMerge(1);
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                assertEquals("Expected single segment", 1, reader.leaves().size());
+                {
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
+                    );
+
+                    // Search with a large collector size to not limit from the collector side
+                    TopDocs results = searcher.search(rescoreQuery, totalDocs);
+
+                    // Then: all 10,050 vectors pass the radius, but results are capped at 10,000
+                    assertEquals("Results should be capped at MAX_RESULTS_RADIAL_RESCORING", 10_000, results.scoreDocs.length);
+                }
+            }
+        }
+    }
+
+    // Given: more than 10k vectors, half within radius and half outside
+    // When: RescoreRadialSearchQuery rescores
+    // Then: only the valid half is returned (capped at 10k since valid count > 10k is impossible here,
+    // but the invalid half is filtered out)
+    @SneakyThrows
+    public void testRescore_whenResultsExceedMaxResultWindow_andHalfAreValid_thenReturnsOnlyValid() {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final int totalDocs = 10_050;
+        final int validCount = totalDocs / 2; // ~5025 valid
+        // Euclidean similarity = 1/(1+dist^2). For vectors close to query, score ≈ 1.0.
+        // For orthogonal vectors, dist^2 ≈ 2, score ≈ 0.33.
+        final float radiusThreshold = 0.9f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (int i = 0; i < totalDocs; i++) {
+                    Document doc = new Document();
+                    float[] vector;
+                    if (i < validCount) {
+                        // Valid: very close to query vector, will pass radius
+                        vector = new float[] { 1.0f, i * 0.00001f, 0.0f };
+                    } else {
+                        // Invalid: orthogonal to query, will NOT pass radius
+                        vector = new float[] { 0.0f, (float) Math.sin(i), (float) Math.cos(i) };
+                    }
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                {
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, totalDocs);
+
+                    // Then: only the valid half is returned, invalid half filtered out
+                    assertEquals("Only valid vectors (first half) should survive rescoring", validCount, results.scoreDocs.length);
+                    for (ScoreDoc scoreDoc : results.scoreDocs) {
+                        assertTrue(
+                            "All returned docs should have score >= threshold, got " + scoreDoc.score,
+                            scoreDoc.score >= radiusThreshold
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Given: more than 10k vectors, ALL are outside the radius (all false positives)
+    // When: RescoreRadialSearchQuery rescores
+    // Then: all filtered out, empty result despite large first-pass set
+    @SneakyThrows
+    public void testRescore_whenResultsExceedMaxResultWindow_andAllAreFalsePositives_thenEmpty() {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final int totalDocs = 10_050;
+        // Very tight radius — nothing should survive since all vectors are far from query
+        final float radiusThreshold = 0.9999f;
+
+        try (Directory directory = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
+                for (int i = 0; i < totalDocs; i++) {
+                    Document doc = new Document();
+                    // All vectors orthogonal/far from query — none will pass tight radius
+                    float[] vector = { 0.0f, (float) Math.sin(i), (float) Math.cos(i) };
+                    doc.add(new KnnFloatVectorField(FIELD_NAME, vector, VectorSimilarityFunction.EUCLIDEAN));
+                    w.addDocument(doc);
+                }
+                w.commit();
+            }
+
+            try (IndexReader reader = DirectoryReader.open(directory)) {
+                {
+
+                    IndexSearcher searcher = new IndexSearcher(reader);
+                    Query innerQuery = new MatchAllDocsQuery();
+
+                    RescoreRadialSearchQuery rescoreQuery = new RescoreRadialSearchQuery(
+                        innerQuery,
+                        FIELD_NAME,
+                        queryVector,
+                        radiusThreshold,
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
+                    );
+
+                    TopDocs results = searcher.search(rescoreQuery, totalDocs);
+
+                    // Then: all false positives filtered, empty result
+                    assertEquals("All false positives should be filtered even with >10k candidates", 0, results.scoreDocs.length);
+                }
+            }
+        }
+    }
+
     // Given: vectors indexed with MAXIMUM_INNER_PRODUCT, inner query returns all (includes false positives)
     // When: RescoreRadialSearchQuery rescores with full precision
     // Then: only vectors with inner product score >= radius are kept
     @SneakyThrows
     public void testRescore_withMaxInnerProduct_filtersOutsideRadius() {
-        int dimension = 3;
-        float[] queryVector = { 1.0f, 0.0f, 0.0f };
-        float[][] vectors = {
+        final float[] queryVector = { 1.0f, 0.0f, 0.0f };
+        final float[][] vectors = {
             { 3.0f, 0.0f, 0.0f },   // ip=3.0, Lucene score = 3.0+1 = 4.0
             { 1.0f, 0.0f, 0.0f },   // ip=1.0, Lucene score = 1.0+1 = 2.0
             { 0.1f, 0.0f, 0.0f },   // ip=0.1, Lucene score = 0.1+1 = 1.1
@@ -505,7 +914,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
         // if ip >= 0: score = ip + 1
         // if ip < 0: score = 1 / (1 - ip)
         // Threshold 1.0 → only vectors with ip >= 0 pass (score >= 1.0)
-        float radiusThreshold = 1.0f;
+        final float radiusThreshold = 1.0f;
 
         try (Directory directory = newDirectory()) {
             try (IndexWriter w = new IndexWriter(directory, newIndexWriterConfig())) {
@@ -518,8 +927,7 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
             }
 
             try (IndexReader reader = DirectoryReader.open(directory)) {
-                try (MockedStatic<ModelDao.OpenSearchKNNModelDao> mocked = Mockito.mockStatic(ModelDao.OpenSearchKNNModelDao.class)) {
-                    mocked.when(ModelDao.OpenSearchKNNModelDao::getInstance).thenReturn(mock(ModelDao.OpenSearchKNNModelDao.class));
+                {
 
                     IndexSearcher searcher = new IndexSearcher(reader);
                     Query innerQuery = new MatchAllDocsQuery();
@@ -529,7 +937,8 @@ public class RescoreRadialSearchQueryTests extends KNNTestCase {
                         FIELD_NAME,
                         queryVector,
                         radiusThreshold,
-                        false
+                        false,
+                        MAX_RESULTS_RADIAL_RESCORING
                     );
 
                     TopDocs results = searcher.search(rescoreQuery, 10);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissSQIndexIT.java
@@ -31,6 +31,17 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
             Mode.ON_DISK,
             CompressionLevel.x32
         );
+
+        // Radial search
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_ENCODER_PARAMS,
+            true,
+            SpaceType.INNER_PRODUCT,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x32
+        );
     }
 
     public void testNestedDiskBasedIndexWithIP() {
@@ -59,6 +70,17 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
             Mode.ON_DISK,
             CompressionLevel.x32
         );
+
+        // Radial search
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_ENCODER_PARAMS,
+            true,
+            SpaceType.L2,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x32
+        );
     }
 
     public void testNestedDiskBasedIndexWithL2() {
@@ -82,6 +104,17 @@ public class MOSFaissSQIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
             VectorDataType.FLOAT,
             SQ_ENCODER_PARAMS,
             false,
+            SpaceType.COSINESIMIL,
+            NO_ADDITIONAL_SETTINGS,
+            Mode.ON_DISK,
+            CompressionLevel.x32
+        );
+
+        // Radial search
+        doTestNonNestedIndex(
+            VectorDataType.FLOAT,
+            SQ_ENCODER_PARAMS,
+            true,
             SpaceType.COSINESIMIL,
             NO_ADDITIONAL_SETTINGS,
             Mode.ON_DISK,


### PR DESCRIPTION
### Description
Radial search (max_distance/min_score) was previously blocked for all quantized indices due to scoring inaccuracy from quantization error. This PR enables radial search on 1-bit SQ (32x compression) indices by introducing RescoreRadialSearchQuery — a wrapper query that runs quantized radial search as a first pass, then rescores
candidates using full-precision vectors to filter out false positives (vectors whose quantized score fell within the radius but
whose true score does not). 
Results are capped at 10k per segment. Supports both Faiss and Lucene engines across all space types (L2, cosine, inner product).

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
N/A

### Check List
- [O] New functionality includes testing.
- [O] New functionality has been documented.
- [O] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [O] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
