### PR TITLE
Introduces BulkVectorScorer for ExactSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix score corruption in multi-segment FAISS indices with ADC [#3385](https://github.com/opensearch-project/k-NN/pull/3385)
 
 ### Refactoring
-
+* Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
 
 ### Enhancements

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
@@ -35,11 +35,11 @@ public class BulkVectorScorer extends Scorer {
         this.cost = matchedDocs != null ? matchedDocs.cost() : vectorScorer.iterator().cost();
     }
 
-    public static BulkVectorScorer fullPrecision(VectorScorer vectorScorer, DocIdSetIterator matchedDocs) throws IOException {
+    public static BulkVectorScorer forKSearch(VectorScorer vectorScorer, DocIdSetIterator matchedDocs) throws IOException {
         return new BulkVectorScorer(vectorScorer, matchedDocs, score -> true);
     }
 
-    public static BulkVectorScorer fullPrecision(VectorScorer vectorScorer, DocIdSetIterator matchedDocs, float minScore)
+    public static BulkVectorScorer forRadialSearch(VectorScorer vectorScorer, DocIdSetIterator matchedDocs, float minScore)
         throws IOException {
         return new BulkVectorScorer(vectorScorer, matchedDocs, score -> score >= minScore);
     }
@@ -78,6 +78,9 @@ public class BulkVectorScorer extends Scorer {
 
             @Override
             public int advance(int target) throws IOException {
+                if (currentDocId >= target) {
+                    return currentDocId;
+                }
                 while (true) {
                     int doc = nextDoc();
                     if (doc == NO_MORE_DOCS) {
@@ -108,9 +111,10 @@ public class BulkVectorScorer extends Scorer {
 
     private int scanBufferForMatch() {
         while (currentBatchIdx < buffer.size) {
-            if (scoreFilter.test(buffer.features[currentBatchIdx])) {
+            float score = buffer.features[currentBatchIdx];
+            if (scoreFilter.test(score)) {
                 currentDocId = buffer.docs[currentBatchIdx];
-                currentScore = buffer.features[currentBatchIdx];
+                currentScore = score;
                 currentBatchIdx++;
                 return currentDocId;
             }

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
@@ -28,7 +28,7 @@ public class BulkVectorScorer extends Scorer {
     private int currentBatchIdx = 0;
     private float currentScore;
 
-    public BulkVectorScorer(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs, final Predicate<Float> scoreFilter)
+    private BulkVectorScorer(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs, final Predicate<Float> scoreFilter)
         throws IOException {
         this.bulkScorer = vectorScorer.bulk(matchedDocs);
         this.scoreFilter = scoreFilter;

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.exactsearch;
+
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.VectorScorer;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+/**
+ * A {@link Scorer} that scores documents using bulk vector scoring, yielding only those
+ * whose score satisfies the provided {@link Predicate}.
+ */
+public class BulkVectorScorer extends Scorer {
+
+    private final DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
+    private final VectorScorer.Bulk bulkScorer;
+    private final Predicate<Float> scoreFilter;
+    private final long cost;
+
+    private int currentDocId = -1;
+    private int currentBatchIdx = 0;
+    private float currentScore;
+
+    public BulkVectorScorer(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs, final Predicate<Float> scoreFilter)
+        throws IOException {
+        this.bulkScorer = vectorScorer.bulk(matchedDocs);
+        this.scoreFilter = scoreFilter;
+        this.cost = matchedDocs != null ? matchedDocs.cost() : vectorScorer.iterator().cost();
+    }
+
+    public static BulkVectorScorer fullPrecision(VectorScorer vectorScorer, DocIdSetIterator matchedDocs) throws IOException {
+        return new BulkVectorScorer(vectorScorer, matchedDocs, score -> true);
+    }
+
+    public static BulkVectorScorer fullPrecision(VectorScorer vectorScorer, DocIdSetIterator matchedDocs, float minScore)
+        throws IOException {
+        return new BulkVectorScorer(vectorScorer, matchedDocs, score -> score >= minScore);
+    }
+
+    @Override
+    public int docID() {
+        return currentDocId;
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+        return new DocIdSetIterator() {
+
+            @Override
+            public int docID() {
+                return currentDocId;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                while (true) {
+                    int result = scanBufferForMatch();
+                    if (result != -1) {
+                        return result;
+                    }
+                    float maxBatchScore = bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer);
+                    currentBatchIdx = 0;
+                    if (buffer.size == 0) {
+                        return currentDocId = NO_MORE_DOCS;
+                    }
+                    if (!scoreFilter.test(maxBatchScore)) {
+                        currentBatchIdx = buffer.size;
+                    }
+                }
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                while (true) {
+                    int doc = nextDoc();
+                    if (doc == NO_MORE_DOCS) {
+                        return NO_MORE_DOCS;
+                    }
+                    if (doc >= target) {
+                        return doc;
+                    }
+                }
+            }
+
+            @Override
+            public long cost() {
+                return cost;
+            }
+        };
+    }
+
+    @Override
+    public float getMaxScore(int upTo) {
+        return Float.MAX_VALUE;
+    }
+
+    @Override
+    public float score() {
+        return currentScore;
+    }
+
+    private int scanBufferForMatch() {
+        while (currentBatchIdx < buffer.size) {
+            if (scoreFilter.test(buffer.features[currentBatchIdx])) {
+                currentDocId = buffer.docs[currentBatchIdx];
+                currentScore = buffer.features[currentBatchIdx];
+                currentBatchIdx++;
+                return currentDocId;
+            }
+            currentBatchIdx++;
+        }
+        return -1;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorer.java
@@ -27,6 +27,7 @@ public class BulkVectorScorer extends Scorer {
     private int currentDocId = -1;
     private int currentBatchIdx = 0;
     private float currentScore;
+    private float minCompetitiveScore = 0f;
 
     private BulkVectorScorer(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs, final Predicate<Float> scoreFilter)
         throws IOException {
@@ -70,7 +71,7 @@ public class BulkVectorScorer extends Scorer {
                     if (buffer.size == 0) {
                         return currentDocId = NO_MORE_DOCS;
                     }
-                    if (!scoreFilter.test(maxBatchScore)) {
+                    if (!scoreFilter.test(maxBatchScore) || maxBatchScore < minCompetitiveScore) {
                         currentBatchIdx = buffer.size;
                     }
                 }
@@ -100,6 +101,11 @@ public class BulkVectorScorer extends Scorer {
     }
 
     @Override
+    public void setMinCompetitiveScore(float score) {
+        this.minCompetitiveScore = score;
+    }
+
+    @Override
     public float getMaxScore(int upTo) {
         return Float.MAX_VALUE;
     }
@@ -112,7 +118,7 @@ public class BulkVectorScorer extends Scorer {
     private int scanBufferForMatch() {
         while (currentBatchIdx < buffer.size) {
             float score = buffer.features[currentBatchIdx];
-            if (scoreFilter.test(score)) {
+            if (scoreFilter.test(score) && score >= minCompetitiveScore) {
                 currentDocId = buffer.docs[currentBatchIdx];
                 currentScore = score;
                 currentBatchIdx++;

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -128,7 +128,10 @@ public class ExactSearcher {
         }
 
         final VectorScorer vectorScorer = createVectorScorer(reader, fieldInfo, leafReaderContext, context);
-        assert vectorScorer != null;
+        if (vectorScorer == null) {
+            log.error("VectorScorer is null for field [{}] in segment [{}]", context.getField(), reader.getSegmentName());
+            throw new IllegalStateException("VectorScorer is null for exact searcher");
+        }
 
         // When nested, matchedDocsIterator is already consumed inside NestedBestChildVectorScorer,
         // so pass null to avoid double consumption of the same iterator.

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -210,7 +210,7 @@ public class ExactSearcher {
         final SpaceType spaceType = getSpaceType(modelDao, fieldInfo);
         final float minScore = context.isMemoryOptimizedSearchEnabled ? context.getRadius() : engine.score(context.getRadius(), spaceType);
 
-        return collectTopK(BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore), context.getMaxResultWindow());
+        return collectTopK(BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore), context.getMaxResultWindow(), false);
     }
 
     /**
@@ -234,9 +234,14 @@ public class ExactSearcher {
     }
 
     private static TopDocs collectTopK(final Scorer scorer, final int heapSize) throws IOException {
+        return collectTopK(scorer, heapSize, true);
+    }
+
+    private static TopDocs collectTopK(final Scorer scorer, final int heapSize, final boolean updateMinCompetitiveScore) throws IOException {
         final HitQueue queue = new HitQueue(heapSize, true);
         ScoreDoc topDoc = queue.top();
         DocIdSetIterator iter = scorer.iterator();
+        int collectedCount = 0;
 
         for (int doc = iter.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iter.nextDoc()) {
             float score = scorer.score();
@@ -244,6 +249,10 @@ public class ExactSearcher {
                 topDoc.score = score;
                 topDoc.doc = doc;
                 topDoc = queue.updateTop();
+                collectedCount++;
+                if (updateMinCompetitiveScore && collectedCount >= heapSize) {
+                    scorer.setMinCompetitiveScore(topDoc.score);
+                }
             }
         }
 

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.DocAndFloatFeatureBuffer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TotalHits;
@@ -88,7 +89,7 @@ public class ExactSearcher {
      * @param context           the {@link ExactSearcherContext} encapsulating query vector, k, radius,
      *                          matched document set, and other search parameters
      * @return {@link TopDocs} containing the scored results sorted by descending score;
-     *         returns {@link TopDocsCollector#EMPTY_TOPDOCS} if no vector scorer can be created
+     * returns {@link TopDocsCollector#EMPTY_TOPDOCS} if no vector scorer can be created
      * @throws IOException if an I/O error occurs while reading vectors or computing scores
      */
     public TopDocs searchLeaf(final LeafReaderContext leafReaderContext, final ExactSearcherContext context) throws IOException {
@@ -114,6 +115,42 @@ public class ExactSearcher {
             return doRadialSearch(fieldInfo, context, vectorScorer, matchedDocs);
         }
         return exactNearestNeighborSearch(context, vectorScorer, matchedDocs);
+    }
+
+    public Scorer exactSearchScorer(final LeafReaderContext leafReaderContext, final ExactSearcherContext context) throws IOException {
+        final SegmentReader reader = Lucene.segmentReader(leafReaderContext.reader());
+        final FieldInfo fieldInfo = FieldInfoExtractor.getFieldInfo(reader, context.getField());
+        if (fieldInfo == null) {
+            log.debug("[KNN] FieldInfo is null for field [{}] in segment [{}]", context.getField(), reader.getSegmentName());
+            return null;
+        }
+
+        final VectorScorer vectorScorer = createVectorScorer(reader, fieldInfo, leafReaderContext, context);
+        if (vectorScorer == null) {
+            log.debug("[KNN] VectorScorer creation failed for field [{}] in segment [{}]", context.getField(), reader.getSegmentName());
+            return null;
+        }
+
+        // When nested, matchedDocsIterator is already consumed inside NestedBestChildVectorScorer,
+        // so pass null to avoid double consumption of the same iterator.
+        final boolean isNested = context.getParentsFilter() != null;
+        final DocIdSetIterator matchedDocs = isNested ? null : context.getMatchedDocsIterator();
+
+        if (context.getRadius() != null) {
+            final KNNEngine engine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
+            if (KNNEngine.FAISS != engine) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support radial search", engine));
+            }
+            final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
+            final float minScore = context.isMemoryOptimizedSearchEnabled
+                ? context.getRadius()
+                : engine.score(context.getRadius(), spaceType);
+
+            return BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, minScore);
+        }
+
+        return BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
     }
 
     /**
@@ -160,7 +197,7 @@ public class ExactSearcher {
      * @param matchedDocs  a {@link DocIdSetIterator} over the candidate document set, or {@code null}
      *                     if all documents in the segment should be considered
      * @return {@link TopDocs} containing all documents whose score meets the minimum threshold,
-     *         up to {@code maxResultWindow} results, sorted by descending score
+     * up to {@code maxResultWindow} results, sorted by descending score
      * @throws IOException              if an I/O error occurs while reading vectors or computing scores
      * @throws IllegalArgumentException if the underlying engine is not FAISS
      */
@@ -220,74 +257,34 @@ public class ExactSearcher {
      *                     to score all documents available to the scorer
      * @param k            the number of top results to return
      * @return {@link TopDocs} containing the {@code k} highest-scoring documents sorted by
-     *         descending score; may contain fewer than {@code k} results if the candidate set
-     *         is smaller or if sentinel entries are discarded
+     * descending score; may contain fewer than {@code k} results if the candidate set
+     * is smaller or if sentinel entries are discarded
      * @throws IOException if an I/O error occurs while reading vectors or computing scores
      */
     private TopDocs searchTopK(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs, final int k) throws IOException {
-        final VectorScorer.Bulk bulkScorer = vectorScorer.bulk(matchedDocs);
-        final DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
-        final HitQueue queue = new HitQueue(k, true);
-        ScoreDoc topDoc = queue.top();
-
-        for (float maxScore = bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer); buffer.size > 0; maxScore =
-            bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer)) {
-            if (maxScore < topDoc.score) {
-                continue;
-            }
-            for (int i = 0; i < buffer.size; i++) {
-                if (buffer.features[i] > topDoc.score) {
-                    topDoc.score = buffer.features[i];
-                    topDoc.doc = buffer.docs[i];
-                    topDoc = queue.updateTop();
-                }
-            }
-        }
-
-        return collectTopDocs(queue);
+        return collectTopK(BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs), k);
     }
 
-    /**
-     * Returns all documents whose similarity score meets or exceeds the specified minimum,
-     * bounded by {@code maxResultWindow}. A fixed-size min-heap ({@link HitQueue}) is used to
-     * retain the highest-scoring results. Batches whose maximum score falls below
-     * {@code minScore} are skipped entirely for efficiency.
-     *
-     * @param vectorScorer   the {@link VectorScorer} used to compute similarity scores
-     * @param matchedDocs    a {@link DocIdSetIterator} over the candidate document set, or {@code null}
-     *                       to score all documents available to the scorer
-     * @param maxResultWindow the maximum number of results to retain in the heap
-     * @param minScore       the minimum similarity score a document must achieve to be included
-     * @return {@link TopDocs} containing documents that meet the minimum score threshold,
-     *         sorted by descending score, up to {@code maxResultWindow} results
-     * @throws IOException if an I/O error occurs while reading vectors or computing scores
-     */
     private TopDocs searchWithMinScore(
         final VectorScorer vectorScorer,
         final DocIdSetIterator matchedDocs,
         final int maxResultWindow,
         final float minScore
     ) throws IOException {
-        final VectorScorer.Bulk bulkScorer = vectorScorer.bulk(matchedDocs);
-        final DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
-        final HitQueue queue = new HitQueue(maxResultWindow, true);
-        ScoreDoc topDoc = queue.top();
+        return collectTopK(BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, minScore), maxResultWindow);
+    }
 
-        for (float maxBatchScore = bulkScorer.nextDocsAndScores(
-            DocIdSetIterator.NO_MORE_DOCS,
-            null,
-            buffer
-        ); buffer.size > 0; maxBatchScore = bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer)) {
-            if (maxBatchScore < minScore) {
-                continue;
-            }
-            for (int i = 0; i < buffer.size; i++) {
-                final float score = buffer.features[i];
-                if (score >= minScore && score > topDoc.score) {
-                    topDoc.score = score;
-                    topDoc.doc = buffer.docs[i];
-                    topDoc = queue.updateTop();
-                }
+    private static TopDocs collectTopK(final Scorer scorer, final int heapSize) throws IOException {
+        final HitQueue queue = new HitQueue(heapSize, true);
+        ScoreDoc topDoc = queue.top();
+        DocIdSetIterator iter = scorer.iterator();
+
+        for (int doc = iter.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iter.nextDoc()) {
+            float score = scorer.score();
+            if (score > topDoc.score) {
+                topDoc.score = score;
+                topDoc.doc = doc;
+                topDoc = queue.updateTop();
             }
         }
 
@@ -445,7 +442,9 @@ public class ExactSearcher {
          */
         boolean useQuantizedVectorsForSearch;
 
-        /** The number of nearest neighbors to return. */
+        /**
+         * The number of nearest neighbors to return.
+         */
         int k;
 
         /**
@@ -464,7 +463,9 @@ public class ExactSearcher {
         @Nullable
         DocIdSetIterator matchedDocsIterator;
 
-        /** The total number of documents matched by the pre-filter, used to select the search strategy. */
+        /**
+         * The total number of documents matched by the pre-filter, used to select the search strategy.
+         */
         long numberOfMatchedDocs;
 
         /**
@@ -475,13 +476,19 @@ public class ExactSearcher {
          */
         BitSetProducer parentsFilter;
 
-        /** The query vector in float representation, used for float and byte vector data types. */
+        /**
+         * The query vector in float representation, used for float and byte vector data types.
+         */
         float[] floatQueryVector;
 
-        /** The query vector in byte representation, used for binary vector data types. */
+        /**
+         * The query vector in byte representation, used for binary vector data types.
+         */
         byte[] byteQueryVector;
 
-        /** The name of the k-NN vector field being searched. */
+        /**
+         * The name of the k-NN vector field being searched.
+         */
         String field;
 
         /**
@@ -490,7 +497,9 @@ public class ExactSearcher {
          */
         Integer maxResultWindow;
 
-        /** The Lucene {@link VectorSimilarityFunction} associated with the vector field. */
+        /**
+         * The Lucene {@link VectorSimilarityFunction} associated with the vector field.
+         */
         VectorSimilarityFunction similarityFunction;
 
         /**

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -237,7 +237,8 @@ public class ExactSearcher {
         return collectTopK(scorer, heapSize, true);
     }
 
-    private static TopDocs collectTopK(final Scorer scorer, final int heapSize, final boolean updateMinCompetitiveScore) throws IOException {
+    private static TopDocs collectTopK(final Scorer scorer, final int heapSize, final boolean updateMinCompetitiveScore)
+        throws IOException {
         final HitQueue queue = new HitQueue(heapSize, true);
         ScoreDoc topDoc = queue.top();
         DocIdSetIterator iter = scorer.iterator();

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -452,7 +452,7 @@ public class ExactSearcher {
 
         /**
          * The maximum number of results to retain during radial search. Acts as an upper bound
-         * on the heap size in {@link #searchWithMinScore} to prevent unbounded memory usage.
+         * on the heap size in {@link #collectTopK(Scorer, int)} to prevent unbounded memory usage.
          */
         Integer maxResultWindow;
 

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.DocAndFloatFeatureBuffer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.HitQueue;
 import org.apache.lucene.search.ScoreDoc;
@@ -44,6 +43,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+
+import static org.opensearch.knn.common.FieldInfoExtractor.extractKNNEngine;
+import static org.opensearch.knn.common.FieldInfoExtractor.getSpaceType;
 
 /**
  * Performs brute-force (exact) k-nearest-neighbor search over vector fields within individual
@@ -126,30 +128,22 @@ public class ExactSearcher {
         }
 
         final VectorScorer vectorScorer = createVectorScorer(reader, fieldInfo, leafReaderContext, context);
-        if (vectorScorer == null) {
-            log.debug("[KNN] VectorScorer creation failed for field [{}] in segment [{}]", context.getField(), reader.getSegmentName());
-            return null;
-        }
+        assert vectorScorer != null;
 
         // When nested, matchedDocsIterator is already consumed inside NestedBestChildVectorScorer,
         // so pass null to avoid double consumption of the same iterator.
-        final boolean isNested = context.getParentsFilter() != null;
-        final DocIdSetIterator matchedDocs = isNested ? null : context.getMatchedDocsIterator();
+        final DocIdSetIterator matchedDocs = context.getParentsFilter() != null ? null : context.getMatchedDocsIterator();
 
         if (context.getRadius() != null) {
-            final KNNEngine engine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
-            if (KNNEngine.FAISS != engine) {
-                throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support radial search", engine));
-            }
-            final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
+            assert extractKNNEngine(fieldInfo) == KNNEngine.FAISS : "Exact searcher for Radial search is only used by FAISS engine";
             final float minScore = context.isMemoryOptimizedSearchEnabled
                 ? context.getRadius()
-                : engine.score(context.getRadius(), spaceType);
+                : KNNEngine.FAISS.score(context.getRadius(), getSpaceType(modelDao, fieldInfo));
 
-            return BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, minScore);
+            return BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore);
         }
 
-        return BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        return BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
     }
 
@@ -176,9 +170,9 @@ public class ExactSearcher {
         final DocIdSetIterator matchedDocs
     ) throws IOException {
         if (context.getMatchedDocsIterator() != null && context.getNumberOfMatchedDocs() <= context.getK()) {
-            return scoreAllDocs(vectorScorer, matchedDocs);
+            return scoreAllDocs(BulkVectorScorer.forKSearch(vectorScorer, matchedDocs));
         }
-        return searchTopK(vectorScorer, matchedDocs, context.getK());
+        return collectTopK(BulkVectorScorer.forKSearch(vectorScorer, matchedDocs), context.getK());
     }
 
     /**
@@ -209,14 +203,14 @@ public class ExactSearcher {
     ) throws IOException {
         assert context.isMemoryOptimizedSearchEnabled != null;
 
-        final KNNEngine engine = FieldInfoExtractor.extractKNNEngine(fieldInfo);
+        final KNNEngine engine = extractKNNEngine(fieldInfo);
         if (KNNEngine.FAISS != engine) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support radial search", engine));
         }
-        final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
+        final SpaceType spaceType = getSpaceType(modelDao, fieldInfo);
         final float minScore = context.isMemoryOptimizedSearchEnabled ? context.getRadius() : engine.score(context.getRadius(), spaceType);
 
-        return searchWithMinScore(vectorScorer, matchedDocs, context.getMaxResultWindow(), minScore);
+        return collectTopK(BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore), context.getMaxResultWindow());
     }
 
     /**
@@ -224,54 +218,19 @@ public class ExactSearcher {
      * by descending score. This method is used as an optimization when the total number of
      * matched documents is small enough (≤ k) that maintaining a bounded heap is unnecessary.
      *
-     * @param vectorScorer the {@link VectorScorer} used to compute similarity scores
-     * @param matchedDocs  a {@link DocIdSetIterator} over the candidate document set, or {@code null}
-     *                     to score all documents available to the scorer
+     * @param scorer the {@link Scorer} lucene scorer for vectors
      * @return {@link TopDocs} containing all scored documents sorted by descending score
      * @throws IOException if an I/O error occurs while reading vectors or computing scores
      */
-    private TopDocs scoreAllDocs(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs) throws IOException {
-        final VectorScorer.Bulk bulkScorer = vectorScorer.bulk(matchedDocs);
-        final DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
+    private TopDocs scoreAllDocs(final Scorer scorer) throws IOException {
         final List<ScoreDoc> scoreDocList = new ArrayList<>();
-
-        bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer);
-        while (buffer.size > 0) {
-            for (int i = 0; i < buffer.size; i++) {
-                scoreDocList.add(new ScoreDoc(buffer.docs[i], buffer.features[i]));
-            }
-            bulkScorer.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, buffer);
+        final DocIdSetIterator scorerIterator = scorer.iterator();
+        for (int docId = scorerIterator.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = scorerIterator.nextDoc()) {
+            scoreDocList.add(new ScoreDoc(docId, scorer.score()));
         }
 
         scoreDocList.sort(Comparator.comparing(scoreDoc -> scoreDoc.score, Comparator.reverseOrder()));
         return new TopDocs(new TotalHits(scoreDocList.size(), TotalHits.Relation.EQUAL_TO), scoreDocList.toArray(ScoreDoc[]::new));
-    }
-
-    /**
-     * Finds the top-{@code k} highest-scoring documents using a fixed-size min-heap ({@link HitQueue}).
-     * Documents are processed in batches via the bulk scorer; batches whose maximum score falls below
-     * the current heap minimum are skipped entirely for efficiency.
-     *
-     * @param vectorScorer the {@link VectorScorer} used to compute similarity scores
-     * @param matchedDocs  a {@link DocIdSetIterator} over the candidate document set, or {@code null}
-     *                     to score all documents available to the scorer
-     * @param k            the number of top results to return
-     * @return {@link TopDocs} containing the {@code k} highest-scoring documents sorted by
-     * descending score; may contain fewer than {@code k} results if the candidate set
-     * is smaller or if sentinel entries are discarded
-     * @throws IOException if an I/O error occurs while reading vectors or computing scores
-     */
-    private TopDocs searchTopK(final VectorScorer vectorScorer, final DocIdSetIterator matchedDocs, final int k) throws IOException {
-        return collectTopK(BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs), k);
-    }
-
-    private TopDocs searchWithMinScore(
-        final VectorScorer vectorScorer,
-        final DocIdSetIterator matchedDocs,
-        final int maxResultWindow,
-        final float minScore
-    ) throws IOException {
-        return collectTopK(BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, minScore), maxResultWindow);
     }
 
     private static TopDocs collectTopK(final Scorer scorer, final int heapSize) throws IOException {
@@ -344,7 +303,7 @@ public class ExactSearcher {
         final ExactSearcherContext context
     ) throws IOException {
         final VectorDataType vectorDataType = FieldInfoExtractor.extractVectorDataType(fieldInfo);
-        final SpaceType spaceType = FieldInfoExtractor.getSpaceType(modelDao, fieldInfo);
+        final SpaceType spaceType = getSpaceType(modelDao, fieldInfo);
         final VectorScorerMode scorerMode = context.isUseQuantizedVectorsForSearch() ? VectorScorerMode.SCORE : VectorScorerMode.RESCORE;
         final boolean isNestedRequired = context.getParentsFilter() != null;
         final BitSet parentBitSet = isNestedRequired ? context.getParentsFilter().getBitSet(leafReaderContext) : null;

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.exactsearch;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.FixedBitSet;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.vectorvalues.TestVectorValues;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BulkVectorScorerTests extends KNNTestCase {
+
+    private static final VectorSimilarityFunction SIMILARITY = VectorSimilarityFunction.EUCLIDEAN;
+
+    @SneakyThrows
+    public void testFullPrecision_allDocsMatched_returnsCorrectScores() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.5f, 0.5f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        DocIdSetIterator iter = scorer.iterator();
+
+        assertEquals(0, iter.nextDoc());
+        assertEquals(SIMILARITY.compare(query, vectors.get(0)), scorer.score(), 1e-5f);
+
+        assertEquals(1, iter.nextDoc());
+        assertEquals(SIMILARITY.compare(query, vectors.get(1)), scorer.score(), 1e-5f);
+
+        assertEquals(2, iter.nextDoc());
+        assertEquals(SIMILARITY.compare(query, vectors.get(2)), scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testFullPrecision_filteredMatchedDocs_onlyScoresMatchedDocs() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.5f, 0.5f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.3f, 0.3f, 0.3f },
+            new float[] { 0.9f, 0.1f, 0.0f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        // Only match docs 1, 3, 4 — skip docs 0 and 2
+        FixedBitSet bitSet = new FixedBitSet(vectors.size());
+        bitSet.set(1);
+        bitSet.set(3);
+        bitSet.set(4);
+        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        DocIdSetIterator iter = scorer.iterator();
+
+        assertEquals(1, iter.nextDoc());
+        assertEquals(SIMILARITY.compare(query, vectors.get(1)), scorer.score(), 1e-5f);
+
+        assertEquals(3, iter.nextDoc());
+        assertEquals(SIMILARITY.compare(query, vectors.get(3)), scorer.score(), 1e-5f);
+
+        assertEquals(4, iter.nextDoc());
+        assertEquals(SIMILARITY.compare(query, vectors.get(4)), scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testMinScore_filteredMatchedDocs_filtersOnBothMatchAndScore() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.9f, 0.1f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.8f, 0.2f, 0.0f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        float score0 = SIMILARITY.compare(query, vectors.get(0));
+        float score1 = SIMILARITY.compare(query, vectors.get(1));
+        float score2 = SIMILARITY.compare(query, vectors.get(2));
+        float score3 = SIMILARITY.compare(query, vectors.get(3));
+        float score4 = SIMILARITY.compare(query, vectors.get(4));
+
+        // Choose minScore so that docs 1 and 3 (orthogonal vectors) are filtered by score
+        float minScore = (score1 + score4) / 2.0f;
+        assertTrue("doc 0 should pass score filter", score0 >= minScore);
+        assertTrue("doc 1 should fail score filter", score1 < minScore);
+        assertTrue("doc 2 should pass score filter", score2 >= minScore);
+        assertTrue("doc 3 should fail score filter", score3 < minScore);
+        assertTrue("doc 4 should pass score filter", score4 >= minScore);
+
+        // Only match docs 0, 2, 3, 4 — doc 0 is NOT in matched set
+        FixedBitSet bitSet = new FixedBitSet(vectors.size());
+        bitSet.set(0);
+        bitSet.set(2);
+        bitSet.set(3);
+        bitSet.set(4);
+        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, minScore);
+
+        DocIdSetIterator iter = scorer.iterator();
+
+        // doc 0: in matched set AND passes score filter
+        assertEquals(0, iter.nextDoc());
+        assertEquals(score0, scorer.score(), 1e-5f);
+
+        // doc 1: NOT in matched set — skipped
+        // doc 2: in matched set AND passes score filter
+        assertEquals(2, iter.nextDoc());
+        assertEquals(score2, scorer.score(), 1e-5f);
+
+        // doc 3: in matched set but fails score filter — skipped
+        // doc 4: in matched set AND passes score filter
+        assertEquals(4, iter.nextDoc());
+        assertEquals(score4, scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testMinScore_noDocsPassFilter() {
+        List<float[]> vectors = List.of(
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, Float.MAX_VALUE);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
+    }
+
+    @SneakyThrows
+    public void testIterator_advance_withFilteredDocs() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.5f, 0.5f, 0.0f },
+            new float[] { 0.3f, 0.3f, 0.3f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        FixedBitSet bitSet = new FixedBitSet(vectors.size());
+        bitSet.set(0);
+        bitSet.set(2);
+        bitSet.set(4);
+        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        DocIdSetIterator iter = scorer.iterator();
+        // Advance past doc 0 and 1 — should land on doc 2 (next matched doc >= 2)
+        int doc = iter.advance(2);
+        assertTrue(doc >= 2);
+        assertNotEquals(DocIdSetIterator.NO_MORE_DOCS, doc);
+        assertEquals(SIMILARITY.compare(query, vectors.get(doc)), scorer.score(), 1e-5f);
+    }
+
+    @SneakyThrows
+    public void testIterator_advancePastEnd() {
+        List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().advance(100));
+    }
+
+    @SneakyThrows
+    public void testDocID_initialState() {
+        List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        assertEquals(-1, scorer.docID());
+    }
+
+    @SneakyThrows
+    public void testGetMaxScore_returnsMaxValue() {
+        List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        assertEquals(Float.MAX_VALUE, scorer.getMaxScore(Integer.MAX_VALUE), 0.0f);
+    }
+
+    @SneakyThrows
+    public void testIterator_cost_reflectsMatchedDocs() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.5f, 0.5f, 0.0f },
+            new float[] { 0.3f, 0.3f, 0.3f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        FixedBitSet bitSet = new FixedBitSet(vectors.size());
+        bitSet.set(1);
+        bitSet.set(3);
+        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        assertEquals(bitSet.cardinality(), scorer.iterator().cost());
+    }
+
+    @SneakyThrows
+    public void testEmptyMatchedDocs() {
+        List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.empty();
+        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
+    }
+
+    private VectorScorer createVectorScorer(List<float[]> vectors, float[] query) throws IOException {
+        TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            vectors,
+            SIMILARITY
+        );
+        return floatVectorValues.scorer(query);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
@@ -15,7 +15,6 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.vectorvalues.TestVectorValues;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class BulkVectorScorerTests extends KNNTestCase {
@@ -141,10 +140,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
     @SneakyThrows
     public void testMinScore_noDocsPassFilter() {
-        List<float[]> vectors = List.of(
-            new float[] { 0.0f, 1.0f, 0.0f },
-            new float[] { 0.0f, 0.0f, 1.0f }
-        );
+        List<float[]> vectors = List.of(new float[] { 0.0f, 1.0f, 0.0f }, new float[] { 0.0f, 0.0f, 1.0f });
         float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
@@ -19,37 +19,75 @@ import java.util.List;
 
 public class BulkVectorScorerTests extends KNNTestCase {
 
-    private static final VectorSimilarityFunction SIMILARITY = VectorSimilarityFunction.EUCLIDEAN;
+    private static final float[] QUERY = new float[] { 1.0f, 0.0f, 0.0f };
 
     @SneakyThrows
-    public void testForRadialSearch_allDocsMatched_returnsCorrectScores() {
+    public void testForKSearch_euclidean_returnsAllDocsWithCorrectScores() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
             new float[] { 0.5f, 0.5f, 0.0f },
             new float[] { 0.0f, 0.0f, 1.0f }
         );
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
-
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
         DocIdSetIterator iter = scorer.iterator();
 
-        assertEquals(0, iter.nextDoc());
-        assertEquals(SIMILARITY.compare(query, vectors.get(0)), scorer.score(), 1e-5f);
-
-        assertEquals(1, iter.nextDoc());
-        assertEquals(SIMILARITY.compare(query, vectors.get(1)), scorer.score(), 1e-5f);
-
-        assertEquals(2, iter.nextDoc());
-        assertEquals(SIMILARITY.compare(query, vectors.get(2)), scorer.score(), 1e-5f);
-
+        for (int i = 0; i < vectors.size(); i++) {
+            assertEquals(i, iter.nextDoc());
+            assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(i)), scorer.score(), 1e-5f);
+        }
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
     }
 
     @SneakyThrows
-    public void testForRadialSearch_filteredMatchedDocs_onlyScoresMatchedDocs() {
+    public void testForKSearch_cosine_returnsAllDocsWithCorrectScores() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.707f, 0.707f, 0.0f },
+            new float[] { -1.0f, 0.0f, 0.0f }
+        );
+
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.COSINE),
+            DocIdSetIterator.all(vectors.size())
+        );
+        DocIdSetIterator iter = scorer.iterator();
+
+        for (int i = 0; i < vectors.size(); i++) {
+            assertEquals(i, iter.nextDoc());
+            assertEquals(VectorSimilarityFunction.COSINE.compare(QUERY, vectors.get(i)), scorer.score(), 1e-5f);
+        }
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testForKSearch_dotProduct_returnsAllDocsWithCorrectScores() {
+        List<float[]> vectors = List.of(
+            new float[] { 0.5f, 0.5f, 0.0f },
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.3f, 0.3f, 0.3f }
+        );
+
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.DOT_PRODUCT),
+            DocIdSetIterator.all(vectors.size())
+        );
+        DocIdSetIterator iter = scorer.iterator();
+
+        for (int i = 0; i < vectors.size(); i++) {
+            assertEquals(i, iter.nextDoc());
+            assertEquals(VectorSimilarityFunction.DOT_PRODUCT.compare(QUERY, vectors.get(i)), scorer.score(), 1e-5f);
+        }
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testForKSearch_filteredMatchedDocs_onlyScoresMatchedDocs() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
             new float[] { 0.5f, 0.5f, 0.0f },
@@ -57,34 +95,32 @@ public class BulkVectorScorerTests extends KNNTestCase {
             new float[] { 0.3f, 0.3f, 0.3f },
             new float[] { 0.9f, 0.1f, 0.0f }
         );
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        // Only match docs 1, 3, 4 — skip docs 0 and 2
         FixedBitSet bitSet = new FixedBitSet(vectors.size());
         bitSet.set(1);
         bitSet.set(3);
         bitSet.set(4);
-        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
-
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            new BitSetIterator(bitSet, bitSet.cardinality())
+        );
         DocIdSetIterator iter = scorer.iterator();
 
         assertEquals(1, iter.nextDoc());
-        assertEquals(SIMILARITY.compare(query, vectors.get(1)), scorer.score(), 1e-5f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(1)), scorer.score(), 1e-5f);
 
         assertEquals(3, iter.nextDoc());
-        assertEquals(SIMILARITY.compare(query, vectors.get(3)), scorer.score(), 1e-5f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(3)), scorer.score(), 1e-5f);
 
         assertEquals(4, iter.nextDoc());
-        assertEquals(SIMILARITY.compare(query, vectors.get(4)), scorer.score(), 1e-5f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(4)), scorer.score(), 1e-5f);
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
     }
 
     @SneakyThrows
-    public void testMinScore_filteredMatchedDocs_filtersOnBothMatchAndScore() {
+    public void testForRadialSearch_euclidean_filtersOnBothMatchAndScore() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
             new float[] { 0.0f, 1.0f, 0.0f },
@@ -92,46 +128,39 @@ public class BulkVectorScorerTests extends KNNTestCase {
             new float[] { 0.0f, 0.0f, 1.0f },
             new float[] { 0.8f, 0.2f, 0.0f }
         );
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        float score0 = SIMILARITY.compare(query, vectors.get(0));
-        float score1 = SIMILARITY.compare(query, vectors.get(1));
-        float score2 = SIMILARITY.compare(query, vectors.get(2));
-        float score3 = SIMILARITY.compare(query, vectors.get(3));
-        float score4 = SIMILARITY.compare(query, vectors.get(4));
+        float score0 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(0));
+        float score1 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(1));
+        float score2 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(2));
+        float score3 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(3));
+        float score4 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(4));
 
-        // Choose minScore so that docs 1 and 3 (orthogonal vectors) are filtered by score
         float minScore = (score1 + score4) / 2.0f;
-        assertTrue("doc 0 should pass score filter", score0 >= minScore);
-        assertTrue("doc 1 should fail score filter", score1 < minScore);
-        assertTrue("doc 2 should pass score filter", score2 >= minScore);
-        assertTrue("doc 3 should fail score filter", score3 < minScore);
-        assertTrue("doc 4 should pass score filter", score4 >= minScore);
+        assertTrue(score0 >= minScore);
+        assertTrue(score1 < minScore);
+        assertTrue(score2 >= minScore);
+        assertTrue(score3 < minScore);
+        assertTrue(score4 >= minScore);
 
-        // Only match docs 0, 2, 3, 4 — doc 0 is NOT in matched set
         FixedBitSet bitSet = new FixedBitSet(vectors.size());
         bitSet.set(0);
         bitSet.set(2);
         bitSet.set(3);
         bitSet.set(4);
-        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore);
-
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            new BitSetIterator(bitSet, bitSet.cardinality()),
+            minScore
+        );
         DocIdSetIterator iter = scorer.iterator();
 
-        // doc 0: in matched set AND passes score filter
         assertEquals(0, iter.nextDoc());
         assertEquals(score0, scorer.score(), 1e-5f);
 
-        // doc 1: NOT in matched set — skipped
-        // doc 2: in matched set AND passes score filter
         assertEquals(2, iter.nextDoc());
         assertEquals(score2, scorer.score(), 1e-5f);
 
-        // doc 3: in matched set but fails score filter — skipped
-        // doc 4: in matched set AND passes score filter
         assertEquals(4, iter.nextDoc());
         assertEquals(score4, scorer.score(), 1e-5f);
 
@@ -139,13 +168,80 @@ public class BulkVectorScorerTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testMinScore_noDocsPassFilter() {
-        List<float[]> vectors = List.of(new float[] { 0.0f, 1.0f, 0.0f }, new float[] { 0.0f, 0.0f, 1.0f });
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+    public void testForRadialSearch_cosine_filtersLowSimilarity() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.707f, 0.707f, 0.0f },
+            new float[] { -1.0f, 0.0f, 0.0f }
+        );
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, Float.MAX_VALUE);
+        float scoreDoc0 = VectorSimilarityFunction.COSINE.compare(QUERY, vectors.get(0));
+        float scoreDoc2 = VectorSimilarityFunction.COSINE.compare(QUERY, vectors.get(2));
+        float minScore = scoreDoc2 - 0.01f;
+
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.COSINE),
+            DocIdSetIterator.all(vectors.size()),
+            minScore
+        );
+        DocIdSetIterator iter = scorer.iterator();
+
+        assertEquals(0, iter.nextDoc());
+        assertEquals(scoreDoc0, scorer.score(), 1e-5f);
+
+        assertEquals(2, iter.nextDoc());
+        assertEquals(scoreDoc2, scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testForRadialSearch_dotProduct_filtersLowScores() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.5f, 0.5f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+
+        float scoreDoc0 = VectorSimilarityFunction.DOT_PRODUCT.compare(QUERY, vectors.get(0));
+        float scoreDoc1 = VectorSimilarityFunction.DOT_PRODUCT.compare(QUERY, vectors.get(1));
+        float scoreDoc2 = VectorSimilarityFunction.DOT_PRODUCT.compare(QUERY, vectors.get(2));
+        float minScore = scoreDoc1 - 0.01f;
+
+        assertTrue(scoreDoc0 >= minScore);
+        assertTrue(scoreDoc1 >= minScore);
+        assertTrue(scoreDoc2 < minScore);
+
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.DOT_PRODUCT),
+            DocIdSetIterator.all(vectors.size()),
+            minScore
+        );
+        DocIdSetIterator iter = scorer.iterator();
+
+        assertEquals(0, iter.nextDoc());
+        assertEquals(scoreDoc0, scorer.score(), 1e-5f);
+
+        assertEquals(1, iter.nextDoc());
+        assertEquals(scoreDoc1, scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testForRadialSearch_noDocsPassFilter() {
+        List<float[]> vectors = List.of(
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size()),
+            Float.MAX_VALUE
+        );
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
     }
