### PR TITLE
Add native SIMD cosine scoring for FP16 and SQ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Convert document vectors to primitive arrays once per document in lateInteractionScore, instead of once per query-vector/document-vector pair [#3453](https://github.com/opensearch-project/k-NN/pull/3453)
 * Terminate remote index build early when the merge has been aborted [#3488](https://github.com/opensearch-project/k-NN/pull/3488)
 * Add NEON SIMD kernel for FP16 L2 similarity [#3512](https://github.com/opensearch-project/k-NN/pull/3512)
+* Add native SIMD cosine scoring for FP16 and SQ formats, removing post-hoc score conversion [#3386](https://github.com/opensearch-project/k-NN/pull/3386)

--- a/jni/include/simd/similarity_function/similarity_function.h
+++ b/jni/include/simd/similarity_function/similarity_function.h
@@ -14,7 +14,11 @@ namespace knn_jni::simd::similarity_function {
         // L2 for FP16
         FP16_L2,
         SQ_IP,
-        SQ_L2
+        SQ_L2,
+        // Cosine for FP16. Vectors are L2-normalized so cosine = inner product with score = (1 + dot) / 2.
+        FP16_COSINE,
+        // Cosine for SQ. Same IP intermediate math as SQ_IP but with cosine score transform.
+        SQ_COSINE
     };
 
     struct SimilarityFunction;

--- a/jni/include/simd/similarity_function/similarity_function.h
+++ b/jni/include/simd/similarity_function/similarity_function.h
@@ -19,7 +19,11 @@ namespace knn_jni::simd::similarity_function {
         // L2 for FP16
         FP16_L2,
         SQ_IP,
-        SQ_L2
+        SQ_L2,
+        // Cosine for FP16. Vectors are L2-normalized so cosine = inner product with score = (1 + dot) / 2.
+        FP16_COSINE,
+        // Cosine for SQ. Same IP intermediate math as SQ_IP but with cosine score transform.
+        SQ_COSINE
     };
 
     struct SimilarityFunction;
@@ -44,8 +48,13 @@ namespace knn_jni::simd::similarity_function {
         SimilarityFunction* similarityFunction;
         // Faiss distance computation function.
         std::unique_ptr<faiss::DistanceComputer> faissFunction;
-        // Temp buffer which is reset per search.
+        // Temp buffer which is reset per search. Also used by getVectorPointer() to reassemble a
+        // vector that straddles two mmap regions, so it may be resized (and reallocated) mid-scan.
         std::vector<uint8_t> tmpBuffer;
+        // Dedicated buffer holding the FP16-converted query for the native FP16 kernel. Kept
+        // separate from tmpBuffer so that a cross-region vector reassembly (which resizes
+        // tmpBuffer) can never invalidate the query pointer held by the kernel.
+        std::vector<uint8_t> queryFP16Buffer;
 
         ~SimdVectorSearchContext();
 

--- a/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
@@ -290,7 +290,7 @@ static FORCE_INLINE void simd4bitDotProductBatch(
     }
 }
 
-template <bool IsMaxIP>
+template <SQMetricMode Mode>
 struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
@@ -331,7 +331,7 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
@@ -356,7 +356,7 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] =
@@ -379,7 +379,7 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                                    + ax * ly * y1
                                    + lx * ly * qcDist;
 
-            if constexpr (IsMaxIP) {
+            if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                 scores[processedCount] += queryAdditional + additional - centroidDp;
             } else {
                 scores[processedCount] =
@@ -387,8 +387,10 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
             }
         }
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP) {
             FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else if constexpr (Mode == SQMetricMode::COSINE) {
+            FaissScoreToLuceneScoreTransform::cosineTransformBulk(scores, numVectors);
         } else {
             FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
         }
@@ -419,9 +421,13 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                       + ax * ly * y1
                       + lx * ly * qcDist;
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
             score += queryAdditional + additional - centroidDp;
-            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            if constexpr (Mode == SQMetricMode::MAX_IP) {
+                return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            } else {
+                return FaissScoreToLuceneScoreTransform::cosineTransform(score);
+            }
         } else {
             score = std::max(0.0F, queryAdditional + additional - 2 * score);
             return FaissScoreToLuceneScoreTransform::l2Transform(score);
@@ -437,14 +443,18 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
 ArmNeonFP16MaxIP<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 ArmNeonFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> FP16_L2_SIMIL_FUNC;
+// 3. Cosine (same IP kernel as MaxIP, but with cosine score transform for L2-normalized vectors)
+ArmNeonFP16MaxIP<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
 
 //
 // SQ
 //
 // 1. Max IP
-ArmNeonSQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+ArmNeonSQSimilarityFunction<SQMetricMode::MAX_IP> SQ_IP_SIMIL_FUNC;
 // 2. L2
-ArmNeonSQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+ArmNeonSQSimilarityFunction<SQMetricMode::L2> SQ_L2_SIMIL_FUNC;
+// 3. Cosine
+ArmNeonSQSimilarityFunction<SQMetricMode::COSINE> SQ_COSINE_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
@@ -456,6 +466,10 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {
         return &SQ_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_COSINE) {
+        return &SQ_COSINE_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &FP16_COSINE_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/arm_neon_simd_similarity_function.cpp
@@ -397,7 +397,7 @@ static FORCE_INLINE void simd4bitDotProductBatch(
     }
 }
 
-template <bool IsMaxIP>
+template <SQMetricMode Mode>
 struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
@@ -438,7 +438,7 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
@@ -463,7 +463,7 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] =
@@ -486,7 +486,7 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                                    + ax * ly * y1
                                    + lx * ly * qcDist;
 
-            if constexpr (IsMaxIP) {
+            if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                 scores[processedCount] += queryAdditional + additional - centroidDp;
             } else {
                 scores[processedCount] =
@@ -494,8 +494,10 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
             }
         }
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP) {
             FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else if constexpr (Mode == SQMetricMode::COSINE) {
+            FaissScoreToLuceneScoreTransform::cosineTransformBulk(scores, numVectors);
         } else {
             FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
         }
@@ -526,9 +528,13 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
                       + ax * ly * y1
                       + lx * ly * qcDist;
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
             score += queryAdditional + additional - centroidDp;
-            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            if constexpr (Mode == SQMetricMode::MAX_IP) {
+                return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            } else {
+                return FaissScoreToLuceneScoreTransform::cosineTransform(score);
+            }
         } else {
             score = std::max(0.0F, queryAdditional + additional - 2 * score);
             return FaissScoreToLuceneScoreTransform::l2Transform(score);
@@ -544,14 +550,18 @@ struct ArmNeonSQSimilarityFunction final : SimilarityFunction {
 ArmNeonFP16MaxIP<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 ArmNeonFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> FP16_L2_SIMIL_FUNC;
+// 3. Cosine (same IP kernel as MaxIP, but with cosine score transform for L2-normalized vectors)
+ArmNeonFP16MaxIP<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
 
 //
 // SQ
 //
 // 1. Max IP
-ArmNeonSQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+ArmNeonSQSimilarityFunction<SQMetricMode::MAX_IP> SQ_IP_SIMIL_FUNC;
 // 2. L2
-ArmNeonSQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+ArmNeonSQSimilarityFunction<SQMetricMode::L2> SQ_L2_SIMIL_FUNC;
+// 3. Cosine
+ArmNeonSQSimilarityFunction<SQMetricMode::COSINE> SQ_COSINE_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
@@ -563,6 +573,10 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {
         return &SQ_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_COSINE) {
+        return &SQ_COSINE_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &FP16_COSINE_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/avx512_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/avx512_simd_similarity_function.cpp
@@ -10,7 +10,6 @@
 #include "faiss_score_to_lucene_transform.cpp"
 
 
-
 //
 // FP16
 //
@@ -262,6 +261,251 @@ struct AVX512SPRFP16L2 final : BaseSimilarityFunction<BulkScoreTransformFunc, Sc
     }
 };
 
+//
+// Native AVX512-FP16 Inner Product for Cosine Similarity
+//
+// Uses native AVX512-FP16 FMA instructions (_mm512_fmadd_ph) at 32 FP16 elements per
+// 512-bit register, with on-the-fly FP32->FP16 query conversion. To bound FP16
+// accumulation rounding error across long vectors, the FP16 accumulator is drained
+// into an FP32 accumulator every FP16_DRAIN_INTERVAL iterations -- trading a small
+// amount of throughput for substantially better numerical accuracy.
+//
+// Routed only from the cosine similarity path, where L2-normalized vectors guarantee
+// per-element products lie in [-1, 1].
+//
+#ifdef __AVX512FP16__
+
+// Drain FP16 accumulator into FP32 accumulator, then zero the FP16 accumulator.
+// Splits the 32 FP16 lanes into two halves of 16, widens each to FP32, and adds
+// to the FP32 accumulator.
+static inline void drain_ph_to_ps(__m512& acc_ps, __m512h& acc_ph) {
+    __m512i raw = _mm512_castph_si512(acc_ph);
+    acc_ps = _mm512_add_ps(acc_ps,
+                _mm512_cvtph_ps(_mm512_castsi512_si256(raw)));
+    acc_ps = _mm512_add_ps(acc_ps,
+                _mm512_cvtph_ps(_mm512_extracti64x4_epi64(raw, 1)));
+    acc_ph = _mm512_castsi512_ph(_mm512_setzero_si512());
+}
+
+// Convert 32 floats to a packed 512-bit float16 register (2x16 FP32 -> 1x32 FP16).
+static inline __m512h cvt2x16_fp32_to_ph(const float* p) {
+    __m256i lo = _mm512_cvtps_ph(_mm512_loadu_ps(p),
+                    _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    __m256i hi = _mm512_cvtps_ph(_mm512_loadu_ps(p + 16),
+                    _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    return _mm512_castsi512_ph(
+        _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1));
+}
+
+//
+// Native AVX512-FP16 Inner Product, cosine path only.
+//
+// PRECONDITION: query and data vectors are L2-normalized. This is the cosine
+// invariant. Running partial sums stay in [-1, +1] throughout, where FP16 ULP
+// is ~5e-4. Cumulative rounding error over dim=768 is ~sqrt(N)*ulp ~= 2e-3
+// expected, ~6e-3 worst-case — well below cosine ranking noise. Therefore we
+// accumulate entirely in FP16 and drain to FP32 only once per vector at the
+// end, before horizontal reduce.
+//
+// DO NOT route any unnormalized similarity through this kernel. The previous
+// version of this code drained to FP32 every FP16_DRAIN_INTERVAL iterations
+// precisely to handle the unnormalized case, where partial sums can grow into
+// binades with much larger ULP and per-FMA rounding error explodes.
+//
+
+template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
+struct AVX512NativeFP16IP final : BaseSimilarityFunction<BulkScoreTransformFunc, ScoreTransformFunc> {
+    void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
+                                   int32_t* internalVectorIds,
+                                   float* scores,
+                                   const int32_t numVectors) {
+
+        int32_t processedCount = 0;
+        const auto* queryPtr = (const float*) srchContext->queryVectorSimdAligned;
+        const int32_t dim = srchContext->dimension;
+
+        constexpr int32_t vecBlock    = 8;
+        constexpr int32_t elemPerLoad = 32;
+
+        const int32_t simdDim = (dim / elemPerLoad) * elemPerLoad;
+        const int32_t tailDim = dim - simdDim;
+
+        // ---- Pre-convert query FP32 -> FP16 (once per call) ----
+        auto& tmpBuf = srchContext->tmpBuffer;
+        const size_t queryFP16Bytes = static_cast<size_t>(dim) * sizeof(_Float16);
+        if (tmpBuf.size() < queryFP16Bytes) {
+            tmpBuf.resize(queryFP16Bytes);
+        }
+        _Float16* queryFP16 = reinterpret_cast<_Float16*>(tmpBuf.data());
+
+        int32_t qi = 0;
+        for (; qi + 16 <= dim; qi += 16) {
+            __m256i converted = _mm512_cvtps_ph(
+                _mm512_loadu_ps(queryPtr + qi),
+                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(queryFP16 + qi), converted);
+        }
+        for (; qi < dim; ++qi) {
+            queryFP16[qi] = static_cast<_Float16>(queryPtr[qi]);
+        }
+
+        // L2-targeted prefetch distance: 8 chunks ahead.
+        // At 64 bytes per chunk per vector and ~40 cycles/iter, this is
+        // ~320 cycles of lookahead — enough to hide DRAM round-trip.
+        // The old 1-chunk-ahead prefetcht0 was far too short for DRAM and
+        // consumed L1D fill buffers (12 entries), causing 39% fb_full stalls.
+        // prefetcht1 routes through the superqueue (48 entries) instead.
+        constexpr int32_t kPrefetchAheadElems = 8 * elemPerLoad;
+
+        // For next-batch prefetch: compute vector addresses inline to
+        // warm TLB and seed HW prefetcher during current batch computation.
+        const auto* mmapBase = (srchContext->mmapPages.size() == 1)
+            ? reinterpret_cast<const uint8_t*>(srchContext->mmapPages[0])
+            : nullptr;
+        const int64_t vecByteStride = srchContext->oneVectorByteSize;
+
+        __m512h sum[vecBlock];
+
+        for (; processedCount <= numVectors - vecBlock; processedCount += vecBlock) {
+            const uint8_t* vectors[vecBlock];
+            srchContext->getVectorPointersInBulk((uint8_t**)vectors, &internalVectorIds[processedCount], vecBlock);
+
+            // Warm first 3 cache lines of each vector into L1/L2.
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                __builtin_prefetch(vectors[v], 0, 3);
+                __builtin_prefetch(vectors[v] + 64, 0, 2);
+                __builtin_prefetch(vectors[v] + 128, 0, 2);
+            }
+
+            // Pipeline: prefetch NEXT batch's first cache lines to overlap
+            // TLB page walks (~140 cycles each) and DRAM fetches with current
+            // batch computation (~2000+ cycles at dim=768).
+            const int32_t nextStart = processedCount + vecBlock;
+            if (mmapBase && nextStart <= numVectors - vecBlock) {
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    const auto* p = mmapBase + vecByteStride * internalVectorIds[nextStart + v];
+                    __builtin_prefetch(p, 0, 2);
+                    __builtin_prefetch(p + 64, 0, 2);
+                    __builtin_prefetch(p + 128, 0, 2);
+                }
+            }
+
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                sum[v] = _mm512_setzero_ph();
+            }
+
+            // Hot loop with L2-targeted prefetch 8 chunks ahead.
+            // The conditional guard mispredicts only once (at the transition
+            // ~8 iters from the end) — ~15 cycles total, negligible vs the
+            // ~39% fb_full elimination from switching prefetcht0 → prefetcht1.
+            int32_t i = 0;
+            for (; i < simdDim; i += elemPerLoad) {
+                __m512h q0 = _mm512_loadu_ph(queryFP16 + i);
+
+                __m512h vRegs[vecBlock];
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    vRegs[v] = _mm512_loadu_ph(vectors[v] + 2 * i);
+                }
+
+                if ((i + kPrefetchAheadElems) < dim) {
+                    const int32_t prefOffset = (i + kPrefetchAheadElems) * 2;
+                    #pragma unroll
+                    for (int32_t v = 0; v < vecBlock; ++v) {
+                        __builtin_prefetch(vectors[v] + prefOffset, 0, 2);
+                    }
+                }
+
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    sum[v] = _mm512_fmadd_ph(q0, vRegs[v], sum[v]);
+                }
+            }
+
+            if (tailDim > 0) {
+                const __mmask32 tailMask = (__mmask32)((1ULL << tailDim) - 1);
+                __m512h q0 = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, queryFP16 + simdDim));
+
+                __m512h vRegs[vecBlock];
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    vRegs[v] = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, vectors[v] + 2 * simdDim));
+                }
+
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    sum[v] = _mm512_fmadd_ph(q0, vRegs[v], sum[v]);
+                }
+            }
+
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                __m512 acc_ps = _mm512_setzero_ps();
+                drain_ph_to_ps(acc_ps, sum[v]);
+                scores[processedCount + v] = _mm512_reduce_add_ps(acc_ps);
+            }
+        }
+
+        // Scalar tail with one-vector-ahead prefetch pipeline
+        {
+            constexpr int32_t unrollFactor = 4;
+
+            for (; processedCount < numVectors; ++processedCount) {
+                const auto* vecPtr = (const uint8_t*) srchContext->getVectorPointer(internalVectorIds[processedCount]);
+
+                if (processedCount + 1 < numVectors) {
+                    const auto* nextPtr = (const uint8_t*) srchContext->getVectorPointer(internalVectorIds[processedCount + 1]);
+                    __builtin_prefetch(nextPtr, 0, 3);
+                    __builtin_prefetch(nextPtr + 64, 0, 2);
+                }
+
+                __m512h s[unrollFactor];
+                #pragma unroll
+                for (int32_t u = 0; u < unrollFactor; ++u) {
+                    s[u] = _mm512_setzero_ph();
+                }
+
+                const int32_t unrolledDim = simdDim & ~(unrollFactor * elemPerLoad - 1);
+                int32_t i = 0;
+
+                for (; i < unrolledDim; i += unrollFactor * elemPerLoad) {
+                    #pragma unroll
+                    for (int32_t u = 0; u < unrollFactor; ++u) {
+                        __m512h q = _mm512_loadu_ph(queryFP16 + i + u * elemPerLoad);
+                        __m512h v = _mm512_loadu_ph(vecPtr + 2 * (i + u * elemPerLoad));
+                        s[u] = _mm512_fmadd_ph(q, v, s[u]);
+                    }
+                }
+
+                for (; i < simdDim; i += elemPerLoad) {
+                    __m512h q = _mm512_loadu_ph(queryFP16 + i);
+                    __m512h v = _mm512_loadu_ph(vecPtr + 2 * i);
+                    s[0] = _mm512_fmadd_ph(q, v, s[0]);
+                }
+
+                if (tailDim > 0) {
+                    const __mmask32 tailMask = (__mmask32)((1ULL << tailDim) - 1);
+                    __m512h q = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, queryFP16 + simdDim));
+                    __m512h v = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, vecPtr + 2 * simdDim));
+                    s[0] = _mm512_fmadd_ph(q, v, s[0]);
+                }
+
+                __m512 acc_ps = _mm512_setzero_ps();
+                #pragma unroll
+                for (int32_t u = 0; u < unrollFactor; ++u) {
+                    drain_ph_to_ps(acc_ps, s[u]);
+                }
+                scores[processedCount] = _mm512_reduce_add_ps(acc_ps);
+            }
+        }
+
+        BulkScoreTransformFunc(scores, numVectors);
+    }
+};
+#endif // __AVX512FP16__
 
 //
 // SQ (ADC: 4-bit query x 1-bit data) - AVX512 SIMD implementation
