### PR TITLE
[Enhancement] Make Merge in nativeEngine can Abort (#2529)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -69,7 +69,7 @@ jobs:
           su `id -un 1000` -c 'git config --global user.email "github-actions[bot]@users.noreply.github.com"'
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -99,7 +99,7 @@ jobs:
 
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -123,7 +123,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -166,7 +166,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -8,7 +8,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v6
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
       - name: Get tag
         id: tag
-        uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
-      - uses: ncipollo/release-action@v1
+        uses: dawidd6/action-get-tag@727a6f0a561be04e09013531e73a3983a65e3479 # v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           bodyFile: release-notes/opensearch-knn.release-notes-${{steps.tag.outputs.tag}}.md

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v1.1.4
+        uses: VachaShah/backport@28c49d91ceec57d7c9f625f1031c1a4d637251f5 # v1.1.4
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           branch_name: backport/backport-${{ github.event.number }}

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -63,7 +63,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: ${{ matrix.java }}
 
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -149,7 +149,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: ${{ matrix.java }}
 

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -8,11 +8,11 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3
         with:
           skipLabels: "autocut, skip-changelog"

--- a/.github/workflows/create-documentation-issue.yml
+++ b/.github/workflows/create-documentation-issue.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         
       - name: Edit the issue template
         run: |
@@ -29,7 +29,7 @@ jobs:
           
       - name: Create Issue From File
         id: create-issue
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4
         with:
           title: Add documentation related to new feature
           content-filepath: ./.github/ISSUE_TEMPLATE/documentation-issue.md

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'opensearch-project/k-NN' && startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
     - name: Delete merged branch
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           github.rest.git.deleteRef({

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update draft release notes
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
         with:
           config-name: draft-release-notes-config.yml
           name: Version (set here)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@master
+        uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0 # master
         with:
           args: --accept=200,403,429  **/*.html **/*.md **/*.txt **/*.json
         env:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,14 +17,14 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Load secret
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
         with:
           # Export loaded secrets as environment variables
           export-env: true
@@ -34,7 +34,7 @@ jobs:
           MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/remote_index_build.yml
+++ b/.github/workflows/remote_index_build.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -56,7 +56,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
         run: |
@@ -66,7 +66,7 @@ jobs:
           su `id -un 1000` -c 'git config --global user.email "github-actions[bot]@users.noreply.github.com"'
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Added engine as a top-level optional parameter while creating vector field [#2736](https://github.com/opensearch-project/k-NN/pull/2736)
 * Migrate k-NN plugin to use GRPC transport-grpc SPI interface [#2833](https://github.com/opensearch-project/k-NN/pull/2833)
 * Native scoring for FP16 [#2922](https://github.com/opensearch-project/k-NN/pull/2922)
+* Make Merge in nativeEngine can Abort [#2529](https://github.com/opensearch-project/k-NN/pull/2529)

--- a/build.gradle
+++ b/build.gradle
@@ -512,6 +512,10 @@ def commonIntegTest(RestIntegTestTask task, project, integTestDependOnJniLib, op
 
 integTest {
     commonIntegTest(it, project, integTestDependOnJniLib, opensearch_tmp_dir, _numNodes)
+    filter {
+        excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
+    }
+    mustRunAfter test
 }
 
 task integTestRemoteIndexBuild(type: RestIntegTestTask) {
@@ -519,11 +523,22 @@ task integTestRemoteIndexBuild(type: RestIntegTestTask) {
     filter {
         // Temporarily skipping this test class, see: https://github.com/opensearch-project/k-NN/issues/2726
         excludeTestsMatching "org.opensearch.knn.index.SegmentReplicationIT"
+        excludeTestsMatching "org.opensearch.knn.index.RelocationIT"
     }
     systemProperty("test.remoteBuild", System.getProperty("test.remoteBuild"))
     systemProperty("test.bucket", System.getProperty("test.bucket"))
     systemProperty("test.base_path", System.getProperty("test.base_path"))
 }
+
+task integTestMultiNode(type: RestIntegTestTask) {
+    commonIntegTest(it, project, integTestDependOnJniLib, opensearch_tmp_dir, 2)
+    filter {
+        includeTestsMatching "org.opensearch.knn.index.RelocationIT"
+    }
+}
+
+// Make integTest run integTestMultiNode after completion
+integTest.finalizedBy integTestMultiNode
 
 def commonIntegTestClusters(OpenSearchCluster cluster, _numNodes){
     cluster.testDistribution = "ARCHIVE"
@@ -548,6 +563,9 @@ def commonIntegTestClusters(OpenSearchCluster cluster, _numNodes){
     // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore
     // i.e. we have to use a custom property to flag when we want to debug opensearch JVM
     // since we also support multi node integration tests we increase debugPort per node
+    cluster.nodes.forEach { node ->
+        node.jvmArgs("-Xmx512m")
+    }
     if (System.getProperty("cluster.debug") != null) {
         def debugPort = 5005
         cluster.nodes.forEach { node ->
@@ -555,6 +573,7 @@ def commonIntegTestClusters(OpenSearchCluster cluster, _numNodes){
             debugPort += 1
         }
     }
+
 
     cluster.systemProperty("java.library.path", "$rootDir/jni/build/release")
     final testSnapshotFolder = file("${buildDir}/testSnapshotFolder")
@@ -581,6 +600,10 @@ testClusters.integTestRemoteIndexBuild {
     keystore 's3.client.default.session_token', "${System.getProperty("session_token")}"
     // Forcing optimistic search for testing
     systemProperty 'mem_opt_srch.force_reenter', 'true'
+}
+
+testClusters.integTestMultiNode {
+    commonIntegTestClusters(it, 2)
 }
 
 task integTestRemote(type: RestIntegTestTask) {

--- a/jni/cmake/init-faiss.cmake
+++ b/jni/cmake/init-faiss.cmake
@@ -102,6 +102,11 @@ set(BUILD_TESTING OFF)          # Avoid building faiss tests
 set(FAISS_ENABLE_GPU OFF)
 set(FAISS_ENABLE_PYTHON OFF)
 
+# On Windows, define FAISS_MAIN_LIB to export symbols when building the Faiss library
+if(${CMAKE_SYSTEM_NAME} STREQUAL Windows)
+    add_compile_definitions(FAISS_MAIN_LIB)
+endif()
+
 if(NOT DEFINED AVX2_ENABLED)
     set(AVX2_ENABLED true)   # set default value as true if the argument is not set
 endif()

--- a/jni/include/jni_util.h
+++ b/jni/include/jni_util.h
@@ -41,6 +41,9 @@ namespace knn_jni {
         // HasExceptionInStack with ability to specify message
         virtual void HasExceptionInStack(JNIEnv* env, const char *message) = 0;
 
+        // Catches a Faiss abort exception and throws the MergeAbortedException exception to the JVM
+        virtual void CatchIndexBuildAbortExceptionAndThrowJava(JNIEnv* env) = 0;
+
         // Catches a C++ exception and throws the corresponding exception to the JVM
         virtual void CatchCppExceptionAndThrowJava(JNIEnv* env) = 0;
         // --------------------------------------------------------------------------
@@ -164,12 +167,13 @@ namespace knn_jni {
     class JNIUtil final : public JNIUtilInterface {
     public:
         // Initialize and Uninitialize methods are used for caching/cleaning up Java classes and methods
-        void Initialize(JNIEnv* env);
+        void Initialize(JNIEnv* env, JavaVM *javaVm);
         void Uninitialize(JNIEnv* env);
 
         void ThrowJavaException(JNIEnv* env, const char* type = "", const char* message = "") final;
         void HasExceptionInStack(JNIEnv* env) final;
         void HasExceptionInStack(JNIEnv* env, const char* message) final;
+        void CatchIndexBuildAbortExceptionAndThrowJava(JNIEnv* env) final;
         void CatchCppExceptionAndThrowJava(JNIEnv* env) final;
         jclass FindClass(JNIEnv * env, const std::string& className) final;
         jmethodID FindMethod(JNIEnv * env, const std::string& className, const std::string& methodName) final;
@@ -215,8 +219,10 @@ namespace knn_jni {
         void CallNonvirtualVoidMethodA(JNIEnv * env, jobject obj, jclass clazz, jmethodID methodID, jvalue* args) final;
         void * GetPrimitiveArrayCritical(JNIEnv * env, jarray array, jboolean *isCopy) final;
         void ReleasePrimitiveArrayCritical(JNIEnv * env, jarray array, void *carray, jint mode) final;
+        JNIEnv* GetJNICurrentEnv();
 
     private:
+        JavaVM* vm;
         std::unordered_map<std::string, jclass> cachedClasses;
         std::unordered_map<std::string, jmethodID> cachedMethods;
     };  // class JNIUtil

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -276,6 +276,13 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
 JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSearchIndex
   (JNIEnv *, jclass, jlong, jfloatArray, jfloat, jobject, jint, jintArray);
 
+/*
+ * Class:     org_opensearch_knn_jni_FaissService
+ * Method:    setMergeInterruptCallback
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterruptCallback(JNIEnv * env, jclass cls);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -18,6 +18,8 @@
 #include "faiss_wrapper.h"
 #include "jni_util.h"
 #include "faiss_stream_support.h"
+#include "faiss/impl/FaissException.h"
+#include "faiss_index_service.h"
 
 static knn_jni::JNIUtil jniUtil;
 static const jint KNN_FAISS_JNI_VERSION = JNI_VERSION_1_1;
@@ -29,7 +31,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         return JNI_ERR;
     }
 
-    jniUtil.Initialize(env);
+    jniUtil.Initialize(env, vm);
 
     return KNN_FAISS_JNI_VERSION;
 }
@@ -37,6 +39,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 void JNI_OnUnload(JavaVM *vm, void *reserved) {
     JNIEnv* env;
     vm->GetEnv((void**)&env, KNN_FAISS_JNI_VERSION);
+    faiss::InterruptCallback::instance.get()->clear_instance();
     jniUtil.Uninitialize(env);
 }
 
@@ -90,7 +93,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToIndex(JN
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
         knn_jni::faiss_wrapper::IndexService indexService(std::move(faissMethods));
         knn_jni::faiss_wrapper::InsertToIndex(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexAddress, threadCount, &indexService);
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
         // NOTE: ADDING DELETE STATEMENT HERE CAUSES A CRASH!
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -104,7 +117,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToBinaryIn
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
         knn_jni::faiss_wrapper::BinaryIndexService binaryIndexService(std::move(faissMethods));
         knn_jni::faiss_wrapper::InsertToIndex(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexAddress, threadCount, &binaryIndexService);
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
         // NOTE: ADDING DELETE STATEMENT HERE CAUSES A CRASH!
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -118,7 +141,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_insertToByteInde
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
         knn_jni::faiss_wrapper::ByteIndexService byteIndexService(std::move(faissMethods));
         knn_jni::faiss_wrapper::InsertToIndex(&jniUtil, env, idsJ, vectorsAddressJ, dimJ, indexAddress, threadCount, &byteIndexService);
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
         // NOTE: ADDING DELETE STATEMENT HERE CAUSES A CRASH!
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
@@ -184,7 +217,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createIndexFromT
                                                         output,
                                                         templateIndexJ,
                                                         parametersJ);
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
 }
@@ -207,7 +250,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createBinaryInde
                                                               output,
                                                               templateIndexJ,
                                                               parametersJ);
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
 }
@@ -230,7 +283,17 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_createByteIndexF
                                                             output,
                                                             templateIndexJ,
                                                             parametersJ);
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::string errormsg = e.msg;
+        std::size_t found = errormsg.find("computation interrupted");
+        if (found != std::string::npos) {
+            jniUtil.CatchIndexBuildAbortExceptionAndThrowJava(env);
+        } else {
+            jniUtil.CatchCppExceptionAndThrowJava(env);
+        }
+    }
+    catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
 }
@@ -353,7 +416,11 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_queryInd
     try {
         return knn_jni::faiss_wrapper::QueryIndex(&jniUtil, env, indexPointerJ, queryVectorJ, kJ, methodParamsJ, parentIdsJ);
 
-    } catch (...) {
+    }
+    catch (const faiss::FaissException& e) {
+        std::cout << "====> query get faiss exception:" << e.what() << "\n";
+    }
+    catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
     return nullptr;
@@ -494,4 +561,15 @@ JNIEXPORT jobjectArray JNICALL Java_org_opensearch_knn_jni_FaissService_rangeSea
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }
     return nullptr;
+}
+
+JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterruptCallback(JNIEnv * env, jclass cls)
+{
+    try {
+        faiss::InterruptCallback::instance.reset(
+            new knn_jni::faiss_wrapper::OpenSearchMergeInterruptCallback(&jniUtil)
+        );
+    } catch (...) {
+        jniUtil.CatchCppExceptionAndThrowJava(env);
+    }
 }

--- a/jni/src/org_opensearch_knn_jni_JNICommons.cpp
+++ b/jni/src/org_opensearch_knn_jni_JNICommons.cpp
@@ -25,7 +25,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         return JNI_ERR;
     }
 
-    jniUtil.Initialize(env);
+    jniUtil.Initialize(env, vm);
 
     return KNN_JNICOMMONS_JNI_VERSION;
 }

--- a/jni/src/org_opensearch_knn_jni_NmslibService.cpp
+++ b/jni/src/org_opensearch_knn_jni_NmslibService.cpp
@@ -25,7 +25,7 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     return JNI_ERR;
   }
 
-  jniUtil.Initialize(env);
+  jniUtil.Initialize(env, vm);
 
   return KNN_NMSLIB_JNI_VERSION;
 }

--- a/jni/src/org_opensearch_knn_jni_SimdVectorComputeService.cpp
+++ b/jni/src/org_opensearch_knn_jni_SimdVectorComputeService.cpp
@@ -15,7 +15,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         return JNI_ERR;
     }
 
-    JNI_UTIL.Initialize(env);
+    JNI_UTIL.Initialize(env, vm);
 
     return KNN_SIMD_COMPUTE_JNI_VERSION;
 }

--- a/jni/tests/test_util.h
+++ b/jni/tests/test_util.h
@@ -86,6 +86,7 @@ namespace test_util {
         MOCK_METHOD(void, HasExceptionInStack, (JNIEnv * env));
         MOCK_METHOD(void, HasExceptionInStack,
                     (JNIEnv * env, const char* message));
+        MOCK_METHOD(void, CatchIndexBuildAbortExceptionAndThrowJava, (JNIEnv * env));
         MOCK_METHOD(jbyteArray, NewByteArray, (JNIEnv * env, jsize len));
         MOCK_METHOD(jobject, NewObject,
                     (JNIEnv * env, jclass clazz, jmethodID methodId, int id,
@@ -121,7 +122,6 @@ namespace test_util {
                 ConvertJavaStringToQuantizationLevel,
                 (JNIEnv *env, jobject javaString),
                 (override));
-
     };
 
 // For our unit tests, we want to ensure that each test tests one function in

--- a/src/main/java/org/apache/lucene/index/MergeAbortChecker.java
+++ b/src/main/java/org/apache/lucene/index/MergeAbortChecker.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.lucene.index;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+import java.lang.reflect.Field;
+
+/**
+ * Utility class for checking if a Lucene segment merge operation has been aborted.
+ * Uses reflection to access the merge state from {@link ConcurrentMergeScheduler.MergeThread}.
+ *
+ * <p>This is used in faiss interrupt callback mechanism to be able to abort faiss index creation
+ * when merge process is aborted by Lucene's {@link IndexWriter}.
+ *
+ * @since 1.0
+ */
+@Log4j2
+@NoArgsConstructor
+public final class MergeAbortChecker {
+
+    /** The reflected field for accessing merge state from MergeThread */
+    private static Field MERGE_FIELD;
+
+    /** The name of the merge field in ConcurrentMergeScheduler.MergeThread */
+    private static final String MERGE_FIELD_NAME = "merge";
+
+    private static boolean hasMergeField;
+    static {
+        try {
+            MERGE_FIELD = ConcurrentMergeScheduler.MergeThread.class.getDeclaredField(MERGE_FIELD_NAME);
+            MERGE_FIELD.setAccessible(true);
+            hasMergeField = true;
+        } catch (NoSuchFieldException e) {
+            hasMergeField = false;
+            log.error("Not find merge field in MergeThread", e);
+        }
+    }
+
+    /**
+     * Checks if the current thread is a merge thread and if its merge operation has been aborted.
+     *
+     * <p>This method uses reflection to access the private merge field from
+     * {@link ConcurrentMergeScheduler.MergeThread} and checks if the associated
+     * {@link MergePolicy.OneMerge} has been aborted.
+     *
+     * @return {@code true} if the current thread is a {@link ConcurrentMergeScheduler.MergeThread}
+     *         and its merge is aborted, {@code false} otherwise (including when not running
+     *         in a merge thread context or when reflection access fails)
+     *
+     * @see ConcurrentMergeScheduler.MergeThread
+     * @see MergePolicy.OneMerge#isAborted()
+     */
+    public static boolean isMergeAborted() {
+        if (!hasMergeField) {
+            return false;
+        }
+        Thread mergeThread = Thread.currentThread();
+        if (mergeThread instanceof ConcurrentMergeScheduler.MergeThread) {
+            try {
+                MergePolicy.OneMerge merge = (MergePolicy.OneMerge) MERGE_FIELD.get(mergeThread);
+                boolean aborted = merge.isAborted();
+                log.debug("Current Thread {} is aborted: {}", mergeThread.getName(), aborted);
+                return aborted;
+            } catch (RuntimeException e) {
+                log.error("Runtime exception while checking merge abort status", e);
+                return false;
+            } catch (IllegalAccessException e) {
+                log.error("IllegalAccessException for reflection merge field access", e);
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/DefaultIndexBuildStrategy.java
@@ -105,6 +105,8 @@ final class DefaultIndexBuildStrategy implements NativeIndexBuildStrategy {
             }
             // Resetting here as vectors are deleted in JNILayer for non-iterative index builds
             vectorTransfer.reset();
+        } catch (IndexBuildAbortedException indexBuildAbortedException) {
+            throw indexBuildAbortedException;
         } catch (Exception exception) {
             throw new RuntimeException(
                 "Failed to build index, field name " + indexInfo.getFieldName() + ", parameters " + indexInfo,

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/IndexBuildAbortedException.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/IndexBuildAbortedException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.nativeindex;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown when native index building is aborted during merge operations.
+ *
+ * <p>This exception is typically thrown when a Lucene merge operation is cancelled
+ * and the associated native index building process needs to be terminated gracefully.
+ */
+public class IndexBuildAbortedException extends IOException {
+
+    /**
+     * Constructs an IndexBuildAbortedException with the specified detail message.
+     *
+     * @param message the detail message explaining why the index build was aborted
+     */
+    public IndexBuildAbortedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an IndexBuildAbortedException with the specified detail message and cause.
+     *
+     * @param message the detail message explaining why the index build was aborted
+     * @param cause the underlying cause of the abort
+     */
+    public IndexBuildAbortedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs an IndexBuildAbortedException with the specified cause.
+     *
+     * @param cause the underlying cause of the abort
+     */
+    public IndexBuildAbortedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedNativeIndexBuildStrategy.java
@@ -126,6 +126,8 @@ final class MemOptimizedNativeIndexBuildStrategy implements NativeIndexBuildStra
                 return null;
             });
 
+        } catch (IndexBuildAbortedException indexBuildAbortedException) {
+            throw indexBuildAbortedException;
         } catch (Exception exception) {
             throw new RuntimeException(
                 "Failed to build index, field name [" + indexInfo.getFieldName() + "], parameters " + indexInfo,

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategy.java
@@ -14,5 +14,5 @@ import java.io.IOException;
  */
 public interface NativeIndexBuildStrategy {
 
-    void buildAndWriteIndex(BuildIndexParams indexInfo) throws IOException;
+    void buildAndWriteIndex(BuildIndexParams indexInfo) throws IOException, IndexBuildAbortedException;
 }

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.jni;
 
+import org.apache.lucene.index.MergeAbortChecker;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQueryResult;
@@ -20,6 +21,7 @@ import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
+import lombok.extern.log4j.Log4j2;
 
 import static org.opensearch.knn.index.KNNSettings.isFaissAVX2Disabled;
 import static org.opensearch.knn.index.KNNSettings.isFaissAVX512Disabled;
@@ -36,6 +38,7 @@ import static org.opensearch.knn.jni.PlatformUtils.isAVX512SPRSupportedBySystem;
  *      src/main/java/org/opensearch/knn/index/query/KNNQueryResult.java
  *      src/main/java/org/opensearch/knn/common/KNNConstants.java
  */
+@Log4j2
 class FaissService {
 
     static {
@@ -58,6 +61,14 @@ class FaissService {
             KNNEngine.FAISS.setInitialized(true);
             return null;
         });
+
+        try {
+            MergeAbortChecker.isMergeAborted();
+            setMergeInterruptCallback();
+        } catch (Exception e) {
+            // Ignore merge abort callback
+            log.warn("Unable to add the mergeAbortChecker during Faiss Initialization", e);
+        }
     }
 
     /**
@@ -463,4 +474,20 @@ class FaissService {
         int indexMaxResultWindow,
         int[] parentIds
     );
+
+    /**
+     * Sets the merge interrupt callback for Faiss operations.
+     *
+     * <p>This method initializes a singleton interrupt callback that allows Faiss operations
+     * to be aborted when Lucene merge operations are cancelled. The callback uses
+     * {@link org.apache.lucene.index.MergeAbortChecker} to detect when the current thread
+     * is a merge thread and if its merge operation has been aborted.
+     *
+     * <p>When the callback detects an aborted merge, it signals Faiss to interrupt
+     * long-running operations like index creation or training, preventing resource
+     * waste and ensuring timely cleanup.
+     *
+     * @see org.apache.lucene.index.MergeAbortChecker#isMergeAborted()
+     */
+    public static native void setMergeInterruptCallback();
 }

--- a/src/test/java/org/opensearch/knn/index/RelocationIT.java
+++ b/src/test/java/org/opensearch/knn/index/RelocationIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index;
+
+import org.junit.BeforeClass;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.common.settings.Settings;
+
+import java.io.IOException;
+
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+public class RelocationIT extends KNNRestTestCase {
+
+    private static final String INDEX_NAME = "relocation-knn-index";
+    private static final String TEST_FIELD = "test-field";
+
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        if (FaissIT.class.getClassLoader() == null) {
+            throw new IllegalStateException("ClassLoader of RelocationIT Class is null");
+        }
+    }
+
+    public void testForcemerge_whenRelocation_and_abortSuccess() throws Exception {
+
+        int dimension = 768;
+        int numNodes = 2;
+        Request nodesNamesRequest = new Request("GET", "_cat/nodes?h=name");
+        Response response = client().performRequest(nodesNamesRequest);
+        assertOK(response);
+
+        String[] nodeNamesStr = new String(response.getEntity().getContent().readAllBytes()).split("\n");
+        assertEquals(numNodes, nodeNamesStr.length);
+
+        Settings indexSettings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.routing.allocation.require._name", nodeNamesStr[0])
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 10000)
+            .put(KNN_INDEX, true)
+            .build();
+
+        createKnnIndex(
+            INDEX_NAME,
+            indexSettings,
+            createKnnIndexMapping(
+                TEST_FIELD,
+                dimension,
+                METHOD_HNSW,
+                KNNEngine.FAISS.getName(),
+                SpaceType.INNER_PRODUCT.getValue(),
+                true,
+                VectorDataType.FLOAT
+            )
+        );
+        waitForClusterHealthGreen(Integer.toString(numNodes));
+
+        logger.info("bulk Write docs");
+        for (int i = 0; i < 10; i++) {
+            addKNNDocsWithParkingAndRating(INDEX_NAME, TEST_FIELD, dimension, i * 1000, 1000);
+            refreshAllIndices();
+        }
+
+        Thread write = new Thread(() -> {
+            try {
+                Settings.Builder updateSettings = Settings.builder().put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0);
+                updateIndexSettings(INDEX_NAME, updateSettings);
+
+                logger.info("Force merge");
+                forceMergeKnnIndex(INDEX_NAME);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        write.start();
+
+        Thread.sleep(1000 * 20);
+
+        logger.info("Update Routing Allocation");
+        Settings.Builder updateSettings = Settings.builder().put("index.routing.allocation.require._name", nodeNamesStr[1]);
+        updateIndexSettings(INDEX_NAME, updateSettings);
+
+        while (true) {
+            Request request = new Request("GET", "_cat/recovery?active_only=true");
+
+            Response resp = client().performRequest(request);
+            String respStr = new String(resp.getEntity().getContent().readAllBytes());
+            if (respStr.isEmpty()) {
+                break;
+            } else {
+                logger.info("recovery: {}", respStr);
+            }
+            Thread.sleep(1000 * 1);
+        }
+        write.join();
+    }
+}


### PR DESCRIPTION
* ADD Merge Abort Caller



* FIX EXCEPTION PATH



* FIX EXCEPTION PATH



* FIX EXCEPTION PATH



* FIX TESTS



* ADD TESTS



* FXIED Tests



* Add Changelog AND SpotlessApply



* Add Abort



* add test method for merge abort



* spotlessApply



* remove LucenePackagePrivateCaller for simply way.



* FIX jnienv calling for singleton instance



* FIX jnienv calling for singleton instance



* FIX RelocationIT tests and checked aborted when merge



* Override InterruptCallback#check for search



* Adds a new exception type and some minor cleaning



* Makes sure RelocationIT runs with ./gradlew build



* Changes Merge Abort log line to warn instead of error



* Removed unit test since it wasn't working



* Fix IT test for integTestRemoteIndexBuild



* Fix CI test for windows



* attempts to fix windows CI



* FIX comments



---------




(cherry picked from commit a2a95f8717cd7114f6f94e667049fecab1056aa4)

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
