### PR TITLE
Intel SVS as a fully JNI-isolated :sandbox engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Features
 * Add rescoring phase after radial search on quantized index [#3347](https://github.com/opensearch-project/k-NN/pull/3347)
 * Add base64 encoded vector indexing support for knn_vector fields [#3350](https://github.com/opensearch-project/k-NN/pull/3350)
+* Add Intel SVS Vamana method (`svs_vamana`) as the first experimental `:sandbox` tenant, with `flat`/`sq`/`lvq` encoders, `cosinesimil`, and `alpha` (opt-in via `-Pknn.sandbox.enabled`) [#3370](https://github.com/opensearch-project/k-NN/pull/3370)
 
 ### Maintenance
 

--- a/build.gradle
+++ b/build.gradle
@@ -357,6 +357,24 @@ opensearchplugin {
     noticeFile = rootProject.file('NOTICE.txt')
 }
 
+// Bundle the experimental :sandbox jar into the plugin zip as a RUNTIME-ONLY artifact, but ONLY when the
+// build opts in via -Pknn.sandbox.enabled=true. By default the :sandbox module is excluded from the build
+// graph entirely (see settings.gradle) and no sandbox jar is bundled, so the produced plugin is unchanged
+// and loads no sandbox tenant. When enabled, the root project still declares NO compile/api dependency on
+// :sandbox (so :sandbox classes never leak onto the root compileClasspath); we only copy the built sandbox
+// jar (+ its META-INF/services provider file) into the bundlePlugin zip so it is discoverable at runtime
+// via ServiceLoader.
+if (project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true') {
+    // Ensure the :sandbox project is evaluated before we reference its tasks.
+    evaluationDependsOn(':sandbox')
+    tasks.named("bundlePlugin").configure {
+        dependsOn ':sandbox:jar'
+        // Reference the sandbox jar lazily via its archive file provider so it lands at the
+        // root of the plugin zip alongside the other runtime jars.
+        from(project(':sandbox').tasks.named('jar').flatMap { it.archiveFile })
+    }
+}
+
 tasks.named("integTest").configure {
     it.dependsOn(project.tasks.named("bundlePlugin"))
 }
@@ -537,6 +555,17 @@ tasks.register('cmakeJniLib', Exec) {
     args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
     args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
     args.add("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
+    // Opt-in build of the isolated Intel SVS sandbox tenant (libopensearchknn_svs), separate from the main
+    // Faiss library: -Pknn.sandbox.enabled=true [-Psvs.prefix=<libsvs-runtime prefix> | -Psvs.url=<artifact>]
+    if (project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true') {
+        args.add("-DCONFIG_SVS=ON")
+        if (project.hasProperty('svs.prefix')) {
+            args.add("-DSVS_RUNTIME_PREFIX=${project.property('svs.prefix')}")
+        }
+        if (project.hasProperty('svs.url')) {
+            args.add("-DSVS_RUNTIME_URL=${project.property('svs.url')}")
+        }
+    }
     def javaHome = Jvm.current().getJavaHome()
     logger.lifecycle("Java home directory used by gradle: $javaHome")
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -570,6 +599,10 @@ tasks.register('buildJniLib', Exec) {
     def knn_libs = ['opensearchknn_faiss', 'opensearchknn_common', 'opensearchknn_nmslib', 'opensearchknn_simd']
     if (project.hasProperty('knn_libs')) {
         knn_libs = ['opensearchknn_common'] + project.knn_libs.split(',').collect { it.trim() }
+    }
+    // Build the isolated SVS native library only when the sandbox tenant is opted in.
+    if (project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true') {
+        knn_libs = knn_libs + 'opensearchknn_svs'
     }
     args.addAll(knn_libs)
     args.add("--parallel")
@@ -662,6 +695,10 @@ integTest {
     commonIntegTest(it, project, integTestDependOnJniLib, opensearch_tmp_dir, _numNodes)
     filter {
         excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
+        // The SVS IT needs the opt-in sandbox tenant (jar + isolated native lib); skip it on default builds.
+        if (!(project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true')) {
+            excludeTestsMatching "org.opensearch.knn.index.FaissSVSVamanaIT"
+        }
     }
     mustRunAfter test
 }
@@ -672,6 +709,10 @@ task integTestRemoteIndexBuild(type: RestIntegTestTask) {
         // Temporarily skipping this test class, see: https://github.com/opensearch-project/k-NN/issues/2726
         excludeTestsMatching "org.opensearch.knn.index.SegmentReplicationIT"
         excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
+        // The SVS IT needs the opt-in sandbox tenant (jar + isolated native lib); skip it on default builds.
+        if (!(project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true')) {
+            excludeTestsMatching "org.opensearch.knn.index.FaissSVSVamanaIT"
+        }
     }
     systemProperty("test.remoteBuild", System.getProperty("test.remoteBuild"))
     systemProperty("test.bucket", System.getProperty("test.bucket"))

--- a/build.gradle
+++ b/build.gradle
@@ -695,10 +695,6 @@ integTest {
     commonIntegTest(it, project, integTestDependOnJniLib, opensearch_tmp_dir, _numNodes)
     filter {
         excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
-        // The SVS IT needs the opt-in sandbox tenant (jar + isolated native lib); skip it on default builds.
-        if (!(project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true')) {
-            excludeTestsMatching "org.opensearch.knn.index.FaissSVSVamanaIT"
-        }
     }
     mustRunAfter test
 }
@@ -709,10 +705,6 @@ task integTestRemoteIndexBuild(type: RestIntegTestTask) {
         // Temporarily skipping this test class, see: https://github.com/opensearch-project/k-NN/issues/2726
         excludeTestsMatching "org.opensearch.knn.index.SegmentReplicationIT"
         excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
-        // The SVS IT needs the opt-in sandbox tenant (jar + isolated native lib); skip it on default builds.
-        if (!(project.hasProperty('knn.sandbox.enabled') && project.property('knn.sandbox.enabled') == 'true')) {
-            excludeTestsMatching "org.opensearch.knn.index.FaissSVSVamanaIT"
-        }
     }
     systemProperty("test.remoteBuild", System.getProperty("test.remoteBuild"))
     systemProperty("test.bucket", System.getProperty("test.bucket"))

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -17,6 +17,8 @@ set(TARGET_LIB_COMMON opensearchknn_common)  # common lib for JNI
 set(TARGET_LIB_NMSLIB opensearchknn_nmslib)  # nmslib JNI
 set(TARGET_LIB_FAISS opensearchknn_faiss)    # faiss JNI
 set(TARGET_LIB_SIMD opensearchknn_simd)      # SIMD computing JNI
+set(TARGET_LIB_SVS opensearchknn_svs)        # Intel SVS JNI (experimental :sandbox tenant, opt-in)
+set(TARGET_LIB_JNI_HELPERS opensearchknn_jni_helpers)  # STATIC marshalling helpers embedded into the SVS lib
 set(TARGET_LIBS "")  # Libs to be installed
 
 set(CMAKE_CXX_STANDARD 17)
@@ -24,6 +26,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 option(CONFIG_FAISS "Configure faiss library build when this is on")
 option(CONFIG_NMSLIB "Configure nmslib library build when this is on")
 option(CONFIG_TEST "Configure tests when this is on")
+# CONFIG_SVS is deliberately NOT part of the CONFIG_ALL auto-on logic below: the experimental
+# Intel SVS tenant must never be built by a default (unflagged) build. It is enabled only when
+# the Gradle property -Pknn.sandbox.enabled=true passes -DCONFIG_SVS=ON.
+option(CONFIG_SVS "Configure the isolated Intel SVS JNI library build when this is on" OFF)
 
 if (${CONFIG_FAISS} STREQUAL OFF AND ${CONFIG_NMSLIB} STREQUAL OFF AND ${CONFIG_TEST} STREQUAL OFF)
     set(CONFIG_ALL ON)
@@ -124,6 +130,17 @@ if (${CONFIG_FAISS} STREQUAL ON OR ${CONFIG_ALL} STREQUAL ON OR ${CONFIG_TEST} S
     )
     opensearch_set_common_properties(${TARGET_LIB_FAISS})
     list(APPEND TARGET_LIBS ${TARGET_LIB_FAISS})
+endif ()
+
+# ---------------------------------------------------------------------------
+
+# ------------------- SVS (experimental :sandbox tenant, opt-in) -------------------
+# Fully isolated from the main faiss JNI library. The main libopensearchknn_faiss*.so is built with
+# FAISS_ENABLE_SVS=OFF and contains zero SVS code. When -DCONFIG_SVS=ON (driven by the Gradle
+# -Pknn.sandbox.enabled=true opt-in) we build a SEPARATE libopensearchknn_svs*.so. All SVS-specific
+# native code + build logic lives under jni/sandbox/.
+if (${CONFIG_SVS} STREQUAL ON)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/sandbox/svs.cmake)
 endif ()
 
 # ---------------------------------------------------------------------------

--- a/jni/sandbox/cmake/fetch-svs-runtime.cmake
+++ b/jni/sandbox/cmake/fetch-svs-runtime.cmake
@@ -1,0 +1,64 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Provide the prebuilt Intel SVS runtime (libsvs_runtime.so + its CMake package config) so that both
+# the SVS-enabled upstream Faiss (built in init-faiss-svs.cmake) and the SVS JNI library can resolve
+# `find_package(svs_runtime)`.
+#
+# This mirrors how current upstream Faiss obtains the runtime: it is NOT built from source, it is the
+# prebuilt conda-forge package `libsvs-runtime` (pinned to 0.3.0 by upstream Faiss in conda/faiss-gpu/
+# meta.yaml). The package contains lib/libsvs_runtime.so* and lib/cmake/svs_runtime/svs_runtimeConfig.cmake.
+#
+# Resolution order:
+#   1. -DSVS_RUNTIME_PREFIX=<dir>  : a local, already-extracted package prefix (offline / air-gapped /
+#                                    reproducible CI). The dir must contain lib/cmake/svs_runtime.
+#   2. -DSVS_RUNTIME_URL=<url>     : a package artifact to download + extract (e.g. a mirrored copy).
+#   3. default URL                 : the conda-forge linux-64 libsvs-runtime 0.3.0 artifact (sha256-pinned).
+#
+# Sets SVS_RUNTIME_PREFIX (cache) to the resolved prefix and prepends it to CMAKE_PREFIX_PATH, then
+# runs find_package(svs_runtime REQUIRED) for this (outer) build. init-faiss-svs.cmake forwards
+# SVS_RUNTIME_PREFIX to the Faiss ExternalProject so its own find_package resolves the same runtime.
+
+set(SVS_RUNTIME_CONDA_DEFAULT_URL
+    "https://anaconda.org/conda-forge/libsvs-runtime/0.3.0/download/linux-64/libsvs-runtime-0.3.0-gc187b54_0_0.conda"
+    CACHE STRING "Default conda-forge libsvs-runtime artifact URL")
+set(SVS_RUNTIME_CONDA_DEFAULT_SHA256
+    "406f34af39beed8d087b424177056cdea4c3b73f2b19d5d3f8b51f3a6fe7d113"
+    CACHE STRING "sha256 of the default conda-forge libsvs-runtime artifact")
+
+if(DEFINED SVS_RUNTIME_PREFIX AND NOT "${SVS_RUNTIME_PREFIX}" STREQUAL "")
+    message(STATUS "SVS runtime: using local prefix ${SVS_RUNTIME_PREFIX}")
+else()
+    include(FetchContent)
+    if(DEFINED SVS_RUNTIME_URL AND NOT "${SVS_RUNTIME_URL}" STREQUAL "")
+        message(STATUS "SVS runtime: fetching ${SVS_RUNTIME_URL}")
+        FetchContent_Declare(svs_runtime_pkg URL "${SVS_RUNTIME_URL}")
+    else()
+        message(STATUS "SVS runtime: fetching ${SVS_RUNTIME_CONDA_DEFAULT_URL}")
+        FetchContent_Declare(svs_runtime_pkg
+            URL "${SVS_RUNTIME_CONDA_DEFAULT_URL}"
+            URL_HASH SHA256=${SVS_RUNTIME_CONDA_DEFAULT_SHA256})
+    endif()
+    FetchContent_MakeAvailable(svs_runtime_pkg)
+
+    # A plain tarball mirror extracts straight to the package prefix (lib/...). A conda-format `.conda`
+    # artifact is a zip holding inner pkg-*.tar.zst archives; extract the payload one into place.
+    if(NOT EXISTS "${svs_runtime_pkg_SOURCE_DIR}/lib/cmake/svs_runtime")
+        file(GLOB _svs_runtime_inner_pkgs "${svs_runtime_pkg_SOURCE_DIR}/pkg-*.tar.zst")
+        foreach(_svs_inner ${_svs_runtime_inner_pkgs})
+            message(STATUS "SVS runtime: extracting inner conda payload ${_svs_inner}")
+            file(ARCHIVE_EXTRACT INPUT "${_svs_inner}" DESTINATION "${svs_runtime_pkg_SOURCE_DIR}")
+        endforeach()
+    endif()
+    set(SVS_RUNTIME_PREFIX "${svs_runtime_pkg_SOURCE_DIR}" CACHE PATH "Resolved SVS runtime prefix" FORCE)
+endif()
+
+if(NOT EXISTS "${SVS_RUNTIME_PREFIX}/lib/cmake/svs_runtime")
+    message(FATAL_ERROR
+        "SVS runtime package at '${SVS_RUNTIME_PREFIX}' is missing lib/cmake/svs_runtime. "
+        "Provide -Psvs.prefix=<dir> (a libsvs-runtime 0.3.0 prefix) or -Psvs.url=<artifact>.")
+endif()
+
+list(PREPEND CMAKE_PREFIX_PATH "${SVS_RUNTIME_PREFIX}")
+find_package(svs_runtime REQUIRED)

--- a/jni/sandbox/cmake/fetch-svs-runtime.cmake
+++ b/jni/sandbox/cmake/fetch-svs-runtime.cmake
@@ -13,7 +13,9 @@
 # Resolution order:
 #   1. -DSVS_RUNTIME_PREFIX=<dir>  : a local, already-extracted package prefix (offline / air-gapped /
 #                                    reproducible CI). The dir must contain lib/cmake/svs_runtime.
-#   2. -DSVS_RUNTIME_URL=<url>     : a package artifact to download + extract (e.g. a mirrored copy).
+#   2. -DSVS_RUNTIME_URL=<url>     : a package artifact to download + extract (e.g. a mirrored copy). MUST be
+#                                    paired with -DSVS_RUNTIME_SHA256=<hex> (checksum-pinned); the only bypass
+#                                    is the dev-only -DSVS_RUNTIME_ALLOW_UNVERIFIED=ON.
 #   3. default URL                 : the conda-forge linux-64 libsvs-runtime 0.3.0 artifact (sha256-pinned).
 #
 # Sets SVS_RUNTIME_PREFIX (cache) to the resolved prefix and prepends it to CMAKE_PREFIX_PATH, then
@@ -32,8 +34,22 @@ if(DEFINED SVS_RUNTIME_PREFIX AND NOT "${SVS_RUNTIME_PREFIX}" STREQUAL "")
 else()
     include(FetchContent)
     if(DEFINED SVS_RUNTIME_URL AND NOT "${SVS_RUNTIME_URL}" STREQUAL "")
-        message(STATUS "SVS runtime: fetching ${SVS_RUNTIME_URL}")
-        FetchContent_Declare(svs_runtime_pkg URL "${SVS_RUNTIME_URL}")
+        # A custom artifact URL must be checksum-pinned, exactly like the default URL, so the downloaded
+        # native runtime cannot be silently swapped. Supply -DSVS_RUNTIME_SHA256=<hex>. The only way to skip
+        # verification is the explicit, documented dev-only escape hatch -DSVS_RUNTIME_ALLOW_UNVERIFIED=ON.
+        if(DEFINED SVS_RUNTIME_SHA256 AND NOT "${SVS_RUNTIME_SHA256}" STREQUAL "")
+            message(STATUS "SVS runtime: fetching ${SVS_RUNTIME_URL} (sha256-pinned)")
+            FetchContent_Declare(svs_runtime_pkg URL "${SVS_RUNTIME_URL}" URL_HASH SHA256=${SVS_RUNTIME_SHA256})
+        elseif(SVS_RUNTIME_ALLOW_UNVERIFIED)
+            message(WARNING
+                "SVS runtime: fetching ${SVS_RUNTIME_URL} WITHOUT checksum verification "
+                "(SVS_RUNTIME_ALLOW_UNVERIFIED=ON). Dev-only; never use for a release build.")
+            FetchContent_Declare(svs_runtime_pkg URL "${SVS_RUNTIME_URL}")
+        else()
+            message(FATAL_ERROR
+                "SVS runtime: a custom -DSVS_RUNTIME_URL requires -DSVS_RUNTIME_SHA256=<hex> to pin the "
+                "artifact. To bypass for local development only, pass -DSVS_RUNTIME_ALLOW_UNVERIFIED=ON.")
+        endif()
     else()
         message(STATUS "SVS runtime: fetching ${SVS_RUNTIME_CONDA_DEFAULT_URL}")
         FetchContent_Declare(svs_runtime_pkg

--- a/jni/sandbox/cmake/init-faiss-svs.cmake
+++ b/jni/sandbox/cmake/init-faiss-svs.cmake
@@ -1,0 +1,94 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build a SEPARATE, SVS-enabled Faiss for the isolated SVS JNI library.
+#
+# This is intentionally NOT the k-NN faiss submodule (jni/external/faiss, pinned at the stock main
+# revision and built FAISS_ENABLE_SVS=OFF). The experimental SVS tenant tracks LATEST UPSTREAM Faiss,
+# which carries the maintained SVS surface (Vamana, IVF-SVS, LeanVec, impl/svs_io) and the current
+# find_package(svs_runtime) model. It is built in its own binary tree so its `faiss*` CMake targets
+# never collide with the main add_subdirectory(external/faiss) build, and so the SVS .so embeds its own
+# faiss object code (kept private via hidden visibility + the version script).
+#
+# Requires fetch-svs-runtime.cmake to have run first (sets SVS_RUNTIME_PREFIX + svs::svs_runtime).
+#
+# Exports to the caller:
+#   SVS_FAISS_INCLUDE_DIR  - include dir for <faiss/...> headers (the upstream source tree)
+#   SVS_FAISS_LINK_LIB     - IMPORTED static lib target to link into libopensearchknn_svs
+#   faiss_svs              - ExternalProject target the SVS lib must depend on (add_dependencies)
+
+include(ExternalProject)
+
+# Pinned to 67f066f7a: an SVS-capable upstream Faiss commit (carries IndexSVSVamana, the SVS factory
+# descriptions and the find_package(svs_runtime) model). The source is built EXACTLY as upstream ships
+# it — no k-NN patches are applied. The SVS JNI wrapper (jni/sandbox/src/svs_wrapper.cpp) deliberately
+# uses only upstream faiss APIs so this can hold.
+set(SVS_FAISS_GIT_REPOSITORY "https://github.com/facebookresearch/faiss.git"
+    CACHE STRING "Upstream Faiss repo for the SVS tenant build")
+set(SVS_FAISS_GIT_TAG "67f066f7a02f76d3178baccf4c31b4839ff0fee8"
+    CACHE STRING "Pinned SVS-capable upstream Faiss commit for the SVS tenant build")
+
+# Pick the host opt-level / faiss variant the same way init-faiss.cmake does, so the SVS lib links a
+# variant matching the CPU it will run on.
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "(aarch64|arm64|ARM64)")
+    set(_svs_faiss_opt_level generic)
+    set(_svs_faiss_variant faiss)
+elseif(AVX512_SPR_ENABLED)
+    set(_svs_faiss_opt_level avx512_spr)
+    set(_svs_faiss_variant faiss_avx512_spr)
+elseif(AVX512_ENABLED)
+    set(_svs_faiss_opt_level avx512)
+    set(_svs_faiss_variant faiss_avx512)
+elseif(AVX2_ENABLED)
+    set(_svs_faiss_opt_level avx2)
+    set(_svs_faiss_variant faiss_avx2)
+else()
+    set(_svs_faiss_opt_level generic)
+    set(_svs_faiss_variant faiss)
+endif()
+
+set(_svs_faiss_prefix   "${CMAKE_BINARY_DIR}/faiss-svs")
+set(_svs_faiss_src      "${_svs_faiss_prefix}/src/faiss_svs")
+set(_svs_faiss_build    "${_svs_faiss_prefix}/src/faiss_svs-build")
+# faiss emits its static libs under <build>/faiss/.
+set(_svs_faiss_lib_path "${_svs_faiss_build}/faiss/${CMAKE_STATIC_LIBRARY_PREFIX}${_svs_faiss_variant}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+ExternalProject_Add(faiss_svs
+    GIT_REPOSITORY    "${SVS_FAISS_GIT_REPOSITORY}"
+    GIT_TAG           "${SVS_FAISS_GIT_TAG}"
+    GIT_SHALLOW       FALSE
+    PREFIX            "${_svs_faiss_prefix}"
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DBUILD_TESTING=OFF
+        -DFAISS_ENABLE_GPU=OFF
+        -DFAISS_ENABLE_PYTHON=OFF
+        -DFAISS_ENABLE_C_API=OFF
+        -DFAISS_ENABLE_SVS=ON
+        -DFAISS_OPT_LEVEL=${_svs_faiss_opt_level}
+        -DCMAKE_PREFIX_PATH=${SVS_RUNTIME_PREFIX}
+    # We only need the static libs; faiss has no usable install for a static, isolated embed here.
+    INSTALL_COMMAND   ""
+    BUILD_BYPRODUCTS  "${_svs_faiss_lib_path}"
+)
+
+set(SVS_FAISS_INCLUDE_DIR "${_svs_faiss_src}" CACHE PATH "SVS-tenant Faiss include dir" FORCE)
+
+# Imported target for the variant static lib. faiss links svs::svs_runtime / BLAS / LAPACK / OpenMP
+# transitively; since we embed the static .a we must re-supply those on the SVS lib's link line.
+# svs::svs_runtime and OpenMP are added on the libopensearchknn_svs target in jni/CMakeLists.txt;
+# BLAS/LAPACK are added here as INTERFACE deps of the imported target.
+# VERIFY (build loop): confirm the variant static lib name/path and the full transitive link closure
+# (MKL vs OpenBLAS) on the chosen build host; faiss CI uses MKL (BLA_VENDOR=Intel10_64_dyn).
+find_package(BLAS REQUIRED)
+find_package(LAPACK REQUIRED)
+
+add_library(${TARGET_LIB_SVS}_faiss_imported STATIC IMPORTED)
+set_target_properties(${TARGET_LIB_SVS}_faiss_imported PROPERTIES
+    IMPORTED_LOCATION "${_svs_faiss_lib_path}"
+    INTERFACE_LINK_LIBRARIES "${BLAS_LIBRARIES};${LAPACK_LIBRARIES}")
+
+set(SVS_FAISS_LINK_LIB "${TARGET_LIB_SVS}_faiss_imported" CACHE STRING "SVS-tenant Faiss link target" FORCE)

--- a/jni/sandbox/cmake/svs_jni.version
+++ b/jni/sandbox/cmake/svs_jni.version
@@ -1,0 +1,19 @@
+# Linker version script for libopensearchknn_svs.
+#
+# The SVS library statically embeds its own copy of Faiss (built FAISS_ENABLE_SVS=ON), which is a
+# DIFFERENT version than the Faiss embedded in libopensearchknn_faiss. Both can be dlopen'd into the
+# same JVM. To prevent the two faiss::* symbol sets from interposing (an ODR hazard that could route
+# calls into the wrong faiss build), we export ONLY the JNI entry points and the JNI lifecycle hooks;
+# every other symbol (all of faiss::*, svs::*, the marshalling helpers) is local to this library.
+#
+# SvsService lives in the sandbox module package org.opensearch.knn.sandbox.svs, so its native methods
+# mangle to Java_org_opensearch_knn_sandbox_svs_SvsService_*. The broad Java_org_opensearch_knn_*
+# pattern keeps this robust to the exact package.
+{
+  global:
+    JNI_OnLoad;
+    JNI_OnUnload;
+    Java_org_opensearch_knn_*;
+  local:
+    *;
+};

--- a/jni/sandbox/include/org_opensearch_knn_sandbox_svs_SvsService.h
+++ b/jni/sandbox/include/org_opensearch_knn_sandbox_svs_SvsService.h
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/* JNI declarations for org.opensearch.knn.sandbox.svs.SvsService */
+
+#include <jni.h>
+
+#ifndef _Included_org_opensearch_knn_sandbox_svs_SvsService
+#define _Included_org_opensearch_knn_sandbox_svs_SvsService
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    isLvqLeanvecEnabled
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_isLvqLeanvecEnabled
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    initIndex
+ * Signature: (JILjava/util/Map;)J
+ */
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_initIndex
+  (JNIEnv *, jclass, jlong, jint, jobject);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    insertToIndex
+ * Signature: ([IJIJI)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_insertToIndex
+  (JNIEnv *, jclass, jintArray, jlong, jint, jlong, jint);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    writeIndex
+ * Signature: (JLorg/opensearch/knn/index/store/IndexOutputWithBuffer;)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_writeIndex
+  (JNIEnv *, jclass, jlong, jobject);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    loadIndexWithStream
+ * Signature: (Lorg/opensearch/knn/index/store/IndexInputWithBuffer;)J
+ */
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_loadIndexWithStream
+  (JNIEnv *, jclass, jobject);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    queryIndex
+ * Signature: (J[FILjava/util/Map;)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ */
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_queryIndex
+  (JNIEnv *, jclass, jlong, jfloatArray, jint, jobject);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    queryIndexWithFilter
+ * Signature: (J[FILjava/util/Map;[JI)[Lorg/opensearch/knn/index/query/KNNQueryResult;
+ */
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_queryIndexWithFilter
+  (JNIEnv *, jclass, jlong, jfloatArray, jint, jobject, jlongArray, jint);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    free
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_free
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    initLibrary
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_initLibrary
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     org_opensearch_knn_sandbox_svs_SvsService
+ * Method:    setMergeInterruptCallback
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_setMergeInterruptCallback
+  (JNIEnv *, jclass);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/jni/sandbox/include/svs_constants.h
+++ b/jni/sandbox/include/svs_constants.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef OPENSEARCH_KNN_JNI_SVS_CONSTANTS_H
+#define OPENSEARCH_KNN_JNI_SVS_CONSTANTS_H
+
+#include <string>
+
+namespace knn_jni {
+    // Intel SVS Vamana parameter names. These live ONLY in the isolated SVS JNI library
+    // (libopensearchknn_svs); the main faiss JNI library carries no SVS symbols. They were
+    // intentionally removed from jni_util when SVS was pulled out of the shared layer.
+    extern const std::string CONSTRUCTION_WINDOW_SIZE;
+    extern const std::string ALPHA;
+    extern const std::string SEARCH_WINDOW_SIZE;
+    extern const std::string SEARCH_BUFFER_CAPACITY;
+}
+
+#endif //OPENSEARCH_KNN_JNI_SVS_CONSTANTS_H

--- a/jni/sandbox/include/svs_wrapper.h
+++ b/jni/sandbox/include/svs_wrapper.h
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#ifndef OPENSEARCH_KNN_SVS_WRAPPER_H
+#define OPENSEARCH_KNN_SVS_WRAPPER_H
+
+#include "jni_util.h"
+
+#include "faiss/impl/io.h"
+#include "faiss/impl/AuxIndexStructures.h"
+
+#include <jni.h>
+#include <iostream>
+
+namespace knn_jni {
+    namespace svs_wrapper {
+        // Create an empty SVS Vamana index from the parameters map (space type, index description, thread
+        // count, and the svs_vamana build parameters) and return the address of its IndexIDMap wrapper.
+        jlong InitIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong numDocs, jint dimJ, jobject parametersJ);
+
+        // Add the vectors at vectorsAddressJ (with the given ids) to the index created by InitIndex.
+        void InsertToIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ, jlong vectorsAddressJ,
+                           jint dimJ, jlong indexAddressJ, jint threadCount);
+
+        // Serialize the index to the provided IndexOutputWithBuffer and free it.
+        void WriteIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject output, jlong indexAddressJ);
+
+        // Load an SVS index from a faiss IOReader; returns the address of the loaded index.
+        jlong LoadIndexWithStream(faiss::IOReader* ioReader);
+
+        // Top-k search; methodParamsJ may carry search_window_size / search_buffer_capacity overrides.
+        jobjectArray QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
+                                jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ);
+
+        // Top-k search restricted to filterIdsJ (bitmap or batch encoding, per filterIdsTypeJ).
+        jobjectArray QueryIndex_WithFilter(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
+                                           jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ,
+                                           jlongArray filterIdsJ, jint filterIdsTypeJ);
+
+        // Free the index at the given address.
+        void Free(jlong indexPointerJ);
+
+        // One-time native library initialization.
+        void InitLibrary();
+
+        // Whether the linked SVS runtime supports LVQ/LeanVec storage (requires Intel AVX-512).
+        bool IsLvqLeanvecEnabled();
+
+        // Map a k-NN space type string to the faiss metric ("cosinesimil" maps to inner product: the Java
+        // layer normalizes vectors for cosine, making the two equivalent).
+        faiss::MetricType TranslateSpaceToMetric(const std::string& spaceType);
+
+        // Interrupt callback that aborts native index building when the Lucene merge driving it is aborted.
+        // Identical to the main faiss library's callback; duplicated so this library stays self-contained.
+        struct OpenSearchMergeInterruptCallback : faiss::InterruptCallback {
+
+            OpenSearchMergeInterruptCallback(JNIUtil *jniUtil) {
+                jutil = jniUtil;
+                JNIEnv* jenv = jutil->GetJNICurrentEnv();
+                mergeHelperClass = jniUtil->FindClass(jenv, "org/apache/lucene/index/MergeAbortChecker");
+                isAbortedMethod = jniUtil->FindMethod(jenv, "org/apache/lucene/index/MergeAbortChecker", "isMergeAborted");
+            }
+
+            bool want_interrupt() override {
+                JNIEnv* jenv = jutil->GetJNICurrentEnv();
+                if (jenv == nullptr) {
+                    std::cerr << "JNIEnv not found\n";
+                    return false;
+                }
+                if (mergeHelperClass == nullptr) {
+                    std::cerr << "MergeAbortChecker class not found\n";
+                    return false;
+                }
+                if (isAbortedMethod == nullptr) {
+                    std::cerr << "isMergeAborted method not found\n";
+                    return false;
+                }
+                return (bool) jenv->CallStaticBooleanMethod(mergeHelperClass, isAbortedMethod);
+            }
+
+            JNIUtil *jutil;
+            jclass mergeHelperClass;
+            jmethodID isAbortedMethod;
+        };
+    }
+}
+
+#endif //OPENSEARCH_KNN_SVS_WRAPPER_H

--- a/jni/sandbox/src/org_opensearch_knn_sandbox_svs_SvsService.cpp
+++ b/jni/sandbox/src/org_opensearch_knn_sandbox_svs_SvsService.cpp
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+#include "org_opensearch_knn_sandbox_svs_SvsService.h"
+
+#include <jni.h>
+
+#include "jni_util.h"
+#include "svs_wrapper.h"
+#include "faiss_stream_support.h"
+#include "faiss/impl/FaissException.h"
+
+static knn_jni::JNIUtil jniUtil;
+static const jint KNN_SVS_JNI_VERSION = JNI_VERSION_1_1;
+
+jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+    // Obtain the JNIEnv from the VM and confirm JNI_VERSION
+    JNIEnv* env;
+    if (vm->GetEnv((void**)&env, KNN_SVS_JNI_VERSION) != JNI_OK) {
+        return JNI_ERR;
+    }
+
+    jniUtil.Initialize(env, vm);
+
+    return KNN_SVS_JNI_VERSION;
+}
+
+void JNI_OnUnload(JavaVM *vm, void *reserved) {
+    JNIEnv* env;
+    vm->GetEnv((void**)&env, KNN_SVS_JNI_VERSION);
+    if (faiss::InterruptCallback::instance.get() != nullptr) {
+        faiss::InterruptCallback::instance.get()->clear_instance();
+    }
+    jniUtil.Uninitialize(env);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_isLvqLeanvecEnabled(JNIEnv * env, jclass cls)
+{
+    try {
+        return knn_jni::svs_wrapper::IsLvqLeanvecEnabled() ? JNI_TRUE : JNI_FALSE;
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return JNI_FALSE;
+}
+
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_initIndex(JNIEnv * env, jclass cls,
+                                                                                 jlong numDocs, jint dimJ,
+                                                                                 jobject parametersJ)
+{
+    try {
+        return knn_jni::svs_wrapper::InitIndex(&jniUtil, env, numDocs, dimJ, parametersJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return (jlong)0;
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_insertToIndex(JNIEnv * env, jclass cls, jintArray idsJ,
+                                                                                    jlong vectorsAddressJ, jint dimJ,
+                                                                                    jlong indexAddress, jint threadCount)
+{
+    try {
+        knn_jni::svs_wrapper::InsertToIndex(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexAddress, threadCount);
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_writeIndex(JNIEnv * env,
+                                                                                 jclass cls,
+                                                                                 jlong indexAddress,
+                                                                                 jobject output)
+{
+    try {
+        knn_jni::svs_wrapper::WriteIndex(&jniUtil, env, output, indexAddress);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT jlong JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_loadIndexWithStream(JNIEnv * env,
+                                                                                           jclass cls,
+                                                                                           jobject readStream)
+{
+    try {
+        // Create a mediator locally.
+        // Note that `readStream` is `IndexInputWithBuffer` type.
+        knn_jni::stream::NativeEngineIndexInputMediator mediator {&jniUtil, env, readStream};
+
+        // Wrap the mediator with a glue code inheriting IOReader.
+        knn_jni::stream::FaissOpenSearchIOReader faissOpenSearchIOReader {&mediator};
+
+        // Pass IOReader to Faiss for loading the vector index.
+        return knn_jni::svs_wrapper::LoadIndexWithStream(&faissOpenSearchIOReader);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+
+    return (jlong)0;
+}
+
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_queryIndex(JNIEnv * env, jclass cls,
+                                                                                         jlong indexPointerJ,
+                                                                                         jfloatArray queryVectorJ,
+                                                                                         jint kJ, jobject methodParamsJ)
+{
+    try {
+        return knn_jni::svs_wrapper::QueryIndex(&jniUtil, env, indexPointerJ, queryVectorJ, kJ, methodParamsJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return nullptr;
+}
+
+JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_queryIndexWithFilter
+  (JNIEnv * env, jclass cls, jlong indexPointerJ, jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ,
+   jlongArray filteredIdsJ, jint filterIdsTypeJ) {
+
+    try {
+        return knn_jni::svs_wrapper::QueryIndex_WithFilter(
+            &jniUtil, env, indexPointerJ, queryVectorJ, kJ, methodParamsJ, filteredIdsJ, filterIdsTypeJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+    return nullptr;
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_free(JNIEnv * env, jclass cls, jlong indexPointerJ)
+{
+    try {
+        knn_jni::svs_wrapper::Free(indexPointerJ);
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_initLibrary(JNIEnv * env, jclass cls)
+{
+    try {
+        knn_jni::svs_wrapper::InitLibrary();
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_sandbox_svs_SvsService_setMergeInterruptCallback(JNIEnv * env, jclass cls)
+{
+    try {
+        faiss::InterruptCallback::instance.reset(
+            new knn_jni::svs_wrapper::OpenSearchMergeInterruptCallback(&jniUtil)
+        );
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
+}

--- a/jni/sandbox/src/svs_constants.cpp
+++ b/jni/sandbox/src/svs_constants.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "svs_constants.h"
+
+// SVS Vamana construction parameters
+const std::string knn_jni::CONSTRUCTION_WINDOW_SIZE = "construction_window_size";
+const std::string knn_jni::ALPHA = "alpha";
+
+// SVS Vamana search parameters
+const std::string knn_jni::SEARCH_WINDOW_SIZE = "search_window_size";
+const std::string knn_jni::SEARCH_BUFFER_CAPACITY = "search_buffer_capacity";

--- a/jni/sandbox/src/svs_wrapper.cpp
+++ b/jni/sandbox/src/svs_wrapper.cpp
@@ -1,0 +1,385 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Native implementation for the isolated SVS engine (libopensearchknn_svs). Deliberately minimal and
+ * self-contained: it only knows how to build, write, load, query (top-k, optionally pre-filtered) and free
+ * an SVS Vamana index, using nothing beyond unmodified upstream faiss APIs (index_factory, IndexIDMap,
+ * read_index/write_index, IDSelector) plus the SVS surface (IndexSVSVamana, SearchParametersSVSVamana).
+ * It shares no translation units with the main faiss JNI library other than the generic JNI marshalling
+ * helpers (jni_util/commons), which are faiss-free.
+ */
+
+#include "svs_wrapper.h"
+
+#include "jni_util.h"
+#include "svs_constants.h"
+#include "commons.h"
+#include "faiss_stream_support.h"
+
+#include "faiss/Index.h"
+#include "faiss/IndexIDMap.h"
+#include "faiss/impl/IDSelector.h"
+#include "faiss/index_factory.h"
+#include "faiss/index_io.h"
+#include "faiss/svs/IndexSVSVamana.h"
+
+#include <omp.h>
+
+#include <algorithm>
+#include <jni.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Defines type of IDSelector
+enum FilterIdsSelectorType{
+    BITMAP = 0, BATCH = 1,
+};
+
+namespace faiss {
+
+// Using jlong to do Bitmap selector, jlong[] equals to lucene FixedBitSet#bits
+struct IDSelectorJlongBitmap : IDSelector {
+    size_t n;
+    const jlong* bitmap;
+
+    /** Construct with a binary mask like Lucene FixedBitSet
+     *
+     * @param n size of the bitmap array
+     * @param bitmap id like Lucene FixedBitSet bits
+     */
+    IDSelectorJlongBitmap(size_t _n, const jlong* _bitmap)
+      : IDSelector(),
+        n(_n),
+        bitmap(_bitmap) {
+    }
+
+    bool is_member(idx_t id) const final {
+        const uint64_t index = id;
+        const uint64_t i = index >> 6ULL;  // div 64
+        if (i >= n) {
+            return false;
+        }
+        return (bitmap[i] >> (index & 63ULL)) & 1ULL;
+    }
+};  // class IDSelectorJlongBitmap
+
+}  // namespace faiss
+
+namespace {
+
+// Extracts the IndexSVSVamana out of the IndexIDMap wrapper, throwing if the index is anything else.
+// This library only ever serves .svs files containing SVS Vamana indices.
+faiss::IndexSVSVamana* extractSVSVamana(faiss::IndexIDMap* idMap) {
+    if (idMap == nullptr) {
+        throw std::runtime_error("Invalid pointer to index");
+    }
+    auto svsIndex = dynamic_cast<faiss::IndexSVSVamana*>(idMap->index);
+    if (svsIndex == nullptr) {
+        throw std::runtime_error("Index is not an SVS Vamana index");
+    }
+    return svsIndex;
+}
+
+// Applies the svs_vamana build parameters that the index factory description cannot carry. The
+// search_window_size / search_buffer_capacity values become the index-level defaults that query-time
+// method_parameters may override.
+void applySVSVamanaParameters(knn_jni::JNIUtilInterface * jniUtil, JNIEnv *env,
+                              const std::unordered_map<std::string, jobject>& parametersCpp,
+                              faiss::IndexSVSVamana* svsIndex) {
+    std::unordered_map<std::string, jobject>::const_iterator value;
+    if ((value = parametersCpp.find(knn_jni::CONSTRUCTION_WINDOW_SIZE)) != parametersCpp.end()) {
+        svsIndex->construction_window_size = static_cast<size_t>(jniUtil->ConvertJavaObjectToCppInteger(env, value->second));
+    }
+    if ((value = parametersCpp.find(knn_jni::SEARCH_WINDOW_SIZE)) != parametersCpp.end()) {
+        svsIndex->search_window_size = static_cast<size_t>(jniUtil->ConvertJavaObjectToCppInteger(env, value->second));
+    }
+    if ((value = parametersCpp.find(knn_jni::SEARCH_BUFFER_CAPACITY)) != parametersCpp.end()) {
+        svsIndex->search_buffer_capacity = static_cast<size_t>(jniUtil->ConvertJavaObjectToCppInteger(env, value->second));
+    }
+    // SVS requires search_buffer_capacity >= search_window_size.
+    if (svsIndex->search_buffer_capacity < svsIndex->search_window_size) {
+        svsIndex->search_buffer_capacity = svsIndex->search_window_size;
+    }
+    // Only override alpha when present: unset keeps the SVS metric-dependent default (1.2 L2, 0.95 IP).
+    // java/lang/Double is not in JNIUtil's cached-class set, so resolve it through the raw JNI env.
+    if ((value = parametersCpp.find(knn_jni::ALPHA)) != parametersCpp.end()) {
+        jclass doubleClass = env->FindClass("java/lang/Double");
+        jniUtil->HasExceptionInStack(env, "Could not find class java/lang/Double");
+        if (doubleClass != nullptr && env->IsInstanceOf(value->second, doubleClass)) {
+            jmethodID doubleValue = env->GetMethodID(doubleClass, "doubleValue", "()D");
+            jniUtil->HasExceptionInStack(env, "Could not find method doubleValue on java/lang/Double");
+            svsIndex->alpha = static_cast<float>(env->CallDoubleMethod(value->second, doubleValue));
+            jniUtil->HasExceptionInStack(env, "Could not call \"doubleValue\" method on Double");
+        } else {
+            // Fall back for integral JSON values (e.g. alpha: 2); Integer IS in the cached set.
+            svsIndex->alpha = static_cast<float>(jniUtil->ConvertJavaObjectToCppInteger(env, value->second));
+        }
+        if (doubleClass != nullptr) {
+            env->DeleteLocalRef(doubleClass);
+        }
+    }
+}
+
+// Builds the KNNQueryResult[] from raw search output; results shorter than k are marked with id -1.
+jobjectArray buildQueryResults(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env,
+                               const std::vector<faiss::idx_t>& ids, const std::vector<float>& dis, int k) {
+    int resultSize = k;
+    auto it = std::find(ids.begin(), ids.end(), -1);
+    if (it != ids.end()) {
+        resultSize = it - ids.begin();
+    }
+
+    jclass resultClass = jniUtil->FindClass(env, "org/opensearch/knn/index/query/KNNQueryResult");
+    jmethodID allArgs = jniUtil->FindMethod(env, "org/opensearch/knn/index/query/KNNQueryResult", "<init>");
+
+    jobjectArray results = jniUtil->NewObjectArray(env, resultSize, resultClass, nullptr);
+    for (int i = 0; i < resultSize; ++i) {
+        jobject result = jniUtil->NewObject(env, resultClass, allArgs, ids[i], dis[i]);
+        jniUtil->SetObjectArrayElement(env, results, i, result);
+        env->DeleteLocalRef(result);
+    }
+    return results;
+}
+
+}  // namespace
+
+jlong knn_jni::svs_wrapper::InitIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong numDocs, jint dimJ,
+                                      jobject parametersJ) {
+    if (dimJ <= 0) {
+        throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
+    }
+    if (parametersJ == nullptr) {
+        throw std::runtime_error("Parameters cannot be null");
+    }
+
+    auto parametersCpp = jniUtil->ConvertJavaMapToCppMap(env, parametersJ);
+
+    jobject spaceTypeJ = knn_jni::GetJObjectFromMapOrThrow(parametersCpp, knn_jni::SPACE_TYPE);
+    std::string spaceTypeCpp(jniUtil->ConvertJavaObjectToCppString(env, spaceTypeJ));
+    faiss::MetricType metric = TranslateSpaceToMetric(spaceTypeCpp);
+    jniUtil->DeleteLocalRef(env, spaceTypeJ);
+
+    jobject indexDescriptionJ = knn_jni::GetJObjectFromMapOrThrow(parametersCpp, knn_jni::INDEX_DESCRIPTION);
+    std::string indexDescriptionCpp(jniUtil->ConvertJavaObjectToCppString(env, indexDescriptionJ));
+    jniUtil->DeleteLocalRef(env, indexDescriptionJ);
+
+    int threadCount = 0;
+    if (parametersCpp.find(knn_jni::INDEX_THREAD_QUANTITY) != parametersCpp.end()) {
+        threadCount = jniUtil->ConvertJavaObjectToCppInteger(env, parametersCpp[knn_jni::INDEX_THREAD_QUANTITY]);
+    }
+
+    std::unordered_map<std::string, jobject> subParametersCpp;
+    if (parametersCpp.find(knn_jni::PARAMETERS) != parametersCpp.end()) {
+        subParametersCpp = jniUtil->ConvertJavaMapToCppMap(env, parametersCpp[knn_jni::PARAMETERS]);
+    }
+
+    // Setting omp threads affects only the current thread's parallel regions.
+    if (threadCount != 0) {
+        omp_set_num_threads(threadCount);
+    }
+
+    // The description (e.g. "SVSVamana64,LVQ4x4") comes from the sandbox method/encoder mapping and is
+    // parsed by the unmodified upstream faiss factory.
+    std::unique_ptr<faiss::Index> index(faiss::index_factory(static_cast<int>(dimJ), indexDescriptionCpp.c_str(), metric));
+
+    auto svsIndex = dynamic_cast<faiss::IndexSVSVamana*>(index.get());
+    if (svsIndex == nullptr) {
+        throw std::runtime_error("Index description \"" + indexDescriptionCpp + "\" is not an SVS Vamana index");
+    }
+    applySVSVamanaParameters(jniUtil, env, subParametersCpp, svsIndex);
+
+    if (!index->is_trained) {
+        throw std::runtime_error("Index is not trained");
+    }
+
+    auto idMap = std::make_unique<faiss::IndexIDMap>(index.get());
+    // The IDMap must free the inner index when it is itself freed.
+    idMap->own_fields = true;
+    index.release();
+
+    return reinterpret_cast<jlong>(idMap.release());
+}
+
+void knn_jni::svs_wrapper::InsertToIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ,
+                                         jlong vectorsAddressJ, jint dimJ, jlong indexAddressJ, jint threadCount) {
+    if (idsJ == nullptr) {
+        throw std::runtime_error("IDs cannot be null");
+    }
+    if (vectorsAddressJ <= 0) {
+        throw std::runtime_error("VectorsAddress cannot be less than 0");
+    }
+    if (dimJ <= 0) {
+        throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
+    }
+
+    auto *inputVectors = reinterpret_cast<std::vector<float>*>(vectorsAddressJ);
+    int dim = static_cast<int>(dimJ);
+    int numVectors = static_cast<int>(inputVectors->size() / static_cast<uint64_t>(dim));
+    if (numVectors == 0) {
+        throw std::runtime_error("Number of vectors cannot be 0");
+    }
+
+    int numIds = jniUtil->GetJavaIntArrayLength(env, idsJ);
+    if (numIds != numVectors) {
+        throw std::runtime_error("Number of IDs does not match number of vectors");
+    }
+    auto ids = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
+
+    if (threadCount != 0) {
+        omp_set_num_threads(threadCount);
+    }
+
+    auto *idMap = reinterpret_cast<faiss::IndexIDMap *>(indexAddressJ);
+    extractSVSVamana(idMap);  // validate the pointer really is an SVS index
+    idMap->add_with_ids(numVectors, inputVectors->data(), ids.data());
+}
+
+void knn_jni::svs_wrapper::WriteIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jobject output,
+                                      jlong indexAddressJ) {
+    if (output == nullptr) {
+        throw std::runtime_error("Index output stream cannot be null");
+    }
+
+    knn_jni::stream::NativeEngineIndexOutputMediator mediator {jniUtil, env, output};
+    knn_jni::stream::FaissOpenSearchIOWriter writer {&mediator};
+
+    // The index is freed after writing (the build strategy creates it solely to write it).
+    std::unique_ptr<faiss::IndexIDMap> idMap(reinterpret_cast<faiss::IndexIDMap *>(indexAddressJ));
+    try {
+        faiss::write_index(idMap.get(), &writer);
+        writer.flush();
+    } catch (std::exception &e) {
+        throw std::runtime_error(std::string("Failed to write index to disk, error=") + e.what());
+    }
+}
+
+jlong knn_jni::svs_wrapper::LoadIndexWithStream(faiss::IOReader* ioReader) {
+    if (ioReader == nullptr) {
+        throw std::runtime_error("IOReader cannot be null");
+    }
+
+    std::unique_ptr<faiss::Index> indexReader(faiss::read_index(ioReader, faiss::IO_FLAG_READ_ONLY));
+
+    // .svs files only ever contain IDMap(IndexSVSVamana); refuse anything else outright.
+    auto idMap = dynamic_cast<faiss::IndexIDMap*>(indexReader.get());
+    if (idMap == nullptr || dynamic_cast<faiss::IndexSVSVamana*>(idMap->index) == nullptr) {
+        throw std::runtime_error("Loaded index is not an SVS Vamana index");
+    }
+
+    return reinterpret_cast<jlong>(indexReader.release());
+}
+
+jobjectArray knn_jni::svs_wrapper::QueryIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jlong indexPointerJ,
+                                              jfloatArray queryVectorJ, jint kJ, jobject methodParamsJ) {
+    return QueryIndex_WithFilter(jniUtil, env, indexPointerJ, queryVectorJ, kJ, methodParamsJ, nullptr, 0);
+}
+
+jobjectArray knn_jni::svs_wrapper::QueryIndex_WithFilter(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env,
+                                                         jlong indexPointerJ, jfloatArray queryVectorJ, jint kJ,
+                                                         jobject methodParamsJ, jlongArray filterIdsJ,
+                                                         jint filterIdsTypeJ) {
+    if (queryVectorJ == nullptr) {
+        throw std::runtime_error("Query Vector cannot be null");
+    }
+
+    auto *indexReader = reinterpret_cast<faiss::IndexIDMap *>(indexPointerJ);
+    auto *svsVamanaReader = extractSVSVamana(indexReader);
+
+    std::unordered_map<std::string, jobject> methodParams;
+    if (methodParamsJ != nullptr) {
+        methodParams = jniUtil->ConvertJavaMapToCppMap(env, methodParamsJ);
+    }
+
+    faiss::SearchParametersSVSVamana svsVamanaParams;
+    // Query-time search_window_size supersedes the index-level value; buffer capacity tracks it when the
+    // index-level capacity is smaller (SVS requires capacity >= window).
+    svsVamanaParams.search_window_size = knn_jni::commons::getIntegerMethodParameter(
+        env, jniUtil, methodParams, knn_jni::SEARCH_WINDOW_SIZE, svsVamanaReader->search_window_size);
+    svsVamanaParams.search_buffer_capacity = std::max(
+        static_cast<size_t>(svsVamanaReader->search_buffer_capacity), svsVamanaParams.search_window_size);
+
+    // The SVS runtime does not pad missing results with faiss's -1 sentinel; slots beyond the number of
+    // results found would otherwise surface as label 0 / distance 0. Clamp k to the segment's vector count
+    // and pre-fill with the faiss sentinels so short result sets (e.g. under a restrictive pre-filter) are
+    // detected by the trim below — which in turn lets the Java layer fall back to exact search.
+    int k = static_cast<int>(std::min<int64_t>(static_cast<int64_t>(kJ), svsVamanaReader->ntotal));
+    if (k <= 0) {
+        std::vector<faiss::idx_t> emptyIds;
+        std::vector<float> emptyDis;
+        return buildQueryResults(jniUtil, env, emptyIds, emptyDis, 0);
+    }
+    std::vector<float> dis(k, std::numeric_limits<float>::infinity());
+    std::vector<faiss::idx_t> ids(k, -1);
+    float* rawQueryVector = jniUtil->GetFloatArrayElements(env, queryVectorJ, nullptr);
+
+    // Set omp threads to 1 so no new OMP threads are created under the search threadpool.
+    omp_set_num_threads(1);
+
+    if (filterIdsJ != nullptr) {
+        jlong *filteredIdsArray = jniUtil->GetLongArrayElements(env, filterIdsJ, nullptr);
+        int filterIdsLength = jniUtil->GetJavaLongArrayLength(env, filterIdsJ);
+        std::unique_ptr<faiss::IDSelector> idSelector;
+        if (filterIdsTypeJ == BITMAP) {
+            idSelector.reset(new faiss::IDSelectorJlongBitmap(filterIdsLength, filteredIdsArray));
+        } else {
+            faiss::idx_t* batchIndices = reinterpret_cast<faiss::idx_t*>(filteredIdsArray);
+            idSelector.reset(new faiss::IDSelectorBatch(filterIdsLength, batchIndices));
+        }
+        svsVamanaParams.sel = idSelector.get();
+        try {
+            indexReader->search(1, rawQueryVector, k, dis.data(), ids.data(), &svsVamanaParams);
+        } catch (...) {
+            jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryVector, JNI_ABORT);
+            jniUtil->ReleaseLongArrayElements(env, filterIdsJ, filteredIdsArray, JNI_ABORT);
+            throw;
+        }
+        jniUtil->ReleaseLongArrayElements(env, filterIdsJ, filteredIdsArray, JNI_ABORT);
+    } else {
+        try {
+            indexReader->search(1, rawQueryVector, k, dis.data(), ids.data(), &svsVamanaParams);
+        } catch (...) {
+            jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryVector, JNI_ABORT);
+            throw;
+        }
+    }
+    jniUtil->ReleaseFloatArrayElements(env, queryVectorJ, rawQueryVector, JNI_ABORT);
+
+    return buildQueryResults(jniUtil, env, ids, dis, k);
+}
+
+void knn_jni::svs_wrapper::Free(jlong indexPointerJ) {
+    auto *index = reinterpret_cast<faiss::Index*>(indexPointerJ);
+    delete index;
+}
+
+void knn_jni::svs_wrapper::InitLibrary() {
+    // No global initialization required today; kept as the single hook for any future setup.
+}
+
+bool knn_jni::svs_wrapper::IsLvqLeanvecEnabled() {
+    return faiss::IndexSVSVamana::is_lvq_leanvec_enabled();
+}
+
+faiss::MetricType knn_jni::svs_wrapper::TranslateSpaceToMetric(const std::string& spaceType) {
+    if (spaceType == knn_jni::L2) {
+        return faiss::METRIC_L2;
+    }
+    if (spaceType == knn_jni::INNER_PRODUCT) {
+        return faiss::METRIC_INNER_PRODUCT;
+    }
+    // Vectors are normalized at the Java layer for cosine, so cosine is equivalent to inner product.
+    if (spaceType == knn_jni::COSINESIMIL) {
+        return faiss::METRIC_INNER_PRODUCT;
+    }
+    throw std::runtime_error("Invalid spaceType: " + spaceType);
+}

--- a/jni/sandbox/svs.cmake
+++ b/jni/sandbox/svs.cmake
@@ -1,0 +1,59 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build logic for the experimental, fully-isolated Intel SVS JNI library (libopensearchknn_svs).
+# Included from jni/CMakeLists.txt only when -DCONFIG_SVS=ON (driven by -Pknn.sandbox.enabled=true).
+# All SVS-specific native code lives under jni/sandbox/; the only sources reused from jni/src are the
+# generic, faiss-free JNI marshalling helpers (jni_util + commons), compiled in as a static copy so the
+# library stays an independent artifact. It embeds its own UNMODIFIED upstream SVS-enabled faiss (no k-NN
+# patches) and exports only its JNI symbols (see svs_jni.version).
+#
+# CMAKE_CURRENT_SOURCE_DIR here is the jni/ root (include() does not change it).
+set(SVS_SANDBOX_DIR ${CMAKE_CURRENT_SOURCE_DIR}/sandbox)
+
+# Provide the SVS runtime (conda-forge libsvs-runtime) and build the SVS-enabled upstream faiss.
+# Sets: svs::svs_runtime, SVS_FAISS_LINK_LIB, SVS_FAISS_INCLUDE_DIR, and the faiss_svs ExternalProject.
+include(${SVS_SANDBOX_DIR}/cmake/fetch-svs-runtime.cmake)
+include(${SVS_SANDBOX_DIR}/cmake/init-faiss-svs.cmake)
+find_package(OpenMP REQUIRED)
+
+# STATIC marshalling helpers (jni_util + commons), embedded into the SVS lib so it carries its own copy
+# and stays runtime-independent of the SHARED opensearchknn_util the other libs link.
+add_library(${TARGET_LIB_JNI_HELPERS} STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/jni_util.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/commons.cpp)
+set_property(TARGET ${TARGET_LIB_JNI_HELPERS} PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(${TARGET_LIB_JNI_HELPERS} PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include $ENV{JAVA_HOME}/include $ENV{JAVA_HOME}/include/${JVM_OS_TYPE})
+
+add_library(
+    ${TARGET_LIB_SVS} SHARED
+    ${SVS_SANDBOX_DIR}/src/org_opensearch_knn_sandbox_svs_SvsService.cpp
+    ${SVS_SANDBOX_DIR}/src/svs_wrapper.cpp
+    ${SVS_SANDBOX_DIR}/src/svs_constants.cpp
+)
+add_dependencies(${TARGET_LIB_SVS} faiss_svs)
+target_link_libraries(${TARGET_LIB_SVS} ${SVS_FAISS_LINK_LIB} ${TARGET_LIB_JNI_HELPERS} svs::svs_runtime OpenMP::OpenMP_CXX)
+target_compile_definitions(${TARGET_LIB_SVS} PRIVATE FAISS_ENABLE_SVS FAISS_SVS_RUNTIME_VERSION=v0)
+target_include_directories(${TARGET_LIB_SVS} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${SVS_SANDBOX_DIR}/include
+    $ENV{JAVA_HOME}/include
+    $ENV{JAVA_HOME}/include/${JVM_OS_TYPE}
+    ${SVS_FAISS_INCLUDE_DIR}
+)
+# Hidden visibility + version script: export ONLY the JNI entry points so this lib's embedded faiss
+# symbols cannot interpose with the (different-version) faiss embedded in libopensearchknn_faiss when
+# both are dlopen'd into the same JVM. $ORIGIN rpath lets it find the bundled libsvs_runtime.so beside it.
+set_target_properties(${TARGET_LIB_SVS} PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+    BUILD_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN")
+if (${CMAKE_SYSTEM_NAME} STREQUAL Linux)
+    target_link_options(${TARGET_LIB_SVS} PRIVATE
+        "-Wl,--version-script=${SVS_SANDBOX_DIR}/cmake/svs_jni.version")
+endif()
+opensearch_set_common_properties(${TARGET_LIB_SVS})
+list(APPEND TARGET_LIBS ${TARGET_LIB_SVS})

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,78 @@
+# OpenSearch k-NN Sandbox Module
+
+## Overview
+
+The `sandbox` module is a **first-class incubation environment** for experimental algorithms, optimizations, and architectural components within the OpenSearch k-NN plugin. It provides a safe space for contributors to propose, develop, and validate bold ideas before they graduate to the main package.
+
+> **⚠️ Experimental**: All code in this module is considered experimental and is **not included in production release artifacts**. APIs may change or be removed without prior notice.
+
+## Purpose
+
+As the k-NN codebase grows with increasingly complex capabilities (new approximate algorithms, quantization techniques, optimizations, tiered storage architectures, etc.), the sandbox provides:
+
+- **Isolation**: Experimental code is kept separate from production-ready code
+- **Safety**: Unproven algorithms don't risk the stability of the main package
+- **Discoverability**: A clear, well-known location for experimental work
+- **Lifecycle Management**: A defined path from experimentation to production
+
+## Lifecycle
+
+Every component in the sandbox follows a defined lifecycle:
+
+```
+1. PROPOSAL  →  2. INCUBATION  →  3. GRADUATION (or REMOVAL)
+```
+
+1. **Proposal**: Open an issue describing the experimental algorithm/optimization
+2. **Incubation**: Implement in `sandbox/`, annotate with `@ExperimentalAlgorithm`, gather feedback
+3. **Graduation**: Once stability, performance, and test coverage thresholds are met, migrate to the main package
+
+## Usage
+
+### Adding Experimental Code
+
+All public classes in this module **must** be annotated with `@ExperimentalAlgorithm`:
+
+```java
+@ExperimentalAlgorithm(
+    description = "Graph-based ANN using vamana algorithm",
+    since = "3.7.0"
+)
+public class VamanaAlgorithm {
+    // experimental implementation
+}
+```
+
+### Building
+
+```bash
+# Build sandbox module only
+./gradlew :sandbox:build
+
+# Run sandbox tests only
+./gradlew :sandbox:test
+```
+
+### Release Isolation
+
+By default the sandbox module is **excluded from the build graph entirely** (see `settings.gradle`), so it is not compiled or bundled and a release build produces a plugin identical to upstream. It is built and its jar bundled into the plugin zip only when the build opts in with `-Pknn.sandbox.enabled=true`; even then the root project declares no compile dependency on the module — the jar is copied in solely so its `ServiceLoader` providers are discoverable at runtime.
+
+## Graduation Criteria
+
+An experimental component may graduate to the main package when it meets **all** of the following:
+
+| Criterion | Threshold |
+|---|---|
+| **Stability** | No critical bugs after a minimum incubation period |
+| **Performance** | Meets or exceeds benchmarks comparable to existing stable algorithms |
+| **Test Coverage** | Comprehensive unit and integration tests |
+| **Community Feedback** | Positive reception from early adopters |
+| **Documentation** | Complete API documentation and usage guides |
+
+## Contributing
+
+1. Open an issue describing your experimental idea
+2. Create your implementation in `sandbox/src/main/java/org/opensearch/knn/sandbox/`
+3. Add comprehensive tests in `sandbox/src/test/java/org/opensearch/knn/sandbox/`
+4. Annotate all public classes with `@ExperimentalAlgorithm`
+5. Open a Draft PR for community review

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java'
+    id 'java-library'
+    id 'jacoco'
+    id "io.freefair.lombok" version "8.14"
+    id 'com.diffplug.spotless' version '6.25.0'
+    id 'opensearch.build'
+    id 'opensearch.java-agent'
+}
+
+repositories {
+    mavenLocal()
+    maven { url = uri("https://ci.opensearch.org/ci/dbc/snapshots/maven/") }
+    mavenCentral()
+    maven { url = uri("https://plugins.gradle.org/m2/") }
+}
+
+description = "Sandbox module for experimental k-NN algorithms and optimizations"
+
+compileJava {
+    options.compilerArgs = ["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor']
+}
+compileTestJava {
+    options.compilerArgs = ["-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor']
+}
+
+dependencies {
+    compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
+    testImplementation "org.opensearch.test:framework:${opensearch_version}"
+
+    // Compile-time-only dependency on the root k-NN project so sandbox tenants can
+    // extend main-module types (e.g. AbstractFaissMethod, Encoder, KNNConstants).
+    // The root project deliberately does NOT depend on :sandbox, so release-artifact
+    // isolation is preserved (bundlePlugin still excludes sandbox classes).
+    compileOnly project(':')
+    testImplementation project(':')
+
+    // Guava is provided to the main plugin at runtime by OpenSearch's transport-grpc module, so the
+    // root project declares it compileOnly. The sandbox test classpath has no such provider, so some
+    // main-module classes exercised in sandbox unit tests (e.g. FaissFlatEncoder, QuantizationConfig)
+    // would fail to initialize without it. Add it for the sandbox test runtime only.
+    testImplementation "com.google.guava:guava:${versions.guava}"
+}
+
+check.dependsOn spotlessCheck

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import org.opensearch.gradle.test.RestIntegTestTask
+
 plugins {
     id 'java'
     id 'java-library'
@@ -12,6 +14,14 @@ plugins {
     id 'opensearch.build'
     id 'opensearch.java-agent'
 }
+
+// Test-cluster support for the REST integration tests.
+apply plugin: 'opensearch.testclusters'
+
+// Opt-in, non-released module with no third-party runtime jars; skip the per-dependency metadata checks.
+dependencyLicenses.enabled = false
+thirdPartyAudit.enabled = false
+loggerUsageCheck.enabled = false
 
 repositories {
     mavenLocal()
@@ -33,18 +43,55 @@ dependencies {
     compileOnly group: 'org.opensearch', name: 'opensearch', version: "${opensearch_version}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 
-    // Compile-time-only dependency on the root k-NN project so sandbox tenants can
-    // extend main-module types (e.g. AbstractFaissMethod, Encoder, KNNConstants).
-    // The root project deliberately does NOT depend on :sandbox, so release-artifact
-    // isolation is preserved (bundlePlugin still excludes sandbox classes).
+    // Compile-only on root so sandbox tenants can extend main-module types; root does NOT depend on
+    // :sandbox, so release-artifact isolation is preserved.
     compileOnly project(':')
     testImplementation project(':')
 
-    // Guava is provided to the main plugin at runtime by OpenSearch's transport-grpc module, so the
-    // root project declares it compileOnly. The sandbox test classpath has no such provider, so some
-    // main-module classes exercised in sandbox unit tests (e.g. FaissFlatEncoder, QuantizationConfig)
-    // would fail to initialize without it. Add it for the sandbox test runtime only.
+    // Root declares guava compileOnly (provided at runtime by transport-grpc); the sandbox test classpath
+    // has no such provider, so add it for the test runtime only.
     testImplementation "com.google.guava:guava:${versions.guava}"
+
+    // KNNRestTestCase (used by the SVS IT) is published by the root project's test-fixtures.
+    testImplementation testFixtures(project(':'))
 }
 
 check.dependsOn spotlessCheck
+
+// Default `test` runs fast unit tests only; the REST IT runs under integTest against a cluster.
+test {
+    exclude '**/*IT.class'
+}
+
+// REST integration tests for the SVS engine. Only meaningful on a flagged build (-Pknn.sandbox.enabled=true),
+// where bundlePlugin's zip carries the sandbox jar + the isolated SVS native lib.
+def sandboxIntegTestCluster = testClusters.create('integTest') {
+    testDistribution = "ARCHIVE"
+    plugin(rootProject.tasks.bundlePlugin.archiveFile)
+}
+
+task integTest(type: RestIntegTestTask) {
+    description = "Run REST integration tests for the experimental :sandbox engines."
+    group = "verification"
+    dependsOn rootProject.tasks.bundlePlugin
+    useCluster sandboxIntegTestCluster
+
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty "java.library.path", "${rootDir}/jni/build/release"
+    systemProperty('project.root', project.rootDir.absolutePath)
+    // KNNRestTestCase reads these to decide http vs https / credentials.
+    systemProperty("https", System.getProperty("https"))
+    systemProperty("user", System.getProperty("user"))
+    systemProperty("password", System.getProperty("password"))
+
+    filter {
+        includeTestsMatching "org.opensearch.knn.sandbox.svs.*IT"
+    }
+
+    mustRunAfter test
+}
+
+check.dependsOn integTest

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/ExperimentalAlgorithm.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/ExperimentalAlgorithm.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation indicating that a class is an experimental algorithm or component
+ * within the k-NN sandbox module.
+ *
+ * <p>Classes annotated with {@code @ExperimentalAlgorithm} are not part of the stable,
+ * production-ready API surface. They may change, be renamed, or be removed without
+ * prior notice in any future release.</p>
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * @ExperimentalAlgorithm(
+ *     description = "Graph-based approximate nearest neighbor using vamana algorithm",
+ *     since = "3.7.0"
+ * )
+ * public class VamanaAlgorithm {
+ *     // experimental implementation
+ * }
+ * }</pre>
+ *
+ * <p><strong>Graduation Criteria</strong></p>
+ * <p>An experimental component may graduate to the main package when it meets:</p>
+ * <ul>
+ *   <li>Stability: No critical bugs after a minimum incubation period</li>
+ *   <li>Performance: Meets or exceeds benchmarks comparable to existing stable algorithms</li>
+ *   <li>Test coverage: Comprehensive unit and integration tests</li>
+ *   <li>Community feedback: Positive reception from early adopters</li>
+ * </ul>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface ExperimentalAlgorithm {
+
+    /**
+     * A brief description of the experimental algorithm or component.
+     *
+     * @return the description string, empty by default
+     */
+    String description() default "";
+
+    /**
+     * The version in which this experimental component was first introduced.
+     *
+     * @return the version string (e.g., "3.7.0"), empty by default
+     */
+    String since() default "";
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/ExperimentalAlgorithm.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/ExperimentalAlgorithm.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
  * <pre>{@code
  * @ExperimentalAlgorithm(
  *     description = "Graph-based approximate nearest neighbor using vamana algorithm",
- *     since = "3.7.0"
+ *     since = "3.8.0"
  * )
  * public class VamanaAlgorithm {
  *     // experimental implementation
@@ -52,7 +52,7 @@ public @interface ExperimentalAlgorithm {
     /**
      * The version in which this experimental component was first introduced.
      *
-     * @return the version string (e.g., "3.7.0"), empty by default
+     * @return the version string (e.g., "3.8.0"), empty by default
      */
     String since() default "";
 }

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/package-info.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The {@code org.opensearch.knn.sandbox} package provides a first-class incubation
+ * environment for experimental algorithms, optimizations, and architectural components
+ * within the OpenSearch k-NN plugin.
+ *
+ * <p>All classes in this package and its sub-packages are considered <strong>experimental</strong>
+ * and are not included in production release artifacts. They follow a defined lifecycle:</p>
+ * <ol>
+ *   <li>New ideas land in this sandbox module.</li>
+ *   <li>They are exposed to early adopters and community feedback under an explicit experimental label.</li>
+ *   <li>Once they meet stability, performance, and test coverage thresholds, they graduate to the main package.</li>
+ * </ol>
+ *
+ * <p>Every public class in this package should be annotated with
+ * {@link org.opensearch.knn.sandbox.ExperimentalAlgorithm @ExperimentalAlgorithm}.</p>
+ *
+ * @see org.opensearch.knn.sandbox.ExperimentalAlgorithm
+ */
+package org.opensearch.knn.sandbox;

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSLVQEncoder.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSLVQEncoder.java
@@ -26,7 +26,7 @@ import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_R
  * {@code SVSStorageKind} supports — {@code (4,0)}, {@code (4,4)}, {@code (4,8)} — are accepted; others are
  * rejected at index creation rather than failing deep in native code.
  */
-@ExperimentalAlgorithm(description = "Intel SVS Vamana LVQ encoder", since = "3.7.0")
+@ExperimentalAlgorithm(description = "Intel SVS Vamana LVQ encoder", since = "3.8.0")
 public class FaissSVSLVQEncoder implements Encoder {
 
     static final int DEFAULT_PRIMARY_BITS = 4;

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSLVQEncoder.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSLVQEncoder.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.Parameter;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.sandbox.ExperimentalAlgorithm;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_ENCODER_LVQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_PRIMARY_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_RESIDUAL_BITS;
+
+/**
+ * LVQ (Locally-adaptive Vector Quantization) encoder for SVS indexes, with {@code primary_bits} and
+ * {@code residual_bits} parameters (both default 4). Only the combinations the SVS runtime's
+ * {@code SVSStorageKind} supports — {@code (4,0)}, {@code (4,4)}, {@code (4,8)} — are accepted; others are
+ * rejected at index creation rather than failing deep in native code.
+ */
+@ExperimentalAlgorithm(description = "Intel SVS Vamana LVQ encoder", since = "3.7.0")
+public class FaissSVSLVQEncoder implements Encoder {
+
+    static final int DEFAULT_PRIMARY_BITS = 4;
+    static final int DEFAULT_RESIDUAL_BITS = 4;
+
+    /** Supported (primary_bits, residual_bits) combinations, mirroring the SVS {@code SVSStorageKind} LVQ kinds. */
+    private static final Set<String> SUPPORTED_BIT_COMBINATIONS = Set.of("4x0", "4x4", "4x8");
+
+    private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(FAISS_SVS_ENCODER_LVQ)
+        .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+        .addParameter(
+            METHOD_PARAMETER_LVQ_PRIMARY_BITS,
+            new Parameter.IntegerParameter(METHOD_PARAMETER_LVQ_PRIMARY_BITS, DEFAULT_PRIMARY_BITS, (v, context) -> v >= 1 && v <= 8)
+        )
+        .addParameter(
+            METHOD_PARAMETER_LVQ_RESIDUAL_BITS,
+            new Parameter.IntegerParameter(METHOD_PARAMETER_LVQ_RESIDUAL_BITS, DEFAULT_RESIDUAL_BITS, (v, context) -> v >= 0 && v <= 8)
+        )
+        .setKnnLibraryIndexingContextGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
+            int primaryBits = readBits(methodComponentContext, METHOD_PARAMETER_LVQ_PRIMARY_BITS, DEFAULT_PRIMARY_BITS);
+            int residualBits = readBits(methodComponentContext, METHOD_PARAMETER_LVQ_RESIDUAL_BITS, DEFAULT_RESIDUAL_BITS);
+            validateBitCombination(primaryBits, residualBits);
+            validatePlatformSupportsLvq();
+
+            SvsMethodAsMapBuilder builder = SvsMethodAsMapBuilder.builder(
+                "LVQ",
+                methodComponent,
+                methodComponentContext,
+                knnMethodConfigContext
+            );
+            // Builds the "LVQ{primary}x{residual}" token, e.g. "LVQ4x4".
+            builder.addParameter(METHOD_PARAMETER_LVQ_PRIMARY_BITS, "", "x");
+            builder.addParameter(METHOD_PARAMETER_LVQ_RESIDUAL_BITS, "", "");
+            return builder.build();
+        }))
+        .build();
+
+    private static int readBits(MethodComponentContext methodComponentContext, String name, int defaultValue) {
+        if (methodComponentContext == null) {
+            return defaultValue;
+        }
+        Object value = methodComponentContext.getParameters().get(name);
+        return value instanceof Integer ? (Integer) value : defaultValue;
+    }
+
+    static void validateBitCombination(int primaryBits, int residualBits) {
+        String combination = String.format(Locale.ROOT, "%dx%d", primaryBits, residualBits);
+        if (SUPPORTED_BIT_COMBINATIONS.contains(combination) == false) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Unsupported LVQ (primary_bits, residual_bits) combination [%s] for encoder [%s]. "
+                        + "Supported combinations are: 4x0, 4x4, 4x8.",
+                    combination,
+                    FAISS_SVS_ENCODER_LVQ
+                )
+            );
+        }
+    }
+
+    private static void validatePlatformSupportsLvq() {
+        if (SvsService.isLvqLeanvecEnabled() == false) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Encoder [%s] is not supported on this node. LVQ compression requires Intel SIMD support "
+                        + "in the SVS runtime, which is unavailable on this platform or build.",
+                    FAISS_SVS_ENCODER_LVQ
+                )
+            );
+        }
+    }
+
+    @Override
+    public MethodComponent getMethodComponent() {
+        return METHOD_COMPONENT;
+    }
+
+    @Override
+    public CompressionLevel calculateCompressionLevel(
+        MethodComponentContext encoderContext,
+        KNNMethodConfigContext knnMethodConfigContext
+    ) {
+        int primaryBits = readBits(encoderContext, METHOD_PARAMETER_LVQ_PRIMARY_BITS, DEFAULT_PRIMARY_BITS);
+        int residualBits = readBits(encoderContext, METHOD_PARAMETER_LVQ_RESIDUAL_BITS, DEFAULT_RESIDUAL_BITS);
+        int totalBits = primaryBits + residualBits;
+        // Map 32/total_bits to the nearest supported CompressionLevel; 4x8 (~2.67x) has no exact enum, use x4.
+        if (totalBits <= 4) {
+            return CompressionLevel.x8;
+        }
+        return CompressionLevel.x4;
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSSQEncoder.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSSQEncoder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.Parameter;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.sandbox.ExperimentalAlgorithm;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_FP16_DESCRIPTION;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_SQ8_DESCRIPTION;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_FP16;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_SQ8;
+
+/**
+ * Scalar-quantization encoder for SVS Vamana, exposed as the unified {@code sq} encoder (matching the HNSW
+ * convention) with a {@code type} parameter: {@code fp16} (default, x2) or {@code sq8} (x4). Unlike the main
+ * {@link org.opensearch.knn.index.engine.faiss.FaissSQEncoder} it has no Lucene {@code bits} path; SVS
+ * quantization is performed natively.
+ */
+@ExperimentalAlgorithm(description = "Intel SVS Vamana scalar-quantization (sq) encoder", since = "3.7.0")
+public class FaissSVSSQEncoder implements Encoder {
+
+    private static final Set<String> SUPPORTED_TYPES = Set.of(FAISS_SVS_SQ_TYPE_FP16, FAISS_SVS_SQ_TYPE_SQ8);
+
+    private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(ENCODER_SQ)
+        .addSupportedDataTypes(Set.of(VectorDataType.FLOAT))
+        .addParameter(
+            FAISS_SVS_SQ_TYPE,
+            new Parameter.StringParameter(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_FP16, (v, context) -> SUPPORTED_TYPES.contains(v))
+        )
+        // 'bits' is the HNSW sq knob, not ours. Declared (null default) only so a user who passes it gets the
+        // targeted message from validateNoBitsParameter, not a generic "unknown parameter" rejection.
+        .addParameter(SQ_BITS, new Parameter.IntegerParameter(SQ_BITS, null, (v, context) -> true))
+        .setKnnLibraryIndexingContextGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
+            validateNoBitsParameter(methodComponentContext);
+            String description = FAISS_SVS_SQ_FP16_DESCRIPTION;
+            if (FAISS_SVS_SQ_TYPE_SQ8.equals(resolveType(methodComponentContext))) {
+                description = FAISS_SVS_SQ_SQ8_DESCRIPTION;
+            }
+            return SvsMethodAsMapBuilder.builder(description, methodComponent, methodComponentContext, knnMethodConfigContext).build();
+        }))
+        .build();
+
+    /**
+     * Rejects the HNSW sq encoder's {@code bits} parameter with a targeted message; SVS sq selects precision
+     * via {@code type} and has no bit-width knob.
+     */
+    static void validateNoBitsParameter(MethodComponentContext methodComponentContext) {
+        if (methodComponentContext == null) {
+            return;
+        }
+        // Only a user-supplied (non-null) bits triggers the message, not the null default from the whitelist.
+        if (methodComponentContext.getParameters().get(SQ_BITS) != null) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "The svs_vamana '%s' encoder uses the '%s' parameter (%s|%s), not '%s'.",
+                    ENCODER_SQ,
+                    FAISS_SVS_SQ_TYPE,
+                    FAISS_SVS_SQ_TYPE_FP16,
+                    FAISS_SVS_SQ_TYPE_SQ8,
+                    SQ_BITS
+                )
+            );
+        }
+    }
+
+    private static String resolveType(MethodComponentContext methodComponentContext) {
+        if (methodComponentContext == null) {
+            return FAISS_SVS_SQ_TYPE_FP16;
+        }
+        Object type = methodComponentContext.getParameters().get(FAISS_SVS_SQ_TYPE);
+        return type instanceof String ? (String) type : FAISS_SVS_SQ_TYPE_FP16;
+    }
+
+    @Override
+    public MethodComponent getMethodComponent() {
+        return METHOD_COMPONENT;
+    }
+
+    @Override
+    public CompressionLevel calculateCompressionLevel(
+        MethodComponentContext encoderContext,
+        KNNMethodConfigContext knnMethodConfigContext
+    ) {
+        return FAISS_SVS_SQ_TYPE_SQ8.equals(resolveType(encoderContext)) ? CompressionLevel.x4 : CompressionLevel.x2;
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSSQEncoder.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSSQEncoder.java
@@ -31,7 +31,7 @@ import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_SQ8;
  * {@link org.opensearch.knn.index.engine.faiss.FaissSQEncoder} it has no Lucene {@code bits} path; SVS
  * quantization is performed natively.
  */
-@ExperimentalAlgorithm(description = "Intel SVS Vamana scalar-quantization (sq) encoder", since = "3.7.0")
+@ExperimentalAlgorithm(description = "Intel SVS Vamana scalar-quantization (sq) encoder", since = "3.8.0")
 public class FaissSVSSQEncoder implements Encoder {
 
     private static final Set<String> SUPPORTED_TYPES = Set.of(FAISS_SVS_SQ_TYPE_FP16, FAISS_SVS_SQ_TYPE_SQ8);

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaMethod.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaMethod.java
@@ -39,7 +39,7 @@ import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_SVS_VAMANA;
 /**
  * SVS Vamana method: graph-based approximate search using the Vamana algorithm (Subramanya et al.).
  */
-@ExperimentalAlgorithm(description = "Intel SVS Vamana graph-based ANN method", since = "3.7.0")
+@ExperimentalAlgorithm(description = "Intel SVS Vamana graph-based ANN method", since = "3.8.0")
 public class FaissSVSVamanaMethod extends AbstractFaissMethod {
 
     private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = Set.of(VectorDataType.FLOAT);

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaMethod.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaMethod.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.Parameter;
+import org.opensearch.knn.index.engine.faiss.AbstractFaissMethod;
+import org.opensearch.knn.index.engine.faiss.FaissFlatEncoder;
+import org.opensearch.knn.sandbox.ExperimentalAlgorithm;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.FAISS_FLAT_DESCRIPTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.DEFAULT_CONSTRUCTION_WINDOW_SIZE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_ENCODER_LVQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_VAMANA_DESCRIPTION;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_ALPHA;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_DEGREE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_SEARCH_BUFFER_CAPACITY;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_SEARCH_WINDOW_SIZE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_SVS_VAMANA;
+
+/**
+ * SVS Vamana method: graph-based approximate search using the Vamana algorithm (Subramanya et al.).
+ */
+@ExperimentalAlgorithm(description = "Intel SVS Vamana graph-based ANN method", since = "3.7.0")
+public class FaissSVSVamanaMethod extends AbstractFaissMethod {
+
+    private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = Set.of(VectorDataType.FLOAT);
+
+    public final static List<SpaceType> SUPPORTED_SPACES = Arrays.asList(SpaceType.L2, SpaceType.INNER_PRODUCT, SpaceType.COSINESIMIL);
+
+    // FLAT, SQ (fp16/sq8), and LVQ. LeanVec is excluded: it requires model training, out of scope for the sandbox.
+    public final static Map<String, Encoder> SUPPORTED_ENCODERS = Map.of(
+        ENCODER_FLAT,
+        new FaissFlatEncoder(),
+        ENCODER_SQ,
+        new FaissSVSSQEncoder(),
+        FAISS_SVS_ENCODER_LVQ,
+        new FaissSVSLVQEncoder()
+    );
+
+    private final static MethodComponentContext DEFAULT_ENCODER_CONTEXT = new MethodComponentContext(ENCODER_FLAT, Collections.emptyMap());
+
+    public final static MethodComponent METHOD_COMPONENT = initMethodComponent();
+
+    public FaissSVSVamanaMethod() {
+        super(METHOD_COMPONENT, Set.copyOf(SUPPORTED_SPACES), new FaissSVSVamanaSearchContext());
+    }
+
+    private static MethodComponent initMethodComponent() {
+        return MethodComponent.Builder.builder(METHOD_SVS_VAMANA)
+            .addSupportedDataTypes(SUPPORTED_DATA_TYPES)
+            .addParameter(
+                METHOD_PARAMETER_DEGREE,
+                new Parameter.IntegerParameter(METHOD_PARAMETER_DEGREE, 64, (v, context) -> v > 0 && v <= 256)
+            )
+            .addParameter(
+                METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE,
+                new Parameter.IntegerParameter(
+                    METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE,
+                    DEFAULT_CONSTRUCTION_WINDOW_SIZE,
+                    (v, context) -> v > 0
+                )
+            )
+            .addParameter(
+                METHOD_PARAMETER_SEARCH_WINDOW_SIZE,
+                new Parameter.IntegerParameter(METHOD_PARAMETER_SEARCH_WINDOW_SIZE, 10, (v, context) -> v > 0)
+            )
+            .addParameter(
+                METHOD_PARAMETER_SEARCH_BUFFER_CAPACITY,
+                new Parameter.IntegerParameter(METHOD_PARAMETER_SEARCH_BUFFER_CAPACITY, 10, (v, context) -> v > 0)
+            )
+            // alpha controls Vamana graph pruning aggressiveness. Default is null: when unset the SVS
+            // runtime applies a metric-dependent default (1.2 for L2, 0.95 for inner product).
+            .addParameter(METHOD_PARAMETER_ALPHA, new Parameter.DoubleParameter(METHOD_PARAMETER_ALPHA, null, (v, context) -> v > 0))
+            .addParameter(
+                METHOD_ENCODER_PARAMETER,
+                new Parameter.MethodComponentContextParameter(
+                    METHOD_ENCODER_PARAMETER,
+                    DEFAULT_ENCODER_CONTEXT,
+                    SUPPORTED_ENCODERS.values().stream().collect(Collectors.toMap(Encoder::getName, Encoder::getMethodComponent))
+                )
+            )
+            .setKnnLibraryIndexingContextGenerator(((methodComponent, methodComponentContext, knnMethodConfigContext) -> {
+                SvsMethodAsMapBuilder methodAsMapBuilder = SvsMethodAsMapBuilder.builder(
+                    FAISS_SVS_VAMANA_DESCRIPTION,
+                    methodComponent,
+                    methodComponentContext,
+                    knnMethodConfigContext
+                );
+                methodAsMapBuilder.addParameter(METHOD_PARAMETER_DEGREE, "", "");
+
+                // Append the encoder for ALL encoders (incl. default flat) so its MethodComponentContext is
+                // normalized into a serializable sub-map; otherwise the raw context fails to serialize into the
+                // field mapping. Flat yields a trailing ",Flat" that SVS's native factory rejects, so drop it.
+                methodAsMapBuilder.addParameter(METHOD_ENCODER_PARAMETER, ",", "");
+                methodAsMapBuilder.dropTrailingDescriptionToken(FAISS_FLAT_DESCRIPTION);
+
+                return methodAsMapBuilder.build();
+            }))
+            .build();
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaSearchContext.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaSearchContext.java
@@ -19,7 +19,7 @@ import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_SEARC
  * recall/latency knob, analogous to {@code ef_search}); {@code search_buffer_capacity} is an index-time
  * parameter only.
  */
-@ExperimentalAlgorithm(description = "Intel SVS Vamana search context", since = "3.7.0")
+@ExperimentalAlgorithm(description = "Intel SVS Vamana search context", since = "3.8.0")
 public final class FaissSVSVamanaSearchContext implements KNNLibrarySearchContext {
 
     @Override

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaSearchContext.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaSearchContext.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.knn.index.engine.KNNLibrarySearchContext;
+import org.opensearch.knn.index.engine.Parameter;
+import org.opensearch.knn.index.engine.model.QueryContext;
+import org.opensearch.knn.sandbox.ExperimentalAlgorithm;
+
+import java.util.Map;
+
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_SEARCH_WINDOW_SIZE;
+
+/**
+ * Faiss SVS Vamana search context. The only query-time tunable is {@code search_window_size} (the
+ * recall/latency knob, analogous to {@code ef_search}); {@code search_buffer_capacity} is an index-time
+ * parameter only.
+ */
+@ExperimentalAlgorithm(description = "Intel SVS Vamana search context", since = "3.7.0")
+public final class FaissSVSVamanaSearchContext implements KNNLibrarySearchContext {
+
+    @Override
+    public Map<String, Parameter<?>> supportedMethodParameters(QueryContext ctx) {
+        return Map.of(
+            METHOD_PARAMETER_SEARCH_WINDOW_SIZE,
+            new Parameter.IntegerParameter(METHOD_PARAMETER_SEARCH_WINDOW_SIZE, null, (v, context) -> v > 0)
+        );
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SVSConstants.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SVSConstants.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+/**
+ * SVS-specific constants used by the sandbox SVS engine classes.
+ *
+ * <p>These constants are intentionally kept local to the sandbox module so that the
+ * experimental SVS integration does not leak names into the main {@code KNNConstants}.
+ * Constants that already exist in the main module (e.g. {@code ENCODER_FLAT},
+ * {@code METHOD_ENCODER_PARAMETER}) are imported from {@code KNNConstants} directly.</p>
+ */
+public final class SVSConstants {
+
+    private SVSConstants() {}
+
+    // The engine name users specify (engine: "svs") and the on-disk file extension for SVS index files.
+    // KNNEngine.EXPERIMENTAL adopts this name/extension at runtime via the SandboxEngineProvider.
+    public static final String SVS_ENGINE_NAME = "svs";
+    public static final String SVS_EXTENSION = ".svs";
+
+    // Method names
+    public static final String METHOD_SVS_VAMANA = "svs_vamana";
+
+    // Faiss index-factory description prefixes
+    public static final String FAISS_SVS_VAMANA_DESCRIPTION = "SVSVamana";
+
+    // Encoder names
+    // FP16 and SQ8 are exposed through the unified {@code sq} encoder (imported from
+    // {@link org.opensearch.knn.common.KNNConstants#ENCODER_SQ}) via the {@code type} parameter below.
+    public static final String FAISS_SVS_ENCODER_LVQ = "lvq";
+
+    // sq encoder type parameter (mirrors the HNSW sq encoder's {@code type} convention).
+    public static final String FAISS_SVS_SQ_TYPE = "type";
+    public static final String FAISS_SVS_SQ_TYPE_FP16 = "fp16";
+    public static final String FAISS_SVS_SQ_TYPE_SQ8 = "sq8";
+
+    // Faiss index-factory descriptions emitted per sq type.
+    public static final String FAISS_SVS_SQ_FP16_DESCRIPTION = "FP16";
+    public static final String FAISS_SVS_SQ_SQ8_DESCRIPTION = "SQI8";
+
+    // Vamana method parameters
+    public static final String METHOD_PARAMETER_DEGREE = "degree";
+    public static final String METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE = "construction_window_size";
+    public static final String METHOD_PARAMETER_SEARCH_WINDOW_SIZE = "search_window_size";
+    public static final String METHOD_PARAMETER_SEARCH_BUFFER_CAPACITY = "search_buffer_capacity";
+    public static final String METHOD_PARAMETER_ALPHA = "alpha";
+
+    // LVQ encoder parameters
+    public static final String METHOD_PARAMETER_LVQ_PRIMARY_BITS = "primary_bits";
+    public static final String METHOD_PARAMETER_LVQ_RESIDUAL_BITS = "residual_bits";
+
+    // Default construction window size (mirrors main KNNSettings default in 3.4-era code).
+    public static final int DEFAULT_CONSTRUCTION_WINDOW_SIZE = 128;
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsEngineProvider.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsEngineProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.engine.KNNLibrary;
+import org.opensearch.knn.index.engine.SandboxEngineProvider;
+import org.opensearch.knn.index.query.KNNQueryResult;
+import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
+
+import java.util.Map;
+
+/**
+ * {@link SandboxEngineProvider} for the experimental Intel SVS engine. Discovered by {@code KNNEngine} via
+ * {@code META-INF/services}, it gives the generic {@code KNNEngine.EXPERIMENTAL} slot its identity:
+ * the engine name {@code "svs"}, the {@link SvsLibrary} (methods/extension/scoring), and the native index
+ * lifecycle — all delegated to {@link SvsService} (the isolated {@code libopensearchknn_svs}).
+ *
+ * <p>{@link #engineName()} and {@link #library()} are evaluated when {@code KNNEngine} initializes; they do
+ * not touch {@link SvsService}, so discovery alone never loads the native library (which loads lazily on the
+ * first native call).
+ *
+ * <p>Operations outside the SVS scope (template builds, radial, nested queries) throw
+ * {@link UnsupportedOperationException}; the corresponding capability sets in {@code KNNEngine} already
+ * exclude this engine, so these are defensive backstops.
+ */
+public class SvsEngineProvider implements SandboxEngineProvider {
+
+    @Override
+    public String engineName() {
+        return SVSConstants.SVS_ENGINE_NAME;
+    }
+
+    @Override
+    public KNNLibrary library() {
+        return SvsLibrary.INSTANCE;
+    }
+
+    @Override
+    public long initIndex(long numDocs, int dim, Map<String, Object> parameters) {
+        return SvsService.initIndex(numDocs, dim, parameters);
+    }
+
+    @Override
+    public void insertToIndex(int[] docs, long vectorsAddress, int dimension, Map<String, Object> parameters, long indexAddress) {
+        int threadCount = (int) parameters.getOrDefault(KNNConstants.INDEX_THREAD_QTY, 0);
+        SvsService.insertToIndex(docs, vectorsAddress, dimension, indexAddress, threadCount);
+    }
+
+    @Override
+    public void writeIndex(IndexOutputWithBuffer output, long indexAddress, Map<String, Object> parameters, boolean skipFlat) {
+        SvsService.writeIndex(indexAddress, output);
+    }
+
+    @Override
+    public void createIndexFromTemplate(
+        int[] ids,
+        long vectorsAddress,
+        int dim,
+        IndexOutputWithBuffer output,
+        byte[] templateIndex,
+        Map<String, Object> parameters
+    ) {
+        throw new UnsupportedOperationException("Template-based index builds are not supported by the experimental SVS engine");
+    }
+
+    @Override
+    public long loadIndex(IndexInputWithBuffer readStream, Map<String, Object> parameters) {
+        return SvsService.loadIndexWithStream(readStream);
+    }
+
+    @Override
+    public KNNQueryResult[] queryIndex(
+        long indexPointer,
+        float[] queryVector,
+        int k,
+        Map<String, ?> methodParameters,
+        long[] filteredIds,
+        int filterIdsType,
+        int[] parentIds
+    ) {
+        if (ArrayUtils.isNotEmpty(parentIds)) {
+            // Reject rather than silently ignore parentIds, which would return multiple children per parent.
+            throw new UnsupportedOperationException("Nested fields are not supported by the experimental SVS engine");
+        }
+        if (ArrayUtils.isNotEmpty(filteredIds)) {
+            return SvsService.queryIndexWithFilter(indexPointer, queryVector, k, methodParameters, filteredIds, filterIdsType);
+        }
+        return SvsService.queryIndex(indexPointer, queryVector, k, methodParameters);
+    }
+
+    @Override
+    public KNNQueryResult[] radiusQueryIndex(
+        long indexPointer,
+        float[] queryVector,
+        float radius,
+        Map<String, ?> methodParameters,
+        int indexMaxResultWindow,
+        long[] filteredIds,
+        int filterIdsType,
+        int[] parentIds
+    ) {
+        throw new UnsupportedOperationException("Radial search is not supported by the experimental SVS engine");
+    }
+
+    @Override
+    public void free(long indexPointer, boolean isBinaryIndex) {
+        // isBinaryIndex is ignored: the SVS engine has no binary indices.
+        SvsService.free(indexPointer);
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsLibrary.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsLibrary.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.KNNMethod;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodResolver;
+import org.opensearch.knn.index.engine.NativeLibrary;
+import org.opensearch.knn.index.engine.ResolvedMethodContext;
+import org.opensearch.knn.index.engine.faiss.Faiss;
+import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
+
+import java.util.Map;
+
+/**
+ * The {@link org.opensearch.knn.index.engine.KNNLibrary} for the experimental Intel SVS engine. SVS indices
+ * are faiss-format ({@code IndexSVSVamana} is a {@code faiss::Index}), so this library reuses faiss's scoring
+ * and only differs where it must:
+ * <ul>
+ *   <li>its file {@link #getExtension() extension} is {@code .svs} (so the codec writes/reads SVS files
+ *       distinctly, and the load path routes them to the SVS engine by extension);</li>
+ *   <li>its sole method is {@code svs_vamana} (it does not expose HNSW/IVF);</li>
+ *   <li>it provides no memory-optimized searcher, so queries go through the native SVS graph search in
+ *       {@code libopensearchknn_svs} rather than reading vectors directly.</li>
+ * </ul>
+ * This library lives in the sandbox; main reaches it only through {@code KNNEngine.EXPERIMENTAL} via the
+ * {@code SandboxEngineProvider} SPI.
+ */
+public class SvsLibrary extends NativeLibrary {
+
+    // Compatibility version tag baked into the file name; matches the faiss family SVS shares its format with.
+    private static final String CURRENT_VERSION = "165";
+
+    private final MethodResolver methodResolver = new SvsMethodResolver();
+
+    public static final SvsLibrary INSTANCE = new SvsLibrary();
+
+    private SvsLibrary() {
+        // score translation is delegated to faiss below, so the base map is empty.
+        super(
+            Map.<String, KNNMethod>of(SVSConstants.METHOD_SVS_VAMANA, new FaissSVSVamanaMethod()),
+            Map.of(),
+            CURRENT_VERSION,
+            SVSConstants.SVS_EXTENSION
+        );
+    }
+
+    @Override
+    public float score(float rawScore, SpaceType spaceType) {
+        return Faiss.INSTANCE.score(rawScore, spaceType);
+    }
+
+    @Override
+    public Float distanceToRadialThreshold(Float distance, SpaceType spaceType) {
+        return Faiss.INSTANCE.distanceToRadialThreshold(distance, spaceType);
+    }
+
+    @Override
+    public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+        return Faiss.INSTANCE.scoreToRadialThreshold(score, spaceType);
+    }
+
+    @Override
+    public ResolvedMethodContext resolveMethod(
+        KNNMethodContext knnMethodContext,
+        KNNMethodConfigContext knnMethodConfigContext,
+        boolean shouldRequireTraining,
+        SpaceType spaceType
+    ) {
+        return methodResolver.resolveMethod(knnMethodContext, knnMethodConfigContext, shouldRequireTraining, spaceType);
+    }
+
+    @Override
+    public VectorSearcherFactory getVectorSearcherFactory() {
+        // No memory-optimized (direct-vector) search for SVS: queries must run through the native SVS graph.
+        return null;
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsMethodAsMapBuilder.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsMethodAsMapBuilder.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import lombok.AllArgsConstructor;
+import org.opensearch.knn.common.KNNConstants;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContextImpl;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.Parameter;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+
+/**
+ * Builds the faiss-style "index description" string (e.g. {@code "SVSVamana64,LVQ4x4"}) + parameter map that
+ * the SVS native factory consumes. SVS indices are faiss-format ({@code IndexSVSVamana} is a {@code faiss::Index}),
+ * so this assembles the description exactly as faiss's own {@code MethodAsMapBuilder} does.
+ *
+ * <p>This is an intentional, self-contained copy of {@code org.opensearch.knn.index.engine.faiss.MethodAsMapBuilder}
+ * (which is package-private in core). Duplicating it here keeps the SVS tenant from forcing any visibility or
+ * API change onto the core faiss package — the core stays untouched and the tenant carries its own copy, the
+ * same trade made for the native JNI helpers. It adds one SVS-only helper,
+ * {@link #dropTrailingDescriptionToken(String)}, not present in the core class.
+ */
+@AllArgsConstructor
+class SvsMethodAsMapBuilder {
+    String indexDescription;
+    MethodComponent methodComponent;
+    Map<String, Object> methodAsMap;
+    KNNMethodConfigContext knnMethodConfigContext;
+    QuantizationConfig quantizationConfig;
+
+    /**
+     * Add a parameter that will be used in the index description for the given method component
+     *
+     * @param parameterName name of the parameter
+     * @param prefix to append to the index description before the parameter
+     * @param suffix to append to the index description after the parameter
+     * @return this builder
+     */
+    @SuppressWarnings("unchecked")
+    SvsMethodAsMapBuilder addParameter(String parameterName, String prefix, String suffix) {
+        indexDescription += prefix;
+
+        // When we add a parameter, what we are doing is taking it from the methods parameter and building it
+        // into the index description string faiss uses to create the index.
+        Map<String, Object> methodParameters = (Map<String, Object>) methodAsMap.get(PARAMETERS);
+        Parameter<?> parameter = methodComponent.getParameters().get(parameterName);
+        Object value = methodParameters.containsKey(parameterName) ? methodParameters.get(parameterName) : parameter.getDefaultValue();
+
+        // Recursion is needed if the parameter is a method component context itself.
+        if (parameter instanceof Parameter.MethodComponentContextParameter) {
+            MethodComponentContext subMethodComponentContext = (MethodComponentContext) value;
+            MethodComponent subMethodComponent = ((Parameter.MethodComponentContextParameter) parameter).getMethodComponent(
+                subMethodComponentContext.getName()
+            );
+
+            KNNLibraryIndexingContext knnLibraryIndexingContext = subMethodComponent.getKNNLibraryIndexingContext(
+                subMethodComponentContext,
+                knnMethodConfigContext
+            );
+            Map<String, Object> subMethodAsMap = knnLibraryIndexingContext.getLibraryParameters();
+            if (subMethodAsMap != null
+                && !subMethodAsMap.isEmpty()
+                && subMethodAsMap.containsKey(KNNConstants.INDEX_DESCRIPTION_PARAMETER)) {
+                indexDescription += subMethodAsMap.get(KNNConstants.INDEX_DESCRIPTION_PARAMETER);
+                subMethodAsMap.remove(KNNConstants.INDEX_DESCRIPTION_PARAMETER);
+            }
+
+            if (quantizationConfig == null || quantizationConfig == QuantizationConfig.EMPTY) {
+                quantizationConfig = knnLibraryIndexingContext.getQuantizationConfig();
+            }
+
+            methodParameters.put(parameterName, subMethodAsMap);
+        } else {
+            // Add the value to the method description
+            indexDescription += value;
+        }
+
+        indexDescription += suffix;
+        return this;
+    }
+
+    /**
+     * Drops a trailing {@code ",<token>"} from the index description if present. SVS methods still call
+     * {@link #addParameter} for the default {@code flat} encoder so it is normalized into the method map and
+     * serializes, then use this to strip the {@code ,Flat} suffix that the native factory does not accept.
+     */
+    SvsMethodAsMapBuilder dropTrailingDescriptionToken(String token) {
+        String suffix = "," + token;
+        if (indexDescription.endsWith(suffix)) {
+            indexDescription = indexDescription.substring(0, indexDescription.length() - suffix.length());
+        }
+        return this;
+    }
+
+    /**
+     * Build
+     *
+     * @return Method as a map
+     */
+    KNNLibraryIndexingContext build() {
+        methodAsMap.put(KNNConstants.INDEX_DESCRIPTION_PARAMETER, indexDescription);
+        return KNNLibraryIndexingContextImpl.builder().parameters(methodAsMap).quantizationConfig(quantizationConfig).build();
+    }
+
+    static SvsMethodAsMapBuilder builder(
+        String baseDescription,
+        MethodComponent methodComponent,
+        MethodComponentContext methodComponentContext,
+        KNNMethodConfigContext knnMethodConfigContext
+    ) {
+        Map<String, Object> initialMap = new HashMap<>();
+        initialMap.put(NAME, methodComponent.getName());
+        initialMap.put(
+            PARAMETERS,
+            MethodComponent.getParameterMapWithDefaultsAdded(methodComponentContext, methodComponent, knnMethodConfigContext)
+        );
+        return new SvsMethodAsMapBuilder(baseDescription, methodComponent, initialMap, knnMethodConfigContext, QuantizationConfig.EMPTY);
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsMethodResolver.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsMethodResolver.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.common.ValidationException;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.engine.AbstractMethodResolver;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.ResolvedMethodContext;
+import org.opensearch.knn.index.engine.TrainingConfigValidationInput;
+import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.sandbox.ExperimentalAlgorithm;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_ENCODER_LVQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_FP16;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_PRIMARY_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_RESIDUAL_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_SVS_VAMANA;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+
+/**
+ * {@link org.opensearch.knn.index.engine.MethodResolver} for the experimental SVS engine. The sole method is
+ * {@code svs_vamana}; this resolver fills in its defaults, maps a user-supplied {@code compression_level} to
+ * the SVS encoders ({@code 2x} -> {@code sq}(fp16), {@code 4x} -> {@code lvq}(4,4), {@code 8x} ->
+ * {@code lvq}(4,0)) and rejects configurations SVS cannot serve ({@code on_disk} mode, training contexts,
+ * unsupported compression levels). It lives entirely in the sandbox: the core Faiss resolver knows nothing
+ * about SVS.
+ */
+@ExperimentalAlgorithm(description = "Intel SVS Vamana method resolver", since = "3.7.0")
+public class SvsMethodResolver extends AbstractMethodResolver {
+
+    // x4 maps to lvq(4,4); the core engines top out differently (no x4) and support higher levels SVS does not.
+    private static final Set<CompressionLevel> SUPPORTED_COMPRESSION_LEVELS = Set.of(
+        CompressionLevel.x1,
+        CompressionLevel.x2,
+        CompressionLevel.x4,
+        CompressionLevel.x8
+    );
+
+    @Override
+    public ResolvedMethodContext resolveMethod(
+        KNNMethodContext knnMethodContext,
+        KNNMethodConfigContext knnMethodConfigContext,
+        boolean shouldRequireTraining,
+        final SpaceType spaceType
+    ) {
+        validateConfig(knnMethodConfigContext, shouldRequireTraining);
+
+        KNNMethodContext resolvedKNNMethodContext = initResolvedKNNMethodContext(
+            knnMethodContext,
+            KNNEngine.EXPERIMENTAL,
+            spaceType,
+            METHOD_SVS_VAMANA
+        );
+
+        String methodName = resolvedKNNMethodContext.getMethodComponentContext().getName();
+        if (METHOD_SVS_VAMANA.equals(methodName) == false) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "Invalid method name [%s] for engine [%s]. The only supported method is [%s].",
+                    methodName,
+                    KNNEngine.EXPERIMENTAL.getName(),
+                    METHOD_SVS_VAMANA
+                )
+            );
+            throw validationException;
+        }
+
+        Map<String, Encoder> encoderMap = FaissSVSVamanaMethod.SUPPORTED_ENCODERS;
+
+        // Fill in parameters for the encoder and then the method.
+        resolveEncoder(resolvedKNNMethodContext, knnMethodConfigContext, encoderMap);
+        CompressionLevel resolvedCompressionLevel = resolveCompressionLevelFromMethodContext(
+            resolvedKNNMethodContext,
+            knnMethodConfigContext,
+            encoderMap
+        );
+
+        validateEncoderConfig(resolvedKNNMethodContext, knnMethodConfigContext, encoderMap);
+        validateCompressionConflicts(knnMethodConfigContext.getCompressionLevel(), resolvedCompressionLevel);
+        knnMethodConfigContext.setCompressionLevel(resolvedCompressionLevel);
+        resolveMethodParams(
+            resolvedKNNMethodContext.getMethodComponentContext(),
+            knnMethodConfigContext,
+            FaissSVSVamanaMethod.METHOD_COMPONENT
+        );
+
+        return ResolvedMethodContext.builder()
+            .knnMethodContext(resolvedKNNMethodContext)
+            .compressionLevel(resolvedCompressionLevel)
+            .build();
+    }
+
+    private void validateConfig(KNNMethodConfigContext knnMethodConfigContext, boolean shouldRequireTraining) {
+        ValidationException validationException = validateNotTrainingContext(shouldRequireTraining, KNNEngine.EXPERIMENTAL, null);
+        validationException = validateCompressionSupported(
+            knnMethodConfigContext.getCompressionLevel(),
+            SUPPORTED_COMPRESSION_LEVELS,
+            KNNEngine.EXPERIMENTAL,
+            validationException
+        );
+        if (knnMethodConfigContext.getMode() == Mode.ON_DISK) {
+            validationException = validationException == null ? new ValidationException() : validationException;
+            validationException.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "mode=on_disk is not supported with %s; SVS is an in-memory execution path. "
+                        + "Use mode=in_memory or a different method.",
+                    METHOD_SVS_VAMANA
+                )
+            );
+        }
+        if (validationException != null) {
+            throw validationException;
+        }
+    }
+
+    /**
+     * Resolves the SVS encoder for a user-supplied {@code compression_level} when no explicit encoder was
+     * given. Other levels require an explicit {@code encoder} block.
+     */
+    private void resolveEncoder(
+        KNNMethodContext resolvedKNNMethodContext,
+        KNNMethodConfigContext knnMethodConfigContext,
+        Map<String, Encoder> encoderMap
+    ) {
+        if (shouldEncoderBeResolved(resolvedKNNMethodContext, knnMethodConfigContext) == false) {
+            return;
+        }
+
+        CompressionLevel resolvedCompressionLevel = CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())
+            ? knnMethodConfigContext.getCompressionLevel()
+            : CompressionLevel.x1;
+        if (resolvedCompressionLevel == CompressionLevel.x1) {
+            return;
+        }
+
+        MethodComponentContext encoderComponentContext;
+        Encoder encoder;
+        if (CompressionLevel.x2 == resolvedCompressionLevel) {
+            encoderComponentContext = new MethodComponentContext(ENCODER_SQ, new HashMap<>());
+            encoderComponentContext.getParameters().put(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_FP16);
+            encoder = encoderMap.get(ENCODER_SQ);
+        } else if (CompressionLevel.x4 == resolvedCompressionLevel) {
+            encoderComponentContext = new MethodComponentContext(FAISS_SVS_ENCODER_LVQ, new HashMap<>());
+            encoderComponentContext.getParameters().put(METHOD_PARAMETER_LVQ_PRIMARY_BITS, 4);
+            encoderComponentContext.getParameters().put(METHOD_PARAMETER_LVQ_RESIDUAL_BITS, 4);
+            encoder = encoderMap.get(FAISS_SVS_ENCODER_LVQ);
+        } else if (CompressionLevel.x8 == resolvedCompressionLevel) {
+            encoderComponentContext = new MethodComponentContext(FAISS_SVS_ENCODER_LVQ, new HashMap<>());
+            encoderComponentContext.getParameters().put(METHOD_PARAMETER_LVQ_PRIMARY_BITS, 4);
+            encoderComponentContext.getParameters().put(METHOD_PARAMETER_LVQ_RESIDUAL_BITS, 0);
+            encoder = encoderMap.get(FAISS_SVS_ENCODER_LVQ);
+        } else {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "Compression level [%s] is not supported for %s via compression_level. "
+                        + "Supported levels are 2x, 4x, 8x; for other levels specify an explicit encoder.",
+                    resolvedCompressionLevel.getName(),
+                    METHOD_SVS_VAMANA
+                )
+            );
+            throw validationException;
+        }
+
+        Map<String, Object> resolvedParams = MethodComponent.getParameterMapWithDefaultsAdded(
+            encoderComponentContext,
+            encoder.getMethodComponent(),
+            knnMethodConfigContext
+        );
+        encoderComponentContext.getParameters().putAll(resolvedParams);
+        resolvedKNNMethodContext.getMethodComponentContext().getParameters().put(METHOD_ENCODER_PARAMETER, encoderComponentContext);
+    }
+
+    private void validateEncoderConfig(
+        KNNMethodContext resolvedKnnMethodContext,
+        KNNMethodConfigContext knnMethodConfigContext,
+        Map<String, Encoder> encoderMap
+    ) {
+        if (isEncoderSpecified(resolvedKnnMethodContext) == false) {
+            return;
+        }
+        Encoder encoder = encoderMap.get(getEncoderName(resolvedKnnMethodContext));
+        if (encoder == null) {
+            return;
+        }
+
+        TrainingConfigValidationInput.TrainingConfigValidationInputBuilder inputBuilder = TrainingConfigValidationInput.builder();
+
+        TrainingConfigValidationOutput validationOutput = encoder.validateEncoderConfig(
+            inputBuilder.knnMethodContext(resolvedKnnMethodContext).knnMethodConfigContext(knnMethodConfigContext).build()
+        );
+
+        if (validationOutput.getValid() != null && !validationOutput.getValid()) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError(validationOutput.getErrorMessage());
+            throw validationException;
+        }
+    }
+}

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsMethodResolver.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsMethodResolver.java
@@ -43,7 +43,7 @@ import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
  * unsupported compression levels). It lives entirely in the sandbox: the core Faiss resolver knows nothing
  * about SVS.
  */
-@ExperimentalAlgorithm(description = "Intel SVS Vamana method resolver", since = "3.7.0")
+@ExperimentalAlgorithm(description = "Intel SVS Vamana method resolver", since = "3.8.0")
 public class SvsMethodResolver extends AbstractMethodResolver {
 
     // x4 maps to lvq(4,4); the core engines top out differently (no x4) and support higher levels SVS does not.

--- a/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsService.java
+++ b/sandbox/src/main/java/org/opensearch/knn/sandbox/svs/SvsService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.MergeAbortChecker;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.query.KNNQueryResult;
+import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
+import org.opensearch.knn.jni.KNNLibraryLoader;
+
+import java.util.Map;
+
+/**
+ * JNI binding for the isolated Intel SVS native library ({@code libopensearchknn_svs}). This is the
+ * sandbox tenant's own service: it loads its own native library (which embeds its own SVS-enabled Faiss)
+ * and owns the full native lifecycle of {@code svs_vamana} indices, completely separate from the main
+ * {@code FaissService}/{@code libopensearchknn_faiss}. It is reached only through {@link SvsEngineProvider}
+ * (the {@code SandboxEngineProvider} SPI behind {@code KNNEngine.EXPERIMENTAL}) — main code never references
+ * this class.
+ *
+ * <p>The native surface is deliberately minimal: build iteratively, write, load, top-k query with an
+ * optional pre-filter, and free.
+ */
+@Log4j2
+public class SvsService {
+
+    /** Base name of the SVS JNI library; variant suffixes (_avx512_spr, etc.) are appended by the loader. */
+    private static final String SVS_JNI_LIBRARY_NAME = "opensearchknn_svs";
+
+    static {
+        // System.loadLibrary is centralized in KNNLibraryLoader (enforced by the validateLibraryUsage task).
+        KNNLibraryLoader.loadLibraryByVariant(SVS_JNI_LIBRARY_NAME);
+        initLibrary();
+        // Mark the experimental engine initialized, mirroring how FaissService marks FAISS initialized.
+        KNNEngine.EXPERIMENTAL.setInitialized(true);
+        try {
+            MergeAbortChecker.isMergeAborted();
+            setMergeInterruptCallback();
+        } catch (Exception e) {
+            log.warn("Unable to add the mergeAbortChecker during SVS initialization", e);
+        }
+    }
+
+    /**
+     * Whether this SVS runtime supports LVQ/LeanVec compression (requires Intel AVX-512 SIMD support).
+     */
+    public static native boolean isLvqLeanvecEnabled();
+
+    public static native long initIndex(long numDocs, int dim, Map<String, Object> parameters);
+
+    public static native void insertToIndex(int[] ids, long vectorsAddress, int dim, long indexAddress, int threadCount);
+
+    public static native void writeIndex(long indexAddress, IndexOutputWithBuffer output);
+
+    public static native long loadIndexWithStream(IndexInputWithBuffer readStream);
+
+    public static native KNNQueryResult[] queryIndex(long indexPointer, float[] queryVector, int k, Map<String, ?> methodParameters);
+
+    public static native KNNQueryResult[] queryIndexWithFilter(
+        long indexPointer,
+        float[] queryVector,
+        int k,
+        Map<String, ?> methodParameters,
+        long[] filterIds,
+        int filterIdsType
+    );
+
+    public static native void free(long indexPointer);
+
+    public static native void initLibrary();
+
+    public static native void setMergeInterruptCallback();
+}

--- a/sandbox/src/main/resources/META-INF/services/org.opensearch.knn.index.engine.SandboxEngineProvider
+++ b/sandbox/src/main/resources/META-INF/services/org.opensearch.knn.index.engine.SandboxEngineProvider
@@ -1,0 +1,1 @@
+org.opensearch.knn.sandbox.svs.SvsEngineProvider

--- a/sandbox/src/test/java/org/opensearch/knn/sandbox/ExperimentalAlgorithmTests.java
+++ b/sandbox/src/test/java/org/opensearch/knn/sandbox/ExperimentalAlgorithmTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Tests for {@link ExperimentalAlgorithm} marker annotation.
+ */
+public class ExperimentalAlgorithmTests extends OpenSearchTestCase {
+
+    @ExperimentalAlgorithm(description = "Test algorithm for validation", since = "3.7.0")
+    private static class SampleExperimentalAlgorithm {
+        // Intentionally empty — used only to verify annotation behavior
+    }
+
+    @ExperimentalAlgorithm
+    private static class MinimalExperimentalAlgorithm {
+        // Intentionally empty — verifies default annotation values
+    }
+
+    public void testAnnotationIsPresent() {
+        assertTrue(
+            "SampleExperimentalAlgorithm should be annotated with @ExperimentalAlgorithm",
+            SampleExperimentalAlgorithm.class.isAnnotationPresent(ExperimentalAlgorithm.class)
+        );
+    }
+
+    public void testAnnotationDescription() {
+        ExperimentalAlgorithm annotation = SampleExperimentalAlgorithm.class.getAnnotation(ExperimentalAlgorithm.class);
+        assertNotNull("Annotation should not be null", annotation);
+        assertEquals("Test algorithm for validation", annotation.description());
+    }
+
+    public void testAnnotationSince() {
+        ExperimentalAlgorithm annotation = SampleExperimentalAlgorithm.class.getAnnotation(ExperimentalAlgorithm.class);
+        assertNotNull("Annotation should not be null", annotation);
+        assertEquals("3.7.0", annotation.since());
+    }
+
+    public void testAnnotationDefaultValues() {
+        ExperimentalAlgorithm annotation = MinimalExperimentalAlgorithm.class.getAnnotation(ExperimentalAlgorithm.class);
+        assertNotNull("Annotation should not be null", annotation);
+        assertEquals("Default description should be empty", "", annotation.description());
+        assertEquals("Default since should be empty", "", annotation.since());
+    }
+
+    public void testAnnotationRetentionPolicy() {
+        java.lang.annotation.Retention retention = ExperimentalAlgorithm.class.getAnnotation(java.lang.annotation.Retention.class);
+        assertNotNull("@Retention should be present", retention);
+        assertEquals("Retention should be RUNTIME", RetentionPolicy.RUNTIME, retention.value());
+    }
+
+    public void testAnnotationTargetType() {
+        java.lang.annotation.Target target = ExperimentalAlgorithm.class.getAnnotation(java.lang.annotation.Target.class);
+        assertNotNull("@Target should be present", target);
+        assertEquals("Should have exactly one target", 1, target.value().length);
+        assertEquals("Target should be TYPE", ElementType.TYPE, target.value()[0]);
+    }
+}

--- a/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSLVQEncoderTests.java
+++ b/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSLVQEncoderTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_ENCODER_LVQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_PRIMARY_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_RESIDUAL_BITS;
+
+public class FaissSVSLVQEncoderTests extends OpenSearchTestCase {
+
+    public void testValidateBitCombination_acceptsSupported() {
+        FaissSVSLVQEncoder.validateBitCombination(4, 0);
+        FaissSVSLVQEncoder.validateBitCombination(4, 4);
+        FaissSVSLVQEncoder.validateBitCombination(4, 8);
+    }
+
+    public void testValidateBitCombination_rejectsUnsupported() {
+        IllegalArgumentException e88 = expectThrows(IllegalArgumentException.class, () -> FaissSVSLVQEncoder.validateBitCombination(8, 8));
+        assertTrue(e88.getMessage().contains("8x8"));
+        assertTrue(e88.getMessage().contains(FAISS_SVS_ENCODER_LVQ));
+
+        expectThrows(IllegalArgumentException.class, () -> FaissSVSLVQEncoder.validateBitCombination(2, 2));
+        expectThrows(IllegalArgumentException.class, () -> FaissSVSLVQEncoder.validateBitCombination(8, 0));
+        expectThrows(IllegalArgumentException.class, () -> FaissSVSLVQEncoder.validateBitCombination(4, 2));
+    }
+
+    public void testCompressionLevel_4x0IsX8() {
+        FaissSVSLVQEncoder encoder = new FaissSVSLVQEncoder();
+        MethodComponentContext mcc = lvq(4, 0);
+        assertEquals(CompressionLevel.x8, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testCompressionLevel_4x4IsX4() {
+        FaissSVSLVQEncoder encoder = new FaissSVSLVQEncoder();
+        MethodComponentContext mcc = lvq(4, 4);
+        assertEquals(CompressionLevel.x4, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testCompressionLevel_4x8IsX4() {
+        FaissSVSLVQEncoder encoder = new FaissSVSLVQEncoder();
+        MethodComponentContext mcc = lvq(4, 8);
+        assertEquals(CompressionLevel.x4, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testCompressionLevel_defaultIsX4() {
+        FaissSVSLVQEncoder encoder = new FaissSVSLVQEncoder();
+        assertEquals(
+            CompressionLevel.x4,
+            encoder.calculateCompressionLevel(new MethodComponentContext(FAISS_SVS_ENCODER_LVQ, Map.of()), null)
+        );
+        assertEquals(CompressionLevel.x4, encoder.calculateCompressionLevel(null, null));
+    }
+
+    private static MethodComponentContext lvq(int primaryBits, int residualBits) {
+        return new MethodComponentContext(
+            FAISS_SVS_ENCODER_LVQ,
+            Map.of(METHOD_PARAMETER_LVQ_PRIMARY_BITS, primaryBits, METHOD_PARAMETER_LVQ_RESIDUAL_BITS, residualBits)
+        );
+    }
+}

--- a/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSSQEncoderTests.java
+++ b/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSSQEncoderTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.Version;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.INDEX_DESCRIPTION_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_FP16_DESCRIPTION;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_SQ8_DESCRIPTION;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_FP16;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_SQ8;
+
+public class FaissSVSSQEncoderTests extends OpenSearchTestCase {
+
+    private KNNMethodConfigContext configContext() {
+        return KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).vectorDataType(VectorDataType.FLOAT).dimension(128).build();
+    }
+
+    public void testCompressionLevel_fp16IsX2() {
+        FaissSVSSQEncoder encoder = new FaissSVSSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_FP16));
+        assertEquals(CompressionLevel.x2, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testCompressionLevel_sq8IsX4() {
+        FaissSVSSQEncoder encoder = new FaissSVSSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_SQ8));
+        assertEquals(CompressionLevel.x4, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testCompressionLevel_defaultIsFp16() {
+        FaissSVSSQEncoder encoder = new FaissSVSSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of());
+        assertEquals(CompressionLevel.x2, encoder.calculateCompressionLevel(mcc, null));
+        assertEquals(CompressionLevel.x2, encoder.calculateCompressionLevel(null, null));
+    }
+
+    public void testInvalidType_rejected() {
+        FaissSVSSQEncoder encoder = new FaissSVSSQEncoder();
+        MethodComponent component = encoder.getMethodComponent();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SVS_SQ_TYPE, "bogus"));
+        assertNotNull(component.validate(mcc, configContext()));
+    }
+
+    public void testBitsParameter_rejectedWithActionableMessage() {
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 8));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FaissSVSSQEncoder.validateNoBitsParameter(mcc));
+        assertTrue(e.getMessage().contains("type"));
+        assertTrue(e.getMessage().contains(SQ_BITS));
+    }
+
+    public void testNoBitsParameter_accepted() {
+        FaissSVSSQEncoder.validateNoBitsParameter(
+            new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_FP16))
+        );
+        FaissSVSSQEncoder.validateNoBitsParameter(new MethodComponentContext(ENCODER_SQ, Map.of()));
+        FaissSVSSQEncoder.validateNoBitsParameter(null);
+    }
+
+    public void testIndexDescription_fp16() {
+        FaissSVSSQEncoder encoder = new FaissSVSSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_FP16));
+        KNNLibraryIndexingContext ctx = encoder.getMethodComponent().getKNNLibraryIndexingContext(mcc, configContext());
+        assertEquals(FAISS_SVS_SQ_FP16_DESCRIPTION, ctx.getLibraryParameters().get(INDEX_DESCRIPTION_PARAMETER));
+    }
+
+    public void testIndexDescription_sq8() {
+        FaissSVSSQEncoder encoder = new FaissSVSSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SVS_SQ_TYPE, FAISS_SVS_SQ_TYPE_SQ8));
+        KNNLibraryIndexingContext ctx = encoder.getMethodComponent().getKNNLibraryIndexingContext(mcc, configContext());
+        assertEquals(FAISS_SVS_SQ_SQ8_DESCRIPTION, ctx.getLibraryParameters().get(INDEX_DESCRIPTION_PARAMETER));
+    }
+}

--- a/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaIT.java
+++ b/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaIT.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.opensearch.knn.index;
+package org.opensearch.knn.sandbox.svs;
 
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -13,6 +13,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 
 import java.util.List;

--- a/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaMethodTests.java
+++ b/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/FaissSVSVamanaMethodTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.Version;
+import org.opensearch.common.ValidationException;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.MethodComponent;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_ENCODER_LVQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_ALPHA;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_DEGREE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_PRIMARY_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_RESIDUAL_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_SVS_VAMANA;
+
+public class FaissSVSVamanaMethodTests extends OpenSearchTestCase {
+
+    private KNNMethodConfigContext configContext() {
+        return KNNMethodConfigContext.builder().versionCreated(Version.CURRENT).vectorDataType(VectorDataType.FLOAT).dimension(128).build();
+    }
+
+    /**
+     * Sanity-checks the names users type in mappings; they are part of the method's public contract.
+     */
+    public void testPublicNames_methodAndEncoderParameters() {
+        assertEquals("svs_vamana", METHOD_SVS_VAMANA);
+        assertEquals("lvq", FAISS_SVS_ENCODER_LVQ);
+        assertEquals("primary_bits", METHOD_PARAMETER_LVQ_PRIMARY_BITS);
+        assertEquals("residual_bits", METHOD_PARAMETER_LVQ_RESIDUAL_BITS);
+    }
+
+    public void testSupportedSpaces_includesL2IPCosine() {
+        assertTrue(FaissSVSVamanaMethod.SUPPORTED_SPACES.contains(SpaceType.L2));
+        assertTrue(FaissSVSVamanaMethod.SUPPORTED_SPACES.contains(SpaceType.INNER_PRODUCT));
+        assertTrue(FaissSVSVamanaMethod.SUPPORTED_SPACES.contains(SpaceType.COSINESIMIL));
+    }
+
+    public void testSupportedEncoders_sqFlatLvq_notSvsPrefixed() {
+        assertTrue(FaissSVSVamanaMethod.SUPPORTED_ENCODERS.containsKey(ENCODER_SQ));
+        assertTrue(FaissSVSVamanaMethod.SUPPORTED_ENCODERS.containsKey(ENCODER_FLAT));
+        assertTrue(FaissSVSVamanaMethod.SUPPORTED_ENCODERS.containsKey(FAISS_SVS_ENCODER_LVQ));
+        // Old svs_-prefixed encoder names must no longer be registered.
+        assertFalse(FaissSVSVamanaMethod.SUPPORTED_ENCODERS.containsKey("svs_fp16"));
+        assertFalse(FaissSVSVamanaMethod.SUPPORTED_ENCODERS.containsKey("svs_sq8"));
+        assertEquals(3, FaissSVSVamanaMethod.SUPPORTED_ENCODERS.size());
+    }
+
+    public void testParametersPresent_degreeConstructionAlpha() {
+        MethodComponent component = FaissSVSVamanaMethod.METHOD_COMPONENT;
+        assertTrue(component.getParameters().containsKey(METHOD_PARAMETER_DEGREE));
+        assertTrue(component.getParameters().containsKey(METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE));
+        assertTrue(component.getParameters().containsKey(METHOD_PARAMETER_ALPHA));
+    }
+
+    public void testDegreeValidation_bounds() {
+        MethodComponent component = FaissSVSVamanaMethod.METHOD_COMPONENT;
+        assertNull(component.validate(new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_DEGREE, 64)), configContext()));
+        ValidationException tooLow = component.validate(
+            new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_DEGREE, 0)),
+            configContext()
+        );
+        assertNotNull(tooLow);
+        ValidationException tooHigh = component.validate(
+            new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_DEGREE, 257)),
+            configContext()
+        );
+        assertNotNull(tooHigh);
+    }
+
+    public void testConstructionWindowValidation_mustBePositive() {
+        MethodComponent component = FaissSVSVamanaMethod.METHOD_COMPONENT;
+        assertNull(
+            component.validate(
+                new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE, 200)),
+                configContext()
+            )
+        );
+        assertNotNull(
+            component.validate(
+                new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_CONSTRUCTION_WINDOW_SIZE, 0)),
+                configContext()
+            )
+        );
+    }
+
+    public void testAlphaValidation_mustBePositive() {
+        MethodComponent component = FaissSVSVamanaMethod.METHOD_COMPONENT;
+        assertNull(component.validate(new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_ALPHA, 1.2)), configContext()));
+        assertNotNull(
+            component.validate(new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_ALPHA, 0.0)), configContext())
+        );
+        assertNotNull(
+            component.validate(new MethodComponentContext(METHOD_SVS_VAMANA, Map.of(METHOD_PARAMETER_ALPHA, -1.0)), configContext())
+        );
+    }
+}

--- a/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/SvsMethodResolverTests.java
+++ b/sandbox/src/test/java/org/opensearch/knn/sandbox/svs/SvsMethodResolverTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.sandbox.svs;
+
+import org.opensearch.Version;
+import org.opensearch.common.ValidationException;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.ResolvedMethodContext;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_ENCODER_LVQ;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.FAISS_SVS_SQ_TYPE_FP16;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_PRIMARY_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_PARAMETER_LVQ_RESIDUAL_BITS;
+import static org.opensearch.knn.sandbox.svs.SVSConstants.METHOD_SVS_VAMANA;
+
+public class SvsMethodResolverTests extends OpenSearchTestCase {
+
+    private static final SvsMethodResolver RESOLVER = new SvsMethodResolver();
+
+    private KNNMethodConfigContext.KNNMethodConfigContextBuilder configBuilder() {
+        return KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).dimension(128).versionCreated(Version.CURRENT);
+    }
+
+    private KNNMethodContext svsVamanaContext() {
+        return new KNNMethodContext(KNNEngine.EXPERIMENTAL, SpaceType.L2, new MethodComponentContext(METHOD_SVS_VAMANA, Map.of()));
+    }
+
+    public void testResolveMethod_whenNoMethodContext_thenDefaultsToSvsVamana() {
+        ResolvedMethodContext resolved = RESOLVER.resolveMethod(null, configBuilder().build(), false, SpaceType.L2);
+        assertEquals(METHOD_SVS_VAMANA, resolved.getKnnMethodContext().getMethodComponentContext().getName());
+        assertEquals(CompressionLevel.x1, resolved.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenOnDisk_thenThrow() {
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> RESOLVER.resolveMethod(svsVamanaContext(), configBuilder().mode(Mode.ON_DISK).build(), false, SpaceType.L2)
+        );
+        assertTrue(e.getMessage().contains("mode=on_disk is not supported with svs_vamana"));
+    }
+
+    public void testResolveMethod_whenTrainingContext_thenThrow() {
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> RESOLVER.resolveMethod(svsVamanaContext(), configBuilder().build(), true, SpaceType.L2)
+        );
+        assertTrue(e.getMessage().contains("training"));
+    }
+
+    public void testResolveMethod_whenWrongMethodName_thenThrow() {
+        KNNMethodContext hnswOnSvs = new KNNMethodContext(
+            KNNEngine.EXPERIMENTAL,
+            SpaceType.L2,
+            new MethodComponentContext("hnsw", Map.of())
+        );
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> RESOLVER.resolveMethod(hnswOnSvs, configBuilder().build(), false, SpaceType.L2)
+        );
+        assertTrue(e.getMessage().contains("Invalid method name"));
+    }
+
+    public void testResolveMethod_whenCompressionX2_thenSqFp16() {
+        ResolvedMethodContext resolved = RESOLVER.resolveMethod(
+            null,
+            configBuilder().compressionLevel(CompressionLevel.x2).build(),
+            false,
+            SpaceType.L2
+        );
+        MethodComponentContext encoder = (MethodComponentContext) resolved.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(ENCODER_SQ, encoder.getName());
+        assertEquals(FAISS_SVS_SQ_TYPE_FP16, encoder.getParameters().get(FAISS_SVS_SQ_TYPE));
+        assertEquals(CompressionLevel.x2, resolved.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenCompressionX4_thenLvq4x4() {
+        ResolvedMethodContext resolved = RESOLVER.resolveMethod(
+            null,
+            configBuilder().compressionLevel(CompressionLevel.x4).build(),
+            false,
+            SpaceType.L2
+        );
+        MethodComponentContext encoder = (MethodComponentContext) resolved.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(FAISS_SVS_ENCODER_LVQ, encoder.getName());
+        assertEquals(4, encoder.getParameters().get(METHOD_PARAMETER_LVQ_PRIMARY_BITS));
+        assertEquals(4, encoder.getParameters().get(METHOD_PARAMETER_LVQ_RESIDUAL_BITS));
+        assertEquals(CompressionLevel.x4, resolved.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenCompressionX8_thenLvq4x0() {
+        ResolvedMethodContext resolved = RESOLVER.resolveMethod(
+            null,
+            configBuilder().compressionLevel(CompressionLevel.x8).build(),
+            false,
+            SpaceType.L2
+        );
+        MethodComponentContext encoder = (MethodComponentContext) resolved.getKnnMethodContext()
+            .getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        assertEquals(FAISS_SVS_ENCODER_LVQ, encoder.getName());
+        assertEquals(4, encoder.getParameters().get(METHOD_PARAMETER_LVQ_PRIMARY_BITS));
+        assertEquals(0, encoder.getParameters().get(METHOD_PARAMETER_LVQ_RESIDUAL_BITS));
+        assertEquals(CompressionLevel.x8, resolved.getCompressionLevel());
+    }
+
+    public void testResolveMethod_whenUnsupportedCompression_thenThrow() {
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> RESOLVER.resolveMethod(
+                svsVamanaContext(),
+                configBuilder().compressionLevel(CompressionLevel.x16).build(),
+                false,
+                SpaceType.L2
+            )
+        );
+        assertTrue(e.getMessage().contains("compression"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,3 +18,10 @@ include ":qa:rolling-upgrade"
 include ":qa:restart-upgrade"
 include ":remote-index-build-client"
 
+// The experimental :sandbox module (e.g. the Intel SVS tenant) is included in the build ONLY when opted
+// in via -Pknn.sandbox.enabled=true. By default it is excluded from the build graph entirely: not
+// compiled, not tested, not bundled — so a default build produces a plugin identical to upstream.
+if (startParameter.projectProperties['knn.sandbox.enabled'] == 'true') {
+    include ":sandbox"
+}
+

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -33,6 +33,9 @@ public class KNNConstants {
     public static final String PROPERTIES = "properties";
     public static final String METHOD_PARAMETER = "method_parameters";
     public static final String METHOD_PARAMETER_EF_SEARCH = "ef_search";
+    // Query-time search-window parameter for the experimental sandbox engine's graph method (analogous to
+    // ef_search for HNSW)
+    public static final String METHOD_PARAMETER_SEARCH_WINDOW_SIZE = "search_window_size";
     public static final String METHOD_PARAMETER_EF_CONSTRUCTION = "ef_construction";
     public static final String METHOD_PARAMETER_M = "m";
     public static final String METHOD_IVF = "ivf";

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
@@ -59,7 +59,8 @@ public final class NativeIndexBuildStrategyFactory {
     ) throws IOException {
         final KNNEngine knnEngine = extractKNNEngine(fieldInfo);
         final boolean isTemplate = fieldInfo.attributes().containsKey(MODEL_ID);
-        final boolean iterative = !isTemplate && KNNEngine.FAISS == knnEngine;
+        // The experimental engine (SVS) builds iteratively via its own native lib, mirroring faiss.
+        final boolean iterative = !isTemplate && (KNNEngine.FAISS == knnEngine || KNNEngine.EXPERIMENTAL == knnEngine);
         final boolean isFaissSQOneBitField = FieldInfoExtractor.isSQField(fieldInfo)
             && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue();
 

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -32,16 +32,29 @@ public enum KNNEngine implements KNNLibrary {
     NMSLIB(NMSLIB_NAME, Nmslib.INSTANCE, Version.V_3_0_0),
     FAISS(FAISS_NAME, Faiss.INSTANCE),
     LUCENE(LUCENE_NAME, Lucene.INSTANCE),
+    // A generic slot for an experimental engine contributed by an opt-in :sandbox tenant (e.g. SVS). Its
+    // name, library (methods/extension/scoring) and native service all come from a SandboxEngineProvider at
+    // runtime. Inert when no tenant is bundled (default build), so main names no specific tenant.
+    EXPERIMENTAL(SandboxEngine.engineName(), SandboxEngine.library()),
     UNDEFINED("undefined");
 
     public static final KNNEngine DEFAULT = FAISS;
     private final Version restrictedFromVersion; // Nullable field
 
-    private static final Set<KNNEngine> CUSTOM_SEGMENT_FILE_ENGINES = ImmutableSet.of(KNNEngine.NMSLIB, KNNEngine.FAISS);
-    private static final Set<KNNEngine> ENGINES_SUPPORTING_FILTERS = ImmutableSet.of(KNNEngine.LUCENE, KNNEngine.FAISS);
+    private static final Set<KNNEngine> CUSTOM_SEGMENT_FILE_ENGINES = withExperimental(KNNEngine.NMSLIB, KNNEngine.FAISS);
+    private static final Set<KNNEngine> ENGINES_SUPPORTING_FILTERS = withExperimental(KNNEngine.LUCENE, KNNEngine.FAISS);
     public static final Set<KNNEngine> ENGINES_SUPPORTING_RADIAL_SEARCH = ImmutableSet.of(KNNEngine.LUCENE, KNNEngine.FAISS);
     public static final Set<KNNEngine> DEPRECATED_ENGINES = ImmutableSet.of(KNNEngine.NMSLIB);
     public static final Set<KNNEngine> ENGINES_SUPPORTING_NESTED_FIELDS = ImmutableSet.of(KNNEngine.LUCENE, KNNEngine.FAISS);
+
+    // Include EXPERIMENTAL in a capability set only when a sandbox engine is actually bundled.
+    private static Set<KNNEngine> withExperimental(KNNEngine... base) {
+        ImmutableSet.Builder<KNNEngine> builder = ImmutableSet.<KNNEngine>builder().add(base);
+        if (SandboxEngine.isPresent()) {
+            builder.add(EXPERIMENTAL);
+        }
+        return builder.build();
+    }
 
     private static Map<KNNEngine, Integer> MAX_DIMENSIONS_BY_ENGINE = Map.of(
         KNNEngine.NMSLIB,
@@ -108,6 +121,10 @@ public enum KNNEngine implements KNNLibrary {
             return UNDEFINED;
         }
 
+        if (SandboxEngine.isPresent() && EXPERIMENTAL.getName().equalsIgnoreCase(name)) {
+            return EXPERIMENTAL;
+        }
+
         throw new IllegalArgumentException(String.format("Invalid engine type: %s", name));
     }
 
@@ -135,6 +152,11 @@ public enum KNNEngine implements KNNLibrary {
 
         if (path.endsWith(KNNEngine.FAISS.getExtension()) || path.endsWith(KNNEngine.FAISS.getCompoundExtension())) {
             return KNNEngine.FAISS;
+        }
+
+        if (SandboxEngine.isPresent()
+            && (path.endsWith(KNNEngine.EXPERIMENTAL.getExtension()) || path.endsWith(KNNEngine.EXPERIMENTAL.getCompoundExtension()))) {
+            return KNNEngine.EXPERIMENTAL;
         }
 
         throw new IllegalArgumentException("No engine matches the path's suffix");

--- a/src/main/java/org/opensearch/knn/index/engine/SandboxEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/SandboxEngine.java
@@ -5,12 +5,14 @@
 
 package org.opensearch.knn.index.engine;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.SpaceType;
 
 import java.util.ServiceLoader;
+
+import static lombok.AccessLevel.PRIVATE;
 
 /**
  * Discovers the optional {@link SandboxEngineProvider} (contributed by an opt-in {@code :sandbox} module)
@@ -19,26 +21,28 @@ import java.util.ServiceLoader;
  * is inert ({@link #library()} returns an {@link InertSandboxLibrary} that never resolves anything), and the
  * plugin behaves exactly as upstream.
  */
+@Log4j2
+@NoArgsConstructor(access = PRIVATE)
 public final class SandboxEngine {
-
-    private static final Logger logger = LogManager.getLogger(SandboxEngine.class);
 
     private static final SandboxEngineProvider PROVIDER = load();
     private static final KNNLibrary INERT_LIBRARY = new InertSandboxLibrary();
 
-    private SandboxEngine() {}
-
     private static SandboxEngineProvider load() {
+        // Trust boundary: this ServiceLoader only finds a provider when the :sandbox jar is on the classpath,
+        // which happens solely under the opt-in -Pknn.sandbox.enabled build. A default build bundles no
+        // provider, so nothing is loaded and the plugin is byte-for-byte upstream; the build flag, not runtime
+        // discovery, is what admits an experimental provider.
         SandboxEngineProvider found = null;
         for (SandboxEngineProvider provider : ServiceLoader.load(SandboxEngineProvider.class, SandboxEngine.class.getClassLoader())) {
             try {
                 if (found == null) {
                     found = provider;
                 } else {
-                    logger.warn("Multiple SandboxEngineProviders found; ignoring [{}]", provider.getClass().getName());
+                    log.warn("Multiple SandboxEngineProviders found; ignoring [{}]", provider.getClass().getName());
                 }
             } catch (Exception | LinkageError e) {
-                logger.warn("Skipping misconfigured SandboxEngineProvider", e);
+                log.warn("Skipping misconfigured SandboxEngineProvider", e);
             }
         }
         return found;

--- a/src/main/java/org/opensearch/knn/index/engine/SandboxEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/SandboxEngine.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.ValidationException;
+import org.opensearch.knn.index.SpaceType;
+
+import java.util.ServiceLoader;
+
+/**
+ * Discovers the optional {@link SandboxEngineProvider} (contributed by an opt-in {@code :sandbox} module)
+ * once at class load, and exposes what {@link KNNEngine#EXPERIMENTAL} and {@code JNIService} need from it.
+ * When no provider is bundled (the default build), {@link #isPresent()} is {@code false}, {@code EXPERIMENTAL}
+ * is inert ({@link #library()} returns an {@link InertSandboxLibrary} that never resolves anything), and the
+ * plugin behaves exactly as upstream.
+ */
+public final class SandboxEngine {
+
+    private static final Logger logger = LogManager.getLogger(SandboxEngine.class);
+
+    private static final SandboxEngineProvider PROVIDER = load();
+    private static final KNNLibrary INERT_LIBRARY = new InertSandboxLibrary();
+
+    private SandboxEngine() {}
+
+    private static SandboxEngineProvider load() {
+        SandboxEngineProvider found = null;
+        for (SandboxEngineProvider provider : ServiceLoader.load(SandboxEngineProvider.class, SandboxEngine.class.getClassLoader())) {
+            try {
+                if (found == null) {
+                    found = provider;
+                } else {
+                    logger.warn("Multiple SandboxEngineProviders found; ignoring [{}]", provider.getClass().getName());
+                }
+            } catch (Exception | LinkageError e) {
+                logger.warn("Skipping misconfigured SandboxEngineProvider", e);
+            }
+        }
+        return found;
+    }
+
+    public static boolean isPresent() {
+        return PROVIDER != null;
+    }
+
+    public static SandboxEngineProvider provider() {
+        return PROVIDER;
+    }
+
+    /** Engine name to expose for EXPERIMENTAL (the tenant's name, e.g. "svs"; a placeholder when absent). */
+    public static String engineName() {
+        return PROVIDER != null ? PROVIDER.engineName() : "experimental";
+    }
+
+    /** Library backing EXPERIMENTAL; an inert placeholder when no tenant is bundled. */
+    public static KNNLibrary library() {
+        return PROVIDER != null ? PROVIDER.library() : INERT_LIBRARY;
+    }
+
+    /**
+     * Placeholder {@link KNNLibrary} behind {@code KNNEngine.EXPERIMENTAL} when no sandbox tenant is
+     * bundled (the default build). No field can carry the engine in that case ({@code getEngine} resolves
+     * it only when a provider {@link #isPresent()}), so none of these methods is reachable through a real
+     * index — but code that iterates all engines (tests, diagnostics) may still touch the enum value.
+     * Iteration-safe accessors return benign values; anything implying actual use throws
+     * {@link UnsupportedOperationException} instead of NPE-ing on a null library.
+     */
+    private static final class InertSandboxLibrary implements KNNLibrary {
+
+        private static final String NOT_BUNDLED = "No experimental sandbox engine is bundled in this build";
+
+        @Override
+        public String getVersion() {
+            return "unavailable";
+        }
+
+        @Override
+        public String getExtension() {
+            // Never written or read: the codec only produces files for fields whose engine resolved to
+            // EXPERIMENTAL, which requires a bundled provider; getEngineNameFromPath is isPresent()-guarded.
+            return ".sandbox-inert";
+        }
+
+        @Override
+        public String getCompoundExtension() {
+            return ".sandbox-inertc";
+        }
+
+        @Override
+        public float score(float rawScore, SpaceType spaceType) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public Float distanceToRadialThreshold(Float distance, SpaceType spaceType) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public Float scoreToRadialThreshold(Float score, SpaceType spaceType) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public ValidationException validateMethod(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public boolean isTrainingRequired(KNNMethodContext knnMethodContext) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public int estimateOverheadInKB(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public KNNLibraryIndexingContext getKNNLibraryIndexingContext(
+            KNNMethodContext knnMethodContext,
+            KNNMethodConfigContext knnMethodConfigContext
+        ) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public KNNLibrarySearchContext getKNNLibrarySearchContext(String methodName) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+
+        @Override
+        public Boolean isInitialized() {
+            return false;
+        }
+
+        @Override
+        public void setInitialized(Boolean isInitialized) {
+            // no-op: there is nothing to initialize
+        }
+
+        @Override
+        public ResolvedMethodContext resolveMethod(
+            KNNMethodContext knnMethodContext,
+            KNNMethodConfigContext knnMethodConfigContext,
+            boolean shouldRequireTraining,
+            SpaceType spaceType
+        ) {
+            throw new UnsupportedOperationException(NOT_BUNDLED);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/engine/SandboxEngineProvider.java
+++ b/src/main/java/org/opensearch/knn/index/engine/SandboxEngineProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.index.query.KNNQueryResult;
+import org.opensearch.knn.index.store.IndexInputWithBuffer;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
+
+import java.util.Map;
+
+/**
+ * Service-provider interface that contributes a complete experimental engine from an (opt-in)
+ * {@code :sandbox} module, discovered at runtime via {@link java.util.ServiceLoader}. It supplies
+ * everything {@link KNNEngine#EXPERIMENTAL} needs to behave like any built-in engine:
+ *
+ * <ul>
+ *   <li>{@link #engineName()} — the engine name users type (e.g. {@code "svs"}); also how
+ *       {@code KNNEngine.getEngine(name)} resolves to {@code EXPERIMENTAL}.</li>
+ *   <li>{@link #library()} — the {@link KNNLibrary} driving method resolution, the file extension (so the
+ *       codec writes/reads the tenant's files), validation and scoring.</li>
+ *   <li>the native index lifecycle — {@code JNIService} routes every {@code EXPERIMENTAL} op here, to the
+ *       tenant's own JNI library (which may embed a different native engine build), fully separate from the
+ *       built-in {@code FaissService}/{@code NmslibService}.</li>
+ * </ul>
+ *
+ * <p>Routing is purely by engine: an {@code EXPERIMENTAL} index is created/loaded under this engine and its
+ * files carry the tenant's extension, so create, load, query and free all dispatch here uniformly — no
+ * per-op routing key is needed. When no provider is bundled (the default build) {@code EXPERIMENTAL} is
+ * inert and the plugin is byte-for-byte upstream. Main holds no compile-time reference to the tenant.
+ */
+public interface SandboxEngineProvider {
+
+    String engineName();
+
+    KNNLibrary library();
+
+    long initIndex(long numDocs, int dim, Map<String, Object> parameters);
+
+    void insertToIndex(int[] docs, long vectorsAddress, int dimension, Map<String, Object> parameters, long indexAddress);
+
+    void writeIndex(IndexOutputWithBuffer output, long indexAddress, Map<String, Object> parameters, boolean skipFlat);
+
+    void createIndexFromTemplate(
+        int[] ids,
+        long vectorsAddress,
+        int dim,
+        IndexOutputWithBuffer output,
+        byte[] templateIndex,
+        Map<String, Object> parameters
+    );
+
+    long loadIndex(IndexInputWithBuffer readStream, Map<String, Object> parameters);
+
+    KNNQueryResult[] queryIndex(
+        long indexPointer,
+        float[] queryVector,
+        int k,
+        Map<String, ?> methodParameters,
+        long[] filteredIds,
+        int filterIdsType,
+        int[] parentIds
+    );
+
+    KNNQueryResult[] radiusQueryIndex(
+        long indexPointer,
+        float[] queryVector,
+        float radius,
+        Map<String, ?> methodParameters,
+        int indexMaxResultWindow,
+        long[] filteredIds,
+        int filterIdsType,
+        int[] parentIds
+    );
+
+    void free(long indexPointer, boolean isBinaryIndex);
+}

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -57,6 +57,7 @@ import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SEARCH_WINDOW_SIZE;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
 import static org.opensearch.knn.index.engine.KNNEngine.FAISS;
@@ -83,6 +84,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     public static final ParseField MIN_SCORE_FIELD = new ParseField(MIN_SCORE);
     public static final ParseField EF_SEARCH_FIELD = new ParseField(METHOD_PARAMETER_EF_SEARCH);
     public static final ParseField NPROBE_FIELD = new ParseField(METHOD_PARAMETER_NPROBES);
+    public static final ParseField SEARCH_WINDOW_SIZE_FIELD = new ParseField(METHOD_PARAMETER_SEARCH_WINDOW_SIZE);
     public static final ParseField METHOD_PARAMS_FIELD = new ParseField(METHOD_PARAMETER);
     public static final ParseField RESCORE_FIELD = new ParseField(RESCORE_PARAMETER);
     public static final ParseField RESCORE_OVERSAMPLE_FIELD = new ParseField(RESCORE_OVERSAMPLE_PARAMETER);

--- a/src/main/java/org/opensearch/knn/index/query/request/MethodParameter.java
+++ b/src/main/java/org/opensearch/knn/index/query/request/MethodParameter.java
@@ -22,8 +22,10 @@ import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SEARCH_WINDOW_SIZE;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.EF_SEARCH_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.NPROBE_FIELD;
+import static org.opensearch.knn.index.query.KNNQueryBuilder.SEARCH_WINDOW_SIZE_FIELD;
 
 /**
  * MethodParameters are engine and algorithm related parameters that clients can pass in knn query
@@ -67,6 +69,25 @@ public enum MethodParameter {
 
             ValidationException validationException = new ValidationException();
             validationException.addValidationError(METHOD_PARAMETER_NPROBES + " should be greater than 0");
+            return validationException;
+        }
+    },
+
+    SEARCH_WINDOW_SIZE(METHOD_PARAMETER_SEARCH_WINDOW_SIZE, Version.V_3_7_0, SEARCH_WINDOW_SIZE_FIELD) {
+        @Override
+        public Integer parse(Object value) {
+            return parseInteger(value, METHOD_PARAMETER_SEARCH_WINDOW_SIZE);
+        }
+
+        @Override
+        public ValidationException validate(Object value) {
+            final Integer searchWindow = parse(value);
+            if (searchWindow != null && searchWindow > 0) {
+                return null;
+            }
+
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError(METHOD_PARAMETER_SEARCH_WINDOW_SIZE + " should be greater than 0");
             return validationException;
         }
     };

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.SandboxEngine;
 import org.opensearch.knn.index.query.KNNQueryResult;
 import org.opensearch.knn.index.store.IndexInputWithBuffer;
 import org.opensearch.knn.index.store.IndexOutputWithBuffer;
@@ -40,6 +41,9 @@ public class JNIService {
      * @return address of the index in memory
      */
     public static long initIndex(long numDocs, int dim, Map<String, Object> parameters, KNNEngine knnEngine) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            return SandboxEngine.provider().initIndex(numDocs, dim, parameters);
+        }
         if (KNNEngine.FAISS == knnEngine) {
             if (IndexUtil.isBinaryIndex(knnEngine, parameters)) {
                 return FaissService.initBinaryIndex(numDocs, dim, parameters);
@@ -74,6 +78,10 @@ public class JNIService {
         long indexAddress,
         KNNEngine knnEngine
     ) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            SandboxEngine.provider().insertToIndex(docs, vectorsAddress, dimension, parameters, indexAddress);
+            return;
+        }
         int threadCount = (int) parameters.getOrDefault(KNNConstants.INDEX_THREAD_QTY, 0);
         if (KNNEngine.FAISS == knnEngine) {
             if (IndexUtil.isBinaryIndex(knnEngine, parameters)) {
@@ -107,6 +115,10 @@ public class JNIService {
         Map<String, Object> parameters,
         boolean skipFlat
     ) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            SandboxEngine.provider().writeIndex(output, indexAddress, parameters, skipFlat);
+            return;
+        }
         if (KNNEngine.FAISS == knnEngine) {
             if (IndexUtil.isBinaryIndex(knnEngine, parameters)) {
                 FaissService.writeBinaryIndex(indexAddress, output, skipFlat);
@@ -174,6 +186,10 @@ public class JNIService {
         Map<String, Object> parameters,
         KNNEngine knnEngine
     ) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            SandboxEngine.provider().createIndexFromTemplate(ids, vectorsAddress, dim, output, templateIndex, parameters);
+            return;
+        }
         if (KNNEngine.FAISS == knnEngine) {
             if (IndexUtil.isBinaryIndex(knnEngine, parameters)) {
                 FaissService.createBinaryIndexFromTemplate(ids, vectorsAddress, dim, output, templateIndex, parameters);
@@ -202,6 +218,9 @@ public class JNIService {
      * @return Pointer to location in memory the index resides in
      */
     public static long loadIndex(IndexInputWithBuffer readStream, Map<String, Object> parameters, KNNEngine knnEngine) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            return SandboxEngine.provider().loadIndex(readStream, parameters);
+        }
         if (KNNEngine.FAISS == knnEngine) {
             if (IndexUtil.isBinaryIndex(knnEngine, parameters)) {
                 return FaissService.loadBinaryIndexWithStream(readStream);
@@ -294,6 +313,10 @@ public class JNIService {
         int filterIdsType,
         int[] parentIds
     ) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            return SandboxEngine.provider()
+                .queryIndex(indexPointer, queryVector, k, methodParameters, filteredIds, filterIdsType, parentIds);
+        }
         if (KNNEngine.NMSLIB == knnEngine) {
             return NmslibService.queryIndex(indexPointer, queryVector, k, methodParameters);
         }
@@ -377,6 +400,10 @@ public class JNIService {
      * @param isBinaryIndex indicate if it is binary index or not
      */
     public static void free(final long indexPointer, final KNNEngine knnEngine, final boolean isBinaryIndex) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            SandboxEngine.provider().free(indexPointer, isBinaryIndex);
+            return;
+        }
         if (KNNEngine.NMSLIB == knnEngine) {
             NmslibService.free(indexPointer);
             return;
@@ -456,6 +483,19 @@ public class JNIService {
         int filterIdsType,
         int[] parentIds
     ) {
+        if (KNNEngine.EXPERIMENTAL == knnEngine) {
+            return SandboxEngine.provider()
+                .radiusQueryIndex(
+                    indexPointer,
+                    queryVector,
+                    radius,
+                    methodParameters,
+                    indexMaxResultWindow,
+                    filteredIds,
+                    filterIdsType,
+                    parentIds
+                );
+        }
         if (KNNEngine.FAISS == knnEngine) {
             if (ArrayUtils.isNotEmpty(filteredIds)) {
                 return FaissService.rangeSearchIndexWithFilter(

--- a/src/main/java/org/opensearch/knn/jni/KNNLibraryLoader.java
+++ b/src/main/java/org/opensearch/knn/jni/KNNLibraryLoader.java
@@ -64,22 +64,31 @@ public class KNNLibraryLoader {
 
     /**
      * Loads the appropriate Faiss library based on system capabilities and settings.
-     *
-     * Selects the highest performance variant available:
-     * 1. AVX512 SPR if supported and not disabled
-     * 2. AVX512 if supported and not disabled
-     * 3. AVX2 if supported and not disabled
-     * 4. Default fallback library
      */
     static void loadFaissLibrary() {
+        loadLibraryByVariant(KNNConstants.FAISS_JNI_LIBRARY_NAME);
+    }
+
+    /**
+     * Loads the highest-performance available variant of a JNI library given its base name, selecting
+     * AVX512-SPR, then AVX512, then AVX2, then the plain library — each taken only when the system supports
+     * it and the corresponding {@code knn.faiss.avx*.disabled} setting has not disabled it (those settings
+     * govern SIMD selection for every variant-built library, not just Faiss). Backs the built-in Faiss and
+     * SIMD libraries, and is public so an experimental {@code :sandbox} tenant can load its own native
+     * library through this class (the only place permitted to call {@link System#loadLibrary}); the base
+     * name is supplied by the tenant, so no tenant-specific name lives here.
+     *
+     * @param baseLibraryName e.g. {@code opensearchknn_faiss}; variant suffixes ({@code _avx512_spr} etc.) are appended.
+     */
+    public static void loadLibraryByVariant(String baseLibraryName) {
         if (!isFaissAVX512SPRDisabled() && isAVX512SPRSupportedBySystem()) {
-            loadLibrary(KNNConstants.FAISS_AVX512_SPR_JNI_LIBRARY_NAME);
+            loadLibrary(baseLibraryName + "_avx512_spr");
         } else if (!isFaissAVX512Disabled() && isAVX512SupportedBySystem()) {
-            loadLibrary(KNNConstants.FAISS_AVX512_JNI_LIBRARY_NAME);
+            loadLibrary(baseLibraryName + "_avx512");
         } else if (!isFaissAVX2Disabled() && isAVX2SupportedBySystem()) {
-            loadLibrary(KNNConstants.FAISS_AVX2_JNI_LIBRARY_NAME);
+            loadLibrary(baseLibraryName + "_avx2");
         } else {
-            loadLibrary(KNNConstants.FAISS_JNI_LIBRARY_NAME);
+            loadLibrary(baseLibraryName);
         }
     }
 
@@ -99,22 +108,8 @@ public class KNNLibraryLoader {
 
     /**
      * Loads the appropriate SIMD computing library based on system capabilities.
-     *
-     * Follows the same selection logic as Faiss library:
-     * 1. AVX512 SPR variant if supported and not disabled
-     * 2. AVX512 variant if supported and not disabled
-     * 3. AVX2 variant if supported and not disabled
-     * 4. Default variant as fallback
      */
     static void loadSimdLibrary() {
-        if (!isFaissAVX512SPRDisabled() && isAVX512SPRSupportedBySystem()) {
-            loadLibrary(KNNConstants.SIMD_COMPUTING_AVX512_SPR_JNI_LIBRARY_NAME);
-        } else if (!isFaissAVX512Disabled() && isAVX512SupportedBySystem()) {
-            loadLibrary(KNNConstants.SIMD_COMPUTING_AVX512_JNI_LIBRARY_NAME);
-        } else if (!isFaissAVX2Disabled() && isAVX2SupportedBySystem()) {
-            loadLibrary(KNNConstants.SIMD_COMPUTING_AVX2_JNI_LIBRARY_NAME);
-        } else {
-            loadLibrary(KNNConstants.DEFAULT_SIMD_COMPUTING_JNI_LIBRARY_NAME);
-        }
+        loadLibraryByVariant(KNNConstants.DEFAULT_SIMD_COMPUTING_JNI_LIBRARY_NAME);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/FaissSVSVamanaIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissSVSVamanaIT.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import lombok.SneakyThrows;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+
+/**
+ * REST integration tests for the experimental {@code svs} engine ({@code svs_vamana} method), requiring a
+ * node built with {@code -Pknn.sandbox.enabled=true} (sandbox jar bundled + the isolated SVS native lib);
+ * excluded from default-build integTest runs. SVS names are written as literals to avoid a test-time
+ * dependency on the sandbox module.
+ */
+public class FaissSVSVamanaIT extends KNNRestTestCase {
+
+    private static final String SVS_ENGINE = "svs";
+    private static final String SVS_VAMANA = "svs_vamana";
+    private static final int DIMENSION = 3;
+    private static final float[][] DOCS = new float[][] { { 1.0f, 1.0f, 1.0f }, { 2.0f, 2.0f, 2.0f }, { 3.0f, 3.0f, 3.0f } };
+
+    @SneakyThrows
+    public void testSVSVamana_whenBasicConfiguration_thenSucceed() {
+        runIndexSearchRoundtrip("test-svs-vamana-basic", SpaceType.L2, builder -> {
+            builder.startObject(PARAMETERS).field("degree", 64).endObject();
+        });
+    }
+
+    @SneakyThrows
+    public void testSVSVamana_withSqFp16Encoder_thenSucceed() {
+        runIndexSearchRoundtrip("test-svs-vamana-sq-fp16", SpaceType.L2, builder -> {
+            builder.startObject(PARAMETERS)
+                .field("degree", 64)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "sq")
+                .startObject(PARAMETERS)
+                .field("type", "fp16")
+                .endObject()
+                .endObject()
+                .endObject();
+        });
+    }
+
+    @SneakyThrows
+    public void testSVSVamana_withLvqEncoder_thenSucceed() {
+        runIndexSearchRoundtrip("test-svs-vamana-lvq", SpaceType.L2, builder -> {
+            builder.startObject(PARAMETERS)
+                .field("degree", 64)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, "lvq")
+                .startObject(PARAMETERS)
+                .field("primary_bits", 4)
+                .field("residual_bits", 4)
+                .endObject()
+                .endObject()
+                .endObject();
+        });
+    }
+
+    // Asserts the SVS search context accepts a query-time search_window_size method parameter.
+    @SneakyThrows
+    public void testSVSVamana_withSearchWindowSizeMethodParameter_thenSucceed() {
+        final String indexName = "test-svs-vamana-sw-param";
+        final String fieldName = "test-field";
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, SVS_VAMANA)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, SVS_ENGINE)
+            .startObject(PARAMETERS)
+            .field("degree", 64)
+            .startObject(METHOD_ENCODER_PARAMETER)
+            .field(NAME, "lvq")
+            .startObject(PARAMETERS)
+            .field("primary_bits", 4)
+            .field("residual_bits", 4)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, builder.toString());
+        bulkAddKnnDocs(indexName, fieldName, DOCS, DOCS.length);
+        refreshAllNonSystemIndices();
+        assertEquals(DOCS.length, getDocCount(indexName));
+
+        int k = 2;
+        KNNQueryBuilder query = KNNQueryBuilder.builder()
+            .fieldName(fieldName)
+            .vector(new float[] { 1.0f, 1.0f, 1.0f })
+            .k(k)
+            .methodParameters(Map.of("search_window_size", 64))
+            .build();
+        Response response = searchKNNIndex(indexName, query, k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), fieldName);
+        assertEquals(k, results.size());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testSVSVamana_withCosinesimil_thenSucceed() {
+        runIndexSearchRoundtrip("test-svs-vamana-cosine", SpaceType.COSINESIMIL, builder -> {
+            builder.startObject(PARAMETERS).field("degree", 64).endObject();
+        });
+    }
+
+    @FunctionalInterface
+    private interface ParamsWriter {
+        void write(XContentBuilder builder) throws Exception;
+    }
+
+    private void runIndexSearchRoundtrip(String indexName, SpaceType spaceType, ParamsWriter paramsWriter) throws Exception {
+        final String fieldName = "test-field";
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, SVS_VAMANA)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field(KNN_ENGINE, SVS_ENGINE);
+        paramsWriter.write(builder);
+        builder.endObject().endObject().endObject().endObject();
+
+        createKnnIndex(indexName, builder.toString());
+        bulkAddKnnDocs(indexName, fieldName, DOCS, DOCS.length);
+        refreshAllNonSystemIndices();
+        assertEquals(DOCS.length, getDocCount(indexName));
+
+        int k = 2;
+        Response response = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName, new float[] { 1.0f, 1.0f, 1.0f }, k), k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), fieldName);
+        assertEquals(k, results.size());
+
+        deleteKNNIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testSVSVamana_whenModeOnDisk_thenRejected() {
+        final String fieldName = "test-field";
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field("mode", "on_disk")
+            .startObject(KNN_METHOD)
+            .field(NAME, SVS_VAMANA)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, SVS_ENGINE)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        ResponseException e = expectThrows(ResponseException.class, () -> createKnnIndex("test-svs-vamana-ondisk", builder.toString()));
+        assertTrue(EntityUtils.toString(e.getResponse().getEntity()).contains("on_disk is not supported with svs_vamana"));
+    }
+
+    // A min_score (radial) query must be rejected with a validation error, not reach the native layer.
+    @SneakyThrows
+    public void testSVSVamana_whenRadialSearch_thenRejected() {
+        final String indexName = "test-svs-vamana-radial";
+        final String fieldName = "test-field";
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .startObject(KNN_METHOD)
+            .field(NAME, SVS_VAMANA)
+            .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .field(KNN_ENGINE, SVS_ENGINE)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, builder.toString());
+        bulkAddKnnDocs(indexName, fieldName, DOCS, DOCS.length);
+        refreshAllNonSystemIndices();
+
+        KNNQueryBuilder radialQuery = KNNQueryBuilder.builder()
+            .fieldName(fieldName)
+            .vector(new float[] { 1.0f, 1.0f, 1.0f })
+            .minScore(0.5f)
+            .build();
+        ResponseException e = expectThrows(ResponseException.class, () -> searchKNNIndex(indexName, radialQuery, 10));
+        assertTrue(EntityUtils.toString(e.getResponse().getEntity()).toLowerCase(java.util.Locale.ROOT).contains("radial"));
+
+        deleteKNNIndex(indexName);
+    }
+}

--- a/src/test/java/org/opensearch/knn/jni/KNNLibraryLoaderBT.java
+++ b/src/test/java/org/opensearch/knn/jni/KNNLibraryLoaderBT.java
@@ -29,7 +29,9 @@ public class KNNLibraryLoaderBT extends KNNTestCase {
         Method[] methods = KNNLibraryLoader.class.getDeclaredMethods();
 
         for (Method method : methods) {
-            if (!Modifier.isPrivate(method.getModifiers())) {
+            // Skip parameterized loaders (e.g. the generic loadLibraryByVariant(baseName)); they cannot be
+            // invoked blindly and are covered through their no-arg callers (loadFaissLibrary, loadSimdLibrary).
+            if (!Modifier.isPrivate(method.getModifiers()) && method.getParameterCount() == 0) {
                 try {
                     method.invoke(null);
                 } catch (Exception e) {


### PR DESCRIPTION
## Description

Adds Intel SVS (Scalable Vector Search) Vamana as an experimental `:sandbox` tenant, isolated from the core plugin all the way down to its own JNI binary. SVS is exposed as its own engine (`engine: "svs"`) and runs in `libopensearchknn_svs*.so`, which embeds its own SVS-enabled Faiss build. The core `libopensearchknn_faiss*.so` contains zero SVS symbols.

The entire tenant (Java module, native library, packaging, and engine availability) is gated behind a single build flag, `-Pknn.sandbox.enabled=true`. Without it, the plugin builds and behaves exactly as it does today.

`svs_vamana` is a graph-based ANN method with optional LVQ or scalar quantization for memory-efficient search. This PR is the engine integration described in [RFC #3224](https://github.com/opensearch-project/k-NN/issues/3224).

## Related Issues

Resolves [#3283](https://github.com/opensearch-project/k-NN/issues/3283).

Relates to [RFC #3224](https://github.com/opensearch-project/k-NN/issues/3224). Builds on the `:sandbox` skeleton in [#3296](https://github.com/opensearch-project/k-NN/pull/3296).

## Design principles

1. One switch, the whole tenant. A single flag (`knn.sandbox.enabled`) flips the Java module, the native `.so`, packaging, and engine availability together. No second knob, no partial state, no runtime toggle.
2. Maximum isolation, down to a separate JNI binary. The tenant has its own `.so` embedding its own Faiss; the core `faiss.so` stays clean. Some native helper code is duplicated into the SVS library, a deliberate trade for a core binary that carries zero tenant code.
3. No compile-time coupling from core to the tenant. The core exposes one generic SPI behind a generic `EXPERIMENTAL` engine slot; the tenant is discovered at runtime via `ServiceLoader`. The dependency arrow is sandbox to core only (`compileOnly project(':')`).
4. Inert by default. With the flag off, the generic engine slot is dormant: it carries an inert placeholder library whose accessors are benign for iteration and throw `UnsupportedOperationException` for any real use. No SVS Java compiles, no SVS `.so` builds, and the plugin zip is identical to a build without this change.


## How the tenant plugs in

A registered, searchable engine must be discovered, resolved, searched (JNI), and loaded, all of which live in the core. This PR keeps compile-time isolation (root has no compile dependency on `:sandbox`) and makes every core change additive and tenant-agnostic:

1. `compileOnly project(':')` in `sandbox/build.gradle`, so sandbox sees core types while root does not depend on sandbox.
2. A generic engine slot, `KNNEngine.EXPERIMENTAL`, whose name, library, and native ops are supplied at runtime by a discovered provider. There is no `"svs"` literal in `KNNEngine`.
3. A generic SPI, `SandboxEngineProvider` (engine name, `KNNLibrary`, and native index lifecycle), discovered once via `ServiceLoader` by a small `SandboxEngine` holder. This is the JDK-standard `ServiceLoader` / `META-INF/services` pattern already used in this repo for `org.apache.lucene.codecs.Codec`, `org.apache.lucene.codecs.KnnVectorsFormat`, `QueryBuilderProtoConverter`, and `PainlessExtension`.
4. Engine-based routing. The engine is stored on the field (as it already is for FAISS, NMSLIB, and LUCENE) and its segment files carry the engine's own `.svs` extension, so `JNIService` routes each native op to the provider with one branch per method, and the codec reads SVS files back by extension. Nothing extra is persisted on the field to route the call.
5. A generic native loader, `KNNLibraryLoader.loadLibraryByVariant(baseName)`, the only place permitted to call `System.loadLibrary`, so the tenant loads its own AVX-variant-selected `.so`. The existing `loadFaissLibrary` and `loadSimdLibrary` delegate to it, so the variant-selection logic exists once. The base name `opensearchknn_svs` lives in the sandbox, not the core.
6. Method resolution stays tenant-side. `SvsLibrary` resolves `svs_vamana` with its own sandbox `SvsMethodResolver` (extending the public `AbstractMethodResolver`); the core `FaissMethodResolver` is untouched.

Hooks 1 through 6 are all tenant-agnostic; a future tenant reuses them unchanged. Only the sandbox-side classes are SVS-specific.

## How a sandbox SVS index loads

Loading happens in four ordered steps:

0. Build flag. Decides whether the SVS `.so` and the provider declaration are present in the artifact at all.
1. Class load. `SandboxEngine` runs `ServiceLoader.load(SandboxEngineProvider.class)` once. In a flagged build it finds the sandbox's provider, so `EXPERIMENTAL` gains the name `"svs"` and its `KNNLibrary`. Discovery does not touch native code.
2. First native use. The first `JNIService` op for an `EXPERIMENTAL` field reaches `SvsService`, whose static initializer calls `loadLibraryByVariant("opensearchknn_svs")` and loads the AVX-appropriate `.so` exactly once (an `$ORIGIN` rpath resolves the co-located `libsvs_runtime.so`).
3. Steady state. The engine value and the `.svs` file extension route create, load, query, and free from then on.

## Functional scope

| Aspect | This PR |
|---|---|
| Engine | `svs` (`KNNEngine.EXPERIMENTAL`), own `libopensearchknn_svs*.so` |
| Method | `svs_vamana` |
| Encoders | `flat` (FP32), `sq` (`type: fp16` \| `sq8`), `lvq` |
| Construction params | `degree`, `construction_window_size`, `alpha`, `search_window_size` / `search_buffer_capacity` (index-time defaults) |
| Query-time param | `search_window_size` (the recall and latency knob, analogous to `ef_search`) |
| Distance | `l2`, `innerproduct`, `cosinesimil` |
| File extension | `.svs` |
| Build flag | `-Pknn.sandbox.enabled=true` (default OFF) |
| Platform guard | `lvq` rejected with a clear error on non-Intel hosts (AVX-512 Sapphire Rapids or newer required) |

## Building and deploying

SVS is opt-in. By default `:sandbox` is excluded from the build graph entirely, so no SVS Java compiles, no SVS `.so` builds, and a normal build and deploy is unchanged.

```bash
# Default build (unchanged plugin):
./gradlew assemble

# SVS-enabled build (one flag):
./gradlew assemble -Pknn.sandbox.enabled=true \
  -Psvs.prefix=<dir with lib/cmake/svs_runtime>   # optional; otherwise the build fetches libsvs-runtime=0.3.0
```

The flagged build compiles `:sandbox`, builds a separate, unmodified upstream Faiss (SVS-capable commit, `FAISS_ENABLE_SVS=ON`, zero k-NN patches) into `libopensearchknn_svs*.so`, links `libsvs_runtime`, and bundles the SVS `.so` and the sandbox jar into the plugin zip. `-Psvs.prefix` is optional and only tells the already-enabled build where the SVS runtime lives (for offline builds); otherwise the build fetches the conda-forge `libsvs-runtime=0.3.0` package. LVQ requires an Intel AVX-512 (Sapphire Rapids or newer) host.

## Impact on the existing (HNSW / IVF / Lucene) path: none

* The default build excludes `:sandbox` from the build graph: no SVS Java compiles, no SVS `.so` builds, and `unzip -l` of the plugin zip shows no sandbox or SVS entries.
* The core `libopensearchknn_faiss*.so` contains zero SVS symbols (`nm` verified) and does not link `libsvs_runtime`.
* The one new enum value (`EXPERIMENTAL`) is inert without a bundled tenant: it carries an inert placeholder library whose iteration-safe accessors return benign values and whose use-implying methods throw `UnsupportedOperationException`, so even code that iterates `KNNEngine.values()` (tests, diagnostics) has no NPE path. Name and path resolution are additionally guarded by `SandboxEngine.isPresent()`; with the flag off, `engine: "svs"` is rejected with `Invalid engine type: svs`. The full core unit-test suite passes on the default build.
* Every core edit is additive (a generic engine slot, a generic SPI, one branch per `JNIService` op, one line in the build-strategy factory). No existing HNSW, IVF, or Lucene code path is modified.
* Two Faiss builds (the core submodule pin and the SVS library's SVS-capable commit) coexist safely in one JVM via hidden symbol visibility plus a JNI-only linker version script; a coexistence integration test exercises an HNSW index and an SVS index in the same node.

## Testing

The SVS tests are opt-in, mirroring the feature: they run only with `-Pknn.sandbox.enabled=true`. So default CI proves the change is inert and causes no regression; SVS correctness is covered by the flagged tests below, which a reviewer can run by building with the flag (LVQ and the native runtime require an Intel AVX-512 Sapphire Rapids host).

Default build (no flag):
* The full core unit-test suite passes (`./gradlew test`).
* `:sandbox` is absent from `./gradlew projects`; `nm` of `faiss.so` is SVS-symbol-free; no SVS artifacts are produced; `engine: "svs"` is rejected with a 400.

Flagged build (`-Pknn.sandbox.enabled=true`):
* `libopensearchknn_svs*.so` builds against a pristine upstream Faiss, links `libsvs_runtime`, exports only JNI symbols (linker version script, so no Faiss-symbol interposition), and carries the SVS and Vamana symbols while `faiss.so` stays SVS-symbol-free.
* `:sandbox` Java unit tests cover the method/encoder resolution and `compression_level` mapping.
* The REST `FaissSVSVamanaIT` exercises the native path end-to-end (index, merge, query, filter, and the validation rejections) and passes 7/7. It is excluded from the default-build `integTest` run.

Native C++ unit tests (`jni_test`) for the SVS wrapper are a tracked follow-up: the SVS test target links a separate runtime that requires Intel AVX-512, so it needs its own gated harness and runner rather than the standard `jni_test` flow. The native path is exercised end-to-end today through `FaissSVSVamanaIT`.

Beyond the above, the change was manually validated on an Intel AVX-512 host across the encoders, distances, `compression_level` mappings, build/query parameters, filtering, and faiss-HNSW coexistence.

## Relationship to the `:sandbox` skeleton ([#3296](https://github.com/opensearch-project/k-NN/pull/3296))

This branch includes the `:sandbox` module skeleton so it builds and CI runs standalone; once #3296 merges, that skeleton commit will be rebased or dropped and this PR retargeted. The generic seam introduced here (the `SandboxEngineProvider` SPI, the `EXPERIMENTAL` engine slot, and `loadLibraryByVariant`) is reusable sandbox infrastructure that may belong in #3296 itself; happy to relocate it if maintainers prefer.

## Follow-up

LeanVec, a learned dimensionality-reduction encoder that further cuts memory for high-dimensional vectors, is a planned follow-up. It needs a per-shard training step that this PR does not yet wire up; the encoder set here (`flat`, `sq`, `lvq`) is the in-memory, no-training set.

## Check List
* [x] New functionality includes testing.
* [ ] New functionality has been documented.
* [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
* [x] Commits are signed per the DCO using `--signoff`.
* [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