@@ -460,7 +704,7 @@ static FORCE_INLINE void avx512_4bitDotProductBatch(
     }
 }
 
-template <bool IsMaxIP>
+template <SQMetricMode Mode>
 struct AVX512SQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
@@ -502,7 +746,7 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
@@ -528,7 +772,7 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] =
@@ -551,7 +795,7 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                                    + ax * ly * y1
                                    + lx * ly * qcDist;
 
-            if constexpr (IsMaxIP) {
+            if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                 scores[processedCount] += queryAdditional + additional - centroidDp;
             } else {
                 scores[processedCount] =
@@ -559,8 +803,10 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
             }
         }
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP) {
             FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else if constexpr (Mode == SQMetricMode::COSINE) {
+            FaissScoreToLuceneScoreTransform::cosineTransformBulk(scores, numVectors);
         } else {
             FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
         }
@@ -591,9 +837,13 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                       + ax * ly * y1
                       + lx * ly * qcDist;
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
             score += queryAdditional + additional - centroidDp;
-            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            if constexpr (Mode == SQMetricMode::MAX_IP) {
+                return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            } else {
+                return FaissScoreToLuceneScoreTransform::cosineTransform(score);
+            }
         } else {
             score = std::max(0.0F, queryAdditional + additional - 2 * score);
             return FaissScoreToLuceneScoreTransform::l2Transform(score);
@@ -609,14 +859,23 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
 AVX512SPRFP16MaxIP<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 AVX512SPRFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> FP16_L2_SIMIL_FUNC;
+// 3. Cosine: Uses native AVX512-FP16 IP kernel when available (SPR+), otherwise falls back to FP32 FMA path.
+//    Safe because cosine guarantees L2-normalized vectors (||v|| = ||q|| = 1), bounding dot product to [-1, 1].
+#ifdef __AVX512FP16__
+AVX512NativeFP16IP<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
+#else
+AVX512SPRFP16MaxIP<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
+#endif
 
 //
 // SQ
 //
 // 1. Max IP
-AVX512SQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+AVX512SQSimilarityFunction<SQMetricMode::MAX_IP> SQ_IP_SIMIL_FUNC;
 // 2. L2
-AVX512SQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+AVX512SQSimilarityFunction<SQMetricMode::L2> SQ_L2_SIMIL_FUNC;
+// 3. Cosine
+AVX512SQSimilarityFunction<SQMetricMode::COSINE> SQ_COSINE_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
@@ -628,6 +887,10 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {
         return &SQ_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_COSINE) {
+        return &SQ_COSINE_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &FP16_COSINE_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/avx512_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/avx512_simd_similarity_function.cpp
@@ -15,7 +15,6 @@
 #include "faiss_score_to_lucene_transform.cpp"
 
 
-
 //
 // FP16
 //
@@ -199,6 +198,250 @@ struct AVX512SPRFP16L2 final : BaseSimilarityFunction<BulkScoreTransformFunc, Sc
         BulkScoreTransformFunc(scores, numVectors);
     }
 };
+
+#ifdef __AVX512FP16__
+
+// Drain FP16 accumulator into FP32 accumulator, then zero the FP16 accumulator.
+// Splits the 32 FP16 lanes into two halves of 16, widens each to FP32, and adds
+// to the FP32 accumulator.
+static inline void drain_ph_to_ps(__m512& acc_ps, __m512h& acc_ph) {
+    __m512i raw = _mm512_castph_si512(acc_ph);
+    acc_ps = _mm512_add_ps(acc_ps,
+                _mm512_cvtph_ps(_mm512_castsi512_si256(raw)));
+    acc_ps = _mm512_add_ps(acc_ps,
+                _mm512_cvtph_ps(_mm512_extracti64x4_epi64(raw, 1)));
+    acc_ph = _mm512_castsi512_ph(_mm512_setzero_si512());
+}
+
+// Convert 32 floats to a packed 512-bit float16 register (2x16 FP32 -> 1x32 FP16).
+static inline __m512h cvt2x16_fp32_to_ph(const float* p) {
+    __m256i lo = _mm512_cvtps_ph(_mm512_loadu_ps(p),
+                    _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    __m256i hi = _mm512_cvtps_ph(_mm512_loadu_ps(p + 16),
+                    _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    return _mm512_castsi512_ph(
+        _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1));
+}
+
+//
+// Native AVX512-FP16 Inner Product, cosine path only.
+//
+// PRECONDITION: query and data vectors are L2-normalized. This is the cosine
+// invariant. Running partial sums stay in [-1, +1] throughout, where FP16 ULP
+// is ~5e-4. Cumulative rounding error over dim=768 is ~sqrt(N)*ulp ~= 2e-3
+// expected, ~6e-3 worst-case — well below cosine ranking noise. Therefore we
+// accumulate entirely in FP16 and drain to FP32 only once per vector at the
+// end, before horizontal reduce.
+//
+// DO NOT route any unnormalized similarity through this kernel. Without the
+// L2-normalization guarantee, partial sums can grow into binades with much
+// larger ULP and per-FMA rounding error explodes.
+//
+
+template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
+struct AVX512NativeFP16IP final : BaseSimilarityFunction<BulkScoreTransformFunc, ScoreTransformFunc> {
+    void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
+                                   int32_t* internalVectorIds,
+                                   float* scores,
+                                   const int32_t numVectors) {
+
+        int32_t processedCount = 0;
+        const auto* queryPtr = (const float*) srchContext->queryVectorSimdAligned;
+        const int32_t dim = srchContext->dimension;
+
+        constexpr int32_t vecBlock    = 8;
+        constexpr int32_t elemPerLoad = 32;
+
+        const int32_t simdDim = (dim / elemPerLoad) * elemPerLoad;
+        const int32_t tailDim = dim - simdDim;
+
+        // ---- Pre-convert query FP32 -> FP16 (once per call) ----
+        // Use a dedicated buffer, NOT srchContext->tmpBuffer: getVectorPointer() reassembles
+        // vectors that straddle two mmap regions into tmpBuffer and may reallocate it mid-scan,
+        // which would dangle this query pointer and produce NaN scores.
+        auto& queryBuf = srchContext->queryFP16Buffer;
+        const size_t queryFP16Bytes = static_cast<size_t>(dim) * sizeof(_Float16);
+        if (queryBuf.size() < queryFP16Bytes) {
+            queryBuf.resize(queryFP16Bytes);
+        }
+        _Float16* queryFP16 = reinterpret_cast<_Float16*>(queryBuf.data());
+
+        int32_t qi = 0;
+        for (; qi + 16 <= dim; qi += 16) {
+            __m256i converted = _mm512_cvtps_ph(
+                _mm512_loadu_ps(queryPtr + qi),
+                _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(queryFP16 + qi), converted);
+        }
+        for (; qi < dim; ++qi) {
+            queryFP16[qi] = static_cast<_Float16>(queryPtr[qi]);
+        }
+
+        // L2-targeted prefetch distance: 8 chunks ahead.
+        // At 64 bytes per chunk per vector and ~40 cycles/iter, this is
+        // ~320 cycles of lookahead — enough to hide DRAM round-trip.
+        // The old 1-chunk-ahead prefetcht0 was far too short for DRAM and
+        // consumed L1D fill buffers (12 entries), causing 39% fb_full stalls.
+        // prefetcht1 routes through the superqueue (48 entries) instead.
+        constexpr int32_t kPrefetchAheadElems = 8 * elemPerLoad;
+
+        // For next-batch prefetch: compute vector addresses inline to
+        // warm TLB and seed HW prefetcher during current batch computation.
+        const auto* mmapBase = (srchContext->mmapPages.size() == 1)
+            ? reinterpret_cast<const uint8_t*>(srchContext->mmapPages[0])
+            : nullptr;
+        const int64_t vecByteStride = srchContext->oneVectorByteSize;
+
+        __m512h sum[vecBlock];
+
+        for (; processedCount <= numVectors - vecBlock; processedCount += vecBlock) {
+            const uint8_t* vectors[vecBlock];
+            srchContext->getVectorPointersInBulk((uint8_t**)vectors, &internalVectorIds[processedCount], vecBlock);
+
+            // Warm first 3 cache lines of each vector into L1/L2.
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                __builtin_prefetch(vectors[v], 0, 3);
+                __builtin_prefetch(vectors[v] + 64, 0, 2);
+                __builtin_prefetch(vectors[v] + 128, 0, 2);
+            }
+
+            // Pipeline: prefetch NEXT batch's first cache lines to overlap
+            // TLB page walks (~140 cycles each) and DRAM fetches with current
+            // batch computation (~2000+ cycles at dim=768).
+            const int32_t nextStart = processedCount + vecBlock;
+            if (mmapBase && nextStart <= numVectors - vecBlock) {
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    const auto* p = mmapBase + vecByteStride * internalVectorIds[nextStart + v];
+                    __builtin_prefetch(p, 0, 2);
+                    __builtin_prefetch(p + 64, 0, 2);
+                    __builtin_prefetch(p + 128, 0, 2);
+                }
+            }
+
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                sum[v] = _mm512_setzero_ph();
+            }
+
+            // Hot loop with L2-targeted prefetch 8 chunks ahead.
+            // The conditional guard mispredicts only once (at the transition
+            // ~8 iters from the end) — ~15 cycles total, negligible vs the
+            // ~39% fb_full elimination from switching prefetcht0 → prefetcht1.
+            int32_t i = 0;
+            for (; i < simdDim; i += elemPerLoad) {
+                __m512h q0 = _mm512_loadu_ph(queryFP16 + i);
+
+                __m512h vRegs[vecBlock];
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    vRegs[v] = _mm512_loadu_ph(vectors[v] + 2 * i);
+                }
+
+                if ((i + kPrefetchAheadElems) < dim) {
+                    const int32_t prefOffset = (i + kPrefetchAheadElems) * 2;
+                    #pragma unroll
+                    for (int32_t v = 0; v < vecBlock; ++v) {
+                        __builtin_prefetch(vectors[v] + prefOffset, 0, 2);
+                    }
+                }
+
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    sum[v] = _mm512_fmadd_ph(q0, vRegs[v], sum[v]);
+                }
+            }
+
+            if (tailDim > 0) {
+                const __mmask32 tailMask = (__mmask32)((1ULL << tailDim) - 1);
+                __m512h q0 = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, queryFP16 + simdDim));
+
+                __m512h vRegs[vecBlock];
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    vRegs[v] = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, vectors[v] + 2 * simdDim));
+                }
+
+                #pragma unroll
+                for (int32_t v = 0; v < vecBlock; ++v) {
+                    sum[v] = _mm512_fmadd_ph(q0, vRegs[v], sum[v]);
+                }
+            }
+
+            #pragma unroll
+            for (int32_t v = 0; v < vecBlock; ++v) {
+                __m512 acc_ps = _mm512_setzero_ps();
+                drain_ph_to_ps(acc_ps, sum[v]);
+                scores[processedCount + v] = _mm512_reduce_add_ps(acc_ps);
+            }
+        }
+
+        // Scalar tail with one-vector-ahead prefetch pipeline
+        {
+            constexpr int32_t unrollFactor = 4;
+
+            for (; processedCount < numVectors; ++processedCount) {
+                const auto* vecPtr = (const uint8_t*) srchContext->getVectorPointer(internalVectorIds[processedCount]);
+
+                // Prefetch the next vector via a computed mmap address rather than getVectorPointer().
+                // In the multi-region layout getVectorPointer() may reassemble a straddling vector into
+                // srchContext->tmpBuffer and resize it, which can reallocate the buffer and invalidate
+                // vecPtr obtained just above. mmapBase is non-null only for the single-region layout, where
+                // getVectorPointer() returns exactly mmapBase + vecByteStride * id and never touches
+                // tmpBuffer, so this computed address is identical and safe. Multi-region simply skips the
+                // next-vector prefetch.
+                if (mmapBase && processedCount + 1 < numVectors) {
+                    const auto* nextPtr = mmapBase + vecByteStride * internalVectorIds[processedCount + 1];
+                    __builtin_prefetch(nextPtr, 0, 3);
+                    __builtin_prefetch(nextPtr + 64, 0, 2);
+                }
+
+                __m512h s[unrollFactor];
+                #pragma unroll
+                for (int32_t u = 0; u < unrollFactor; ++u) {
+                    s[u] = _mm512_setzero_ph();
+                }
+
+                const int32_t unrolledDim = simdDim & ~(unrollFactor * elemPerLoad - 1);
+                int32_t i = 0;
+
+                for (; i < unrolledDim; i += unrollFactor * elemPerLoad) {
+                    #pragma unroll
+                    for (int32_t u = 0; u < unrollFactor; ++u) {
+                        __m512h q = _mm512_loadu_ph(queryFP16 + i + u * elemPerLoad);
+                        __m512h v = _mm512_loadu_ph(vecPtr + 2 * (i + u * elemPerLoad));
+                        s[u] = _mm512_fmadd_ph(q, v, s[u]);
+                    }
+                }
+
+                for (; i < simdDim; i += elemPerLoad) {
+                    __m512h q = _mm512_loadu_ph(queryFP16 + i);
+                    __m512h v = _mm512_loadu_ph(vecPtr + 2 * i);
+                    s[0] = _mm512_fmadd_ph(q, v, s[0]);
+                }
+
+                if (tailDim > 0) {
+                    const __mmask32 tailMask = (__mmask32)((1ULL << tailDim) - 1);
+                    __m512h q = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, queryFP16 + simdDim));
+                    __m512h v = _mm512_castsi512_ph(_mm512_maskz_loadu_epi16(tailMask, vecPtr + 2 * simdDim));
+                    s[0] = _mm512_fmadd_ph(q, v, s[0]);
+                }
+
+                __m512 acc_ps = _mm512_setzero_ps();
+                #pragma unroll
+                for (int32_t u = 0; u < unrollFactor; ++u) {
+                    drain_ph_to_ps(acc_ps, s[u]);
+                }
+                scores[processedCount] = _mm512_reduce_add_ps(acc_ps);
+            }
+        }
+
+        BulkScoreTransformFunc(scores, numVectors);
+    }
+};
+#endif // __AVX512FP16__
+
 
 //
 // SQ (ADC: 4-bit query x 1-bit data) - AVX512 SIMD implementation
