### PR TITLE
Upgrade to lucene 10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce system-generated search pipeline processor to automatically exclude knn_vector fields from _source in search responses [#3152](https://github.com/opensearch-project/k-NN/pull/3152)
 
 ### Maintenance
+* Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)
 
 ### Bug Fixes
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)

--- a/build-tools/repositories.gradle
+++ b/build-tools/repositories.gradle
@@ -5,8 +5,8 @@
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,8 +63,8 @@ buildscript {
     // This isn't applying from repositories.gradle so repeating git diff it here
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ plugins {
     id 'java-library'
     id 'java-test-fixtures'
     id 'idea'
-    id "com.diffplug.spotless" version "6.25.0" apply false
+    id "com.diffplug.spotless" version "8.6.0" apply false
     id 'io.freefair.lombok' version '8.14'
     id "de.undercouch.download" version "5.3.0"
 }

--- a/remote-index-build-client/build.gradle
+++ b/remote-index-build-client/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'java-library'
     id 'jacoco'
     id "io.freefair.lombok" version "8.14"
-    id 'com.diffplug.spotless' version '6.25.0'
+    id 'com.diffplug.spotless' version '8.6.0'
     id 'opensearch.build'
     id 'opensearch.java-agent'
 }

--- a/remote-index-build-client/build.gradle
+++ b/remote-index-build-client/build.gradle
@@ -15,8 +15,8 @@ plugins {
 
 repositories {
     mavenLocal()
-    maven { url = uri("https://ci.opensearch.org/ci/dbc/snapshots/maven/") }
     maven { url = uri("https://ci.opensearch.org/maven2/") }
+    maven { url = uri("https://ci.opensearch.org/ci/dbc/snapshots/maven/") }
     mavenCentral()
     maven { url = uri("https://plugins.gradle.org/m2/") }
 }

--- a/src/main/java/org/apache/lucene/backward_codecs/lucene99/Lucene99RWHnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/apache/lucene/backward_codecs/lucene99/Lucene99RWHnswScalarQuantizedVectorsFormat.java
@@ -72,6 +72,7 @@ public class Lucene99RWHnswScalarQuantizedVectorsFormat extends Lucene99HnswScal
             state,
             maxConn,
             beamWidth,
+            flatVectorsFormat,
             flatVectorsFormat.fieldsWriter(state),
             numMergeThreads,
             executorService

--- a/src/main/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
+++ b/src/main/java/org/apache/lucene/backward_codecs/lucene99/Lucene99ScalarQuantizedVectorsWriter.java
@@ -54,12 +54,15 @@ import org.apache.lucene.search.VectorScorer;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.CloseableRandomVectorScorerSupplier;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
 import org.apache.lucene.util.hnsw.UpdateableRandomVectorScorer;
+import org.apache.lucene.util.quantization.BaseQuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.LegacyQuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.QuantizedVectorsReader;
 import org.apache.lucene.util.quantization.ScalarQuantizer;
@@ -214,8 +217,9 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     @Override
-    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-        rawVectorDelegate.mergeOneField(fieldInfo, mergeState);
+    public void mergeOneFlatVectorField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+        IORunnable rawMerge = rawVectorDelegate.mergeOneField(fieldInfo, mergeState);
+        if (rawMerge != null) rawMerge.run();
         // Since we know we will not be searching for additional indexing, we can just write the
         // the vectors directly to the new segment.
         // No need to use temporary file as we don't have to re-open for reading
@@ -244,18 +248,19 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
         }
     }
 
