### PR TITLE
[Backport 3.7] Fix derived source for mixed-case vector fields (#3313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 * Use KNN1040ScalarQuantizedVectorsFormat for Faiss SQ flat format to enable prefetch [#3302](https://github.com/opensearch-project/k-NN/pull/3302)
+* Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
 * Fix score to radius conversion for IP with faiss [#3336](https://github.com/opensearch-project/k-NN/pull/3336)
 
 ### Refactoring

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -14,6 +14,7 @@ import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.opensearch.knn.TestUtils.BWC_VERSION;
@@ -114,6 +115,85 @@ public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
         } else {
             validateDerivedSetting(indexName, true);
         }
+    }
+
+    public void testMixedCaseDerivedSourceField_indexOnOld_reconstructOnNew() throws Exception {
+        waitForClusterHealthGreen(NODES_BWC_CLUSTER);
+        String indexName = getIndexName("knn-bwc", "mixed-case-derived-source-", false);
+        int dimension = 3;
+
+        if (isRunningAgainstOldCluster()) {
+            Settings settings = Settings.builder()
+                .put("number_of_shards", 1)
+                .put("number_of_replicas", 0)
+                .put("index.knn", true)
+                .put("index.knn.derived_source.enabled", true)
+                .build();
+
+            createKnnIndex(indexName, settings, createMixedCaseVectorMapping(dimension));
+            addKnnDoc(indexName, "1", createMixedCaseVectorDoc());
+            refreshIndex(indexName);
+            flushIndex(indexName);
+        } else {
+            refreshIndex(indexName);
+            List<?> retrievedVector = extractVector(getKnnDoc(indexName, "1"), "vectorSearch", "nameVector");
+
+            assertNotNull("Mixed-case vector field should be reconstructed from old lowercase segment metadata", retrievedVector);
+            assertEquals(dimension, retrievedVector.size());
+            assertEquals(1.0f, ((Number) retrievedVector.get(0)).floatValue(), 0.0f);
+            assertEquals(2.0f, ((Number) retrievedVector.get(1)).floatValue(), 0.0f);
+            assertEquals(3.0f, ((Number) retrievedVector.get(2)).floatValue(), 0.0f);
+
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    private String createMixedCaseVectorMapping(int dimension) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("vectorSearch")
+            .startObject("properties")
+            .startObject("nameVector")
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject("method")
+            .field("engine", "lucene")
+            .field("space_type", "l2")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        return builder.toString();
+    }
+
+    private String createMixedCaseVectorDoc() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("vectorSearch")
+            .array("nameVector", 1.0f, 2.0f, 3.0f)
+            .endObject()
+            .endObject();
+        return builder.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<?> extractVector(Map<String, Object> source, String... path) {
+        Object current = source;
+        for (String key : path) {
+            if (current instanceof Map) {
+                current = ((Map<String, Object>) current).get(key);
+            } else {
+                return null;
+            }
+        }
+        if (current instanceof List) {
+            return (List<?>) current;
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java
@@ -5,12 +5,15 @@
 
 package org.opensearch.knn.index.codec.KNN10010Codec;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.StoredFieldsWriter;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
@@ -25,10 +28,11 @@ import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttribut
 import org.opensearch.knn.index.util.IndexUtil;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 @AllArgsConstructor
+@Log4j2
 public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat {
     // Stores the delegate codec name (in case it is different from the default one)
     static final String KNN_DELEGATE_CODEC_NAME = "knn_delegate_stored_fields_codec_key";
@@ -45,16 +49,13 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         throws IOException {
 
         final StoredFieldsFormat delegatingFormat = getStoredFieldsFormat(segmentInfo);
-        List<DerivedFieldInfo> derivedVectorFields = Stream.concat(
-            DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false)
-                .stream()
-                .filter(field -> fieldInfos.fieldInfo(field) != null)
-                .map(field -> new DerivedFieldInfo(fieldInfos.fieldInfo(field), false)),
-            DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, true)
-                .stream()
-                .filter(field -> fieldInfos.fieldInfo(field) != null)
-                .map(field -> new DerivedFieldInfo(fieldInfos.fieldInfo(field), true))
-        ).toList();
+        List<DerivedFieldInfo> derivedVectorFields = new ArrayList<>();
+        for (String field : DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false)) {
+            addDerivedFieldInfo(derivedVectorFields, fieldInfos, field, false);
+        }
+        for (String field : DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, true)) {
+            addDerivedFieldInfo(derivedVectorFields, fieldInfos, field, true);
+        }
 
         // If no fields have it enabled, we can just short-circuit and return the delegate's fieldReader
         if (derivedVectorFields.isEmpty()) {
@@ -79,6 +80,41 @@ public class KNN10010DerivedSourceStoredFieldsFormat extends StoredFieldsFormat 
         } else {
             return delegate;
         }
+    }
+
+    private void addDerivedFieldInfo(List<DerivedFieldInfo> derivedFieldInfos, FieldInfos fieldInfos, String field, boolean isNested) {
+        FieldInfo fieldInfo = getFieldInfo(fieldInfos, field);
+        if (fieldInfo == null) {
+            return;
+        }
+        derivedFieldInfos.add(new DerivedFieldInfo(fieldInfo, isNested));
+    }
+
+    @VisibleForTesting
+    static FieldInfo getFieldInfo(FieldInfos fieldInfos, String field) {
+        FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
+        if (fieldInfo != null) {
+            return fieldInfo;
+        }
+
+        FieldInfo matchedFieldInfo = null;
+        for (FieldInfo candidate : fieldInfos) {
+            if (candidate.name.equalsIgnoreCase(field) == false) {
+                continue;
+            }
+            if (matchedFieldInfo == null || candidate.hasVectorValues() && !matchedFieldInfo.hasVectorValues()) {
+                matchedFieldInfo = candidate;
+            } else if (matchedFieldInfo.hasVectorValues() && candidate.hasVectorValues()) {
+                log.warn(
+                    "Skipping derived vector field [{}] because field infos [{}] and [{}] both match case-insensitively",
+                    field,
+                    matchedFieldInfo.name,
+                    candidate.name
+                );
+                return null;
+            }
+        }
+        return matchedFieldInfo;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -140,7 +140,7 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
         for (MappedFieldType fieldType : mapperService.fieldTypes()) {
             if (fieldType instanceof KNNVectorFieldType knnVectorFieldType) {
                 if (IndexUtil.isDerivedEnabledForField(knnVectorFieldType, mapperService)) {
-                    String fieldName = fieldType.name().toLowerCase();
+                    String fieldName = fieldType.name();
                     boolean isNested = mapperService.documentMapper().mappers().getNestedScope(fieldType.name()) != null;
 
                     if (isNested) {

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsFormatTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN10010Codec;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
+public class DerivedSourceStoredFieldsFormatTests extends KNNTestCase {
+    private static final String NMSLIB_ENGINE_NAME = "nmslib";
+
+    public void testGetFieldInfoReturnsExactMatch() {
+        FieldInfo exactFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { exactFieldInfo });
+
+        assertSame(exactFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorSearch.nameVector"));
+    }
+
+    public void testGetFieldInfoFallsBackToUnambiguousCaseInsensitiveMatch() {
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo });
+
+        assertSame(mixedCaseFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoDoesNotGuessWhenCaseInsensitiveMatchIsAmbiguous() {
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")
+            .fieldNumber(1)
+            .vectorDimension(16)
+            .build();
+        FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector")
+            .fieldNumber(2)
+            .vectorDimension(16)
+            .build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo, lowerCaseFieldInfo });
+
+        assertNull(KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoFallsBackToFirstCaseInsensitiveMatchWhenNoVectorHints() {
+        FieldInfo mixedCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector").fieldNumber(1).build();
+        FieldInfo lowerCaseFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(2).build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { mixedCaseFieldInfo, lowerCaseFieldInfo });
+
+        assertSame(mixedCaseFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoPrefersVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
+        FieldInfo nonVectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(1).build();
+        FieldInfo vectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")
+            .fieldNumber(2)
+            .vectorDimension(16)
+            .build();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { nonVectorFieldInfo, vectorFieldInfo });
+
+        assertSame(vectorFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    public void testGetFieldInfoPrefersNativeFaissVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
+        assertNativeVectorFieldPreferred(FAISS_NAME);
+    }
+
+    public void testGetFieldInfoPrefersNativeNmslibVectorFieldWhenCaseInsensitiveMatchHasSingleVectorField() {
+        assertNativeVectorFieldPreferred(NMSLIB_ENGINE_NAME);
+    }
+
+    private void assertNativeVectorFieldPreferred(String engineName) {
+        FieldInfo nonVectorFieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.namevector").fieldNumber(1).build();
+        FieldInfo nativeVectorFieldInfo = nativeVectorFieldInfo(engineName);
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { nonVectorFieldInfo, nativeVectorFieldInfo });
+
+        assertTrue(nativeVectorFieldInfo.hasVectorValues());
+        assertSame(nativeVectorFieldInfo, KNN10010DerivedSourceStoredFieldsFormat.getFieldInfo(fieldInfos, "vectorsearch.namevector"));
+    }
+
+    private FieldInfo nativeVectorFieldInfo(String engineName) {
+        return KNNCodecTestUtil.FieldInfoBuilder.builder("vectorSearch.nameVector")
+            .fieldNumber(2)
+            .addAttribute(KNNVectorFieldMapper.KNN_FIELD, "true")
+            .addAttribute(KNN_METHOD, METHOD_HNSW)
+            .addAttribute(KNN_ENGINE, engineName)
+            .addAttribute(VECTOR_DATA_TYPE_FIELD, VectorDataType.FLOAT.getValue())
+            .vectorDimension(16)
+            .build();
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -13,14 +13,24 @@ import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.MappingLookup;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.KNNCodecTestUtil;
+import org.opensearch.knn.index.codec.derivedsource.DerivedSourceSegmentAttributeParser;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.util.IndexUtil;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
@@ -53,5 +63,41 @@ public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
         byte[] shiftedBytes = new byte[originalBytes.length + 2];
         System.arraycopy(originalBytes, 0, shiftedBytes, 1, originalBytes.length);
         derivedSourceStoredFieldsWriter.writeField(fieldInfo, new BytesRef(shiftedBytes, 1, originalBytes.length));
+    }
+
+    @SneakyThrows
+    public void testFinishPreservesMixedCaseVectorFieldNamesInSegmentAttributes() {
+        StoredFieldsWriter delegate = mock(StoredFieldsWriter.class);
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        MapperService mapperService = mock(MapperService.class);
+        DocumentMapper documentMapper = mock(DocumentMapper.class);
+        MappingLookup mappingLookup = mock(MappingLookup.class);
+        KNNVectorFieldType vectorFieldType = mock(KNNVectorFieldType.class);
+        Map<String, String> fakeAttributes = new HashMap<>();
+
+        String fieldName = "vectorSearch.nameVector";
+        when(vectorFieldType.name()).thenReturn(fieldName);
+        when(mapperService.fieldTypes()).thenReturn(List.of(vectorFieldType));
+        when(mapperService.documentMapper()).thenReturn(documentMapper);
+        when(documentMapper.metadataMapper(SourceFieldMapper.class)).thenReturn(null);
+        when(documentMapper.mappers()).thenReturn(mappingLookup);
+        when(mappingLookup.getMapper(fieldName)).thenReturn(null);
+        when(mappingLookup.getNestedScope(fieldName)).thenReturn(null);
+        when(segmentInfo.putAttribute(any(), any())).thenAnswer(t -> fakeAttributes.put(t.getArgument(0), t.getArgument(1)));
+        when(segmentInfo.getAttribute(any())).thenAnswer(t -> fakeAttributes.get(t.getArgument(0)));
+
+        assertTrue(IndexUtil.isDerivedEnabledForField(vectorFieldType, mapperService));
+
+        KNN10010DerivedSourceStoredFieldsWriter derivedSourceStoredFieldsWriter = new KNN10010DerivedSourceStoredFieldsWriter(
+            "mock-codec",
+            delegate,
+            segmentInfo,
+            mapperService
+        );
+
+        derivedSourceStoredFieldsWriter.finish(1);
+
+        assertEquals(List.of(fieldName), DerivedSourceSegmentAttributeParser.parseDerivedVectorFields(segmentInfo, false));
+        verify(delegate).finish(1);
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -330,6 +330,60 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         deleteKNNIndex(indexName);
     }
 
+    @SneakyThrows
+    public void testDerivedSource_withMixedCaseObjectVectorField() {
+        String indexName = getIndexName("derived-source", "mixed-case", false);
+        int dimension = 3;
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.knn", true)
+            .put("index.knn.derived_source.enabled", true)
+            .build();
+
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject("vectorSearch")
+            .startObject(KNNConstants.PROPERTIES)
+            .startObject("nameVector")
+            .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension)
+            .startObject("method")
+            .field("engine", "lucene")
+            .field("space_type", "l2")
+            .field("name", "hnsw")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, settings, mappingBuilder.toString());
+
+        XContentBuilder docBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("vectorSearch")
+            .array("nameVector", 1.0f, 2.0f, 3.0f)
+            .endObject()
+            .endObject();
+
+        addKnnDoc(indexName, "1", docBuilder.toString());
+        refreshIndex(indexName);
+
+        List<?> retrievedVector = extractVector(getKnnDoc(indexName, "1"), "vectorSearch", "nameVector");
+
+        assertNotNull("Mixed-case vector field should be reconstructed instead of returning the mask value", retrievedVector);
+        assertEquals(dimension, retrievedVector.size());
+        assertEquals(1.0f, ((Number) retrievedVector.get(0)).floatValue(), 0.0f);
+        assertEquals(2.0f, ((Number) retrievedVector.get(1)).floatValue(), 0.0f);
+        assertEquals(3.0f, ((Number) retrievedVector.get(2)).floatValue(), 0.0f);
+
+        deleteKNNIndex(indexName);
+    }
+
     /**
      * Single method for running end to end tests for different index configurations for derived source. In general,
      * flow of operations are


### PR DESCRIPTION
* Fix derived source for mixed-case vector fields



* Add BWC coverage for derived source field casing



* Add changelog entry for mixed-case derived source fix



* Handle case-insensitive conflicts by preferring vector field



* Avoid stream wrappers for derived field lookup



* Handle ambiguous case-insensitive matches without vector hints



* Update src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsFormat.java




* Apply spotless formatting for derived source field resolution



* Avoid guessing when case-insensitive matches lack vector hints



* Simplify case-insensitive derived field matching



* Trigger CI rerun for BWC investigation



* Add native engine field info coverage



---------

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