@@ -154,28 +250,27 @@ public class BulkVectorScorerTests extends KNNTestCase {
     public void testIterator_advance_withFilteredDocs() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
-            new float[] { 0.0f, 1.0f, 0.0f },
-            new float[] { 0.0f, 0.0f, 1.0f },
             new float[] { 0.5f, 0.5f, 0.0f },
-            new float[] { 0.3f, 0.3f, 0.3f }
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.3f, 0.3f, 0.3f },
+            new float[] { 0.9f, 0.1f, 0.0f }
         );
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
         FixedBitSet bitSet = new FixedBitSet(vectors.size());
         bitSet.set(0);
         bitSet.set(2);
         bitSet.set(4);
-        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
-
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            new BitSetIterator(bitSet, bitSet.cardinality())
+        );
         DocIdSetIterator iter = scorer.iterator();
-        // Advance past doc 0 and 1 — should land on doc 2 (next matched doc >= 2)
+
         int doc = iter.advance(2);
         assertTrue(doc >= 2);
         assertNotEquals(DocIdSetIterator.NO_MORE_DOCS, doc);
-        assertEquals(SIMILARITY.compare(query, vectors.get(doc)), scorer.score(), 1e-5f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(doc)), scorer.score(), 1e-5f);
     }
 
     @SneakyThrows