@@ -397,7 +640,7 @@ static FORCE_INLINE void avx512_4bitDotProductBatch(
     }
 }
 
-template <bool IsMaxIP>
+template <SQMetricMode Mode>
 struct AVX512SQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
@@ -439,7 +682,7 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
@@ -465,7 +708,7 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] =
@@ -488,7 +731,7 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                                    + ax * ly * y1
                                    + lx * ly * qcDist;
 
-            if constexpr (IsMaxIP) {
+            if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                 scores[processedCount] += queryAdditional + additional - centroidDp;
             } else {
                 scores[processedCount] =
@@ -496,8 +739,10 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
             }
         }
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP) {
             FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else if constexpr (Mode == SQMetricMode::COSINE) {
+            FaissScoreToLuceneScoreTransform::cosineTransformBulk(scores, numVectors);
         } else {
             FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
         }
@@ -528,9 +773,13 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
                       + ax * ly * y1
                       + lx * ly * qcDist;
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
             score += queryAdditional + additional - centroidDp;
-            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            if constexpr (Mode == SQMetricMode::MAX_IP) {
+                return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            } else {
+                return FaissScoreToLuceneScoreTransform::cosineTransform(score);
+            }
         } else {
             score = std::max(0.0F, queryAdditional + additional - 2 * score);
             return FaissScoreToLuceneScoreTransform::l2Transform(score);
@@ -546,14 +795,23 @@ struct AVX512SQSimilarityFunction final : SimilarityFunction {
 AVX512SPRFP16MaxIP<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 AVX512SPRFP16L2<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> FP16_L2_SIMIL_FUNC;
+// 3. Cosine: Uses native AVX512-FP16 IP kernel when available (SPR+), otherwise falls back to FP32 FMA path.
+//    Safe because cosine guarantees L2-normalized vectors (||v|| = ||q|| = 1), bounding dot product to [-1, 1].
+#ifdef __AVX512FP16__
+AVX512NativeFP16IP<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
+#else
+AVX512SPRFP16MaxIP<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> FP16_COSINE_SIMIL_FUNC;
+#endif
 
 //
 // SQ
 //
 // 1. Max IP
-AVX512SQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+AVX512SQSimilarityFunction<SQMetricMode::MAX_IP> SQ_IP_SIMIL_FUNC;
 // 2. L2
-AVX512SQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+AVX512SQSimilarityFunction<SQMetricMode::L2> SQ_L2_SIMIL_FUNC;
+// 3. Cosine
+AVX512SQSimilarityFunction<SQMetricMode::COSINE> SQ_COSINE_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
@@ -565,6 +823,10 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {
         return &SQ_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_COSINE) {
+        return &SQ_COSINE_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &FP16_COSINE_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
@@ -44,6 +44,8 @@ struct DefaultFP16SimilarityFunction final : BaseSimilarityFunction<BulkScoreTra
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> DEFAULT_FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> DEFAULT_FP16_L2_SIMIL_FUNC;
+// 3. Cosine (same IP kernel, but with cosine score transform for L2-normalized vectors)
+DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> DEFAULT_FP16_COSINE_SIMIL_FUNC;
 
 
 //
@@ -156,7 +158,7 @@ static FORCE_INLINE void default4bitDotProductBatch(
     }
 }
 
-template <bool IsMaxIP>
+template <SQMetricMode Mode>
 struct DefaultSQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
@@ -194,7 +196,7 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
@@ -216,7 +218,7 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] =
@@ -239,7 +241,7 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                                    + ax * ly * y1
                                    + lx * ly * qcDist;
 
-            if constexpr (IsMaxIP) {
+            if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                 scores[processedCount] += queryAdditional + additional - centroidDp;
             } else {
                 scores[processedCount] =
@@ -247,8 +249,10 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
             }
         }
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP) {
             FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else if constexpr (Mode == SQMetricMode::COSINE) {
+            FaissScoreToLuceneScoreTransform::cosineTransformBulk(scores, numVectors);
         } else {
             FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
         }
@@ -279,9 +283,13 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                     + ax * ly * y1
                     + lx * ly * qcDist;
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
             score += queryAdditional + additional - centroidDp;
-            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            if constexpr (Mode == SQMetricMode::MAX_IP) {
+                return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            } else {
+                return FaissScoreToLuceneScoreTransform::cosineTransform(score);
+            }
         } else {
             score = std::max(0.0F, queryAdditional + additional - 2 * score);
             return FaissScoreToLuceneScoreTransform::l2Transform(score);
@@ -293,9 +301,11 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
 // SQ
 //
 // 1. Max IP
-DefaultSQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+DefaultSQSimilarityFunction<SQMetricMode::MAX_IP> SQ_IP_SIMIL_FUNC;
 // 2. L2
-DefaultSQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+DefaultSQSimilarityFunction<SQMetricMode::L2> SQ_L2_SIMIL_FUNC;
+// 3. Cosine
+DefaultSQSimilarityFunction<SQMetricMode::COSINE> SQ_COSINE_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
@@ -307,6 +317,10 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {
         return &SQ_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_COSINE) {
+        return &SQ_COSINE_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &DEFAULT_FP16_COSINE_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
+++ b/jni/src/simd/similarity_function/default_simd_similarity_function.cpp
@@ -49,6 +49,8 @@ struct DefaultFP16SimilarityFunction final : BaseSimilarityFunction<BulkScoreTra
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk, FaissScoreToLuceneScoreTransform::ipToMaxIpTransform> DEFAULT_FP16_MAX_INNER_PRODUCT_SIMIL_FUNC;
 // 2. L2
 DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::l2TransformBulk, FaissScoreToLuceneScoreTransform::l2Transform> DEFAULT_FP16_L2_SIMIL_FUNC;
+// 3. Cosine (same IP kernel, but with cosine score transform for L2-normalized vectors)
+DefaultFP16SimilarityFunction<FaissScoreToLuceneScoreTransform::cosineTransformBulk, FaissScoreToLuceneScoreTransform::cosineTransform> DEFAULT_FP16_COSINE_SIMIL_FUNC;
 
 
 //
@@ -161,7 +163,7 @@ static FORCE_INLINE void default4bitDotProductBatch(
     }
 }
 
-template <bool IsMaxIP>
+template <SQMetricMode Mode>
 struct DefaultSQSimilarityFunction final : SimilarityFunction {
     HOT_SPOT void calculateSimilarityInBulk(SimdVectorSearchContext* srchContext,
                                             int32_t* internalVectorIds,
@@ -199,7 +201,7 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] = std::max(0.0F, queryAdditional + additional - 2 * scores[processedCount + i]);
@@ -221,7 +223,7 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                                            + ax * ly * y1
                                            + lx * ly * scores[processedCount + i];
 
-                if constexpr (IsMaxIP) {
+                if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                     scores[processedCount + i] += queryAdditional + additional - centroidDp;
                 } else {
                     scores[processedCount + i] =
@@ -244,7 +246,7 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                                    + ax * ly * y1
                                    + lx * ly * qcDist;
 
-            if constexpr (IsMaxIP) {
+            if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
                 scores[processedCount] += queryAdditional + additional - centroidDp;
             } else {
                 scores[processedCount] =
@@ -252,8 +254,10 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
             }
         }
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP) {
             FaissScoreToLuceneScoreTransform::ipToMaxIpTransformBulk(scores, numVectors);
+        } else if constexpr (Mode == SQMetricMode::COSINE) {
+            FaissScoreToLuceneScoreTransform::cosineTransformBulk(scores, numVectors);
         } else {
             FaissScoreToLuceneScoreTransform::l2TransformBulk(scores, numVectors);
         }
@@ -284,9 +288,13 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
                     + ax * ly * y1
                     + lx * ly * qcDist;
 
-        if constexpr (IsMaxIP) {
+        if constexpr (Mode == SQMetricMode::MAX_IP || Mode == SQMetricMode::COSINE) {
             score += queryAdditional + additional - centroidDp;
-            return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            if constexpr (Mode == SQMetricMode::MAX_IP) {
+                return FaissScoreToLuceneScoreTransform::ipToMaxIpTransform(score);
+            } else {
+                return FaissScoreToLuceneScoreTransform::cosineTransform(score);
+            }
         } else {
             score = std::max(0.0F, queryAdditional + additional - 2 * score);
             return FaissScoreToLuceneScoreTransform::l2Transform(score);
@@ -298,9 +306,11 @@ struct DefaultSQSimilarityFunction final : SimilarityFunction {
 // SQ
 //
 // 1. Max IP
-DefaultSQSimilarityFunction<true> SQ_IP_SIMIL_FUNC;
+DefaultSQSimilarityFunction<SQMetricMode::MAX_IP> SQ_IP_SIMIL_FUNC;
 // 2. L2
-DefaultSQSimilarityFunction<false> SQ_L2_SIMIL_FUNC;
+DefaultSQSimilarityFunction<SQMetricMode::L2> SQ_L2_SIMIL_FUNC;
+// 3. Cosine
+DefaultSQSimilarityFunction<SQMetricMode::COSINE> SQ_COSINE_SIMIL_FUNC;
 
 #ifndef __NO_SELECT_FUNCTION
 SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSimilarityFunctionType nativeFunctionType) {
@@ -312,6 +322,10 @@ SimilarityFunction* SimilarityFunction::selectSimilarityFunction(const NativeSim
         return &SQ_IP_SIMIL_FUNC;
     } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_L2) {
         return &SQ_L2_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::SQ_COSINE) {
+        return &SQ_COSINE_SIMIL_FUNC;
+    } else if (nativeFunctionType == NativeSimilarityFunctionType::FP16_COSINE) {
+        return &DEFAULT_FP16_COSINE_SIMIL_FUNC;
     }
 
     throw std::runtime_error("Invalid native similarity function type was given, nativeFunctionType="

--- a/jni/src/simd/similarity_function/faiss_score_to_lucene_transform.cpp
+++ b/jni/src/simd/similarity_function/faiss_score_to_lucene_transform.cpp
@@ -71,6 +71,42 @@ struct FaissScoreToLuceneScoreTransform final {
         }
     }
 
+    // Convert inner product value to cosine score for L2-normalized vectors.
+    // Theoretically dot product is in [-1, 1], but SQ quantization noise can push it slightly
+    // outside this range, so we clamp the output to [0, 1] to match Lucene's behavior.
+    static float cosineTransform(const float dotProduct) noexcept {
+        const float raw = (1.0f + dotProduct) * 0.5f;
+        return raw < 0.0f ? 0.0f : (raw > 1.0f ? 1.0f : raw);
+    }
+
+    // Bulk version of cosineTransform.
+    static void cosineTransformBulk(float* scores, const int32_t numScores) noexcept {
+        int32_t i = 0;
+        for (; (i + 8) <= numScores ; i += 8, scores += 8) {
+            scores[0] = cosineTransform(scores[0]);
+            scores[1] = cosineTransform(scores[1]);
+            scores[2] = cosineTransform(scores[2]);
+            scores[3] = cosineTransform(scores[3]);
+            scores[4] = cosineTransform(scores[4]);
+            scores[5] = cosineTransform(scores[5]);
+            scores[6] = cosineTransform(scores[6]);
+            scores[7] = cosineTransform(scores[7]);
+        }
+
+        for (; (i + 4) <= numScores ; i += 4, scores += 4) {
+            scores[0] = cosineTransform(scores[0]);
+            scores[1] = cosineTransform(scores[1]);
+            scores[2] = cosineTransform(scores[2]);
+            scores[3] = cosineTransform(scores[3]);
+        }
+
+        while (i < numScores) {
+            *scores = cosineTransform(*scores);
+            ++i;
+            ++scores;
+        }
+    }
+
 private:
     FaissScoreToLuceneScoreTransform() = delete;
 };

--- a/jni/src/simd/similarity_function/faiss_score_to_lucene_transform.cpp
+++ b/jni/src/simd/similarity_function/faiss_score_to_lucene_transform.cpp
@@ -76,6 +76,42 @@ struct FaissScoreToLuceneScoreTransform final {
         }
     }
 
+    // Convert inner product value to cosine score for L2-normalized vectors.
+    // Theoretically dot product is in [-1, 1], but SQ quantization noise can push it slightly
+    // outside this range, so we clamp the output to [0, 1] to match Lucene's behavior.
+    static float cosineTransform(const float dotProduct) noexcept {
+        const float raw = (1.0f + dotProduct) * 0.5f;
+        return raw < 0.0f ? 0.0f : (raw > 1.0f ? 1.0f : raw);
+    }
+
+    // Bulk version of cosineTransform.
+    static void cosineTransformBulk(float* scores, const int32_t numScores) noexcept {
+        int32_t i = 0;
+        for (; (i + 8) <= numScores ; i += 8, scores += 8) {
+            scores[0] = cosineTransform(scores[0]);
+            scores[1] = cosineTransform(scores[1]);
+            scores[2] = cosineTransform(scores[2]);
+            scores[3] = cosineTransform(scores[3]);
+            scores[4] = cosineTransform(scores[4]);
+            scores[5] = cosineTransform(scores[5]);
+            scores[6] = cosineTransform(scores[6]);
+            scores[7] = cosineTransform(scores[7]);
+        }
+
+        for (; (i + 4) <= numScores ; i += 4, scores += 4) {
+            scores[0] = cosineTransform(scores[0]);
+            scores[1] = cosineTransform(scores[1]);
+            scores[2] = cosineTransform(scores[2]);
+            scores[3] = cosineTransform(scores[3]);
+        }
+
+        while (i < numScores) {
+            *scores = cosineTransform(*scores);
+            ++i;
+            ++scores;
+        }
+    }
+
 private:
     FaissScoreToLuceneScoreTransform() = delete;
 };

