### PR TITLE
Check to see if Lucene's search budget has exhausted when deciding to exact search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)
 * Integrated proper ef_search functionality into MOS and Lucene with oversample_factor [#3331](https://github.com/opensearch-project/k-NN/pull/3331)
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
+* Check to see if Lucene's search budget has exhausted when deciding to exact search in MOS [#3354](https://github.com/opensearch-project/k-NN/pull/3354)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNWeight.java
@@ -198,16 +198,19 @@ public abstract class KNNWeight extends Weight {
             }
         }
         final Integer annResult = knnExplanation.getAnnResult(context.id());
+        final Boolean exhaustedSearch = knnExplanation.getExhaustedSearch(context.id());
         if (annResult != null && annResult == 0 && isMissingNativeEngineFiles(context)) {
             sb.append(KNNConstants.EXACT_SEARCH).append(" since no native engine files are available");
         }
-        if (annResult != null && isFilteredExactSearchRequireAfterANNSearch(cardinality, annResult)) {
+        if (annResult != null && isFilteredExactSearchRequireAfterANNSearch(cardinality, exhaustedSearch, annResult)) {
             boolean isExactSearchDisabled = KNNSettings.isKnnIndexFaissEfficientFilterExactSearchDisabled(knnQuery.getIndexName());
             if (isExactSearchDisabled) {
                 sb.append(KNNConstants.ANN_SEARCH)
                     .append(", it is not falling back to exact search after ")
                     .append(KNNConstants.ANN_SEARCH)
                     .append(" search since exact search is disabled,");
+            } else if (exhaustedSearch) {
+                sb.append(KNNConstants.EXACT_SEARCH).append(" since lucene vector search has exhausted number of steps.");
             } else {
                 sb.append(KNNConstants.EXACT_SEARCH)
                     .append(" since the number of documents returned are less than K = ")
@@ -216,7 +219,7 @@ public abstract class KNNWeight extends Weight {
                     .append(cardinality);
             }
         }
-        if (annResult != null && annResult > 0 && !isFilteredExactSearchRequireAfterANNSearch(cardinality, annResult)) {
+        if (annResult != null && annResult > 0 && !isFilteredExactSearchRequireAfterANNSearch(cardinality, exhaustedSearch, annResult)) {
             sb.append(KNNConstants.ANN_SEARCH);
         }
         sb.append(" with vectorDataType = ").append(knnQuery.getVectorDataType());
@@ -345,13 +348,17 @@ public abstract class KNNWeight extends Weight {
         final TopDocs topDocs = approximateSearch(context, filterBitSet, filterCardinality, k);
         stopStopWatchAndLog(log, annStopWatch, "ANN search", knnQuery.getShardId(), segmentName, knnQuery.getField());
 
+        int annResultsCount = topDocs.scoreDocs.length;
+        boolean annSearchBudgetExhausted = topDocs.totalHits.relation() != TotalHits.Relation.EQUAL_TO;
+
         if (knnQuery.isExplain()) {
-            knnExplanation.addLeafResult(context.id(), topDocs.scoreDocs.length);
+            knnExplanation.addLeafResult(context.id(), annResultsCount);
+            knnExplanation.addExhaustedSearch(context.id(), annSearchBudgetExhausted);
         }
         // See whether we have to perform exact search based on approx search results
         // This is required if there are no native engine files or if approximate search returned
         // results less than K, though we have more than k filtered docs
-        if (isExactSearchRequire(context, filterCardinality, topDocs.scoreDocs.length)) {
+        if (isExactSearchRequire(context, filterCardinality, annSearchBudgetExhausted, annResultsCount)) {
             final BitSetIterator docs = filterWeight != null ? new BitSetIterator(filterBitSet, filterCardinality) : null;
             final TopDocs result = doExactSearch(context, docs, filterCardinality, k);
             return new PerLeafResult(
@@ -664,16 +671,22 @@ public abstract class KNNWeight extends Weight {
      * This condition mainly checks whether exact search should be performed or not
      * @param context LeafReaderContext
      * @param filterIdsCount count of filtered Doc ids
+     * @param annSearchBudgetExhausted whether the search budget has been exhausted on lucene
      * @param annResultCount Count of Nearest Neighbours we got after doing filtered ANN Search.
      * @return boolean - true if exactSearch needs to be done after ANNSearch.
      */
-    private boolean isExactSearchRequire(final LeafReaderContext context, final int filterIdsCount, final int annResultCount) {
+    private boolean isExactSearchRequire(
+        final LeafReaderContext context,
+        final int filterIdsCount,
+        final boolean annSearchBudgetExhausted,
+        final int annResultCount
+    ) {
         if (annResultCount == 0 && isMissingNativeEngineFiles(context)) {
             log.debug("Perform exact search after approximate search since no native engine files are available");
             return true;
         }
 
-        if (isFilteredExactSearchRequireAfterANNSearch(filterIdsCount, annResultCount)) {
+        if (isFilteredExactSearchRequireAfterANNSearch(filterIdsCount, annSearchBudgetExhausted, annResultCount)) {
 
             // Disable the fallback mechanism to exact search after ANN Search when the index setting is set to true
             if (KNNSettings.isKnnIndexFaissEfficientFilterExactSearchDisabled(knnQuery.getIndexName())) {
@@ -698,13 +711,25 @@ public abstract class KNNWeight extends Weight {
 
     /**
      * This condition mainly checks during filtered search we have more than K elements in filterIds but the ANN
-     * doesn't yield K nearest neighbors.
+     * doesn't yield K nearest neighbors. Also check to make sure that we didn't hit Lucene's visit budget to match
+     * behavior on low filtering percentages.
      * @param filterIdsCount count of filtered Doc ids
+     * @param annSearchBudgetExhausted whether the search budget has been exhausted on lucene
      * @param annResultCount Count of Nearest Neighbours we got after doing filtered ANN Search.
      * @return boolean - true if exactSearch needs to be done after ANNSearch.
      */
-    private boolean isFilteredExactSearchRequireAfterANNSearch(final int filterIdsCount, final int annResultCount) {
-        return filterWeight != null && filterIdsCount >= knnQuery.getK() && knnQuery.getK() > annResultCount;
+    private boolean isFilteredExactSearchRequireAfterANNSearch(
+        final int filterIdsCount,
+        final boolean annSearchBudgetExhausted,
+        final int annResultCount
+    ) {
+        if (filterWeight == null) {
+            return false;
+        }
+        if (filterIdsCount < knnQuery.getK()) {
+            return false;
+        }
+        return knnQuery.getK() > annResultCount || annSearchBudgetExhausted;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/explain/KnnExplanation.java
+++ b/src/main/java/org/opensearch/knn/index/query/explain/KnnExplanation.java
@@ -20,6 +20,8 @@ public class KnnExplanation {
 
     private final Map<Object, Integer> annResultPerLeaf;
 
+    private final Map<Object, Boolean> exhaustedSearchPerLeaf;
+
     private final Map<Integer, Float> rawScores;
 
     private final Map<Object, Scorer> knnScorerPerLeaf;
@@ -30,6 +32,7 @@ public class KnnExplanation {
 
     public KnnExplanation() {
         this.annResultPerLeaf = new ConcurrentHashMap<>();
+        this.exhaustedSearchPerLeaf = new ConcurrentHashMap<>();
         this.rawScores = new ConcurrentHashMap<>();
         this.knnScorerPerLeaf = new ConcurrentHashMap<>();
         this.cardinality = 0;
@@ -37,6 +40,10 @@ public class KnnExplanation {
 
     public void addLeafResult(Object leafId, int annResult) {
         this.annResultPerLeaf.put(leafId, annResult);
+    }
+
+    public void addExhaustedSearch(Object leafId, boolean exhausted) {
+        this.exhaustedSearchPerLeaf.put(leafId, exhausted);
     }
 
     public void addRawScore(int docId, float rawScore) {
@@ -49,6 +56,10 @@ public class KnnExplanation {
 
     public Integer getAnnResult(Object leafId) {
         return this.annResultPerLeaf.get(leafId);
+    }
+
+    public Boolean getExhaustedSearch(Object leafId) {
+        return this.exhaustedSearchPerLeaf.get(leafId);
     }
 
     public Float getRawScore(int docId) {

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -209,8 +209,9 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         TopDocs topDocs = knnCollector.topDocs();
         // Align `hitCount` logic with the non-memory-optimized path by setting it to the size of the result set.
         // Note: DefaultKNNWeight defines `hitCount` as the number of results returned per Lucene segment,
-        // while Lucene’s implementation interprets it as the total number of vectors visited during search.
-        topDocs = new TopDocs(new TotalHits(topDocs.scoreDocs.length, TotalHits.Relation.EQUAL_TO), topDocs.scoreDocs);
+        // while Lucene’s implementation interprets it as the total number of vectors visited during search. We will
+        // preserve the totalHits relation so that we know if we exhausted Lucene's search budget.
+        topDocs = new TopDocs(new TotalHits(topDocs.scoreDocs.length, topDocs.totalHits.relation()), topDocs.scoreDocs);
         if (topDocs.scoreDocs.length == 0) {
             log.debug("[KNN] Query yielded 0 results");
             return EMPTY_TOPDOCS;

--- a/src/test/java/org/opensearch/knn/integ/FilteredSearchANNSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FilteredSearchANNSearchIT.java
@@ -332,4 +332,5 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         entity = EntityUtils.toString(response.getEntity());
         assertEquals(0, parseIds(entity).size());
     }
+
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MOSFaissFloatIndexIT.java
@@ -5,9 +5,27 @@
 
 package org.opensearch.knn.memoryoptsearch;
 
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
 
 public class MOSFaissFloatIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
 
@@ -47,5 +65,106 @@ public class MOSFaissFloatIndexIT extends AbstractMemoryOptimizedKnnSearchIT {
     public void testWhenNoIndexBuilt() {
         doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, true, SpaceType.L2, NO_BUILD_HNSW);
         doTestNonNestedIndex(VectorDataType.FLOAT, EMPTY_PARAMS, false, SpaceType.L2, NO_BUILD_HNSW);
+    }
+
+    /**
+     * Test that when Lucene's HNSW exhausts its visit budget due to a low-selectivity filter,
+     * the MOS path falls back to exact search. We verify this by checking that the explain output
+     * contains the exhausted budget message.
+     */
+    @SneakyThrows
+    public void testFilteredSearch_whenVisitBudgetExhausted_thenFallbackToExactSearch() {
+        String indexName = INDEX_NAME + "_budget_exhausted";
+        String filterFieldName = "rarity";
+        int dimension = 32;
+        int k = 5;
+        int totalDocs = 200;
+        int matchingDocs = 10;
+
+        // Create MOS-enabled index with HNSW
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject("method")
+            .field("name", "hnsw")
+            .field("engine", "faiss")
+            .field("space_type", "l2")
+            .startObject("parameters")
+            .field("m", 16)
+            .field("ef_construction", 100)
+            .field("ef_search", 1)
+            .endObject()
+            .endObject()
+            .endObject()
+            .startObject(filterFieldName)
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put(KNN_INDEX, true)
+            .put(MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
+            .build();
+        createKnnIndex(indexName, settings, mapping);
+
+        // Index docs: only matchingDocs have "rare", rest have "common"
+        for (int i = 0; i < totalDocs; i++) {
+            float[] vector = new float[dimension];
+            for (int d = 0; d < dimension; d++) {
+                vector[d] = (float) (i * 7 + d * 3) % 100;
+            }
+            String filterValue = i < matchingDocs ? "rare" : "common";
+            addKnnDocWithAttributes(indexName, String.valueOf(i), FIELD_NAME, vector, ImmutableMap.of(filterFieldName, filterValue));
+        }
+
+        refreshIndex(indexName);
+        forceMergeKnnIndex(indexName);
+
+        // Disable pre-ANN exact search threshold
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 0));
+
+        // Query near doc 0
+        float[] queryVector = new float[dimension];
+        for (int d = 0; d < dimension; d++) {
+            queryVector[d] = (float) (d * 3) % 100;
+        }
+
+        // Build query with filter and minimal ef_search
+        KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(k)
+            .filter(QueryBuilders.termQuery(filterFieldName, "rare"))
+            .methodParameters(Map.of(METHOD_PARAMETER_EF_SEARCH, 1))
+            .build();
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder().startObject().startObject("query");
+        knnQueryBuilder.doXContent(queryBuilder, ToXContent.EMPTY_PARAMS);
+        queryBuilder.endObject().endObject();
+
+        Response response = performSearch(indexName, queryBuilder.toString(), "explain=true");
+        String entity = EntityUtils.toString(response.getEntity());
+        List<Object> hits = parseSearchResponseHits(entity);
+
+        // We should get k results
+        assertEquals(k, hits.size());
+
+        // Verify explain confirms the exhausted budget triggered exact search
+        for (Object hit : hits) {
+            Map<String, Object> hitMap = (Map<String, Object>) hit;
+            String explanation = hitMap.get("_explanation").toString();
+            assertTrue(
+                "Expected explanation to mention exhausted search budget, got: " + explanation,
+                explanation.contains("since lucene vector search has exhausted number of steps")
+            );
+        }
+
+        deleteKNNIndex(indexName);
     }
 }


### PR DESCRIPTION
### Description
Lucene engine has a check such that it falls back to exact search if we hit a visit limit before finding qualified candidates. This change takes the conditional from Lucene and applies the same logic to Memory Optimized Search.

After this change we will see a more aggressive exact search strategy in MOS when filtered docs are sparse in the graph. We should see a recall gain in low filtering percentages (~1-5%).

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
