### PR TITLE
Add base64 encoded vector indexing support for knn_vector fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,16 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 3.7](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
+## [Unreleased 3.8](https://github.com/opensearch-project/k-NN/compare/main...HEAD)
 ### Features
-* Add debug mode to MMR rerank that injects per-hit scoring details (original_score, max_similarity_to_selected, mmr_score, mmr_formula) into _source via the `debug` flag in the mmr search extension [#3254](https://github.com/opensearch-project/k-NN/pull/3254)
-* Support derived source for knn with other fields [#3260](https://github.com/opensearch-project/k-NN/pull/3260)
-* Added support for 1 bit SQ with remote build [#3270](https://github.com/opensearch-project/k-NN/pull/3270)
 * Add rescoring phase after radial search on quantized index [#3347](https://github.com/opensearch-project/k-NN/pull/3347)
+* Add base64 encoded vector indexing support for knn_vector fields [#3350](https://github.com/opensearch-project/k-NN/pull/3350)
 
 ### Maintenance
-* Update Gradle wrapper to 9.4.1 and Jacoco to 0.8.14 to match core OpenSearch [#3308](https://github.com/opensearch-project/k-NN/pull/3308)
 
 ### Bug Fixes
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
-* Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable prefetch [#3302](https://github.com/opensearch-project/k-NN/pull/3302)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
-* Fix score to radius conversion for IP with faiss [#3336](https://github.com/opensearch-project/k-NN/pull/3336)
 * Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)
 
 
@@ -26,7 +21,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ### Enhancements
-* Add the bulkscore logic in MOS when K is greater than number of docs in segment [#3285](https://github.com/opensearch-project/k-NN/pull/3285)
-* Added capability to retrieve float data type vectors using doc_values [#3321](https://github.com/opensearch-project/k-NN/pull/3321)
-* Add base64 binary encoding as default format for knn_vector docvalue_fields [#3324](https://github.com/opensearch-project/k-NN/pull/3324)
-* Add support for binary and byte field support in doc_values [#3340](https://github.com/opensearch-project/k-NN/pull/3340)

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -6,8 +6,11 @@
 package org.opensearch.knn.index.mapper;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -73,6 +76,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
 
     public static final String CONTENT_TYPE = "knn_vector";
     public static final String KNN_FIELD = "knn_field";
+    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
 
     private static KNNVectorFieldMapper toType(FieldMapper in) {
         return (KNNVectorFieldMapper) in;
@@ -832,6 +836,21 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             perDimensionValidator.validateByte(value);
             vector.add((byte) value);
             context.parser().nextToken();
+        } else if (token == XContentParser.Token.VALUE_STRING) {
+            final byte[] decoded;
+            try {
+                decoded = BASE64_DECODER.decode(context.parser().text());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Invalid base64 encoding for vector field [%s]: %s", name(), e.getMessage()),
+                    e
+                );
+            }
+            validateVectorDimension(dimension, decoded.length, dataType);
+            // Per-dimension validation is intentionally skipped: base64-decoded bytes are inherently
+            // in [-128, 127] range, cannot be NaN/Inf, and have no decimal component — all checks
+            // that validateByte() performs are satisfied by construction for raw byte values.
+            return Optional.of(decoded);
         } else if (token == XContentParser.Token.VALUE_NULL) {
             context.path().remove();
             return Optional.empty();
@@ -867,6 +886,36 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
             perDimensionValidator.validate(value);
             vector.add(value);
             context.parser().nextToken();
+        } else if (token == XContentParser.Token.VALUE_STRING) {
+            final byte[] decoded;
+            try {
+                decoded = BASE64_DECODER.decode(context.parser().text());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Invalid base64 encoding for vector field [%s]: %s", name(), e.getMessage()),
+                    e
+                );
+            }
+            if (decoded.length % Float.BYTES != 0) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "Base64 encoded vector for field [%s] has invalid byte length [%d], must be a multiple of %d (float size)",
+                        name(),
+                        decoded.length,
+                        Float.BYTES
+                    )
+                );
+            }
+            int numFloats = decoded.length / Float.BYTES;
+            validateVectorDimension(dimension, numFloats, vectorDataType);
+            final float[] array = new float[numFloats];
+            ByteBuffer.wrap(decoded).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(array);
+            for (int idx = 0; idx < numFloats; idx++) {
+                array[idx] = perDimensionProcessor.process(array[idx]);
+                perDimensionValidator.validate(array[idx]);
+            }
+            return Optional.of(array);
         } else if (token == XContentParser.Token.VALUE_NULL) {
             context.path().remove();
             return Optional.empty();

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -2865,6 +2865,168 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         return xContentBuilder;
     }
 
+    public void testBase64Indexing_allDataTypes_parsesCorrectly() throws IOException {
+        // --- Float ---
+        float[] expectedFloat = TEST_VECTOR;
+        java.nio.ByteBuffer buffer = java.nio.ByteBuffer.allocate(expectedFloat.length * Float.BYTES)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        buffer.asFloatBuffer().put(expectedFloat);
+        String floatBase64 = java.util.Base64.getEncoder().encodeToString(buffer.array());
+
+        EngineFieldMapper floatMapper = createFieldMapperForBase64Test(VectorDataType.FLOAT, TEST_DIMENSION);
+        ParseContext floatCtx = createParseContextForBase64(floatBase64);
+        Optional<float[]> floatResult = floatMapper.getFloatsFromContext(floatCtx, TEST_DIMENSION);
+        assertTrue("Float base64 should parse", floatResult.isPresent());
+        assertArrayEquals(expectedFloat, floatResult.get(), 0.0f);
+
+        // --- Byte ---
+        byte[] expectedByte = TEST_BYTE_VECTOR;
+        String byteBase64 = java.util.Base64.getEncoder().encodeToString(expectedByte);
+
+        EngineFieldMapper byteMapper = createFieldMapperForBase64Test(VectorDataType.BYTE, TEST_DIMENSION);
+        ParseContext byteCtx = createParseContextForBase64(byteBase64);
+        Optional<byte[]> byteResult = byteMapper.getBytesFromContext(byteCtx, TEST_DIMENSION, VectorDataType.BYTE);
+        assertTrue("Byte base64 should parse", byteResult.isPresent());
+        assertArrayEquals(expectedByte, byteResult.get());
+
+        // --- Binary (dimension = bits, so dimension 8*TEST_DIMENSION needs TEST_DIMENSION bytes) ---
+        int binaryDimension = TEST_DIMENSION * Byte.SIZE;
+        byte[] expectedBinary = TEST_BYTE_VECTOR;
+        String binaryBase64 = java.util.Base64.getEncoder().encodeToString(expectedBinary);
+
+        EngineFieldMapper binaryMapper = createFieldMapperForBase64Test(VectorDataType.BINARY, binaryDimension);
+        ParseContext binaryCtx = createParseContextForBase64(binaryBase64);
+        Optional<byte[]> binaryResult = binaryMapper.getBytesFromContext(binaryCtx, binaryDimension, VectorDataType.BINARY);
+        assertTrue("Binary base64 should parse", binaryResult.isPresent());
+        assertArrayEquals(expectedBinary, binaryResult.get());
+    }
+
+    public void testBase64Indexing_invalidInput_throwsException() throws IOException {
+        // --- Float: byte length not multiple of 4 ---
+        String invalidFloatBase64 = java.util.Base64.getEncoder().encodeToString(new byte[] { 1, 2, 3 });
+        EngineFieldMapper floatMapper = createFieldMapperForBase64Test(VectorDataType.FLOAT, TEST_DIMENSION);
+        ParseContext floatCtx = createParseContextForBase64(invalidFloatBase64);
+        IllegalArgumentException floatEx = expectThrows(
+            IllegalArgumentException.class,
+            () -> floatMapper.getFloatsFromContext(floatCtx, TEST_DIMENSION)
+        );
+        assertTrue(floatEx.getMessage().contains("invalid byte length"));
+
+        // --- Byte: wrong dimension ---
+        byte[] wrongDimByteVector = new byte[TEST_DIMENSION + 1];
+        Arrays.fill(wrongDimByteVector, (byte) 5);
+        String wrongDimByteBase64 = java.util.Base64.getEncoder().encodeToString(wrongDimByteVector);
+        EngineFieldMapper byteMapper = createFieldMapperForBase64Test(VectorDataType.BYTE, TEST_DIMENSION);
+        ParseContext byteCtx = createParseContextForBase64(wrongDimByteBase64);
+        expectThrows(IllegalArgumentException.class, () -> byteMapper.getBytesFromContext(byteCtx, TEST_DIMENSION, VectorDataType.BYTE));
+
+        // --- Binary: wrong dimension (dimension=16 bits expects 2 bytes, provide 3) ---
+        int binaryDimension = 16;
+        byte[] wrongDimBinaryVector = new byte[] { 1, 2, 3 };
+        String wrongDimBinaryBase64 = java.util.Base64.getEncoder().encodeToString(wrongDimBinaryVector);
+        EngineFieldMapper binaryMapper = createFieldMapperForBase64Test(VectorDataType.BINARY, binaryDimension);
+        ParseContext binaryCtx = createParseContextForBase64(wrongDimBinaryBase64);
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> binaryMapper.getBytesFromContext(binaryCtx, binaryDimension, VectorDataType.BINARY)
+        );
+    }
+
+    public void testBase64Indexing_malformedBase64_throwsDescriptiveError() throws IOException {
+        String malformedBase64 = "not!valid@base64$$";
+
+        // Float path: malformed base64 should mention field name
+        EngineFieldMapper floatMapper = createFieldMapperForBase64Test(VectorDataType.FLOAT, TEST_DIMENSION);
+        ParseContext floatCtx = createParseContextForBase64(malformedBase64);
+        IllegalArgumentException floatEx = expectThrows(
+            IllegalArgumentException.class,
+            () -> floatMapper.getFloatsFromContext(floatCtx, TEST_DIMENSION)
+        );
+        assertTrue(floatEx.getMessage().contains("Invalid base64 encoding for vector field"));
+        assertTrue(floatEx.getMessage().contains(TEST_FIELD_NAME));
+        assertNotNull(floatEx.getCause());
+
+        // Byte path: malformed base64 should mention field name
+        EngineFieldMapper byteMapper = createFieldMapperForBase64Test(VectorDataType.BYTE, TEST_DIMENSION);
+        ParseContext byteCtx = createParseContextForBase64(malformedBase64);
+        IllegalArgumentException byteEx = expectThrows(
+            IllegalArgumentException.class,
+            () -> byteMapper.getBytesFromContext(byteCtx, TEST_DIMENSION, VectorDataType.BYTE)
+        );
+        assertTrue(byteEx.getMessage().contains("Invalid base64 encoding for vector field"));
+        assertTrue(byteEx.getMessage().contains(TEST_FIELD_NAME));
+        assertNotNull(byteEx.getCause());
+    }
+
+    private EngineFieldMapper createFieldMapperForBase64Test(VectorDataType dataType, int dimension) {
+        KNNMethodConfigContext knnMethodConfigContext = KNNMethodConfigContext.builder()
+            .vectorDataType(dataType)
+            .versionCreated(CURRENT)
+            .dimension(dimension)
+            .build();
+
+        KNNMethodContext luceneMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.DEFAULT,
+            new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
+        );
+
+        OriginalMappingParameters originalMappingParameters = new OriginalMappingParameters(
+            dataType,
+            dimension,
+            luceneMethodContext,
+            Mode.NOT_CONFIGURED.getName(),
+            CompressionLevel.NOT_CONFIGURED.getName(),
+            null,
+            SpaceType.UNDEFINED.getValue(),
+            KNNEngine.UNDEFINED.getName()
+        );
+        originalMappingParameters.setResolvedKnnMethodContext(originalMappingParameters.getKnnMethodContext());
+
+        return EngineFieldMapper.createFieldMapper(
+            TEST_FIELD_NAME,
+            TEST_FIELD_NAME,
+            Collections.emptyMap(),
+            knnMethodConfigContext,
+            FieldMapper.MultiFields.empty(),
+            FieldMapper.CopyTo.empty(),
+            new Explicit<>(true, true),
+            false,
+            true,
+            originalMappingParameters,
+            CURRENT
+        );
+    }
+
+    @SneakyThrows
+    private ParseContext createParseContextForBase64(String base64Value) {
+        XContentParser parser = createXContentParserForBase64(base64Value);
+        IndexSettings indexSettingsMock = mock(IndexSettings.class);
+        when(indexSettingsMock.getSettings()).thenReturn(Settings.EMPTY);
+        ParseContext.Document document = new ParseContext.Document();
+        ContentPath contentPath = new ContentPath();
+        ParseContext parseContext = mock(ParseContext.class);
+        when(parseContext.doc()).thenReturn(document);
+        when(parseContext.path()).thenReturn(contentPath);
+        when(parseContext.parser()).thenReturn(parser);
+        when(parseContext.indexSettings()).thenReturn(indexSettingsMock);
+        return parseContext;
+    }
+
+    @SneakyThrows
+    private XContentParser createXContentParserForBase64(final String base64Value) {
+        XContentParser parser = XContentHelper.createParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            new BytesArray("{\"" + TEST_FIELD_NAME + "\":\"" + base64Value + "\"}"),
+            MediaTypeRegistry.JSON
+        );
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        return parser;
+    }
+
     private static float[] createInitializedFloatArray(int dimension, float value) {
         float[] array = new float[dimension];
         Arrays.fill(array, value);

--- a/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
@@ -1738,6 +1738,406 @@ public class DocValueFieldsIT extends KNNRestTestCase {
 
     // Helper methods
 
+    /**
+     * Verifies that vectors of all data types (float, byte, binary) can be indexed as
+     * base64-encoded strings and correctly retrieved via docvalue_fields.
+     */
+    @SneakyThrows
+    public void testIndexing_base64String_allDataTypes_roundTrip() {
+        // --- Float: base64 little-endian floats ---
+        String floatIndex = TEST_INDEX + "_base64_float";
+        createKnnIndex(
+            floatIndex,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+                .method(
+                    KNNJsonIndexMappingsBuilder.Method.builder()
+                        .methodName(METHOD_HNSW)
+                        .spaceType(SpaceType.L2.getValue())
+                        .engine(KNNEngine.LUCENE.getName())
+                        .build()
+                )
+                .build()
+                .getIndexMapping()
+        );
+
+        ByteBuffer buffer = ByteBuffer.allocate(DIMENSION * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (float v : VECTOR_1) {
+            buffer.putFloat(v);
+        }
+        String floatBase64 = Base64.getEncoder().encodeToString(buffer.array());
+        Request floatReq = new Request("POST", "/" + floatIndex + "/_doc/1?refresh=true");
+        floatReq.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + floatBase64 + "\"}");
+        client().performRequest(floatReq);
+
+        Response floatResp = searchKNNIndex(floatIndex, buildArrayDocValueQuery(), 1);
+        List<Map<String, Object>> floatHits = parseSearchHits(EntityUtils.toString(floatResp.getEntity()));
+        assertEquals(1, floatHits.size());
+        List<List<Double>> floatDv = getDocValueField(floatHits.get(0), VECTOR_FIELD);
+        assertNotNull(floatDv);
+        for (int i = 0; i < DIMENSION; i++) {
+            assertEquals("Float mismatch at " + i, VECTOR_1[i], floatDv.get(0).get(i).floatValue(), 0.001f);
+        }
+        deleteKNNIndex(floatIndex);
+
+        // --- Byte: base64 raw bytes ---
+        String byteIndex = TEST_INDEX + "_base64_byte";
+        Byte[] byteVector = { 10, -20, 127, -128 };
+        createKnnIndex(
+            byteIndex,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.BYTE.getValue())
+                .method(
+                    KNNJsonIndexMappingsBuilder.Method.builder()
+                        .methodName(METHOD_HNSW)
+                        .spaceType(SpaceType.L2.getValue())
+                        .engine(KNNEngine.LUCENE.getName())
+                        .build()
+                )
+                .build()
+                .getIndexMapping()
+        );
+
+        byte[] byteRaw = { 10, -20, 127, -128 };
+        String byteBase64 = Base64.getEncoder().encodeToString(byteRaw);
+        Request byteReq = new Request("POST", "/" + byteIndex + "/_doc/1?refresh=true");
+        byteReq.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + byteBase64 + "\"}");
+        client().performRequest(byteReq);
+
+        Response byteResp = searchKNNIndex(byteIndex, buildArrayDocValueQuery(), 1);
+        List<Map<String, Object>> byteHits = parseSearchHits(EntityUtils.toString(byteResp.getEntity()));
+        assertEquals(1, byteHits.size());
+        List<List<Integer>> byteDv = getIntDocValueField(byteHits.get(0), VECTOR_FIELD);
+        assertNotNull(byteDv);
+        assertByteVectorEquals("Byte base64", byteVector, byteDv.get(0));
+        deleteKNNIndex(byteIndex);
+
+        // --- Binary: base64 raw bytes (dimension = bits, 32 bits = 4 bytes) ---
+        int binaryDimension = 32;
+        String binaryIndex = TEST_INDEX + "_base64_binary";
+        createKnnIndex(
+            binaryIndex,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(binaryDimension)
+                .vectorDataType(VectorDataType.BINARY.getValue())
+                .method(KNNJsonIndexMappingsBuilder.Method.builder().methodName(METHOD_HNSW).engine(KNNEngine.LUCENE.getName()).build())
+                .build()
+                .getIndexMapping()
+        );
+
+        byte[] binaryRaw = { 42, -86, 85, -1 };
+        Byte[] binaryVector = { 42, -86, 85, -1 };
+        String binaryBase64 = Base64.getEncoder().encodeToString(binaryRaw);
+        Request binaryReq = new Request("POST", "/" + binaryIndex + "/_doc/1?refresh=true");
+        binaryReq.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + binaryBase64 + "\"}");
+        client().performRequest(binaryReq);
+
+        Response binaryResp = searchKNNIndex(binaryIndex, buildArrayDocValueQuery(), 1);
+        List<Map<String, Object>> binaryHits = parseSearchHits(EntityUtils.toString(binaryResp.getEntity()));
+        assertEquals(1, binaryHits.size());
+        List<List<Integer>> binaryDv = getIntDocValueField(binaryHits.get(0), VECTOR_FIELD);
+        assertNotNull(binaryDv);
+        assertByteVectorEquals("Binary base64", binaryVector, binaryDv.get(0));
+        deleteKNNIndex(binaryIndex);
+    }
+
+    /**
+     * Verifies that indexing a float vector via base64 produces the same KNN search results
+     * as indexing via a JSON array. This confirms the vectors are stored identically.
+     */
+    @SneakyThrows
+    public void testIndexing_base64VsArray_sameKnnSearchResults() {
+        String indexName = TEST_INDEX + "_base64_vs_array";
+
+        createKnnIndex(
+            indexName,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+                .method(
+                    KNNJsonIndexMappingsBuilder.Method.builder()
+                        .methodName(METHOD_HNSW)
+                        .spaceType(SpaceType.L2.getValue())
+                        .engine(KNNEngine.LUCENE.getName())
+                        .build()
+                )
+                .build()
+                .getIndexMapping()
+        );
+
+        // Index doc 1 via JSON array
+        addKnnDoc(indexName, "1", VECTOR_FIELD, Floats.asList(VECTOR_1).toArray());
+
+        // Index doc 2 via base64 string (same vector as VECTOR_1)
+        ByteBuffer buffer = ByteBuffer.allocate(DIMENSION * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (float v : VECTOR_1) {
+            buffer.putFloat(v);
+        }
+        String base64Vector = Base64.getEncoder().encodeToString(buffer.array());
+        Request request = new Request("POST", "/" + indexName + "/_doc/2?refresh=true");
+        request.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + base64Vector + "\"}");
+        client().performRequest(request);
+
+        // Index doc 3 via JSON array (different vector)
+        addKnnDoc(indexName, "3", VECTOR_FIELD, Floats.asList(VECTOR_3).toArray());
+        refreshIndex(indexName);
+
+        // KNN search for VECTOR_1 should return doc 1 and doc 2 with same vectors
+        String query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(VECTOR_FIELD)
+            .field("vector", VECTOR_1)
+            .field("k", 3)
+            .endObject()
+            .endObject()
+            .endObject()
+            .startArray("docvalue_fields")
+            .startObject()
+            .field("field", VECTOR_FIELD)
+            .field("format", "array")
+            .endObject()
+            .endArray()
+            .field("_source", false)
+            .endObject()
+            .toString();
+
+        Response response = searchKNNIndex(indexName, query, 3);
+        List<Map<String, Object>> hits = parseSearchHits(EntityUtils.toString(response.getEntity()));
+        assertEquals(3, hits.size());
+
+        List<List<Double>> vec1 = getDocValueField(hits.get(0), VECTOR_FIELD);
+        List<List<Double>> vec2 = getDocValueField(hits.get(1), VECTOR_FIELD);
+        assertNotNull(vec1);
+        assertNotNull(vec2);
+        for (int i = 0; i < DIMENSION; i++) {
+            assertEquals("vec1 mismatch at " + i, VECTOR_1[i], vec1.get(0).get(i).floatValue(), 0.001f);
+            assertEquals("vec2 mismatch at " + i, VECTOR_1[i], vec2.get(0).get(i).floatValue(), 0.001f);
+        }
+
+        deleteKNNIndex(indexName);
+    }
+
+    /**
+     * Verifies that indexing invalid base64 strings results in errors for both float
+     * (not multiple of 4 bytes) and byte (wrong dimension) data types.
+     */
+    @SneakyThrows
+    public void testIndexing_invalidBase64_throwsError() {
+        // --- Float: 3 bytes is not a valid float vector (not multiple of 4) ---
+        String floatIndex = TEST_INDEX + "_base64_invalid_float";
+        createKnnIndex(
+            floatIndex,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+                .method(
+                    KNNJsonIndexMappingsBuilder.Method.builder()
+                        .methodName(METHOD_HNSW)
+                        .spaceType(SpaceType.L2.getValue())
+                        .engine(KNNEngine.LUCENE.getName())
+                        .build()
+                )
+                .build()
+                .getIndexMapping()
+        );
+
+        String invalidFloatBase64 = Base64.getEncoder().encodeToString(new byte[] { 1, 2, 3 });
+        Request floatReq = new Request("POST", "/" + floatIndex + "/_doc/1?refresh=true");
+        floatReq.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + invalidFloatBase64 + "\"}");
+        ResponseException floatEx = expectThrows(ResponseException.class, () -> client().performRequest(floatReq));
+        assertTrue(floatEx.getMessage().contains("invalid byte length"));
+        deleteKNNIndex(floatIndex);
+
+        // --- Byte: 5 bytes for dimension=4 is wrong ---
+        String byteIndex = TEST_INDEX + "_base64_invalid_byte";
+        createKnnIndex(
+            byteIndex,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.BYTE.getValue())
+                .method(
+                    KNNJsonIndexMappingsBuilder.Method.builder()
+                        .methodName(METHOD_HNSW)
+                        .spaceType(SpaceType.L2.getValue())
+                        .engine(KNNEngine.LUCENE.getName())
+                        .build()
+                )
+                .build()
+                .getIndexMapping()
+        );
+
+        String invalidByteBase64 = Base64.getEncoder().encodeToString(new byte[] { 1, 2, 3, 4, 5 });
+        Request byteReq = new Request("POST", "/" + byteIndex + "/_doc/1?refresh=true");
+        byteReq.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + invalidByteBase64 + "\"}");
+        ResponseException byteEx = expectThrows(ResponseException.class, () -> client().performRequest(byteReq));
+        assertTrue(byteEx.getMessage().contains("mismatch"));
+        deleteKNNIndex(byteIndex);
+
+        // --- Binary: dimension=32 bits expects 4 bytes, provide 3 ---
+        int binaryDimension = 32;
+        String binaryIndex = TEST_INDEX + "_base64_invalid_binary";
+        createKnnIndex(
+            binaryIndex,
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(binaryDimension)
+                .vectorDataType(VectorDataType.BINARY.getValue())
+                .method(KNNJsonIndexMappingsBuilder.Method.builder().methodName(METHOD_HNSW).engine(KNNEngine.LUCENE.getName()).build())
+                .build()
+                .getIndexMapping()
+        );
+
+        String invalidBinaryBase64 = Base64.getEncoder().encodeToString(new byte[] { 1, 2, 3 });
+        Request binaryReq = new Request("POST", "/" + binaryIndex + "/_doc/1?refresh=true");
+        binaryReq.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + invalidBinaryBase64 + "\"}");
+        ResponseException binaryEx = expectThrows(ResponseException.class, () -> client().performRequest(binaryReq));
+        assertTrue(binaryEx.getMessage().contains("must be 8 times"));
+        deleteKNNIndex(binaryIndex);
+    }
+
+    /**
+     * Verifies base64 indexing end-to-end: ingest 10 docs via base64, reindex to a second index,
+     * update vectors via update_by_query on both indices, and validate all docs in the search
+     * response from both indices after each operation.
+     */
+    @SneakyThrows
+    public void testIndexing_base64_reindexAndUpdateByQuery() {
+        String sourceIndex = TEST_INDEX + "_base64_reindex_src";
+        String destIndex = TEST_INDEX + "_base64_reindex_dest";
+        int numDocs = 10;
+
+        String mapping = KNNJsonIndexMappingsBuilder.builder()
+            .fieldName(VECTOR_FIELD)
+            .dimension(DIMENSION)
+            .vectorDataType(VectorDataType.FLOAT.getValue())
+            .method(
+                KNNJsonIndexMappingsBuilder.Method.builder()
+                    .methodName(METHOD_HNSW)
+                    .spaceType(SpaceType.L2.getValue())
+                    .engine(KNNEngine.FAISS.getName())
+                    .build()
+            )
+            .build()
+            .getIndexMapping();
+
+        createKnnIndex(sourceIndex, mapping);
+
+        // Ingest 10 docs via base64
+        float[][] vectors = new float[numDocs][DIMENSION];
+        for (int i = 0; i < numDocs; i++) {
+            for (int d = 0; d < DIMENSION; d++) {
+                vectors[i][d] = (i + 1) * (d + 1) * 0.1f;
+            }
+            ByteBuffer buffer = ByteBuffer.allocate(DIMENSION * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+            for (float v : vectors[i]) {
+                buffer.putFloat(v);
+            }
+            String base64 = Base64.getEncoder().encodeToString(buffer.array());
+            Request req = new Request("POST", "/" + sourceIndex + "/_doc/" + i + "?refresh=true");
+            req.setJsonEntity("{\"" + VECTOR_FIELD + "\":\"" + base64 + "\"}");
+            client().performRequest(req);
+        }
+        refreshIndex(sourceIndex);
+
+        // Validate all docs on source index
+        assertAllDocsHaveCorrectVectors(sourceIndex, numDocs, vectors);
+
+        // Reindex to destination
+        createKnnIndex(destIndex, mapping);
+        reindex(sourceIndex, destIndex);
+        refreshIndex(destIndex);
+
+        // Validate all docs on dest index
+        assertAllDocsHaveCorrectVectors(destIndex, numDocs, vectors);
+
+        // Update all docs in both indices via update_by_query with a new vector
+        float[] updatedVector = new float[DIMENSION];
+        for (int d = 0; d < DIMENSION; d++) {
+            updatedVector[d] = 99.0f + d;
+        }
+        StringBuilder scriptSource = new StringBuilder("ctx._source." + VECTOR_FIELD + " = [");
+        for (int d = 0; d < DIMENSION; d++) {
+            if (d > 0) scriptSource.append(",");
+            scriptSource.append(updatedVector[d]).append("f");
+        }
+        scriptSource.append("]");
+
+        String updateQuery = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("script")
+            .field("source", scriptSource.toString())
+            .field("lang", "painless")
+            .endObject()
+            .endObject()
+            .toString();
+
+        updateKnnDocByQuery(sourceIndex, updateQuery);
+        updateKnnDocByQuery(destIndex, updateQuery);
+
+        // After update, all docs should have the same updated vector
+        float[][] updatedVectors = new float[numDocs][DIMENSION];
+        for (int i = 0; i < numDocs; i++) {
+            System.arraycopy(updatedVector, 0, updatedVectors[i], 0, DIMENSION);
+        }
+        assertAllDocsHaveCorrectVectors(sourceIndex, numDocs, updatedVectors);
+        assertAllDocsHaveCorrectVectors(destIndex, numDocs, updatedVectors);
+
+        deleteKNNIndex(sourceIndex);
+        deleteKNNIndex(destIndex);
+    }
+
+    private void assertAllDocsHaveCorrectVectors(String indexName, int expectedCount, float[][] expectedVectors) throws Exception {
+        String query = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .startArray("docvalue_fields")
+            .startObject()
+            .field("field", VECTOR_FIELD)
+            .field("format", "array")
+            .endObject()
+            .endArray()
+            .field("_source", false)
+            .field("size", expectedCount)
+            .startObject("sort")
+            .field("_id", "asc")
+            .endObject()
+            .endObject()
+            .toString();
+
+        Response response = searchKNNIndex(indexName, query, expectedCount);
+        List<Map<String, Object>> hits = parseSearchHits(EntityUtils.toString(response.getEntity()));
+        assertEquals("[" + indexName + "] Expected " + expectedCount + " hits", expectedCount, hits.size());
+
+        for (int i = 0; i < hits.size(); i++) {
+            String docId = (String) hits.get(i).get("_id");
+            int docIdx = Integer.parseInt(docId);
+            List<List<Double>> dvField = getDocValueField(hits.get(i), VECTOR_FIELD);
+            assertNotNull("[" + indexName + "] doc " + docId + " should have docvalue_fields", dvField);
+            assertEquals("[" + indexName + "] doc " + docId + " dimension mismatch", DIMENSION, dvField.get(0).size());
+            for (int d = 0; d < DIMENSION; d++) {
+                assertEquals(
+                    "[" + indexName + "] doc " + docId + " vector mismatch at index " + d,
+                    expectedVectors[docIdx][d],
+                    dvField.get(0).get(d).floatValue(),
+                    0.001f
+                );
+            }
+        }
+    }
+
     private void createHnswIndex(KNNEngine engine) throws Exception {
         KNNJsonIndexMappingsBuilder.Method method = KNNJsonIndexMappingsBuilder.Method.builder()
             .methodName(METHOD_HNSW)
@@ -1922,6 +2322,24 @@ public class DocValueFieldsIT extends KNNRestTestCase {
             result.add(n.doubleValue());
         }
         return result;
+    }
+
+    private String buildArrayDocValueQuery() throws IOException {
+        return XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("match_all")
+            .endObject()
+            .endObject()
+            .startArray("docvalue_fields")
+            .startObject()
+            .field("field", VECTOR_FIELD)
+            .field("format", "array")
+            .endObject()
+            .endArray()
+            .field("_source", false)
+            .endObject()
+            .toString();
     }
 
     private String buildSortedDocValueFieldsQuery() throws IOException {


### PR DESCRIPTION
### Description
Vectors can now be indexed as base64-encoded strings in addition to JSON arrays. Float vectors use little-endian byte encoding (symmetric with the doc_values binary output format), while byte/binary vectors use raw byte encoding. This enables efficient bulk ingestion pipelines that avoid JSON array serialization overhead.

Some Benchmarking details added in the GH issue. #3322

### Related Issues
Resolves https://github.com/opensearch-project/k-NN/issues/3322
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