--- a/jni/src/simd/similarity_function/simd_similarity_function_common.cpp
+++ b/jni/src/simd/similarity_function/simd_similarity_function_common.cpp
@@ -234,8 +234,34 @@ SimdVectorSearchContext* SimilarityFunction::saveSearchContext(
         // Assign query to Faiss function
         THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction->set_query(
             reinterpret_cast<float*>(THREAD_LOCAL_SIMD_VEC_SRCH_CTX.queryVectorSimdAligned));
+    } else if (nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::FP16_COSINE)) {
+        // FP16_COSINE shares the on-disk FP16 layout with FP16_MAX_INNER_PRODUCT. Vectors are
+        // L2-normalized at index time, so cosine equals the inner product, and the kernel emits
+        // a (1 + dot) / 2 Lucene score directly via cosineTransform. On platforms with native
+        // AVX-512-FP16 support FP16_COSINE binds to AVX512NativeFP16IP (true FP16 FMA, 32
+        // elements per 512-bit register); elsewhere it falls back to the FP32-converted IP
+        // kernel used by FP16_MAX_INNER_PRODUCT. The single-vector calculateSimilarity path
+        // goes through BaseSimilarityFunction, which calls the Faiss IP distance computer
+        // below and applies cosineTransform on top of the raw IP result.
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.similarityFunction = selectSimilarityFunction(
+            NativeSimilarityFunctionType::FP16_COSINE);
+
+        // FP16 vector bytes = 2 bytes * dimension
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.oneVectorByteSize = 2 * dimension;
+
+        // Faiss FP16 IP distance computer for the single-vector path; cosineTransform is
+        // applied on top of the raw IP result by BaseSimilarityFunction.
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction.reset(
+            faiss::ScalarQuantizer {static_cast<size_t>(dimension), faiss::ScalarQuantizer::QuantizerType::QT_fp16}
+                                   .get_distance_computer(faiss::MetricType::METRIC_INNER_PRODUCT));
+
+        // Assign query to Faiss function
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction->set_query(
+            reinterpret_cast<float*>(THREAD_LOCAL_SIMD_VEC_SRCH_CTX.queryVectorSimdAligned));
     } else if (nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_IP)
-               || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_L2)) {
+               || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_L2)
+               || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_COSINE)) {
+         // SQ_COSINE shares on-disk layout and IP math with SQ_IP; only the score-transform kernel differs.
          // Set similarity function to offload similarity calculation
          THREAD_LOCAL_SIMD_VEC_SRCH_CTX.similarityFunction =
              selectSimilarityFunction(static_cast<NativeSimilarityFunctionType>(nativeFunctionTypeOrd));
@@ -286,6 +312,14 @@ SimdVectorSearchContext* SimilarityFunction::getSearchContext() {
 //
 using BulkScoreTransform = void (*)(float*/*scores*/, int32_t/*num scores to transform*/);
 using ScoreTransform = float (*)(float/*score*/);
+
+// Metric mode for SQ (Scalar Quantized) similarity functions.
+// Controls both intermediate score computation and final score transformation.
+enum class SQMetricMode {
+    MAX_IP,   // Inner product: score += correction; ipToMaxIpTransform
+    L2,       // L2 distance: score = max(0, correction - 2*score); l2Transform
+    COSINE    // Cosine (normalized IP): score += correction; cosineTransform
+};
 
 template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
 struct BaseSimilarityFunction : SimilarityFunction {

--- a/jni/src/simd/similarity_function/simd_similarity_function_common.cpp
+++ b/jni/src/simd/similarity_function/simd_similarity_function_common.cpp
@@ -61,6 +61,17 @@ void SimdVectorSearchContext::getVectorPointersInBulk(uint8_t* vectors[], int32_
 
     // There are multiple mapped regions.
     if (mmapPages.empty() == false) {
+        // A vector that straddles two mmap regions is reassembled by getVectorPointer() into
+        // tmpBuffer via tmpBuffer.resize(), which may reallocate the underlying storage. If two
+        // (or more) vectors in this same batch straddle, the second resize() would reallocate and
+        // dangle the pointer we already stored in vectors[] for the earlier straddling vector,
+        // making the kernel read freed/moved memory. Pre-reserve the worst-case headroom for the
+        // whole batch up front (every vector reassembled needs at most oneVectorByteSize bytes plus
+        // one padding byte for even-address alignment) so no resize() inside the loop can reallocate,
+        // keeping every pointer returned in this call stable. reserve() preserves existing contents,
+        // so the query-correction prefix some kernels keep at the front of tmpBuffer is untouched.
+        tmpBuffer.reserve(tmpBuffer.size() + static_cast<size_t>(numVectors) * (static_cast<size_t>(oneVectorByteSize) + 1));
+
         for (int32_t i = 0 ; i < numVectors ; ++i) {
             vectors[i] = getVectorPointer(internalVectorIds[i]);
         }
@@ -239,8 +250,34 @@ SimdVectorSearchContext* SimilarityFunction::saveSearchContext(
         // Assign query to Faiss function
         THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction->set_query(
             reinterpret_cast<float*>(THREAD_LOCAL_SIMD_VEC_SRCH_CTX.queryVectorSimdAligned));
+    } else if (nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::FP16_COSINE)) {
+        // FP16_COSINE shares the on-disk FP16 layout with FP16_MAX_INNER_PRODUCT. Vectors are
+        // L2-normalized at index time, so cosine equals the inner product, and the kernel emits
+        // a (1 + dot) / 2 Lucene score directly via cosineTransform. On platforms with native
+        // AVX-512-FP16 support FP16_COSINE binds to AVX512NativeFP16IP (true FP16 FMA, 32
+        // elements per 512-bit register); elsewhere it falls back to the FP32-converted IP
+        // kernel used by FP16_MAX_INNER_PRODUCT. The single-vector calculateSimilarity path
+        // goes through BaseSimilarityFunction, which calls the Faiss IP distance computer
+        // below and applies cosineTransform on top of the raw IP result.
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.similarityFunction = selectSimilarityFunction(
+            NativeSimilarityFunctionType::FP16_COSINE);
+
+        // FP16 vector bytes = 2 bytes * dimension
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.oneVectorByteSize = 2 * dimension;
+
+        // Faiss FP16 IP distance computer for the single-vector path; cosineTransform is
+        // applied on top of the raw IP result by BaseSimilarityFunction.
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction.reset(
+            faiss::ScalarQuantizer {static_cast<size_t>(dimension), faiss::ScalarQuantizer::QuantizerType::QT_fp16}
+                                   .get_distance_computer(faiss::MetricType::METRIC_INNER_PRODUCT));
+
+        // Assign query to Faiss function
+        THREAD_LOCAL_SIMD_VEC_SRCH_CTX.faissFunction->set_query(
+            reinterpret_cast<float*>(THREAD_LOCAL_SIMD_VEC_SRCH_CTX.queryVectorSimdAligned));
     } else if (nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_IP)
-               || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_L2)) {
+               || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_L2)
+               || nativeFunctionTypeOrd == static_cast<int32_t>(NativeSimilarityFunctionType::SQ_COSINE)) {
+         // SQ_COSINE shares on-disk layout and IP math with SQ_IP; only the score-transform kernel differs.
          // Set similarity function to offload similarity calculation
          THREAD_LOCAL_SIMD_VEC_SRCH_CTX.similarityFunction =
              selectSimilarityFunction(static_cast<NativeSimilarityFunctionType>(nativeFunctionTypeOrd));
@@ -291,6 +328,14 @@ SimdVectorSearchContext* SimilarityFunction::getSearchContext() {
 //
 using BulkScoreTransform = void (*)(float*/*scores*/, int32_t/*num scores to transform*/);
 using ScoreTransform = float (*)(float/*score*/);
+
+// Metric mode for SQ (Scalar Quantized) similarity functions.
+// Controls both intermediate score computation and final score transformation.
+enum class SQMetricMode {
+    MAX_IP,   // Inner product: score += correction; ipToMaxIpTransform
+    L2,       // L2 distance: score = max(0, correction - 2*score); l2Transform
+    COSINE    // Cosine (normalized IP): score += correction; cosineTransform
+};
 
 template <BulkScoreTransform BulkScoreTransformFunc, ScoreTransform ScoreTransformFunc>
 struct BaseSimilarityFunction : SimilarityFunction {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -243,10 +243,10 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
                 targetCorrectiveTerms.additionalCorrection(),
                 targetCorrectiveTerms.quantizedComponentSum(),
                 addressAndSize,
-                similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-                    || similarityFunction == VectorSimilarityFunction.COSINE
+                similarityFunction == VectorSimilarityFunction.COSINE ? SimdVectorComputeService.SimilarityFunctionType.SQ_COSINE.ordinal()
+                    : similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
                         ? SimdVectorComputeService.SimilarityFunctionType.SQ_IP.ordinal()
-                        : SimdVectorComputeService.SimilarityFunctionType.SQ_L2.ordinal(),
+                    : SimdVectorComputeService.SimilarityFunctionType.SQ_L2.ordinal(),
                 dimension,
                 centroidDp
             );

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
@@ -194,6 +195,14 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         // For cosine similarity, the query vector is expected to already be normalized.
         // Normalization is performed upfront in KNNQueryBuilder via VectorTransformerFactory
         // for Lucene cosine with SQ 1-bit and flat methods and for Faiss.
+        //
+        // The SQ_COSINE native kernel treats cosine as a plain inner product ((1 + dot) / 2),
+        // which is only correct when both the query and the stored vectors are L2-normalized.
+        // Guard the query-normalization half of that invariant here; a violation means the query
+        // reached this scorer without the expected upstream normalization (i.e. a misroute or a
+        // missing VectorTransformer), which would silently produce invalid cosine scores.
+        assert similarityFunction != VectorSimilarityFunction.COSINE || isNormalized(target)
+            : "SQ_COSINE requires an L2-normalized query; got squared norm " + VectorUtil.dotProduct(target, target);
 
         // Perform scalar quantization
         final OptimizedScalarQuantizer.QuantizationResult targetCorrectiveTerms = quantizer.scalarQuantize(
@@ -216,6 +225,17 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
             targetCopy.length,
             quantizedByteVectorValues.getCentroidDP()
         );
+    }
+
+    /**
+     * Returns whether {@code vector} is (approximately) L2-normalized, i.e. its squared magnitude
+     * is within a small tolerance of 1.0. Used only by assertions to catch un-normalized cosine
+     * queries; the tolerance is deliberately loose to absorb float rounding from upstream
+     * normalization and quantization.
+     */
+    private static boolean isNormalized(final float[] vector) {
+        final float squaredNorm = VectorUtil.dotProduct(vector, vector);
+        return Math.abs(squaredNorm - 1.0f) <= 1e-2f;
     }
 
     /**
@@ -262,10 +282,10 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
                 targetCorrectiveTerms.additionalCorrection(),
                 targetCorrectiveTerms.quantizedComponentSum(),
                 addressAndSize,
-                similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
-                    || similarityFunction == VectorSimilarityFunction.COSINE
+                similarityFunction == VectorSimilarityFunction.COSINE ? SimdVectorComputeService.SimilarityFunctionType.SQ_COSINE.ordinal()
+                    : similarityFunction == VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT
                         ? SimdVectorComputeService.SimilarityFunctionType.SQ_IP.ordinal()
-                        : SimdVectorComputeService.SimilarityFunctionType.SQ_L2.ordinal(),
+                    : SimdVectorComputeService.SimilarityFunctionType.SQ_L2.ordinal(),
                 dimension,
                 centroidDp
             );

--- a/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorer.java
@@ -41,7 +41,7 @@ public class NativeEngines990KnnVectorsScorer implements FlatVectorsScorer {
         if (nativeType != null) {
             final FloatVectorValues bottomValues = WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues);
             if (bottomValues instanceof MMapVectorValues mmapValues) {
-                return new NativeRandomVectorScorer(target, vectorValues, mmapValues, nativeType);
+                return NativeRandomVectorScorer.create(target, vectorValues, mmapValues, nativeType);
             }
         }
         return delegate.getRandomVectorScorer(similarityFunction, vectorValues, target);
@@ -70,6 +70,10 @@ public class NativeEngines990KnnVectorsScorer implements FlatVectorsScorer {
         return switch (similarityFunction) {
             case MAXIMUM_INNER_PRODUCT -> SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT;
             case EUCLIDEAN -> SimdVectorComputeService.SimilarityFunctionType.FP16_L2;
+            // COSINE binds to the FP16_COSINE kernel: on AVX-512-FP16-capable platforms this is the
+            // native AVX512NativeFP16IP kernel; elsewhere it falls back to the FP32-converted IP kernel.
+            // Either way the kernel emits a (1 + dot) / 2 Lucene score directly for L2-normalized vectors.
+            case COSINE -> SimdVectorComputeService.SimilarityFunctionType.FP16_COSINE;
             default -> null;
         };
     }

--- a/src/main/java/org/opensearch/knn/index/query/MemoryOptimizedSearchScoreConverter.java
+++ b/src/main/java/org/opensearch/knn/index/query/MemoryOptimizedSearchScoreConverter.java
@@ -43,20 +43,23 @@ public final class MemoryOptimizedSearchScoreConverter {
      * @return Converted value to be used during Lucene search algorithm.
      */
     public static float distanceToRadialThreshold(final float distance, final SpaceType spaceType) {
-        switch (spaceType) {
-            case INNER_PRODUCT:
-                // Faiss distance for IP is -dot. Negate to get raw dot product for Lucene.
-                return KNNEngine.LUCENE.distanceToRadialThreshold(-distance, spaceType);
-            case COSINESIMIL:
-                // For cosine similarity, `distance = 1 - inner_product_value`.
-                // therefore, we should extract it then convert it to max_inner_product_value
-                final float innerProductValue = KNNEngine.FAISS.distanceToRadialThreshold(distance, SpaceType.COSINESIMIL);
-
-                // Convert inner product value to max inner product value.
-                return SpaceType.INNER_PRODUCT.scoreTranslation(-innerProductValue);
-            default:
-                return KNNEngine.LUCENE.distanceToRadialThreshold(distance, spaceType);
+        if (spaceType == SpaceType.INNER_PRODUCT) {
+            // Faiss distance for IP is -dot. Negate to recover the raw dot product before Lucene's conversion.
+            return KNNEngine.LUCENE.distanceToRadialThreshold(-distance, spaceType);
         }
+        // The memory-optimized scorer emits Lucene-native scores for cosine and L2, including
+        // cosine (FP16_COSINE / SQ_COSINE apply the (1 + dot) / 2 transform in-kernel). Therefore the
+        // radial threshold is expressed in Lucene score space, so we can delegate to the Lucene engine
+        // directly. For COSINESIMIL this yields (2 - distance) / 2, matching the scorer output.
+        //
+        // The ADC (binary-quantized) path is the one exception: it scores a float query against 1-bit
+        // vectors and emits MaxIP-format scores that MemoryOptimizedKNNWeight post-converts to cosine.
+        // Those scores are NOT Lucene-native, so this converter would be wrong for them. That mismatch is
+        // unreachable, however, because ADC requires the BQ encoder and ResolvedIndexSpec#supportsRadialSearch()
+        // rejects radial search for BQ (and every quantized index) up front in KNNQueryBuilder. If radial
+        // search is ever enabled for BQ/ADC, this method (and scoreToRadialThreshold below) must convert the
+        // threshold from cosine to MaxIP space for the ADC case first.
+        return KNNEngine.LUCENE.distanceToRadialThreshold(distance, spaceType);
     }
 
     /**
@@ -67,16 +70,17 @@ public final class MemoryOptimizedSearchScoreConverter {
      * @return Converted radial threshold for Lucene
      */
     public static float scoreToRadialThreshold(final float score, final SpaceType spaceType) {
-        if (spaceType != SpaceType.COSINESIMIL) {
-            return KNNEngine.LUCENE.scoreToRadialThreshold(score, spaceType);
-        }
-
-        // Since `score = (2 - (1 - inner_product_value)) / 2 = (1 + inner_product_value) / 2`,
-        // we should extract it then convert it to max inner product value.
-        final float innerProductValue = KNNEngine.FAISS.scoreToRadialThreshold(score, SpaceType.COSINESIMIL);
-
-        // Convert inner product value to max inner product value.
-        return SpaceType.INNER_PRODUCT.scoreTranslation(-innerProductValue);
+        // The memory-optimized scorer emits Lucene-native scores for every space type reachable here,
+        // including cosine (FP16_COSINE / SQ_COSINE apply the (1 + dot) / 2 transform in-kernel). The
+        // user-supplied min_score is already in that same Lucene score space, so we can delegate to the
+        // Lucene engine uniformly, which returns the score unchanged.
+        //
+        // The ADC (binary-quantized) cosine path emits MaxIP-format scores (post-converted to cosine in
+        // MemoryOptimizedKNNWeight) rather than Lucene-native scores, so it would need the threshold
+        // converted from cosine to MaxIP space. It never reaches this method: ADC requires the BQ encoder,
+        // and ResolvedIndexSpec#supportsRadialSearch() rejects radial search for BQ up front. If that gate
+        // is ever relaxed for BQ/ADC, add the ADC threshold conversion here (see distanceToRadialThreshold).
+        return KNNEngine.LUCENE.scoreToRadialThreshold(score, spaceType);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -30,7 +30,6 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
-import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
 import org.opensearch.lucene.OptimisticKnnCollectorManager;
 import org.opensearch.lucene.ReentrantKnnCollectorManager;
 
@@ -216,9 +215,9 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
             log.debug("[KNN] Query yielded 0 results");
             return EMPTY_TOPDOCS;
         }
-        if (spaceType == SpaceType.COSINESIMIL) {
-            MemoryOptimizedSearchScoreConverter.convertToCosineScore(topDocs.scoreDocs);
-        }
+        // Cosine scores are now produced directly by the scorer via VectorSimilarityFunction.COSINE
+        // (FaissMemoryOptimizedSearcher overrides MAXIMUM_INNER_PRODUCT -> COSINE for cosinesimil fields),
+        // so the MaxIP -> cosine post-conversion is no longer needed.
         addExplainIfRequired(topDocs, knnEngine, spaceType);
         return topDocs;
     }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -106,7 +106,8 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                             filterIdsBitSet,
                             reader,
                             knnEngine,
-                            spaceType
+                            spaceType,
+                            false
                         );
                     }
 
