### PR TITLE
Fixes RescoreParser to pass the rescore flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable prefetch [#3302](https://github.com/opensearch-project/k-NN/pull/3302)
+* Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)
 
 ### Refactoring
 

--- a/build.gradle
+++ b/build.gradle
@@ -807,7 +807,7 @@ run {
 // Task to start a dedicated coordinator node that joins the running test cluster.
 // Start the cluster first: ./gradlew run -PnumNodes=2
 // Then in another terminal: ./gradlew startCoordinator
-// The coordinator node will be available at localhost:9202
+// The coordinator node will be available at localhost:9200+numNodes (e.g. 9202 for 2 nodes)
 task startCoordinator(type: Exec) {
     def distroDir = "${buildDir}/testclusters/integTest-0/distro/${opensearch_version_no_snapshot}-ARCHIVE"
     def coordDir = "${buildDir}/testclusters/coordinator-0"
@@ -824,14 +824,16 @@ task startCoordinator(type: Exec) {
         }
 
         def seedHosts = (0..<_numNodes).collect { "127.0.0.1:${9300 + it}" }.join('", "')
+        def coordHttpPort = 9200 + _numNodes
+        def coordTransportPort = 9300 + _numNodes
         file("${coordDir}/config/opensearch.yml").text = """\
 cluster.name: integTest
 node.name: coordinator-0
 node.roles: []
 discovery.seed_hosts: ["${seedHosts}"]
 network.host: 127.0.0.1
-http.port: 9202
-transport.port: 9302
+http.port: ${coordHttpPort}
+transport.port: ${coordTransportPort}
 path.data: ${coordDir}/data
 path.logs: ${coordDir}/logs
 """

--- a/build.gradle
+++ b/build.gradle
@@ -804,6 +804,45 @@ run {
     }
 }
 
+// Task to start a dedicated coordinator node that joins the running test cluster.
+// Start the cluster first: ./gradlew run -PnumNodes=2
+// Then in another terminal: ./gradlew startCoordinator
+// The coordinator node will be available at localhost:9202
+task startCoordinator(type: Exec) {
+    def distroDir = "${buildDir}/testclusters/integTest-0/distro/${opensearch_version_no_snapshot}-ARCHIVE"
+    def coordDir = "${buildDir}/testclusters/coordinator-0"
+
+    doFirst {
+        delete coordDir
+        file("${coordDir}/data").mkdirs()
+        file("${coordDir}/logs").mkdirs()
+        file("${coordDir}/config").mkdirs()
+
+        copy {
+            from "${distroDir}/config"
+            into "${coordDir}/config"
+        }
+
+        def seedHosts = (0..<_numNodes).collect { "127.0.0.1:${9300 + it}" }.join('", "')
+        file("${coordDir}/config/opensearch.yml").text = """\
+cluster.name: integTest
+node.name: coordinator-0
+node.roles: []
+discovery.seed_hosts: ["${seedHosts}"]
+network.host: 127.0.0.1
+http.port: 9202
+transport.port: 9302
+path.data: ${coordDir}/data
+path.logs: ${coordDir}/logs
+"""
+    }
+
+    environment "OPENSEARCH_HOME", distroDir
+    environment "OPENSEARCH_PATH_CONF", "${coordDir}/config"
+    environment "OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m"
+    commandLine "${distroDir}/bin/opensearch"
+}
+
 // updateVersion: Task to auto increment to the next development iteration
 task updateVersion {
     onlyIf { System.getProperty('newVersion') }

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -1164,6 +1164,12 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
      */
     public void testCompression32xWithRescoreParametersRestartUpgrade() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        // mode and compression_level parameters are only supported on or after 2.17.0
+        if (isRunningAgainstOldCluster() && isModeAndCompressionSupported(getBWCVersion()) == false) {
+            return;
+        }
+
         int dimension = 8;
         int k = 4;
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -1166,7 +1166,7 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
 
         // mode and compression_level parameters are only supported on or after 2.17.0
-        if (isRunningAgainstOldCluster() && isModeAndCompressionSupported(getBWCVersion()) == false) {
+        if (isModeAndCompressionSupported(getBWCVersion()) == false) {
             return;
         }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -21,12 +21,17 @@ import org.opensearch.knn.index.engine.faiss.QFrameBitEncoder;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
+import org.opensearch.knn.index.query.parser.RescoreParser;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE;
@@ -1145,6 +1150,119 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
         } else {
             assertEquals(NUM_DOCS + 1, getDocCount(testIndex));
             validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
+            deleteKNNIndex(testIndex);
+        }
+    }
+
+    /**
+     * Test BWC for 32x compression level with various rescore search parameters.
+     * Creates an index with 32x compression in old cluster, then validates search works
+     * with different rescore configurations after upgrade:
+     * - rescore disabled (rescore: false)
+     * - rescore with explicit oversample_factor
+     * - rescore with default (implicit) settings
+     */
+    public void testCompression32xWithRescoreParametersRestartUpgrade() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        int dimension = 8;
+        int k = 4;
+
+        if (isRunningAgainstOldCluster()) {
+            String mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(PROPERTIES)
+                .startObject(TEST_FIELD)
+                .field(VECTOR_TYPE, KNN_VECTOR)
+                .field(DIMENSION, dimension)
+                .field(COMPRESSION_LEVEL_PARAMETER, CompressionLevel.x32.getName())
+                .field(MODE_PARAMETER, Mode.ON_DISK.getName())
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .startObject(KNN_METHOD)
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(NAME, METHOD_HNSW)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .toString();
+            createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping);
+
+            Float[] vector1 = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+            Float[] vector2 = { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+            Float[] vector3 = { 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f };
+            Float[] vector4 = { 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f };
+            addKnnDoc(testIndex, "1", TEST_FIELD, vector1);
+            addKnnDoc(testIndex, "2", TEST_FIELD, vector2);
+            addKnnDoc(testIndex, "3", TEST_FIELD, vector3);
+            addKnnDoc(testIndex, "4", TEST_FIELD, vector4);
+            flush(testIndex, true);
+        } else {
+            float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+
+            // Search with rescore disabled
+            Response response = searchKNNIndex(
+                testIndex,
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("query")
+                    .startObject("knn")
+                    .startObject(TEST_FIELD)
+                    .field("vector", queryVector)
+                    .field("k", k)
+                    .field(RescoreParser.RESCORE_PARAMETER, false)
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject(),
+                k
+            );
+            assertOK(response);
+            List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), TEST_FIELD);
+            assertEquals(k, results.size());
+
+            // Search with explicit rescore oversample_factor
+            response = searchKNNIndex(
+                testIndex,
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("query")
+                    .startObject("knn")
+                    .startObject(TEST_FIELD)
+                    .field("vector", queryVector)
+                    .field("k", k)
+                    .startObject(RescoreParser.RESCORE_PARAMETER)
+                    .field(RescoreParser.RESCORE_OVERSAMPLE_PARAMETER, 2.0f)
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject(),
+                k
+            );
+            assertOK(response);
+            results = parseSearchResponse(EntityUtils.toString(response.getEntity()), TEST_FIELD);
+            assertEquals(k, results.size());
+
+            // Search with default rescore (no rescore parameter specified)
+            response = searchKNNIndex(
+                testIndex,
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("query")
+                    .startObject("knn")
+                    .startObject(TEST_FIELD)
+                    .field("vector", queryVector)
+                    .field("k", k)
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject(),
+                k
+            );
+            assertOK(response);
+            results = parseSearchResponse(EntityUtils.toString(response.getEntity()), TEST_FIELD);
+            assertEquals(k, results.size());
+
             deleteKNNIndex(testIndex);
         }
     }

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -637,6 +637,12 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
      */
     public void testCompression32xWithRescoreParametersRollingUpgrade() throws Exception {
         waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+
+        // mode and compression_level parameters are only supported on or after 2.17.0
+        if (isModeAndCompressionSupported(getBWCVersion()) == false) {
+            return;
+        }
+
         int dimension = 8;
         int k = 4;
 

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -5,8 +5,14 @@
 
 package org.opensearch.knn.bwc;
 
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.query.parser.RescoreParser;
+
+import java.util.List;
 
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
 
@@ -618,6 +624,128 @@ public class IndexingIT extends AbstractRollingUpgradeTestCase {
                 validateKNNSearch(testIndex, TEST_FIELD, DIMENSIONS, NUM_DOCS, K);
                 deleteKNNIndex(testIndex);
         }
+    }
+
+    /**
+     * Test BWC for 32x compression level with various rescore search parameters during rolling upgrade.
+     * Creates an index with 32x compression in old cluster, then validates search works
+     * with different rescore configurations in mixed and upgraded clusters:
+     * - rescore disabled (rescore: false)
+     * - rescore with explicit oversample_factor
+     * - rescore with default (implicit) settings
+     * - rescore with high oversample_factor
+     */
+    public void testCompression32xWithRescoreParametersRollingUpgrade() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        int dimension = 8;
+        int k = 4;
+
+        switch (getClusterType()) {
+            case OLD:
+                String mapping = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject("properties")
+                    .startObject(TEST_FIELD)
+                    .field("type", "knn_vector")
+                    .field("dimension", dimension)
+                    .field("compression_level", "32x")
+                    .field("mode", "on_disk")
+                    .field("space_type", "l2")
+                    .startObject("method")
+                    .field("name", ALGO)
+                    .field("engine", FAISS_NAME)
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .toString();
+                createKnnIndex(testIndex, getKNNDefaultIndexSettings(), mapping);
+
+                Float[] vector1 = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+                Float[] vector2 = { 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f };
+                Float[] vector3 = { 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f };
+                Float[] vector4 = { 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f };
+                addKnnDoc(testIndex, "1", TEST_FIELD, vector1);
+                addKnnDoc(testIndex, "2", TEST_FIELD, vector2);
+                addKnnDoc(testIndex, "3", TEST_FIELD, vector3);
+                addKnnDoc(testIndex, "4", TEST_FIELD, vector4);
+                flush(testIndex, true);
+                break;
+            case MIXED:
+                validateRescoreSearch(k, dimension);
+                break;
+            case UPGRADED:
+                validateRescoreSearch(k, dimension);
+                deleteKNNIndex(testIndex);
+        }
+    }
+
+    private void validateRescoreSearch(int k, int dimension) throws Exception {
+        float[] queryVector = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+
+        // Search with rescore disabled
+        Response response = searchKNNIndex(
+            testIndex,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(TEST_FIELD)
+                .field("vector", queryVector)
+                .field("k", k)
+                .field(RescoreParser.RESCORE_PARAMETER, false)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            k
+        );
+        assertOK(response);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), TEST_FIELD);
+        assertEquals(k, results.size());
+
+        // Search with explicit rescore oversample_factor
+        response = searchKNNIndex(
+            testIndex,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(TEST_FIELD)
+                .field("vector", queryVector)
+                .field("k", k)
+                .startObject(RescoreParser.RESCORE_PARAMETER)
+                .field(RescoreParser.RESCORE_OVERSAMPLE_PARAMETER, 2.0f)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            k
+        );
+        assertOK(response);
+        results = parseSearchResponse(EntityUtils.toString(response.getEntity()), TEST_FIELD);
+        assertEquals(k, results.size());
+
+        // Search with default rescore (no rescore parameter)
+        response = searchKNNIndex(
+            testIndex,
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("knn")
+                .startObject(TEST_FIELD)
+                .field("vector", queryVector)
+                .field("k", k)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject(),
+            k
+        );
+        assertOK(response);
+        results = parseSearchResponse(EntityUtils.toString(response.getEntity()), TEST_FIELD);
+        assertEquals(k, results.size());
     }
 
 }

