### PR TITLE
Fix isFaissSQfp16 to not apply FP16 validation when SQ encoder uses b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
 * Check to see if Lucene's search budget has exhausted when deciding to exact search in MOS [#3354](https://github.com/opensearch-project/k-NN/pull/3354)
 * Fix FAISS SQ merge failure when segment has no live vectors [#3381](https://github.com/opensearch-project/k-NN/pull/3381)
+* Fix isFaissSQfp16 to skip FP16 validation when SQ encoder uses bits=1 [#3366](https://github.com/opensearch-project/k-NN/pull/3366)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFP16Util.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFP16Util.java
@@ -17,6 +17,7 @@ import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_CLIP;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_ENCODER_FP16;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.FP16_MAX_VALUE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MIN_VALUE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
@@ -95,13 +96,16 @@ public class FaissFP16Util {
      */
     static boolean isFaissSQfp16(MethodComponentContext methodComponentContext) {
         MethodComponentContext encoderContext = extractEncoderMethodComponentContext(methodComponentContext);
-        if (encoderContext == null) {
+        if (encoderContext == null || !ENCODER_SQ.equals(encoderContext.getName())) {
             return false;
         }
 
-        // returns true if encoder name is "sq" and type is "fp16"
-        return ENCODER_SQ.equals(encoderContext.getName())
-            && FAISS_SQ_ENCODER_FP16.equals(encoderContext.getParameters().getOrDefault(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16));
+        Object bitsObj = encoderContext.getParameters().get(SQ_BITS);
+        if (bitsObj instanceof Integer && (Integer) bitsObj == FaissSQEncoder.Bits.ONE.getValue()) {
+            return false;
+        }
+
+        return FAISS_SQ_ENCODER_FP16.equals(encoderContext.getParameters().getOrDefault(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16));
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissFP16UtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissFP16UtilTests.java
@@ -6,14 +6,23 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.MethodComponentContext;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_ENCODER_FP16;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MAX_VALUE;
 import static org.opensearch.knn.common.KNNConstants.FP16_MIN_VALUE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
 import static org.opensearch.knn.index.engine.faiss.FaissFP16Util.clipVectorValueToFP16Range;
+import static org.opensearch.knn.index.engine.faiss.FaissFP16Util.isFaissSQfp16;
 import static org.opensearch.knn.index.engine.faiss.FaissFP16Util.validateFP16VectorValue;
 
 public class FaissFP16UtilTests extends KNNTestCase {
@@ -55,6 +64,54 @@ public class FaissFP16UtilTests extends KNNTestCase {
         assertEquals(65504.0f, clipVectorValueToFP16Range(1000000.89f), 0.0f);
         assertEquals(-65504.0f, clipVectorValueToFP16Range(-65504.10f), 0.0f);
         assertEquals(-65504.0f, clipVectorValueToFP16Range(-1000000.89f), 0.0f);
+    }
+
+    public void testIsFaissSQfp16_nullContext_returnsFalse() {
+        assertFalse(isFaissSQfp16(null));
+    }
+
+    public void testIsFaissSQfp16_noEncoder_returnsFalse() {
+        MethodComponentContext methodContext = new MethodComponentContext(METHOD_HNSW, new HashMap<>());
+        assertFalse(isFaissSQfp16(methodContext));
+    }
+
+    public void testIsFaissSQfp16_nonSQEncoder_returnsFalse() {
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_FLAT, new HashMap<>());
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        MethodComponentContext methodContext = new MethodComponentContext(METHOD_HNSW, params);
+        assertFalse(isFaissSQfp16(methodContext));
+    }
+
+    public void testIsFaissSQfp16_sqEncoderWithBits1_returnsFalse() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(SQ_BITS, FaissSQEncoder.Bits.ONE.getValue());
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        MethodComponentContext methodContext = new MethodComponentContext(METHOD_HNSW, params);
+        assertFalse(isFaissSQfp16(methodContext));
+    }
+
+    public void testIsFaissSQfp16_sqEncoderWithTypeFp16_returnsTrue() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16);
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        MethodComponentContext methodContext = new MethodComponentContext(METHOD_HNSW, params);
+        assertTrue(isFaissSQfp16(methodContext));
+    }
+
+    public void testIsFaissSQfp16_sqEncoderWithBits16_returnsTrue() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(SQ_BITS, FaissSQEncoder.Bits.SIXTEEN.getValue());
+        encoderParams.put(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16);
+        MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
+        Map<String, Object> params = new HashMap<>();
+        params.put(METHOD_ENCODER_PARAMETER, encoderContext);
+        MethodComponentContext methodContext = new MethodComponentContext(METHOD_HNSW, params);
+        assertTrue(isFaissSQfp16(methodContext));
     }
 
 }


### PR DESCRIPTION
### Description
When SQ encoder is configured with `bits=1` (x32 compression), `isFaissSQfp16()` incorrectly returns `true` because `getOrDefault(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16)` falls back to the default `"fp16"` value. This causes FP16 range validation to be incorrectly applied to vectors that use 1-bit quantization.

This Fix
- Moves the encoder name check (`ENCODER_SQ`) into the null guard for early return
- Adds an explicit check for `bits=1` using `FaissSQEncoder.Bits.ONE` to skip FP16 validation
- Adds unit tests for isFaissSQfp16() covering null context, no encoder, non-SQ encoder, bits=1, bits=16, and fp16 type cases

### Reproduction
Create an index with SQ encoder bits=1:
```
% curl -X PUT "localhost:9200/test-sq-bits1" -H 'Content-Type: application/json' -d '{
    "settings": {
      "index": {
        "knn": true
      }
    },
    "mappings": {
      "properties": {
        "my_vector": {
          "type": "knn_vector",
          "dimension": 3,
          "method": {
            "name": "hnsw",
            "engine": "faiss",
            "parameters": {
              "encoder": {
                "name": "sq",
                "parameters": {
                  "bits": 1
                }
              }
            }
          }
        }
      }
    }
  }'
```
Index a vector with values outside FP16 range:
```
% curl -X POST "localhost:9200/test-sq-bits1/_doc/1" -H 'Content-Type: application/json' -d '{
  "my_vector": [100000.0, -100000.0, 50000.5]
}'
```

Without fix — incorrectly fails with FP16 validation error:
```
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "failed to parse field [my_vector] of type [knn_vector] in document with id '1'. Preview of field's value: '100000.0'"
      } 
    ],
    "type": "mapper_parsing_exception",
    "reason": "failed to parse field [my_vector] of type [knn_vector] in document with id '1'. Preview of field's value: '100000.0'",
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "encoder name is set as [sq] and type is set as [fp16] in index mapping. But, KNN vector values are not within in the FP16 range [-65504.000000, 65504.000000]"
    }
  },
  "status": 400
}
```
With fix — succeeds as expected:
```
{
  "_index": "test-sq-bits1",
  "_id": "1",
  "_version": 1,
  "result": "created",
  "_shards": {
    "total": 2,
    "successful": 1,
    "failed": 0
  },
  "_seq_no": 0,
  "_primary_term": 1
}
```


- Adds unit tests covering null context, no encoder, non-SQ encoder, bits=1, bits=16, and fp16 type cases

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
