### PR TITLE
Update step SHA versions, remove maven mirrors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -69,7 +69,7 @@ jobs:
           su `id -un 1000` -c 'git config --global user.email "github-actions[bot]@users.noreply.github.com"'
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -99,7 +99,7 @@ jobs:
 
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -123,7 +123,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -166,7 +166,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
       - name: Get tag
         id: tag
-        uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
-      - uses: ncipollo/release-action@v1
+        uses: dawidd6/action-get-tag@727a6f0a561be04e09013531e73a3983a65e3479 # v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           bodyFile: release-notes/opensearch-knn.release-notes-${{steps.tag.outputs.tag}}.md

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v1.1.4
+        uses: VachaShah/backport@28c49d91ceec57d7c9f625f1031c1a4d637251f5 # v1.1.4
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           branch_name: backport/backport-${{ github.event.number }}

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -53,9 +53,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - name: Install dependencies
         run: |
@@ -98,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout k-NN
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
@@ -107,9 +109,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: gradle
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         java: [ 11, 17 ]
         bwc_version : [ "1.1.0", "1.2.4", "1.3.8", "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0", "2.12.0", "2.13.0", "2.14.0", "2.15.0", "2.16.0", "2.17.0", "2.18.0", "2.19.0" ]
-        opensearch_version : [ "2.19.5-SNAPSHOT" ]
+        opensearch_version : [ "2.19.6-SNAPSHOT" ]
 
     name: k-NN Restart-Upgrade BWC Tests
     runs-on: ubuntu-latest
@@ -53,11 +53,9 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: ${{ matrix.java }}
-          distribution: temurin
-          cache: gradle
 
       - name: Install dependencies
         run: |
@@ -91,7 +89,7 @@ jobs:
       matrix:
         java: [ 11, 17 ]
         bwc_version: [ "1.3.8", "2.0.1", "2.1.0", "2.2.1", "2.3.0", "2.4.1", "2.5.0", "2.6.0", "2.7.0", "2.8.0", "2.9.0", "2.10.0", "2.11.0", "2.12.0", "2.13.0", "2.14.0", "2.15.0", "2.16.0", "2.17.0", "2.18.0", "2.19.0"]
-        opensearch_version: [ "2.19.5-SNAPSHOT" ]
+        opensearch_version: [ "2.19.6-SNAPSHOT" ]
 
     name: k-NN Rolling-Upgrade BWC Tests
     runs-on: ubuntu-latest
@@ -109,11 +107,9 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: ${{ matrix.java }}
-          distribution: temurin
-          cache: gradle
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/changelog_verifier.yml
+++ b/.github/workflows/changelog_verifier.yml
@@ -8,11 +8,11 @@ jobs:
   verify-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3
         with:
           skipLabels: "autocut, skip-changelog"

--- a/.github/workflows/create-documentation-issue.yml
+++ b/.github/workflows/create-documentation-issue.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         
       - name: Edit the issue template
         run: |