--- a/src/main/java/org/opensearch/knn/index/query/parser/RescoreParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/RescoreParser.java
@@ -32,6 +32,7 @@ public final class RescoreParser {
 
     public static final String RESCORE_PARAMETER = "rescore";
     public static final String RESCORE_OVERSAMPLE_PARAMETER = "oversample_factor";
+    public static final String RESCORE_ENABLED_PARAMETER = "rescore_enabled";
 
     private static final ObjectParser<RescoreContext.RescoreContextBuilder, Void> INTERNAL_PARSER = createInternalObjectParser();
 
@@ -92,7 +93,11 @@ public final class RescoreParser {
         if (oversample == null) {
             return null;
         }
-        return RescoreContext.builder().oversampleFactor(oversample).build();
+        RescoreContext.RescoreContextBuilder builder = RescoreContext.builder().oversampleFactor(oversample);
+        if (IndexUtil.isVersionOnOrAfterMinRequiredVersion(in.getVersion(), RESCORE_ENABLED_PARAMETER)) {
+            builder.rescoreEnabled(in.readBoolean());
+        }
+        return builder.build();
     }
 
     /**
@@ -106,6 +111,9 @@ public final class RescoreParser {
             return;
         }
         out.writeOptionalFloat(rescoreContext == null ? null : rescoreContext.getOversampleFactor());
+        if (rescoreContext != null && IndexUtil.isVersionOnOrAfterMinRequiredVersion(out.getVersion(), RESCORE_ENABLED_PARAMETER)) {
+            out.writeBoolean(rescoreContext.isRescoreEnabled());
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -52,6 +52,7 @@ import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE_FAISS_INDEX_LOAD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_PARAMETER;
+import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_ENABLED_PARAMETER;
 
 public class IndexUtil {
 
@@ -71,6 +72,7 @@ public class IndexUtil {
     private static final Version MINIMAL_EXPAND_NESTED_FEATURE = Version.V_2_19_0;
     private static final Version MINIMAL_TOP_LEVEL_ENGINE_FEATURE = Version.V_3_2_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_NULL_K = Version.V_3_3_0;
+    private static final Version MINIMAL_RESCORE_ENABLED_FEATURE = Version.V_3_7_0;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -432,6 +434,7 @@ public class IndexUtil {
                 put(KNNConstants.METHOD_PARAMETER, MINIMAL_SUPPORTED_VERSION_FOR_METHOD_PARAMETERS);
                 put(KNNConstants.MODEL_VECTOR_DATA_TYPE_KEY, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VECTOR_DATA_TYPE);
                 put(RESCORE_PARAMETER, MINIMAL_RESCORE_FEATURE);
+                put(RESCORE_ENABLED_PARAMETER, MINIMAL_RESCORE_ENABLED_FEATURE);
                 put(KNNConstants.MINIMAL_MODE_AND_COMPRESSION_FEATURE, MINIMAL_MODE_AND_COMPRESSION_FEATURE);
                 put(KNNConstants.TOP_LEVEL_SPACE_TYPE_FEATURE, MINIMAL_TOP_LEVEL_SPACE_TYPE_FEATURE);
                 put(KNNConstants.MODEL_VERSION, MINIMAL_SUPPORTED_VERSION_FOR_MODEL_VERSION);

--- a/src/test/java/org/opensearch/knn/index/query/parser/RescoreParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/RescoreParserTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.query.parser;
 
 import lombok.SneakyThrows;
+import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
@@ -28,6 +29,28 @@ public class RescoreParserTests extends KNNTestCase {
         validateStreams(rescoreContext);
         validateStreams(null);
         validateStreams(RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT);
+    }
+
+    @SneakyThrows
+    public void testStreams_withOlderVersion() {
+        // Simulate a node running a version that doesn't support RESCORE_ENABLED_PARAMETER
+        RescoreContext rescoreContext = RescoreContext.builder()
+            .oversampleFactor(RescoreContext.DEFAULT_OVERSAMPLE_FACTOR)
+            .rescoreEnabled(false)
+            .build();
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(Version.V_3_6_0);
+            RescoreParser.streamOutput(output, rescoreContext);
+
+            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry())) {
+                in.setVersion(Version.V_3_6_0);
+                RescoreContext parsedRescoreContext = RescoreParser.streamInput(in);
+                // Older version doesn't serialize rescoreEnabled, so it defaults to true
+                assertEquals(RescoreContext.DEFAULT_OVERSAMPLE_FACTOR, parsedRescoreContext.getOversampleFactor(), 0.0001);
+                assertTrue(parsedRescoreContext.isRescoreEnabled());
+            }
+        }
     }
 
     private void validateStreams(RescoreContext rescoreContext) throws IOException {

--- a/src/test/java/org/opensearch/knn/index/query/parser/RescoreParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/RescoreParserTests.java
@@ -27,6 +27,7 @@ public class RescoreParserTests extends KNNTestCase {
         RescoreContext rescoreContext = RescoreContext.builder().oversampleFactor(RescoreContext.DEFAULT_OVERSAMPLE_FACTOR).build();
         validateStreams(rescoreContext);
         validateStreams(null);
+        validateStreams(RescoreContext.EXPLICITLY_DISABLED_RESCORE_CONTEXT);
     }
 
     private void validateStreams(RescoreContext rescoreContext) throws IOException {

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -2800,6 +2800,19 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return version.onOrAfter(Version.V_2_18_0);
     }
 
+    // mode and compression_level parameters are only supported on or after V_2_17_0
+    protected boolean isModeAndCompressionSupported(final Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get();
+        if (versionString.endsWith("-SNAPSHOT")) {
+            versionString = versionString.substring(0, versionString.length() - 9);
+        }
+        final Version version = Version.fromString(versionString);
+        return version.onOrAfter(Version.V_2_17_0);
+    }
+
     /**
      * Binary Scalar Quantizer is only supported on or after V_3_6_0
      */


### PR DESCRIPTION
For coordinator-data node setup, rescore set to false is not passed through streams. This causes rescoring to execute even when its not disabled explicitly by user

### Related Issues
N/A

### Testing
`./gradlew run -PnumNodes=2`
`./gradlew startCoordinator`

Request:
```
curl -s 'localhost:9202/test-rescore/_search?explain=true' -H 'Content-Type: application/json' -d '{
    "query": {"knn": {"my_vector": {"vector": [0.5, 1.0, 1.5, 2.0], "k": 3, "rescore": false}}}
  }'
```
Response:
```
Before fix (via coordinator node port 9202):
  
  {
    "_explanation": {
      "value": 0.11764706,
      "description": "the type of knn search executed was Disk-based and the first pass k was 100 with vector dimension of 4, over sampling factor of 1.0, shard level rescoring enabled",
      "details": [
        {
          "value": 0.11764706,
          "description": "the type of knn search executed at leaf was Approximate-NN with vectorDataType = FLOAT, spaceType = l2",
          "details": []
        }
      ]
    }
  }
  
  After fix (via coordinator node port 9202):
  
  {
    "_explanation": {
      "value": 0.11764706,
      "description": "the type of knn search executed was Disk-based and the first pass k was 100 with vector dimension of 4, over sampling factor of 1.0, shard level rescoring disabled",
      "details": [
        {
          "value": 0.11764706,
          "description": "the type of knn search executed at leaf was Approximate-NN with vectorDataType = FLOAT, spaceType = l2",
          "details": []
        }
      ]
    }
  }
```

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