@@ -186,36 +281,32 @@ public class BulkVectorScorerTests extends KNNTestCase {
             new float[] { 0.0f, 0.0f, 1.0f },
             new float[] { 0.5f, 0.5f, 0.0f }
         );
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
-
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
         DocIdSetIterator iter = scorer.iterator();
 
-        // Position at doc 2
         assertEquals(0, iter.nextDoc());
         assertEquals(1, iter.nextDoc());
         assertEquals(2, iter.nextDoc());
 
-        // advance(2) should return current doc since we're already at 2
         assertEquals(2, iter.advance(2));
-        assertEquals(SIMILARITY.compare(query, vectors.get(2)), scorer.score(), 1e-5f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(2)), scorer.score(), 1e-5f);
 
-        // advance(1) should also return current doc since we're past 1
         assertEquals(2, iter.advance(1));
-        assertEquals(SIMILARITY.compare(query, vectors.get(2)), scorer.score(), 1e-5f);
+        assertEquals(VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(2)), scorer.score(), 1e-5f);
     }
 
     @SneakyThrows
     public void testIterator_advancePastEnd() {
         List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().advance(100));
     }
@@ -223,11 +314,11 @@ public class BulkVectorScorerTests extends KNNTestCase {
     @SneakyThrows
     public void testDocID_initialState() {
         List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
 
         assertEquals(-1, scorer.docID());
     }
@@ -235,11 +326,11 @@ public class BulkVectorScorerTests extends KNNTestCase {
     @SneakyThrows
     public void testGetMaxScore_returnsMaxValue() {
         List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
 
         assertEquals(Float.MAX_VALUE, scorer.getMaxScore(Integer.MAX_VALUE), 0.0f);
     }
@@ -248,20 +339,20 @@ public class BulkVectorScorerTests extends KNNTestCase {
     public void testIterator_cost_reflectsMatchedDocs() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
-            new float[] { 0.0f, 1.0f, 0.0f },
-            new float[] { 0.0f, 0.0f, 1.0f },
             new float[] { 0.5f, 0.5f, 0.0f },
-            new float[] { 0.3f, 0.3f, 0.3f }
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.3f, 0.3f, 0.3f },
+            new float[] { 0.9f, 0.1f, 0.0f }
         );
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
         FixedBitSet bitSet = new FixedBitSet(vectors.size());
         bitSet.set(1);
         bitSet.set(3);
-        DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            new BitSetIterator(bitSet, bitSet.cardinality())
+        );
 
         assertEquals(bitSet.cardinality(), scorer.iterator().cost());
     }
