### PR TITLE
[Backport 3.7] Add support for binary and byte field support in doc_v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add the bulkscore logic in MOS when K is greater than number of docs in segment [#3285](https://github.com/opensearch-project/k-NN/pull/3285)
 * Added capability to retrieve float data type vectors using doc_values [#3321](https://github.com/opensearch-project/k-NN/pull/3321)
 * Add base64 binary encoding as default format for knn_vector docvalue_fields [#3324](https://github.com/opensearch-project/k-NN/pull/3324)
+* Add support for binary and byte field support in doc_values [#3340](https://github.com/opensearch-project/k-NN/pull/3340)

--- a/release-notes/opensearch-k-NN.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-k-NN.release-notes-3.7.0.0.md
@@ -13,6 +13,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
 
 * Add bulk scoring logic in Memory Optimized Search when K exceeds the number of docs in a segment for improved SIMD/vectorization performance ([#3285](https://github.com/opensearch-project/k-NN/pull/3285))
 * Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable I/O prefetch during exact search rescoring ([#3302](https://github.com/opensearch-project/k-NN/pull/3302))
+* Add support for binary and byte field support in doc_values [#3340](https://github.com/opensearch-project/k-NN/pull/3340)
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDVLeafFieldData.java
@@ -102,18 +102,19 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
      * iterator so that multiple {@code Leaf} instances obtained from the same
      * {@code KNNVectorDVLeafFieldData} cannot interfere with each other's state.
      *
-     * <p><b>Return type:</b> Depends on the format:
+     * <p><b>Return type:</b> Depends on the format and vector data type:
      * <ul>
-     *   <li>Array format ({@link KNNVectorDocValueFormat#ARRAY_FORMAT}): returns {@code float[]},
-     *       serialized by {@link org.opensearch.core.xcontent.XContentBuilder} as a JSON numeric array.</li>
+     *   <li>Array format ({@link KNNVectorDocValueFormat#ARRAY_FORMAT}): returns {@code float[]} for
+     *       FLOAT vectors or {@code byte[]} for BYTE/BINARY vectors, serialized by
+     *       {@link org.opensearch.core.xcontent.XContentBuilder} as a JSON numeric array.</li>
      *   <li>Binary format ({@link KNNVectorDocValueFormat#BINARY_FORMAT}, the default): returns a
-     *       base64-encoded {@link String} of little-endian float bytes.</li>
+     *       base64-encoded {@link String}. For FLOAT vectors, bytes are in little-endian order.
+     *       For BYTE/BINARY vectors, raw bytes are encoded directly.</li>
      * </ul>
      *
      * @param format the {@link KNNVectorDocValueFormat} that determines output encoding (array or binary)
      * @return a leaf fetcher that yields vector values per document, or an empty fetcher
      *         if the field has no vectors in this segment
-     * @throws UnsupportedOperationException if the vector data type is BYTE or BINARY
      * @throws IllegalArgumentException if format is not an instance of {@link KNNVectorDocValueFormat}
      */
     @Override
@@ -124,12 +125,6 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
             );
         }
         final boolean isBinary = knnFormat.isBinary();
-
-        if (vectorDataType == VectorDataType.BYTE || vectorDataType == VectorDataType.BINARY) {
-            throw new UnsupportedOperationException(
-                "docvalue_fields is not supported for [" + vectorDataType + "] vector field '" + fieldName + "'"
-            );
-        }
 
         final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, fieldName);
         // This is important because if for a segment there is no vector field present and then customer still ask for
@@ -165,15 +160,31 @@ public class KNNVectorDVLeafFieldData implements LeafFieldData {
 
             @Override
             public Object nextValue() throws IOException {
-                // We don't need a conditional clone here since encodeToBinary will convert the array to string.
-                if (isBinary) {
-                    return KNNVectorDocValueFormat.encodeToBinary((float[]) vectorValues.getVector());
+                if (vectorDataType == VectorDataType.FLOAT) {
+                    if (isBinary) {
+                        // Convert float[] to little-endian byte[]; XContentBuilder will base64-encode it
+                        return KNNVectorDocValueFormat.floatToLittleEndianBytes((float[]) vectorValues.getVector());
+                    }
+                    return vectorValues.conditionalCloneVector();
                 }
-                // We need a conditional clone since vector returned from here will be added in a map, so we do the clone
-                // since vectorValues keep a single copy of vector array for all docs.
-                return vectorValues.conditionalCloneVector();
+                // BYTE and BINARY data types both store byte[] vectors.
+                // For binary format, return byte[] directly — XContentBuilder base64-encodes it.
+                // For array format, convert to int[] since XContentBuilder treats byte[] as a binary blob,
+                // but serializes int[] as a JSON numeric array (e.g., [10, -20, 127]).
+                if (isBinary) {
+                    return vectorValues.conditionalCloneVector();
+                }
+                return toIntArray((byte[]) vectorValues.conditionalCloneVector());
             }
         };
+    }
+
+    private static int[] toIntArray(final byte[] bytes) {
+        final int[] ints = new int[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            ints[i] = bytes[i];
+        }
+        return ints;
     }
 
     private static final DocValueFetcher.Leaf EMPTY_DOCVALUE_FETCHER_LEAF = new DocValueFetcher.Leaf() {

--- a/src/main/java/org/opensearch/knn/index/KNNVectorDocValueFormat.java
+++ b/src/main/java/org/opensearch/knn/index/KNNVectorDocValueFormat.java
@@ -14,13 +14,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
-import java.util.Base64;
 
 /**
  * DocValueFormat for knn_vector fields. Supports two modes:
  * <ul>
  *   <li>{@code array} — vectors are returned as JSON numeric arrays</li>
- *   <li>{@code binary} (default) — vectors are returned as base64-encoded little-endian byte strings (with padding)</li>
+ *   <li>{@code binary} (default) — vectors are returned as byte arrays that XContentBuilder
+ *       base64-encodes during serialization</li>
  * </ul>
  */
 @Getter
@@ -33,7 +33,6 @@ public enum KNNVectorDocValueFormat implements DocValueFormat {
 
     private final String formatName;
     private final boolean binary;
-    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 
     KNNVectorDocValueFormat(final String formatName, boolean binary) {
         this.formatName = formatName;
@@ -78,15 +77,15 @@ public enum KNNVectorDocValueFormat implements DocValueFormat {
     }
 
     /**
-     * Encodes a float[] vector as a base64 string with little-endian byte order.
-     * Each float is written as 4 bytes in little-endian format (native byte order on x86/ARM),
-     * then the resulting byte array is base64-encoded.
+     * Converts a float[] vector to a little-endian byte array.
+     * Each float is written as 4 bytes in little-endian format (native byte order on x86/ARM).
+     * The returned byte[] is suitable for direct return from {@code nextValue()} —
+     * XContentBuilder will base64-encode it during serialization.
      */
-    public static String encodeToBinary(final float[] vector) {
+    public static byte[] floatToLittleEndianBytes(final float[] vector) {
         final ByteBuffer buffer = ByteBuffer.allocate(vector.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
-        buffer.asFloatBuffer().put(vector); // Bulk operation optimized by the JVM
-        final byte[] bytes = buffer.array();
-        return BASE64_ENCODER.encodeToString(bytes);
+        buffer.asFloatBuffer().put(vector);
+        return buffer.array();
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorDVLeafFieldDataTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -213,7 +214,7 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
         }
     }
 
-    public void testGetLeafValueFetcher_binaryFormat_returnsBase64String() throws IOException {
+    public void testGetLeafValueFetcher_binaryFormat_returnsByteArray() throws IOException {
         KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
             leafReaderContext.reader(),
             MOCK_INDEX_FIELD_NAME,
@@ -225,15 +226,13 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
         assertTrue(leaf.advanceExact(0));
         assertEquals(1, leaf.docValueCount());
         Object value = leaf.nextValue();
-        assertTrue(value instanceof String);
-        String base64 = (String) value;
-
-        // Decode and verify
-        byte[] decoded = java.util.Base64.getDecoder().decode(base64);
-        assertEquals(SAMPLE_VECTOR_1.length * Float.BYTES, decoded.length);
-        ByteBuffer buffer = ByteBuffer.wrap(decoded).order(ByteOrder.LITTLE_ENDIAN);
+        // Returns byte[] (little-endian floats) which XContentBuilder will base64-encode during serialization
+        assertTrue("Binary format for float vector should return byte[]", value instanceof byte[]);
+        byte[] bytes = (byte[]) value;
+        assertEquals("Byte array length should be dimension * 4", SAMPLE_VECTOR_1.length * Float.BYTES, bytes.length);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < SAMPLE_VECTOR_1.length; i++) {
-            assertEquals(SAMPLE_VECTOR_1[i], buffer.getFloat(), 0.001f);
+            assertEquals("Value mismatch at index " + i, SAMPLE_VECTOR_1[i], buffer.getFloat(), 0.001f);
         }
     }
 
@@ -274,43 +273,162 @@ public class KNNVectorDVLeafFieldDataTests extends KNNTestCase {
             assertTrue("advanceExact should succeed for doc " + docId, leaf.advanceExact(docId));
             assertEquals("docValueCount should be 1 for doc " + docId, 1, leaf.docValueCount());
             Object value = leaf.nextValue();
-            assertTrue("Binary format should produce a String for doc " + docId, value instanceof String);
+            assertTrue("Binary format should produce a byte[] for doc " + docId, value instanceof byte[]);
 
-            byte[] decoded = java.util.Base64.getDecoder().decode((String) value);
-            assertEquals("Decoded byte length mismatch for doc " + docId, ALL_VECTORS[docId].length * Float.BYTES, decoded.length);
-            ByteBuffer buffer = ByteBuffer.wrap(decoded).order(ByteOrder.LITTLE_ENDIAN);
+            byte[] bytes = (byte[]) value;
+            assertEquals("Byte array length mismatch for doc " + docId, ALL_VECTORS[docId].length * Float.BYTES, bytes.length);
+            ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
             for (int i = 0; i < ALL_VECTORS[docId].length; i++) {
                 assertEquals("Value mismatch at index " + i + " for doc " + docId, ALL_VECTORS[docId][i], buffer.getFloat(), 0.001f);
             }
         }
     }
 
-    public void testGetLeafValueFetcher_byteVectorDataType_throwsUnsupportedOp() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
-            leafReaderContext.reader(),
-            MOCK_INDEX_FIELD_NAME,
-            VectorDataType.BYTE
-        );
-        UnsupportedOperationException ex = expectThrows(
-            UnsupportedOperationException.class,
-            () -> leafFieldData.getLeafValueFetcher(KNNVectorDocValueFormat.ARRAY_FORMAT)
-        );
-        assertTrue(ex.getMessage().contains("docvalue_fields is not supported"));
-        assertTrue(ex.getMessage().contains("BYTE"));
+    public void testGetLeafValueFetcher_byteVector_arrayFormat_returnsCorrectValues() throws IOException {
+        byte[] byteVector1 = new byte[] { 1, -3, 127, -128 };
+        byte[] byteVector2 = new byte[] { 0, 50, -50, 100 };
+
+        try (Directory byteVectorDir = newDirectory()) {
+            IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+            try (IndexWriter writer = new IndexWriter(byteVectorDir, conf)) {
+                Document doc1 = new Document();
+                doc1.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, byteVector1, VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc1);
+
+                Document doc2 = new Document();
+                doc2.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, byteVector2, VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc2);
+                writer.commit();
+            }
+
+            try (DirectoryReader byteReader = DirectoryReader.open(byteVectorDir)) {
+                LeafReaderContext ctx = byteReader.getContext().leaves().get(0);
+                KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+                    ctx.reader(),
+                    MOCK_INDEX_FIELD_NAME,
+                    VectorDataType.BYTE
+                );
+                DocValueFetcher.Leaf leaf = leafFieldData.getLeafValueFetcher(KNNVectorDocValueFormat.ARRAY_FORMAT);
+
+                assertTrue("advanceExact should succeed for doc 0", leaf.advanceExact(0));
+                assertEquals(1, leaf.docValueCount());
+                Object value0 = leaf.nextValue();
+                assertTrue("Array format for byte vector should return int[]", value0 instanceof int[]);
+                assertArrayEquals("Byte vector mismatch for doc 0", new int[] { 1, -3, 127, -128 }, (int[]) value0);
+
+                assertTrue("advanceExact should succeed for doc 1", leaf.advanceExact(1));
+                assertEquals(1, leaf.docValueCount());
+                Object value1 = leaf.nextValue();
+                assertTrue("Array format for byte vector should return int[]", value1 instanceof int[]);
+                assertArrayEquals("Byte vector mismatch for doc 1", new int[] { 0, 50, -50, 100 }, (int[]) value1);
+            }
+        }
     }
 
-    public void testGetLeafValueFetcher_binaryVectorDataType_throwsUnsupportedOp() {
-        KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
-            leafReaderContext.reader(),
-            MOCK_INDEX_FIELD_NAME,
-            VectorDataType.BINARY
-        );
-        UnsupportedOperationException ex = expectThrows(
-            UnsupportedOperationException.class,
-            () -> leafFieldData.getLeafValueFetcher(KNNVectorDocValueFormat.ARRAY_FORMAT)
-        );
-        assertTrue(ex.getMessage().contains("docvalue_fields is not supported"));
-        assertTrue(ex.getMessage().contains("BINARY"));
+    public void testGetLeafValueFetcher_byteVector_binaryFormat_returnsByteArray() throws IOException {
+        byte[] byteVector = new byte[] { 10, 20, -30, 40 };
+
+        try (Directory byteVectorDir = newDirectory()) {
+            IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+            try (IndexWriter writer = new IndexWriter(byteVectorDir, conf)) {
+                Document doc = new Document();
+                doc.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, byteVector, VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+                writer.commit();
+            }
+
+            try (DirectoryReader byteReader = DirectoryReader.open(byteVectorDir)) {
+                LeafReaderContext ctx = byteReader.getContext().leaves().get(0);
+                KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+                    ctx.reader(),
+                    MOCK_INDEX_FIELD_NAME,
+                    VectorDataType.BYTE
+                );
+                DocValueFetcher.Leaf leaf = leafFieldData.getLeafValueFetcher(KNNVectorDocValueFormat.BINARY_FORMAT);
+
+                assertTrue("advanceExact should succeed for doc 0", leaf.advanceExact(0));
+                assertEquals(1, leaf.docValueCount());
+                Object value = leaf.nextValue();
+                // Returns byte[] which XContentBuilder will base64-encode during serialization
+                assertTrue("Binary format for byte vector should return byte[]", value instanceof byte[]);
+                assertArrayEquals("Byte vector should match original", byteVector, (byte[]) value);
+            }
+        }
+    }
+
+    public void testGetLeafValueFetcher_binaryVector_arrayFormat_returnsCorrectValues() throws IOException {
+        // Binary vectors: dimension is in bits, stored as byte[dimension/8]
+        byte[] binaryVector1 = new byte[] { (byte) 0b10101010, (byte) 0b01010101 }; // 16 bits
+        byte[] binaryVector2 = new byte[] { (byte) 0xFF, (byte) 0x00 };
+
+        try (Directory binaryVectorDir = newDirectory()) {
+            IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+            try (IndexWriter writer = new IndexWriter(binaryVectorDir, conf)) {
+                Document doc1 = new Document();
+                doc1.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, binaryVector1, VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc1);
+
+                Document doc2 = new Document();
+                doc2.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, binaryVector2, VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc2);
+                writer.commit();
+            }
+
+            try (DirectoryReader binaryReader = DirectoryReader.open(binaryVectorDir)) {
+                LeafReaderContext ctx = binaryReader.getContext().leaves().get(0);
+                KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+                    ctx.reader(),
+                    MOCK_INDEX_FIELD_NAME,
+                    VectorDataType.BINARY
+                );
+                DocValueFetcher.Leaf leaf = leafFieldData.getLeafValueFetcher(KNNVectorDocValueFormat.ARRAY_FORMAT);
+
+                assertTrue("advanceExact should succeed for doc 0", leaf.advanceExact(0));
+                assertEquals(1, leaf.docValueCount());
+                Object value0 = leaf.nextValue();
+                assertTrue("Array format for binary vector should return int[]", value0 instanceof int[]);
+                int[] expected0 = new int[] { (byte) 0b10101010, (byte) 0b01010101 };
+                assertArrayEquals("Binary vector mismatch for doc 0", expected0, (int[]) value0);
+
+                assertTrue("advanceExact should succeed for doc 1", leaf.advanceExact(1));
+                assertEquals(1, leaf.docValueCount());
+                Object value1 = leaf.nextValue();
+                assertTrue("Array format for binary vector should return int[]", value1 instanceof int[]);
+                int[] expected1 = new int[] { (byte) 0xFF, (byte) 0x00 };
+                assertArrayEquals("Binary vector mismatch for doc 1", expected1, (int[]) value1);
+            }
+        }
+    }
+
+    public void testGetLeafValueFetcher_binaryVector_binaryFormat_returnsByteArray() throws IOException {
+        byte[] binaryVector = new byte[] { (byte) 0xAB, (byte) 0xCD, (byte) 0xEF, (byte) 0x01 };
+
+        try (Directory binaryVectorDir = newDirectory()) {
+            IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+            try (IndexWriter writer = new IndexWriter(binaryVectorDir, conf)) {
+                Document doc = new Document();
+                doc.add(new KnnByteVectorField(MOCK_INDEX_FIELD_NAME, binaryVector, VectorSimilarityFunction.EUCLIDEAN));
+                writer.addDocument(doc);
+                writer.commit();
+            }
+
+            try (DirectoryReader binaryReader = DirectoryReader.open(binaryVectorDir)) {
+                LeafReaderContext ctx = binaryReader.getContext().leaves().get(0);
+                KNNVectorDVLeafFieldData leafFieldData = new KNNVectorDVLeafFieldData(
+                    ctx.reader(),
+                    MOCK_INDEX_FIELD_NAME,
+                    VectorDataType.BINARY
+                );
+                DocValueFetcher.Leaf leaf = leafFieldData.getLeafValueFetcher(KNNVectorDocValueFormat.BINARY_FORMAT);
+
+                assertTrue("advanceExact should succeed for doc 0", leaf.advanceExact(0));
+                assertEquals(1, leaf.docValueCount());
+                Object value = leaf.nextValue();
+                // Returns byte[] which XContentBuilder will base64-encode during serialization
+                assertTrue("Binary format for binary vector should return byte[]", value instanceof byte[]);
+                assertArrayEquals("Binary vector should match original", binaryVector, (byte[]) value);
+            }
+        }
     }
 
     public void testGetLeafValueFetcher_fieldNotInSegment_returnsEmptyLeaf() throws IOException {

--- a/src/test/java/org/opensearch/knn/index/KNNVectorDocValueFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/KNNVectorDocValueFormatTests.java
@@ -12,7 +12,6 @@ import org.opensearch.knn.KNNTestCase;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Base64;
 
 public class KNNVectorDocValueFormatTests extends KNNTestCase {
 
@@ -88,27 +87,27 @@ public class KNNVectorDocValueFormatTests extends KNNTestCase {
         assertTrue("Error should list supported formats", ex.getMessage().contains("binary"));
     }
 
-    public void testEncodeToBinary() {
+    public void testFloatToLittleEndianBytes() {
         // Simple vector
         float[] vector = { 1.0f, 2.0f, 3.0f, 4.0f };
-        String encoded = KNNVectorDocValueFormat.encodeToBinary(vector);
-        assertNotNull("Encoded string should not be null", encoded);
-        assertFalse("Encoded string should not be empty", encoded.isEmpty());
-        assertDecodedVectorEquals("Simple vector", vector, encoded);
+        byte[] bytes = KNNVectorDocValueFormat.floatToLittleEndianBytes(vector);
+        assertNotNull("Byte array should not be null", bytes);
+        assertEquals("Byte array length should be dimension * 4", vector.length * Float.BYTES, bytes.length);
+        assertDecodedVectorEquals("Simple vector", vector, bytes);
 
         // Single element
         float[] single = { 42.5f };
-        assertDecodedVectorEquals("Single element vector", single, KNNVectorDocValueFormat.encodeToBinary(single));
+        assertDecodedVectorEquals("Single element vector", single, KNNVectorDocValueFormat.floatToLittleEndianBytes(single));
 
         // Negative and edge values
         float[] edgeCases = { -1.5f, -100.0f, 0.0f, Float.MAX_VALUE, Float.MIN_VALUE };
-        assertDecodedVectorEquals("Edge case vector", edgeCases, KNNVectorDocValueFormat.encodeToBinary(edgeCases));
+        assertDecodedVectorEquals("Edge case vector", edgeCases, KNNVectorDocValueFormat.floatToLittleEndianBytes(edgeCases));
 
         // Empty vector
         float[] empty = {};
-        String emptyEncoded = KNNVectorDocValueFormat.encodeToBinary(empty);
-        assertNotNull("Empty vector encoding should not be null", emptyEncoded);
-        assertEquals("Empty vector should decode to 0 bytes", 0, Base64.getDecoder().decode(emptyEncoded).length);
+        byte[] emptyBytes = KNNVectorDocValueFormat.floatToLittleEndianBytes(empty);
+        assertNotNull("Empty vector encoding should not be null", emptyBytes);
+        assertEquals("Empty vector should produce 0 bytes", 0, emptyBytes.length);
 
         // High dimension (768d)
         int dimension = 768;
@@ -116,23 +115,23 @@ public class KNNVectorDocValueFormatTests extends KNNTestCase {
         for (int i = 0; i < dimension; i++) {
             highDim[i] = i * 0.01f;
         }
-        assertDecodedVectorEquals("768d vector", highDim, KNNVectorDocValueFormat.encodeToBinary(highDim));
+        assertDecodedVectorEquals("768d vector", highDim, KNNVectorDocValueFormat.floatToLittleEndianBytes(highDim));
     }
 
-    public void testEncodeToBinary_nullVector_throwsNPE() {
-        expectThrows(NullPointerException.class, () -> KNNVectorDocValueFormat.encodeToBinary(null));
+    public void testFloatToLittleEndianBytes_nullVector_throwsNPE() {
+        expectThrows(NullPointerException.class, () -> KNNVectorDocValueFormat.floatToLittleEndianBytes(null));
     }
 
-    public void testEncodeToBinary_usesLittleEndian() {
+    public void testFloatToLittleEndianBytes_usesLittleEndian() {
         float[] vector = { 1.0f };
-        byte[] decoded = Base64.getDecoder().decode(KNNVectorDocValueFormat.encodeToBinary(vector));
+        byte[] bytes = KNNVectorDocValueFormat.floatToLittleEndianBytes(vector);
 
         // 1.0f in IEEE 754 is 0x3F800000
         // Little-endian: 0x00, 0x00, 0x80, 0x3F
-        assertEquals("Byte 0 should be 0x00 (little-endian)", (byte) 0x00, decoded[0]);
-        assertEquals("Byte 1 should be 0x00 (little-endian)", (byte) 0x00, decoded[1]);
-        assertEquals("Byte 2 should be 0x80 (little-endian)", (byte) 0x80, decoded[2]);
-        assertEquals("Byte 3 should be 0x3F (little-endian)", (byte) 0x3F, decoded[3]);
+        assertEquals("Byte 0 should be 0x00 (little-endian)", (byte) 0x00, bytes[0]);
+        assertEquals("Byte 1 should be 0x00 (little-endian)", (byte) 0x00, bytes[1]);
+        assertEquals("Byte 2 should be 0x80 (little-endian)", (byte) 0x80, bytes[2]);
+        assertEquals("Byte 3 should be 0x3F (little-endian)", (byte) 0x3F, bytes[3]);
     }
 
     public void testToString() {
@@ -140,11 +139,10 @@ public class KNNVectorDocValueFormatTests extends KNNTestCase {
         assertEquals("BINARY_FORMAT toString mismatch", "knn_vector(binary)", KNNVectorDocValueFormat.BINARY_FORMAT.toString());
     }
 
-    private void assertDecodedVectorEquals(String label, float[] expected, String base64Encoded) {
-        byte[] decoded = Base64.getDecoder().decode(base64Encoded);
-        assertEquals(label + ": decoded byte length mismatch", expected.length * Float.BYTES, decoded.length);
+    private void assertDecodedVectorEquals(String label, float[] expected, byte[] bytes) {
+        assertEquals(label + ": byte length mismatch", expected.length * Float.BYTES, bytes.length);
 
-        ByteBuffer buffer = ByteBuffer.wrap(decoded).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
         for (int i = 0; i < expected.length; i++) {
             assertEquals(label + ": value mismatch at index " + i, expected[i], buffer.getFloat(), 0.0f);
         }

--- a/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
@@ -622,13 +622,16 @@ public class DocValueFieldsIT extends KNNRestTestCase {
     }
 
     /**
-     * Verifies that requesting docvalue_fields on a BYTE vector field throws an error
-     * for both Faiss and Lucene engines, since only FLOAT vectors are supported.
+     * Verifies that docvalue_fields with array format on BYTE vector fields returns correct
+     * integer arrays for both Faiss and Lucene engines.
      */
     @SneakyThrows
-    public void testDocValueFields_byteVectorField_throwsError() {
+    public void testDocValueFields_byteVectorField_arrayFormat_returnsIntegerArray() {
+        Byte[] byteVector1 = { 1, -2, 127, -128 };
+        Byte[] byteVector2 = { 0, 50, -50, 100 };
+
         for (KNNEngine engine : List.of(KNNEngine.FAISS, KNNEngine.LUCENE)) {
-            String indexName = TEST_INDEX + "_byte_" + engine.getName();
+            String indexName = TEST_INDEX + "_byte_array_" + engine.getName();
             KNNJsonIndexMappingsBuilder.Method method = KNNJsonIndexMappingsBuilder.Method.builder()
                 .methodName(METHOD_HNSW)
                 .spaceType(SpaceType.L2.getValue())
@@ -644,7 +647,8 @@ public class DocValueFieldsIT extends KNNRestTestCase {
                 .getIndexMapping();
 
             createKnnIndex(indexName, mapping);
-            addKnnDoc(indexName, "1", VECTOR_FIELD, new Byte[] { 1, 2, 3, 4 });
+            addKnnDoc(indexName, "1", VECTOR_FIELD, byteVector1);
+            addKnnDoc(indexName, "2", VECTOR_FIELD, byteVector2);
             refreshIndex(indexName);
 
             String query = XContentFactory.jsonBuilder()
@@ -660,26 +664,107 @@ public class DocValueFieldsIT extends KNNRestTestCase {
                 .endObject()
                 .endArray()
                 .field("_source", false)
+                .startObject("sort")
+                .field("_id", "asc")
+                .endObject()
                 .endObject()
                 .toString();
 
-            ResponseException ex = expectThrows(ResponseException.class, () -> searchKNNIndex(indexName, query, 1));
-            assertTrue("Expected error for engine " + engine.getName(), ex.getMessage().contains("docvalue_fields is not supported"));
-            assertTrue("Expected BYTE in error for engine " + engine.getName(), ex.getMessage().contains("BYTE"));
+            Response response = searchKNNIndex(indexName, query, 10);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<Map<String, Object>> hits = parseSearchHits(responseBody);
+
+            assertEquals("[" + engine.getName() + "] Expected 2 hits", 2, hits.size());
+
+            List<List<Integer>> dvField1 = getIntDocValueField(hits.get(0), VECTOR_FIELD);
+            assertNotNull("[" + engine.getName() + "] doc 1 should have vector", dvField1);
+            assertEquals(1, dvField1.size());
+            assertByteVectorEquals("[" + engine.getName() + "] doc 1", byteVector1, dvField1.get(0));
+
+            List<List<Integer>> dvField2 = getIntDocValueField(hits.get(1), VECTOR_FIELD);
+            assertNotNull("[" + engine.getName() + "] doc 2 should have vector", dvField2);
+            assertEquals(1, dvField2.size());
+            assertByteVectorEquals("[" + engine.getName() + "] doc 2", byteVector2, dvField2.get(0));
 
             deleteKNNIndex(indexName);
         }
     }
 
     /**
-     * Verifies that requesting docvalue_fields on a BINARY vector field throws an error
-     * for both Faiss and Lucene engines, since only FLOAT vectors are supported.
+     * Verifies that docvalue_fields with binary (base64) format on BYTE vector fields returns
+     * correct base64-encoded byte arrays for both Faiss and Lucene engines.
      */
     @SneakyThrows
-    public void testDocValueFields_binaryVectorField_throwsError() {
-        int binaryDimension = 8;
+    public void testDocValueFields_byteVectorField_binaryFormat_returnsBase64() {
+        Byte[] byteVector = { 10, -20, 127, -128 };
+
         for (KNNEngine engine : List.of(KNNEngine.FAISS, KNNEngine.LUCENE)) {
-            String indexName = TEST_INDEX + "_binary_" + engine.getName();
+            String indexName = TEST_INDEX + "_byte_binary_" + engine.getName();
+            KNNJsonIndexMappingsBuilder.Method method = KNNJsonIndexMappingsBuilder.Method.builder()
+                .methodName(METHOD_HNSW)
+                .spaceType(SpaceType.L2.getValue())
+                .engine(engine.getName())
+                .build();
+
+            String mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.BYTE.getValue())
+                .method(method)
+                .build()
+                .getIndexMapping();
+
+            createKnnIndex(indexName, mapping);
+            addKnnDoc(indexName, "1", VECTOR_FIELD, byteVector);
+            refreshIndex(indexName);
+
+            String query = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("match_all")
+                .endObject()
+                .endObject()
+                .startArray("docvalue_fields")
+                .startObject()
+                .field("field", VECTOR_FIELD)
+                .field("format", "binary")
+                .endObject()
+                .endArray()
+                .field("_source", false)
+                .endObject()
+                .toString();
+
+            Response response = searchKNNIndex(indexName, query, 1);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<Map<String, Object>> hits = parseSearchHits(responseBody);
+
+            assertEquals(1, hits.size());
+            List<String> binaryValues = getBinaryDocValueField(hits.get(0), VECTOR_FIELD);
+            assertNotNull("[" + engine.getName() + "] binary field should not be null", binaryValues);
+            assertEquals(1, binaryValues.size());
+
+            byte[] decoded = Base64.getDecoder().decode(binaryValues.get(0));
+            assertEquals("[" + engine.getName() + "] decoded length mismatch", byteVector.length, decoded.length);
+            for (int i = 0; i < byteVector.length; i++) {
+                assertEquals("[" + engine.getName() + "] byte mismatch at index " + i, byteVector[i].byteValue(), decoded[i]);
+            }
+
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    /**
+     * Verifies that docvalue_fields with array format on BINARY vector fields returns correct
+     * integer arrays for both Faiss and Lucene engines.
+     */
+    @SneakyThrows
+    public void testDocValueFields_binaryVectorField_arrayFormat_returnsIntegerArray() {
+        int binaryDimension = 8; // 8 bits = 1 byte
+        Byte[] binaryVector1 = { -86 }; // 0xAA = 10101010
+        Byte[] binaryVector2 = { 85 };  // 0x55 = 01010101
+
+        for (KNNEngine engine : List.of(KNNEngine.FAISS, KNNEngine.LUCENE)) {
+            String indexName = TEST_INDEX + "_binary_array_" + engine.getName();
             KNNJsonIndexMappingsBuilder.Method method = KNNJsonIndexMappingsBuilder.Method.builder()
                 .methodName(METHOD_HNSW)
                 .engine(engine.getName())
@@ -694,7 +779,8 @@ public class DocValueFieldsIT extends KNNRestTestCase {
                 .getIndexMapping();
 
             createKnnIndex(indexName, mapping);
-            addKnnDoc(indexName, "1", VECTOR_FIELD, new Byte[] { 42 });
+            addKnnDoc(indexName, "1", VECTOR_FIELD, binaryVector1);
+            addKnnDoc(indexName, "2", VECTOR_FIELD, binaryVector2);
             refreshIndex(indexName);
 
             String query = XContentFactory.jsonBuilder()
@@ -710,12 +796,88 @@ public class DocValueFieldsIT extends KNNRestTestCase {
                 .endObject()
                 .endArray()
                 .field("_source", false)
+                .startObject("sort")
+                .field("_id", "asc")
+                .endObject()
                 .endObject()
                 .toString();
 
-            ResponseException ex = expectThrows(ResponseException.class, () -> searchKNNIndex(indexName, query, 1));
-            assertTrue("Expected error for engine " + engine.getName(), ex.getMessage().contains("docvalue_fields is not supported"));
-            assertTrue("Expected BINARY in error for engine " + engine.getName(), ex.getMessage().contains("BINARY"));
+            Response response = searchKNNIndex(indexName, query, 10);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<Map<String, Object>> hits = parseSearchHits(responseBody);
+
+            assertEquals("[" + engine.getName() + "] Expected 2 hits", 2, hits.size());
+
+            List<List<Integer>> dvField1 = getIntDocValueField(hits.get(0), VECTOR_FIELD);
+            assertNotNull("[" + engine.getName() + "] doc 1 should have vector", dvField1);
+            assertByteVectorEquals("[" + engine.getName() + "] doc 1", binaryVector1, dvField1.get(0));
+
+            List<List<Integer>> dvField2 = getIntDocValueField(hits.get(1), VECTOR_FIELD);
+            assertNotNull("[" + engine.getName() + "] doc 2 should have vector", dvField2);
+            assertByteVectorEquals("[" + engine.getName() + "] doc 2", binaryVector2, dvField2.get(0));
+
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    /**
+     * Verifies that docvalue_fields with binary (base64) format on BINARY vector fields returns
+     * correct base64-encoded byte arrays for both Faiss and Lucene engines.
+     */
+    @SneakyThrows
+    public void testDocValueFields_binaryVectorField_binaryFormat_returnsBase64() {
+        int binaryDimension = 8;
+        Byte[] binaryVector = { 42 };
+
+        for (KNNEngine engine : List.of(KNNEngine.FAISS, KNNEngine.LUCENE)) {
+            String indexName = TEST_INDEX + "_binary_b64_" + engine.getName();
+            KNNJsonIndexMappingsBuilder.Method method = KNNJsonIndexMappingsBuilder.Method.builder()
+                .methodName(METHOD_HNSW)
+                .engine(engine.getName())
+                .build();
+
+            String mapping = KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(binaryDimension)
+                .vectorDataType(VectorDataType.BINARY.getValue())
+                .method(method)
+                .build()
+                .getIndexMapping();
+
+            createKnnIndex(indexName, mapping);
+            addKnnDoc(indexName, "1", VECTOR_FIELD, binaryVector);
+            refreshIndex(indexName);
+
+            String query = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("match_all")
+                .endObject()
+                .endObject()
+                .startArray("docvalue_fields")
+                .startObject()
+                .field("field", VECTOR_FIELD)
+                .field("format", "binary")
+                .endObject()
+                .endArray()
+                .field("_source", false)
+                .endObject()
+                .toString();
+
+            Response response = searchKNNIndex(indexName, query, 1);
+            String responseBody = EntityUtils.toString(response.getEntity());
+            List<Map<String, Object>> hits = parseSearchHits(responseBody);
+
+            assertEquals(1, hits.size());
+            List<String> binaryValues = getBinaryDocValueField(hits.get(0), VECTOR_FIELD);
+            assertNotNull("[" + engine.getName() + "] binary field should not be null", binaryValues);
+            assertEquals(1, binaryValues.size());
+
+            byte[] decoded = Base64.getDecoder().decode(binaryValues.get(0));
+            assertEquals("[" + engine.getName() + "] decoded length mismatch", binaryVector.length, decoded.length);
+            for (int i = 0; i < binaryVector.length; i++) {
+                assertEquals("[" + engine.getName() + "] byte mismatch at index " + i, binaryVector[i].byteValue(), decoded[i]);
+            }
 
             deleteKNNIndex(indexName);
         }
@@ -1680,6 +1842,21 @@ public class DocValueFieldsIT extends KNNRestTestCase {
         Map<String, Object> fields = (Map<String, Object>) hit.get("fields");
         if (fields == null) return null;
         return (List<String>) fields.get(fieldName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<List<Integer>> getIntDocValueField(Map<String, Object> hit, String fieldName) {
+        Map<String, Object> fields = (Map<String, Object>) hit.get("fields");
+        if (fields == null) return null;
+        return (List<List<Integer>>) fields.get(fieldName);
+    }
+
+    private void assertByteVectorEquals(String label, Byte[] expected, List<Integer> actual) {
+        assertNotNull(label + " vector should not be null", actual);
+        assertEquals(label + " dimension mismatch", expected.length, actual.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(label + " value mismatch at index " + i, expected[i].intValue(), actual.get(i).intValue());
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description
Add support for binary and byte field support in doc_values (#3340)

This PR somehow got missed since the original PR was not merged on time even when required approvals were there. :( 

Backport of : https://github.com/opensearch-project/k-NN/pull/3340

### Related Issues
NA
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