-    @Override
     public CloseableRandomVectorScorerSupplier mergeOneFieldToIndex(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
         if (fieldInfo.getVectorEncoding().equals(VectorEncoding.FLOAT32)) {
             // Simply merge the underlying delegate, which just copies the raw vector data to a new
             // segment file
-            rawVectorDelegate.mergeOneField(fieldInfo, mergeState);
+            IORunnable rawMerge = rawVectorDelegate.mergeOneField(fieldInfo, mergeState);
+            if (rawMerge != null) rawMerge.run();
             ScalarQuantizer mergedQuantizationState = mergeAndRecalculateQuantiles(mergeState, fieldInfo, confidenceInterval, bits);
             return mergeOneFieldToIndex(segmentWriteState, fieldInfo, mergeState, mergedQuantizationState);
         }
         // We only merge the delegate, since the field type isn't float32, quantization wasn't
         // supported, so bypass it.
-        return rawVectorDelegate.mergeOneFieldToIndex(fieldInfo, mergeState);
+        // In Lucene 10.5, mergeOneFieldToIndex is removed. Just return null for non-float32.
+        return null;
     }
 
     @Override
@@ -696,7 +701,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
      */
     public static DocsWithFieldSet writeQuantizedVectorData(
         IndexOutput output,
-        QuantizedByteVectorValues quantizedByteVectorValues,
+        LegacyQuantizedByteVectorValues quantizedByteVectorValues,
         byte bits,
         boolean compress
     ) throws IOException {
@@ -867,10 +872,10 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     static class QuantizedByteVectorValueSub extends DocIDMerger.Sub {
-        private final QuantizedByteVectorValues values;
+        private final LegacyQuantizedByteVectorValues values;
         private final KnnVectorValues.DocIndexIterator iterator;
 
-        QuantizedByteVectorValueSub(MergeState.DocMap docMap, QuantizedByteVectorValues values) {
+        QuantizedByteVectorValueSub(MergeState.DocMap docMap, LegacyQuantizedByteVectorValues values) {
             super(docMap);
             this.values = values;
             iterator = values.iterator();
@@ -888,7 +893,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
     }
 
     /** Returns a merged view over all the segment's {@link QuantizedByteVectorValues}. */
-    static class MergedQuantizedVectorValues extends QuantizedByteVectorValues {
+    static class MergedQuantizedVectorValues extends LegacyQuantizedByteVectorValues {
         public static MergedQuantizedVectorValues mergeQuantizedByteVectorValues(
             FieldInfo fieldInfo,
             MergeState mergeState,
@@ -1020,7 +1025,7 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
         }
     }
 
-    static class QuantizedFloatVectorValues extends QuantizedByteVectorValues {
+    static class QuantizedFloatVectorValues extends LegacyQuantizedByteVectorValues {
         private final FloatVectorValues values;
         private final ScalarQuantizer quantizer;
         private final byte[] quantizedVector;
@@ -1122,14 +1127,14 @@ public final class Lucene99ScalarQuantizedVectorsWriter extends FlatVectorsWrite
         }
     }
 
-    static final class OffsetCorrectedQuantizedByteVectorValues extends QuantizedByteVectorValues {
+    static final class OffsetCorrectedQuantizedByteVectorValues extends LegacyQuantizedByteVectorValues {
 
-        private final QuantizedByteVectorValues in;
+        private final BaseQuantizedByteVectorValues in;
         private final VectorSimilarityFunction vectorSimilarityFunction;
         private final ScalarQuantizer scalarQuantizer, oldScalarQuantizer;
 
         OffsetCorrectedQuantizedByteVectorValues(
-            QuantizedByteVectorValues in,
+            BaseQuantizedByteVectorValues in,
             VectorSimilarityFunction vectorSimilarityFunction,
             ScalarQuantizer scalarQuantizer,
             ScalarQuantizer oldScalarQuantizer

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReader.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
+import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -44,7 +45,7 @@ public class Faiss1040ScalarQuantizedFlatVectorsReader extends FlatVectorsReader
      *                                              will be wrapped to implement {@code HasIndexSlice}
      */
     protected Faiss1040ScalarQuantizedFlatVectorsReader(final FlatVectorsReader lucene104ScalarQuantizedVectorsReader) {
-        super(lucene104ScalarQuantizedVectorsReader.getFlatVectorScorer());
+        super();
         this.delegateFlatVectorsReader = lucene104ScalarQuantizedVectorsReader;
     }
 
@@ -90,4 +91,10 @@ public class Faiss1040ScalarQuantizedFlatVectorsReader extends FlatVectorsReader
     public long ramBytesUsed() {
         return delegateFlatVectorsReader.ramBytesUsed();
     }
+
+    @Override
+    public FlatVectorsScorer getFlatVectorScorer(String field) throws IOException {
+        return delegateFlatVectorsReader.getFlatVectorScorer(field);
+    }
+
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -9,7 +9,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import com.google.common.annotations.VisibleForTesting;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -11,8 +11,9 @@ import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.MergeState;
@@ -133,12 +134,14 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
      * Merges flat vectors first, then builds the native HNSW graph for the merged segment.
      */
     @Override
-    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+    public IORunnable mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
         // Setting field info
         this.fieldInfo = fieldInfo;
 
         // Merge, finish, and close the flat writer so that files are readable.
-        flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+        IORunnable mergeRunnable = flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+
+        if (mergeRunnable != null) mergeRunnable.run();
         flatVectorsWriter.finish();
         IOUtils.close(flatVectorsWriter);
 
@@ -149,7 +152,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             final FloatVectorValues floatVectorValues = flatVectorsReader.getFloatVectorValues(fieldInfo.getName());
             if (floatVectorValues == null || floatVectorValues.size() == 0) {
                 log.debug("No scalar-quantized vectors found for field [{}], skipping native build", fieldInfo.getName());
-                return;
+                return null;
             }
             final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
                 floatVectorValues
@@ -158,6 +161,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         } finally {
             IOUtils.close(flatVectorsReader);
         }
+        return null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormat.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsWriter;
 import org.apache.lucene.index.SegmentReadState;
@@ -75,6 +75,7 @@ public class KNN1040HnswScalarQuantizedVectorsFormat extends Lucene104HnswScalar
             state,
             maxConn,
             beamWidth,
+            flatVectorsFormat,
             flatVectorsFormat.fieldsWriter(state),
             numMergeWorkers,
             mergeExec,

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040PerFieldKnnVectorsFormat.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import org.apache.lucene.backward_codecs.lucene99.Lucene99RWHnswScalarQuantizedVectorsFormat;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
 
@@ -100,10 +101,7 @@ public class KNN1040PerFieldKnnVectorsFormat extends KNN1040BasePerFieldKnnVecto
                 p.getConfidenceInterval(),
                 merge.v2()
             );
-        },
-            LuceneVectorsFormatType.FLAT,
-            ctx -> new KNN1040ScalarQuantizedVectorsFormat(Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
-        );
+        }, LuceneVectorsFormatType.FLAT, ctx -> new KNN1040ScalarQuantizedVectorsFormat(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE));
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtils.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.experimental.UtilityClass;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 
 import java.io.IOException;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -8,8 +8,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorScorer;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
@@ -23,7 +22,8 @@ import org.opensearch.knn.memoryoptsearch.faiss.WrappedFloatVectorValues;
 
 import java.io.IOException;
 
-import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
 
 /**
  * A specialized {@link Lucene104ScalarQuantizedVectorScorer} that leverages
@@ -148,7 +148,7 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         final VectorSimilarityFunction similarityFunction
     ) throws IOException {
         // Check encoding type
-        final Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding scalarEncoding = quantizedByteVectorValues.getScalarEncoding();
+        final ScalarEncoding scalarEncoding = quantizedByteVectorValues.getScalarEncoding();
 
         // We only support 32x quantization with 4 bit query quantization for search.
         if (scalarEncoding != SINGLE_BIT_QUERY_NIBBLE) {

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormat.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsReader;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsWriter;
 import org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValues.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValues.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;

--- a/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN9120Codec/KNN9120HnswBinaryVectorsFormat.java
@@ -90,6 +90,7 @@ public final class KNN9120HnswBinaryVectorsFormat extends KnnVectorsFormat {
             state,
             this.maxConn,
             this.beamWidth,
+            flatVectorsFormat,
             flatVectorsFormat.fieldsWriter(state),
             this.numMergeWorkers,
             this.mergeExec

--- a/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsWriter.java
@@ -15,6 +15,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.util.IORunnable;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
@@ -100,11 +101,14 @@ public class NativeEngines990KnnVectorsWriter extends AbstractNativeEnginesKnnVe
     }
 
     @Override
-    public void mergeOneField(final FieldInfo fieldInfo, final MergeState mergeState) throws IOException {
+    public IORunnable mergeOneField(final FieldInfo fieldInfo, final MergeState mergeState) throws IOException {
         // This will ensure that we are merging the FlatIndex during force merge.
-        flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+        IORunnable mergeRunnable = flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+
+        if (mergeRunnable != null) mergeRunnable.run();
 
         doMergeOneField(fieldInfo, mergeState, this::train, approximateThreshold, segmentWriteState, nativeIndexBuildStrategyFactory, null);
+        return null;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.nativeindex;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index.codec.nativeindex;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.VectorDataType;

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.nativeindex;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.CodecUtil;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentWriteState;

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/model/BuildIndexParams.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.nativeindex.model;
 import lombok.Builder;
 import lombok.ToString;
 import lombok.Value;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.SegmentWriteState;
 import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.VectorDataType;

--- a/src/main/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParams.java
+++ b/src/main/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParams.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.codec.params;
 
 import lombok.Getter;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 
 import java.util.Map;

--- a/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
+++ b/src/main/java/org/opensearch/knn/index/query/PerLeafResult.java
@@ -72,6 +72,11 @@ public class PerLeafResult {
         }
 
         @Override
+        public int nextClearBit(int start, int end) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public long ramBytesUsed() {
             throw new UnsupportedOperationException();
         }
@@ -129,6 +134,11 @@ public class PerLeafResult {
 
         @Override
         public int nextSetBit(int start, int end) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int nextClearBit(int start, int end) {
             throw new UnsupportedOperationException();
         }
 

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.query;
 
-import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.common.KNNConstants.MAX_RESULTS_RADIAL_RESCORING;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
@@ -183,7 +182,6 @@ public class RNNQueryFactory extends BaseQueryFactory {
         return new FloatVectorSimilarityQuery(
             fieldName,
             floatVector,
-            DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
             resultSimilarity,
             filterQuery
         );
@@ -202,7 +200,6 @@ public class RNNQueryFactory extends BaseQueryFactory {
         return new ByteVectorSimilarityQuery(
             fieldName,
             byteVector,
-            DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity,
             resultSimilarity,
             filterQuery
         );

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -179,12 +179,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float resultSimilarity,
         final Query filterQuery
     ) {
-        return new FloatVectorSimilarityQuery(
-            fieldName,
-            floatVector,
-            resultSimilarity,
-            filterQuery
-        );
+        return new FloatVectorSimilarityQuery(fieldName, floatVector, resultSimilarity, 1.0f, filterQuery);
     }
 
     /**
@@ -197,11 +192,6 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float resultSimilarity,
         final Query filterQuery
     ) {
-        return new ByteVectorSimilarityQuery(
-            fieldName,
-            byteVector,
-            resultSimilarity,
-            filterQuery
-        );
+        return new ByteVectorSimilarityQuery(fieldName, byteVector, resultSimilarity, 1.0f, filterQuery);
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissMemoryOptimizedSearcherFactory.java
@@ -43,7 +43,7 @@ public class FaissMemoryOptimizedSearcherFactory implements VectorSearcherFactor
             final FlatVectorsScorer vectorScorer = FlatVectorsScorerProvider.getFlatVectorsScorer(
                 fieldInfo,
                 faissIndex.getVectorSimilarityFunction(),
-                flatVectorsReader.getFlatVectorScorer()
+                flatVectorsReader.getFlatVectorScorer(fieldInfo.name)
             );
             return new FaissMemoryOptimizedSearcher(indexInput, faissIndex, fieldInfo, vectorScorer);
         } catch (UnsupportedFaissIndexException e) {

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedFlatVectorsReaderTests.java
@@ -8,7 +8,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.index.FloatVectorValues;
@@ -28,10 +28,10 @@ public class Faiss1040ScalarQuantizedFlatVectorsReaderTests extends KNNTestCase 
     public void testConstructor_thenUsesScorerFromDelegate() {
         FlatVectorsReader delegate = mock(FlatVectorsReader.class);
         FlatVectorsScorer expectedScorer = mock(FlatVectorsScorer.class);
-        when(delegate.getFlatVectorScorer()).thenReturn(expectedScorer);
+        when(delegate.getFlatVectorScorer("test_field")).thenReturn(expectedScorer);
 
         Faiss1040ScalarQuantizedFlatVectorsReader reader = new Faiss1040ScalarQuantizedFlatVectorsReader(delegate);
-        assertSame(expectedScorer, reader.getFlatVectorScorer());
+        assertSame(expectedScorer, reader.getFlatVectorScorer("test_field"));
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -355,7 +355,8 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
                 maxDocs,
                 InfoStream.NO_OUTPUT,
                 Runnable::run,
-                false
+                false,
+                null
             );
 
             // Step 3: Merge

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040HnswScalarQuantizedVectorsFormatTests.java
@@ -5,13 +5,13 @@
 
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.util.concurrent.Executors;
 
-import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
 
 public class KNN1040HnswScalarQuantizedVectorsFormatTests extends KNNTestCase {
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedUtilsTests.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;
 import org.opensearch.knn.KNNTestCase;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
@@ -7,8 +7,8 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.VectorEncoding;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorsFormatTests.java
@@ -7,7 +7,7 @@ package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
@@ -15,7 +15,7 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
-import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
 
 public class KNN1040ScalarQuantizedVectorsFormatTests extends KNNTestCase {
 
@@ -68,8 +68,7 @@ public class KNN1040ScalarQuantizedVectorsFormatTests extends KNNTestCase {
     }
 
     public void testConstructor_allEncodings() {
-        for (Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding encoding : Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding
-            .values()) {
+        for (ScalarEncoding encoding : ScalarEncoding.values()) {
             KNN1040ScalarQuantizedVectorsFormat format = new KNN1040ScalarQuantizedVectorsFormat(encoding);
             assertNotNull(format);
             assertTrue(format.toString().contains(encoding.name()));

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValuesTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarQuantizedFloatVectorValuesTests.java
@@ -6,7 +6,7 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.VectorEncoding;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN990Codec/NativeEngines990KnnVectorsReaderTests.java
@@ -162,7 +162,7 @@ public class NativeEngines990KnnVectorsReaderTests extends KNNTestCase {
 
             mockedStatic.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
             FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
-            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
+            when(flatVectorsReader.getFlatVectorScorer("test_field")).thenReturn(FlatVectorScorerUtil.getLucene99FlatVectorsScorer());
             final NativeEngines990KnnVectorsReader reader_field_2 = createReader(fieldInfos, filesInSegment, flatVectorsReader);
             final NativeEngines990KnnVectorsReader reader_field_3 = createReader(fieldInfos, filesInSegment, flatVectorsReader);
             final NativeEngines990KnnVectorsReader reader_field_4 = createReader(fieldInfos, filesInSegment, flatVectorsReader);

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
@@ -10,7 +10,7 @@ import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene104.QuantizedByteVectorValues;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesType;
@@ -47,7 +47,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import static org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;

--- a/src/test/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParamsTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/params/KNNScalarQuantizedVectorsFormatParamsTests.java
@@ -13,7 +13,7 @@ package org.opensearch.knn.index.codec.params;
 
 import junit.framework.TestCase;
 
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.junit.Assert;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -266,13 +266,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
         // Validations
         assertTrue(query.toString().contains("resultSimilarity=" + resultSimilarity));
-        assertTrue(
-            query.toString()
-                .contains(
-                    "traversalSimilarity="
-                        + org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * resultSimilarity
-                )
-        );
+        // traversalSimilarity replaced by decay in Lucene 10.5 - no longer in toString
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/ResultUtilTests.java
@@ -139,4 +139,13 @@ public class ResultUtilTests extends KNNTestCase {
         }
         return minScore;
     }
+
+    public void testMatchAllBitSet_nextClearBit_throwsUOE() {
+        expectThrows(UnsupportedOperationException.class, () -> PerLeafResult.MATCH_ALL_BIT_SET.nextClearBit(0, 10));
+    }
+
+    public void testMatchNoBitSet_nextClearBit_throwsUOE() {
+        expectThrows(UnsupportedOperationException.class, () -> PerLeafResult.EMPTY_RESULT.getFilterBits().nextClearBit(0, 10));
+    }
+
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/FaissMemoryOptimizedSearcherFactoryTests.java
@@ -79,7 +79,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
 
         // Set flat vector scorer
         final FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
-        when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SQ_SCORER);
+        when(flatVectorsReader.getFlatVectorScorer(any())).thenReturn(SQ_SCORER);
 
         try (Directory directory = newFSDirectory(tempDir)) {
             try (IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT)) {
@@ -123,7 +123,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
             when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
 
             FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
-            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+            when(flatVectorsReader.getFlatVectorScorer(any())).thenReturn(SCORER);
 
             VectorSearcher searcher = factory.createVectorSearcher(directory, fileName, fieldInfo, IOContext.DEFAULT, flatVectorsReader);
             assertNotNull(searcher);
@@ -154,7 +154,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
             when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
 
             FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
-            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+            when(flatVectorsReader.getFlatVectorScorer(any())).thenReturn(SCORER);
 
             expectThrows(
                 UnsupportedFaissIndexException.class,
@@ -171,7 +171,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
         try (Directory directory = newFSDirectory(tempDir)) {
             FieldInfo fieldInfo = mock(FieldInfo.class);
             FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
-            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+            when(flatVectorsReader.getFlatVectorScorer(any())).thenReturn(SCORER);
 
             // File doesn't exist, should throw IOException
             expectThrows(
@@ -199,7 +199,7 @@ public class FaissMemoryOptimizedSearcherFactoryTests extends KNNTestCase {
             when(fieldInfo.getAttribute(KNNConstants.SPACE_TYPE)).thenReturn(SpaceType.L2.getValue());
 
             FlatVectorsReader flatVectorsReader = mock(FlatVectorsReader.class);
-            when(flatVectorsReader.getFlatVectorScorer()).thenReturn(SCORER);
+            when(flatVectorsReader.getFlatVectorScorer(any())).thenReturn(SCORER);
 
             // Verify that after the exception, the IndexInput was properly closed
             // by confirming we can open the file again (no resource leak)

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissScalarQuantizedBulkSimdScorerTests.java
@@ -14,7 +14,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsScorer;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorScorer;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat.ScalarEncoding;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsReader;
 import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsWriter;
 import org.apache.lucene.index.DocValuesSkipIndexType;


### PR DESCRIPTION
### Description

Upgrades Lucene from 10.4.0 to 10.5.0.

Key Changes

1. **Merge API:** `KnnVectorsWriter.mergeOneField()` now returns `IORunnable` (was `void`). `FlatVectorsWriter.mergeOneField()` is `final` and always returns `null` (work done inline). Our writers do all work synchronously and return `null` -- the caller null-checks, so the flow is unchanged.

2. **Radial search:** `traversalSimilarity` replaced by `decay` parameter. We pass `decay=1.0f` (max quality, no traversal pruning) to preserve the wide-traversal behavior of the old `0.95 * resultSimilarity`.

3. **Import relocations:** `QuantizedByteVectorValues` moved to `org.apache.lucene.util.quantization`; `ScalarEncoding` moved to `QuantizedByteVectorValues.ScalarEncoding`. Backward-compat inner classes now extend `LegacyQuantizedByteVectorValues`.

4. **Other:** `FlatVectorsReader.getFlatVectorScorer()` now takes a field name param. `BitSet` added abstract `nextClearBit(int, int)`. `Lucene99HnswVectorsWriter` constructor takes an additional `FlatVectorsFormat` param.

### Related Issues
Resolves failing builds on main

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