@@ -29,7 +29,7 @@ jobs:
           
       - name: Create Issue From File
         id: create-issue
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4
         with:
           title: Add documentation related to new feature
           content-filepath: ./.github/ISSUE_TEMPLATE/documentation-issue.md

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'opensearch-project/k-NN' && startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
     - name: Delete merged branch
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           github.rest.git.deleteRef({

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update draft release notes
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
         with:
           config-name: draft-release-notes-config.yml
           name: Version (set here)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@master
+        uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0 # master
         with:
           args: --accept=200,403,429  **/*.html **/*.md **/*.txt **/*.json
         env:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,14 +17,14 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Load secret
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
         with:
           # Export loaded secrets as environment variables
           export-env: true
@@ -34,7 +34,7 @@ jobs:
           MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       - name: Checkout k-NN
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Setup git user so that patches for native libraries can be applied and committed
       - name: Setup git user
         run: |
@@ -66,7 +66,7 @@ jobs:
           su `id -un 1000` -c 'git config --global user.email "github-actions[bot]@users.noreply.github.com"'
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     ext {
         // build.version_qualifier parameter applies to knn plugin artifacts only. OpenSearch version must be set
         // explicitly as 'opensearch.version' property, for instance opensearch.version=2.0.0-rc1-SNAPSHOT
-        opensearch_version = System.getProperty("opensearch.version", "2.19.5-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.6-SNAPSHOT")
         version_qualifier = System.getProperty("build.version_qualifier", "")
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
@@ -334,6 +334,7 @@ task cmakeJniLib(type:Exec) {
     args.add("-DAVX512_SPR_ENABLED=${avx512_spr_enabled}")
     args.add("-DCOMMIT_LIB_PATCHES=${commit_lib_patches}")
     args.add("-DAPPLY_LIB_PATCHES=${apply_lib_patches}")
+    args.add("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
     def javaHome = Jvm.current().getJavaHome()
     logger.lifecycle("Java home directory used by gradle: $javaHome")
     if (Os.isFamily(Os.FAMILY_MAC)) {

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -9,7 +9,7 @@ allprojects {
         java {
             target 'src/**/*.java'
             removeUnusedImports()
-	    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
+	    eclipse().configFile rootProject.file('buildSrc/formatterConfig.xml')
 	    trimTrailingWhitespace()
         }
     }

--- a/jni/cmake/init-nmslib.cmake
+++ b/jni/cmake/init-nmslib.cmake
@@ -20,6 +20,8 @@ if(NOT DEFINED APPLY_LIB_PATCHES OR "${APPLY_LIB_PATCHES}" STREQUAL true)
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0002-Adds-ability-to-pass-ef-parameter-in-the-query-for-h.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0003-Added-streaming-apis-for-vector-index-loading-in-Hnsw.patch")
     list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0004-Added-a-new-save-apis-in-Hnsw-with-streaming-interfa.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0005-Add-util-include-to-fix-pragma-error.patch")
+    list(APPEND PATCH_FILE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/patches/nmslib/0006-Added-NMSLIB_SIMD_FLAGS-also-introduces-AppleClang-in-CMake.patch")
 
     # Get patch id of the last commit
     execute_process(COMMAND sh -c "git --no-pager show HEAD | git patch-id --stable" OUTPUT_VARIABLE PATCH_ID_OUTPUT_FROM_COMMIT WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/nmslib)

--- a/jni/patches/nmslib/0005-Add-util-include-to-fix-pragma-error.patch
+++ b/jni/patches/nmslib/0005-Add-util-include-to-fix-pragma-error.patch
@@ -1,0 +1,26 @@
+From d9e3486454a843448119dff5b7011b9184123aa2 Mon Sep 17 00:00:00 2001
+From: John Mazanec <jmazane@amazon.com>
+Date: Mon, 3 Mar 2025 12:33:59 -0800
+Subject: [PATCH] Add util include to fix pragma error
+
+Adds include method in distcomp_scalar.cc to fix error related
+to pragma statements.
+---
+ similarity_search/src/distcomp_scalar.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/similarity_search/src/distcomp_scalar.cc b/similarity_search/src/distcomp_scalar.cc
+index 0aed6eb..245075f 100644
+--- a/similarity_search/src/distcomp_scalar.cc
++++ b/similarity_search/src/distcomp_scalar.cc
+@@ -15,6 +15,7 @@
+ #include "portable_intrinsics.h"
+ #include "distcomp.h"
+ #include "string.h"
++#include "utils.h"
+ 
+ #include <cstdlib>
+ #include <limits>
+-- 
+2.39.5 (Apple Git-154)
+

--- a/jni/patches/nmslib/0006-Added-NMSLIB_SIMD_FLAGS-also-introduces-AppleClang-in-CMake.patch
+++ b/jni/patches/nmslib/0006-Added-NMSLIB_SIMD_FLAGS-also-introduces-AppleClang-in-CMake.patch
@@ -1,0 +1,78 @@
+From 4147a630c63d94edcf3a2febc575faf454b07fe2 Mon Sep 17 00:00:00 2001
+From: Dooyong Kim <kdooyong@amazon.com>
+Date: Tue, 23 Sep 2025 22:50:43 -0700
+Subject: [PATCH] Add NMSLIB_SIMD_FLAGS, use AppleClang in CMake.
+
+Signed-off-by: Dooyong Kim <kdooyong@amazon.com>
+---
+ similarity_search/CMakeLists.txt | 29 +++++++++++++++--------------
+ 1 file changed, 15 insertions(+), 14 deletions(-)
+
+diff --git a/similarity_search/CMakeLists.txt b/similarity_search/CMakeLists.txt
+index bc6ef3c..03a3275 100644
+--- a/similarity_search/CMakeLists.txt
++++ b/similarity_search/CMakeLists.txt
+@@ -35,10 +35,9 @@ if(NOT WIN32)
+ endif()
+ #message(FATAL_ERROR "stopping... compiler version is: ${CMAKE_CXX_COMPILER_ID} ${CXX_COMPILER_VERSION}")
+ 
+-set(SIMD_FLAGS " -march=native")
+-#set(SIMD_FLAGS "-march=x86-64")
+-#set(SIMD_FLAGS "-march=core2")
+-#set(SIMD_FLAGS "-fpic -msse4.2")
++if(NOT NMSLIB_SIMD_FLAGS)
++    set(NMSLIB_SIMD_FLAGS "-march=native" CACHE STRING "SIMD compile flags for NMSLIB" FORCE)
++endif()
+ 
+ set(WARN_FLAGS "-Wall -Wunreachable-code -Wcast-align") 
+ 
+@@ -47,22 +46,22 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+     if (CXX_COMPILER_VERSION VERSION_LESS 4.7)
+         message(FATAL_ERROR "GCC version must be at least 4.7!")
+     endif()
+-    set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -Ofast -lm -DNDEBUG -std=c++11 -pthread  -DHAVE_CXX0X ${SIMD_FLAGS} -Wl,--no-as-needed -fpic")
+-    set (CMAKE_CXX_FLAGS_DEBUG   "${WARN_FLAGS} -ggdb  -lm -DNDEBUG -std=c++11 -pthread  -DHAVE_CXX0X ${SIMD_FLAGS} -Wl,--no-as-needed -fpic")
++    set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -Ofast -lm -DNDEBUG -std=c++11 -pthread  -DHAVE_CXX0X ${NMSLIB_SIMD_FLAGS} -Wl,--no-as-needed -fpic")
++    set (CMAKE_CXX_FLAGS_DEBUG   "${WARN_FLAGS} -ggdb  -lm -DNDEBUG -std=c++11 -pthread  -DHAVE_CXX0X ${NMSLIB_SIMD_FLAGS} -Wl,--no-as-needed -fpic")
+ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+     if (CXX_COMPILER_VERSION VERSION_LESS 14.0.1)
+         message(FATAL_ERROR "Intel version must be at least 14.0.1!")
+     endif()
+-    set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wunreachable-code -Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -fpic")
+-    set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wunreachable-code -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -fpic")
+-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
++    set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wunreachable-code -Ofast -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${NMSLIB_SIMD_FLAGS} -fpic")
++    set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wunreachable-code -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${NMSLIB_SIMD_FLAGS} -fpic")
++elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+     if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+         # MACOSX
+-        set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread -fpic ${SIMD_FLAGS}")
+-        set (CMAKE_CXX_FLAGS_DEBUG   "${WARN_FLAGS} -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread -fpic ${SIMD_FLAGS}")
++        set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread -fpic ${NMSLIB_SIMD_FLAGS}")
++        set (CMAKE_CXX_FLAGS_DEBUG   "${WARN_FLAGS} -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread -fpic ${NMSLIB_SIMD_FLAGS}")
+     else()
+-        set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -Wl,--no-as-needed -fpic")
+-        set (CMAKE_CXX_FLAGS_DEBUG   "${WARN_FLAGS} -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${SIMD_FLAGS} -Wl,--no-as-needed -fpic")
++        set (CMAKE_CXX_FLAGS_RELEASE "${WARN_FLAGS} -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${NMSLIB_SIMD_FLAGS} -Wl,--no-as-needed -fpic")
++        set (CMAKE_CXX_FLAGS_DEBUG   "${WARN_FLAGS} -ggdb  -DNDEBUG -std=c++11 -DHAVE_CXX0X -pthread ${NMSLIB_SIMD_FLAGS} -Wl,--no-as-needed -fpic")
+     endif()
+ elseif(WIN32)
+     # TODO how can we add support for later versions? There seems to be no flag with the semantics "version x or higher"
+@@ -70,7 +69,7 @@ elseif(WIN32)
+          message(FATAL_ERROR "On Windows, only MSVC version should be >= 12, code 1800, current version ${MSVC_VERSION}!") 
+     endif()
+ else ()
+-    message(FATAL_ERROR "Unrecognized compiler (use GCC, Clang, Intel compiler, or MSVC (on Windows)!")
++    message(FATAL_ERROR "Unrecognized compiler (use GCC, AppleClang, Clang, Intel compiler, or MSVC (on Windows)!, compiler was ${CMAKE_CXX_COMPILER_ID}")
+ endif()
+ 
+ if (WITH_EXTRAS)
+@@ -117,3 +116,5 @@ message(STATUS "OS:                ${CMAKE_SYSTEM_NAME}")
+ message(STATUS "Compiler:          ${CMAKE_CXX_COMPILER_ID} ${CXX_COMPILER_VERSION}")
+ message(STATUS "CXX flags release: ${CMAKE_CXX_FLAGS_RELEASE}")
+ message(STATUS "CXX flags debug:   ${CMAKE_CXX_FLAGS_DEBUG}")
++
++
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
### Description
1. Pin all GitHub Actions to commit SHAs from main
2. Remove unreachable Spotless p2 mirror redirect

### Related Issues
- N/A

### Check List
- [ ] ~New functionality includes testing.~
- [ ] ~New functionality has been documented.~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