@@ -130,12 +131,13 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                         filterIdsBitSet,
                         reader,
                         knnEngine,
-                        spaceType
+                        spaceType,
+                        false
                     );
                 }
 
                 if (adcTransformedVector != null) {
-                    // ADC case
+                    // ADC case: the scorer emits MaxIP-format scores, so cosine requires post-conversion.
                     return queryIndex(
                         adcTransformedVector,
                         cardinality,
@@ -144,7 +146,8 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                         filterIdsBitSet,
                         reader,
                         knnEngine,
-                        spaceType
+                        spaceType,
+                        true
                     );
                 }
 
@@ -157,11 +160,22 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                     filterIdsBitSet,
                     reader,
                     knnEngine,
-                    spaceType
+                    spaceType,
+                    false
                 );
             } else {
                 // Radius search
-                return queryIndex(knnQuery.getVector(), cardinality, cardinality, context, filterIdsBitSet, reader, knnEngine, spaceType);
+                return queryIndex(
+                    knnQuery.getVector(),
+                    cardinality,
+                    cardinality,
+                    context,
+                    filterIdsBitSet,
+                    reader,
+                    knnEngine,
+                    spaceType,
+                    false
+                );
             }
         } catch (Exception e) {
             GRAPH_QUERY_ERRORS.increment();
@@ -177,7 +191,8 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         final BitSet filterIdsBitSet,
         final SegmentReader reader,
         final KNNEngine knnEngine,
-        final SpaceType spaceType
+        final SpaceType spaceType,
+        final boolean isAdc
     ) throws IOException {
         assert (targetVector instanceof float[] || targetVector instanceof byte[]);
 
@@ -214,7 +229,12 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
             log.debug("[KNN] Query yielded 0 results");
             return EMPTY_TOPDOCS;
         }
