### PR TITLE
Ignore flaky test testKNNQuery_withModelDifferentCombination_thenSuccess due to timeout

### DIFF
--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -21,6 +21,7 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.VectorUtil;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.client.ResponseException;
@@ -1577,6 +1578,7 @@ public class FaissIT extends KNNRestTestCase {
         deleteKnnDoc(INDEX_NAME, "1");
     }
 
+    @Ignore
     @SneakyThrows
     public void testKNNQuery_withModelDifferentCombination_thenSuccess() {
 


### PR DESCRIPTION
### Description
testKNNQuery_withModelDifferentCombination_thenSuccess is timing out occasionally. Marking test with Ignore since it is flaky.

### Related Issues
Resolves #3353 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
