### PR TITLE
Parameterize tests based on compression level for 32x defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add rescoring phase after radial search on quantized index [#3347](https://github.com/opensearch-project/k-NN/pull/3347)
 * Add base64 encoded vector indexing support for knn_vector fields [#3350](https://github.com/opensearch-project/k-NN/pull/3350)
 * Introduce system-generated search pipeline processor to automatically exclude knn_vector fields from _source in search responses [#3152](https://github.com/opensearch-project/k-NN/pull/3152)
+* Parameterize integration test framework for compression level [#3416](https://github.com/opensearch-project/k-NN/pull/3416)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/DerivedSourceBWCRestartIT.java
@@ -9,6 +9,11 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.knn.DerivedSourceTestCase;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import org.opensearch.knn.CompressionTestConfig;
+
+import java.util.Collection;
+import java.util.List;
 import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
@@ -23,6 +28,15 @@ import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
 import static org.opensearch.knn.TestUtils.RESTART_UPGRADE_OLD_CLUSTER;
 
 public class DerivedSourceBWCRestartIT extends DerivedSourceTestCase {
+
+    public DerivedSourceBWCRestartIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     public void testFlat_indexAndForceMergeOnOld_injectOnNew() throws IOException {
         List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts = getFlatIndexContexts("knn-bwc", false, false);

--- a/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
+++ b/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
@@ -19,7 +19,8 @@ import org.junit.Assert;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.NestedKnnDocBuilder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.K;
 import static org.opensearch.knn.common.KNNConstants.KNN;
@@ -50,7 +50,11 @@ import static org.hamcrest.Matchers.containsString;
  * This class contains the IT for some advanced and tricky use-case of filters.
  * <a href="https://github.com/opensearch-project/k-NN/issues/1356">Github issue</a>
  */
-public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
+public class AdvancedFilteringUseCasesIT extends KNNCompressionRestTestCase {
+
+    public AdvancedFilteringUseCasesIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     private static final String INDEX_NAME = "advanced_filtering_test_index";
 
@@ -495,7 +499,6 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
      *     }
      * }
      */
-    // Pinned to FP32: relies on uncompressed score precision
     @SneakyThrows
     private String createNestedMappings(final int dimension, final String engine) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -506,9 +509,9 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD)
             .startObject(FIELD_NAME_VECTOR)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
-            .startObject(KNN_METHOD)
+            .field(DIMENSION, dimension);
+        addCompressionForEngine(builder, engine);
+        builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNN_ENGINE, engine)
@@ -541,7 +544,6 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
      *     }
      * }
      */
-    // Pinned to FP32: relies on uncompressed score precision
     @SneakyThrows
     private String createVectorNonNestedMappings(final int dimension, final String engine) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -552,9 +554,9 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
             .endObject()
             .startObject(FIELD_NAME_VECTOR)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
-            .startObject(KNN_METHOD)
+            .field(DIMENSION, dimension);
+        addCompressionForEngine(builder, engine);
+        builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNN_ENGINE, engine)
@@ -564,5 +566,10 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
             .endObject();
 
         return builder.toString();
+    }
+
+    @SneakyThrows
+    private void addCompressionForEngine(final XContentBuilder builder, final String engine) {
+        addCompressionMappingFields(builder);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
+++ b/src/test/java/org/opensearch/knn/index/AdvancedFilteringUseCasesIT.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.K;
 import static org.opensearch.knn.common.KNNConstants.KNN;
@@ -494,6 +495,7 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
      *     }
      * }
      */
+    // Pinned to FP32: relies on uncompressed score precision
     @SneakyThrows
     private String createNestedMappings(final int dimension, final String engine) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -505,6 +507,7 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
             .startObject(FIELD_NAME_VECTOR)
             .field(TYPE, TYPE_KNN_VECTOR)
             .field(DIMENSION, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
@@ -538,6 +541,7 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
      *     }
      * }
      */
+    // Pinned to FP32: relies on uncompressed score precision
     @SneakyThrows
     private String createVectorNonNestedMappings(final int dimension, final String engine) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