-        if (spaceType == SpaceType.COSINESIMIL) {
+        // For the FP16 and SQ formats the scorer now emits cosine scores directly via
+        // VectorSimilarityFunction.COSINE (the FP16_COSINE / SQ_COSINE kernels apply the (1 + dot) / 2
+        // transform in-kernel), so no post-conversion is needed. The ADC (binary-quantized) path scores a
+        // float query against 1-bit vectors and still emits MaxIP-format scores, so it retains the
+        // MaxIP -> cosine post-conversion here.
+        if (isAdc && spaceType == SpaceType.COSINESIMIL) {
             MemoryOptimizedSearchScoreConverter.convertToCosineScore(topDocs.scoreDocs);
         }
         addExplainIfRequired(topDocs, knnEngine, spaceType);

--- a/src/main/java/org/opensearch/knn/jni/SimdVectorComputeService.java
+++ b/src/main/java/org/opensearch/knn/jni/SimdVectorComputeService.java
@@ -25,7 +25,11 @@ public class SimdVectorComputeService {
         // FP16 Maximum Inner Product. The result will be the same as we acquired from VectorSimilarityFunction.EUCLIDEAN.
         FP16_L2,
         SQ_IP,
-        SQ_L2
+        SQ_L2,
+        // FP16 Cosine. Vectors are guaranteed to be L2-normalized, so cosine = inner product with score = (1 + dot) / 2.
+        FP16_COSINE,
+        // SQ Cosine. Same IP math as SQ_IP but with cosine score transform.
+        SQ_COSINE
     }
 
     public static native void saveSQSearchContext(

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.common.RobustUniqueRandomIterator;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.WarmupUtil;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
@@ -32,6 +33,7 @@ import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
 import java.io.IOException;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.EXHAUSTIVE_BULK_SCORE_ORDS;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 /**
  * This searcher directly reads FAISS index file via the provided {@link IndexInput} then perform vector search on it.
@@ -56,7 +58,13 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     ) {
         this.indexInput = indexInput;
         this.faissIndex = faissIndex;
-        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
+        // Faiss's on-disk format only stores METRIC_INNER_PRODUCT or METRIC_L2; there is no
+        // cosine metric. Cosinesimil indices are written as IP on L2-normalized vectors, so
+        // faissIndex.getVectorSimilarityFunction() reports MAXIMUM_INNER_PRODUCT for them.
+        // Recover the user-declared space type from FieldInfo so cosine routes to the
+        // dedicated FP16_COSINE / SQ_COSINE SIMD kernels in NativeEngines990KnnVectorsScorer
+        // and KNN1040ScalarQuantizedVectorScorer, which emit (1 + dot) / 2 directly.
+        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = resolveKnnVectorSimilarityFunction(fieldInfo, faissIndex);
 
         if (knnVectorSimilarityFunction != KNNVectorSimilarityFunction.HAMMING) {
             vectorSimilarityFunction = knnVectorSimilarityFunction.getVectorSimilarityFunction();
@@ -67,6 +75,28 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         this.isAdc = FieldInfoExtractor.isAdc(fieldInfo);
         this.flatVectorsScorer = flatVectorsScorer;
         this.hnsw = extractFaissHnsw(faissIndex);
+    }
+
+    /**
+     * Resolve the similarity function for this field, preferring the user-declared space type
+     * recorded in FieldInfo over the metric derived from the Faiss header.
+     *
+     * <p>This matters for {@code cosinesimil} (and any future space whose vectors are stored
+     * with a different underlying Faiss metric than the user-facing similarity). Faiss only
+     * knows {@code METRIC_INNER_PRODUCT} and {@code METRIC_L2}; cosine indices are written as
+     * IP on normalized vectors, so reading back from the header collapses cosine to IP and
+     * the FP16_COSINE / SQ_COSINE kernel arms in the downstream scorers never fire.
+     */
+    private static KNNVectorSimilarityFunction resolveKnnVectorSimilarityFunction(final FieldInfo fieldInfo, final FaissIndex faissIndex) {
+        final String spaceTypeString = fieldInfo.getAttribute(SPACE_TYPE);
+        if (spaceTypeString != null && spaceTypeString.isEmpty() == false) {
+            final SpaceType declared = SpaceType.getSpace(spaceTypeString);
+            final KNNVectorSimilarityFunction declaredFn = declared.getKnnVectorSimilarityFunction();
+            if (declaredFn != null) {
+                return declaredFn;
+            }
+        }
+        return faissIndex.getVectorSimilarityFunction();
     }
 
     private static FaissHNSW extractFaissHnsw(final FaissIndex faissIndex) {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcher.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.memoryoptsearch.faiss;
 
 import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
@@ -25,6 +26,7 @@ import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.common.RobustUniqueRandomIterator;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.util.WarmupUtil;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
@@ -32,10 +34,12 @@ import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissCagraHNSW;
 import java.io.IOException;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.EXHAUSTIVE_BULK_SCORE_ORDS;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 
 /**
  * This searcher directly reads FAISS index file via the provided {@link IndexInput} then perform vector search on it.
  */
+@Log4j2
 public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     private final IndexInput indexInput;
     private final FaissIndex faissIndex;
@@ -56,7 +60,13 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
     ) {
         this.indexInput = indexInput;
         this.faissIndex = faissIndex;
-        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = faissIndex.getVectorSimilarityFunction();
+        // Faiss's on-disk format only stores METRIC_INNER_PRODUCT or METRIC_L2; there is no
+        // cosine metric. Cosinesimil indices are written as IP on L2-normalized vectors, so
+        // faissIndex.getVectorSimilarityFunction() reports MAXIMUM_INNER_PRODUCT for them.
+        // Recover the user-declared space type from FieldInfo so cosine routes to the
+        // dedicated FP16_COSINE / SQ_COSINE SIMD kernels in NativeEngines990KnnVectorsScorer
+        // and KNN1040ScalarQuantizedVectorScorer, which emit (1 + dot) / 2 directly.
+        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = resolveKnnVectorSimilarityFunction(fieldInfo, faissIndex);
 
         if (knnVectorSimilarityFunction != KNNVectorSimilarityFunction.HAMMING) {
             vectorSimilarityFunction = knnVectorSimilarityFunction.getVectorSimilarityFunction();
@@ -67,6 +77,49 @@ public class FaissMemoryOptimizedSearcher implements VectorSearcher {
         this.isAdc = FieldInfoExtractor.isAdc(fieldInfo);
         this.flatVectorsScorer = flatVectorsScorer;
         this.hnsw = extractFaissHnsw(faissIndex);
+    }
+
+    /**
+     * Resolve the similarity function for this field. For {@code cosinesimil} we prefer the
+     * user-declared space type recorded in FieldInfo over the metric derived from the Faiss
+     * header; for every other space we trust the Faiss header.
+     *
+     * <p>The override is intentionally limited to cosine. Faiss only knows
+     * {@code METRIC_INNER_PRODUCT} and {@code METRIC_L2}; cosine indices are written as IP on
+     * normalized vectors, so reading back from the header collapses cosine to IP and the
+     * FP16_COSINE / SQ_COSINE kernel arms in the downstream scorers never fire. Every other
+     * supported space maps to the same metric the header reports, so overriding them would only
+     * risk masking a genuine on-disk mismatch behind a stale declared attribute.
+     */
+    private static KNNVectorSimilarityFunction resolveKnnVectorSimilarityFunction(final FieldInfo fieldInfo, final FaissIndex faissIndex) {
+        final String spaceTypeString = fieldInfo.getAttribute(SPACE_TYPE);
+        if (spaceTypeString != null && spaceTypeString.isEmpty() == false) {
+            try {
+                final SpaceType declared = SpaceType.getSpace(spaceTypeString);
+                // Only cosine legitimately disagrees with the Faiss header: cosine indices are written as
+                // METRIC_INNER_PRODUCT on normalized vectors, so the header collapses cosine to IP and the
+                // COSINE kernel arms would never fire. For every other space the declared value and the
+                // Faiss-reported metric agree, so we keep trusting the on-disk header there rather than let
+                // a (possibly stale or mismatched) declared attribute silently override the real metric.
+                if (declared == SpaceType.COSINESIMIL) {
+                    final KNNVectorSimilarityFunction declaredFn = declared.getKnnVectorSimilarityFunction();
+                    if (declaredFn != null) {
+                        return declaredFn;
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                // SpaceType.getSpace throws on an unrecognized space string. The attribute is normally
+                // written by k-NN itself so this should not happen, but rather than fail searcher
+                // construction we fall back to the similarity reported by the Faiss header.
+                log.warn(
+                    "Unrecognized space type attribute [{}] for field [{}]; falling back to Faiss-reported similarity.",
+                    spaceTypeString,
+                    fieldInfo.name,
+                    e
+                );
+            }
+        }
+        return faissIndex.getVectorSimilarityFunction();
     }
 
     private static FaissHNSW extractFaissHnsw(final FaissIndex faissIndex) {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/NativeRandomVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/NativeRandomVectorScorer.java
@@ -27,11 +27,33 @@ import java.io.IOException;
 public class NativeRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
 
     /**
+     * Factory method that creates a {@link NativeRandomVectorScorer} and initialises the
+     * native search context. Callers should prefer this over {@code new} so that unit tests
+     * can intercept construction via {@code Mockito.mockStatic} without a loaded native library:
+     * the constructor calls the native method {@link SimdVectorComputeService#saveSearchContext},
+     * which cannot be intercepted by standard bytecode instrumentation.
+     *
+     * @param query                  the query vector
+     * @param knnVectorValues        document-to-ordinal mapping
+     * @param mmapVectorValues       native memory address and size of the vector data
+     * @param similarityFunctionType the SIMD similarity function to use
+     * @return a new {@link NativeRandomVectorScorer} ready for scoring
+     */
+    public static NativeRandomVectorScorer create(
+        final float[] query,
+        final KnnVectorValues knnVectorValues,
+        final MMapVectorValues mmapVectorValues,
+        final SimdVectorComputeService.SimilarityFunctionType similarityFunctionType
+    ) {
+        return new NativeRandomVectorScorer(query, knnVectorValues, mmapVectorValues, similarityFunctionType);
+    }
+
+    /**
      * Constructs a native-backed scorer for computing similarity between the given query
      * vector and a set of memory-mapped vectors.
      *
      * @param query                  the query vector represented as a {@code float[]} array
-     * @param knnVectorValues        the {@link KnnVectorValues} providing document–vector mappings
+     * @param knnVectorValues        the {@link KnnVectorValues} providing document-to-ordinal mappings
      * @param mmapVectorValues       the {@link MMapVectorValues} describing native memory chunks
      * @param similarityFunctionType the similarity function type
      */

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/NativeRandomVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/NativeRandomVectorScorer.java
@@ -27,15 +27,38 @@ import java.io.IOException;
 public class NativeRandomVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
 
     /**
+     * Factory method that creates a {@link NativeRandomVectorScorer} and initialises the
+     * native search context. This is the sole entry point for constructing the scorer (the
+     * constructor is package-private), so all callers go through this static factory. Unit
+     * tests can stub it via {@code Mockito.mockStatic} to obtain a scorer without a loaded
+     * native library; because the factory is mocked, the constructor -- and its call to the
+     * native method {@link SimdVectorComputeService#saveSearchContext} -- never runs.
+     *
+     * @param query                  the query vector
+     * @param knnVectorValues        document-to-ordinal mapping
+     * @param mmapVectorValues       native memory address and size of the vector data
+     * @param similarityFunctionType the SIMD similarity function to use
+     * @return a new {@link NativeRandomVectorScorer} ready for scoring
+     */
+    public static NativeRandomVectorScorer create(
+        final float[] query,
+        final KnnVectorValues knnVectorValues,
+        final MMapVectorValues mmapVectorValues,
+        final SimdVectorComputeService.SimilarityFunctionType similarityFunctionType
+    ) {
+        return new NativeRandomVectorScorer(query, knnVectorValues, mmapVectorValues, similarityFunctionType);
+    }
+
+    /**
      * Constructs a native-backed scorer for computing similarity between the given query
      * vector and a set of memory-mapped vectors.
      *
      * @param query                  the query vector represented as a {@code float[]} array
-     * @param knnVectorValues        the {@link KnnVectorValues} providing document–vector mappings
+     * @param knnVectorValues        the {@link KnnVectorValues} providing document-to-ordinal mappings
      * @param mmapVectorValues       the {@link MMapVectorValues} describing native memory chunks
      * @param similarityFunctionType the similarity function type
      */
-    public NativeRandomVectorScorer(
+    NativeRandomVectorScorer(
         final float[] query,
         final KnnVectorValues knnVectorValues,
         final MMapVectorValues mmapVectorValues,

--- a/src/test/java/org/opensearch/knn/index/ADCIT.java
+++ b/src/test/java/org/opensearch/knn/index/ADCIT.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.Test;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -34,14 +35,14 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.TYPE;
 import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
+import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
 
 public class ADCIT extends KNNRestTestCase {
 
     private static final String TEST_FIELD_NAME = "test-field";
 
-    private void makeOnlyQBitIndex(String indexName, String name, int dimension, int bits, boolean isUnderTest, SpaceType spaceType)
-        throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
+    private XContentBuilder qBitMapping(String name, int dimension, int bits, boolean isUnderTest, SpaceType spaceType) throws IOException {
+        return XContentFactory.jsonBuilder()
             .startObject()
             .startObject(PROPERTIES_FIELD)
             .startObject(TEST_FIELD_NAME)
@@ -64,7 +65,29 @@ public class ADCIT extends KNNRestTestCase {
             .endObject()
             .endObject()
             .endObject();
-        createKnnIndex(indexName, builder.toString());
+    }
+
+    private void makeOnlyQBitIndex(String indexName, String name, int dimension, int bits, boolean isUnderTest, SpaceType spaceType)
+        throws IOException {
+        createKnnIndex(indexName, qBitMapping(name, dimension, bits, isUnderTest, spaceType).toString());
+    }
+
+    private void makeOnlyQBitIndex(
+        String indexName,
+        String name,
+        int dimension,
+        int bits,
+        boolean isUnderTest,
+        SpaceType spaceType,
+        boolean memoryOptimized
+    ) throws IOException {
+        final String mapping = qBitMapping(name, dimension, bits, isUnderTest, spaceType).toString();
+        if (memoryOptimized) {
+            final Settings settings = Settings.builder().put("index.knn", true).put(MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true).build();
+            createKnnIndex(indexName, settings, mapping);
+        } else {
+            createKnnIndex(indexName, mapping);
+        }
     }
 
     @Test
@@ -80,6 +103,95 @@ public class ADCIT extends KNNRestTestCase {
     @Test
     public void testADCWithCosineSim() {
         adcTestSpaceType(SpaceType.COSINESIMIL);
+    }
+
+    /**
+     * ADC cosine scoring with memory-optimized search (MOS) enabled must agree with the standard
+     * (MOS-disabled, native Faiss) path.
+     *
+     * <p>Regression guard for the ADC cosine fix: the memory-optimized ADC path emits MaxIP-format
+     * scores and relies on a MaxIP -> cosine post-conversion in MemoryOptimizedKNNWeight. When that
+     * conversion was inadvertently removed, MOS returned roughly 2x the standard value. Neither ADCIT
+     * nor the MOS suite exercised ADC + cosine with MOS enabled, so no integration test covered this
+     * branch.</p>
+     */
+    @Test
+    @SneakyThrows
+    public void testADCWithCosineSim_whenMemoryOptimized_thenMatchesStandardScores() {
+        final int dimension = 8;
+        final int bits = 1;
+        final int k = 10;
+        final SpaceType spaceType = SpaceType.COSINESIMIL;
+
+        // Generate 10 random vectors that we'll reuse across both indices.
+        List<Float[]> vectors = new ArrayList<>();
+        Random random = new Random(42);
+        for (int i = 0; i < 10; i++) {
+            Float[] vector = new Float[dimension];
+            for (int j = 0; j < dimension; j++) {
+                vector[j] = random.nextFloat();
+            }
+            vectors.add(vector);
+        }
+
+        // Standard index: ADC enabled, MOS disabled -> native Faiss search path (DefaultKNNWeight).
+        String standardIndexName = "adc-cosine-standard";
+        makeOnlyQBitIndex(standardIndexName, QFrameBitEncoder.ENABLE_ADC_PARAM, dimension, bits, true, spaceType, false);
+
+        // Memory-optimized index: ADC enabled, MOS enabled -> MemoryOptimizedKNNWeight ADC branch.
+        String memoryOptimizedIndexName = "adc-cosine-memory-optimized";
+        makeOnlyQBitIndex(memoryOptimizedIndexName, QFrameBitEncoder.ENABLE_ADC_PARAM, dimension, bits, true, spaceType, true);
+
+        for (int i = 0; i < 10; i++) {
+            addKnnDoc(standardIndexName, String.valueOf(i + 1), ImmutableList.of(TEST_FIELD_NAME), ImmutableList.of(vectors.get(i)));
+            addKnnDoc(memoryOptimizedIndexName, String.valueOf(i + 1), ImmutableList.of(TEST_FIELD_NAME), ImmutableList.of(vectors.get(i)));
+        }
+        forceMergeKnnIndex(standardIndexName);
+        forceMergeKnnIndex(memoryOptimizedIndexName);
+
+        XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("query")
+            .startObject("knn")
+            .startObject(TEST_FIELD_NAME)
+            .array("vector", vectors.get(0))
+            .field("k", k)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        String standardResponse = EntityUtils.toString(searchKNNIndex(standardIndexName, queryBuilder, k).getEntity());
+        List<Object> standardHits = parseSearchResponseHits(standardResponse);
+
+        String memoryOptimizedResponse = EntityUtils.toString(searchKNNIndex(memoryOptimizedIndexName, queryBuilder, k).getEntity());
+        List<Object> memoryOptimizedHits = parseSearchResponseHits(memoryOptimizedResponse);
+
+        assertEquals(10, standardHits.size());
+        assertEquals("MOS should return the same number of hits as standard search", standardHits.size(), memoryOptimizedHits.size());
+
+        for (int i = 0; i < standardHits.size(); i++) {
+            Map<String, Object> standardHit = (Map<String, Object>) standardHits.get(i);
+            Map<String, Object> memoryOptimizedHit = (Map<String, Object>) memoryOptimizedHits.get(i);
+
+            assertEquals("Doc order should match at position " + i, standardHit.get("_id"), memoryOptimizedHit.get("_id"));
+
+            double standardScore = (Double) standardHit.get("_score");
+            double memoryOptimizedScore = (Double) memoryOptimizedHit.get("_score");
+
+            // MOS must produce the same scores as the standard (native Faiss) path (documented invariant).
+            // This is the regression guard for the ADC cosine fix: without the MaxIP -> cosine post-conversion
+            // in MemoryOptimizedKNNWeight, MOS returned the raw MaxIP score (~2x the standard value).
+            //
+            // Note: 1-bit ADC reconstructs data vectors that are not unit-norm, so the asymmetric cosine
+            // score can legitimately exceed 1.0 on both the standard and MOS paths -- we therefore assert
+            // parity with the standard path rather than an absolute [0, 1] bound. The epsilon comfortably
+            // tolerates minor native-vs-Java float differences while still catching the 2x regression.
+            assertEquals("Scores should match at position " + i, standardScore, memoryOptimizedScore, 0.05);
+        }
+
+        deleteKNNIndex(standardIndexName);
+        deleteKNNIndex(memoryOptimizedIndexName);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
+
 /**
  * Integration tests for radial search (max_distance and min_score) on Faiss and Lucene HNSW.
  * Covers both ANN path (no filter) and ExactSearcher path (with filter, Faiss only) across
@@ -51,7 +53,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
     private final float threshold;
     private final int expectedCount;
     private final boolean useFilter;
-    private final boolean mosEnabled;
+    private final boolean memoryOptimized;
 
     public RadialSearchIT(
         CompressionTestConfig compressionConfig,
@@ -64,7 +66,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
         float threshold,
         int expectedCount,
         boolean useFilter,
-        boolean mosEnabled
+        boolean memoryOptimized
     ) {
         super(compressionConfig);
         this.testName = testName;
@@ -76,7 +78,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
         this.threshold = threshold;
         this.expectedCount = expectedCount;
         this.useFilter = useFilter;
-        this.mosEnabled = mosEnabled;
+        this.memoryOptimized = memoryOptimized;
     }
 
     @ParametersFactory(argumentFormatting = "{1}_compression:{0}")
@@ -138,6 +140,25 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
             SpaceType.COSINESIMIL,
             cosVectors,
             cosQuery,
+            true,
+            new Object[] { "max_distance", 0.1f, 2 },
+            new Object[] { "max_distance", 0.5f, 3 },
+            new Object[] { "min_score", 0.99f, 1 },
+            new Object[] { "min_score", 0.8f, 3 }
+        );
+
+        // Faiss Cosine with memory-optimized search enabled. This exercises
+        // MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold / scoreToRadialThreshold for cosine,
+        // which is otherwise untested with MOS: every other cosine + MOS radial test uses min_score only, so
+        // the cosine max_distance -> (2 - distance) / 2 threshold conversion had no integration coverage.
+        addRadialCases(
+            params,
+            "Faiss_COSINE_mos",
+            KNNEngine.FAISS,
+            SpaceType.COSINESIMIL,
+            cosVectors,
+            cosQuery,
+            true,
             true,
             new Object[] { "max_distance", 0.1f, 2 },
             new Object[] { "max_distance", 0.5f, 3 },
@@ -215,7 +236,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
     /**
      * Generates test cases for ANN, ExactSearcher, and optionally MOS paths for a given engine/space configuration.
      * Each threshold entry produces one test case; if exactSearcher is true, a mirror set with filter is added.
-     * If mosEnabled is true, generates MOS-specific test cases.
+     * If memoryOptimized is true, generates MOS-specific test cases.
      */
     private static void addRadialCases(
         List<Object[]> params,
@@ -225,7 +246,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
         float[][] vectors,
         float[] query,
         boolean includeExact,
-        boolean mosEnabled,
+        boolean memoryOptimized,
         Object[]... thresholds
     ) {
         for (Object[] t : thresholds) {
@@ -243,7 +264,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
                     threshold,
                     expected,
                     false,
-                    mosEnabled }
+                    memoryOptimized }
             );
             if (includeExact) {
                 params.add(
@@ -257,7 +278,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
                         threshold,
                         expected,
                         true,
-                        mosEnabled }
+                        memoryOptimized }
                 );
             }
         }
@@ -484,11 +505,10 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
         mapping.endObject().endObject().startObject(FILTER_FIELD).field("type", "keyword").endObject().endObject().endObject();
 
         Settings.Builder settingsBuilder = Settings.builder().put("index.knn", true);
-        if (mosEnabled) {
-            settingsBuilder.put("index.knn.memory_optimized_search", true);
+        if (memoryOptimized && engine == KNNEngine.FAISS) {
+            settingsBuilder.put(MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true);
         }
-        Settings settings = settingsBuilder.build();
-        createKnnIndex(indexName, settings, mapping.toString());
+        createKnnIndex(indexName, settingsBuilder.build(), mapping.toString());
 
         for (int i = 0; i < testVectors.length; i++) {
             indexDocument(indexName, String.valueOf(i + 1), testVectors[i]);

--- a/src/test/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/scorer/NativeEngines990KnnVectorsScorerTests.java
@@ -13,13 +13,13 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.mockito.MockedStatic;
-import org.opensearch.knn.jni.SimdVectorComputeService;
 import org.opensearch.knn.memoryoptsearch.faiss.MMapVectorValues;
 import org.opensearch.knn.memoryoptsearch.faiss.NativeRandomVectorScorer;
 import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
 
 import java.io.IOException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -37,12 +37,16 @@ public class NativeEngines990KnnVectorsScorerTests extends TestCase {
         FloatVectorValues mmapValues = mock(FloatVectorValues.class, withSettings().extraInterfaces(MMapVectorValues.class));
         when(((MMapVectorValues) mmapValues).getAddressAndSize()).thenReturn(new long[] { 100L, 200L });
         float[] target = new float[] { 1.0f, 2.0f };
+        NativeRandomVectorScorer expectedScorer = mock(NativeRandomVectorScorer.class);
 
+        // Mock the factory method rather than the native SimdVectorComputeService.saveSearchContext --
+        // static native methods cannot be intercepted by Mockito's bytecode instrumentation.
         try (
-            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class);
-            MockedStatic<SimdVectorComputeService> ignored = mockStatic(SimdVectorComputeService.class)
+            MockedStatic<NativeRandomVectorScorer> nativeMock = mockStatic(NativeRandomVectorScorer.class);
+            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class)
         ) {
             wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(mmapValues);
+            nativeMock.when(() -> NativeRandomVectorScorer.create(any(), any(), any(), any())).thenReturn(expectedScorer);
 
             RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, vectorValues, target);
 
@@ -57,12 +61,16 @@ public class NativeEngines990KnnVectorsScorerTests extends TestCase {
         FloatVectorValues mmapValues = mock(FloatVectorValues.class, withSettings().extraInterfaces(MMapVectorValues.class));
         when(((MMapVectorValues) mmapValues).getAddressAndSize()).thenReturn(new long[] { 100L, 200L });
         float[] target = new float[] { 1.0f, 2.0f };
+        NativeRandomVectorScorer expectedScorer = mock(NativeRandomVectorScorer.class);
 
+        // Mock the factory method rather than the native SimdVectorComputeService.saveSearchContext --
+        // static native methods cannot be intercepted by Mockito's bytecode instrumentation.
         try (
-            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class);
-            MockedStatic<SimdVectorComputeService> ignored = mockStatic(SimdVectorComputeService.class)
+            MockedStatic<NativeRandomVectorScorer> nativeMock = mockStatic(NativeRandomVectorScorer.class);
+            MockedStatic<WrappedFloatVectorValues> wrappedMock = mockStatic(WrappedFloatVectorValues.class)
         ) {
             wrappedMock.when(() -> WrappedFloatVectorValues.getBottomFloatVectorValues(vectorValues)).thenReturn(mmapValues);
+            nativeMock.when(() -> NativeRandomVectorScorer.create(any(), any(), any(), any())).thenReturn(expectedScorer);
 
             RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, vectorValues, target);
 

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherTests.java
@@ -89,6 +89,7 @@ import org.opensearch.knn.quantization.models.quantizationState.QuantizationStat
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -104,6 +105,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.knn.common.KNNConstants.ADC_ENABLED_FAISS_INDEX_INTERNAL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
@@ -407,6 +409,89 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    private static KNNVectorSimilarityFunction invokeResolveSimilarity(final FieldInfo fieldInfo, final FaissIndex faissIndex) {
+        final Method method = FaissMemoryOptimizedSearcher.class.getDeclaredMethod(
+            "resolveKnnVectorSimilarityFunction",
+            FieldInfo.class,
+            FaissIndex.class
+        );
+        method.setAccessible(true);
+        return (KNNVectorSimilarityFunction) method.invoke(null, fieldInfo, faissIndex);
+    }
+
+    /**
+     * Cosine is the one space where the declared attribute must override the Faiss header: cosine
+     * indices are written as METRIC_INNER_PRODUCT on normalized vectors, so the header reports IP.
+     * The resolver must return COSINE so the FP16_COSINE / SQ_COSINE kernels fire.
+     */
+    public void testResolveSimilarity_whenCosineDeclared_thenOverridesFaissHeaderWithCosine() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(SpaceType.COSINESIMIL.getValue());
+
+        final FaissIndex faissIndex = mock(FaissIndex.class);
+        // Faiss collapses cosine to inner product on disk.
+        when(faissIndex.getVectorSimilarityFunction()).thenReturn(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT);
+
+        assertEquals(KNNVectorSimilarityFunction.COSINE, invokeResolveSimilarity(fieldInfo, faissIndex));
+    }
+
+    /**
+     * For every non-cosine declared space the resolver must NOT override; it trusts the metric the
+     * Faiss header reports so a stale/mismatched declared attribute can never mask the on-disk metric.
+     * Here the declared attribute (L2 / IP) is deliberately made to disagree with the header, and the
+     * resolver must still return the header's value.
+     */
+    public void testResolveSimilarity_whenNonCosineDeclared_thenTrustsFaissHeader() {
+        for (final SpaceType declared : new SpaceType[] { SpaceType.L2, SpaceType.INNER_PRODUCT }) {
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(declared.getValue());
+
+            final FaissIndex faissIndex = mock(FaissIndex.class);
+            when(faissIndex.getVectorSimilarityFunction()).thenReturn(KNNVectorSimilarityFunction.COSINE);
+
+            assertEquals(
+                "Non-cosine declared space [" + declared + "] must defer to the Faiss header",
+                KNNVectorSimilarityFunction.COSINE,
+                invokeResolveSimilarity(fieldInfo, faissIndex)
+            );
+            verify(faissIndex).getVectorSimilarityFunction();
+        }
+    }
+
+    /**
+     * An unrecognized space-type attribute must not fail searcher construction: the resolver logs a
+     * warning and falls back to the Faiss-reported similarity. Exercises the IllegalArgumentException
+     * catch branch.
+     */
+    public void testResolveSimilarity_whenUnrecognizedSpaceType_thenFallsBackToFaissHeader() {
+        final FieldInfo fieldInfo = mock(FieldInfo.class);
+        when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn("not-a-real-space-type");
+
+        final FaissIndex faissIndex = mock(FaissIndex.class);
+        when(faissIndex.getVectorSimilarityFunction()).thenReturn(KNNVectorSimilarityFunction.EUCLIDEAN);
+
+        assertEquals(KNNVectorSimilarityFunction.EUCLIDEAN, invokeResolveSimilarity(fieldInfo, faissIndex));
+        verify(faissIndex).getVectorSimilarityFunction();
+    }
+
+    /**
+     * A missing / empty space-type attribute skips the declared-override block entirely and defers to
+     * the Faiss header.
+     */
+    public void testResolveSimilarity_whenNoSpaceTypeAttribute_thenUsesFaissHeader() {
+        for (final String attr : new String[] { null, "" }) {
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(attr);
+
+            final FaissIndex faissIndex = mock(FaissIndex.class);
+            when(faissIndex.getVectorSimilarityFunction()).thenReturn(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT);
+
+            assertEquals(KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT, invokeResolveSimilarity(fieldInfo, faissIndex));
+            verify(faissIndex).getVectorSimilarityFunction();
+        }
+    }
+
+    @SneakyThrows
     private void doSearchTest(final TestingSpec testingSpec, final IndexingType indexingType) {
         final List<SpaceType> spaceTypes;
         if (testingSpec.dataType == VectorDataType.BINARY) {
@@ -575,17 +660,17 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         }
 
         // Search via VectorReader
+        final boolean isAdc = testingSpec.quantizationConfig != null && testingSpec.quantizationConfig.enableADC;
         final KNNQueryResult[] resultsFromVectorReader = doSearchViaVectorReader(
             buildInfo,
             queryForVectorReader,
-            testingSpec.quantizationConfig != null && testingSpec.quantizationConfig.enableADC
-                ? VectorDataType.FLOAT
-                : testingSpec.dataType,
+            isAdc ? VectorDataType.FLOAT : testingSpec.dataType,
             filteredIds,
             k,
             doExhaustiveSearch,
             spaceType,
-            testingSpec.directoryClass
+            testingSpec.directoryClass,
+            isAdc
         );
 
         // Validate results
@@ -620,7 +705,8 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         final int k,
         final boolean exhaustiveSearch,
         final SpaceType spaceType,
-        final Class<D> directoryClass
+        final Class<D> directoryClass,
+        final boolean isAdc
     ) {
         // Make KNN vector field info
         KNNCodecTestUtil.FieldInfoBuilder fieldInfoBuilder = KNNCodecTestUtil.FieldInfoBuilder.builder(TARGET_FIELD)
@@ -742,7 +828,11 @@ public class FaissMemoryOptimizedSearcherTests extends KNNTestCase {
         // Make results
         final TopDocs topDocs = knnCollector.topDocs();
         final ScoreDoc[] scoreDocs = topDocs.scoreDocs;
-        if (spaceType == SpaceType.COSINESIMIL) {
+        // For FP16 / SQ formats the scorer emits cosine scores directly (the FP16_COSINE / SQ_COSINE
+        // kernels apply the (1 + dot) / 2 transform in-kernel), so no post-conversion is needed here -
+        // this mirrors MemoryOptimizedKNNWeight. The ADC path still emits MaxIP-format scores, so cosine
+        // requires the MaxIP -> cosine post-conversion, matching production.
+        if (isAdc && spaceType == SpaceType.COSINESIMIL) {
             MemoryOptimizedSearchScoreConverter.convertToCosineScore(scoreDocs);
         }
         assertTrue(scoreDocs.length >= k);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchScoreConverterTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/MemoryOptimizedSearchScoreConverterTests.java
@@ -34,19 +34,16 @@ public class MemoryOptimizedSearchScoreConverterTests {
             1e-6
         );
 
-        // For cosine though, score function between Faiss and Lucene is different
-        // Faiss's score = (1 + inner_product_value) / 2
-        // Since MAXIMUM_INNER_PRODUCT is being used in Lucene, we should get max_inner_product value which is 1.54.
-        // inner_product_value = 2 * score - 1
-        // max_inner_product_value = inner_product_value + 1 if inner_product_value >= 0 else 1 / -inner_product_value
+        // For cosine, the scorer now emits Lucene-native cosine scores directly (score = (1 + cosine) / 2),
+        // so the min_score threshold is used as-is, just like L2 and inner product.
         final float faissCosine1 = 0.77F;
         final float luceneRadius1 = MemoryOptimizedSearchScoreConverter.scoreToRadialThreshold(faissCosine1, SpaceType.COSINESIMIL);
-        assertEquals(luceneRadius1, 1.54F, 1e-6);
+        assertEquals(faissCosine1, luceneRadius1, 1e-6);
 
         // When two vectors are perpendicular to each other.
         final float faissCosine2 = 0.5F;
         final float luceneRadius2 = MemoryOptimizedSearchScoreConverter.scoreToRadialThreshold(faissCosine2, SpaceType.COSINESIMIL);
-        assertEquals(luceneRadius2, 1F, 1e-6);
+        assertEquals(faissCosine2, luceneRadius2, 1e-6);
     }
 
     @Test
@@ -81,38 +78,40 @@ public class MemoryOptimizedSearchScoreConverterTests {
         );
         assertEquals(1 / (1 + faissIpDistance3), luceneIpRadius3, 1e-6);
 
-        // For cosine, the input distance is actually `1 - inner product value (whose range is in [-1, 1])`
+        // For cosine, the input distance is `1 - inner product value (whose range is in [-1, 1])`.
+        // The scorer now emits Lucene-native cosine scores, so the threshold is the cosine score
+        // itself: score = (2 - distance) / 2.
         final float faissCosineDistance1 = 0;
         final float luceneCosineRadius1 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance1,
             SpaceType.COSINESIMIL
         );
-        // inner product value is 1 from distance `0`, hence it should be 1 + the value.
-        assertEquals(1 + 1, luceneCosineRadius1, 1e-6);
+        // inner product value is 1 from distance `0`, hence cosine score is (2 - 0) / 2 = 1.
+        assertEquals((2 - faissCosineDistance1) / 2, luceneCosineRadius1, 1e-6);
 
         final float faissCosineDistance2 = 2;
         final float luceneCosineRadius2 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance2,
             SpaceType.COSINESIMIL
         );
-        // inner product value is -1, hence max inner product value should be 1 / (1 + 1)
-        assertEquals(1F / (1 + 1), luceneCosineRadius2, 1e-6);
+        // inner product value is -1, hence cosine score is (2 - 2) / 2 = 0.
+        assertEquals((2 - faissCosineDistance2) / 2, luceneCosineRadius2, 1e-6);
 
         final float faissCosineDistance3 = 1.44F;
         final float luceneCosineRadius3 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance3,
             SpaceType.COSINESIMIL
         );
-        // inner product value is -0.44, hence max inner product value should be 1 / (1 + 0.44)
-        assertEquals(1 / (1 + 0.44F), luceneCosineRadius3, 1e-6);
+        // inner product value is -0.44, hence cosine score is (2 - 1.44) / 2 = 0.28.
+        assertEquals((2 - faissCosineDistance3) / 2, luceneCosineRadius3, 1e-6);
 
         final float faissCosineDistance4 = 0.77F;
         final float luceneCosineRadius4 = MemoryOptimizedSearchScoreConverter.distanceToRadialThreshold(
             faissCosineDistance4,
             SpaceType.COSINESIMIL
         );
-        // inner product value is 0.23, hence max inner product value should be 1 / (1 + 0.44)
-        assertEquals(1.23F, luceneCosineRadius4, 1e-6);
+        // inner product value is 0.23, hence cosine score is (2 - 0.77) / 2 = 0.615.
+        assertEquals((2 - faissCosineDistance4) / 2, luceneCosineRadius4, 1e-6);
     }
 
     @Test

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/NativeRandomVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/NativeRandomVectorScorerTests.java
@@ -11,6 +11,7 @@ import lombok.SneakyThrows;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.util.VectorUtil;
 import org.junit.Test;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.KNNVectorSimilarityFunction;
@@ -34,6 +35,7 @@ public class NativeRandomVectorScorerTests extends KNNTestCase {
         doFp16ScoringTest(
             SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT,
             KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
+            false,
             false
         );
 
@@ -41,24 +43,47 @@ public class NativeRandomVectorScorerTests extends KNNTestCase {
         doFp16ScoringTest(
             SimdVectorComputeService.SimilarityFunctionType.FP16_MAXIMUM_INNER_PRODUCT,
             KNNVectorSimilarityFunction.MAXIMUM_INNER_PRODUCT,
-            true
+            true,
+            false
         );
     }
 
     @Test
     public void fp16MaxL2Test() {
         // Single MemorySegment scenario
-        doFp16ScoringTest(SimdVectorComputeService.SimilarityFunctionType.FP16_L2, KNNVectorSimilarityFunction.EUCLIDEAN, false);
+        doFp16ScoringTest(SimdVectorComputeService.SimilarityFunctionType.FP16_L2, KNNVectorSimilarityFunction.EUCLIDEAN, false, false);
 
         // Multi MemorySegments scenario
-        doFp16ScoringTest(SimdVectorComputeService.SimilarityFunctionType.FP16_L2, KNNVectorSimilarityFunction.EUCLIDEAN, true);
+        doFp16ScoringTest(SimdVectorComputeService.SimilarityFunctionType.FP16_L2, KNNVectorSimilarityFunction.EUCLIDEAN, true, false);
+    }
+
+    /**
+     * Focused kernel-level reproduction for the FP16 cosine scoring regression.
+     *
+     * <p>This directly exercises the native FP16_COSINE kernel (both single-vector and bulk),
+     * bypassing the memory-optimized-search wiring (the {@code MMapVectorValues} gate) that
+     * otherwise falls back to the Lucene delegate and hides the bug. Query and document vectors
+     * are L2-normalized to mirror how cosinesimil indices are stored, so cosine == inner product
+     * and the correct score is {@code (1 + dot) / 2 == KNNVectorSimilarityFunction.COSINE.compare}.</p>
+     *
+     * <p>Run with {@code KNN_COSINE_DEBUG=1} to have the native layer print the raw
+     * {@code query_to_code} / SIMD dot value that is fed into cosineTransform.</p>
+     */
+    @Test
+    public void fp16CosineTest() {
+        // Single MemorySegment scenario
+        doFp16ScoringTest(SimdVectorComputeService.SimilarityFunctionType.FP16_COSINE, KNNVectorSimilarityFunction.COSINE, false, true);
+
+        // Multi MemorySegments scenario
+        doFp16ScoringTest(SimdVectorComputeService.SimilarityFunctionType.FP16_COSINE, KNNVectorSimilarityFunction.COSINE, true, true);
     }
 
     @SneakyThrows
     private void doFp16ScoringTest(
         final SimdVectorComputeService.SimilarityFunctionType functionType,
         final KNNVectorSimilarityFunction similarityFunction,
-        final boolean multiSegmentsScenario
+        final boolean multiSegmentsScenario,
+        final boolean normalizeVectors
     ) {
 
         // Create repo
@@ -89,10 +114,20 @@ public class NativeRandomVectorScorerTests extends KNNTestCase {
             final ByteBuffer byteBuffer = ByteBuffer.allocate(numVectors * dimension * Short.BYTES).order(ByteOrder.nativeOrder());
             final ShortBuffer shortBuffer = byteBuffer.asShortBuffer();
             for (int i = 0; i < numVectors; ++i) {
+                float[] raw = new float[dimension];
+                for (int j = 0; j < dimension; ++j) {
+                    raw[j] = Randomness.get().nextFloat();
+                }
+                // For cosine, mirror how cosinesimil indices are stored: L2-normalize before FP16
+                // quantization so cosine == inner product and the correct score is (1 + dot) / 2.
+                if (normalizeVectors) {
+                    VectorUtil.l2normalize(raw);
+                }
+                // Quantize the (optionally normalized) raw vector to FP16; this is the vector that is
+                // actually stored and scored, so cosine sees the L2-normalized data it requires.
                 float[] vector = new float[dimension];
                 for (int j = 0; j < dimension; ++j) {
-                    final float floatValue = Randomness.get().nextFloat();
-                    final short fp16Value = Float.floatToFloat16(floatValue);
+                    final short fp16Value = Float.floatToFloat16(raw[j]);
                     shortBuffer.put(fp16Value);
                     vector[j] = Float.float16ToFloat(fp16Value);
                 }
@@ -105,6 +140,11 @@ public class NativeRandomVectorScorerTests extends KNNTestCase {
         float[] queryVec = new float[dimension];
         for (int j = 0; j < dimension; ++j) {
             queryVec[j] = Float.float16ToFloat(Float.floatToFloat16(Randomness.get().nextFloat()));
+        }
+        // The FP16_COSINE kernel scores as (1 + dot) / 2, which only equals cosine when the query is
+        // L2-normalized as well. Mirror how cosinesimil queries are normalized before scoring.
+        if (normalizeVectors) {
+            VectorUtil.l2normalize(queryVec);
         }
 
         // Test vector scoring
@@ -146,14 +186,18 @@ public class NativeRandomVectorScorerTests extends KNNTestCase {
                 // Save search context first
                 SimdVectorComputeService.saveSearchContext(queryVec, addressAndSize, functionType.ordinal());
 
-                // Test single vector scoring
+                // Cosine reconstructs L2-normalized FP16 vectors, so allow a touch more slack for
+                // FP16 norm drift; still far tighter than the ~0.1-0.4 error the regression produces.
+                final float tolerance = normalizeVectors ? 3e-3f : 1e-3f;
+
+                // Test single vector scoring (native scoreSimilarity -> Faiss query_to_code + transform)
                 for (int i = 0; i < numVectors; ++i) {
                     final float score = SimdVectorComputeService.scoreSimilarity(i);
                     final float expectedScore = similarityFunction.compare(queryVec, vectors.get(i));
-                    assertEquals(expectedScore, score, 1e-3);
+                    assertEquals("single-vector score mismatch for " + functionType + " at id=" + i, expectedScore, score, tolerance);
                 }
 
-                // Test bulk scoring
+                // Test bulk scoring (native scoreSimilarityInBulk -> SIMD kernel + transform)
                 final int batchSize = 10;
                 for (int i = 0; i < numVectors; i += batchSize) {
                     int[] vectorIds = java.util.stream.IntStream.rangeClosed(i, i + batchSize).toArray();
@@ -162,7 +206,12 @@ public class NativeRandomVectorScorerTests extends KNNTestCase {
 
                     for (int j = 0; j < batchSize; j++) {
                         final float expectedScore = similarityFunction.compare(queryVec, vectors.get(vectorIds[j]));
-                        assertEquals(expectedScore, scores[j], 1e-3);
+                        assertEquals(
+                            "bulk score mismatch for " + functionType + " at id=" + vectorIds[j],
+                            expectedScore,
+                            scores[j],
+                            tolerance
+                        );
                     }
                 }
             }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -201,15 +201,11 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 assertNotNull("Test scorer should not be null", testScorer);
 
                 // ---- Step 4: Compare scores ----
-                final boolean isCosine = similarityFunction == VectorSimilarityFunction.COSINE;
                 int maxOrd = truthScorer.maxOrd();
                 assertEquals("maxOrd mismatch", maxOrd, testScorer.maxOrd());
 
                 for (int ord = 0; ord < maxOrd; ord++) {
                     float actual = testScorer.score(ord);
-                    if (isCosine) {
-                        actual = convertMaxIpToCosineScore(actual);
-                    }
                     float expected = truthScorer.score(ord);
                     assertEquals("Score mismatch at ord=" + ord + " for " + similarityFunction, expected, actual, 1e-2);
                 }
@@ -227,9 +223,6 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                     testScorer.bulkScore(ords, bulkScores, batchSize);
                     for (int j = 0; j < batchSize; j++) {
                         float actualBulk = bulkScores[j];
-                        if (isCosine) {
-                            actualBulk = convertMaxIpToCosineScore(actualBulk);
-                        }
                         float expected = truthScorer.score(ords[j]);
                         assertEquals(
                             "Bulk score mismatch at ord=" + ords[j] + " (batch=" + batchSize + ") for " + similarityFunction,

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -87,6 +87,123 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
         }
     }
 
+    /**
+     * The SQ_COSINE kernel treats cosine as a plain inner product ((1 + dot) / 2), which is only
+     * correct when both the stored vectors and the query are L2-normalized. getRandomVectorScorer()
+     * guards the query half of that invariant with an assertion; verify that an un-normalized cosine
+     * query trips it. Assertions are enabled in the test JVM (-ea); guard against environments where
+     * they are not so the test does not spuriously fail.
+     */
+    @Test
+    @SneakyThrows
+    public void testSQCosine_whenQueryNotNormalized_thenAssertionError() {
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true; // intentional side effect
+        assumeTrue("Assertions must be enabled (-ea) to exercise the normalization guard", assertionsEnabled);
+
+        final int dimension = 128;
+        final ScalarEncoding encoding = ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+        final FlatVectorsScorer defaultScorer = FlatVectorScorerUtil.getLucene99FlatVectorsScorer();
+        final FlatVectorsFormat rawVectorFormat = getRawVectorFormat();
+
+        final FieldInfo fieldInfo = new FieldInfo(
+            FIELD_NAME,
+            0,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Map.of(),
+            0,
+            0,
+            0,
+            dimension,
+            VectorEncoding.FLOAT32,
+            VectorSimilarityFunction.COSINE,
+            false,
+            false
+        );
+        final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fieldInfo });
+
+        final Path tempDir = createTempDir();
+        try (MMapDirectory dir = new MMapDirectory(tempDir)) {
+            final SegmentInfo segmentInfo = new SegmentInfo(
+                dir,
+                Version.LATEST,
+                Version.LATEST,
+                "_0",
+                NUM_VECTORS,
+                false,
+                false,
+                null,
+                Collections.emptyMap(),
+                StringHelper.randomId(),
+                new HashMap<>(),
+                null
+            );
+            final SegmentWriteState writeState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                dir,
+                segmentInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT
+            );
+            final Lucene104ScalarQuantizedVectorScorer luceneVectorScorer = new Lucene104ScalarQuantizedVectorScorer(defaultScorer);
+
+            try (
+                FlatVectorsWriter writer = new Lucene104ScalarQuantizedVectorsWriter(
+                    writeState,
+                    encoding,
+                    rawVectorFormat.fieldsWriter(writeState),
+                    luceneVectorScorer
+                )
+            ) {
+                @SuppressWarnings("unchecked")
+                FlatFieldVectorsWriter<float[]> fieldWriter = (FlatFieldVectorsWriter<float[]>) writer.addField(fieldInfo);
+                for (int i = 0; i < NUM_VECTORS; i++) {
+                    float[] vec = randomCosineVector(dimension);
+                    VectorUtil.l2normalize(vec);
+                    fieldWriter.addValue(i, vec);
+                }
+                writer.flush(NUM_VECTORS, null);
+                writer.finish();
+            }
+
+            final SegmentReadState readState = new SegmentReadState(dir, segmentInfo, fieldInfos, IOContext.DEFAULT);
+            try (
+                FlatVectorsReader reader = new Lucene104ScalarQuantizedVectorsReader(
+                    readState,
+                    rawVectorFormat.fieldsReader(readState),
+                    luceneVectorScorer
+                )
+            ) {
+                final KNN1040ScalarQuantizedVectorScorer simdFlatScorer = new KNN1040ScalarQuantizedVectorScorer(defaultScorer);
+
+                // Deliberately un-normalized query: shift every component so the L2 norm is far from 1.
+                final float[] unnormalizedQuery = randomCosineVector(dimension);
+                for (int i = 0; i < dimension; i++) {
+                    unnormalizedQuery[i] += 10.0f;
+                }
+                assertTrue(
+                    "Test query must be un-normalized",
+                    Math.abs(VectorUtil.dotProduct(unnormalizedQuery, unnormalizedQuery) - 1.0f) > 1e-2f
+                );
+
+                final var floatVectorValues = reader.getFloatVectorValues(FIELD_NAME);
+                expectThrows(
+                    AssertionError.class,
+                    () -> simdFlatScorer.getRandomVectorScorer(VectorSimilarityFunction.COSINE, floatVectorValues, unnormalizedQuery)
+                );
+            }
+        }
+
+        IOUtils.rm(tempDir);
+    }
+
     @SneakyThrows
     private void doTest(final VectorSimilarityFunction similarityFunction, final int dimension) {
         final ScalarEncoding encoding = ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
@@ -202,15 +319,11 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                 assertNotNull("Test scorer should not be null", testScorer);
 
                 // ---- Step 4: Compare scores ----
-                final boolean isCosine = similarityFunction == VectorSimilarityFunction.COSINE;
                 int maxOrd = truthScorer.maxOrd();
                 assertEquals("maxOrd mismatch", maxOrd, testScorer.maxOrd());
 
                 for (int ord = 0; ord < maxOrd; ord++) {
                     float actual = testScorer.score(ord);
-                    if (isCosine) {
-                        actual = convertMaxIpToCosineScore(actual);
-                    }
                     float expected = truthScorer.score(ord);
                     assertEquals("Score mismatch at ord=" + ord + " for " + similarityFunction, expected, actual, 1e-2);
                 }
@@ -228,9 +341,6 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
                     testScorer.bulkScore(ords, bulkScores, batchSize);
                     for (int j = 0; j < batchSize; j++) {
                         float actualBulk = bulkScores[j];
-                        if (isCosine) {
-                            actualBulk = convertMaxIpToCosineScore(actualBulk);
-                        }
                         float expected = truthScorer.score(ords[j]);
                         assertEquals(
                             "Bulk score mismatch at ord=" + ords[j] + " (batch=" + batchSize + ") for " + similarityFunction,
@@ -280,22 +390,5 @@ public class FaissScalarQuantizedBulkSimdScorerTests extends KNNTestCase {
             v[dimension - 1] = -(Randomness.get().nextFloat() * 0.5f + 0.5f);
         }
         return v;
-    }
-
-    /**
-     * Converts a Faiss MAX_IP score (used internally for cosine) to the Lucene cosine score.
-     * Faiss uses MAX_IP under the hood for cosine similarity on normalized vectors.
-     * The MAX_IP transform maps: ip >= 0 → 1 + ip, ip < 0 → 1 / (1 - ip).
-     * This reverses that, then applies the cosine score formula: (1 + ip) / 2.
-     */
-    private static float convertMaxIpToCosineScore(float maxIpScore) {
-        float innerProductValue;
-        if (maxIpScore >= 1) {
-            innerProductValue = maxIpScore - 1;
-        } else {
-            innerProductValue = 1 - 1 / maxIpScore;
-        }
-        innerProductValue = Math.clamp(innerProductValue, -1, 1);
-        return Math.max((1 + innerProductValue) / 2.0f, 0.0f);
     }
 }


### PR DESCRIPTION
Currently, cosine similarity in the memory-optimized search (MOS) path was handled differently depending on the storage format. For SQ, the SIMD bulk scorer computed a MaxIP score and `MemoryOptimizedKNNWeight` then post-converted it to a cosine score via `MemoryOptimizedSearchScoreConverter.convertToCosineScore()`. For FP16, cosine fell through to the Lucene delegate entirely, missing the SIMD fast path. In neither case did the scorer itself emit a cosine score.

This patch collapses cosine scoring into the SIMD kernel by introducing dedicated `FP16_COSINE` and `SQ_COSINE` similarity function types. Each reuses the underlying inner-product computation and applies a `(1 + dot) / 2` transform in-kernel, so callers receive correctly-ranged `[0, 1]` scores directly with no post-processing.

On AVX-512-FP16-capable hardware, `FP16_COSINE` additionally binds to a new native kernel, `AVX512NativeFP16IP`, which uses `_mm512_fmadd_ph` at 32 FP16 elements per 512-bit register. The FP16 accumulator is mathematically safe here specifically because cosine guarantees L2-normalized vectors and therefore bounded dot products, so this kernel is opt-in via the COSINE route only.

**C++ / JNI layer:**

- Add `FP16_COSINE` and `SQ_COSINE` to `NativeSimilarityFunctionType`.
- Add `cosineTransform` / `cosineTransformBulk` to `FaissScoreToLuceneScoreTransform`, with output clamped to `[0, 1]` to absorb SQ quantization noise that can push the raw dot product slightly outside `[-1, 1]`.
- Replace the `bool IsMaxIP` template parameter on the SQ similarity structs with `enum class SQMetricMode {MAX_IP, L2, COSINE}`. `SQ_COSINE` shares the quantized inner-product math with `SQ_IP`; only the transform differs.
- Add `AVX512NativeFP16IP`, gated on `__AVX512FP16__`, used only for `FP16_COSINE`.
- Wire `FP16_COSINE` and `SQ_COSINE` through the AVX-512, ARM NEON, and scalar fallback similarity-function tables, and through `saveSearchContext` in `simd_similarity_function_common.cpp`.

**Java layer:**

- Add `FP16_COSINE` and `SQ_COSINE` to `SimdVectorComputeService.SimilarityFunctionType`.
- Route `VectorSimilarityFunction.COSINE -> SQ_COSINE` in `KNN1040ScalarQuantizedVectorScorer` and `-> FP16_COSINE` in `NativeEngines990KnnVectorsScorer.getNativeFunctionType()`, so `cosinesimil` fields reach the new kernels on both the SQ and FP16 paths.
- `FaissMemoryOptimizedSearcher` resolves the similarity function from the user-declared space type in `FieldInfo` (via the new `resolveKnnVectorSimilarityFunction`) instead of the Faiss header metric. Faiss has no cosine metric — `cosinesimil` indices are written as inner product on L2-normalized vectors, so `faissIndex.getVectorSimilarityFunction()` reports `MAXIMUM_INNER_PRODUCT` for them. Recovering the declared COSINE space is what routes `cosinesimil` fields to the new `FP16_COSINE` / `SQ_COSINE` kernels; the override is intentionally scoped to cosine, since every other space agrees with the Faiss-reported metric.
- Expose `NativeRandomVectorScorer.create()` as a static factory with a package-private constructor. The constructor invokes the native `saveSearchContext`, which cannot be intercepted by Mockito's bytecode instrumentation, so tests now mock the factory via `Mockito.mockStatic` instead.

**Cleanup:**

- Remove the `convertToCosineScore()` call from `MemoryOptimizedKNNWeight` for the FP16 and SQ paths; cosine scores are now produced at the scorer level. The ADC (binary-quantized) path still scores a float query against 1-bit vectors and emits MaxIP-format scores, so it retains the MaxIP -> cosine post-conversion on the ADC branch only.
- Drop the manual MaxIP -> cosine conversion in `FaissScalarQuantizedBulkSimdScorerTests`; the scorer's output is already correctly cosine-scaled.


### Check List
- [X] New functionality includes testing.
- [X] Commits are signed per the DCO using `--signoff`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