@@ -269,19 +360,19 @@ public class BulkVectorScorerTests extends KNNTestCase {
     @SneakyThrows
     public void testEmptyMatchedDocs() {
         List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
-        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
-        VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        DocIdSetIterator matchedDocs = DocIdSetIterator.empty();
-        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.empty()
+        );
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
     }
 
-    private VectorScorer createVectorScorer(List<float[]> vectors, float[] query) throws IOException {
+    private VectorScorer createVectorScorer(List<float[]> vectors, float[] query, VectorSimilarityFunction similarity) throws IOException {
         TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
             vectors,
-            SIMILARITY
+            similarity
         );
         return floatVectorValues.scorer(query);
     }

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
@@ -22,7 +22,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
     private static final VectorSimilarityFunction SIMILARITY = VectorSimilarityFunction.EUCLIDEAN;
 
     @SneakyThrows
-    public void testFullPrecision_allDocsMatched_returnsCorrectScores() {
+    public void testForRadialSearch_allDocsMatched_returnsCorrectScores() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
             new float[] { 0.5f, 0.5f, 0.0f },
@@ -32,7 +32,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
         DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         DocIdSetIterator iter = scorer.iterator();
 
@@ -49,7 +49,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testFullPrecision_filteredMatchedDocs_onlyScoresMatchedDocs() {
+    public void testForRadialSearch_filteredMatchedDocs_onlyScoresMatchedDocs() {
         List<float[]> vectors = List.of(
             new float[] { 1.0f, 0.0f, 0.0f },
             new float[] { 0.5f, 0.5f, 0.0f },
@@ -67,7 +67,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
         DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         DocIdSetIterator iter = scorer.iterator();
 
@@ -117,7 +117,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
         DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, minScore);
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore);
 
         DocIdSetIterator iter = scorer.iterator();
 
@@ -145,7 +145,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
         DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs, Float.MAX_VALUE);
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, Float.MAX_VALUE);
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
     }
