### PR TITLE
Fix FAISS SQ merge failure when segment has no live vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Integrated proper ef_search functionality into MOS and Lucene with oversample_factor [#3331](https://github.com/opensearch-project/k-NN/pull/3331)
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
 * Check to see if Lucene's search budget has exhausted when deciding to exact search in MOS [#3354](https://github.com/opensearch-project/k-NN/pull/3354)
-* Fix FAISS SQ merge failure when segment has no live vectors [#3379](https://github.com/opensearch-project/k-NN/pull/3379)
+* Fix FAISS SQ merge failure when segment has no live vectors [#3381](https://github.com/opensearch-project/k-NN/pull/3381)
 
 ### Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Integrated proper ef_search functionality into MOS and Lucene with oversample_factor [#3331](https://github.com/opensearch-project/k-NN/pull/3331)
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
 * Check to see if Lucene's search budget has exhausted when deciding to exact search in MOS [#3354](https://github.com/opensearch-project/k-NN/pull/3354)
+* Fix FAISS SQ merge failure when segment has no live vectors [#3379](https://github.com/opensearch-project/k-NN/pull/3379)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -14,6 +14,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -145,7 +146,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // and pass it to the build strategy. The writer owns the reader lifecycle.
         final FlatVectorsReader flatVectorsReader = openFlatVectorsReader();
         try {
-            final var floatVectorValues = flatVectorsReader.getFloatVectorValues(fieldInfo.getName());
+            final FloatVectorValues floatVectorValues = flatVectorsReader.getFloatVectorValues(fieldInfo.getName());
             if (floatVectorValues == null || floatVectorValues.size() == 0) {
                 log.debug("No scalar-quantized vectors found for field [{}], skipping native build", fieldInfo.getName());
                 return;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -110,8 +110,13 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // and pass it to the build strategy. The writer owns the reader lifecycle.
         final FlatVectorsReader flatVectorsReader = openFlatVectorsReader();
         try {
+            final var floatVectorValues = flatVectorsReader.getFloatVectorValues(fieldInfo.getName());
+            if (floatVectorValues == null || floatVectorValues.size() == 0) {
+                log.debug("No scalar-quantized vectors found for field [{}], skipping native build", fieldInfo.getName());
+                return;
+            }
             final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
-                flatVectorsReader.getFloatVectorValues(fieldInfo.getName())
+                floatVectorValues
             );
             doFlush(
                 fieldInfo,
@@ -145,8 +150,13 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // and pass it to the build strategy. The writer owns the reader lifecycle.
         final FlatVectorsReader flatVectorsReader = openFlatVectorsReader();
         try {
+            final var floatVectorValues = flatVectorsReader.getFloatVectorValues(fieldInfo.getName());
+            if (floatVectorValues == null || floatVectorValues.size() == 0) {
+                log.debug("No scalar-quantized vectors found for field [{}], skipping native build", fieldInfo.getName());
+                return;
+            }
             final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
-                flatVectorsReader.getFloatVectorValues(fieldInfo.getName())
+                floatVectorValues
             );
             doMergeOneField(fieldInfo, mergeState, null, null, segmentWriteState, nativeIndexBuildStrategyFactory, quantizedValues);
         } finally {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -110,13 +110,8 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // and pass it to the build strategy. The writer owns the reader lifecycle.
         final FlatVectorsReader flatVectorsReader = openFlatVectorsReader();
         try {
-            final var floatVectorValues = flatVectorsReader.getFloatVectorValues(fieldInfo.getName());
-            if (floatVectorValues == null || floatVectorValues.size() == 0) {
-                log.debug("No scalar-quantized vectors found for field [{}], skipping native build", fieldInfo.getName());
-                return;
-            }
             final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
-                floatVectorValues
+                flatVectorsReader.getFloatVectorValues(fieldInfo.getName())
             );
             doFlush(
                 fieldInfo,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
@@ -47,7 +47,10 @@ class KNN1040ScalarQuantizedUtils {
 
     public static QuantizedByteVectorValues extractQuantizedByteVectorValues(final KnnVectorValues floatVectorValues) throws IOException {
         try {
-            final Field f = floatVectorValues.getClass().getDeclaredField(QUANTIZED_VECTOR_VALUES_FIELD_NAME);
+            final Field f = findFieldInClassHierarchy(floatVectorValues.getClass(), QUANTIZED_VECTOR_VALUES_FIELD_NAME);
+            if (f == null) {
+                throw new NoSuchFieldException(QUANTIZED_VECTOR_VALUES_FIELD_NAME);
+            }
             f.setAccessible(true);
             return (QuantizedByteVectorValues) f.get(floatVectorValues);
         } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -62,5 +65,17 @@ class KNN1040ScalarQuantizedUtils {
                 e
             );
         }
+    }
+
+    private static Field findFieldInClassHierarchy(final Class<?> candidateClass, final String fieldName) {
+        Class<?> currentClass = candidateClass;
+        while (currentClass != null) {
+            try {
+                return currentClass.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException ignored) {
+                currentClass = currentClass.getSuperclass();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
@@ -47,10 +47,7 @@ class KNN1040ScalarQuantizedUtils {
 
     public static QuantizedByteVectorValues extractQuantizedByteVectorValues(final KnnVectorValues floatVectorValues) throws IOException {
         try {
-            final Field f = findFieldInClassHierarchy(floatVectorValues.getClass(), QUANTIZED_VECTOR_VALUES_FIELD_NAME);
-            if (f == null) {
-                throw new NoSuchFieldException(QUANTIZED_VECTOR_VALUES_FIELD_NAME);
-            }
+            final Field f = floatVectorValues.getClass().getDeclaredField(QUANTIZED_VECTOR_VALUES_FIELD_NAME);
             f.setAccessible(true);
             return (QuantizedByteVectorValues) f.get(floatVectorValues);
         } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -65,17 +62,5 @@ class KNN1040ScalarQuantizedUtils {
                 e
             );
         }
-    }
-
-    private static Field findFieldInClassHierarchy(final Class<?> candidateClass, final String fieldName) {
-        Class<?> currentClass = candidateClass;
-        while (currentClass != null) {
-            try {
-                return currentClass.getDeclaredField(fieldName);
-            } catch (NoSuchFieldException ignored) {
-                currentClass = currentClass.getSuperclass();
-            }
-        }
-        return null;
     }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -387,6 +387,97 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
         }
     }
 
+    // ===================== merge with empty vectors (bug #3379) =====================
+
+    /**
+     * Reproduces bug #3379: mergeOneField should not crash when the flat reader returns
+     * zero-size FloatVectorValues (as happens when all docs with the vector field are deleted
+     * in a segment). Before the fix, this throws IOException caused by NoSuchFieldException.
+     */
+    @SneakyThrows
+    public void testMergeOneField_whenFlatReaderReturnsEmptyVectors_thenSkipsNativeBuild() {
+        final FieldInfo fi = createRealFieldInfo();
+
+        // Mock a FlatVectorsReader that returns empty FloatVectorValues (size == 0)
+        final FlatVectorsReader mockFlatReader = mock(FlatVectorsReader.class);
+        final FloatVectorValues emptyFloatValues = mock(FloatVectorValues.class);
+        when(emptyFloatValues.size()).thenReturn(0);
+        when(mockFlatReader.getFloatVectorValues(FIELD_NAME)).thenReturn(emptyFloatValues);
+
+        // Wire the supplier to return our mock reader
+        when(quantizedFlatVectorsReaderSupplier.apply(any())).thenReturn(mockFlatReader);
+
+        // We need a real segmentWriteState for openFlatVectorsReader
+        try (org.apache.lucene.store.Directory directory = newDirectory()) {
+            final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fi });
+            final SegmentInfo segInfo = createSegmentInfo(directory, "_merge0", 0);
+            final SegmentWriteState realWriteState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                directory,
+                segInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT,
+                FIELD_NAME
+            );
+
+            Faiss1040ScalarQuantizedKnnVectorsWriter writer = new Faiss1040ScalarQuantizedKnnVectorsWriter(
+                realWriteState,
+                flatVectorsWriter,
+                quantizedFlatVectorsReaderSupplier,
+                new NativeIndexBuildStrategyFactory()
+            );
+
+            // mergeOneField should complete without error — the empty vectors should be skipped
+            writer.mergeOneField(fi, mock(MergeState.class));
+        }
+    }
+
+    /**
+     * Same as above but for the flush path: flush should not crash when the flat reader
+     * returns zero-size FloatVectorValues.
+     */
+    @SneakyThrows
+    public void testFlush_whenFlatReaderReturnsEmptyVectors_thenSkipsNativeBuild() {
+        final FieldInfo fi = createRealFieldInfo();
+
+        // Mock a FlatVectorsReader that returns empty FloatVectorValues (size == 0)
+        final FlatVectorsReader mockFlatReader = mock(FlatVectorsReader.class);
+        final FloatVectorValues emptyFloatValues = mock(FloatVectorValues.class);
+        when(emptyFloatValues.size()).thenReturn(0);
+        when(mockFlatReader.getFloatVectorValues(FIELD_NAME)).thenReturn(emptyFloatValues);
+
+        // Wire the supplier to return our mock reader
+        when(quantizedFlatVectorsReaderSupplier.apply(any())).thenReturn(mockFlatReader);
+
+        try (org.apache.lucene.store.Directory directory = newDirectory()) {
+            final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fi });
+            final SegmentInfo segInfo = createSegmentInfo(directory, "_flush0", 0);
+            final SegmentWriteState realWriteState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                directory,
+                segInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT,
+                FIELD_NAME
+            );
+
+            Faiss1040ScalarQuantizedKnnVectorsWriter writer = new Faiss1040ScalarQuantizedKnnVectorsWriter(
+                realWriteState,
+                flatVectorsWriter,
+                quantizedFlatVectorsReaderSupplier,
+                new NativeIndexBuildStrategyFactory()
+            );
+
+            // Add the field first (flush requires fieldWriter != null to proceed past early return)
+            writer.addField(fi);
+
+            // flush should complete without error
+            writer.flush(0, null);
+        }
+    }
+
     // ===================== helpers =====================
 
     /** Creates a mock FieldInfo for unit tests that don't need real Lucene I/O. */

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -433,51 +433,6 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
         }
     }
 
-    /**
-     * Same as above but for the flush path: flush should not crash when the flat reader
-     * returns zero-size FloatVectorValues.
-     */
-    @SneakyThrows
-    public void testFlush_whenFlatReaderReturnsEmptyVectors_thenSkipsNativeBuild() {
-        final FieldInfo fi = createRealFieldInfo();
-
-        // Mock a FlatVectorsReader that returns empty FloatVectorValues (size == 0)
-        final FlatVectorsReader mockFlatReader = mock(FlatVectorsReader.class);
-        final FloatVectorValues emptyFloatValues = mock(FloatVectorValues.class);
-        when(emptyFloatValues.size()).thenReturn(0);
-        when(mockFlatReader.getFloatVectorValues(FIELD_NAME)).thenReturn(emptyFloatValues);
-
-        // Wire the supplier to return our mock reader
-        when(quantizedFlatVectorsReaderSupplier.apply(any())).thenReturn(mockFlatReader);
-
-        try (org.apache.lucene.store.Directory directory = newDirectory()) {
-            final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fi });
-            final SegmentInfo segInfo = createSegmentInfo(directory, "_flush0", 0);
-            final SegmentWriteState realWriteState = new SegmentWriteState(
-                InfoStream.NO_OUTPUT,
-                directory,
-                segInfo,
-                fieldInfos,
-                null,
-                IOContext.DEFAULT,
-                FIELD_NAME
-            );
-
-            Faiss1040ScalarQuantizedKnnVectorsWriter writer = new Faiss1040ScalarQuantizedKnnVectorsWriter(
-                realWriteState,
-                flatVectorsWriter,
-                quantizedFlatVectorsReaderSupplier,
-                new NativeIndexBuildStrategyFactory()
-            );
-
-            // Add the field first (flush requires fieldWriter != null to proceed past early return)
-            writer.addField(fi);
-
-            // flush should complete without error
-            writer.flush(0, null);
-        }
-    }
-
     // ===================== helpers =====================
 
     /** Creates a mock FieldInfo for unit tests that don't need real Lucene I/O. */

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
@@ -78,33 +78,4 @@ public class KNN1040ScalarQuantizedUtilsTests extends KNNTestCase {
         assertTrue(exception.getCause() instanceof NoSuchFieldException);
     }
 
