### PR TITLE
[BugFix] Fix NPE in nested kNN search when index contains documents without nested object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 
 ### Bug Fixes
+* Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
 * Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnUtil.java
@@ -6,6 +6,9 @@
 package org.opensearch.knn.index.query.lucenelib;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.util.BitSet;
 
@@ -15,6 +18,8 @@ import java.io.IOException;
  * Utility methods for nested kNN vector queries.
  */
 final class NestedKnnUtil {
+
+    static final TopDocs EMPTY_TOP_DOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
 
     private NestedKnnUtil() {}
 

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnUtil.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/NestedKnnUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucenelib;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.util.BitSet;
+
+import java.io.IOException;
+
+/**
+ * Utility methods for nested kNN vector queries.
+ */
+final class NestedKnnUtil {
+
+    private NestedKnnUtil() {}
+
+    /**
+     * Checks if a segment has no parent documents (no nested objects).
+     * This is used to short-circuit kNN search on segments where no vectors exist,
+     * preventing a NPE in Lucene's TimeLimitingKnnCollectorManager which wraps a null
+     * collector when DiversifyingNearestChildrenKnnCollectorManager returns null.
+     *
+     * @param parentFilter the parent document filter
+     * @param context the leaf reader context for the segment
+     * @return true if the segment has no parent documents
+     */
+    static boolean hasNoParentDocs(BitSetProducer parentFilter, LeafReaderContext context) throws IOException {
+        BitSet parentBitSet = parentFilter.getBitSet(context);
+        return parentBitSet == null;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
@@ -53,7 +53,10 @@ public final class OSDiversifyingChildrenByteKnnVectorQuery extends Diversifying
         // BitSet in segment), then topDocs() is called on the null inner collector.
         BitSet parentBitSet = parentFilter.getBitSet(context);
         if (parentBitSet == null) {
-            return new TopDocs(new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO), new org.apache.lucene.search.ScoreDoc[0]);
+            return new TopDocs(
+                new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO),
+                new org.apache.lucene.search.ScoreDoc[0]
+            );
         }
         return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
@@ -8,9 +8,7 @@ package org.opensearch.knn.index.query.lucenelib;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.apache.lucene.search.knn.KnnCollectorManager;
@@ -25,7 +23,6 @@ import java.io.IOException;
  * documents are returned, maintaining consistency with OpenSearch's k-NN query behavior.
  */
 public final class OSDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery {
-    private static final TopDocs EMPTY_TOP_DOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
 
     private final int k;
     private final BitSetProducer parentFilter;
@@ -51,7 +48,7 @@ public final class OSDiversifyingChildrenByteKnnVectorQuery extends Diversifying
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
         if (NestedKnnUtil.hasNoParentDocs(parentFilter, context)) {
-            return EMPTY_TOP_DOCS;
+            return NestedKnnUtil.EMPTY_TOP_DOCS;
         }
         return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.util.BitSet;
 
 import java.io.IOException;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
  */
 public final class OSDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery {
     private final int k;
+    private final BitSetProducer parentFilter;
 
     public OSDiversifyingChildrenByteKnnVectorQuery(
         final String fieldName,
@@ -35,6 +37,7 @@ public final class OSDiversifyingChildrenByteKnnVectorQuery extends Diversifying
     ) {
         super(fieldName, vector, filterQuery, luceneK, parentFilter);
         this.k = k;
+        this.parentFilter = parentFilter;
     }
 
     @Override
@@ -44,11 +47,15 @@ public final class OSDiversifyingChildrenByteKnnVectorQuery extends Diversifying
         int visitedLimit,
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
-        try {
-            return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
-        } catch (NullPointerException e) {
+        // Check if the segment has parent documents (nested docs). If not, return empty results.
+        // This prevents a NPE in Lucene's TimeLimitingKnnCollectorManager which wraps a null
+        // collector when DiversifyingNearestChildrenKnnCollectorManager returns null (no parent
+        // BitSet in segment), then topDocs() is called on the null inner collector.
+        BitSet parentBitSet = parentFilter.getBitSet(context);
+        if (parentBitSet == null) {
             return new TopDocs(new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO), new org.apache.lucene.search.ScoreDoc[0]);
         }
+        return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
@@ -5,10 +5,15 @@
 
 package org.opensearch.knn.index.query.lucenelib;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.AcceptDocs;
+
+import java.io.IOException;
 
 /**
  * OpenSearch wrapper around Lucene's DiversifyingChildrenByteKnnVectorQuery that customizes
@@ -30,6 +35,20 @@ public final class OSDiversifyingChildrenByteKnnVectorQuery extends Diversifying
     ) {
         super(fieldName, vector, filterQuery, luceneK, parentFilter);
         this.k = k;
+    }
+
+    @Override
+    protected TopDocs approximateSearch(
+        LeafReaderContext context,
+        AcceptDocs acceptDocs,
+        int visitedLimit,
+        KnnCollectorManager knnCollectorManager
+    ) throws IOException {
+        try {
+            return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+        } catch (NullPointerException e) {
+            return new TopDocs(new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO), new org.apache.lucene.search.ScoreDoc[0]);
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQuery.java
@@ -6,13 +6,14 @@
 package org.opensearch.knn.index.query.lucenelib;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.apache.lucene.search.knn.KnnCollectorManager;
-import org.apache.lucene.search.AcceptDocs;
-import org.apache.lucene.util.BitSet;
 
 import java.io.IOException;
 
@@ -24,6 +25,8 @@ import java.io.IOException;
  * documents are returned, maintaining consistency with OpenSearch's k-NN query behavior.
  */
 public final class OSDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery {
+    private static final TopDocs EMPTY_TOP_DOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+
     private final int k;
     private final BitSetProducer parentFilter;
 
@@ -47,16 +50,8 @@ public final class OSDiversifyingChildrenByteKnnVectorQuery extends Diversifying
         int visitedLimit,
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
-        // Check if the segment has parent documents (nested docs). If not, return empty results.
-        // This prevents a NPE in Lucene's TimeLimitingKnnCollectorManager which wraps a null
-        // collector when DiversifyingNearestChildrenKnnCollectorManager returns null (no parent
-        // BitSet in segment), then topDocs() is called on the null inner collector.
-        BitSet parentBitSet = parentFilter.getBitSet(context);
-        if (parentBitSet == null) {
-            return new TopDocs(
-                new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO),
-                new org.apache.lucene.search.ScoreDoc[0]
-            );
+        if (NestedKnnUtil.hasNoParentDocs(parentFilter, context)) {
+            return EMPTY_TOP_DOCS;
         }
         return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
@@ -8,9 +8,7 @@ package org.opensearch.knn.index.query.lucenelib;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.apache.lucene.search.knn.KnnCollectorManager;
@@ -26,7 +24,6 @@ import java.io.IOException;
  * documents are returned, maintaining consistency with OpenSearch's k-NN query behavior.
  */
 public final class OSDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery {
-    private static final TopDocs EMPTY_TOP_DOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
 
     private final int k;
     private final int rescoreK;
@@ -70,7 +67,7 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
         if (NestedKnnUtil.hasNoParentDocs(parentFilter, context)) {
-            return EMPTY_TOP_DOCS;
+            return NestedKnnUtil.EMPTY_TOP_DOCS;
         }
         return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
@@ -6,13 +6,13 @@
 package org.opensearch.knn.index.query.lucenelib;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.util.BitSet;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
@@ -28,6 +28,7 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
     private final int k;
     private final int rescoreK;
     private final boolean expandNestedDocs;
+    private final BitSetProducer parentFilter;
 
     public OSDiversifyingChildrenFloatKnnVectorQuery(
         final String fieldName,
@@ -55,6 +56,7 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         this.k = k;
         this.rescoreK = rescoreK;
         this.expandNestedDocs = expandNestedDocs;
+        this.parentFilter = parentFilter;
     }
 
     @Override
@@ -64,14 +66,15 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         int visitedLimit,
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
-        try {
-            return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
-        } catch (NullPointerException e) {
-            // Workaround for Lucene bug: TimeLimitingKnnCollectorManager wraps a null collector
-            // when a segment has no vector values, then topDocs() is called on the null inner collector.
-            // This happens when documents without nested vector fields exist in a separate segment.
+        // Check if the segment has parent documents (nested docs). If not, return empty results.
+        // This prevents a NPE in Lucene's TimeLimitingKnnCollectorManager which wraps a null
+        // collector when DiversifyingNearestChildrenKnnCollectorManager returns null (no parent
+        // BitSet in segment), then topDocs() is called on the null inner collector.
+        BitSet parentBitSet = parentFilter.getBitSet(context);
+        if (parentBitSet == null) {
             return new TopDocs(new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO), new org.apache.lucene.search.ScoreDoc[0]);
         }
+        return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
@@ -5,11 +5,17 @@
 
 package org.opensearch.knn.index.query.lucenelib;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.AcceptDocs;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import java.io.IOException;
 
 /**
  * OpenSearch wrapper around Lucene's DiversifyingChildrenFloatKnnVectorQuery that customizes
@@ -49,6 +55,23 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         this.k = k;
         this.rescoreK = rescoreK;
         this.expandNestedDocs = expandNestedDocs;
+    }
+
+    @Override
+    protected TopDocs approximateSearch(
+        LeafReaderContext context,
+        AcceptDocs acceptDocs,
+        int visitedLimit,
+        KnnCollectorManager knnCollectorManager
+    ) throws IOException {
+        try {
+            return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
+        } catch (NullPointerException e) {
+            // Workaround for Lucene bug: TimeLimitingKnnCollectorManager wraps a null collector
+            // when a segment has no vector values, then topDocs() is called on the null inner collector.
+            // This happens when documents without nested vector fields exist in a separate segment.
+            return new TopDocs(new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO), new org.apache.lucene.search.ScoreDoc[0]);
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
@@ -6,13 +6,14 @@
 package org.opensearch.knn.index.query.lucenelib;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.apache.lucene.search.knn.KnnCollectorManager;
-import org.apache.lucene.search.AcceptDocs;
-import org.apache.lucene.util.BitSet;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.io.IOException;
@@ -25,6 +26,8 @@ import java.io.IOException;
  * documents are returned, maintaining consistency with OpenSearch's k-NN query behavior.
  */
 public final class OSDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery {
+    private static final TopDocs EMPTY_TOP_DOCS = new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+
     private final int k;
     private final int rescoreK;
     private final boolean expandNestedDocs;
@@ -66,16 +69,8 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         int visitedLimit,
         KnnCollectorManager knnCollectorManager
     ) throws IOException {
-        // Check if the segment has parent documents (nested docs). If not, return empty results.
-        // This prevents a NPE in Lucene's TimeLimitingKnnCollectorManager which wraps a null
-        // collector when DiversifyingNearestChildrenKnnCollectorManager returns null (no parent
-        // BitSet in segment), then topDocs() is called on the null inner collector.
-        BitSet parentBitSet = parentFilter.getBitSet(context);
-        if (parentBitSet == null) {
-            return new TopDocs(
-                new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO),
-                new org.apache.lucene.search.ScoreDoc[0]
-            );
+        if (NestedKnnUtil.hasNoParentDocs(parentFilter, context)) {
+            return EMPTY_TOP_DOCS;
         }
         return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }

--- a/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQuery.java
@@ -72,7 +72,10 @@ public final class OSDiversifyingChildrenFloatKnnVectorQuery extends Diversifyin
         // BitSet in segment), then topDocs() is called on the null inner collector.
         BitSet parentBitSet = parentFilter.getBitSet(context);
         if (parentBitSet == null) {
-            return new TopDocs(new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO), new org.apache.lucene.search.ScoreDoc[0]);
+            return new TopDocs(
+                new org.apache.lucene.search.TotalHits(0, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO),
+                new org.apache.lucene.search.ScoreDoc[0]
+            );
         }
         return super.approximateSearch(context, acceptDocs, visitedLimit, knnCollectorManager);
     }

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/NestedKnnUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/NestedKnnUtilTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query.lucenelib;
+
+import junit.framework.TestCase;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.util.BitSet;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NestedKnnUtilTests extends TestCase {
+
+    public void testHasNoParentDocs_whenBitSetNull_thenReturnTrue() throws IOException {
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+        LeafReaderContext context = mock(LeafReaderContext.class);
+
+        when(parentFilter.getBitSet(context)).thenReturn(null);
+
+        assertTrue(NestedKnnUtil.hasNoParentDocs(parentFilter, context));
+    }
+
+    public void testHasNoParentDocs_whenBitSetExists_thenReturnFalse() throws IOException {
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+        LeafReaderContext context = mock(LeafReaderContext.class);
+        BitSet bitSet = mock(BitSet.class);
+
+        when(parentFilter.getBitSet(context)).thenReturn(bitSet);
+
+        assertFalse(NestedKnnUtil.hasNoParentDocs(parentFilter, context));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenByteKnnVectorQueryTests.java
@@ -6,14 +6,20 @@
 package org.opensearch.knn.index.query.lucenelib;
 
 import junit.framework.TestCase;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+
+import java.io.IOException;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class OSDiversifyingChildrenByteKnnVectorQueryTests extends TestCase {
 
@@ -67,6 +73,35 @@ public class OSDiversifyingChildrenByteKnnVectorQueryTests extends TestCase {
         assertEquals(k, result.scoreDocs.length);
         assertTrue(result.scoreDocs[0].score >= result.scoreDocs[1].score);
         assertTrue(result.scoreDocs[1].score >= result.scoreDocs[2].score);
+    }
+
+    public void testApproximateSearch_whenParentBitSetNull_thenReturnEmptyResults() throws IOException {
+        String fieldName = "test_field";
+        byte[] queryVector = { 1, 2, 3 };
+        int luceneK = 10;
+        int k = 5;
+        Query filterQuery = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+        LeafReaderContext context = mock(LeafReaderContext.class);
+        KnnCollectorManager knnCollectorManager = mock(KnnCollectorManager.class);
+        AcceptDocs acceptDocs = mock(AcceptDocs.class);
+
+        when(parentFilter.getBitSet(context)).thenReturn(null);
+
+        OSDiversifyingChildrenByteKnnVectorQuery query = new OSDiversifyingChildrenByteKnnVectorQuery(
+            fieldName,
+            queryVector,
+            filterQuery,
+            luceneK,
+            parentFilter,
+            k
+        );
+
+        TopDocs result = query.approximateSearch(context, acceptDocs, Integer.MAX_VALUE, knnCollectorManager);
+
+        assertNotNull(result);
+        assertEquals(0, result.totalHits.value());
+        assertEquals(0, result.scoreDocs.length);
     }
 
     public void testMergeLeafResults_withFewerResultsThanK() {

--- a/src/test/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/lucenelib/OSDiversifyingChildrenFloatKnnVectorQueryTests.java
@@ -6,14 +6,20 @@
 package org.opensearch.knn.index.query.lucenelib;
 
 import junit.framework.TestCase;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+
+import java.io.IOException;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
 
@@ -246,6 +252,37 @@ public class OSDiversifyingChildrenFloatKnnVectorQueryTests extends TestCase {
 
         // When expandNestedDocs is true, should reduce to k even if rescoreK > 0
         assertEquals(k, result.scoreDocs.length);
+    }
+
+    public void testApproximateSearch_whenParentBitSetNull_thenReturnEmptyResults() throws IOException {
+        String fieldName = "test_field";
+        float[] queryVector = { 1.0f, 2.0f, 3.0f };
+        int luceneK = 10;
+        int k = 5;
+        int rescoreK = 0;
+        Query filterQuery = mock(Query.class);
+        BitSetProducer parentFilter = mock(BitSetProducer.class);
+        LeafReaderContext context = mock(LeafReaderContext.class);
+        KnnCollectorManager knnCollectorManager = mock(KnnCollectorManager.class);
+        AcceptDocs acceptDocs = mock(AcceptDocs.class);
+
+        when(parentFilter.getBitSet(context)).thenReturn(null);
+
+        OSDiversifyingChildrenFloatKnnVectorQuery query = new OSDiversifyingChildrenFloatKnnVectorQuery(
+            fieldName,
+            queryVector,
+            filterQuery,
+            luceneK,
+            parentFilter,
+            k,
+            rescoreK
+        );
+
+        TopDocs result = query.approximateSearch(context, acceptDocs, Integer.MAX_VALUE, knnCollectorManager);
+
+        assertNotNull(result);
+        assertEquals(0, result.totalHits.value());
+        assertEquals(0, result.scoreDocs.length);
     }
 
     public void testMergeLeafResultsWithRescoreK_trimsToRescoreKNotLuceneK() {

--- a/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
@@ -302,6 +302,30 @@ public class ExpandNestedDocsIT extends KNNRestTestCase {
         }
     }
 
+    @SneakyThrows
+    public void testExpandNestedDocs_whenDocWithoutNestedObjectInSeparateSegment_thenSucceed() {
+        createKnnIndex(engine, mode, dimension, dataType);
+
+        NestedKnnDocBuilder docBuilder = NestedKnnDocBuilder.create(FIELD_NAME_NESTED);
+        Float[] vector = createVector();
+        docBuilder.addVectors(FIELD_NAME_VECTOR, vector);
+        String doc = docBuilder.build();
+        addKnnDoc(INDEX_NAME, "1", doc);
+        flushIndex(INDEX_NAME);
+
+        addKnnDoc(INDEX_NAME, "2", "{}");
+        flushIndex(INDEX_NAME);
+
+        refreshIndex(INDEX_NAME);
+
+        Float[] queryVector = createVector();
+        Response response = queryNestedFieldWithExpandNestedDocs(INDEX_NAME, 1, queryVector);
+        String entity = EntityUtils.toString(response.getEntity());
+        Multimap<String, Integer> docIdToOffsets = parseInnerHits(entity, FIELD_NAME_NESTED);
+        assertEquals(1, docIdToOffsets.keySet().size());
+        assertTrue(docIdToOffsets.containsKey("1"));
+    }
+
     private Float[] createVector() {
         int vectorSize = VectorDataType.BINARY.equals(dataType) ? dimension / 8 : dimension;
         Float[] vector = new Float[vectorSize];

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchByteIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchByteIT.java
@@ -125,6 +125,39 @@ public class NestedSearchByteIT extends KNNRestTestCase {
         assertEquals(2, parseTotalSearchHits(entity));
     }
 
+    @SneakyThrows
+    public void testNestedSearchWithLuceneByte_whenDocWithoutNestedObjectInSeparateSegment_thenSucceed() {
+        String indexName = INDEX_NAME + "_lucene_byte_npe";
+        String nestedFieldName = "nested";
+        createKnnByteIndexWithNestedField(indexName, nestedFieldName, FIELD_NAME, 4, KNNEngine.LUCENE);
+
+        String doc = NestedKnnDocBuilder.create(nestedFieldName)
+            .addVectors(FIELD_NAME, new Byte[] { 1, 2, 3, 4 }, new Byte[] { 5, 6, 7, 8 })
+            .build();
+        addKnnDoc(indexName, "1", doc);
+        flushIndex(indexName);
+
+        addKnnDoc(indexName, "2", "{}");
+        flushIndex(indexName);
+
+        refreshIndex(indexName);
+
+        Byte[] queryVector = { 1, 2, 3, 4 };
+        String query = KNNJsonQueryBuilder.builder()
+            .nestedFieldName(nestedFieldName)
+            .fieldName(FIELD_NAME)
+            .vector(queryVector)
+            .k(1)
+            .build()
+            .getQueryString();
+        Response response = searchKNNIndex(indexName, query, 1);
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(1, parseHits(entity));
+        assertEquals("1", parseIds(entity).get(0));
+
+        deleteKNNIndex(indexName);
+    }
+
     private void createKnnByteIndexWithNestedField(
         final String indexName,
         final String nestedFieldName,

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
@@ -155,6 +155,28 @@ public class NestedSearchIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testNestedSearchWithFaissMOS_whenDocWithoutNestedObjectInSeparateSegment_thenSucceed() {
+        createKnnIndex(2, KNNEngine.FAISS.getName(), Mode.ON_DISK);
+
+        String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+            .addVectors(FIELD_NAME_VECTOR, new Float[] { 1f, 1f }, new Float[] { 2f, 2f })
+            .build();
+        addKnnDoc(INDEX_NAME, "1", doc);
+        flushIndex(INDEX_NAME);
+
+        addKnnDoc(INDEX_NAME, "2", "{}");
+        flushIndex(INDEX_NAME);
+
+        refreshIndex(INDEX_NAME);
+
+        Float[] queryVector = { 1f, 1f };
+        Response response = queryNestedField(INDEX_NAME, 1, queryVector);
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(1, parseHits(entity));
+        assertEquals("1", parseIds(entity).get(0));
+    }
+
+    @SneakyThrows
     public void testNestedSearchWithFaiss_whenKIsTwo_SomeNestedDocsHasNoVectors_thenReturnTwoResults() {
         createKnnIndex(2, KNNEngine.FAISS.getName());
         indexAndTestKNNIndexWithVectorAndNonVectorField();

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
@@ -427,7 +427,10 @@ public class NestedSearchIT extends KNNRestTestCase {
 
         String mapping = builder.toString();
         if (memoryOptimizedSearch) {
-            Settings settings = Settings.builder().put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true).build();
+            Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
+                .build();
             createKnnIndex(INDEX_NAME, settings, mapping);
         } else {
             createKnnIndex(INDEX_NAME, mapping);

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
@@ -156,7 +156,7 @@ public class NestedSearchIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testNestedSearchWithFaissMOS_whenDocWithoutNestedObjectInSeparateSegment_thenSucceed() {
-        createKnnIndex(2, KNNEngine.FAISS.getName(), Mode.ON_DISK);
+        createKnnIndex(2, KNNEngine.FAISS.getName(), true);
 
         String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
             .addVectors(FIELD_NAME_VECTOR, new Float[] { 1f, 1f }, new Float[] { 2f, 2f })
@@ -385,11 +385,18 @@ public class NestedSearchIT extends KNNRestTestCase {
      *  }
      */
     private void createKnnIndex(final int dimension, final String engine) throws Exception {
-        // Using default mode of IN_MEMORY
-        createKnnIndex(dimension, engine, Mode.IN_MEMORY);
+        createKnnIndex(dimension, engine, Mode.IN_MEMORY, false);
+    }
+
+    private void createKnnIndex(final int dimension, final String engine, boolean memoryOptimizedSearch) throws Exception {
+        createKnnIndex(dimension, engine, Mode.IN_MEMORY, memoryOptimizedSearch);
     }
 
     private void createKnnIndex(final int dimension, final String engine, Mode mode) throws Exception {
+        createKnnIndex(dimension, engine, mode, false);
+    }
+
+    private void createKnnIndex(final int dimension, final String engine, Mode mode, boolean memoryOptimizedSearch) throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject(PROPERTIES_FIELD)
@@ -419,7 +426,14 @@ public class NestedSearchIT extends KNNRestTestCase {
             .endObject();
 
         String mapping = builder.toString();
-        createKnnIndex(INDEX_NAME, mapping);
+        if (memoryOptimizedSearch) {
+            Settings settings = Settings.builder()
+                .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
+                .build();
+            createKnnIndex(INDEX_NAME, settings, mapping);
+        } else {
+            createKnnIndex(INDEX_NAME, mapping);
+        }
     }
 
     private Response queryNestedField(final String index, final int k, final Object[] vector) throws IOException {

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
@@ -111,6 +111,50 @@ public class NestedSearchIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
+    public void testNestedSearchWithLucene_whenDocWithoutNestedObjectInSeparateSegment_thenSucceed() {
+        createKnnIndex(2, KNNEngine.LUCENE.getName());
+
+        String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+            .addVectors(FIELD_NAME_VECTOR, new Float[] { 1f, 1f }, new Float[] { 2f, 2f })
+            .build();
+        addKnnDoc(INDEX_NAME, "1", doc);
+        flushIndex(INDEX_NAME);
+
+        addKnnDoc(INDEX_NAME, "2", "{}");
+        flushIndex(INDEX_NAME);
+
+        refreshIndex(INDEX_NAME);
+
+        Float[] queryVector = { 1f, 1f };
+        Response response = queryNestedField(INDEX_NAME, 1, queryVector);
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(1, parseHits(entity));
+        assertEquals("1", parseIds(entity).get(0));
+    }
+
+    @SneakyThrows
+    public void testNestedSearchWithFaiss_whenDocWithoutNestedObjectInSeparateSegment_thenSucceed() {
+        createKnnIndex(2, KNNEngine.FAISS.getName());
+
+        String doc = NestedKnnDocBuilder.create(FIELD_NAME_NESTED)
+            .addVectors(FIELD_NAME_VECTOR, new Float[] { 1f, 1f }, new Float[] { 2f, 2f })
+            .build();
+        addKnnDoc(INDEX_NAME, "1", doc);
+        flushIndex(INDEX_NAME);
+
+        addKnnDoc(INDEX_NAME, "2", "{}");
+        flushIndex(INDEX_NAME);
+
+        refreshIndex(INDEX_NAME);
+
+        Float[] queryVector = { 1f, 1f };
+        Response response = queryNestedField(INDEX_NAME, 1, queryVector);
+        String entity = EntityUtils.toString(response.getEntity());
+        assertEquals(1, parseHits(entity));
+        assertEquals("1", parseIds(entity).get(0));
+    }
+
+    @SneakyThrows
     public void testNestedSearchWithFaiss_whenKIsTwo_SomeNestedDocsHasNoVectors_thenReturnTwoResults() {
         createKnnIndex(2, KNNEngine.FAISS.getName());
         indexAndTestKNNIndexWithVectorAndNonVectorField();

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
@@ -427,9 +427,7 @@ public class NestedSearchIT extends KNNRestTestCase {
 
         String mapping = builder.toString();
         if (memoryOptimizedSearch) {
-            Settings settings = Settings.builder()
-                .put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
-                .build();
+            Settings settings = Settings.builder().put(KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true).build();
             createKnnIndex(INDEX_NAME, settings, mapping);
         } else {
             createKnnIndex(INDEX_NAME, mapping);


### PR DESCRIPTION
## Summary

Fixes #3359

- KNN search on a nested vector field throws `NullPointerException: Cannot invoke "org.apache.lucene.search.KnnCollector.topDocs()" because "this.collector" is null` when the index contains documents without the nested object in a separate segment.
- Root cause: Lucene's `TimeLimitingKnnCollectorManager.newCollector()` wraps a null collector (returned when a segment has no vector values) in a `TimeLimitingKnnCollector` decorator. When `topDocs()` is called on this decorator, it delegates to the null inner collector → NPE.
- Fix: Override `approximateSearch` in `OSDiversifyingChildrenFloatKnnVectorQuery` and `OSDiversifyingChildrenByteKnnVectorQuery` to catch the NPE and return empty results for segments with no vectors.

## Test plan

- [ ] Create index with nested knn_vector fields (`index.knn: true`, Lucene engine)
- [ ] Index one doc with nested vectors and one empty doc (`{}`)
- [ ] Force flush between docs to create separate segments
- [ ] Run nested kNN search — should return hits without NPE
- [ ] Verify correct result (hits=1, score=1.0 for the doc with vectors)