@@ -168,7 +168,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
         DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         DocIdSetIterator iter = scorer.iterator();
         // Advance past doc 0 and 1 — should land on doc 2 (next matched doc >= 2)
@@ -179,13 +179,43 @@ public class BulkVectorScorerTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testIterator_advance_whenAlreadyAtOrPastTarget_returnsCurrentDoc() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f },
+            new float[] { 0.5f, 0.5f, 0.0f }
+        );
+        float[] query = new float[] { 1.0f, 0.0f, 0.0f };
+
+        VectorScorer vectorScorer = createVectorScorer(vectors, query);
+        DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
+
+        DocIdSetIterator iter = scorer.iterator();
+
+        // Position at doc 2
+        assertEquals(0, iter.nextDoc());
+        assertEquals(1, iter.nextDoc());
+        assertEquals(2, iter.nextDoc());
+
+        // advance(2) should return current doc since we're already at 2
+        assertEquals(2, iter.advance(2));
+        assertEquals(SIMILARITY.compare(query, vectors.get(2)), scorer.score(), 1e-5f);
+
+        // advance(1) should also return current doc since we're past 1
+        assertEquals(2, iter.advance(1));
+        assertEquals(SIMILARITY.compare(query, vectors.get(2)), scorer.score(), 1e-5f);
+    }
+
+    @SneakyThrows
     public void testIterator_advancePastEnd() {
         List<float[]> vectors = List.of(new float[] { 1.0f, 0.0f, 0.0f });
         float[] query = new float[] { 1.0f, 0.0f, 0.0f };
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
         DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().advance(100));
     }
