### PR TITLE
Add expression scripting unsupported integration test

### DIFF
--- a/src/test/java/org/opensearch/knn/integ/ExpressionScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ExpressionScriptScoreIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.integ;
+
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
+import org.opensearch.knn.integ.PainlessScriptHelper.MappingProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
+
+/**
+ * Verifies that Lucene Expression scripting is not supported for the knn_vector
+ * field type. A script_score query using lang: "expression" against a knn_vector
+ * field is rejected by the server with an error indicating the field must be
+ * numeric, date, or geopoint, since knn_vector does not expose numeric doc values.
+ * For comparison, the Painless equivalent (doc['my_vector'].value) is supported and
+ * exercised in PainlessScriptScoreIT. This test guards that unsupported behavior so
+ * the rejection stays explicit if the scripting paths change.
+ */
+public final class ExpressionScriptScoreIT extends KNNRestTestCase {
+
+    private static final String EXPRESSION_LANG = "expression";
+
+    private List<MappingProperty> buildKnnVectorMapping() {
+        List<MappingProperty> properties = new ArrayList<>();
+        properties.add(MappingProperty.builder().name(FIELD_NAME).type(KNNVectorFieldMapper.CONTENT_TYPE).dimension("2").build());
+        return properties;
+    }
+
+    private void buildSingleDocIndex() throws Exception {
+        createKnnIndex(INDEX_NAME, createMapping(buildKnnVectorMapping()));
+        addKnnDoc(INDEX_NAME, "1", FIELD_NAME, new Float[] { 1.0f, 1.0f });
+    }
+
+    /**
+     * doc['my_vector'].value uses standard Expression field-access syntax. The
+     * request is rejected with HTTP 400 and an error indicating the field must be
+     * numeric, date, or geopoint, confirming Expression cannot operate on a
+     * knn_vector field.
+     */
+    public void testExpressionScriptingUnsupportedOnKnnVector() throws Exception {
+        buildSingleDocIndex();
+        try {
+            String source = String.format("doc['%s'].value", FIELD_NAME);
+            QueryBuilder qb = new MatchAllQueryBuilder();
+            Request request = constructScriptScoreContextSearchRequest(
+                INDEX_NAME,
+                qb,
+                Collections.emptyMap(),
+                EXPRESSION_LANG,
+                source,
+                1,
+                Collections.emptyMap()
+            );
+
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(request));
+            Response response = e.getResponse();
+            int statusCode = response.getStatusLine().getStatusCode();
+            String body = EntityUtils.toString(response.getEntity());
+            logger.info("Expression script_score on knn_vector rejected as expected: {}", response.getStatusLine());
+            logger.info("Response body: {}", body);
+
+            assertEquals("Expected HTTP 400 for lang=expression on knn_vector", 400, statusCode);
+            assertTrue(
+                "Expected error indicating the field must be numeric, date, or geopoint, but was: " + body,
+                body.contains("must be numeric, date, or geopoint")
+            );
+        } finally {
+            deleteKNNIndex(INDEX_NAME);
+        }
+    }
+}


### PR DESCRIPTION
### Description

Adds an integration test that documents and guards the current behavior for Lucene Expression scripting over `knn_vector`. The new test creates a `knn_vector` index, runs a `script_score` query with `lang: "expression"`, and asserts that the request is rejected with HTTP 400 and an error indicating the field must be numeric, date, or geopoint.

While investigating #459, I focused on the Expression scripting path. Painless scripting over `knn_vector` is already covered by `PainlessScriptScoreIT`, but Expression scripting currently rejects `knn_vector` because the field does not expose numeric doc values. This test captures that observable behavior so the rejection remains explicit if the scripting paths change later.

This PR does not implement full Expression support for `knn_vector`. It adds focused integration coverage for the current unsupported behavior and provides a concrete baseline for maintainer guidance on whether Expression support should be handled in this plugin, documented separately, or pursued in OpenSearch core.

### Issues Resolved

Refs #459

### Check List

* [x] New functionality includes testing.
* [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.