@@ -549,6 +553,7 @@ public class AdvancedFilteringUseCasesIT extends KNNRestTestCase {
             .startObject(FIELD_NAME_VECTOR)
             .field(TYPE, TYPE_KNN_VECTOR)
             .field(DIMENSION, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())

--- a/src/test/java/org/opensearch/knn/index/Compression32XIT.java
+++ b/src/test/java/org/opensearch/knn/index/Compression32XIT.java
@@ -314,8 +314,6 @@ public class Compression32XIT extends KNNCompressionRestTestCase {
         assertEquals(label() + " min_score should succeed", 200, minScoreResponse.getStatusLine().getStatusCode());
     }
 
-    // Script scoring operates on raw vectors, so x32 and fp32 indices must return identical scores.
-    // Builds both compression variants internally, so it runs once per engine under the compressed config.
     @SneakyThrows
     public void testScriptScoring() {
         assumeTrue(

--- a/src/test/java/org/opensearch/knn/index/Compression32XIT.java
+++ b/src/test/java/org/opensearch/knn/index/Compression32XIT.java
@@ -8,16 +8,17 @@ package org.opensearch.knn.index;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -46,15 +47,21 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE
 import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.index.KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD;
 import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD;
 import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_MODE;
 
 /**
- * Integration tests for 32x compression (SQ 1-bit) across both Faiss and Lucene engines.
- * Parameterized by engine to ensure symmetric coverage.
+ * Integration tests for vector search across Faiss and Lucene engines, parameterized by both engine
+ * and compression (FP32 / no compression and SQ 1-bit / 32x). Recall, space type, filtering, lifecycle,
+ * nested, and dimension tests run under every engine x compression combination and assert against
+ * config-specific recall thresholds. Tests that exercise quantization-only behavior (in-memory
+ * quantization effect, rescore-improves-recall, x32-vs-fp32 script equivalence, memory-optimized search)
+ * are guarded to run only under the compressed configuration.
  */
 @Log4j2
-public class Compression32XIT extends KNNRestTestCase {
+public class Compression32XIT extends KNNCompressionRestTestCase {
 
     private static final int DIMENSION = 128;
     private static final int DOC_COUNT = 100;
@@ -66,7 +73,6 @@ public class Compression32XIT extends KNNRestTestCase {
     private static final double MIN_RECALL_X32_L2 = 0.70;
     private static final double MIN_RECALL_X32_IP = 0.60;
     private static final double MIN_RECALL_X32_COSINE = 0.70;
-    private static final double MIN_RECALL_FP32 = 0.95;
 
     private static final int DIMENSION_SMALL = 64;
     private static final String FIELD_NAME_2 = "test_field_2";
@@ -118,57 +124,57 @@ public class Compression32XIT extends KNNRestTestCase {
 
     private final String engineName;
 
-    public Compression32XIT(String engineName) {
+    public Compression32XIT(CompressionTestConfig compressionConfig, String engineName) {
+        super(compressionConfig);
         this.engineName = engineName;
     }
 
-    @ParametersFactory(argumentFormatting = "engine:%1$s")
-    public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[] { FAISS_NAME }, new Object[] { LUCENE_NAME });
+    @ParametersFactory(argumentFormatting = "compression:%1$s, engine:%2$s")
+    public static Collection<Object[]> compressionParameters() {
+        List<Object[]> params = new ArrayList<>();
+        for (CompressionTestConfig config : CompressionTestConfig.values()) {
+            params.add(new Object[] { config, FAISS_NAME });
+            params.add(new Object[] { config, LUCENE_NAME });
+        }
+        return params;
     }
 
-    private String prefix() {
-        return engineName + "_x32_";
+    @Override
+    protected String prefix() {
+        return engineName + "_" + compressionConfig.name().toLowerCase(Locale.ROOT) + "_";
     }
 
-    // Verifies explicit mode=on_disk + compression_level=32x produces acceptable recall
+    private String label() {
+        return engineName + " " + compressionConfig.name();
+    }
+
+    private float minRecall(SpaceType spaceType) {
+        return compressionConfig.getMinRecallThreshold(spaceType);
+    }
+
     @SneakyThrows
-    public void testX32_kSearch() {
+    public void testKSearch() {
         String indexName = prefix() + "ksearch";
-        createX32Index(indexName, SpaceType.L2, DIMENSION);
+        createVectorIndex(indexName, SpaceType.L2, DIMENSION);
         bulkAddKnnDocs(indexName, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
         forceMergeKnnIndex(indexName, 1);
 
         List<List<String>> searchResults = bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K);
         double recall = TestUtils.calculateRecallValue(searchResults, GROUND_TRUTH_L2, K);
-        logger.info("[{}] x32 k-search recall: {}", engineName, recall);
-        assertTrue(engineName + " x32 recall should be >= " + MIN_RECALL_X32_L2 + " but was " + recall, recall >= MIN_RECALL_X32_L2);
+        float threshold = minRecall(SpaceType.L2);
+        logger.info("[{}] k-search recall: {}", label(), recall);
+        assertTrue(label() + " recall should be >= " + threshold + " but was " + recall, recall >= threshold);
     }
 
-    // Verifies compression_level=1x opts out of quantization and retains FP32-level recall
     @SneakyThrows
-    public void testX32_optOut() {
-        String indexName = prefix() + "optout";
-        createFP32Index(indexName, SpaceType.L2, DIMENSION);
-        bulkAddKnnDocs(indexName, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
-        forceMergeKnnIndex(indexName, 1);
-
-        List<List<String>> searchResults = bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K);
-        double recall = TestUtils.calculateRecallValue(searchResults, GROUND_TRUTH_L2, K);
-        logger.info("[{}] FP32 opt-out recall: {}", engineName, recall);
-        assertTrue(engineName + " FP32 recall should be >= " + MIN_RECALL_FP32 + " but was " + recall, recall >= MIN_RECALL_FP32);
-    }
-
-    // Validates x32 recall across L2, inner product, and cosine space types
-    @SneakyThrows
-    public void testX32_spaceTypes() {
+    public void testSpaceTypes() {
         String indexL2 = prefix() + "l2";
         String indexIP = prefix() + "ip";
         String indexCosine = prefix() + "cosine";
 
-        createX32Index(indexL2, SpaceType.L2, DIMENSION);
-        createX32Index(indexIP, SpaceType.INNER_PRODUCT, DIMENSION);
-        createX32Index(indexCosine, SpaceType.COSINESIMIL, DIMENSION);
+        createVectorIndex(indexL2, SpaceType.L2, DIMENSION);
+        createVectorIndex(indexIP, SpaceType.INNER_PRODUCT, DIMENSION);
+        createVectorIndex(indexCosine, SpaceType.COSINESIMIL, DIMENSION);
 
         bulkAddKnnDocs(indexL2, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
         bulkAddKnnDocs(indexIP, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
@@ -178,32 +184,33 @@ public class Compression32XIT extends KNNRestTestCase {
         forceMergeKnnIndex(indexIP, 1);
         forceMergeKnnIndex(indexCosine, 1);
 
-        List<List<String>> resultsL2 = bulkSearch(indexL2, FIELD_NAME, QUERY_VECTORS, K);
-        double recallL2 = TestUtils.calculateRecallValue(resultsL2, GROUND_TRUTH_L2, K);
-        assertTrue(engineName + " L2 recall should be >= " + MIN_RECALL_X32_L2 + " but was " + recallL2, recallL2 >= MIN_RECALL_X32_L2);
-
-        List<List<String>> resultsIP = bulkSearch(indexIP, FIELD_NAME, QUERY_VECTORS, K);
-        double recallIP = TestUtils.calculateRecallValue(resultsIP, GROUND_TRUTH_IP, K);
-        assertTrue(engineName + " IP recall should be >= " + MIN_RECALL_X32_IP + " but was " + recallIP, recallIP >= MIN_RECALL_X32_IP);
-
-        List<List<String>> resultsCosine = bulkSearch(indexCosine, FIELD_NAME, QUERY_VECTORS, K);
-        double recallCosine = TestUtils.calculateRecallValue(resultsCosine, GROUND_TRUTH_COSINE, K);
+        double recallL2 = TestUtils.calculateRecallValue(bulkSearch(indexL2, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_L2, K);
         assertTrue(
-            engineName + " Cosine recall should be >= " + MIN_RECALL_X32_COSINE + " but was " + recallCosine,
-            recallCosine >= MIN_RECALL_X32_COSINE
+            label() + " L2 recall should be >= " + minRecall(SpaceType.L2) + " but was " + recallL2,
+            recallL2 >= minRecall(SpaceType.L2)
         );
 
-        // Validate score ranges per space type
+        double recallIP = TestUtils.calculateRecallValue(bulkSearch(indexIP, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_IP, K);
+        assertTrue(
+            label() + " IP recall should be >= " + minRecall(SpaceType.INNER_PRODUCT) + " but was " + recallIP,
+            recallIP >= minRecall(SpaceType.INNER_PRODUCT)
+        );
+
+        double recallCosine = TestUtils.calculateRecallValue(bulkSearch(indexCosine, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_COSINE, K);
+        assertTrue(
+            label() + " Cosine recall should be >= " + minRecall(SpaceType.COSINESIMIL) + " but was " + recallCosine,
+            recallCosine >= minRecall(SpaceType.COSINESIMIL)
+        );
+
         validateScoreRanges(indexL2, SpaceType.L2, 0.0f, 1.0f);
         validateScoreRanges(indexIP, SpaceType.INNER_PRODUCT, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
         validateScoreRanges(indexCosine, SpaceType.COSINESIMIL, 0.0f, 2.0f);
     }
 
-    // Validates x32 works with multiple knn_vector fields of different dimensions in one index
     @SneakyThrows
-    public void testX32_multiField() {
+    public void testMultiField() {
         String indexName = prefix() + "multifield";
-        createX32MultiFieldIndex(indexName);
+        createMultiFieldIndex(indexName);
 
         for (int i = 0; i < DOC_COUNT; i++) {
             addKnnDoc(
@@ -216,45 +223,46 @@ public class Compression32XIT extends KNNRestTestCase {
         refreshIndex(indexName);
         forceMergeKnnIndex(indexName, 1);
 
-        List<List<String>> resultsField1 = bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K);
-        double recallField1 = TestUtils.calculateRecallValue(resultsField1, GROUND_TRUTH_L2, K);
+        double recallField1 = TestUtils.calculateRecallValue(bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_L2, K);
         assertTrue(
-            engineName + " field1 recall should be >= " + MIN_RECALL_X32_L2 + " but was " + recallField1,
-            recallField1 >= MIN_RECALL_X32_L2
+            label() + " field1 recall should be >= " + minRecall(SpaceType.L2) + " but was " + recallField1,
+            recallField1 >= minRecall(SpaceType.L2)
         );
 
-        List<List<String>> resultsField2 = bulkSearch(indexName, FIELD_NAME_2, QUERY_VECTORS_SMALL, K);
-        double recallField2 = TestUtils.calculateRecallValue(resultsField2, GROUND_TRUTH_SMALL, K);
+        double recallField2 = TestUtils.calculateRecallValue(
+            bulkSearch(indexName, FIELD_NAME_2, QUERY_VECTORS_SMALL, K),
+            GROUND_TRUTH_SMALL,
+            K
+        );
         assertTrue(
-            engineName + " field2 recall should be >= " + MIN_RECALL_X32_L2 + " but was " + recallField2,
-            recallField2 >= MIN_RECALL_X32_L2
+            label() + " field2 recall should be >= " + minRecall(SpaceType.L2) + " but was " + recallField2,
+            recallField2 >= minRecall(SpaceType.L2)
         );
     }
 
-    // Validates x32 recall survives force merge, close/reopen, and snapshot/restore
     @SneakyThrows
-    public void testX32_lifecycle() {
+    public void testLifecycle() {
         String indexName = prefix() + "lifecycle";
-        createX32Index(indexName, SpaceType.L2, DIMENSION);
+        createVectorIndex(indexName, SpaceType.L2, DIMENSION);
         bulkAddKnnDocs(indexName, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
         forceMergeKnnIndex(indexName, 1);
 
-        List<List<String>> resultsAfterMerge = bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K);
-        double recallAfterMerge = TestUtils.calculateRecallValue(resultsAfterMerge, GROUND_TRUTH_L2, K);
+        float threshold = minRecall(SpaceType.L2);
+
+        double recallAfterMerge = TestUtils.calculateRecallValue(bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_L2, K);
         assertTrue(
-            engineName + " recall after merge should be >= " + MIN_RECALL_X32_L2 + " but was " + recallAfterMerge,
-            recallAfterMerge >= MIN_RECALL_X32_L2
+            label() + " recall after merge should be >= " + threshold + " but was " + recallAfterMerge,
+            recallAfterMerge >= threshold
         );
 
         closeIndex(indexName);
         openIndex(indexName);
         ensureGreen(indexName);
 
-        List<List<String>> resultsAfterReopen = bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K);
-        double recallAfterReopen = TestUtils.calculateRecallValue(resultsAfterReopen, GROUND_TRUTH_L2, K);
+        double recallAfterReopen = TestUtils.calculateRecallValue(bulkSearch(indexName, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_L2, K);
         assertTrue(
-            engineName + " recall after reopen should be >= " + MIN_RECALL_X32_L2 + " but was " + recallAfterReopen,
-            recallAfterReopen >= MIN_RECALL_X32_L2
+            label() + " recall after reopen should be >= " + threshold + " but was " + recallAfterReopen,
+            recallAfterReopen >= threshold
         );
 
         String repositoryName = prefix() + "repo-" + randomLowerCaseString();
@@ -271,19 +279,21 @@ public class Compression32XIT extends KNNRestTestCase {
         String restoredIndexName = indexName + restoreSuffix;
         ensureGreen(restoredIndexName);
 
-        List<List<String>> resultsAfterRestore = bulkSearch(restoredIndexName, FIELD_NAME, QUERY_VECTORS, K);
-        double recallAfterRestore = TestUtils.calculateRecallValue(resultsAfterRestore, GROUND_TRUTH_L2, K);
+        double recallAfterRestore = TestUtils.calculateRecallValue(
+            bulkSearch(restoredIndexName, FIELD_NAME, QUERY_VECTORS, K),
+            GROUND_TRUTH_L2,
+            K
+        );
         assertTrue(
-            engineName + " recall after restore should be >= " + MIN_RECALL_X32_L2 + " but was " + recallAfterRestore,
-            recallAfterRestore >= MIN_RECALL_X32_L2
+            label() + " recall after restore should be >= " + threshold + " but was " + recallAfterRestore,
+            recallAfterRestore >= threshold
         );
     }
 
-    // Validates radial search (max_distance, min_score) works on x32 quantized indices
     @SneakyThrows
-    public void testX32_radialSearch() {
+    public void testRadialSearch() {
         String indexName = prefix() + "radial";
-        createX32Index(indexName, SpaceType.L2, DIMENSION);
+        createVectorIndex(indexName, SpaceType.L2, DIMENSION);
         for (int i = 0; i < INDEX_VECTORS.length; i++) {
             addKnnDoc(indexName, String.valueOf(i), FIELD_NAME, INDEX_VECTORS[i]);
         }
@@ -295,18 +305,23 @@ public class Compression32XIT extends KNNRestTestCase {
         Request maxDistanceRequest = new Request("POST", "/" + indexName + "/_search");
         maxDistanceRequest.setJsonEntity(maxDistanceQuery);
         Response maxDistResponse = client().performRequest(maxDistanceRequest);
-        assertEquals(engineName + " max_distance should succeed", 200, maxDistResponse.getStatusLine().getStatusCode());
+        assertEquals(label() + " max_distance should succeed", 200, maxDistResponse.getStatusLine().getStatusCode());
 
         String minScoreQuery = buildRadialSearchQuery(FIELD_NAME, queryVector, "min_score", 0.001f);
         Request minScoreRequest = new Request("POST", "/" + indexName + "/_search");
         minScoreRequest.setJsonEntity(minScoreQuery);
         Response minScoreResponse = client().performRequest(minScoreRequest);
-        assertEquals(engineName + " min_score should succeed", 200, minScoreResponse.getStatusLine().getStatusCode());
+        assertEquals(label() + " min_score should succeed", 200, minScoreResponse.getStatusLine().getStatusCode());
     }
 
-    // Script scoring operates on raw vectors, so x32 and fp32 indices must return identical scores
+    // Script scoring operates on raw vectors, so x32 and fp32 indices must return identical scores.
+    // Builds both compression variants internally, so it runs once per engine under the compressed config.
     @SneakyThrows
-    public void testX32_scriptScoring() {
+    public void testScriptScoring() {
+        assumeTrue(
+            "Script scoring equivalence builds both variants internally; run once under the compressed config",
+            compressionConfig.isCompressed()
+        );
         String x32IndexName = prefix() + "script_x32";
         String fp32IndexName = prefix() + "script_fp32";
         int docCount = 20;
@@ -353,25 +368,26 @@ public class Compression32XIT extends KNNRestTestCase {
         }
     }
 
-    // Recall baseline with a larger dataset (200 docs, 128-dim) to catch scale-dependent issues
     @SneakyThrows
-    public void testX32_recallBaseline() {
+    public void testRecallBaseline() {
         String indexName = prefix() + "recall_baseline";
-        createX32Index(indexName, SpaceType.L2, DIMENSION);
+        createVectorIndex(indexName, SpaceType.L2, DIMENSION);
         bulkAddKnnDocs(indexName, FIELD_NAME, BASELINE_INDEX_VECTORS, BASELINE_DOC_COUNT);
         forceMergeKnnIndex(indexName, 1);
 
         List<List<String>> searchResults = bulkSearch(indexName, FIELD_NAME, BASELINE_QUERY_VECTORS, K);
         double recall = TestUtils.calculateRecallValue(searchResults, GROUND_TRUTH_BASELINE, K);
-        logger.info("[{}] x32 recall baseline (200 docs): {}", engineName, recall);
-        assertTrue(engineName + " recall baseline should be >= " + MIN_RECALL_X32_L2 + " but was " + recall, recall >= MIN_RECALL_X32_L2);
+        float threshold = minRecall(SpaceType.L2);
+        logger.info("[{}] recall baseline (200 docs): {}", label(), recall);
+        assertTrue(label() + " recall baseline should be >= " + threshold + " but was " + recall, recall >= threshold);
     }
 
-    // Verifies x32 with mode=in_memory produces acceptable recall and scores differ from fp32 ANN
+    // Quantization-only: in_memory mode produces acceptable recall, and on_disk scores differ from in_memory.
     @SneakyThrows
     public void testX32_inMemory() {
+        assumeTrue("Validates in-memory quantization behavior; compressed config only", compressionConfig.isCompressed());
         String indexName = prefix() + "in_memory";
-        createX32InMemoryIndex(indexName, SpaceType.L2);
+        createInMemoryIndex(indexName, SpaceType.L2);
         bulkAddKnnDocs(indexName, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
         forceMergeKnnIndex(indexName, 1);
 
@@ -383,9 +399,8 @@ public class Compression32XIT extends KNNRestTestCase {
             recall >= MIN_RECALL_X32_L2
         );
 
-        // On-disk x32 with rescore disabled should produce different scores than in-memory (quantization effect)
         String onDiskIndex = prefix() + "in_memory_compare";
-        createX32Index(onDiskIndex, SpaceType.L2, DIMENSION);
+        createVectorIndex(onDiskIndex, SpaceType.L2, DIMENSION);
         bulkAddKnnDocs(onDiskIndex, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
         forceMergeKnnIndex(onDiskIndex, 1);
 
@@ -394,20 +409,18 @@ public class Compression32XIT extends KNNRestTestCase {
         Response inMemResponse = searchKNNIndex(indexName, inMemQuery, K);
         List<KNNResult> inMemResults = parseSearchResponse(EntityUtils.toString(inMemResponse.getEntity()), FIELD_NAME);
 
-        // Verify in-memory results are valid (scores > 0, correct count)
-        assertFalse(engineName + " in-memory should return results", inMemResults.isEmpty());
         assertEquals(engineName + " in-memory should return K results", K, inMemResults.size());
         for (KNNResult r : inMemResults) {
             assertTrue(engineName + " in-memory scores should be positive", r.getScore() > 0);
         }
     }
 
-    // In-memory mode: rescore is a no-op because search already uses full-precision vectors.
-    // Differs from testX32_inMemory which validates recall; this test proves rescore has no effect.
+    // Quantization-only: in_memory rescore is a no-op because search already uses full-precision vectors.
     @SneakyThrows
     public void testX32_rescoreWithInMemory() {
+        assumeTrue("Validates rescore no-op under in-memory quantization; compressed config only", compressionConfig.isCompressed());
         String indexName = prefix() + "in_memory_rescore";
-        createX32InMemoryIndex(indexName, SpaceType.L2);
+        createInMemoryIndex(indexName, SpaceType.L2);
         bulkAddKnnDocs(indexName, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
         forceMergeKnnIndex(indexName, 1);
 
@@ -445,11 +458,10 @@ public class Compression32XIT extends KNNRestTestCase {
         }
     }
 
-    // Filtered ANN search: results must respect the filter predicate
     @SneakyThrows
-    public void testX32_filtering() {
+    public void testFiltering() {
         String indexName = prefix() + "filter";
-        createX32IndexWithFilterField(indexName, SpaceType.L2);
+        createVectorIndexWithFilterField(indexName, SpaceType.L2);
 
         int halfCount = DOC_COUNT / 2;
         for (int i = 0; i < DOC_COUNT; i++) {
@@ -463,19 +475,18 @@ public class Compression32XIT extends KNNRestTestCase {
         Response response = searchKNNIndex(indexName, filteredQuery, K);
         List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
 
-        assertFalse(engineName + " filtered results should not be empty", results.isEmpty());
+        assertFalse(label() + " filtered results should not be empty", results.isEmpty());
         assertTrue(results.size() <= K);
         for (KNNResult result : results) {
             int docId = Integer.parseInt(result.getDocId());
-            assertTrue(engineName + " filtered result should only contain alpha docs (id < " + halfCount + ")", docId < halfCount);
+            assertTrue(label() + " filtered result should only contain alpha docs (id < " + halfCount + ")", docId < halfCount);
         }
     }
 
-    // Filtered search + rescore: validates filter correctness, result stability, and score ordering
     @SneakyThrows
-    public void testX32_filteringWithRescore() {
+    public void testFilteringWithRescore() {
         String indexName = prefix() + "filter_rescore";
-        createX32IndexWithFilterField(indexName, SpaceType.L2);
+        createVectorIndexWithFilterField(indexName, SpaceType.L2);
 
         int halfCount = BASELINE_DOC_COUNT / 2;
         for (int i = 0; i < BASELINE_DOC_COUNT; i++) {
@@ -506,24 +517,23 @@ public class Compression32XIT extends KNNRestTestCase {
 
         for (KNNResult result : firstResults) {
             int docId = Integer.parseInt(result.getDocId());
-            assertTrue(engineName + " filtered+rescored should only contain alpha docs", docId < halfCount);
+            assertTrue(label() + " filtered+rescored should only contain alpha docs", docId < halfCount);
         }
 
         List<String> firstIds = firstResults.stream().map(KNNResult::getDocId).collect(Collectors.toList());
         List<String> secondIds = secondResults.stream().map(KNNResult::getDocId).collect(Collectors.toList());
-        assertEquals(engineName + " rescored results should be stable", firstIds, secondIds);
+        assertEquals(label() + " rescored results should be stable", firstIds, secondIds);
 
         for (int i = 0; i < firstResults.size() - 1; i++) {
             assertTrue(
-                engineName + " scores should be in descending order",
+                label() + " scores should be in descending order",
                 firstResults.get(i).getScore() >= firstResults.get(i + 1).getScore()
             );
         }
     }
 
-    // Validates x32 compression works with nested field type
     @SneakyThrows
-    public void testX32_nested() {
+    public void testNested() {
         String indexName = prefix() + "nested";
         String nestedPath = "nested_field";
         String nestedFieldPath = "nested_field.vector";
@@ -539,9 +549,8 @@ public class Compression32XIT extends KNNRestTestCase {
             .startObject("properties")
             .startObject("vector")
             .field("type", "knn_vector")
-            .field("dimension", nestedDimension)
-            .field(MODE_PARAMETER, "on_disk")
-            .field(COMPRESSION_LEVEL_PARAMETER, "32x");
+            .field("dimension", nestedDimension);
+        addCompressionMappingFields(builder);
         addMethodParams(builder, SpaceType.L2);
         builder.endObject().endObject().endObject().endObject().endObject();
 
@@ -573,13 +582,12 @@ public class Compression32XIT extends KNNRestTestCase {
 
         Response searchResponse = searchKNNIndex(indexName, queryBuilder, k);
         List<Object> hits = parseSearchResponseHits(EntityUtils.toString(searchResponse.getEntity()));
-        assertFalse(engineName + " nested search should return results", hits.isEmpty());
+        assertFalse(label() + " nested search should return results", hits.isEmpty());
         assertTrue(hits.size() <= k);
     }
 
-    // Validates x32 with nested field + expand_nested_docs (inner_hits)
     @SneakyThrows
-    public void testX32_expandNestedDocs() {
+    public void testExpandNestedDocs() {
         String indexName = prefix() + "expand_nested";
         String nestedPath = "nested_field";
         String vectorField = nestedPath + ".vector";
@@ -596,15 +604,13 @@ public class Compression32XIT extends KNNRestTestCase {
             .startObject("properties")
             .startObject("vector")
             .field("type", "knn_vector")
-            .field("dimension", nestedDimension)
-            .field(MODE_PARAMETER, "on_disk")
-            .field(COMPRESSION_LEVEL_PARAMETER, "32x");
+            .field("dimension", nestedDimension);
+        addCompressionMappingFields(mappingBuilder);
         addMethodParams(mappingBuilder, SpaceType.L2);
         mappingBuilder.endObject().endObject().endObject().endObject().endObject();
 
         createKnnIndex(indexName, defaultSettings(), mappingBuilder.toString());
 
-        // Index parent docs each with multiple nested vectors
         for (int p = 0; p < numParentDocs; p++) {
             XContentBuilder docBuilder = XContentFactory.jsonBuilder().startObject();
             docBuilder.startArray(nestedPath);
@@ -621,7 +627,6 @@ public class Compression32XIT extends KNNRestTestCase {
         refreshIndex(indexName);
         forceMergeKnnIndex(indexName, 1);
 
-        // Query with expand_nested_docs + inner_hits
         float[] queryVector = new float[nestedDimension];
         Arrays.fill(queryVector, 1.0f);
         XContentBuilder queryBuilder = XContentFactory.jsonBuilder()
@@ -648,20 +653,19 @@ public class Compression32XIT extends KNNRestTestCase {
         String responseBody = EntityUtils.toString(response.getEntity());
         List<Object> hits = parseSearchResponseHits(responseBody);
 
-        // With expand_nested_docs, we can get more hits than parent docs
-        assertFalse(engineName + " expand_nested should return results", hits.isEmpty());
-        assertTrue(engineName + " expand_nested results should be <= k", hits.size() <= k);
+        assertFalse(label() + " expand_nested should return results", hits.isEmpty());
+        assertTrue(label() + " expand_nested results should be <= k", hits.size() <= k);
     }
 
-    // Tests x32 at dimension extremes and non-multiples-of-8 to catch quantization edge cases
     @SneakyThrows
-    public void testX32_dimensions() {
+    public void testDimensions() {
         int highDim = 768;
         int lowDim = 3;
         int oddDim = 13;
         int nonAlignedDim = 37;
         int docCount = 50;
         int queryCount = 5;
+        float threshold = minRecall(SpaceType.L2);
 
         float[][] highDimVectors = TestUtils.getIndexVectors(docCount, highDim, true);
         float[][] highDimQueries = TestUtils.getQueryVectors(queryCount, highDim, docCount, true);
@@ -669,46 +673,47 @@ public class Compression32XIT extends KNNRestTestCase {
         float[][] lowDimQueries = TestUtils.getQueryVectors(queryCount, lowDim, docCount, true);
 
         String highDimIndex = prefix() + "highdim";
-        createX32Index(highDimIndex, SpaceType.L2, highDim);
+        createVectorIndex(highDimIndex, SpaceType.L2, highDim);
         bulkAddKnnDocs(highDimIndex, FIELD_NAME, highDimVectors, docCount);
         forceMergeKnnIndex(highDimIndex, 1);
 
         String lowDimIndex = prefix() + "lowdim";
-        createX32Index(lowDimIndex, SpaceType.L2, lowDim);
+        createVectorIndex(lowDimIndex, SpaceType.L2, lowDim);
         bulkAddKnnDocs(lowDimIndex, FIELD_NAME, lowDimVectors, docCount);
         forceMergeKnnIndex(lowDimIndex, 1);
 
         List<Set<String>> groundTruthHighDim = TestUtils.computeGroundTruthValues(highDimVectors, highDimQueries, SpaceType.L2, K);
-        List<List<String>> highDimResults = bulkSearch(highDimIndex, FIELD_NAME, highDimQueries, K);
-        double recallHighDim = TestUtils.calculateRecallValue(highDimResults, groundTruthHighDim, K);
-        assertTrue(engineName + " high-dim recall should be >= " + MIN_RECALL_X32_L2, recallHighDim >= MIN_RECALL_X32_L2);
+        double recallHighDim = TestUtils.calculateRecallValue(
+            bulkSearch(highDimIndex, FIELD_NAME, highDimQueries, K),
+            groundTruthHighDim,
+            K
+        );
+        assertTrue(label() + " high-dim recall should be >= " + threshold, recallHighDim >= threshold);
 
         List<Set<String>> groundTruthLowDim = TestUtils.computeGroundTruthValues(lowDimVectors, lowDimQueries, SpaceType.L2, K);
-        List<List<String>> lowDimResults = bulkSearch(lowDimIndex, FIELD_NAME, lowDimQueries, K);
-        double recallLowDim = TestUtils.calculateRecallValue(lowDimResults, groundTruthLowDim, K);
-        assertTrue(engineName + " low-dim recall should be >= " + MIN_RECALL_X32_L2, recallLowDim >= MIN_RECALL_X32_L2);
+        double recallLowDim = TestUtils.calculateRecallValue(bulkSearch(lowDimIndex, FIELD_NAME, lowDimQueries, K), groundTruthLowDim, K);
+        assertTrue(label() + " low-dim recall should be >= " + threshold, recallLowDim >= threshold);
 
-        // Non-multiple-of-8 dimensions (tests quantization padding/alignment)
         for (int dim : new int[] { oddDim, nonAlignedDim }) {
             float[][] vectors = TestUtils.getIndexVectors(docCount, dim, true);
             float[][] queries = TestUtils.getQueryVectors(queryCount, dim, docCount, true);
             String idx = prefix() + "dim" + dim;
-            createX32Index(idx, SpaceType.L2, dim);
+            createVectorIndex(idx, SpaceType.L2, dim);
             bulkAddKnnDocs(idx, FIELD_NAME, vectors, docCount);
             forceMergeKnnIndex(idx, 1);
 
             List<Set<String>> gt = TestUtils.computeGroundTruthValues(vectors, queries, SpaceType.L2, K);
-            List<List<String>> results = bulkSearch(idx, FIELD_NAME, queries, K);
-            double recall = TestUtils.calculateRecallValue(results, gt, K);
-            assertTrue(engineName + " dim=" + dim + " recall should be >= " + MIN_RECALL_X32_L2, recall >= MIN_RECALL_X32_L2);
+            double recall = TestUtils.calculateRecallValue(bulkSearch(idx, FIELD_NAME, queries, K), gt, K);
+            assertTrue(label() + " dim=" + dim + " recall should be >= " + threshold, recall >= threshold);
         }
     }
 
-    // Validates rescore improves recall monotonically: no-rescore < default < high oversample
+    // Quantization-only: rescore improves recall monotonically (no-rescore < default < high oversample).
     @SneakyThrows
     public void testX32_rescoreVariations() {
+        assumeTrue("Validates rescore lifts quantized recall; compressed config only", compressionConfig.isCompressed());
         String indexName = prefix() + "rescore_variations";
-        createX32Index(indexName, SpaceType.L2, DIMENSION);
+        createVectorIndex(indexName, SpaceType.L2, DIMENSION);
         bulkAddKnnDocs(indexName, FIELD_NAME, BASELINE_INDEX_VECTORS, BASELINE_DOC_COUNT);
         forceMergeKnnIndex(indexName, 1);
 
@@ -722,7 +727,6 @@ public class Compression32XIT extends KNNRestTestCase {
         );
         double recallNoRescore = calculateRecallFromResults(noRescoreResults, groundTruth, K);
 
-        // Default rescore (no explicit oversample -- uses system default)
         List<List<KNNResult>> defaultRescoreResults = searchWithRescore(
             indexName,
             BASELINE_QUERY_VECTORS,
@@ -732,7 +736,6 @@ public class Compression32XIT extends KNNRestTestCase {
         double recallDefaultRescore = calculateRecallFromResults(defaultRescoreResults, groundTruth, K);
         assertTrue(engineName + " default rescore recall should be >= " + MIN_RECALL_X32_L2, recallDefaultRescore >= MIN_RECALL_X32_L2);
 
-        // Explicit 3x oversample
         List<List<KNNResult>> explicit3xResults = searchWithRescore(
             indexName,
             BASELINE_QUERY_VECTORS,
@@ -741,7 +744,6 @@ public class Compression32XIT extends KNNRestTestCase {
         );
         double recallExplicit3x = calculateRecallFromResults(explicit3xResults, groundTruth, K);
 
-        // 5x oversample
         List<List<KNNResult>> highOversampleResults = searchWithRescore(
             indexName,
             BASELINE_QUERY_VECTORS,
@@ -754,6 +756,80 @@ public class Compression32XIT extends KNNRestTestCase {
         assertTrue(engineName + " default rescore should improve recall", recallDefaultRescore >= recallNoRescore);
         assertTrue(engineName + " explicit 3x should improve recall", recallExplicit3x >= recallNoRescore);
         assertTrue(engineName + " higher oversample should improve recall", recallHighOversample >= recallExplicit3x);
+    }
+
+    // Explicit memory-optimized-search path under x32: ANN recall across L2, IP, and cosine.
+    @SneakyThrows
+    public void testX32_mos_annSpaceTypes() {
+        assumeTrue("Memory-optimized search is exercised under the compressed config only", compressionConfig.isCompressed());
+        assumeTrue("Memory-optimized search is only supported on the FAISS engine", FAISS_NAME.equals(engineName));
+
+        Settings mosSettings = mosSettings();
+        String indexL2 = prefix() + "mos_l2";
+        String indexIP = prefix() + "mos_ip";
+        String indexCosine = prefix() + "mos_cosine";
+
+        createVectorIndex(indexL2, SpaceType.L2, DIMENSION, mosSettings);
+        createVectorIndex(indexIP, SpaceType.INNER_PRODUCT, DIMENSION, mosSettings);
+        createVectorIndex(indexCosine, SpaceType.COSINESIMIL, DIMENSION, mosSettings);
+
+        bulkAddKnnDocs(indexL2, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
+        bulkAddKnnDocs(indexIP, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
+        bulkAddKnnDocs(indexCosine, FIELD_NAME, INDEX_VECTORS, DOC_COUNT);
+
+        forceMergeKnnIndex(indexL2, 1);
+        forceMergeKnnIndex(indexIP, 1);
+        forceMergeKnnIndex(indexCosine, 1);
+
+        double recallL2 = TestUtils.calculateRecallValue(bulkSearch(indexL2, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_L2, K);
+        assertTrue(engineName + " MOS L2 recall should be >= " + MIN_RECALL_X32_L2 + " but was " + recallL2, recallL2 >= MIN_RECALL_X32_L2);
+
+        double recallIP = TestUtils.calculateRecallValue(bulkSearch(indexIP, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_IP, K);
+        assertTrue(engineName + " MOS IP recall should be >= " + MIN_RECALL_X32_IP + " but was " + recallIP, recallIP >= MIN_RECALL_X32_IP);
+
+        double recallCosine = TestUtils.calculateRecallValue(bulkSearch(indexCosine, FIELD_NAME, QUERY_VECTORS, K), GROUND_TRUTH_COSINE, K);
+        assertTrue(
+            engineName + " MOS Cosine recall should be >= " + MIN_RECALL_X32_COSINE + " but was " + recallCosine,
+            recallCosine >= MIN_RECALL_X32_COSINE
+        );
+
+        validateScoreRanges(indexL2, SpaceType.L2, 0.0f, 1.0f);
+        validateScoreRanges(indexIP, SpaceType.INNER_PRODUCT, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+        validateScoreRanges(indexCosine, SpaceType.COSINESIMIL, 0.0f, 2.0f);
+    }
+
+    // MOS filter-fallback path under x32: a high filtered_exact_search_threshold forces exact search.
+    @SneakyThrows
+    public void testX32_mos_filterFallback() {
+        assumeTrue("Memory-optimized search is exercised under the compressed config only", compressionConfig.isCompressed());
+        assumeTrue("Memory-optimized search is only supported on the FAISS engine", FAISS_NAME.equals(engineName));
+
+        String indexName = prefix() + "mos_filter_fallback";
+        createVectorIndexWithFilterField(indexName, SpaceType.L2, mosSettings());
+
+        int halfCount = DOC_COUNT / 2;
+        for (int i = 0; i < DOC_COUNT; i++) {
+            String category = (i < halfCount) ? "alpha" : "beta";
+            addKnnDocWithAttributes(indexName, String.valueOf(i), FIELD_NAME, INDEX_VECTORS[i], Map.of("category", category));
+        }
+        forceMergeKnnIndex(indexName, 1);
+
+        updateIndexSettings(indexName, Settings.builder().put(ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, DOC_COUNT));
+
+        float[] queryVector = QUERY_VECTORS[0];
+        KNNQueryBuilder filteredQuery = new KNNQueryBuilder(FIELD_NAME, queryVector, K, QueryBuilders.termQuery("category", "alpha"));
+        Response response = searchKNNIndex(indexName, filteredQuery, K);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+
+        assertFalse(engineName + " MOS filter-fallback results should not be empty", results.isEmpty());
+        assertTrue(results.size() <= K);
+        for (KNNResult result : results) {
+            int docId = Integer.parseInt(result.getDocId());
+            assertTrue(engineName + " MOS filter-fallback should only contain alpha docs (id < " + halfCount + ")", docId < halfCount);
+        }
+        for (int i = 0; i < results.size() - 1; i++) {
+            assertTrue(engineName + " MOS scores should be descending", results.get(i).getScore() >= results.get(i + 1).getScore());
+        }
     }
 
     // --- Helper methods ---
@@ -832,6 +908,16 @@ public class Compression32XIT extends KNNRestTestCase {
             .build();
     }
 
+    private Settings mosSettings() {
+        return Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put(KNN_INDEX, true)
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
+            .put(MEMORY_OPTIMIZED_KNN_SEARCH_MODE, true)
+            .build();
+    }
+
     @SneakyThrows
     private void addMethodParams(XContentBuilder builder, SpaceType spaceType) {
         builder.startObject(KNN_METHOD)
@@ -848,38 +934,27 @@ public class Compression32XIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    private void createX32Index(String indexName, SpaceType spaceType, int dimension) {
+    private void createVectorIndex(String indexName, SpaceType spaceType, int dimension) {
+        createVectorIndex(indexName, spaceType, dimension, defaultSettings());
+    }
+
+    @SneakyThrows
+    private void createVectorIndex(String indexName, SpaceType spaceType, int dimension, Settings settings) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(MODE_PARAMETER, "on_disk")
-            .field(COMPRESSION_LEVEL_PARAMETER, "32x");
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
         addMethodParams(builder, spaceType);
         builder.endObject().endObject().endObject();
 
-        createKnnIndex(indexName, defaultSettings(), builder.toString());
+        createKnnIndex(indexName, settings, builder.toString());
     }
 
     @SneakyThrows
-    private void createFP32Index(String indexName, SpaceType spaceType, int dimension) {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x");
-        addMethodParams(builder, spaceType);
-        builder.endObject().endObject().endObject();
-
-        createKnnIndex(indexName, defaultSettings(), builder.toString());
-    }
-
-    @SneakyThrows
-    private void createX32InMemoryIndex(String indexName, SpaceType spaceType) {
+    private void createInMemoryIndex(String indexName, SpaceType spaceType) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -895,38 +970,37 @@ public class Compression32XIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    private void createX32IndexWithFilterField(String indexName, SpaceType spaceType) {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .field(MODE_PARAMETER, "on_disk")
-            .field(COMPRESSION_LEVEL_PARAMETER, "32x");
-        addMethodParams(builder, spaceType);
-        builder.endObject().startObject("category").field("type", "keyword").endObject().endObject().endObject();
-
-        createKnnIndex(indexName, defaultSettings(), builder.toString());
+    private void createVectorIndexWithFilterField(String indexName, SpaceType spaceType) {
+        createVectorIndexWithFilterField(indexName, spaceType, defaultSettings());
     }
 
     @SneakyThrows
-    private void createX32MultiFieldIndex(String indexName) {
+    private void createVectorIndexWithFilterField(String indexName, SpaceType spaceType, Settings settings) {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .field(MODE_PARAMETER, "on_disk")
-            .field(COMPRESSION_LEVEL_PARAMETER, "32x");
-        addMethodParams(builder, SpaceType.L2);
-        builder.endObject()
-            .startObject(FIELD_NAME_2)
+            .field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
+        addMethodParams(builder, spaceType);
+        builder.endObject().startObject("category").field("type", "keyword").endObject().endObject().endObject();
+
+        createKnnIndex(indexName, settings, builder.toString());
+    }
+
+    @SneakyThrows
+    private void createMultiFieldIndex(String indexName) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", DIMENSION_SMALL)
-            .field(MODE_PARAMETER, "on_disk")
-            .field(COMPRESSION_LEVEL_PARAMETER, "32x");
+            .field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
+        addMethodParams(builder, SpaceType.L2);
+        builder.endObject().startObject(FIELD_NAME_2).field("type", "knn_vector").field("dimension", DIMENSION_SMALL);
+        addCompressionMappingFields(builder);
         addMethodParams(builder, SpaceType.L2);
         builder.endObject().endObject().endObject();
 

--- a/src/test/java/org/opensearch/knn/index/ExplainIT.java
+++ b/src/test/java/org/opensearch/knn/index/ExplainIT.java
@@ -290,14 +290,15 @@ public class ExplainIT extends KNNRestTestCase {
         });
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     private void createDefaultKnnIndex(int dimension) throws IOException {
-        // Create Mappings
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)

--- a/src/test/java/org/opensearch/knn/index/ExplainIT.java
+++ b/src/test/java/org/opensearch/knn/index/ExplainIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.ParseException;
@@ -15,7 +16,8 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
@@ -24,6 +26,7 @@ import org.opensearch.knn.index.query.parser.RescoreParser;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +43,16 @@ import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.RADIAL_SEARCH;
 
-public class ExplainIT extends KNNRestTestCase {
+public class ExplainIT extends KNNCompressionRestTestCase {
+
+    public ExplainIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     @SneakyThrows
     public void testExplain_whenDefault_thenANNSearch() {
@@ -290,16 +302,15 @@ public class ExplainIT extends KNNRestTestCase {
         });
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     private void createDefaultKnnIndex(int dimension) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
-            .startObject(KNN_METHOD)
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2)
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +31,8 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -81,13 +84,22 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
-import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
-public class FaissIT extends KNNRestTestCase {
+public class FaissIT extends KNNCompressionRestTestCase {
+
+    public FaissIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
+
     private static final String DOC_ID_1 = "doc1";
     private static final String DOC_ID_2 = "doc2";
     private static final String DOC_ID_3 = "doc3";
@@ -238,7 +250,6 @@ public class FaissIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     @SneakyThrows
     public void testRadialSearchWithCosineAndFilter_ensureThresholdEnforced_thenSucceed() {
         String indexName = "test-index-cosine-radial";
@@ -252,7 +263,6 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
             .field(DIMENSION_FIELD_NAME, dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
@@ -867,7 +877,6 @@ public class FaissIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testIVFSQFP16_whenIndexedAndQueried_thenSucceed() {
-
         String modelId = "test-model-ivf-sqfp16";
         int dimension = 128;
         int numDocs = 100;
@@ -2380,45 +2389,38 @@ public class FaissIT extends KNNRestTestCase {
         assertEquals(1, resultsQuery2.size());
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     public void testCosineSimilarity_withHNSW_withExactSearch_thenSucceed() throws Exception {
         testCosineSimilarityForApproximateSearch(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     @ExpectRemoteBuildValidation
     public void testCosineSimilarity_withHNSW_withApproximate_thenSucceed() throws Exception {
         testCosineSimilarityForApproximateSearch(ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
         validateGraphEviction();
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     @ExpectRemoteBuildValidation
     public void testCosineSimilarity_withGraph_withRadialSearch_withDistanceThreshold_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, null, 0.1f);
         validateGraphEviction();
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     @ExpectRemoteBuildValidation
     public void testCosineSimilarity_withGraph_withRadialSearch_withScore_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0.9f, null);
         validateGraphEviction();
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     public void testCosineSimilarity_withNoGraphs_withRadialSearch_withDistanceThreshold_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, null, 0.1f);
         validateGraphEviction();
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     public void testCosineSimilarity_withNoGraphs_withRadialSearch_withScore_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0.9f, null);
         validateGraphEviction();
     }
 
-    // Pinned to FP32: relies on uncompressed score precision
     public void testEndToEnd_withApproxAndExactSearch_inSameIndex_ForCosineSpaceType() throws Exception {
         String indexName = randomLowerCaseString();
         String fieldName = randomLowerCaseString();
@@ -2430,9 +2432,9 @@ public class FaissIT extends KNNRestTestCase {
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
@@ -2650,9 +2652,9 @@ public class FaissIT extends KNNRestTestCase {
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())

--- a/src/test/java/org/opensearch/knn/index/FaissIT.java
+++ b/src/test/java/org/opensearch/knn/index/FaissIT.java
@@ -81,6 +81,7 @@ import static org.opensearch.knn.common.KNNConstants.MODEL_DESCRIPTION;
 import static org.opensearch.knn.common.KNNConstants.MODEL_ID;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
@@ -237,6 +238,7 @@ public class FaissIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     @SneakyThrows
     public void testRadialSearchWithCosineAndFilter_ensureThresholdEnforced_thenSucceed() {
         String indexName = "test-index-cosine-radial";
@@ -250,6 +252,7 @@ public class FaissIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
             .field(DIMENSION_FIELD_NAME, dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
@@ -2377,51 +2380,58 @@ public class FaissIT extends KNNRestTestCase {
         assertEquals(1, resultsQuery2.size());
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     public void testCosineSimilarity_withHNSW_withExactSearch_thenSucceed() throws Exception {
         testCosineSimilarityForApproximateSearch(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     @ExpectRemoteBuildValidation
     public void testCosineSimilarity_withHNSW_withApproximate_thenSucceed() throws Exception {
         testCosineSimilarityForApproximateSearch(ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
         validateGraphEviction();
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     @ExpectRemoteBuildValidation
     public void testCosineSimilarity_withGraph_withRadialSearch_withDistanceThreshold_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, null, 0.1f);
         validateGraphEviction();
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     @ExpectRemoteBuildValidation
     public void testCosineSimilarity_withGraph_withRadialSearch_withScore_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0.9f, null);
         validateGraphEviction();
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     public void testCosineSimilarity_withNoGraphs_withRadialSearch_withDistanceThreshold_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, null, 0.1f);
         validateGraphEviction();
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     public void testCosineSimilarity_withNoGraphs_withRadialSearch_withScore_thenSucceed() throws Exception {
         testCosineSimilarityForRadialSearch(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, 0.9f, null);
         validateGraphEviction();
     }
 
+    // Pinned to FP32: relies on uncompressed score precision
     public void testEndToEnd_withApproxAndExactSearch_inSameIndex_ForCosineSpaceType() throws Exception {
         String indexName = randomLowerCaseString();
         String fieldName = randomLowerCaseString();
         SpaceType spaceType = SpaceType.COSINESIMIL;
         Integer dimension = testData.indexData.vectors[0].length;
 
-        // Create an index
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
@@ -2635,13 +2645,13 @@ public class FaissIT extends KNNRestTestCase {
 
     private void indexTestData(int approximateThreshold, String indexName, SpaceType spaceType, String fieldName) throws Exception {
         Integer dimension = testData.indexData.vectors[0].length;
-        // Create an index
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
             .field("dimension", dimension)
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)

--- a/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
@@ -5,32 +5,43 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.junit.Assert;
-import org.opensearch.knn.KNNRestTestCase;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.stats.StatNames;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 
 import static org.opensearch.knn.index.KNNCircuitBreaker.CB_TIME_INTERVAL;
 
 /**
  * Integration tests to test Circuit Breaker functionality
  */
-public class KNNCircuitBreakerIT extends KNNRestTestCase {
+public class KNNCircuitBreakerIT extends KNNCompressionRestTestCase {
     private static final Integer ALWAYS_BUILD_GRAPH = 0;
     private static final String INDEX_1 = INDEX_NAME + "1";
     private static final String INDEX_2 = INDEX_NAME + "2";
+
+    public KNNCircuitBreakerIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     /**
      * Base setup for all circuit breaker tests.
@@ -101,7 +112,6 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
         Assert.assertTrue(getGraphMemoryPercentage() > 20.0);
     }
 
-    // Pinned to FP32: relies on uncompressed memory size assumptions
     private void generateCbLoad(String indexName1, String indexName2) throws Exception {
         int numNodes = Integer.parseInt(System.getProperty("cluster.number_of_nodes", "1"));
         Settings settings = Settings.builder()
@@ -111,17 +121,14 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
             .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, ALWAYS_BUILD_GRAPH)
             .build();
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", "2")
-            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
+            .field("dimension", "2");
+        addCompressionMappingFields(builder);
+        String mapping = builder.endObject().endObject().endObject().toString();
         createKnnIndex(indexName1, settings, mapping);
         createKnnIndex(indexName2, settings, mapping);
 

--- a/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNCircuitBreakerIT.java
@@ -10,6 +10,7 @@ import org.opensearch.knn.KNNRestTestCase;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.plugin.stats.StatNames;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
@@ -18,6 +19,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 
 import static org.opensearch.knn.index.KNNCircuitBreaker.CB_TIME_INTERVAL;
 
@@ -98,8 +101,8 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
         Assert.assertTrue(getGraphMemoryPercentage() > 20.0);
     }
 
+    // Pinned to FP32: relies on uncompressed memory size assumptions
     private void generateCbLoad(String indexName1, String indexName2) throws Exception {
-        // Create index with 1 primary and numNodes-1 replicas so that the data will be on every node in the cluster
         int numNodes = Integer.parseInt(System.getProperty("cluster.number_of_nodes", "1"));
         Settings settings = Settings.builder()
             .put("number_of_shards", 1)
@@ -108,8 +111,19 @@ public class KNNCircuitBreakerIT extends KNNRestTestCase {
             .put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, ALWAYS_BUILD_GRAPH)
             .build();
 
-        createKnnIndex(indexName1, settings, createKnnIndexMapping(FIELD_NAME, 2));
-        createKnnIndex(indexName2, settings, createKnnIndexMapping(FIELD_NAME, 2));
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", "2")
+            .field(COMPRESSION_LEVEL_PARAMETER, "1x")
+            .endObject()
+            .endObject()
+            .endObject()
+            .toString();
+        createKnnIndex(indexName1, settings, mapping);
+        createKnnIndex(indexName2, settings, mapping);
 
         Float[] vector = { 1.3f, 2.2f };
         int docsInIndex = 10; // through testing, 10 is minimum number of docs to trip circuit breaker at 1kb

--- a/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
@@ -5,10 +5,12 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
@@ -18,6 +20,7 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
@@ -30,7 +33,16 @@ import static org.opensearch.knn.common.KNNConstants.TYPE;
 import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
-public class KNNMapperSearcherIT extends KNNRestTestCase {
+public class KNNMapperSearcherIT extends KNNCompressionRestTestCase {
+
+    public KNNMapperSearcherIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     private static final String INDEX_NAME = "test_index";
     private static final String FIELD_NAME = "test_vector";
@@ -57,7 +69,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNResultsWithForceMerge() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addTestData();
         forceMergeKnnIndex(INDEX_NAME);
 
@@ -80,7 +92,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNResultsUpdateDocAndForceMerge() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addDocWithNumericField(INDEX_NAME, "1", "abc", 100);
         addTestData();
         forceMergeKnnIndex(INDEX_NAME);
@@ -103,7 +115,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
     }
 
     public void testKNNResultsWithoutForceMerge() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addTestData();
 
         /**
@@ -127,7 +139,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
     }
 
     public void testKNNResultsWithNewDoc() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addTestData();
 
         float[] queryVector = { 1.0f, 1.0f }; // vector to be queried
@@ -170,7 +182,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
     }
 
     public void testKNNResultsWithUpdateDoc() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addTestData();
 
         float[] queryVector = { 1.0f, 1.0f }; // vector to be queried
@@ -199,7 +211,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
     }
 
     public void testKNNResultsWithDeleteDoc() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addTestData();
 
         float[] queryVector = { 1.0f, 1.0f }; // vector to be queried
@@ -248,7 +260,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
      * K &gt; &gt; number of docs
      */
     public void testLargeK() throws Exception {
-        createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, createFieldMapping(2));
         addTestData();
 
         float[] queryVector = { 1.0f, 1.0f }; // vector to be queried
@@ -398,7 +410,7 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
         // Check with FlatMapper
         String indexName = INDEX_NAME + "_flat_index";
         createBasicKnnIndex(indexName, FIELD_NAME, testVector.length);
-        putMappingRequest(indexName, createKnnIndexMapping(FIELD_NAME, testVector.length));
+        putMappingRequest(indexName, createFieldMapping(testVector.length));
     }
 
     /**
@@ -418,6 +430,20 @@ public class KNNMapperSearcherIT extends KNNRestTestCase {
      *     }
      * }
      */
+    @SneakyThrows
+    private String createFieldMapping(final int dimension) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(PROPERTIES_FIELD)
+            .startObject(FIELD_NAME)
+            .field(TYPE, TYPE_KNN_VECTOR)
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
+
+        return builder.toString();
+    }
+
     @SneakyThrows
     private String createVectorMapping(final int dimension, final String engine, final String dataType, final boolean isStored) {
         XContentBuilder builder = XContentFactory.jsonBuilder()

--- a/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
+++ b/src/test/java/org/opensearch/knn/index/KNNMapperSearcherIT.java
@@ -41,7 +41,7 @@ public class KNNMapperSearcherIT extends KNNCompressionRestTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     private static final String INDEX_NAME = "test_index";
@@ -410,7 +410,7 @@ public class KNNMapperSearcherIT extends KNNCompressionRestTestCase {
         // Check with FlatMapper
         String indexName = INDEX_NAME + "_flat_index";
         createBasicKnnIndex(indexName, FIELD_NAME, testVector.length);
-        putMappingRequest(indexName, createFieldMapping(testVector.length));
+        putMappingRequest(indexName, createKnnIndexMapping(FIELD_NAME, testVector.length));
     }
 
     /**

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
@@ -20,7 +21,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.KNNConstants;
@@ -30,6 +32,7 @@ import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -55,7 +58,16 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.VECTOR;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
-public class LuceneEngineIT extends KNNRestTestCase {
+public class LuceneEngineIT extends KNNCompressionRestTestCase {
+
+    public LuceneEngineIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     private static final int DIMENSION = 3;
     private static final String DOC_ID = "doc1";
@@ -153,8 +165,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD_NAME)
             .startObject(luceneField)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(DIMENSION_FIELD_NAME, DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, luceneSpaceType.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
@@ -166,8 +179,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .endObject()
             .startObject(nmslibField)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(DIMENSION_FIELD_NAME, DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, nmslibSpaceType.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
@@ -204,8 +218,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD_NAME)
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(DIMENSION_FIELD_NAME, DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
@@ -296,8 +311,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD_NAME)
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(DIMENSION_FIELD_NAME, DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
@@ -341,8 +357,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD_NAME)
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(DIMENSION_FIELD_NAME, DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
@@ -943,8 +960,11 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
             .field(DIMENSION_FIELD_NAME, dimension)
-            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType);
+        if (vectorDataType == VectorDataType.FLOAT) {
+            addCompressionMappingFields(builder);
+        }
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
@@ -1049,8 +1069,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", 2)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field("dimension", 2);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE)
@@ -1219,8 +1240,9 @@ public class LuceneEngineIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD_NAME)
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
-            .field(DIMENSION_FIELD_NAME, DIMENSION)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(DIMENSION_FIELD_NAME, DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -66,7 +66,7 @@ public class LuceneEngineIT extends KNNCompressionRestTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     private static final int DIMENSION = 3;
@@ -1173,10 +1173,21 @@ public class LuceneEngineIT extends KNNCompressionRestTestCase {
 
             final String responseBody = EntityUtils.toString(searchKNNIndex(INDEX_NAME, builder, expectedResults[i]).getEntity());
             final List<KNNResult> radiusResults = parseSearchResponse(responseBody, FIELD_NAME);
+            final List<Float> actualScores = parseSearchResponseScore(responseBody, FIELD_NAME);
+
+            if (compressionConfig != CompressionTestConfig.X1) {
+                assertTrue(radiusResults.size() <= expectedResults[i]);
+                for (int j = 0; j < actualScores.size(); j++) {
+                    assertTrue(actualScores.get(j) > 0.0f);
+                    if (j > 0) {
+                        assertTrue(actualScores.get(j - 1) >= actualScores.get(j));
+                    }
+                }
+                continue;
+            }
 
             assertEquals(expectedResults[i], radiusResults.size());
 
-            List<Float> actualScores = parseSearchResponseScore(responseBody, FIELD_NAME);
             for (KNNResult result : radiusResults) {
                 float[] vector = result.getVector();
                 float distance = TestUtils.computeDistFromSpaceType(spaceType, vector, searchVectors[i]);

--- a/src/test/java/org/opensearch/knn/index/MinScoreIT.java
+++ b/src/test/java/org/opensearch/knn/index/MinScoreIT.java
@@ -12,7 +12,8 @@ import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -28,7 +29,7 @@ import static org.opensearch.knn.index.KNNSettings.MEMORY_OPTIMIZED_KNN_SEARCH_M
  * Integration tests for min_score filtering with different KNN engines.
  * Tests the score-to-distance transformations for various space types.
  */
-public class MinScoreIT extends KNNRestTestCase {
+public class MinScoreIT extends KNNCompressionRestTestCase {
 
     private final boolean memoryOptimized;
     private final KNNEngine knnEngine;
@@ -39,6 +40,7 @@ public class MinScoreIT extends KNNRestTestCase {
     private final int[] expectedCounts;
 
     public MinScoreIT(
+        CompressionTestConfig compressionConfig,
         boolean memoryOptimized,
         KNNEngine knnEngine,
         SpaceType spaceType,
@@ -47,6 +49,7 @@ public class MinScoreIT extends KNNRestTestCase {
         float[] minScores,
         int[] expectedCounts
     ) {
+        super(compressionConfig);
         this.memoryOptimized = memoryOptimized;
         this.knnEngine = knnEngine;
         this.spaceType = spaceType;
@@ -152,6 +155,7 @@ public class MinScoreIT extends KNNRestTestCase {
         for (TestScenario scenario : scenarios) {
             params.add(
                 new Object[] {
+                    CompressionTestConfig.X1,
                     memoryOptimized,
                     KNNEngine.FAISS,
                     scenario.spaceType,
@@ -172,6 +176,7 @@ public class MinScoreIT extends KNNRestTestCase {
         for (TestScenario scenario : scenarios) {
             params.add(
                 new Object[] {
+                    CompressionTestConfig.X1,
                     false, // memory optimization not applicable for Lucene
                     KNNEngine.LUCENE,
                     scenario.spaceType,
@@ -184,8 +189,8 @@ public class MinScoreIT extends KNNRestTestCase {
         return params;
     }
 
-    @ParametersFactory
-    public static Collection<Object[]> parameters() {
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
         List<TestScenario> scenarios = Arrays.asList(
             innerProductScenario(),
             cosineScenario(),
@@ -203,7 +208,6 @@ public class MinScoreIT extends KNNRestTestCase {
     private static final int DIMENSION = 2;
     private static final String FIELD_NAME = "test_vector";
 
-    // Pinned to FP32: relies on uncompressed score precision
     public void testMinScore_withDifferentMetrics_thenCorrectlyFiltersResults() throws Exception {
         String indexName = "test_"
             + knnEngine.getName()
@@ -212,24 +216,22 @@ public class MinScoreIT extends KNNRestTestCase {
             + "_minscore_"
             + (memoryOptimized ? "optimized" : "standard");
 
-        // Create index with specified space type and engine
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
 
         if (knnEngine == KNNEngine.LUCENE) {
-            builder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, "1x")
-                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            builder.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
                 .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .endObject();
         } else {
-            builder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, "1x")
-                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            builder.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
                 .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())

--- a/src/test/java/org/opensearch/knn/index/MinScoreIT.java
+++ b/src/test/java/org/opensearch/knn/index/MinScoreIT.java
@@ -203,6 +203,7 @@ public class MinScoreIT extends KNNRestTestCase {
     private static final int DIMENSION = 2;
     private static final String FIELD_NAME = "test_vector";
 
+    // Pinned to FP32: relies on uncompressed score precision
     public void testMinScore_withDifferentMetrics_thenCorrectlyFiltersResults() throws Exception {
         String indexName = "test_"
             + knnEngine.getName()
@@ -220,15 +221,15 @@ public class MinScoreIT extends KNNRestTestCase {
             .field("dimension", DIMENSION);
 
         if (knnEngine == KNNEngine.LUCENE) {
-            // Lucene engine configuration
-            builder.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            builder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, "1x")
+                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
                 .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .endObject();
         } else {
-            // Faiss engine configuration
-            builder.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            builder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, "1x")
+                .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
                 .startObject(KNNConstants.KNN_METHOD)
                 .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
                 .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -18,7 +18,8 @@ import lombok.SneakyThrows;
 import org.apache.hc.core5.http.ParseException;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
@@ -52,9 +53,13 @@ import static org.opensearch.knn.index.KNNSettings.ADVANCED_FILTERED_EXACT_SEARC
 import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX;
 import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN;
 
-public class OpenSearchIT extends KNNRestTestCase {
+public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     static TestUtils.TestData testData;
+
+    public OpenSearchIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     @BeforeClass
     public static void setUpClass() throws IOException {
@@ -78,14 +83,14 @@ public class OpenSearchIT extends KNNRestTestCase {
         List<Integer> efSearchValues = ImmutableList.of(16, 32, 64, 128);
         Integer dimension = testData.indexData.vectors[0].length;
 
-        // Create an index with a single FAISS knn_vector field
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNNConstants.KNN_ENGINE, knnEngine.getName()) // FAISS engine
@@ -100,7 +105,9 @@ public class OpenSearchIT extends KNNRestTestCase {
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
         createKnnIndex(indexName, buildKNNIndexSettings(0), mapping);
-        assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
+        if (compressionConfig == CompressionTestConfig.FP32) {
+            assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
+        }
 
         // Index the test data
         for (int i = 0; i < testData.indexData.docs.length; i++) {
@@ -150,6 +157,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testAddDoc_blockedWhenCbTrips() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         updateClusterSettings("knn.circuit_breaker.triggered", "true");
 
@@ -165,6 +173,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testUpdateDoc_blockedWhenCbTrips() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
@@ -183,6 +192,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testAddAndSearchIndex_whenCBTrips() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         for (int i = 1; i <= 4; i++) {
             Float[] vector = { (float) i, (float) (i + 1) };
@@ -214,6 +224,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testIndexingVectorValidation_differentSizes() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
@@ -235,6 +246,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testIndexingVectorValidation_zeroVector() {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
         final boolean valid = randomBoolean();
         final String method = KNNConstants.METHOD_HNSW;
@@ -263,6 +275,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testVectorMappingValidation_noDimension() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         String mapping = XContentFactory.jsonBuilder()
@@ -280,6 +293,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testVectorMappingValidation_invalidDimension() {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         Exception ex = expectThrows(
@@ -302,6 +316,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testVectorMappingValidation_invalidVectorNaN() throws IOException {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
@@ -312,6 +327,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testVectorMappingValidation_invalidVectorInfinity() throws IOException {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
@@ -322,6 +338,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testVectorMappingValidation_updateDimension() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
@@ -331,6 +348,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testVectorMappingValidation_multiFieldsDifferentDimension() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         String f4 = FIELD_NAME + "-4";
@@ -362,6 +380,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testExistsQuery() throws Exception {
+        assumeUncompressed();
         String field1 = "field1";
         String field2 = "field2";
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList(field1, field2), Arrays.asList(2, 2)));
@@ -396,6 +415,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testIndexingVectorValidation_updateVectorWithNull() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
@@ -579,6 +599,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNIndex_whenBuildGraphThresholdIsPresent_thenGetThresholdValue() throws Exception {
+        assumeUncompressed();
         final Integer buildVectorDataStructureThreshold = randomIntBetween(
             INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
             INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX
@@ -601,6 +622,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNIndex_whenBuildThresholdIsNotProvided_thenShouldNotReturnSetting() throws Exception {
+        assumeUncompressed();
         final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
         final String indexName = "test-index-with-build-graph-settings";
         createKnnIndex(indexName, getDefaultIndexSettings(), knnIndexMapping);
@@ -616,6 +638,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNIndex_whenGetIndexSettingWithDefaultIsCalled_thenReturnDefaultBuildGraphThresholdValue() throws Exception {
+        assumeUncompressed();
         final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
         final String indexName = "test-index-with-build-vector-graph-settings";
         createKnnIndex(indexName, getDefaultIndexSettings(), knnIndexMapping);
@@ -645,16 +668,16 @@ public class OpenSearchIT extends KNNRestTestCase {
         final Integer dimension = testData.indexData.vectors[0].length;
         final Settings knnIndexSettings = buildKNNIndexSettings(-1);
 
-        // Create an index with a single FAISS knn_vector field
         final XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
-            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName()) // FAISS only
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(KNNConstants.PARAMETERS)
             .endObject()
             .endObject()
@@ -713,14 +736,14 @@ public class OpenSearchIT extends KNNRestTestCase {
         final Integer dimension = testData.indexData.vectors[0].length;
         final Settings knnIndexSettings = buildKNNIndexSettings(testData.indexData.docs.length);
 
-        // Create an index
         final XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(KNNConstants.PARAMETERS)
@@ -761,6 +784,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testCreateNonKNNIndex_withKNNModelID_throwsException() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(createKNNDefaultScriptScoreSettings()).build();
         ResponseException ex = expectThrows(
             ResponseException.class,
@@ -771,6 +795,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testCreateNonKNNIndex_withKNNMethodParams_throwsException() throws Exception {
+        assumeUncompressed();
         Settings settings = Settings.builder().put(createKNNDefaultScriptScoreSettings()).build();
         ResponseException ex = expectThrows(
             ResponseException.class,
@@ -799,14 +824,14 @@ public class OpenSearchIT extends KNNRestTestCase {
         final Integer dimension = testData.indexData.vectors[0].length;
         final Settings knnIndexSettings = buildKNNIndexSettings(-1);
 
-        // Create an index
         final XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(fieldName1)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(KNNConstants.PARAMETERS)
@@ -815,8 +840,9 @@ public class OpenSearchIT extends KNNRestTestCase {
             .endObject()
             .startObject(fieldName2)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.KNN_ENGINE, KNNEngine.FAISS.getName())
             .startObject(KNNConstants.PARAMETERS)
@@ -873,6 +899,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNIndexSearchFieldsParameter() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2", "vector3"), Arrays.asList(2, 3, 5)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {
@@ -955,6 +982,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNIndexSearchFieldsParameterWithOtherFields() throws Exception {
+        assumeUncompressed();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -1061,6 +1089,7 @@ public class OpenSearchIT extends KNNRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNIndexSearchFieldsParameterDocsWithOnlyOtherFields() throws Exception {
+        assumeUncompressed();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -1158,6 +1187,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNVectorMappingUpdate_whenMethodRemoved_thenThrowsException() throws Exception {
+        assumeUncompressed();
         String indexName = "test-knn-index";
         String fieldName = "my_vector2";
 
@@ -1195,6 +1225,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testCreateKNNIndexWithDifferentDimension() throws Exception {
+        assumeUncompressed();
         String indexName = "test-knn-index-partial";
         String fieldName = "my_vector2";
 
@@ -1218,6 +1249,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNVectorMappingUpdate_whenMethodPartiallyRemoved_thenThrowsException() throws Exception {
+        assumeUncompressed();
         String indexName = "test-knn-index-success";
         String fieldName = "my_vector2";
 
@@ -1256,6 +1288,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {
@@ -1308,6 +1341,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_FaissNested() throws Exception {
+        assumeUncompressed();
         int dimension = 3;
         String nestedFieldPath = "nested_field.my_vector";
         String mapping = createKnnIndexNestedMapping(dimension, nestedFieldPath, "faiss");
@@ -1375,6 +1409,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_MultipleResults() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {
@@ -1417,6 +1452,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_FaissFilter() throws Exception {
+        assumeUncompressed();
         int dim = 3;
         String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "faiss", "l2", false);
         createKnnIndex(INDEX_NAME, mapping);
@@ -1558,6 +1594,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_Rescore() throws Exception {
+        assumeUncompressed();
         int dim = 3;
         int k = 2;
         createOnDiskIndex(INDEX_NAME, dim, SpaceType.L2); // by default uses 32x and FAISS IVF
@@ -1613,6 +1650,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_RescoreComplex() throws Exception {
+        assumeUncompressed();
         int dim = 3;
         int k = 2;
         createOnDiskIndex(INDEX_NAME, dim, SpaceType.L2); // by default uses 32x and FAISS IVF
@@ -1667,6 +1705,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_RescoreLucene() throws Exception {
+        assumeUncompressed();
         int dim = 3;
         int k = 2;
         String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "lucene", "l2", false);
@@ -1723,6 +1762,7 @@ public class OpenSearchIT extends KNNRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_Radial() throws Exception {
+        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Floats;
 
@@ -43,6 +44,7 @@ import org.opensearch.search.profile.query.QueryTimingType;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -59,6 +61,11 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     public OpenSearchIT(CompressionTestConfig compressionConfig) {
         super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
     }
 
     @BeforeClass
@@ -105,7 +112,7 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
         Map<String, Object> mappingMap = xContentBuilderToMap(builder);
         String mapping = builder.toString();
         createKnnIndex(indexName, buildKNNIndexSettings(0), mapping);
-        if (compressionConfig == CompressionTestConfig.FP32) {
+        if (compressionConfig == CompressionTestConfig.X1) {
             assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
         }
 
@@ -157,7 +164,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testAddDoc_blockedWhenCbTrips() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         updateClusterSettings("knn.circuit_breaker.triggered", "true");
 
@@ -173,7 +179,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testUpdateDoc_blockedWhenCbTrips() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         Float[] vector = { 6.0f, 6.0f };
         addKnnDoc(INDEX_NAME, "1", FIELD_NAME, vector);
@@ -192,7 +197,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testAddAndSearchIndex_whenCBTrips() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(FIELD_NAME, 2));
         for (int i = 1; i <= 4; i++) {
             Float[] vector = { (float) i, (float) (i + 1) };
@@ -224,7 +228,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testIndexingVectorValidation_differentSizes() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
@@ -246,7 +249,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     @SneakyThrows
     public void testIndexingVectorValidation_zeroVector() {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
         final boolean valid = randomBoolean();
         final String method = KNNConstants.METHOD_HNSW;
@@ -275,7 +277,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testVectorMappingValidation_noDimension() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         String mapping = XContentFactory.jsonBuilder()
@@ -293,7 +294,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testVectorMappingValidation_invalidDimension() {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         Exception ex = expectThrows(
@@ -316,7 +316,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testVectorMappingValidation_invalidVectorNaN() throws IOException {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
@@ -327,7 +326,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testVectorMappingValidation_invalidVectorInfinity() throws IOException {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 2));
@@ -338,7 +336,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testVectorMappingValidation_updateDimension() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
@@ -348,7 +345,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testVectorMappingValidation_multiFieldsDifferentDimension() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         String f4 = FIELD_NAME + "-4";
@@ -380,7 +376,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testExistsQuery() throws Exception {
-        assumeUncompressed();
         String field1 = "field1";
         String field2 = "field2";
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList(field1, field2), Arrays.asList(2, 2)));
@@ -415,7 +410,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testIndexingVectorValidation_updateVectorWithNull() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(getKNNDefaultIndexSettings()).build();
 
         createKnnIndex(INDEX_NAME, settings, createKnnIndexMapping(FIELD_NAME, 4));
@@ -599,7 +593,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNIndex_whenBuildGraphThresholdIsPresent_thenGetThresholdValue() throws Exception {
-        assumeUncompressed();
         final Integer buildVectorDataStructureThreshold = randomIntBetween(
             INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN,
             INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX
@@ -622,7 +615,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNIndex_whenBuildThresholdIsNotProvided_thenShouldNotReturnSetting() throws Exception {
-        assumeUncompressed();
         final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
         final String indexName = "test-index-with-build-graph-settings";
         createKnnIndex(indexName, getDefaultIndexSettings(), knnIndexMapping);
@@ -638,7 +630,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNIndex_whenGetIndexSettingWithDefaultIsCalled_thenReturnDefaultBuildGraphThresholdValue() throws Exception {
-        assumeUncompressed();
         final String knnIndexMapping = createKnnIndexMapping(FIELD_NAME, KNNEngine.getMaxDimensionByEngine(KNNEngine.DEFAULT));
         final String indexName = "test-index-with-build-vector-graph-settings";
         createKnnIndex(indexName, getDefaultIndexSettings(), knnIndexMapping);
@@ -784,7 +775,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testCreateNonKNNIndex_withKNNModelID_throwsException() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(createKNNDefaultScriptScoreSettings()).build();
         ResponseException ex = expectThrows(
             ResponseException.class,
@@ -795,7 +785,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testCreateNonKNNIndex_withKNNMethodParams_throwsException() throws Exception {
-        assumeUncompressed();
         Settings settings = Settings.builder().put(createKNNDefaultScriptScoreSettings()).build();
         ResponseException ex = expectThrows(
             ResponseException.class,
@@ -899,7 +888,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNIndexSearchFieldsParameter() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2", "vector3"), Arrays.asList(2, 3, 5)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {
@@ -982,7 +970,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNIndexSearchFieldsParameterWithOtherFields() throws Exception {
-        assumeUncompressed();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -1089,7 +1076,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNIndexSearchFieldsParameterDocsWithOnlyOtherFields() throws Exception {
-        assumeUncompressed();
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
@@ -1187,7 +1173,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNVectorMappingUpdate_whenMethodRemoved_thenThrowsException() throws Exception {
-        assumeUncompressed();
         String indexName = "test-knn-index";
         String fieldName = "my_vector2";
 
@@ -1225,7 +1210,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testCreateKNNIndexWithDifferentDimension() throws Exception {
-        assumeUncompressed();
         String indexName = "test-knn-index-partial";
         String fieldName = "my_vector2";
 
@@ -1249,7 +1233,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNVectorMappingUpdate_whenMethodPartiallyRemoved_thenThrowsException() throws Exception {
-        assumeUncompressed();
         String indexName = "test-knn-index-success";
         String fieldName = "my_vector2";
 
@@ -1288,7 +1271,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {
@@ -1341,7 +1323,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_FaissNested() throws Exception {
-        assumeUncompressed();
         int dimension = 3;
         String nestedFieldPath = "nested_field.my_vector";
         String mapping = createKnnIndexNestedMapping(dimension, nestedFieldPath, "faiss");
@@ -1409,7 +1390,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_MultipleResults() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {
@@ -1452,7 +1432,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_FaissFilter() throws Exception {
-        assumeUncompressed();
         int dim = 3;
         String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "faiss", "l2", false);
         createKnnIndex(INDEX_NAME, mapping);
@@ -1594,7 +1573,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_Rescore() throws Exception {
-        assumeUncompressed();
         int dim = 3;
         int k = 2;
         createOnDiskIndex(INDEX_NAME, dim, SpaceType.L2); // by default uses 32x and FAISS IVF
@@ -1650,7 +1628,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_RescoreComplex() throws Exception {
-        assumeUncompressed();
         int dim = 3;
         int k = 2;
         createOnDiskIndex(INDEX_NAME, dim, SpaceType.L2); // by default uses 32x and FAISS IVF
@@ -1705,7 +1682,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_RescoreLucene() throws Exception {
-        assumeUncompressed();
         int dim = 3;
         int k = 2;
         String mapping = createKnnIndexMapping(FIELD_NAME, dim, "hnsw", "lucene", "l2", false);
@@ -1762,7 +1738,6 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNSearchWithProfilerEnabled_Radial() throws Exception {
-        assumeUncompressed();
         createKnnIndex(INDEX_NAME, createKnnIndexMapping(Arrays.asList("vector1", "vector2"), Arrays.asList(2, 3)));
         // Add docs with knn_vector fields
         for (int i = 1; i <= 20; i++) {

--- a/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/OpenSearchIT.java
@@ -65,7 +65,7 @@ public class OpenSearchIT extends KNNCompressionRestTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     @BeforeClass

--- a/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
@@ -12,7 +12,8 @@ import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -25,15 +26,18 @@ import java.util.List;
 /**
  * Integration tests for radial search (max_distance and min_score) on Faiss and Lucene HNSW.
  * Covers both ANN path (no filter) and ExactSearcher path (with filter, Faiss only) across
- * L2, cosine, and inner product space types.
+ * L2, cosine, and inner product space types, parameterized by compression (FP32 and SQ 1-bit / 32x).
  *
  * Validates the distanceToRadialThreshold and scoreToRadialThreshold transformations,
  * specifically the fix for Faiss IP max_distance (DISTANCE_TRANSLATIONS: distance -> -1 * distance).
+ *
+ * FP32 asserts exact result counts. Under 1-bit quantization at dimension 2 the per-threshold
+ * counts are not reliably exact, so the 32x runs assert the radial query succeeds with valid,
+ * descending scores and a sane result count (the proven Compression32XIT radial pattern).
  */
-public class RadialSearchIT extends KNNRestTestCase {
+public class RadialSearchIT extends KNNCompressionRestTestCase {
 
     private static final int DIMENSION = 2;
-    private static final String FIELD_NAME = "test_vector";
     private static final String FILTER_FIELD = "color";
 
     private final String testName;
@@ -48,6 +52,7 @@ public class RadialSearchIT extends KNNRestTestCase {
     private final boolean mosEnabled;
 
     public RadialSearchIT(
+        CompressionTestConfig compressionConfig,
         String testName,
         KNNEngine engine,
         SpaceType spaceType,
@@ -59,6 +64,7 @@ public class RadialSearchIT extends KNNRestTestCase {
         boolean useFilter,
         boolean mosEnabled
     ) {
+        super(compressionConfig);
         this.testName = testName;
         this.engine = engine;
         this.spaceType = spaceType;
@@ -71,12 +77,22 @@ public class RadialSearchIT extends KNNRestTestCase {
         this.mosEnabled = mosEnabled;
     }
 
-    @ParametersFactory(argumentFormatting = "{0}")
-    public static Collection<Object[]> parameters() {
+    @ParametersFactory(argumentFormatting = "{1}_compression:{0}")
+    public static Collection<Object[]> compressionParameters() {
+        List<Object[]> baseParams = new ArrayList<>();
+        addFaissParams(baseParams);
+        addFaissMosParams(baseParams);
+        addLuceneParams(baseParams);
+
         List<Object[]> params = new ArrayList<>();
-        addFaissParams(params);
-        addFaissMosParams(params);
-        addLuceneParams(params);
+        for (CompressionTestConfig config : CompressionTestConfig.values()) {
+            for (Object[] base : baseParams) {
+                Object[] row = new Object[base.length + 1];
+                row[0] = config;
+                System.arraycopy(base, 0, row, 1, base.length);
+                params.add(row);
+            }
+        }
         return params;
     }
 
@@ -441,15 +457,16 @@ public class RadialSearchIT extends KNNRestTestCase {
     }
 
     public void testRadialSearch_thenCorrectResults() throws Exception {
-        String indexName = "test_radial_" + testName.toLowerCase().replace(" ", "_");
+        String indexName = prefix() + testName.toLowerCase().replace(" ", "_");
 
         XContentBuilder mapping = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .field("dimension", DIMENSION);
+        addCompressionMappingFields(mapping);
+        mapping.field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
             .field(KNNConstants.KNN_ENGINE, engine.getName());
@@ -479,11 +496,32 @@ public class RadialSearchIT extends KNNRestTestCase {
         Response response = searchKNNIndex(indexName, query, 10);
         List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
 
-        assertEquals(
-            String.format("[%s] Expected %d results but got %d", testName, expectedCount, results.size()),
-            expectedCount,
-            results.size()
-        );
+        if (compressionConfig == CompressionTestConfig.FP32) {
+            assertEquals(
+                String.format("[%s] Expected %d results but got %d", testName, expectedCount, results.size()),
+                expectedCount,
+                results.size()
+            );
+        } else {
+            assertTrue(
+                String.format(
+                    "[%s] quantized radial returned %d results, expected at most %d",
+                    testName,
+                    results.size(),
+                    testVectors.length
+                ),
+                results.size() <= testVectors.length
+            );
+            for (int i = 0; i < results.size(); i++) {
+                assertTrue(String.format("[%s] score should be positive", testName), results.get(i).getScore() > 0.0f);
+                if (i > 0) {
+                    assertTrue(
+                        String.format("[%s] scores should be in descending order", testName),
+                        results.get(i - 1).getScore() >= results.get(i).getScore()
+                    );
+                }
+            }
+        }
 
         deleteKNNIndex(indexName);
     }

--- a/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
+++ b/src/test/java/org/opensearch/knn/index/RadialSearchIT.java
@@ -496,7 +496,7 @@ public class RadialSearchIT extends KNNCompressionRestTestCase {
         Response response = searchKNNIndex(indexName, query, 10);
         List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
 
-        if (compressionConfig == CompressionTestConfig.FP32) {
+        if (compressionConfig == CompressionTestConfig.X1) {
             assertEquals(
                 String.format("[%s] Expected %d results but got %d", testName, expectedCount, results.size()),
                 expectedCount,

--- a/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
+++ b/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
@@ -34,7 +34,7 @@ public class RestoreSnapshotIT extends KNNCompressionRestTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     @Before

--- a/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
+++ b/src/test/java/org/opensearch/knn/index/RestoreSnapshotIT.java
@@ -5,22 +5,37 @@
 
 package org.opensearch.knn.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.junit.Before;
 import org.junit.Test;
 import lombok.SneakyThrows;
+
+import java.util.List;
+import java.util.Collection;
+
 import static org.hamcrest.Matchers.containsString;
 
-public class RestoreSnapshotIT extends KNNRestTestCase {
+public class RestoreSnapshotIT extends KNNCompressionRestTestCase {
 
     private String index = "test-index";;
     private String snapshot = "snapshot-" + index;
     private String repository = "repo";
+
+    public RestoreSnapshotIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     @Before
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/SegmentReplicationIT.java
+++ b/src/test/java/org/opensearch/knn/index/SegmentReplicationIT.java
@@ -18,11 +18,17 @@ import org.junit.Assert;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
+import java.io.IOException;
 import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.NAME;
 
 /**
  * This IT class contains will contain special cases of IT for segment replication behavior.
@@ -30,13 +36,17 @@ import java.util.List;
  * at-least 2 node configuration.
  */
 @Log4j2
-public class SegmentReplicationIT extends KNNRestTestCase {
+public class SegmentReplicationIT extends KNNCompressionRestTestCase {
     private static final String INDEX_NAME = "segment-replicated-knn-index";
+
+    public SegmentReplicationIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     @SneakyThrows
     @ExpectRemoteBuildValidation
     public void testSearchOnReplicas_whenIndexHasDeletedDocs_thenSuccess() {
-        createKnnIndex(INDEX_NAME, getKNNSegmentReplicatedIndexSettings(), createKNNIndexMethodFieldMapping(FIELD_NAME, 2));
+        createKnnIndex(INDEX_NAME, getKNNSegmentReplicatedIndexSettings(), createFieldMapping(2));
 
         Float[] vector = { 1.3f, 2.2f };
         int docsInIndex = 10;
@@ -92,5 +102,17 @@ public class SegmentReplicationIT extends KNNRestTestCase {
             return false;
         }
         return true;
+    }
+
+    private String createFieldMapping(int dimension) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNN_METHOD).field(NAME, METHOD_HNSW).endObject().endObject().endObject().endObject();
+        return builder.toString();
     }
 }

--- a/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
+++ b/src/test/java/org/opensearch/knn/index/VectorDataTypeIT.java
@@ -805,8 +805,13 @@ public class VectorDataTypeIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
             .field(DIMENSION, dimension)
-            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType)
-            .startObject(KNNConstants.KNN_METHOD)
+            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType);
+
+        if (VectorDataType.FLOAT.getValue().equals(vectorDataType)) {
+            builder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, "1x");
+        }
+
+        builder.startObject(KNNConstants.KNN_METHOD)
             .field(KNNConstants.NAME, METHOD_HNSW)
             .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
             .field(KNNConstants.KNN_ENGINE, engine)

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.opensearch.client.Request;
@@ -14,6 +15,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.CompressionTestConfig;
 import org.opensearch.knn.DerivedSourceTestCase;
 import org.opensearch.knn.DerivedSourceUtils;
 import org.opensearch.knn.Pair;
@@ -23,6 +25,7 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -39,6 +42,15 @@ import static org.opensearch.knn.common.KNNConstants.DIMENSION;
  * a few gaps in functionality. Ignoring tests for now as feature is experimental.
  */
 public class DerivedSourceIT extends DerivedSourceTestCase {
+
+    public DerivedSourceIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     private final String snapshot = "snapshot-test";
     private final String repository = "repo";
@@ -279,8 +291,9 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .field("path_match", "similar_products_vector.*.clip_vit_base_patch32")
             .startObject("mapping")
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .startObject("method")
+            .field("dimension", dimension);
+        addCompressionMappingFields(mappingsBuilder);
+        mappingsBuilder.startObject("method")
             .field("engine", "faiss")
             .field("space_type", "l2")
             .field("name", "hnsw")
@@ -349,8 +362,9 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject("nameVector")
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .startObject("method")
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingBuilder);
+        mappingBuilder.startObject("method")
             .field("engine", "lucene")
             .field("space_type", "l2")
             .field("name", "hnsw")
@@ -413,7 +427,11 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
         testReindex(indexConfigContexts);
 
         // Snapshot restore
-        testSnapshotRestore(repository, snapshot + getTestName().toLowerCase(Locale.ROOT), indexConfigContexts);
+        testSnapshotRestore(
+            repository,
+            snapshot + getTestName().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9-]", ""),
+            indexConfigContexts
+        );
     }
 
     @SneakyThrows
@@ -427,10 +445,9 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .endObject()
-            .endObject()
-            .endObject();
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
         String mapping = builder.toString();
         createKnnIndex(indexName, mapping);
         validateDerivedSetting(indexName, true);
@@ -448,10 +465,9 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject("properties")
             .startObject(fieldName)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .endObject()
-            .endObject()
-            .endObject();
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
         String mapping = builder.toString();
         expectThrows(
             ResponseException.class,
@@ -483,21 +499,19 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject(VECTOR_FIELD_1)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(KNNConstants.DIMENSION, DIMENSION)
-            .endObject()
+            .field(KNNConstants.DIMENSION, DIMENSION);
+        addCompressionMappingFields(mappingBuilder);
+        mappingBuilder.endObject()
             .startObject(VECTOR_FIELD_2)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(KNNConstants.DIMENSION, DIMENSION)
-            .endObject()
+            .field(KNNConstants.DIMENSION, DIMENSION);
+        addCompressionMappingFields(mappingBuilder);
+        mappingBuilder.endObject()
             .startObject(VECTOR_FIELD_3)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(KNNConstants.DIMENSION, DIMENSION)
-            .endObject()
-            .startObject(TEXT_FIELD)
-            .field(KNNConstants.TYPE, "text")
-            .endObject()
-            .endObject()
-            .endObject();
+            .field(KNNConstants.DIMENSION, DIMENSION);
+        addCompressionMappingFields(mappingBuilder);
+        mappingBuilder.endObject().startObject(TEXT_FIELD).field(KNNConstants.TYPE, "text").endObject().endObject().endObject();
 
         createKnnIndex(
             indexName,
@@ -637,17 +651,14 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject(VECTOR_FIELD_1)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithIncludes);
+        mappingWithIncludes.endObject()
             .startObject(VECTOR_FIELD_2)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
-            .startObject(TEXT_FIELD)
-            .field(KNNConstants.TYPE, "text")
-            .endObject()
-            .endObject()
-            .endObject();
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithIncludes);
+        mappingWithIncludes.endObject().startObject(TEXT_FIELD).field(KNNConstants.TYPE, "text").endObject().endObject().endObject();
 
         createKnnIndex(
             indexWithIncludes,
@@ -677,17 +688,14 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject(VECTOR_FIELD_1)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithExcludes);
+        mappingWithExcludes.endObject()
             .startObject(VECTOR_FIELD_2)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
-            .startObject(TEXT_FIELD)
-            .field(KNNConstants.TYPE, "text")
-            .endObject()
-            .endObject()
-            .endObject();
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithExcludes);
+        mappingWithExcludes.endObject().startObject(TEXT_FIELD).field(KNNConstants.TYPE, "text").endObject().endObject().endObject();
 
         createKnnIndex(
             indexWithExcludes,
@@ -718,17 +726,14 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject(VECTOR_FIELD_1)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithBoth);
+        mappingWithBoth.endObject()
             .startObject(VECTOR_FIELD_2)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
-            .startObject(TEXT_FIELD)
-            .field(KNNConstants.TYPE, "text")
-            .endObject()
-            .endObject()
-            .endObject();
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithBoth);
+        mappingWithBoth.endObject().startObject(TEXT_FIELD).field(KNNConstants.TYPE, "text").endObject().endObject().endObject();
 
         createKnnIndex(
             indexWithBoth,
@@ -758,12 +763,14 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject(VECTOR_FIELD_1)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithWildcardIncludes);
+        mappingWithWildcardIncludes.endObject()
             .startObject(VECTOR_FIELD_2)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithWildcardIncludes);
+        mappingWithWildcardIncludes.endObject()
             .startObject(TEXT_FIELD)
             .field(KNNConstants.TYPE, "text")
             .endObject()
@@ -802,12 +809,14 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
             .startObject(KNNConstants.PROPERTIES)
             .startObject(VECTOR_FIELD_1)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithWildcardExcludes);
+        mappingWithWildcardExcludes.endObject()
             .startObject(VECTOR_FIELD_2)
             .field(KNNConstants.TYPE, KNNConstants.TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .endObject()
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(mappingWithWildcardExcludes);
+        mappingWithWildcardExcludes.endObject()
             .startObject(TEXT_FIELD)
             .field(KNNConstants.TYPE, "text")
             .endObject()

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -49,7 +49,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     private final String snapshot = "snapshot-test";

--- a/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DocValueFieldsIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -13,8 +14,9 @@ import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNJsonIndexMappingsBuilder;
-import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -29,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +42,16 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
  * Validates that vectors can be retrieved directly from doc values in search responses
  * across different engines, data types, query types, and field configurations.
  */
-public class DocValueFieldsIT extends KNNRestTestCase {
+public class DocValueFieldsIT extends KNNCompressionRestTestCase {
+
+    public DocValueFieldsIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     private static final String TEST_INDEX = "docvalue_fields_test_index";
     private static final String VECTOR_FIELD = "test_vector";
@@ -237,13 +249,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
             .engine(KNNEngine.FAISS.getName())
             .build();
 
-        String mapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(VECTOR_FIELD)
-            .dimension(highDimension)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(method)
-            .build()
-            .getIndexMapping();
+        String mapping = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(highDimension)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(method).build().getIndexMapping();
 
         createKnnIndex(indexName, mapping);
 
@@ -897,13 +908,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
             .engine(KNNEngine.FAISS.getName())
             .build();
 
-        String mapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(VECTOR_FIELD)
-            .dimension(DIMENSION)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(method)
-            .build()
-            .getIndexMapping();
+        String mapping = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(method).build().getIndexMapping();
 
         Settings settings = Settings.builder()
             .put("number_of_shards", 1)
@@ -986,13 +996,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
             .engine(KNNEngine.FAISS.getName())
             .build();
 
-        String mapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(VECTOR_FIELD)
-            .dimension(DIMENSION)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(method)
-            .build()
-            .getIndexMapping();
+        String mapping = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(method).build().getIndexMapping();
 
         Settings settings = Settings.builder()
             .put("number_of_shards", 1)
@@ -1107,13 +1116,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
                 .engine(engine.getName())
                 .build();
 
-            String mapping = KNNJsonIndexMappingsBuilder.builder()
-                .fieldName(VECTOR_FIELD)
-                .dimension(DIMENSION)
-                .vectorDataType(VectorDataType.FLOAT.getValue())
-                .method(method)
-                .build()
-                .getIndexMapping();
+            String mapping = addCompressionMappingFields(
+                KNNJsonIndexMappingsBuilder.builder()
+                    .fieldName(VECTOR_FIELD)
+                    .dimension(DIMENSION)
+                    .vectorDataType(VectorDataType.FLOAT.getValue())
+            ).method(method).build().getIndexMapping();
 
             createKnnIndex(indexName, mapping);
             addKnnDoc(indexName, "1", VECTOR_FIELD, Floats.asList(VECTOR_1).toArray());
@@ -1185,13 +1193,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
                 .engine(engine.getName())
                 .build();
 
-            String mapping = KNNJsonIndexMappingsBuilder.builder()
-                .fieldName(VECTOR_FIELD)
-                .dimension(DIMENSION)
-                .vectorDataType(VectorDataType.FLOAT.getValue())
-                .method(method)
-                .build()
-                .getIndexMapping();
+            String mapping = addCompressionMappingFields(
+                KNNJsonIndexMappingsBuilder.builder()
+                    .fieldName(VECTOR_FIELD)
+                    .dimension(DIMENSION)
+                    .vectorDataType(VectorDataType.FLOAT.getValue())
+            ).method(method).build().getIndexMapping();
 
             createKnnIndex(indexName, mapping);
             addKnnDoc(indexName, "1", VECTOR_FIELD, Floats.asList(VECTOR_1).toArray());
@@ -1748,19 +1755,18 @@ public class DocValueFieldsIT extends KNNRestTestCase {
         String floatIndex = TEST_INDEX + "_base64_float";
         createKnnIndex(
             floatIndex,
-            KNNJsonIndexMappingsBuilder.builder()
-                .fieldName(VECTOR_FIELD)
-                .dimension(DIMENSION)
-                .vectorDataType(VectorDataType.FLOAT.getValue())
-                .method(
-                    KNNJsonIndexMappingsBuilder.Method.builder()
-                        .methodName(METHOD_HNSW)
-                        .spaceType(SpaceType.L2.getValue())
-                        .engine(KNNEngine.LUCENE.getName())
-                        .build()
-                )
-                .build()
-                .getIndexMapping()
+            addCompressionMappingFields(
+                KNNJsonIndexMappingsBuilder.builder()
+                    .fieldName(VECTOR_FIELD)
+                    .dimension(DIMENSION)
+                    .vectorDataType(VectorDataType.FLOAT.getValue())
+            ).method(
+                KNNJsonIndexMappingsBuilder.Method.builder()
+                    .methodName(METHOD_HNSW)
+                    .spaceType(SpaceType.L2.getValue())
+                    .engine(KNNEngine.LUCENE.getName())
+                    .build()
+            ).build().getIndexMapping()
         );
 
         ByteBuffer buffer = ByteBuffer.allocate(DIMENSION * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
@@ -1856,19 +1862,18 @@ public class DocValueFieldsIT extends KNNRestTestCase {
 
         createKnnIndex(
             indexName,
-            KNNJsonIndexMappingsBuilder.builder()
-                .fieldName(VECTOR_FIELD)
-                .dimension(DIMENSION)
-                .vectorDataType(VectorDataType.FLOAT.getValue())
-                .method(
-                    KNNJsonIndexMappingsBuilder.Method.builder()
-                        .methodName(METHOD_HNSW)
-                        .spaceType(SpaceType.L2.getValue())
-                        .engine(KNNEngine.LUCENE.getName())
-                        .build()
-                )
-                .build()
-                .getIndexMapping()
+            addCompressionMappingFields(
+                KNNJsonIndexMappingsBuilder.builder()
+                    .fieldName(VECTOR_FIELD)
+                    .dimension(DIMENSION)
+                    .vectorDataType(VectorDataType.FLOAT.getValue())
+            ).method(
+                KNNJsonIndexMappingsBuilder.Method.builder()
+                    .methodName(METHOD_HNSW)
+                    .spaceType(SpaceType.L2.getValue())
+                    .engine(KNNEngine.LUCENE.getName())
+                    .build()
+            ).build().getIndexMapping()
         );
 
         // Index doc 1 via JSON array
@@ -1935,19 +1940,18 @@ public class DocValueFieldsIT extends KNNRestTestCase {
         String floatIndex = TEST_INDEX + "_base64_invalid_float";
         createKnnIndex(
             floatIndex,
-            KNNJsonIndexMappingsBuilder.builder()
-                .fieldName(VECTOR_FIELD)
-                .dimension(DIMENSION)
-                .vectorDataType(VectorDataType.FLOAT.getValue())
-                .method(
-                    KNNJsonIndexMappingsBuilder.Method.builder()
-                        .methodName(METHOD_HNSW)
-                        .spaceType(SpaceType.L2.getValue())
-                        .engine(KNNEngine.LUCENE.getName())
-                        .build()
-                )
-                .build()
-                .getIndexMapping()
+            addCompressionMappingFields(
+                KNNJsonIndexMappingsBuilder.builder()
+                    .fieldName(VECTOR_FIELD)
+                    .dimension(DIMENSION)
+                    .vectorDataType(VectorDataType.FLOAT.getValue())
+            ).method(
+                KNNJsonIndexMappingsBuilder.Method.builder()
+                    .methodName(METHOD_HNSW)
+                    .spaceType(SpaceType.L2.getValue())
+                    .engine(KNNEngine.LUCENE.getName())
+                    .build()
+            ).build().getIndexMapping()
         );
 
         String invalidFloatBase64 = Base64.getEncoder().encodeToString(new byte[] { 1, 2, 3 });
@@ -2016,19 +2020,18 @@ public class DocValueFieldsIT extends KNNRestTestCase {
         String destIndex = TEST_INDEX + "_base64_reindex_dest";
         int numDocs = 10;
 
-        String mapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(VECTOR_FIELD)
-            .dimension(DIMENSION)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(
-                KNNJsonIndexMappingsBuilder.Method.builder()
-                    .methodName(METHOD_HNSW)
-                    .spaceType(SpaceType.L2.getValue())
-                    .engine(KNNEngine.FAISS.getName())
-                    .build()
-            )
-            .build()
-            .getIndexMapping();
+        String mapping = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(
+            KNNJsonIndexMappingsBuilder.Method.builder()
+                .methodName(METHOD_HNSW)
+                .spaceType(SpaceType.L2.getValue())
+                .engine(KNNEngine.FAISS.getName())
+                .build()
+        ).build().getIndexMapping();
 
         createKnnIndex(sourceIndex, mapping);
 
@@ -2145,13 +2148,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
             .engine(engine.getName())
             .build();
 
-        String mapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(VECTOR_FIELD)
-            .dimension(DIMENSION)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(method)
-            .build()
-            .getIndexMapping();
+        String mapping = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(method).build().getIndexMapping();
 
         createKnnIndex(TEST_INDEX, mapping);
     }
@@ -2163,13 +2165,12 @@ public class DocValueFieldsIT extends KNNRestTestCase {
             .engine(engine.getName())
             .build();
 
-        String mapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(VECTOR_FIELD)
-            .dimension(DIMENSION)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(method)
-            .build()
-            .getIndexMapping();
+        String mapping = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder()
+                .fieldName(VECTOR_FIELD)
+                .dimension(DIMENSION)
+                .vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(method).build().getIndexMapping();
 
         createKnnIndex(indexName, mapping);
     }

--- a/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
@@ -9,7 +9,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -20,7 +19,8 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.util.CollectionUtils;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.NestedKnnDocBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
@@ -38,6 +38,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static org.opensearch.knn.common.Constants.FIELD_FILTER;
 import static org.opensearch.knn.common.Constants.FIELD_TERM;
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
 import static org.opensearch.knn.common.KNNConstants.K;
@@ -56,8 +57,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 @Log4j2
-@AllArgsConstructor
-public class ExpandNestedDocsIT extends KNNRestTestCase {
+public class ExpandNestedDocsIT extends KNNCompressionRestTestCase {
     private static final String INDEX_NAME = "test-index-expand-nested-search";
     private static final String FIELD_NAME_NESTED = "test_nested";
     private static final String FIELD_NAME_VECTOR = "test_vector";
@@ -69,14 +69,25 @@ public class ExpandNestedDocsIT extends KNNRestTestCase {
     private static final String PROPERTIES_FIELD = "properties";
     private static final String INNER_HITS = "inner_hits";
 
-    private String description;
-    private KNNEngine engine;
-    private VectorDataType dataType;
-    private Mode mode;
-    private Integer dimension;
+    private final KNNEngine engine;
+    private final VectorDataType dataType;
+    private final Mode mode;
+    private final Integer dimension;
+
+    public ExpandNestedDocsIT(String description, KNNEngine engine, VectorDataType dataType, Mode mode, Integer dimension) {
+        super(deriveCompressionConfig(dataType, mode));
+        this.engine = engine;
+        this.dataType = dataType;
+        this.mode = mode;
+        this.dimension = dimension;
+    }
+
+    private static CompressionTestConfig deriveCompressionConfig(VectorDataType dataType, Mode mode) {
+        return (mode == Mode.ON_DISK && dataType == VectorDataType.FLOAT) ? CompressionTestConfig.SQ_1BIT : CompressionTestConfig.FP32;
+    }
 
     @ParametersFactory(argumentFormatting = "description:%1$s; engine:%2$s, data_type:%3$s, mode:%4$s, dimension:%5$s")
-    public static Collection<Object[]> parameters() throws IOException {
+    public static Collection<Object[]> compressionParameters() {
         int dimension = 1;
         return Arrays.asList(
             $$(
@@ -409,34 +420,6 @@ public class ExpandNestedDocsIT extends KNNRestTestCase {
         createKnnIndex(engine, mode, dimension, vectorDataType, 1);
     }
 
-    /**
-     * {
-     * 		"dynamic": false,
-     *      "properties": {
-     *          "test_nested": {
-     *              "type": "nested",
-     *              "properties": {
-     *                  "test_vector": {
-     *                      "type": "knn_vector",
-     *                      "dimension": 3,
-     *                      "mode": "in_memory",
-     *                      "data_type: "float",
-     *                      "method": {
-     *                          "name": "hnsw",
-     *                          "engine": "lucene"
-     *                      }
-     *                  },
-     *                  "storage": {
-     *                      "type": "boolean"
-     *                  }
-     *              }
-     *          },
-     *          "parking": {
-     *              "type": "boolean"
-     *          }
-     *      }
-     *  }
-     */
     private void createKnnIndex(
         final KNNEngine engine,
         final Mode mode,
@@ -455,8 +438,11 @@ public class ExpandNestedDocsIT extends KNNRestTestCase {
             .field(TYPE, TYPE_KNN_VECTOR)
             .field(DIMENSION, dimension)
             .field(MODE_PARAMETER, Mode.NOT_CONFIGURED.equals(mode) ? null : mode.getName())
-            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue())
-            .startObject(KNN_METHOD)
+            .field(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
+        if (vectorDataType == VectorDataType.FLOAT) {
+            builder.field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+        }
+        builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, engine.getName())
             .endObject()

--- a/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
@@ -436,10 +436,12 @@ public class ExpandNestedDocsIT extends KNNCompressionRestTestCase {
             .startObject(FIELD_NAME_VECTOR)
             .field(TYPE, TYPE_KNN_VECTOR)
             .field(DIMENSION, dimension)
-            .field(MODE_PARAMETER, Mode.NOT_CONFIGURED.equals(mode) ? null : mode.getName())
             .field(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
         if (vectorDataType == VectorDataType.FLOAT) {
             addCompressionMappingFields(builder);
+        }
+        if (!(vectorDataType == VectorDataType.FLOAT && compressionConfig.isCompressed())) {
+            builder.field(MODE_PARAMETER, Mode.NOT_CONFIGURED.equals(mode) ? null : mode.getName());
         }
         builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)

--- a/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/ExpandNestedDocsIT.java
@@ -38,7 +38,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static org.opensearch.knn.common.Constants.FIELD_FILTER;
 import static org.opensearch.knn.common.Constants.FIELD_TERM;
-import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.EXPAND_NESTED;
 import static org.opensearch.knn.common.KNNConstants.K;
@@ -83,7 +82,7 @@ public class ExpandNestedDocsIT extends KNNCompressionRestTestCase {
     }
 
     private static CompressionTestConfig deriveCompressionConfig(VectorDataType dataType, Mode mode) {
-        return (mode == Mode.ON_DISK && dataType == VectorDataType.FLOAT) ? CompressionTestConfig.SQ_1BIT : CompressionTestConfig.FP32;
+        return (mode == Mode.ON_DISK && dataType == VectorDataType.FLOAT) ? CompressionTestConfig.X32 : CompressionTestConfig.X1;
     }
 
     @ParametersFactory(argumentFormatting = "description:%1$s; engine:%2$s, data_type:%3$s, mode:%4$s, dimension:%5$s")
@@ -440,7 +439,7 @@ public class ExpandNestedDocsIT extends KNNCompressionRestTestCase {
             .field(MODE_PARAMETER, Mode.NOT_CONFIGURED.equals(mode) ? null : mode.getName())
             .field(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
         if (vectorDataType == VectorDataType.FLOAT) {
-            builder.field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+            addCompressionMappingFields(builder);
         }
         builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)

--- a/src/test/java/org/opensearch/knn/integ/FilteredSearchANNSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FilteredSearchANNSearchIT.java
@@ -12,8 +12,10 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNJsonQueryBuilder;
-import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.index.KNNSettings;
 import java.util.List;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
@@ -22,16 +24,20 @@ import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 
 @Log4j2
-public class FilteredSearchANNSearchIT extends KNNRestTestCase {
+public class FilteredSearchANNSearchIT extends KNNCompressionRestTestCase {
+
+    public FilteredSearchANNSearchIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
     @SneakyThrows
     @ExpectRemoteBuildValidation
     public void testFilteredSearchWithFaissHnsw_whenFiltersMatchAllDocs_thenReturnCorrectResults() {
         String filterFieldName = "color";
         final int expectResultSize = randomIntBetween(1, 3);
         final String filterValue = "red";
-        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), createKnnIndexMapping(FIELD_NAME, 3, METHOD_HNSW, FAISS_NAME));
+        createFaissHnswIndex(3, null);
 
-        // ingest 5 vector docs into the index with the same field {"color": "red"}
         for (int i = 0; i < 5; i++) {
             addKnnDocWithAttributes(String.valueOf(i), new float[] { i, i, i }, ImmutableMap.of(filterFieldName, filterValue));
         }
@@ -42,7 +48,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         updateIndexSettings(INDEX_NAME, Settings.builder().put(KNNSettings.ADVANCED_FILTERED_EXACT_SEARCH_THRESHOLD, 0));
 
         Float[] queryVector = { 3f, 3f, 3f };
-        // All docs in one segment will match the filters value
         String query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -67,32 +72,8 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
     public void testFilteredSearchWithNonVectorFields_whenValid_thenSucceed() {
         String filterFieldName = "category";
         String filterValue = "electronics";
+        createFaissHnswIndex(3, filterFieldName);
 
-        // Create mapping with both vector and non-vector fields
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", 3)
-            .startObject("method")
-            .field("name", METHOD_HNSW)
-            .field("engine", FAISS_NAME)
-            .endObject()
-            .endObject()
-            .startObject(filterFieldName)
-            .field("type", "keyword")
-            .endObject()
-            .startObject("description")
-            .field("type", "text")
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
-
-        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), mapping);
-
-        // Add mixed content
         for (int i = 0; i < 5; i++) {
             addKnnDocWithAttributes(String.valueOf(i), new float[] { i, i, i }, ImmutableMap.of(filterFieldName, filterValue));
         }
@@ -106,7 +87,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         int segmentCountAfterDelete = getTotalSegmentCount(INDEX_NAME);
         assertTrue(segmentCountAfterDelete > segmentCountBeforeDelete);
 
-        // Test filtered search
         Float[] queryVector = { 2f, 2f, 2f };
         String query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
@@ -123,7 +103,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         List<String> docIds = parseIds(entity);
         assertTrue(docIds.size() > 0);
 
-        // Test filter matches 0 docs
         query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -137,7 +116,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         entity = EntityUtils.toString(response.getEntity());
         assertEquals(0, parseIds(entity).size());
 
-        // Test filter matches only non-vector doc
         query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -161,38 +139,13 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
     public void testMixedSegmentsFilteredSearch_whenValid_thenSucceed() {
         String filterFieldName = "category";
         String filterValue = "electronics";
+        createFaissHnswIndex(3, filterFieldName);
 
-        // Create mapping with both vector and non-vector fields
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", 3)
-            .startObject("method")
-            .field("name", METHOD_HNSW)
-            .field("engine", FAISS_NAME)
-            .endObject()
-            .endObject()
-            .startObject(filterFieldName)
-            .field("type", "keyword")
-            .endObject()
-            .startObject("description")
-            .field("type", "text")
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
-
-        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), mapping);
-
-        // Add vector docs with attributes
         for (int i = 0; i < 6; i++) {
             addKnnDocWithAttributes(String.valueOf(i), new float[] { i, i, i }, ImmutableMap.of(filterFieldName, filterValue));
         }
         flush(INDEX_NAME, true);
 
-        // Add non-vector doc (gets its own segment)
         addNonKNNDoc(INDEX_NAME, "6", filterFieldName, "books");
         flush(INDEX_NAME, true);
 
@@ -200,7 +153,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         int segmentCount = getTotalSegmentCount(INDEX_NAME);
         assertTrue(segmentCount >= 2);
 
-        // Test filtered search on mixed segments
         Float[] queryVector = { 2f, 2f, 2f };
         String query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
@@ -217,7 +169,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         List<String> docIds = parseIds(entity);
         assertTrue(docIds.size() > 0);
 
-        // Test filter matches 0 docs
         query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -231,7 +182,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         entity = EntityUtils.toString(response.getEntity());
         assertEquals(0, parseIds(entity).size());
 
-        // Test filter matches only non-vector doc
         query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -254,40 +204,15 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
     @SneakyThrows
     public void testVectorFieldRemovalByUpdate_whenValid_thenSucceed() {
         String filterFieldName = "category";
+        createFaissHnswIndex(3, filterFieldName);
 
-        String mapping = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", 3)
-            .startObject("method")
-            .field("name", METHOD_HNSW)
-            .field("engine", FAISS_NAME)
-            .endObject()
-            .endObject()
-            .startObject(filterFieldName)
-            .field("type", "keyword")
-            .endObject()
-            .startObject("description")
-            .field("type", "text")
-            .endObject()
-            .endObject()
-            .endObject()
-            .toString();
-
-        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), mapping);
-
-        // Add doc with both vector and filter field
         String docId = "0";
         addKnnDocWithAttributes(docId, new float[] { 1f, 1f, 1f }, ImmutableMap.of(filterFieldName, "electronics"));
 
-        // Update doc to remove vector field, keeping only filter field
         addNonKNNDoc(INDEX_NAME, docId, filterFieldName, "books");
 
         flush(INDEX_NAME, true);
 
-        // Verify filtered search returns no results for original filter value
         assertEquals(1, getDocCount(INDEX_NAME));
         Float[] queryVector = { 1f, 1f, 1f };
         String query = KNNJsonQueryBuilder.builder()
@@ -304,7 +229,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         String entity = EntityUtils.toString(response.getEntity());
         assertEquals(0, parseIds(entity).size());
 
-        // Test filter matches 0 docs
         query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -318,7 +242,6 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         entity = EntityUtils.toString(response.getEntity());
         assertEquals(0, parseIds(entity).size());
 
-        // Test filter matches only non-vector doc
         query = KNNJsonQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -333,4 +256,27 @@ public class FilteredSearchANNSearchIT extends KNNRestTestCase {
         assertEquals(0, parseIds(entity).size());
     }
 
+    @SneakyThrows
+    private void createFaissHnswIndex(int dimension, String keywordFilterField) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject("method").field("name", METHOD_HNSW).field("engine", FAISS_NAME).endObject().endObject();
+
+        if (keywordFilterField != null) {
+            builder.startObject(keywordFilterField)
+                .field("type", "keyword")
+                .endObject()
+                .startObject("description")
+                .field("type", "text")
+                .endObject();
+        }
+
+        builder.endObject().endObject();
+        createKnnIndex(INDEX_NAME, getKNNDefaultIndexSettings(), builder.toString());
+    }
 }

--- a/src/test/java/org/opensearch/knn/integ/IndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/IndexIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.primitives.Floats;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
@@ -13,9 +14,11 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNJsonIndexMappingsBuilder;
 import org.opensearch.knn.KNNJsonQueryBuilder;
-import org.opensearch.knn.KNNRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.index.SpaceType;
@@ -28,6 +31,7 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,8 +42,17 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
  * This class contains integration tests for index
  */
 @Log4j2
-public class IndexIT extends KNNRestTestCase {
+public class IndexIT extends KNNCompressionRestTestCase {
     private static TestUtils.TestData testData;
+
+    public IndexIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     @BeforeClass
     public static void setUpClass() throws IOException {
@@ -63,13 +76,14 @@ public class IndexIT extends KNNRestTestCase {
         ingestTestData(INDEX_NAME, FIELD_NAME);
 
         int k = 100;
+        float minRecall = getMinRecallThreshold(SpaceType.L2);
         for (int i = 0; i < testData.queries.length; i++) {
             List<KNNResult> knnResults = runKnnQuery(INDEX_NAME, FIELD_NAME, testData.queries[i], k);
             float recall = getRecall(
                 Set.of(Arrays.copyOf(testData.groundTruthValues[i], k)),
                 knnResults.stream().map(KNNResult::getDocId).collect(Collectors.toSet())
             );
-            assertTrue("Recall: " + recall, recall > 0.9);
+            assertTrue("Recall: " + recall, recall >= minRecall);
         }
     }
 
@@ -82,14 +96,15 @@ public class IndexIT extends KNNRestTestCase {
     public void testIndexWithNonVectorFields_whenValid_thenSucceed() {
         String indexName = INDEX_NAME + "_mixed";
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 128)
-            .field("data_type", VectorDataType.FLOAT.getValue())
-            .startObject("method")
+            .field("data_type", VectorDataType.FLOAT.getValue());
+        addCompressionMappingFields(mappingBuilder);
+        String mapping = mappingBuilder.startObject("method")
             .field("name", METHOD_HNSW)
             .field("space_type", SpaceType.L2.getValue())
             .field("engine", KNNEngine.FAISS.getName())
@@ -168,14 +183,15 @@ public class IndexIT extends KNNRestTestCase {
     public void testLuceneWithNonVectorFields_whenValid_thenSucceed() {
         String indexName = INDEX_NAME + "_lucene_mixed";
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 128)
-            .field("data_type", VectorDataType.FLOAT.getValue())
-            .startObject("method")
+            .field("data_type", VectorDataType.FLOAT.getValue());
+        addCompressionMappingFields(mappingBuilder);
+        String mapping = mappingBuilder.startObject("method")
             .field("name", METHOD_HNSW)
             .field("space_type", SpaceType.L2.getValue())
             .field("engine", KNNEngine.LUCENE.getName())
@@ -221,14 +237,15 @@ public class IndexIT extends KNNRestTestCase {
     public void testMixedSegmentsWithFaiss_whenValid_thenSucceed() {
         String indexName = INDEX_NAME + "_faiss_mixed_segments";
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 128)
-            .field("data_type", VectorDataType.FLOAT.getValue())
-            .startObject("method")
+            .field("data_type", VectorDataType.FLOAT.getValue());
+        addCompressionMappingFields(mappingBuilder);
+        String mapping = mappingBuilder.startObject("method")
             .field("name", METHOD_HNSW)
             .field("space_type", SpaceType.L2.getValue())
             .field("engine", KNNEngine.FAISS.getName())
@@ -274,14 +291,15 @@ public class IndexIT extends KNNRestTestCase {
     public void testMixedSegmentsWithLucene_whenValid_thenSucceed() {
         String indexName = INDEX_NAME + "_lucene_mixed_segments";
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 128)
-            .field("data_type", VectorDataType.FLOAT.getValue())
-            .startObject("method")
+            .field("data_type", VectorDataType.FLOAT.getValue());
+        addCompressionMappingFields(mappingBuilder);
+        String mapping = mappingBuilder.startObject("method")
             .field("name", METHOD_HNSW)
             .field("space_type", SpaceType.L2.getValue())
             .field("engine", KNNEngine.LUCENE.getName())
@@ -327,14 +345,15 @@ public class IndexIT extends KNNRestTestCase {
     public void testVectorFieldRemovalByUpdate_whenValid_thenSucceed() {
         String indexName = INDEX_NAME + "_vector_removal";
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 128)
-            .field("data_type", VectorDataType.FLOAT.getValue())
-            .startObject("method")
+            .field("data_type", VectorDataType.FLOAT.getValue());
+        addCompressionMappingFields(mappingBuilder);
+        String mapping = mappingBuilder.startObject("method")
             .field("name", METHOD_HNSW)
             .field("space_type", SpaceType.L2.getValue())
             .field("engine", KNNEngine.FAISS.getName())
@@ -379,14 +398,15 @@ public class IndexIT extends KNNRestTestCase {
     public void testVectorFieldRemovalByUpdateLucene_whenValid_thenSucceed() {
         String indexName = INDEX_NAME + "_vector_removal_lucene";
 
-        String mapping = XContentFactory.jsonBuilder()
+        XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", 128)
-            .field("data_type", VectorDataType.FLOAT.getValue())
-            .startObject("method")
+            .field("data_type", VectorDataType.FLOAT.getValue());
+        addCompressionMappingFields(mappingBuilder);
+        String mapping = mappingBuilder.startObject("method")
             .field("name", METHOD_HNSW)
             .field("space_type", SpaceType.L2.getValue())
             .field("engine", KNNEngine.LUCENE.getName())
@@ -470,14 +490,10 @@ public class IndexIT extends KNNRestTestCase {
             .engine(knnEngine.getName())
             .build();
 
-        String knnIndexMapping = KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(fieldName)
-            .dimension(dimension)
-            .vectorDataType(VectorDataType.FLOAT.getValue())
-            .method(method)
-            .build()
-            .getIndexMapping();
+        KNNJsonIndexMappingsBuilder.KNNJsonIndexMappingsBuilderBuilder mappingBuilder = addCompressionMappingFields(
+            KNNJsonIndexMappingsBuilder.builder().fieldName(fieldName).dimension(dimension).vectorDataType(VectorDataType.FLOAT.getValue())
+        ).method(method);
 
-        createKnnIndex(indexName, knnIndexMapping);
+        createKnnIndex(indexName, mappingBuilder.build().getIndexMapping());
     }
 }

--- a/src/test/java/org/opensearch/knn/integ/IndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/IndexIT.java
@@ -51,7 +51,7 @@ public class IndexIT extends KNNCompressionRestTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     @BeforeClass

--- a/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -41,6 +43,7 @@ import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -71,60 +74,55 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
         super(compressionConfig);
     }
 
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
+
     @ExpectRemoteBuildValidation
     public void testKNNL2ScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNScriptScore(SpaceType.L2);
     }
 
     public void testKNNL2ByteScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.L2);
     }
 
     @ExpectRemoteBuildValidation
     public void testKNNL1ScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNScriptScore(SpaceType.L1);
     }
 
     public void testKNNL1ByteScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.L1);
     }
 
     @ExpectRemoteBuildValidation
     public void testKNNLInfScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNScriptScore(SpaceType.LINF);
     }
 
     public void testKNNLInfByteScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.LINF);
     }
 
     @ExpectRemoteBuildValidation
     public void testKNNCosineScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNScriptScore(SpaceType.COSINESIMIL);
     }
 
     public void testKNNByteCosineScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.COSINESIMIL);
     }
 
     @SneakyThrows
     public void testKNNHammingScriptScore() {
-        assumeUncompressed();
         testKNNScriptScoreOnBinaryIndex(SpaceType.HAMMING);
     }
 
     @SuppressWarnings("unchecked")
     @SneakyThrows
     public void testKNNHammingScriptScore_whenNonBinary_thenException() {
-        assumeUncompressed();
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BYTE);
         final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
@@ -153,7 +151,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testKNNNonHammingScriptScore_whenBinary_thenException() {
-        assumeUncompressed();
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BINARY);
         final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
@@ -181,7 +178,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNInvalidSourceScript() throws Exception {
-        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -223,7 +219,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
     }
 
     public void testInvalidSpace() throws Exception {
-        assumeUncompressed();
         String INVALID_SPACE = "dummy";
         /*
          * Create knn index and populate data
@@ -248,7 +243,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
     }
 
     public void testMissingParamsInScript() throws Exception {
-        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -282,7 +276,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
     }
 
     public void testUnequalDimensions() throws Exception {
-        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -306,7 +299,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testKNNScoreForNonVectorDocument() throws Exception {
-        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -350,7 +342,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testHammingScriptScore_Long() throws Exception {
-        assumeUncompressed();
         createIndex(INDEX_NAME, Settings.EMPTY);
         String longMapping = XContentFactory.jsonBuilder()
             .startObject()
@@ -460,7 +451,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testHammingScriptScore_Base64() throws Exception {
-        assumeUncompressed();
         createIndex(INDEX_NAME, Settings.EMPTY);
         String longMapping = XContentFactory.jsonBuilder()
             .startObject()
@@ -571,7 +561,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNInnerProdScriptScore() throws Exception {
-        assumeUncompressed();
         testKNNScriptScore(SpaceType.INNER_PRODUCT);
     }
 
@@ -617,7 +606,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
     }
 
     public void testKNNScriptScoreWithRequestCacheEnabled() throws Exception {
-        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -726,7 +714,6 @@ public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
     @SuppressWarnings("unchecked")
     @ExpectRemoteBuildValidation
     public void testKNNScriptScoreOnModelBasedIndex() throws Exception {
-        assumeUncompressed();
         int dimensions = randomIntBetween(2, 10);
         String trainMapping = createKnnIndexMapping(TRAIN_FIELD_PARAMETER, dimensions);
         createKnnIndex(TRAIN_INDEX_PARAMETER, trainMapping);

--- a/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNScriptScoringIT.java
@@ -11,7 +11,8 @@ import java.util.function.Function;
 
 import lombok.SneakyThrows;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
@@ -62,54 +63,68 @@ import static org.opensearch.knn.common.KNNConstants.TYPE_KNN_VECTOR;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_FIELD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.TRAIN_INDEX_PARAMETER;
 
-public class KNNScriptScoringIT extends KNNRestTestCase {
+public class KNNScriptScoringIT extends KNNCompressionRestTestCase {
 
     private static final String TEST_MODEL = "test-model";
 
+    public KNNScriptScoringIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
     @ExpectRemoteBuildValidation
     public void testKNNL2ScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNScriptScore(SpaceType.L2);
     }
 
     public void testKNNL2ByteScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.L2);
     }
 
     @ExpectRemoteBuildValidation
     public void testKNNL1ScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNScriptScore(SpaceType.L1);
     }
 
     public void testKNNL1ByteScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.L1);
     }
 
     @ExpectRemoteBuildValidation
     public void testKNNLInfScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNScriptScore(SpaceType.LINF);
     }
 
     public void testKNNLInfByteScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.LINF);
     }
 
     @ExpectRemoteBuildValidation
     public void testKNNCosineScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNScriptScore(SpaceType.COSINESIMIL);
     }
 
     public void testKNNByteCosineScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNByteScriptScore(SpaceType.COSINESIMIL);
     }
 
     @SneakyThrows
     public void testKNNHammingScriptScore() {
+        assumeUncompressed();
         testKNNScriptScoreOnBinaryIndex(SpaceType.HAMMING);
     }
 
     @SuppressWarnings("unchecked")
     @SneakyThrows
     public void testKNNHammingScriptScore_whenNonBinary_thenException() {
+        assumeUncompressed();
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BYTE);
         final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
@@ -138,6 +153,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testKNNNonHammingScriptScore_whenBinary_thenException() {
+        assumeUncompressed();
         final int dims = randomIntBetween(2, 10) * 8;
         final float[] queryVector = randomVector(dims, VectorDataType.BINARY);
         final BiFunction<byte[], byte[], Float> scoreFunction = (BiFunction<byte[], byte[], Float>) getScoreFunction(
@@ -165,6 +181,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     }
 
     public void testKNNInvalidSourceScript() throws Exception {
+        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -206,6 +223,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     }
 
     public void testInvalidSpace() throws Exception {
+        assumeUncompressed();
         String INVALID_SPACE = "dummy";
         /*
          * Create knn index and populate data
@@ -230,6 +248,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     }
 
     public void testMissingParamsInScript() throws Exception {
+        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -263,6 +282,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     }
 
     public void testUnequalDimensions() throws Exception {
+        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -286,6 +306,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testKNNScoreForNonVectorDocument() throws Exception {
+        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -329,6 +350,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testHammingScriptScore_Long() throws Exception {
+        assumeUncompressed();
         createIndex(INDEX_NAME, Settings.EMPTY);
         String longMapping = XContentFactory.jsonBuilder()
             .startObject()
@@ -438,6 +460,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testHammingScriptScore_Base64() throws Exception {
+        assumeUncompressed();
         createIndex(INDEX_NAME, Settings.EMPTY);
         String longMapping = XContentFactory.jsonBuilder()
             .startObject()
@@ -548,10 +571,53 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
 
     @ExpectRemoteBuildValidation
     public void testKNNInnerProdScriptScore() throws Exception {
+        assumeUncompressed();
         testKNNScriptScore(SpaceType.INNER_PRODUCT);
     }
 
+    @SuppressWarnings("unchecked")
+    public void testKNNScriptScore_faiss_onCompressedIndex() throws Exception {
+        String indexName = prefix() + "scriptscore";
+        createHnswIndex(indexName, FAISS_NAME, SpaceType.L2, 2);
+
+        Map<String, Float[]> documents = new HashMap<>();
+        documents.put("1", new Float[] { 6.0f, 6.0f });
+        documents.put("2", new Float[] { 2.0f, 2.0f });
+        documents.put("3", new Float[] { 4.0f, 4.0f });
+        documents.put("4", new Float[] { 3.0f, 3.0f });
+        for (Map.Entry<String, Float[]> doc : documents.entrySet()) {
+            addKnnDoc(indexName, doc.getKey(), FIELD_NAME, doc.getValue());
+        }
+        forceMergeKnnIndex(indexName);
+
+        float[] queryVector = { 1.0f, 1.0f };
+        Map<String, Object> params = new HashMap<>();
+        params.put("field", FIELD_NAME);
+        params.put("query_value", queryVector);
+        params.put("space_type", SpaceType.L2.getValue());
+        Request request = constructKNNScriptQueryRequest(indexName, new MatchAllQueryBuilder(), params, documents.size());
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<Object> hits = (List<Object>) ((Map<String, Object>) createParser(
+            MediaTypeRegistry.getDefaultMediaType().xContent(),
+            responseBody
+        ).map().get("hits")).get("hits");
+
+        List<String> docIds = hits.stream().map(hit -> ((String) ((Map<String, Object>) hit).get("_id"))).collect(Collectors.toList());
+        assertEquals(Arrays.asList("2", "4", "3", "1"), docIds);
+
+        List<Double> scores = hits.stream().map(hit -> ((Double) ((Map<String, Object>) hit).get("_score"))).collect(Collectors.toList());
+        double[] expectedScores = { 1.0 / (1 + 2), 1.0 / (1 + 8), 1.0 / (1 + 18), 1.0 / (1 + 50) };
+        for (int i = 0; i < expectedScores.length; i++) {
+            assertEquals(expectedScores[i], scores.get(i), 0.001);
+        }
+        deleteKNNIndex(indexName);
+    }
+
     public void testKNNScriptScoreWithRequestCacheEnabled() throws Exception {
+        assumeUncompressed();
         /*
          * Create knn index and populate data
          */
@@ -660,6 +726,7 @@ public class KNNScriptScoringIT extends KNNRestTestCase {
     @SuppressWarnings("unchecked")
     @ExpectRemoteBuildValidation
     public void testKNNScriptScoreOnModelBasedIndex() throws Exception {
+        assumeUncompressed();
         int dimensions = randomIntBetween(2, 10);
         String trainMapping = createKnnIndexMapping(TRAIN_FIELD_PARAMETER, dimensions);
         createKnnIndex(TRAIN_INDEX_PARAMETER, trainMapping);

--- a/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/NestedSearchIT.java
@@ -13,13 +13,13 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.NestedKnnDocBuilder;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
-import org.opensearch.knn.index.mapper.Mode;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,7 +37,6 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRU
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
-import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.PATH;
@@ -49,7 +48,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_OVERSAMPLE_PARAMETER;
 import static org.opensearch.knn.index.query.parser.RescoreParser.RESCORE_PARAMETER;
 
-public class NestedSearchIT extends KNNRestTestCase {
+public class NestedSearchIT extends KNNCompressionRestTestCase {
     private static final String INDEX_NAME = "test-index-nested-search";
     private static final String FIELD_NAME_NESTED = "test_nested";
     private static final String FIELD_NAME_VECTOR = "test_vector";
@@ -60,6 +59,10 @@ public class NestedSearchIT extends KNNRestTestCase {
     private static final int EF_CONSTRUCTION = 128;
     private static final int M = 16;
     private static final SpaceType SPACE_TYPE = SpaceType.L2;
+
+    public NestedSearchIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     @SneakyThrows
     public void testNestedSearchWithLucene_whenKIsTwo_thenReturnTwoResults() {
@@ -179,12 +182,6 @@ public class NestedSearchIT extends KNNRestTestCase {
     @SneakyThrows
     public void testNestedSearchWithFaiss_whenKIsTwo_SomeNestedDocsHasNoVectors_thenReturnTwoResults() {
         createKnnIndex(2, KNNEngine.FAISS.getName());
-        indexAndTestKNNIndexWithVectorAndNonVectorField();
-    }
-
-    @SneakyThrows
-    public void testNestedSearchWithOnDisk_whenKIsTwo_SomeNestedDocsHasNoVectors_thenReturnTwoResults() {
-        createKnnIndex(2, KNNEngine.FAISS.getName(), Mode.ON_DISK);
         indexAndTestKNNIndexWithVectorAndNonVectorField();
     }
 
@@ -385,18 +382,10 @@ public class NestedSearchIT extends KNNRestTestCase {
      *  }
      */
     private void createKnnIndex(final int dimension, final String engine) throws Exception {
-        createKnnIndex(dimension, engine, Mode.IN_MEMORY, false);
+        createKnnIndex(dimension, engine, false);
     }
 
     private void createKnnIndex(final int dimension, final String engine, boolean memoryOptimizedSearch) throws Exception {
-        createKnnIndex(dimension, engine, Mode.IN_MEMORY, memoryOptimizedSearch);
-    }
-
-    private void createKnnIndex(final int dimension, final String engine, Mode mode) throws Exception {
-        createKnnIndex(dimension, engine, mode, false);
-    }
-
-    private void createKnnIndex(final int dimension, final String engine, Mode mode, boolean memoryOptimizedSearch) throws Exception {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
             .startObject(PROPERTIES_FIELD)
@@ -408,9 +397,9 @@ public class NestedSearchIT extends KNNRestTestCase {
             .endObject()
             .startObject(FIELD_NAME_VECTOR)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(DIMENSION, dimension)
-            .field(MODE_PARAMETER, mode.getName())
-            .startObject(KNN_METHOD)
+            .field(DIMENSION, dimension);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(METHOD_PARAMETER_SPACE_TYPE, SPACE_TYPE)
             .field(KNN_ENGINE, engine)

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptFieldsIT.java
@@ -10,7 +10,8 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapper;
 import org.opensearch.knn.integ.PainlessScriptHelper.MappingProperty;
@@ -30,9 +31,13 @@ import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
 // it is clear if similarity method is supported by script_score, then same is applicable for script_fields
 // provided script_fields context is supported. Hence, we test for one similarity method to verify that script_fields
 // context is supported by this plugin.
-public final class PainlessScriptFieldsIT extends KNNRestTestCase {
+public final class PainlessScriptFieldsIT extends KNNCompressionRestTestCase {
 
     private static final String NUMERIC_INDEX_FIELD_NAME = "price";
+
+    public PainlessScriptFieldsIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     private void buildTestIndex(final Map<String, Float[]> knnDocuments) throws Exception {
         List<MappingProperty> properties = buildMappingProperties();

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.knn.CompressionTestConfig;
@@ -29,6 +30,7 @@ import org.opensearch.script.Script;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +48,11 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     public PainlessScriptScoreIT(CompressionTestConfig compressionConfig) {
         super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
     }
 
     /*
@@ -128,7 +135,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testL2ScriptScoreFails() throws Exception {
-        assumeUncompressed();
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -190,7 +196,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testL2ScriptScore() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
@@ -240,7 +245,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testGetValueReturnsDocValues() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("doc['%s'].value[0]", FIELD_NAME);
         Map<String, Float[]> testData = getKnnVectorTestData();
@@ -260,7 +264,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testGetValueScriptFailsWithMissingField() throws Exception {
-        assumeUncompressed();
         String source = String.format("doc['%s']", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getKnnVectorTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -269,7 +272,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testGetValueScriptFailsWithOutOfBoundException() throws Exception {
-        assumeUncompressed();
         Map<String, Float[]> testData = getKnnVectorTestData();
         String source = String.format("doc['%s'].value[%d]", FIELD_NAME, testData.get("1").length);
         Request request = buildPainlessScoreScriptRequest(source, testData.size(), testData);
@@ -278,7 +280,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testGetValueScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : doc['%s'].value[0]", FIELD_NAME, FIELD_NAME);
         Map<String, Float[]> testData = getKnnVectorTestData();
@@ -298,7 +299,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testL2ScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
@@ -317,7 +317,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testCosineSimilarityScriptScoreFails() throws Exception {
-        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -326,7 +325,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testCosineSimilarityScriptScore() throws Exception {
-        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         Response response = client().performRequest(request);
@@ -343,7 +341,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testCosineSimilarityScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -362,7 +359,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     // test fails without size check before executing method
     public void testCosineSimilarityNormalizedScriptScoreFails() throws Exception {
-        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -371,7 +367,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testCosineSimilarityNormalizedScriptScore() throws Exception {
-        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         Response response = client().performRequest(request);
@@ -388,7 +383,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testCosineSimilarityNormalizedScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
         String source = String.format(
             "doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)",
             FIELD_NAME,
@@ -411,7 +405,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     // L1 tests
     public void testL1ScriptScoreFails() throws Exception {
-        assumeUncompressed();
         String source = String.format("1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -420,7 +413,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testL1ScriptScore() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
@@ -439,7 +431,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testL1ScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
@@ -459,7 +450,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     // L-inf tests
     public void testLInfScriptScoreFails() throws Exception {
-        assumeUncompressed();
         String source = String.format("1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -468,7 +458,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testLInfScriptScore() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
@@ -487,7 +476,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testLInfScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
@@ -506,7 +494,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testInnerProdScriptScoreFails() throws Exception {
-        assumeUncompressed();
         String source = String.format("float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -515,7 +502,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testInnerProdScriptScore() throws Exception {
-        assumeUncompressed();
 
         String source = String.format("float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getInnerProdTestData());
@@ -534,7 +520,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testInnerProdScriptScoreWithNumericField() throws Exception {
-        assumeUncompressed();
 
         String source = String.format(
             "if (doc['%s'].size() == 0) "
@@ -560,7 +545,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testScriptedMetricIsSupported() throws Exception {
-        assumeUncompressed();
         Map<String, Float[]> testData = getKnnVectorTestData();
         // sum of first value from each vector
         String initScriptSource = "state.x = []";
@@ -589,7 +573,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
     }
 
     public void testL2ScriptingWithLuceneBackedIndex() throws Exception {
-        assumeUncompressed();
         List<MappingProperty> properties = new ArrayList<>();
         KNNMethodContext knnMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
@@ -624,7 +607,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     @SneakyThrows
     public void testHammingPainlessScript_whenBinary_thenSuccess() {
-        assumeUncompressed();
         int dimensions = 16;
         String mappingForKnnDisabled = createKnnIndexMapping(FIELD_NAME, dimensions, VectorDataType.BINARY);
 
@@ -649,7 +631,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     @SneakyThrows
     public void testPainlessScript_whenNonBinary_thenException() {
-        assumeUncompressed();
         int dimensions = 2;
         String mapping = createKnnIndexMapping(FIELD_NAME, dimensions);
         String source = String.format("1/(1 + hamming([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
@@ -662,7 +643,6 @@ public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     @SneakyThrows
     public void testNonPainlessScript_whenBinary_thenException() {
-        assumeUncompressed();
         List<String> functions = Arrays.asList("l2Squared", "lInfNorm", "l1Norm", "innerProduct", "cosineSimilarity");
         int dimensions = 16;
         String mapping = createKnnIndexMapping(FIELD_NAME, dimensions, VectorDataType.BINARY);

--- a/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
+++ b/src/test/java/org/opensearch/knn/integ/PainlessScriptScoreIT.java
@@ -7,7 +7,8 @@ package org.opensearch.knn.integ;
 
 import lombok.SneakyThrows;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.engine.KNNMethodContext;
@@ -37,11 +38,15 @@ import java.util.Map;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.integ.PainlessScriptHelper.createMapping;
 
-public final class PainlessScriptScoreIT extends KNNRestTestCase {
+public final class PainlessScriptScoreIT extends KNNCompressionRestTestCase {
 
     public static final int AGGREGATION_FIELD_NAME_MIN_LENGTH = 2;
     public static final int AGGREGATION_FIELD_NAME_MAX_LENGTH = 5;
     private static final String NUMERIC_INDEX_FIELD_NAME = "price";
+
+    public PainlessScriptScoreIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     /*
      creates KnnIndex based on properties, we add single non-knn vector documents to verify whether actions
@@ -123,6 +128,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL2ScriptScoreFails() throws Exception {
+        assumeUncompressed();
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -184,6 +190,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL2ScriptScore() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
@@ -201,7 +208,39 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
         deleteKNNIndex(INDEX_NAME);
     }
 
+    public void testL2ScriptScore_faiss_onCompressedIndex() throws Exception {
+        String indexName = prefix() + "painless_l2";
+        createHnswIndex(indexName, KNNEngine.FAISS.getName(), SpaceType.L2, 2);
+        for (Map.Entry<String, Float[]> doc : getL2TestData().entrySet()) {
+            addKnnDoc(indexName, doc.getKey(), FIELD_NAME, doc.getValue());
+        }
+        forceMergeKnnIndex(indexName);
+
+        String source = String.format("1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
+        Request request = constructScriptScoreContextSearchRequest(
+            indexName,
+            new MatchAllQueryBuilder(),
+            Collections.emptyMap(),
+            Script.DEFAULT_SCRIPT_LANG,
+            source,
+            3,
+            Collections.emptyMap()
+        );
+        Response response = client().performRequest(request);
+        assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
+
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(response.getEntity()), FIELD_NAME);
+        assertEquals(3, results.size());
+
+        String[] expectedDocIDs = { "2", "4", "3", "1" };
+        for (int i = 0; i < results.size(); i++) {
+            assertEquals(expectedDocIDs[i], results.get(i).getDocId());
+        }
+        deleteKNNIndex(indexName);
+    }
+
     public void testGetValueReturnsDocValues() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("doc['%s'].value[0]", FIELD_NAME);
         Map<String, Float[]> testData = getKnnVectorTestData();
@@ -221,6 +260,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testGetValueScriptFailsWithMissingField() throws Exception {
+        assumeUncompressed();
         String source = String.format("doc['%s']", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getKnnVectorTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -229,6 +269,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testGetValueScriptFailsWithOutOfBoundException() throws Exception {
+        assumeUncompressed();
         Map<String, Float[]> testData = getKnnVectorTestData();
         String source = String.format("doc['%s'].value[%d]", FIELD_NAME, testData.get("1").length);
         Request request = buildPainlessScoreScriptRequest(source, testData.size(), testData);
@@ -237,6 +278,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testGetValueScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : doc['%s'].value[0]", FIELD_NAME, FIELD_NAME);
         Map<String, Float[]> testData = getKnnVectorTestData();
@@ -256,6 +298,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL2ScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + l2Squared([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL2TestData());
@@ -274,6 +317,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityScriptScoreFails() throws Exception {
+        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -282,6 +326,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityScriptScore() throws Exception {
+        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         Response response = client().performRequest(request);
@@ -298,6 +343,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'])", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -316,6 +362,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     // test fails without size check before executing method
     public void testCosineSimilarityNormalizedScriptScoreFails() throws Exception {
+        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -324,6 +371,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityNormalizedScriptScore() throws Exception {
+        assumeUncompressed();
         String source = String.format("1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getCosineTestData());
         Response response = client().performRequest(request);
@@ -340,6 +388,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testCosineSimilarityNormalizedScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
         String source = String.format(
             "doc['%s'].size() == 0 ? 0 : 1 + cosineSimilarity([2.0f, -2.0f], doc['%s'], 3.0f)",
             FIELD_NAME,
@@ -362,6 +411,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     // L1 tests
     public void testL1ScriptScoreFails() throws Exception {
+        assumeUncompressed();
         String source = String.format("1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -370,6 +420,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL1ScriptScore() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
@@ -388,6 +439,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL1ScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + l1Norm([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getL1TestData());
@@ -407,6 +459,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     // L-inf tests
     public void testLInfScriptScoreFails() throws Exception {
+        assumeUncompressed();
         String source = String.format("1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -415,6 +468,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testLInfScriptScore() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
@@ -433,6 +487,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testLInfScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("doc['%s'].size() == 0 ? 0 : 1/(1 + lInfNorm([1.0f, 1.0f], doc['%s']))", FIELD_NAME, FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getLInfTestData());
@@ -451,6 +506,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testInnerProdScriptScoreFails() throws Exception {
+        assumeUncompressed();
         String source = String.format("float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getInnerProdTestData());
         addDocWithNumericField(INDEX_NAME, "100", NUMERIC_INDEX_FIELD_NAME, 1000);
@@ -459,6 +515,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testInnerProdScriptScore() throws Exception {
+        assumeUncompressed();
 
         String source = String.format("float x = innerProduct([1.0f, 1.0f], doc['%s']); return x >= 0? 2-1/(x+1):1/(1-x);", FIELD_NAME);
         Request request = buildPainlessScoreScriptRequest(source, 3, getInnerProdTestData());
@@ -477,6 +534,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testInnerProdScriptScoreWithNumericField() throws Exception {
+        assumeUncompressed();
 
         String source = String.format(
             "if (doc['%s'].size() == 0) "
@@ -502,6 +560,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testScriptedMetricIsSupported() throws Exception {
+        assumeUncompressed();
         Map<String, Float[]> testData = getKnnVectorTestData();
         // sum of first value from each vector
         String initScriptSource = "state.x = []";
@@ -530,6 +589,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
     }
 
     public void testL2ScriptingWithLuceneBackedIndex() throws Exception {
+        assumeUncompressed();
         List<MappingProperty> properties = new ArrayList<>();
         KNNMethodContext knnMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
@@ -564,6 +624,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testHammingPainlessScript_whenBinary_thenSuccess() {
+        assumeUncompressed();
         int dimensions = 16;
         String mappingForKnnDisabled = createKnnIndexMapping(FIELD_NAME, dimensions, VectorDataType.BINARY);
 
@@ -588,6 +649,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testPainlessScript_whenNonBinary_thenException() {
+        assumeUncompressed();
         int dimensions = 2;
         String mapping = createKnnIndexMapping(FIELD_NAME, dimensions);
         String source = String.format("1/(1 + hamming([1.0f, 1.0f], doc['%s']))", FIELD_NAME);
@@ -600,6 +662,7 @@ public final class PainlessScriptScoreIT extends KNNRestTestCase {
 
     @SneakyThrows
     public void testNonPainlessScript_whenBinary_thenException() {
+        assumeUncompressed();
         List<String> functions = Arrays.asList("l2Squared", "lInfNorm", "l1Norm", "innerProduct", "cosineSimilarity");
         int dimensions = 16;
         String mapping = createKnnIndexMapping(FIELD_NAME, dimensions, VectorDataType.BINARY);

--- a/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
@@ -46,7 +46,7 @@ public class TopLevelEngineParameterIT extends KNNCompressionRestTestCase {
 
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelEngineParameterIT.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.integ;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
@@ -16,13 +17,15 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
@@ -31,11 +34,20 @@ import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 
-public class TopLevelEngineParameterIT extends KNNRestTestCase {
+public class TopLevelEngineParameterIT extends KNNCompressionRestTestCase {
     private final static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f };
     private final static int DIMENSION = 2;
     private final static int K = 1;
     private static final String INDEX_NAME = "top-level-engine-index";
+
+    public TopLevelEngineParameterIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     @SneakyThrows
     public void testBaseCase() {
@@ -93,10 +105,9 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
             .field("dimension", DIMENSION)
-            .field(TOP_LEVEL_PARAMETER_ENGINE, KNNEngine.LUCENE.getName())
-            .endObject()
-            .endObject()
-            .endObject();
+            .field(TOP_LEVEL_PARAMETER_ENGINE, KNNEngine.LUCENE.getName());
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
 
         String mapping = builder.toString();
         createKnnIndex(INDEX_NAME, mapping);
@@ -113,10 +124,9 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
-            .endObject()
-            .endObject()
-            .endObject()
             .endObject();
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
 
         String mapping = builder.toString();
         createKnnIndex(INDEX_NAME, mapping);
@@ -133,10 +143,9 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
-            .endObject()
-            .endObject()
-            .endObject()
             .endObject();
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
 
         String mapping = builder.toString();
         createKnnIndex(INDEX_NAME, mapping);
@@ -148,10 +157,9 @@ public class TopLevelEngineParameterIT extends KNNRestTestCase {
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .endObject()
-            .endObject()
-            .endObject();
+            .field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.endObject().endObject().endObject();
 
         String mapping = builder.toString();
         createKnnIndex(INDEX_NAME, mapping);

--- a/src/test/java/org/opensearch/knn/integ/TopLevelSpaceTypeParameterIT.java
+++ b/src/test/java/org/opensearch/knn/integ/TopLevelSpaceTypeParameterIT.java
@@ -8,7 +8,8 @@ package org.opensearch.knn.integ;
 import lombok.SneakyThrows;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
 
@@ -20,11 +21,15 @@ import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 
-public class TopLevelSpaceTypeParameterIT extends KNNRestTestCase {
+public class TopLevelSpaceTypeParameterIT extends KNNCompressionRestTestCase {
     private final static float[] TEST_VECTOR = new float[] { 1.0f, 2.0f };
     private final static int DIMENSION = 2;
     private final static int K = 1;
     private static final String INDEX_NAME = "top-level-space-type-index";
+
+    public TopLevelSpaceTypeParameterIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     @SneakyThrows
     public void testBaseCase() {
@@ -45,13 +50,10 @@ public class TopLevelSpaceTypeParameterIT extends KNNRestTestCase {
     }
 
     private void createTestIndexWithTopLevelSpaceTypeOnly() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .field(KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties").startObject(FIELD_NAME);
+        builder.field("type", "knn_vector").field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.field(KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, FAISS_NAME)
@@ -65,13 +67,10 @@ public class TopLevelSpaceTypeParameterIT extends KNNRestTestCase {
     }
 
     private void createTestIndexWithTopLevelSpaceTypeAndMethodSpaceType() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .field(KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties").startObject(FIELD_NAME);
+        builder.field("type", "knn_vector").field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.field(KNNConstants.TOP_LEVEL_PARAMETER_SPACE_TYPE, SpaceType.INNER_PRODUCT.getValue())
             .startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, FAISS_NAME)
@@ -86,13 +85,10 @@ public class TopLevelSpaceTypeParameterIT extends KNNRestTestCase {
     }
 
     private void createTestIndexWithNoSpaceType() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("properties")
-            .startObject(FIELD_NAME)
-            .field("type", "knn_vector")
-            .field("dimension", DIMENSION)
-            .startObject(KNN_METHOD)
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("properties").startObject(FIELD_NAME);
+        builder.field("type", "knn_vector").field("dimension", DIMENSION);
+        addCompressionMappingFields(builder);
+        builder.startObject(KNN_METHOD)
             .field(NAME, METHOD_HNSW)
             .field(KNN_ENGINE, FAISS_NAME)
             .endObject()

--- a/src/test/java/org/opensearch/knn/integ/search/ConcurrentSegmentSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/search/ConcurrentSegmentSearchIT.java
@@ -64,7 +64,7 @@ public class ConcurrentSegmentSearchIT extends KNNCompressionRestTestCase {
         final XContentBuilder indexBuilder = createFaissHnswIndexMapping(fieldName, dimension);
         String mapping = indexBuilder.toString();
         createKnnIndex(indexName, mapping);
-        if (compressionConfig == CompressionTestConfig.FP32) {
+        if (compressionConfig == CompressionTestConfig.X1) {
             Map<String, Object> mappingMap = xContentBuilderToMap(indexBuilder);
             assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
         }

--- a/src/test/java/org/opensearch/knn/integ/search/ConcurrentSegmentSearchIT.java
+++ b/src/test/java/org/opensearch/knn/integ/search/ConcurrentSegmentSearchIT.java
@@ -11,9 +11,10 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.BeforeClass;
 import org.opensearch.client.Response;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNJsonIndexMappingsBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.index.SpaceType;
@@ -34,9 +35,13 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
  * Note that this is simply a sanity test to make sure that concurrent search code path is hit E2E and scores are intact
  * There is no latency verification as it can be better encapsulated in nightly runs.
  */
-public class ConcurrentSegmentSearchIT extends KNNRestTestCase {
+public class ConcurrentSegmentSearchIT extends KNNCompressionRestTestCase {
 
     static TestUtils.TestData testData;
+
+    public ConcurrentSegmentSearchIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     @BeforeClass
     public static void setUpClass() throws IOException {
@@ -53,16 +58,17 @@ public class ConcurrentSegmentSearchIT extends KNNRestTestCase {
     @SneakyThrows
     @ExpectRemoteBuildValidation
     public void testConcurrentSegmentSearch_thenSucceed() {
-        String indexName = "test-concurrent-segment";
+        String indexName = prefix() + "concurrent_segment";
         String fieldName = "test-field-1";
         int dimension = testData.indexData.vectors[0].length;
         final XContentBuilder indexBuilder = createFaissHnswIndexMapping(fieldName, dimension);
-        Map<String, Object> mappingMap = xContentBuilderToMap(indexBuilder);
         String mapping = indexBuilder.toString();
         createKnnIndex(indexName, mapping);
-        assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
+        if (compressionConfig == CompressionTestConfig.FP32) {
+            Map<String, Object> mappingMap = xContentBuilderToMap(indexBuilder);
+            assertEquals(new TreeMap<>(mappingMap), new TreeMap<>(getIndexMappingAsMap(indexName)));
+        }
 
-        // Index the test data
         for (int i = 0; i < testData.indexData.docs.length; i++) {
             addKnnDoc(
                 indexName,
@@ -103,19 +109,26 @@ public class ConcurrentSegmentSearchIT extends KNNRestTestCase {
      */
     @SneakyThrows
     private XContentBuilder createFaissHnswIndexMapping(String fieldName, int dimension) {
-        return KNNJsonIndexMappingsBuilder.builder()
-            .fieldName(fieldName)
-            .dimension(dimension)
-            .method(
-                KNNJsonIndexMappingsBuilder.Method.builder()
-                    .engine(KNNEngine.FAISS.getName())
-                    .methodName(METHOD_HNSW)
-                    .spaceType(SpaceType.L2.getValue())
-                    .parameters(KNNJsonIndexMappingsBuilder.Method.Parameters.builder().efConstruction(128).efSearch(128).m(16).build())
-                    .build()
-            )
-            .build()
-            .getIndexMappingBuilder();
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension);
+        addCompressionMappingFields(builder);
+        return builder.startObject("method")
+            .field("name", METHOD_HNSW)
+            .field("engine", KNNEngine.FAISS.getName())
+            .field("space_type", SpaceType.L2.getValue())
+            .startObject("parameters")
+            .field("ef_construction", 128)
+            .field("ef_search", 128)
+            .field("m", 16)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractMemoryOptimizedKnnSearchIT.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/AbstractMemoryOptimizedKnnSearchIT.java
@@ -82,8 +82,18 @@ public abstract class AbstractMemoryOptimizedKnnSearchIT extends KNNRestTestCase
             spaceType,
             additionalSettings,
             Mode.NOT_CONFIGURED,
-            CompressionLevel.NOT_CONFIGURED
+            defaultCompressionLevel(dataType, methodParams)
         );
+    }
+
+    private static CompressionLevel defaultCompressionLevel(final VectorDataType dataType, final String methodParams) {
+        // Compression is only valid for float32 without an explicit encoder. Pin to 1x there so the plugin's
+        // default compression flip does not silently change these ANN assertions. Byte, binary and encoder-based
+        // configurations reject compression, so leave them unconfigured.
+        if (dataType == VectorDataType.FLOAT && EMPTY_PARAMS.equals(methodParams)) {
+            return CompressionLevel.x1;
+        }
+        return CompressionLevel.NOT_CONFIGURED;
     }
 
     protected void doTestNonNestedIndex(
@@ -120,7 +130,14 @@ public abstract class AbstractMemoryOptimizedKnnSearchIT extends KNNRestTestCase
         final SpaceType spaceType,
         final Consumer<Settings.Builder> additionalSettings
     ) {
-        doTestNestedIndex(dataType, methodParams, spaceType, additionalSettings, Mode.NOT_CONFIGURED, CompressionLevel.NOT_CONFIGURED);
+        doTestNestedIndex(
+            dataType,
+            methodParams,
+            spaceType,
+            additionalSettings,
+            Mode.NOT_CONFIGURED,
+            defaultCompressionLevel(dataType, methodParams)
+        );
     }
 
     protected void doTestNestedIndex(

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/NonNestedNMappingSchema.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/NonNestedNMappingSchema.java
@@ -26,14 +26,14 @@ class NonNestedNMappingSchema {
     private CompressionLevel compressionLevel;
 
     static String createModeCompressionLevelPartInMapping(final Mode mode, final CompressionLevel compressionLevel) {
-        if (mode == Mode.NOT_CONFIGURED && compressionLevel == CompressionLevel.NOT_CONFIGURED) {
-            return "";
+        final StringBuilder builder = new StringBuilder();
+        if (mode != Mode.NOT_CONFIGURED) {
+            builder.append("\"mode\": \"").append(mode.getName()).append("\",\n");
         }
-
-        return """
-              "mode": "%s",
-              "compression_level": "%s",
-            """.formatted(mode == Mode.NOT_CONFIGURED ? "null" : mode.getName(), compressionLevel.getName());
+        if (compressionLevel != CompressionLevel.NOT_CONFIGURED) {
+            builder.append("\"compression_level\": \"").append(compressionLevel.getName()).append("\",\n");
+        }
+        return builder.toString();
     }
 
     public String createString() {

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -810,9 +810,10 @@ public class RecallTestsIT extends KNNCompressionRestTestCase {
             .startObject(PROPERTIES_FIELD)
             .startObject(TRAIN_FIELD_NAME)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(DIMENSION, TEST_DIMENSION);
-        addCompressionMappingFields(trainingIndexBuilder);
-        trainingIndexBuilder.endObject().endObject().endObject();
+            .field(DIMENSION, TEST_DIMENSION)
+            .endObject()
+            .endObject()
+            .endObject();
         createIndexAndIngestDocs(
             TRAIN_INDEX_NAME,
             TRAIN_FIELD_NAME,

--- a/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
+++ b/src/test/java/org/opensearch/knn/recall/RecallTestsIT.java
@@ -11,18 +11,21 @@
 
 package org.opensearch.knn.recall;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.common.annotation.ExpectRemoteBuildValidation;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.faiss.QFrameBitEncoder;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,7 +68,16 @@ import static org.opensearch.knn.index.KNNSettings.KNN_MEMORY_CIRCUIT_BREAKER_EN
  * This test suite can take a long time to run. The primary reason is that training can take a long time for PQ.
  * The parameters for PQ have been reduced significantly, but it still takes time.
  */
-public class RecallTestsIT extends KNNRestTestCase {
+public class RecallTestsIT extends KNNCompressionRestTestCase {
+
+    public RecallTestsIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
+
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return List.<Object[]>of(new Object[] { CompressionTestConfig.X1 });
+    }
 
     private static final String PROPERTIES_FIELD = "properties";
     private final static String TEST_INDEX_PREFIX_NAME = "test_index";
@@ -386,8 +398,9 @@ public class RecallTestsIT extends KNNRestTestCase {
                 .startObject(PROPERTIES_FIELD)
                 .startObject(TEST_FIELD_NAME)
                 .field(TYPE, TYPE_KNN_VECTOR)
-                .field(DIMENSION, TEST_DIMENSION)
-                .startObject(KNN_METHOD)
+                .field(DIMENSION, TEST_DIMENSION);
+            addCompressionMappingFields(builder);
+            builder.startObject(KNN_METHOD)
                 .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
                 .field(KNN_ENGINE, KNNEngine.LUCENE.getName())
                 .field(NAME, METHOD_HNSW)
@@ -435,8 +448,9 @@ public class RecallTestsIT extends KNNRestTestCase {
                 .startObject(PROPERTIES_FIELD)
                 .startObject(TEST_FIELD_NAME)
                 .field(TYPE, TYPE_KNN_VECTOR)
-                .field(DIMENSION, TEST_DIMENSION)
-                .startObject(KNN_METHOD)
+                .field(DIMENSION, TEST_DIMENSION);
+            addCompressionMappingFields(builder);
+            builder.startObject(KNN_METHOD)
                 .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
                 .field(KNN_ENGINE, KNNEngine.FAISS.getName())
                 .field(NAME, METHOD_HNSW)
@@ -796,10 +810,9 @@ public class RecallTestsIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD)
             .startObject(TRAIN_FIELD_NAME)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(DIMENSION, TEST_DIMENSION)
-            .endObject()
-            .endObject()
-            .endObject();
+            .field(DIMENSION, TEST_DIMENSION);
+        addCompressionMappingFields(trainingIndexBuilder);
+        trainingIndexBuilder.endObject().endObject().endObject();
         createIndexAndIngestDocs(
             TRAIN_INDEX_NAME,
             TRAIN_FIELD_NAME,

--- a/src/test/java/org/opensearch/knn/search/extension/MMRSearchExtBuilderIT.java
+++ b/src/test/java/org/opensearch/knn/search/extension/MMRSearchExtBuilderIT.java
@@ -12,7 +12,8 @@ import org.junit.Before;
 import org.opensearch.client.Response;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.knn.KNNRestTestCase;
+import org.opensearch.knn.CompressionTestConfig;
+import org.opensearch.knn.KNNCompressionRestTestCase;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -48,7 +49,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_FIELD_PATH;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_FIELD_SPACE_TYPE;
 import static org.opensearch.search.pipeline.SearchPipelineService.ENABLED_SYSTEM_GENERATED_FACTORIES_SETTING;
 
-public class MMRSearchExtBuilderIT extends KNNRestTestCase {
+public class MMRSearchExtBuilderIT extends KNNCompressionRestTestCase {
     private static final int DIMENSION_NUM = 2;
     private static final String FIELD_NAME = "vector_field";
     private static final String INDEX_NAME = "test_index";
@@ -57,6 +58,10 @@ public class MMRSearchExtBuilderIT extends KNNRestTestCase {
     private static final float[] DIVERSE_VECTOR_1 = new float[] { 1f, 2f };
     private static final float[] DIVERSE_VECTOR_2 = new float[] { 2f, 1f };
     private float DELTA = 1e-6F;
+
+    public MMRSearchExtBuilderIT(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     @Before
     public void setUpForMMR() {
@@ -225,8 +230,9 @@ public class MMRSearchExtBuilderIT extends KNNRestTestCase {
             .startObject(PROPERTIES_FIELD)
             .startObject(FIELD_NAME)
             .field(TYPE, TYPE_KNN_VECTOR)
-            .field(DIMENSION, DIMENSION_NUM)
-            .startObject(KNN_METHOD)
+            .field(DIMENSION, DIMENSION_NUM);
+        addCompressionMappingFields(mappingBuilder);
+        mappingBuilder.startObject(KNN_METHOD)
             .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
             .field(KNN_ENGINE, KNNEngine.FAISS.getName())
             .field(NAME, METHOD_HNSW)

--- a/src/testFixtures/java/org/opensearch/knn/CompressionTestConfig.java
+++ b/src/testFixtures/java/org/opensearch/knn/CompressionTestConfig.java
@@ -10,31 +10,29 @@ import lombok.Getter;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.index.mapper.Mode;
-import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Test configurations for dual-path coverage of FP32 (no compression) and SQ 1-bit (32x compression).
+ * Test configurations for dual-path coverage of an unconfigured index (no explicit compression) and 32x compression.
  * Provides compression-specific thresholds, eligibility flags, and helper methods for parameterized testing.
  */
 @Getter
 @AllArgsConstructor
 public enum CompressionTestConfig {
-    FP32(CompressionLevel.x1, Mode.IN_MEMORY, null, createFP32Thresholds(), true, true, true, true),
-    SQ_1BIT(CompressionLevel.x32, Mode.ON_DISK, ScalarQuantizationType.ONE_BIT, createSQ1BitThresholds(), true, true, true, true);
+    X1(CompressionLevel.x1, Mode.NOT_CONFIGURED, createDefaultThresholds(), true, true, true, true),
+    X32(CompressionLevel.x32, Mode.ON_DISK, createX32Thresholds(), true, true, true, true);
 
     private final CompressionLevel compressionLevel;
     private final Mode mode;
-    private final ScalarQuantizationType expectedQuantizationType;
     private final Map<SpaceType, Float> recallThresholds;
     private final boolean radialSearchEligible;
     private final boolean mosEligible;
     private final boolean scriptScoringEligible;
     private final boolean searchEligible;
 
-    private static Map<SpaceType, Float> createFP32Thresholds() {
+    private static Map<SpaceType, Float> createDefaultThresholds() {
         Map<SpaceType, Float> thresholds = new HashMap<>();
         thresholds.put(SpaceType.L2, 0.95f);
         thresholds.put(SpaceType.COSINESIMIL, 0.95f);
@@ -42,7 +40,7 @@ public enum CompressionTestConfig {
         return thresholds;
     }
 
-    private static Map<SpaceType, Float> createSQ1BitThresholds() {
+    private static Map<SpaceType, Float> createX32Thresholds() {
         Map<SpaceType, Float> thresholds = new HashMap<>();
         thresholds.put(SpaceType.L2, 0.70f);
         thresholds.put(SpaceType.COSINESIMIL, 0.70f);
@@ -59,7 +57,7 @@ public enum CompressionTestConfig {
     }
 
     public boolean isCompressed() {
-        return this != FP32;
+        return this != X1;
     }
 
     /**

--- a/src/testFixtures/java/org/opensearch/knn/CompressionTestConfig.java
+++ b/src/testFixtures/java/org/opensearch/knn/CompressionTestConfig.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test configurations for dual-path coverage of FP32 (no compression) and SQ 1-bit (32x compression).
+ * Provides compression-specific thresholds, eligibility flags, and helper methods for parameterized testing.
+ */
+@Getter
+@AllArgsConstructor
+public enum CompressionTestConfig {
+    FP32(CompressionLevel.x1, Mode.IN_MEMORY, null, createFP32Thresholds(), true, true, true, true),
+    SQ_1BIT(CompressionLevel.x32, Mode.ON_DISK, ScalarQuantizationType.ONE_BIT, createSQ1BitThresholds(), true, true, true, true);
+
+    private final CompressionLevel compressionLevel;
+    private final Mode mode;
+    private final ScalarQuantizationType expectedQuantizationType;
+    private final Map<SpaceType, Float> recallThresholds;
+    private final boolean radialSearchEligible;
+    private final boolean mosEligible;
+    private final boolean scriptScoringEligible;
+    private final boolean searchEligible;
+
+    private static Map<SpaceType, Float> createFP32Thresholds() {
+        Map<SpaceType, Float> thresholds = new HashMap<>();
+        thresholds.put(SpaceType.L2, 0.95f);
+        thresholds.put(SpaceType.COSINESIMIL, 0.95f);
+        thresholds.put(SpaceType.INNER_PRODUCT, 0.95f);
+        return thresholds;
+    }
+
+    private static Map<SpaceType, Float> createSQ1BitThresholds() {
+        Map<SpaceType, Float> thresholds = new HashMap<>();
+        thresholds.put(SpaceType.L2, 0.70f);
+        thresholds.put(SpaceType.COSINESIMIL, 0.70f);
+        thresholds.put(SpaceType.INNER_PRODUCT, 0.60f);
+        return thresholds;
+    }
+
+    public String getCompressionLevelName() {
+        return compressionLevel.getName();
+    }
+
+    public String getModeName() {
+        return mode.getName();
+    }
+
+    public boolean isCompressed() {
+        return this != FP32;
+    }
+
+    /**
+     * Get minimum recall threshold for a specific space type.
+     * Falls back to L2 threshold if space type not found.
+     */
+    public float getMinRecallThreshold(SpaceType spaceType) {
+        return recallThresholds.getOrDefault(spaceType, recallThresholds.get(SpaceType.L2));
+    }
+
+    /**
+     * Get minimum recall threshold using default L2 space type for backward compatibility.
+     */
+    public float getMinRecallThreshold() {
+        return getMinRecallThreshold(SpaceType.L2);
+    }
+
+    /**
+     * Check if this configuration is eligible for a specific test category.
+     */
+    public boolean isEligibleFor(TestCategory category) {
+        switch (category) {
+            case SEARCH:
+                return searchEligible;
+            case RADIAL:
+                return radialSearchEligible;
+            case MOS:
+                return mosEligible;
+            case SCRIPT_SCORING:
+                return scriptScoringEligible;
+            case INFRASTRUCTURE:
+                return true; // All configs support infrastructure tests
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Test categories for eligibility checking.
+     */
+    public enum TestCategory {
+        SEARCH,
+        RADIAL,
+        MOS,
+        SCRIPT_SCORING,
+        INFRASTRUCTURE
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -29,7 +29,11 @@ import java.util.function.Supplier;
 
 import static org.opensearch.knn.TestUtils.BWC_VERSION;
 
-public class DerivedSourceTestCase extends KNNRestTestCase {
+public class DerivedSourceTestCase extends KNNCompressionRestTestCase {
+
+    public DerivedSourceTestCase(CompressionTestConfig compressionConfig) {
+        super(compressionConfig);
+    }
 
     private static final List<Pair<String, Boolean>> INDEX_PREFIX_TO_ENABLED = List.of(
         new Pair<>("original-enable-", true),
@@ -1160,11 +1164,12 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
     }
 
     protected String getIndexName(String testPrefix, String indexPrefix, boolean addRandom) {
-        String indexName = (testPrefix + "-" + indexPrefix + getTestName()).toLowerCase(Locale.ROOT);
+        String rawName = (testPrefix + "-" + indexPrefix + getTestName()).toLowerCase(Locale.ROOT);
+        String indexName = rawName.replaceAll("[^a-z0-9-]", "");
         if (addRandom) {
-            indexName += randomAlphaOfLength(6);
+            indexName += randomAlphaOfLength(6).toLowerCase(Locale.ROOT);
         }
-        return indexName.toLowerCase(Locale.ROOT);
+        return indexName;
     }
 
     protected Supplier<Integer> randomIntegerSupplier(long randomSeed, int min, int max) {

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
@@ -17,6 +17,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.indices.replication.common.ReplicationType;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil;
@@ -408,6 +409,9 @@ public class DerivedSourceUtils {
             builder.field("type", "knn_vector");
             builder.field("dimension", dimension);
             builder.field("data_type", vectorDataType.getValue());
+            if (vectorDataType == VectorDataType.FLOAT) {
+                builder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, "1x");
+            }
             builder.endObject();
             return builder;
         }

--- a/src/testFixtures/java/org/opensearch/knn/KNNCompressionRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNCompressionRestTestCase.java
@@ -49,18 +49,18 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
     }
 
     /**
-     * Default parameterization that runs tests for both FP32 and SQ_1BIT compression.
+     * Default parameterization that runs tests for both X1 and X32 compression.
      * Subclasses can override this method to filter which compression configs they support.
      */
     @ParametersFactory(argumentFormatting = "compression:%1$s")
     public static Collection<Object[]> compressionParameters() {
-        return Arrays.asList(new Object[] { CompressionTestConfig.FP32 }, new Object[] { CompressionTestConfig.SQ_1BIT });
+        return Arrays.asList(new Object[] { CompressionTestConfig.X1 }, new Object[] { CompressionTestConfig.X32 });
     }
 
     /**
      * Returns supported compression configurations for this test class.
      * Override this method to restrict which compression levels a test supports.
-     * Default: all configurations (FP32, SQ_1BIT)
+     * Default: all configurations (NOT_CONFIGURED, X32)
      */
     protected List<CompressionTestConfig> supportedConfigs() {
         return Arrays.asList(CompressionTestConfig.values());
@@ -93,10 +93,9 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(MODE_PARAMETER, compressionConfig.getModeName())
-            .field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+            .field("dimension", dimension);
 
+        addCompressionMappingFields(builder);
         addMethodParams(builder, engine, spaceType, m, efConstruction);
         builder.endObject().endObject().endObject();
 
@@ -113,10 +112,9 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
             .startObject("properties")
             .startObject(FIELD_NAME)
             .field("type", "knn_vector")
-            .field("dimension", dimension)
-            .field(MODE_PARAMETER, compressionConfig.getModeName())
-            .field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+            .field("dimension", dimension);
 
+        addCompressionMappingFields(builder);
         addMethodParams(builder, engine, spaceType, DEFAULT_HNSW_M, DEFAULT_HNSW_EF_CONSTRUCTION);
         builder.endObject().startObject("category").field("type", "keyword").endObject().endObject().endObject();
 
@@ -148,23 +146,21 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
         for (float score : scores) {
             assertTrue("Score should be positive", score > 0.0f);
 
-            // Space type specific bounds (compression affects precision but not valid range)
             switch (spaceType) {
                 case L2:
-                    // L2 scores are transformed: score = 1/(1+distance), so 0 < score <= 1
+
                     assertTrue("L2 score should be <= 1.0", score <= 1.0f);
                     break;
                 case COSINESIMIL:
-                    // Cosine scores: 0 < score <= 2 (after transformation)
+
                     assertTrue("Cosine score should be <= 2.0", score <= 2.0f);
                     break;
                 case INNER_PRODUCT:
-                    // IP scores can be any positive value after transformation
+
                     break;
             }
         }
 
-        // Verify scores are in descending order (relevance ranking)
         for (int i = 0; i < scores.size() - 1; i++) {
             assertTrue("Scores should be in descending order", scores.get(i) >= scores.get(i + 1));
         }
@@ -175,29 +171,19 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
      * Quantized compression generally has lower recall due to approximation.
      */
     protected float getMinRecallThreshold(SpaceType spaceType) {
-        if (compressionConfig == CompressionTestConfig.FP32) {
-            return 0.95f; // High precision expectation for uncompressed
+        if (compressionConfig == CompressionTestConfig.X1) {
+            return 0.95f;
         }
 
-        // Quantized thresholds vary by space type due to different approximation characteristics
         switch (spaceType) {
             case L2:
             case COSINESIMIL:
                 return 0.70f;
             case INNER_PRODUCT:
-                return 0.60f; // IP quantization can be more lossy
+                return 0.60f;
             default:
                 return 0.70f;
         }
-    }
-
-    /**
-     * Skips the current test for any non-FP32 configuration. Use in tests that assert
-     * uncompressed-specific behavior (exact scores, memory size, settings, mapping round-trips)
-     * so they execute only once under the parameterized class.
-     */
-    protected void assumeUncompressed() {
-        assumeTrue("Test is only applicable to the uncompressed (FP32) configuration", compressionConfig == CompressionTestConfig.FP32);
     }
 
     /**
@@ -205,7 +191,7 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
      * All configurations support it since script scoring uses stored vectors, not quantized index.
      */
     protected boolean isScriptScoringSupported() {
-        return true; // Script scoring works on doc_values regardless of index compression
+        return true;
     }
 
     /**
@@ -213,7 +199,7 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
      * Both FP32 and quantized support radial search.
      */
     protected boolean isRadialSearchSupported() {
-        return true; // Radial search supported for all compression levels
+        return true;
     }
 
     /**
@@ -238,6 +224,21 @@ public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
         if (compressionConfig.isCompressed()) {
             builder.field(MODE_PARAMETER, compressionConfig.getModeName());
         }
+    }
+
+    /**
+     * Applies the compression-related fields (compression_level and mode when compressed) to a
+     * {@link KNNJsonIndexMappingsBuilder} builder. Returns the same builder so it can be chained
+     * fluently. Injects nothing for the NOT_CONFIGURED configuration.
+     */
+    protected KNNJsonIndexMappingsBuilder.KNNJsonIndexMappingsBuilderBuilder addCompressionMappingFields(
+        KNNJsonIndexMappingsBuilder.KNNJsonIndexMappingsBuilderBuilder builder
+    ) {
+        if (compressionConfig.isCompressed()) {
+            builder.compressionLevel(compressionConfig.getCompressionLevelName());
+            builder.mode(compressionConfig.getModeName());
+        }
+        return builder;
     }
 
     @SneakyThrows

--- a/src/testFixtures/java/org/opensearch/knn/KNNCompressionRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNCompressionRestTestCase.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import lombok.SneakyThrows;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.index.SpaceType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_M;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.index.KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD;
+import static org.opensearch.knn.index.KNNSettings.KNN_INDEX;
+
+/**
+ * Base class for integration tests that need to run across different compression levels.
+ * Provides parameterization infrastructure, helper methods for index creation with compression,
+ * and assertion helpers that adapt to compression-specific thresholds.
+ */
+public abstract class KNNCompressionRestTestCase extends KNNRestTestCase {
+
+    private static final int DEFAULT_HNSW_M = 16;
+    private static final int DEFAULT_HNSW_EF_CONSTRUCTION = 100;
+    private static final int DEFAULT_HNSW_EF_SEARCH = 100;
+
+    protected final CompressionTestConfig compressionConfig;
+
+    public KNNCompressionRestTestCase(CompressionTestConfig compressionConfig) {
+        this.compressionConfig = compressionConfig;
+    }
+
+    /**
+     * Default parameterization that runs tests for both FP32 and SQ_1BIT compression.
+     * Subclasses can override this method to filter which compression configs they support.
+     */
+    @ParametersFactory(argumentFormatting = "compression:%1$s")
+    public static Collection<Object[]> compressionParameters() {
+        return Arrays.asList(new Object[] { CompressionTestConfig.FP32 }, new Object[] { CompressionTestConfig.SQ_1BIT });
+    }
+
+    /**
+     * Returns supported compression configurations for this test class.
+     * Override this method to restrict which compression levels a test supports.
+     * Default: all configurations (FP32, SQ_1BIT)
+     */
+    protected List<CompressionTestConfig> supportedConfigs() {
+        return Arrays.asList(CompressionTestConfig.values());
+    }
+
+    /**
+     * Creates index name prefix that includes compression level for uniqueness
+     */
+    protected String prefix() {
+        String sanitizedTestName = getTestName().toLowerCase().replaceAll("[^a-z0-9]", "_");
+        return sanitizedTestName + "_" + compressionConfig.name().toLowerCase() + "_";
+    }
+
+    /**
+     * Creates an HNSW index with the compression settings from the current test configuration.
+     * Uses default HNSW parameters optimized for test performance.
+     */
+    @SneakyThrows
+    protected void createHnswIndex(String indexName, String engine, SpaceType spaceType, int dimension) {
+        createHnswIndex(indexName, engine, spaceType, dimension, DEFAULT_HNSW_M, DEFAULT_HNSW_EF_CONSTRUCTION);
+    }
+
+    /**
+     * Creates an HNSW index with custom HNSW parameters and compression from test configuration.
+     */
+    @SneakyThrows
+    protected void createHnswIndex(String indexName, String engine, SpaceType spaceType, int dimension, int m, int efConstruction) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, compressionConfig.getModeName())
+            .field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+
+        addMethodParams(builder, engine, spaceType, m, efConstruction);
+        builder.endObject().endObject().endObject();
+
+        createKnnIndex(indexName, getDefaultCompressionIndexSettings(), builder.toString());
+    }
+
+    /**
+     * Creates an HNSW index with additional filter fields for filtered search tests.
+     */
+    @SneakyThrows
+    protected void createHnswIndexWithFilterField(String indexName, String engine, SpaceType spaceType, int dimension) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .field(MODE_PARAMETER, compressionConfig.getModeName())
+            .field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+
+        addMethodParams(builder, engine, spaceType, DEFAULT_HNSW_M, DEFAULT_HNSW_EF_CONSTRUCTION);
+        builder.endObject().startObject("category").field("type", "keyword").endObject().endObject().endObject();
+
+        createKnnIndex(indexName, getDefaultCompressionIndexSettings(), builder.toString());
+    }
+
+    /**
+     * Asserts that recall meets the minimum threshold for the current compression configuration.
+     * Uses different thresholds for FP32 vs quantized compression.
+     */
+    protected void assertRecall(double actualRecall, SpaceType spaceType) {
+        float expectedMinRecall = getMinRecallThreshold(spaceType);
+        String message = String.format(
+            "%s recall should be >= %.3f but was %.3f",
+            compressionConfig.name(),
+            expectedMinRecall,
+            actualRecall
+        );
+        assertTrue(message, actualRecall >= expectedMinRecall);
+    }
+
+    /**
+     * Asserts that search scores are within valid ranges for the space type and compression level.
+     * FP32 can assert tighter bounds, quantized compression allows broader ranges due to approximation.
+     */
+    protected void assertScoreInRange(List<Float> scores, SpaceType spaceType) {
+        assertFalse("Scores should not be empty", scores.isEmpty());
+
+        for (float score : scores) {
+            assertTrue("Score should be positive", score > 0.0f);
+
+            // Space type specific bounds (compression affects precision but not valid range)
+            switch (spaceType) {
+                case L2:
+                    // L2 scores are transformed: score = 1/(1+distance), so 0 < score <= 1
+                    assertTrue("L2 score should be <= 1.0", score <= 1.0f);
+                    break;
+                case COSINESIMIL:
+                    // Cosine scores: 0 < score <= 2 (after transformation)
+                    assertTrue("Cosine score should be <= 2.0", score <= 2.0f);
+                    break;
+                case INNER_PRODUCT:
+                    // IP scores can be any positive value after transformation
+                    break;
+            }
+        }
+
+        // Verify scores are in descending order (relevance ranking)
+        for (int i = 0; i < scores.size() - 1; i++) {
+            assertTrue("Scores should be in descending order", scores.get(i) >= scores.get(i + 1));
+        }
+    }
+
+    /**
+     * Returns minimum recall threshold based on compression config and space type.
+     * Quantized compression generally has lower recall due to approximation.
+     */
+    protected float getMinRecallThreshold(SpaceType spaceType) {
+        if (compressionConfig == CompressionTestConfig.FP32) {
+            return 0.95f; // High precision expectation for uncompressed
+        }
+
+        // Quantized thresholds vary by space type due to different approximation characteristics
+        switch (spaceType) {
+            case L2:
+            case COSINESIMIL:
+                return 0.70f;
+            case INNER_PRODUCT:
+                return 0.60f; // IP quantization can be more lossy
+            default:
+                return 0.70f;
+        }
+    }
+
+    /**
+     * Skips the current test for any non-FP32 configuration. Use in tests that assert
+     * uncompressed-specific behavior (exact scores, memory size, settings, mapping round-trips)
+     * so they execute only once under the parameterized class.
+     */
+    protected void assumeUncompressed() {
+        assumeTrue("Test is only applicable to the uncompressed (FP32) configuration", compressionConfig == CompressionTestConfig.FP32);
+    }
+
+    /**
+     * Returns whether the current compression configuration supports script scoring.
+     * All configurations support it since script scoring uses stored vectors, not quantized index.
+     */
+    protected boolean isScriptScoringSupported() {
+        return true; // Script scoring works on doc_values regardless of index compression
+    }
+
+    /**
+     * Returns whether radial search is supported for current compression configuration.
+     * Both FP32 and quantized support radial search.
+     */
+    protected boolean isRadialSearchSupported() {
+        return true; // Radial search supported for all compression levels
+    }
+
+    /**
+     * Default index settings optimized for compression testing.
+     */
+    protected Settings getDefaultCompressionIndexSettings() {
+        return Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put(KNN_INDEX, true)
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0)
+            .build();
+    }
+
+    /**
+     * Writes the compression-related mapping fields (compression_level, and mode when compressed)
+     * into an open knn_vector field object so existing custom mappings can adopt the current config.
+     */
+    @SneakyThrows
+    protected void addCompressionMappingFields(XContentBuilder builder) {
+        builder.field(COMPRESSION_LEVEL_PARAMETER, compressionConfig.getCompressionLevelName());
+        if (compressionConfig.isCompressed()) {
+            builder.field(MODE_PARAMETER, compressionConfig.getModeName());
+        }
+    }
+
+    @SneakyThrows
+    private void addMethodParams(XContentBuilder builder, String engine, SpaceType spaceType, int m, int efConstruction) {
+        builder.startObject(KNN_METHOD)
+            .field(NAME, METHOD_HNSW)
+            .field(KNN_ENGINE, engine)
+            .field(METHOD_PARAMETER_SPACE_TYPE, spaceType.getValue())
+            .startObject(PARAMETERS)
+            .field(METHOD_PARAMETER_M, m)
+            .field(METHOD_PARAMETER_EF_CONSTRUCTION, efConstruction);
+
+        if (FAISS_NAME.equals(engine)) {
+            builder.field(METHOD_PARAMETER_EF_SEARCH, DEFAULT_HNSW_EF_SEARCH);
+        }
+
+        builder.endObject().endObject();
+    }
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNJsonIndexMappingsBuilder.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNJsonIndexMappingsBuilder.java
@@ -25,6 +25,8 @@ public class KNNJsonIndexMappingsBuilder {
     private Integer dimension;
     private String nestedFieldName;
     private String vectorDataType;
+    private String compressionLevel;
+    private String mode;
     private Method method;
 
     public XContentBuilder getIndexMappingBuilder() throws IOException {
@@ -39,6 +41,7 @@ public class KNNJsonIndexMappingsBuilder {
                 .field("type", "knn_vector")
                 .field("dimension", dimension);
             addVectorDataType(xContentBuilder);
+            addCompression(xContentBuilder);
             addMethod(xContentBuilder);
             xContentBuilder.endObject().endObject().endObject().endObject().endObject();
             return xContentBuilder;
@@ -50,6 +53,7 @@ public class KNNJsonIndexMappingsBuilder {
                 .field("type", "knn_vector")
                 .field("dimension", dimension);
             addVectorDataType(xContentBuilder);
+            addCompression(xContentBuilder);
             addMethod(xContentBuilder);
             xContentBuilder.endObject().endObject().endObject();
             return xContentBuilder;
@@ -65,6 +69,15 @@ public class KNNJsonIndexMappingsBuilder {
             return;
         }
         xContentBuilder.field("data_type", vectorDataType);
+    }
+
+    private void addCompression(final XContentBuilder xContentBuilder) throws IOException {
+        if (compressionLevel != null) {
+            xContentBuilder.field(KNNConstants.COMPRESSION_LEVEL_PARAMETER, compressionLevel);
+        }
+        if (mode != null) {
+            xContentBuilder.field(KNNConstants.MODE_PARAMETER, mode);
+        }
     }
 
     private void addMethod(final XContentBuilder xContentBuilder) throws IOException {


### PR DESCRIPTION
### Description

Introduces compression-aware test parameterization across all integration tests to ensure test stability after the 32x default compression flip ([RFC #3290](https://github.com/opensearch-project/k-NN/issues/3290)).

Every IT class that creates a float HNSW index without explicit compression will silently resolve to 32x (SQ 1-bit) after the default flip. Tests with exact-score assertions would break. This PR adds a `KNNCompressionRestTestCase` base class that parameterizes tests by compression level, so each test class explicitly declares which compression configurations it supports and gets config-appropriate recall thresholds.

**Infrastructure:**
- `KNNCompressionRestTestCase`: base class with `@ParametersFactory`, index creation helpers that inject compression from config, and recall assertion helpers
- `CompressionTestConfig`: enum carrying per-space-type recall thresholds, mode, and eligibility flags

### Related Issues
Related #3290

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
