### PR TITLE
Fix IP score conversion for faiss using MOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix FAISS SQ merge failure when segment has no live vectors [#3381](https://github.com/opensearch-project/k-NN/pull/3381)
 * Fix isFaissSQfp16 to skip FP16 validation when SQ encoder uses bits=1 [#3366](https://github.com/opensearch-project/k-NN/pull/3366)
 * Fix score corruption in multi-segment FAISS indices with ADC [#3385](https://github.com/opensearch-project/k-NN/pull/3385)
+* Fix radial search max_distance threshold conversion for inner product with memory-optimized search [#3369](https://github.com/opensearch-project/k-NN/pull/3369)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/query/MemoryOptimizedSearchScoreConverter.java
+++ b/src/main/java/org/opensearch/knn/index/query/MemoryOptimizedSearchScoreConverter.java
@@ -43,16 +43,20 @@ public final class MemoryOptimizedSearchScoreConverter {
      * @return Converted value to be used during Lucene search algorithm.
      */
     public static float distanceToRadialThreshold(final float distance, final SpaceType spaceType) {
-        if (spaceType != SpaceType.COSINESIMIL) {
-            return KNNEngine.LUCENE.distanceToRadialThreshold(distance, spaceType);
+        switch (spaceType) {
+            case INNER_PRODUCT:
+                // Faiss distance for IP is -dot. Negate to get raw dot product for Lucene.
+                return KNNEngine.LUCENE.distanceToRadialThreshold(-distance, spaceType);
+            case COSINESIMIL:
+                // For cosine similarity, `distance = 1 - inner_product_value`.
+                // therefore, we should extract it then convert it to max_inner_product_value
+                final float innerProductValue = KNNEngine.FAISS.distanceToRadialThreshold(distance, SpaceType.COSINESIMIL);
+
+                // Convert inner product value to max inner product value.
+                return SpaceType.INNER_PRODUCT.scoreTranslation(-innerProductValue);
+            default:
+                return KNNEngine.LUCENE.distanceToRadialThreshold(distance, spaceType);
         }
-
-        // For cosine similarity, `distance = 1 - inner_product_value`.
-        // therefore, we should extract it then convert it to max_inner_product_value
-        final float innerProductValue = KNNEngine.FAISS.distanceToRadialThreshold(distance, SpaceType.COSINESIMIL);
-
-        // Convert inner product value to max inner product value.
-        return SpaceType.INNER_PRODUCT.scoreTranslation(-innerProductValue);
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
@@ -45,6 +45,7 @@ public class RadialSearchIT extends KNNRestTestCase {
     private final float threshold;
     private final int expectedCount;
     private final boolean useFilter;
+    private final boolean mosEnabled;
 
     public RadialSearchIT(
         String testName,
@@ -55,7 +56,8 @@ public class RadialSearchIT extends KNNRestTestCase {
         String searchType,
         float threshold,
         int expectedCount,
-        boolean useFilter
+        boolean useFilter,
+        boolean mosEnabled
     ) {
         this.testName = testName;
         this.engine = engine;
@@ -66,12 +68,14 @@ public class RadialSearchIT extends KNNRestTestCase {
         this.threshold = threshold;
         this.expectedCount = expectedCount;
         this.useFilter = useFilter;
+        this.mosEnabled = mosEnabled;
     }
 
     @ParametersFactory(argumentFormatting = "{0}")
     public static Collection<Object[]> parameters() {
         List<Object[]> params = new ArrayList<>();
         addFaissParams(params);
+        addFaissMosParams(params);
         addLuceneParams(params);
         return params;
     }
@@ -177,9 +181,23 @@ public class RadialSearchIT extends KNNRestTestCase {
         );
     }
 
+    private static void addRadialCases(
+        List<Object[]> params,
+        String prefix,
+        KNNEngine engine,
+        SpaceType spaceType,
+        float[][] vectors,
+        float[] query,
+        boolean includeExact,
+        Object[]... thresholds
+    ) {
+        addRadialCases(params, prefix, engine, spaceType, vectors, query, includeExact, false, thresholds);
+    }
+
     /**
-     * Generates test cases for both ANN and ExactSearcher paths for a given engine/space configuration.
+     * Generates test cases for ANN, ExactSearcher, and optionally MOS paths for a given engine/space configuration.
      * Each threshold entry produces one test case; if exactSearcher is true, a mirror set with filter is added.
+     * If mosEnabled is true, generates MOS-specific test cases.
      */
     private static void addRadialCases(
         List<Object[]> params,
@@ -189,6 +207,7 @@ public class RadialSearchIT extends KNNRestTestCase {
         float[][] vectors,
         float[] query,
         boolean includeExact,
+        boolean mosEnabled,
         Object[]... thresholds
     ) {
         for (Object[] t : thresholds) {
@@ -205,7 +224,8 @@ public class RadialSearchIT extends KNNRestTestCase {
                     searchType,
                     threshold,
                     expected,
-                    false }
+                    false,
+                    mosEnabled }
             );
             if (includeExact) {
                 params.add(
@@ -218,10 +238,131 @@ public class RadialSearchIT extends KNNRestTestCase {
                         searchType,
                         threshold,
                         expected,
-                        true }
+                        true,
+                        mosEnabled }
                 );
             }
         }
+    }
+
+    private static void addFaissMosParams(List<Object[]> params) {
+        // MOS uses Lucene's search algorithm on Faiss-built HNSW graphs.
+        // After the fix, max_distance for IP should produce the same results regardless of sign convention.
+        // MOS does not support ExactSearcher (filter path), so includeExact=false.
+
+        // MOS L2: same behavior as standard Faiss L2
+        float[][] l2Vectors = {
+            { 1.0f, 0.0f },     // dist=0.0, score=1.0
+            { 1.0f, 0.5f },     // dist=0.25, score=0.8
+            { 0.0f, 0.0f },     // dist=1.0, score=0.5
+            { 0.0f, 3.0f }      // dist=10.0, score=0.091
+        };
+        float[] l2Query = { 1.0f, 0.0f };
+
+        addRadialCases(
+            params,
+            "Faiss_MOS_L2",
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            l2Vectors,
+            l2Query,
+            true,
+            true,
+            new Object[] { "max_distance", 0.5f, 2 },
+            new Object[] { "max_distance", 2.0f, 3 },
+            new Object[] { "min_score", 0.9f, 1 },
+            new Object[] { "min_score", 0.75f, 2 }
+        );
+
+        // MOS Cosine
+        float[][] cosVectors = {
+            { 1.0f, 0.0f },     // cos=1.0, score=1.0
+            { 3.0f, 1.0f },     // cos=0.949, score=0.975
+            { 1.0f, 1.0f },     // cos=0.707, score=0.854
+            { 0.0f, 1.0f }      // cos=0.0, score=0.5
+        };
+        float[] cosQuery = { 1.0f, 0.0f };
+
+        // MOS + Cosine + ExactSearcher has a pre-existing scoring mismatch (tracked separately).
+        // The VectorScorer produces scores in a different space than the MOS-converted threshold.
+        addRadialCases(
+            params,
+            "Faiss_MOS_COSINE",
+            KNNEngine.FAISS,
+            SpaceType.COSINESIMIL,
+            cosVectors,
+            cosQuery,
+            false,
+            true,
+            new Object[] { "max_distance", 0.1f, 2 },
+            new Object[] { "max_distance", 0.5f, 3 },
+            new Object[] { "min_score", 0.99f, 1 },
+            new Object[] { "min_score", 0.8f, 3 }
+        );
+
+        // MOS IP: The critical test. Negative max_distance (Faiss convention) should be selective.
+        // After abs() fix, both negative and positive values produce correct results.
+        float[][] ipVectors = {
+            { 1.0f, 0.0f },     // dot=1.0, score=2.0
+            { 0.8f, 0.1f },     // dot=0.8, score=1.8
+            { 0.3f, 0.3f },     // dot=0.3, score=1.3
+            { 0.0f, 1.0f }      // dot=0.0, score=1.0
+        };
+        float[] ipQuery = { 1.0f, 0.0f };
+
+        addRadialCases(
+            params,
+            "Faiss_MOS_IP",
+            KNNEngine.FAISS,
+            SpaceType.INNER_PRODUCT,
+            ipVectors,
+            ipQuery,
+            true,
+            true,
+            // Negative max_distance: Faiss convention d=-dot, so -0.5 means dot >= 0.5
+            new Object[] { "max_distance", -0.5f, 2 },
+            new Object[] { "max_distance", -0.1f, 3 },
+            // Positive max_distance: d=-dot convention means dot >= -0.1 (broad), returns all 4
+            new Object[] { "max_distance", 0.1f, 4 },
+            // min_score is engine-independent, should match standard Faiss exactly
+            new Object[] { "min_score", 1.9f, 1 },
+            new Object[] { "min_score", 1.4f, 2 },
+            new Object[] { "min_score", 1.01f, 3 }
+        );
+
+        // MOS IP with negative dot products
+        float[][] ipNegVectors = {
+            { 1.0f, 0.0f },     // dot=1.0, score=2.0, distance=-1.0
+            { 0.5f, 0.5f },     // dot=0.5, score=1.5, distance=-0.5
+            { -0.3f, 0.5f },    // dot=-0.3, score=0.769, distance=0.3
+            { -0.8f, 0.2f },    // dot=-0.8, score=0.556, distance=0.8
+            { -1.0f, 0.0f }     // dot=-1.0, score=0.5, distance=1.0
+        };
+        float[] ipNegQuery = { 1.0f, 0.0f };
+
+        addRadialCases(
+            params,
+            "Faiss_MOS_IP_neg",
+            KNNEngine.FAISS,
+            SpaceType.INNER_PRODUCT,
+            ipNegVectors,
+            ipNegQuery,
+            true,
+            true,
+            // Negative max_distance (Faiss convention): -0.4 means dot >= 0.4
+            new Object[] { "max_distance", -0.4f, 2 },
+            new Object[] { "max_distance", -0.01f, 2 },
+            // Positive max_distance: 0.4 means dot >= -0.4 (broad), returns 3 (dot: 1.0, 0.5, -0.3)
+            new Object[] { "max_distance", 0.4f, 3 },
+            // Very large positive: returns all 5
+            new Object[] { "max_distance", 0.9f, 4 },
+            new Object[] { "max_distance", 1.1f, 5 },
+            // min_score tests (same as non-MOS)
+            new Object[] { "min_score", 1.4f, 2 },
+            new Object[] { "min_score", 0.6f, 3 },
+            new Object[] { "min_score", 0.55f, 4 },
+            new Object[] { "min_score", 0.45f, 5 }
+        );
     }
 
     private static void addLuceneParams(List<Object[]> params) {
@@ -322,7 +463,11 @@ public class RadialSearchIT extends KNNRestTestCase {
 
         mapping.endObject().endObject().startObject(FILTER_FIELD).field("type", "keyword").endObject().endObject().endObject();
 
-        Settings settings = Settings.builder().put("index.knn", true).build();
+        Settings.Builder settingsBuilder = Settings.builder().put("index.knn", true);
+        if (mosEnabled) {
+            settingsBuilder.put("index.knn.memory_optimized_search", true);
+        }
+        Settings settings = settingsBuilder.build();
         createKnnIndex(indexName, settings, mapping.toString());
 
         for (int i = 0; i < testVectors.length; i++) {

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchScoreConverterTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchScoreConverterTests.java
@@ -56,15 +56,16 @@ public class MemoryOptimizedSearchScoreConverterTests {
         final float luceneL2Radius = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(faissL2Distance, SpaceType.L2);
         assertEquals(1 / (1 + faissL2Distance), luceneL2Radius, 1e-6);
 
-        // For IP, the input distance is actually `inner product value`
-        // We're expecting converted maximum inner product.
+        // For IP, the input is Faiss distance (d = -dot). We negate before passing to Lucene's conversion.
+        // distanceToRadialThreshold(-0.5, IP) -> negate to 0.5 -> Lucene: 0.5 > 0 -> 0.5 + 1 = 1.5
         final float faissIpDistance1 = -0.5F;
         final float luceneIpRadius1 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissIpDistance1,
             SpaceType.INNER_PRODUCT
         );
-        assertEquals(1 / (1 - faissIpDistance1), luceneIpRadius1, 1e-6);
+        assertEquals(1 + (-1 * faissIpDistance1), luceneIpRadius1, 1e-6);
 
+        // distanceToRadialThreshold(0, IP) -> negate to 0 -> Lucene: 0 <= 0 -> 1/(1-0) = 1.0
         final float faissIpDistance2 = 0;
         final float luceneIpRadius2 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissIpDistance2,
@@ -72,12 +73,13 @@ public class MemoryOptimizedSearchScoreConverterTests {
         );
         assertEquals(1, luceneIpRadius2, 1e-6);
 
+        // distanceToRadialThreshold(5.5, IP) -> negate to -5.5 -> Lucene: -5.5 <= 0 -> 1/(1-(-5.5)) = 1/6.5
         final float faissIpDistance3 = 5.5F;
         final float luceneIpRadius3 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissIpDistance3,
             SpaceType.INNER_PRODUCT
         );
-        assertEquals(1 + faissIpDistance3, luceneIpRadius3, 1e-6);
+        assertEquals(1 / (1 + faissIpDistance3), luceneIpRadius3, 1e-6);
 
         // For cosine, the input distance is actually `1 - inner product value (whose range is in [-1, 1])`
         final float faissCosineDistance1 = 0;


### PR DESCRIPTION
### Description
Fix radial search max_distance for inner product space when memory-optimized search (MOS) is enabled.

CPP Faiss applies` -1 * distance` via Faiss.DISTANCE_TRANSLATIONS to convert from Faiss distance convention to the raw dot product before downstream processing. MOS was skipping this step, causing the Lucene formula to interpret the value with the wrong sign and produce a near-zero threshold that triggers exhaustive scan.

Also adds integration test coverage for MOS radial search across the full matrix: L2/cosine/IP x max_distance/min_score x ANN/exact search fallback.

### Related Issues
Related - #3335

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