@@ -197,7 +227,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
         DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         assertEquals(-1, scorer.docID());
     }
@@ -209,7 +239,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
         DocIdSetIterator matchedDocs = DocIdSetIterator.all(vectors.size());
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         assertEquals(Float.MAX_VALUE, scorer.getMaxScore(Integer.MAX_VALUE), 0.0f);
     }
@@ -231,7 +261,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
         DocIdSetIterator matchedDocs = new BitSetIterator(bitSet, bitSet.cardinality());
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         assertEquals(bitSet.cardinality(), scorer.iterator().cost());
     }
@@ -243,7 +273,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
         VectorScorer vectorScorer = createVectorScorer(vectors, query);
         DocIdSetIterator matchedDocs = DocIdSetIterator.empty();
-        BulkVectorScorer scorer = BulkVectorScorer.fullPrecision(vectorScorer, matchedDocs);
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(vectorScorer, matchedDocs);
 
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
     }

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
@@ -232,10 +232,7 @@ public class BulkVectorScorerTests extends KNNTestCase {
 
     @SneakyThrows
     public void testForRadialSearch_noDocsPassFilter() {
-        List<float[]> vectors = List.of(
-            new float[] { 0.0f, 1.0f, 0.0f },
-            new float[] { 0.0f, 0.0f, 1.0f }
-        );
+        List<float[]> vectors = List.of(new float[] { 0.0f, 1.0f, 0.0f }, new float[] { 0.0f, 0.0f, 1.0f });
 
         BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(
             createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/BulkVectorScorerTests.java
@@ -366,6 +366,115 @@ public class BulkVectorScorerTests extends KNNTestCase {
         assertEquals(DocIdSetIterator.NO_MORE_DOCS, scorer.iterator().nextDoc());
     }
 
+    @SneakyThrows
+    public void testSetMinCompetitiveScore_skipsBatchBelowThreshold() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.9f, 0.1f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
+
+        float highScore = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(0));
+        scorer.setMinCompetitiveScore(highScore);
+
+        DocIdSetIterator iter = scorer.iterator();
+        assertEquals(0, iter.nextDoc());
+        assertEquals(highScore, scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testSetMinCompetitiveScore_filtersIndividualDocsInBatch() {
+        List<float[]> vectors = List.of(
+            new float[] { 0.9f, 0.1f, 0.0f },
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f }
+        );
+
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
+
+        float scoreDoc1 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(1));
+        float scoreDoc0 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(0));
+        float minCompetitive = (scoreDoc0 + scoreDoc1) / 2.0f;
+        assertTrue(scoreDoc1 >= minCompetitive);
+        assertTrue(scoreDoc0 < minCompetitive);
+
+        scorer.setMinCompetitiveScore(minCompetitive);
+
+        DocIdSetIterator iter = scorer.iterator();
+        assertEquals(1, iter.nextDoc());
+        assertEquals(scoreDoc1, scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testSetMinCompetitiveScore_zeroDoesNotFilter() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+
+        BulkVectorScorer scorer = BulkVectorScorer.forKSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size())
+        );
+
+        scorer.setMinCompetitiveScore(0f);
+
+        DocIdSetIterator iter = scorer.iterator();
+        assertEquals(0, iter.nextDoc());
+        assertEquals(1, iter.nextDoc());
+        assertEquals(2, iter.nextDoc());
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
+    @SneakyThrows
+    public void testSetMinCompetitiveScore_radialSearchStillFiltersOnMinScore() {
+        List<float[]> vectors = List.of(
+            new float[] { 1.0f, 0.0f, 0.0f },
+            new float[] { 0.9f, 0.1f, 0.0f },
+            new float[] { 0.0f, 1.0f, 0.0f },
+            new float[] { 0.0f, 0.0f, 1.0f }
+        );
+
+        float scoreDoc0 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(0));
+        float scoreDoc1 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(1));
+        float scoreDoc2 = VectorSimilarityFunction.EUCLIDEAN.compare(QUERY, vectors.get(2));
+
+        float radialMinScore = scoreDoc2 + 0.01f;
+        assertTrue(scoreDoc0 >= radialMinScore);
+        assertTrue(scoreDoc1 >= radialMinScore);
+        assertTrue(scoreDoc2 < radialMinScore);
+
+        BulkVectorScorer scorer = BulkVectorScorer.forRadialSearch(
+            createVectorScorer(vectors, QUERY, VectorSimilarityFunction.EUCLIDEAN),
+            DocIdSetIterator.all(vectors.size()),
+            radialMinScore
+        );
+
+        // minCompetitiveScore not set — radial filter alone decides
+        DocIdSetIterator iter = scorer.iterator();
+        assertEquals(0, iter.nextDoc());
+        assertEquals(scoreDoc0, scorer.score(), 1e-5f);
+
+        assertEquals(1, iter.nextDoc());
+        assertEquals(scoreDoc1, scorer.score(), 1e-5f);
+
+        assertEquals(DocIdSetIterator.NO_MORE_DOCS, iter.nextDoc());
+    }
+
     private VectorScorer createVectorScorer(List<float[]> vectors, float[] query, VectorSimilarityFunction similarity) throws IOException {
         TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
             vectors,

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
@@ -12,7 +12,9 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.FSDirectory;
@@ -33,6 +35,7 @@ import org.opensearch.knn.index.vectorvalues.TestVectorValues;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -528,6 +531,172 @@ public class ExactSearcherTests extends KNNTestCase {
             assertEquals(topDocs.scoreDocs.length, dataVectors.size());
             List<Float> actualScores = Arrays.stream(topDocs.scoreDocs).map(scoreDoc -> scoreDoc.score).toList();
             assertEquals(expectedScores, actualScores);
+        }
+    }
+
+    @SneakyThrows
+    public void testExactSearchScorer_whenSegmentHasNoVectorField_thenReturnsNull() {
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+
+        final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+            .field(FIELD_NAME)
+            .floatQueryVector(queryVector)
+            .k(10)
+            .build();
+
+        ExactSearcher exactSearcher = new ExactSearcher(null);
+        final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+        final SegmentReader reader = mock(SegmentReader.class);
+        when(leafReaderContext.reader()).thenReturn(reader);
+
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        when(reader.getFieldInfos()).thenReturn(fieldInfos);
+        when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(null);
+
+        Scorer scorer = exactSearcher.exactSearchScorer(leafReaderContext, exactSearcherContext);
+        assertNull(scorer);
+    }
+
+    @SneakyThrows
+    public void testExactSearchScorer_kSearch_returnsFullPrecisionScorer() {
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = SpaceType.L2;
+        final List<float[]> dataVectors = List.of(
+            new float[] { 1.0f, 2.0f, 3.0f },
+            new float[] { 4.0f, 5.0f, 6.0f },
+            new float[] { 0.0f, 1.0f, 2.0f }
+        );
+        final VectorSimilarityFunction similarityFunction = spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+
+        final TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            dataVectors,
+            similarityFunction
+        );
+        final KNNVectorValues knnFloatVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues);
+
+        DocIdSetIterator matchedDocsIterator = DocIdSetIterator.all(dataVectors.size());
+
+        final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+            .field(FIELD_NAME)
+            .floatQueryVector(queryVector)
+            .matchedDocsIterator(matchedDocsIterator)
+            .k(10)
+            .build();
+
+        try (MockedStatic<KNNVectorValuesFactory> vectorValuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+
+            vectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnFloatVectorValues);
+
+            Scorer scorer = exactSearcher.exactSearchScorer(leafReaderContext, exactSearcherContext);
+            assertNotNull(scorer);
+            assertTrue(scorer instanceof BulkVectorScorer);
+
+            // Verify the scorer returns all docs with correct scores
+            List<Float> actualScores = new ArrayList<>();
+            DocIdSetIterator iter = scorer.iterator();
+            while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                actualScores.add(scorer.score());
+            }
+
+            assertEquals(dataVectors.size(), actualScores.size());
+            for (int i = 0; i < dataVectors.size(); i++) {
+                float expected = similarityFunction.compare(queryVector, dataVectors.get(i));
+                assertEquals(expected, actualScores.get(i), 1e-5f);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void testExactSearchScorer_radialSearch_returnsMinScoreScorer() {
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = SpaceType.L2;
+        final List<float[]> dataVectors = List.of(
+            new float[] { 0.1f, 2.0f, 3.0f },
+            new float[] { 100.0f, 100.0f, 100.0f },
+            new float[] { 0.2f, 2.1f, 3.1f }
+        );
+        final VectorSimilarityFunction similarityFunction = spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+
+        // Compute scores to set a threshold
+        float score0 = similarityFunction.compare(queryVector, dataVectors.get(0));
+        float score1 = similarityFunction.compare(queryVector, dataVectors.get(1));
+        float score2 = similarityFunction.compare(queryVector, dataVectors.get(2));
+
+        // score0 and score2 should be high (close vectors), score1 should be low (far vector)
+        float minScore = (score1 + Math.min(score0, score2)) / 2.0f;
+
+        final TestVectorValues.PreDefinedFloatVectorValues floatVectorValues = new TestVectorValues.PreDefinedFloatVectorValues(
+            dataVectors,
+            similarityFunction
+        );
+        final KNNVectorValues knnFloatVectorValues = KNNVectorValuesFactory.getVectorValues(VectorDataType.FLOAT, floatVectorValues);
+
+        DocIdSetIterator matchedDocsIterator = DocIdSetIterator.all(dataVectors.size());
+
+        final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+            .field(FIELD_NAME)
+            .floatQueryVector(queryVector)
+            .matchedDocsIterator(matchedDocsIterator)
+            .radius(minScore)
+            .isMemoryOptimizedSearchEnabled(true)
+            .k(10)
+            .build();
+
+        try (MockedStatic<KNNVectorValuesFactory> vectorValuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            when(fieldInfo.attributes()).thenReturn(
+                Map.of(
+                    SPACE_TYPE,
+                    spaceType.getValue(),
+                    KNN_ENGINE,
+                    KNNEngine.FAISS.getName(),
+                    PARAMETERS,
+                    String.format(Locale.ROOT, "{\"%s\":\"%s\"}", INDEX_DESCRIPTION_PARAMETER, "HNSW32")
+                )
+            );
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+
+            vectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnFloatVectorValues);
+
+            Scorer scorer = exactSearcher.exactSearchScorer(leafReaderContext, exactSearcherContext);
+            assertNotNull(scorer);
+            assertTrue(scorer instanceof BulkVectorScorer);
+
+            // Verify the scorer only returns docs passing the minScore threshold
+            List<Integer> matchedDocIds = new ArrayList<>();
+            List<Float> actualScores = new ArrayList<>();
+            DocIdSetIterator iter = scorer.iterator();
+            while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                matchedDocIds.add(iter.docID());
+                actualScores.add(scorer.score());
+            }
+
+            // doc 1 (far vector) should be filtered out
+            for (int docId : matchedDocIds) {
+                float docScore = similarityFunction.compare(queryVector, dataVectors.get(docId));
+                assertTrue("doc " + docId + " should meet min score threshold", docScore >= minScore);
+            }
+            assertFalse("doc 1 should be filtered out", matchedDocIds.contains(1));
         }
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
@@ -29,6 +29,7 @@ import org.opensearch.knn.index.codec.KNNCodecVersion;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
+import org.opensearch.knn.index.query.scorers.VectorScorers;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValuesFactory;
 import org.opensearch.knn.index.vectorvalues.TestVectorValues;