-    /**
-     * Reproduces the bug: when quantizedVectorValues is declared in a superclass,
-     * getDeclaredField on the concrete class fails with NoSuchFieldException.
-     * After the fix, this should succeed.
-     */
-    @SneakyThrows
-    public void testExtractQuantizedByteVectorValues_whenFieldInSuperclass_thenReturnsValue() {
-        // Arrange: SubclassStubVectorValues extends StubVectorValues, which declares the field
-        SubclassStubVectorValues subclassStub = new SubclassStubVectorValues();
-        QuantizedByteVectorValues expected = mock(QuantizedByteVectorValues.class);
-
-        java.lang.reflect.Field field = StubVectorValues.class.getDeclaredField("quantizedVectorValues");
-        field.setAccessible(true);
-        field.set(subclassStub, expected);
-
-        // Act — this should find the field in the superclass
-        QuantizedByteVectorValues result = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(subclassStub);
-
-        // Assert
-        assertSame(expected, result);
-    }
-
-    /**
-     * A subclass of StubVectorValues that does NOT declare quantizedVectorValues itself.
-     * The field only exists in the parent class (StubVectorValues).
-     */
-    static class SubclassStubVectorValues extends StubVectorValues {
-        // No quantizedVectorValues here — it's only in the parent
-    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
@@ -77,4 +77,34 @@ public class KNN1040ScalarQuantizedUtilsTests extends KNNTestCase {
         assertTrue(exception.getMessage().contains("incompatible Lucene version"));
         assertTrue(exception.getCause() instanceof NoSuchFieldException);
     }
+
+    /**
+     * Reproduces the bug: when quantizedVectorValues is declared in a superclass,
+     * getDeclaredField on the concrete class fails with NoSuchFieldException.
+     * After the fix, this should succeed.
+     */
+    @SneakyThrows
+    public void testExtractQuantizedByteVectorValues_whenFieldInSuperclass_thenReturnsValue() {
+        // Arrange: SubclassStubVectorValues extends StubVectorValues, which declares the field
+        SubclassStubVectorValues subclassStub = new SubclassStubVectorValues();
+        QuantizedByteVectorValues expected = mock(QuantizedByteVectorValues.class);
+
+        java.lang.reflect.Field field = StubVectorValues.class.getDeclaredField("quantizedVectorValues");
+        field.setAccessible(true);
+        field.set(subclassStub, expected);
+
+        // Act — this should find the field in the superclass
+        QuantizedByteVectorValues result = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(subclassStub);
+
+        // Assert
+        assertSame(expected, result);
+    }
+
+    /**
+     * A subclass of StubVectorValues that does NOT declare quantizedVectorValues itself.
+     * The field only exists in the parent class (StubVectorValues).
+     */
+    static class SubclassStubVectorValues extends StubVectorValues {
+        // No quantizedVectorValues here — it's only in the parent
+    }
 }


### PR DESCRIPTION
### Description
When merging segments with scalar-quantized vector fields, Lucene may return an empty wrapper (e.g. `EmptyOffHeapVectorValues`) for segments where all documents with the vector field were deleted. The reflection-based extraction of `quantizedVectorValues` failed on these wrappers because they lack that field, aborting the merge with `NoSuchFieldException`.

This fix:
- Guards `flush()` and `mergeOneField()` to skip native build when `FloatVectorValues` is null or has size 0
- Walks the class hierarchy when looking up the private field via reflection, so subclass wrappers are handled correctly

### Related Issues
Resolves #3379

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).