### PR TITLE
Fix score corruption in multi-segment FAISS indices with ADC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
 * Check to see if Lucene's search budget has exhausted when deciding to exact search in MOS [#3354](https://github.com/opensearch-project/k-NN/pull/3354)
 * Fix FAISS SQ merge failure when segment has no live vectors [#3381](https://github.com/opensearch-project/k-NN/pull/3381)
+* Fix score corruption in multi-segment FAISS indices with ADC [#3385](https://github.com/opensearch-project/k-NN/pull/3385)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -406,10 +406,11 @@ public class ExactSearcher {
             (KNNVectorValuesIterator.DocIdsIteratorValues) quantizedValues.getVectorValuesIterator();
 
         if (SegmentLevelQuantizationUtil.isAdcEnabled(quantizationInfo)) {
-            SegmentLevelQuantizationUtil.transformVectorWithADC(context.getFloatQueryVector(), quantizationInfo, spaceType);
+            float[] transformQuery = context.getFloatQueryVector().clone();
+            SegmentLevelQuantizationUtil.transformVectorWithADC(transformQuery, quantizationInfo, spaceType);
             return VectorScorers.createScorer(
                 quantizedIteratorValues,
-                context.getFloatQueryVector(),
+                transformQuery,
                 scorerMode,
                 spaceType,
                 fieldInfo,

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
@@ -361,6 +361,75 @@ public class ExactSearcherTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testExactSearch_whenQuantizationWithADC_thenQueryVectorNotMutated() {
+        try (
+            MockedStatic<KNNVectorValuesFactory> valuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class);
+            MockedStatic<org.opensearch.knn.index.query.SegmentLevelQuantizationInfo> quantizationInfoMockedStatic = Mockito.mockStatic(
+                org.opensearch.knn.index.query.SegmentLevelQuantizationInfo.class
+            );
+            MockedStatic<org.opensearch.knn.index.query.SegmentLevelQuantizationUtil> quantizationUtilMockedStatic = Mockito.mockStatic(
+                org.opensearch.knn.index.query.SegmentLevelQuantizationUtil.class
+            )
+        ) {
+            final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };
+            final float[] queryVectorSnapshot = queryVector.clone();
+            final List<byte[]> quantizedDataVectors = List.of(new byte[] { 1, 0, 1 }, new byte[] { 0, 1, 0 }, new byte[] { 1, 1, 1 });
+            final SpaceType spaceType = SpaceType.L2;
+
+            final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
+                .field(FIELD_NAME)
+                .floatQueryVector(queryVector)
+                .useQuantizedVectorsForSearch(true)
+                .k(10)
+                .build();
+
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+            when(leafReaderContext.reader()).thenReturn(reader);
+
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            when(fieldInfo.getAttribute(QFRAMEWORK_CONFIG)).thenReturn("type=binary,bits=1,random_rotation=false,enable_adc=true");
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+
+            final org.opensearch.knn.index.query.SegmentLevelQuantizationInfo quantizationInfo = mock(
+                org.opensearch.knn.index.query.SegmentLevelQuantizationInfo.class
+            );
+            quantizationInfoMockedStatic.when(
+                () -> org.opensearch.knn.index.query.SegmentLevelQuantizationInfo.build(reader, fieldInfo, FIELD_NAME)
+            ).thenReturn(quantizationInfo);
+            quantizationUtilMockedStatic.when(
+                () -> org.opensearch.knn.index.query.SegmentLevelQuantizationUtil.isAdcEnabled(quantizationInfo)
+            ).thenReturn(true);
+            quantizationUtilMockedStatic.when(
+                () -> org.opensearch.knn.index.query.SegmentLevelQuantizationUtil.transformVectorWithADC(any(float[].class), any(), any())
+            ).thenAnswer(invocation -> {
+                float[] vec = invocation.getArgument(0);
+                for (int i = 0; i < vec.length; i++) {
+                    vec[i] = 999.0f;
+                }
+                return null;
+            });
+
+            final KNNVectorValues knnFloatVectorValues = TestVectorValues.createKNNFloatVectorValues(
+                List.of(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, new float[] { 2, 3, 4 })
+            );
+            final KNNVectorValues knnByteVectorValues = TestVectorValues.createKNNBinaryVectorValues(quantizedDataVectors);
+            valuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnFloatVectorValues);
+            valuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader, true))
+                .thenReturn(knnByteVectorValues);
+
+            exactSearcher.searchLeaf(leafReaderContext, exactSearcherContext);
+
+            assertArrayEquals("ADC transformation must not mutate the shared query vector", queryVectorSnapshot, queryVector, 0.0f);
+        }
+    }
+
+    @SneakyThrows
     private void doTestRadialSearch_whenNoEngineFiles_thenSuccess(final boolean memoryOptimizedSearchEnabled) {
         // Prepare data before mocking static factory
         final float[] queryVector = new float[] { 0.1f, 2.0f, 3.0f };


### PR DESCRIPTION
### Description
`ExactSearcher.createVectorScorer()` mutates the shared `queryVector` array via `transformVectorWithADC()`. Consequently, subsequent segments in multi-segment FAISS indices with ADC enabled observe a corrupted query vector and return incorrect scores. To solve this problem, the query vector is cloned before applying the ADC transformation.

### Related Issues
Resolves #3384 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