@@ -614,6 +615,48 @@ public class ExactSearcherTests extends KNNTestCase {
                 float expected = similarityFunction.compare(queryVector, dataVectors.get(i));
                 assertEquals(expected, actualScores.get(i), 1e-5f);
             }
+        }
+    }
+
+    @SneakyThrows
+    public void testExactSearchScorer_whenVectorScorerIsNull_thenThrowsIllegalStateException() {
+        final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+        final SpaceType spaceType = SpaceType.L2;
+
+        final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+            .field(FIELD_NAME)
+            .floatQueryVector(queryVector)
+            .k(10)
+            .build();
+
+        try (
+            MockedStatic<KNNVectorValuesFactory> vectorValuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<VectorScorers> vectorScorersMockedStatic = Mockito.mockStatic(VectorScorers.class)
+        ) {
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+
+            final List<float[]> dataVectors = List.of(new float[] { 1.0f, 2.0f, 3.0f });
+            final KNNVectorValues knnFloatVectorValues = TestVectorValues.createKNNFloatVectorValues(dataVectors);
+            vectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnFloatVectorValues);
+
+            vectorScorersMockedStatic.when(() -> VectorScorers.createScorer(any(), any(float[].class), any(), any(), any(), any(), any()))
+                .thenReturn(null);
+
+            IllegalStateException exception = expectThrows(
+                IllegalStateException.class,
+                () -> exactSearcher.exactSearchScorer(leafReaderContext, exactSearcherContext)
+            );
+            assertTrue(exception.getMessage().contains("VectorScorer is null"));
         }
     }
 


