### PR TITLE
Fix NPE on k-NN explain with rescore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)
 
 ### Bug Fixes
+* Fix NPE on k-NN query with rescore and explain when Lucene engine is used [#3084](https://github.com/opensearch-project/k-NN/issues/3084)
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)

--- a/src/main/java/org/opensearch/knn/index/query/common/DocAndScoreQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/common/DocAndScoreQuery.java
@@ -67,6 +67,10 @@ final class DocAndScoreQuery extends Query {
                     throw new RuntimeException(e);
                 }
 
+                if (knnWeight == null) {
+                    return Explanation.match(score, "k-NN score");
+                }
+
                 return knnWeight.explain(context, doc, score);
             }
 

--- a/src/test/java/org/opensearch/knn/index/query/common/DocAndScoreQueryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/common/DocAndScoreQueryTests.java
@@ -104,6 +104,18 @@ public class DocAndScoreQueryTests extends OpenSearchTestCase {
         verify(knnWeight).explain(leaf1, 1, 1.2f);
     }
 
+    @SneakyThrows
+    public void testWeight_whenKnnWeightNull_thenExplainDoesNotThrow() {
+        int[] expectedDocs = { 0, 1, 2, 3, 4 };
+        float[] expectedScores = { 0.1f, 1.2f, 2.3f, 5.1f, 3.4f };
+        int[] findSegments = { 0, 2, 5 };
+
+        objectUnderTest = new DocAndScoreQuery(4, expectedDocs, expectedScores, findSegments, readerContext.id(), null);
+        Weight weight = objectUnderTest.createWeight(indexSearcher, ScoreMode.COMPLETE, 1);
+
+        assertNotNull(weight.explain(leaf1, 1));
+    }
+
     private IndexReader createTestIndexReader() throws IOException {
         ByteBuffersDirectory directory = new ByteBuffersDirectory();
         IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new MockAnalyzer(random())));


### PR DESCRIPTION
## Summary
- Fixes a `null_pointer_exception` when running a k-NN search with `rescore` and `explain=true` on Lucene engine indices ([#3084](https://github.com/opensearch-project/k-NN/issues/3084))
- `DocAndScoreQuery` created during shard-level rescore does not carry a `KNNWeight`, but `explain()` unconditionally delegated to `knnWeight.explain()`
- Return a basic score explanation when `knnWeight` is null instead of throwing



