### PR TITLE
Preserve non-XContent source in derived source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)
 
 ### Bug Fixes
+* Preserve raw non-XContent `_source` fields when derived source is enabled [#3402](https://github.com/opensearch-project/k-NN/pull/3402)
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsWriter.java
@@ -242,13 +242,14 @@ public class KNN10010DerivedSourceStoredFieldsWriter extends StoredFieldsWriter 
                 MediaTypeRegistry.JSON
             );
         } catch (NotXContentException e) {
-            // If the content is not XContent, skip writing altogether. See:
-            // https://github.com/opensearch-project/k-NN/issues/2880
+            // Some OpenSearch internal documents, such as no-op tombstones, store _source as raw bytes rather than XContent.
+            // Derived source can only mask vector fields after parsing XContent, so preserve non-XContent _source unchanged.
             log.warn(
                 "Encountered NotXContent while deserializing _source field. Instead found String: [{}]",
-                new String(bytesRef.bytes, 0, Math.min(bytesRef.bytes.length, 512)),
+                new String(bytesRef.bytes, bytesRef.offset, Math.min(bytesRef.length, 512)),
                 e
             );
+            delegate.writeField(fieldInfo, bytesRef);
             return;
         }
         // Apply mask on vector fields in parsed source (idempotent - safe to apply even if already masked)

--- a/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformer.java
@@ -12,6 +12,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.compress.NotXContentException;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -140,11 +141,23 @@ public class DerivedSourceVectorTransformer {
         // Reference:
         // https://github.com/opensearch-project/OpenSearch/blob/2.18.0/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java#L322
         // Deserialize the source into a modifiable map
-        Tuple<? extends MediaType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(
-            BytesReference.fromByteBuffer(ByteBuffer.wrap(sourceAsBytes)),
-            true,
-            MediaTypeRegistry.getDefaultMediaType()
-        );
+        Tuple<? extends MediaType, Map<String, Object>> mapTuple;
+        try {
+            mapTuple = XContentHelper.convertToMap(
+                BytesReference.fromByteBuffer(ByteBuffer.wrap(sourceAsBytes)),
+                true,
+                MediaTypeRegistry.getDefaultMediaType()
+            );
+        } catch (NotXContentException e) {
+            // Some OpenSearch internal documents, such as no-op tombstones, store _source as raw bytes rather than XContent.
+            // Derived source can only inject vector fields after parsing XContent, so preserve non-XContent _source unchanged.
+            log.warn(
+                "Encountered NotXContent while deserializing _source field. Instead found String: [{}]",
+                new String(sourceAsBytes, 0, Math.min(sourceAsBytes.length, 512)),
+                e
+            );
+            return sourceAsBytes;
+        }
         // Have to create a copy of the map here to ensure that is mutable
         Map<String, Object> sourceAsMap = mapTuple.v2();
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/DerivedSourceStoredFieldsWriterTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -63,6 +64,38 @@ public class DerivedSourceStoredFieldsWriterTests extends KNNTestCase {
         byte[] shiftedBytes = new byte[originalBytes.length + 2];
         System.arraycopy(originalBytes, 0, shiftedBytes, 1, originalBytes.length);
         derivedSourceStoredFieldsWriter.writeField(fieldInfo, new BytesRef(shiftedBytes, 1, originalBytes.length));
+    }
+
+    @SneakyThrows
+    public void testWriteFieldPreservesNonXContentSource() {
+        StoredFieldsWriter delegate = mock(StoredFieldsWriter.class);
+        SegmentInfo segmentInfo = mock(SegmentInfo.class);
+        MapperService mapperService = mock(MapperService.class);
+        DocumentMapper documentMapper = mock(DocumentMapper.class);
+        MappingLookup mappingLookup = mock(MappingLookup.class);
+        KNNVectorFieldType vectorFieldType = mock(KNNVectorFieldType.class);
+
+        String fieldName = "vector";
+        when(vectorFieldType.name()).thenReturn(fieldName);
+        when(mapperService.fieldTypes()).thenReturn(List.of(vectorFieldType));
+        when(mapperService.documentMapper()).thenReturn(documentMapper);
+        when(documentMapper.metadataMapper(SourceFieldMapper.class)).thenReturn(null);
+        when(documentMapper.mappers()).thenReturn(mappingLookup);
+        when(mappingLookup.getMapper(fieldName)).thenReturn(null);
+        when(mappingLookup.getNestedScope(fieldName)).thenReturn(null);
+
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder(SourceFieldMapper.NAME).build();
+        BytesRef rawSource = new BytesRef("filling gaps");
+        KNN10010DerivedSourceStoredFieldsWriter derivedSourceStoredFieldsWriter = new KNN10010DerivedSourceStoredFieldsWriter(
+            "mock-codec",
+            delegate,
+            segmentInfo,
+            mapperService
+        );
+
+        derivedSourceStoredFieldsWriter.writeField(fieldInfo, rawSource);
+
+        verify(delegate).writeField(same(fieldInfo), same(rawSource));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/derivedsource/DerivedSourceVectorTransformerTests.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -114,6 +115,16 @@ public class DerivedSourceVectorTransformerTests extends OpenSearchTestCase {
             new String[] { "test_vector", "temp_vector", "user_vector" },
             new String[] {}
         );
+    }
+
+    public void testInjectVectors_whenSourceIsNonXContent_thenPreservesOriginalSource() throws Exception {
+        DerivedSourceVectorTransformer transformer = createTransformerWithFields("test_vector");
+        transformer.initialize(null, null);
+        byte[] rawSource = "filling gaps".getBytes(StandardCharsets.UTF_8);
+
+        byte[] transformedSource = transformer.injectVectors(0, rawSource);
+
+        assertArrayEquals(rawSource, transformedSource);
     }
 
     private void assertFieldFiltering(String[] includes, String[] excludes, String[] expectedPresent, String[] expectedAbsent) {


### PR DESCRIPTION
### Description
Preserve raw non-XContent `_source` fields when k-NN derived source is enabled.

OpenSearch engine-generated documents can store `_source` as raw bytes rather than XContent. For example, no-op tombstones store their reason string directly in `_source`. Derived source can only mask or inject vector fields after parsing XContent, so this change makes non-XContent `_source` a pass-through case:

* `KNN10010DerivedSourceStoredFieldsWriter` delegates the original `_source` bytes when parsing throws `NotXContentException`.
* `DerivedSourceVectorTransformer` returns non-XContent `_source` bytes unchanged on read instead of attempting vector injection.
* Unit tests cover both the writer and reader-side transformer behavior.

This addresses the follow-up failure mode introduced by #2882 while preserving the original intent of #2880.

### Related Issues
Resolves #3401

Related:
* #2880
* #2882
* opensearch-project/OpenSearch#19330
* opensearch-project/OpenSearch#22317

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented. Not applicable; this is an internal bug fix.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). Not applicable; there are no API changes.
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose). Not applicable; this is an internal bug fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