### PR DESCRIPTION
### Description

Introduces BulkVectorScorer, a Lucene Scorer implementation that wraps the bulk vector scoring API and encapsulates score filtering logic. This replaces the manual buffer-iteration loops previously spread across ExactSearcher methods, consolidating all exact-search scoring into a single reusable abstraction.

#### Key changes
- **New BulkVectorScorer class** — A Scorer backed by VectorScorer.Bulk that iterates documents in batches, applies a score predicate, and exposes standard 
- DocIdSetIterator semantics (nextDoc, advance, cost). Two factory methods express intent:
    - forKSearch — accepts all scores (used for top-k collection)
    - forRadialSearch — filters to scores ≥ a minimum threshold
- **Simplified ExactSearcher** — Removed searchTopK, searchWithMinScore, and the raw buffer loop in scoreAllDocs. All paths now construct the appropriate BulkVectorScorer and pass it to collectTopK or the simplified scoreAllDocs(Scorer). This eliminates duplicated iteration logic and makes the scoring strategy explicit at the call site.

### Test plan

  - [x] New BulkVectorScorerTests — covers k-search scoring, radial search filtering, filtered doc iteration, advance() semantics (including at/past target),
  cost, initial state, empty docs, and edge cases
  - [x] New ExactSearcherTests — unit tests for exact searcher flows
  - [x] Existing integration tests (MOSFaissFloatIndexIT, FilteredSearchANNSearchIT) validate end-to-end behavior


### Related Issues
Partially Resolves [#3348](https://github.com/opensearch-project/k-NN/issues/3348)

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
