### PR TITLE
fixed flaky warmup legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)
+* Re-enable flaky BWC test testKNNWarmupCustomLegacyFieldMapping and restore legacy index settings in BWC test fixtures [#2415](https://github.com/opensearch-project/k-NN/issues/2415)
 
 ### Bug Fixes
 * Fix NPE in nested kNN search when index contains documents without nested object [#3368](https://github.com/opensearch-project/k-NN/pull/3368)

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/IndexingIT.java
@@ -34,8 +34,6 @@ import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER
 import static org.opensearch.knn.common.KNNConstants.MODE_PARAMETER;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE;
-import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_M_MIN_VALUE;
 import static org.opensearch.knn.TestUtils.KNN_VECTOR;
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
 import static org.opensearch.knn.TestUtils.PROPERTIES;
@@ -292,7 +290,10 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
     }
 
     // Custom Legacy Field Mapping
-    // space_type : "innerproduct", engine : "nmslib", m : 2, ef_construction : 2
+    // space_type : "innerproduct", engine : "nmslib", m : 50, ef_construction : 1024
+    // Note: avoid the minimum m/ef_construction values here. Inner product is a non-metric space; combined with a
+    // minimal graph (m=2, ef_construction=2) and this test's collinear vectors, HNSW recall becomes nondeterministic
+    // and the exact top-k assertions in validateKNNSearch flake (see issue #2415).
     public void testKNNIndexCustomLegacyFieldMapping() throws Exception {
 
         // When the cluster is in old version, create a KNN index with custom legacy field mapping settings
@@ -300,8 +301,8 @@ public class IndexingIT extends AbstractRestartUpgradeTestCase {
         if (isRunningAgainstOldCluster()) {
             Settings.Builder indexMappingSettings = createKNNIndexCustomLegacyFieldMappingIndexSettingsBuilder(
                 SpaceType.INNER_PRODUCT,
-                KNN_ALGO_PARAM_M_MIN_VALUE,
-                KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE
+                M,
+                EF_CONSTRUCTION
             );
             if (isApproximateThresholdSupported(getBWCVersion())) {
                 indexMappingSettings.put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0);

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/WarmupIT.java
@@ -11,8 +11,6 @@ import org.opensearch.knn.index.SpaceType;
 
 import java.util.Collections;
 
-import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_M_MIN_VALUE;
-import static org.opensearch.knn.TestUtils.KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE;
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.TestUtils.NODES_BWC_CLUSTER;
 
@@ -45,8 +43,10 @@ public class WarmupIT extends AbstractRestartUpgradeTestCase {
     }
 
     // Custom Legacy Field Mapping
-    // space_type : "innerproduct", engine : "nmslib", m : 2, ef_construction : 2
-    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/k-NN/issues/2415")
+    // space_type : "innerproduct", engine : "nmslib", m : 50, ef_construction : 1024
+    // Note: avoid the minimum m/ef_construction values here. Inner product is a non-metric space; combined with a
+    // minimal graph (m=2, ef_construction=2) and this test's collinear vectors, HNSW recall becomes nondeterministic
+    // and the exact top-k assertions in validateKNNSearch flake (see issue #2415).
     public void testKNNWarmupCustomLegacyFieldMapping() throws Exception {
 
         // When the cluster is in old version, create a KNN index with custom legacy field mapping settings
@@ -54,8 +54,8 @@ public class WarmupIT extends AbstractRestartUpgradeTestCase {
         if (isRunningAgainstOldCluster()) {
             Settings.Builder indexMappingSettings = createKNNIndexCustomLegacyFieldMappingIndexSettingsBuilder(
                 SpaceType.INNER_PRODUCT,
-                KNN_ALGO_PARAM_M_MIN_VALUE,
-                KNN_ALGO_PARAM_EF_CONSTRUCTION_MIN_VALUE
+                M,
+                EF_CONSTRUCTION
             );
             if (isApproximateThresholdSupported(getBWCVersion())) {
                 indexMappingSettings.put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0);

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -68,6 +68,9 @@ import org.opensearch.index.query.functionscore.ScriptScoreQueryBuilder;
 import static org.opensearch.knn.TestUtils.FIELD;
 import static org.opensearch.knn.TestUtils.INDEX_KNN;
 import static org.opensearch.knn.TestUtils.KNN_VECTOR;
+import static org.opensearch.knn.TestUtils.LEGACY_KNN_ALGO_PARAM_EF_CONSTRUCTION;
+import static org.opensearch.knn.TestUtils.LEGACY_KNN_ALGO_PARAM_M;
+import static org.opensearch.knn.TestUtils.LEGACY_KNN_SPACE_TYPE;
 import static org.opensearch.knn.TestUtils.NUMBER_OF_REPLICAS;
 import static org.opensearch.knn.TestUtils.NUMBER_OF_SHARDS;
 import static org.opensearch.knn.TestUtils.PROPERTIES;
@@ -2271,12 +2274,23 @@ public class KNNRestTestCase extends ODFERestTestCase {
         }
     }
 
+    /**
+     * Builds index settings that configure the k-NN field through the legacy index settings. These settings were
+     * removed from KNNSettings in 3.0, but 2.x clusters still accept them, so BWC tests use this builder when
+     * creating indices on old clusters to verify legacy indices survive an upgrade.
+     */
     protected Settings.Builder createKNNIndexCustomLegacyFieldMappingIndexSettingsBuilder(
         SpaceType spaceType,
         Integer m,
         Integer ef_construction
     ) {
-        return Settings.builder().put(NUMBER_OF_SHARDS, 1).put(NUMBER_OF_REPLICAS, 0).put(INDEX_KNN, true);
+        return Settings.builder()
+            .put(NUMBER_OF_SHARDS, 1)
+            .put(NUMBER_OF_REPLICAS, 0)
+            .put(INDEX_KNN, true)
+            .put(LEGACY_KNN_SPACE_TYPE, spaceType.getValue())
+            .put(LEGACY_KNN_ALGO_PARAM_M, m)
+            .put(LEGACY_KNN_ALGO_PARAM_EF_CONSTRUCTION, ef_construction);
     }
 
     protected Settings createKNNIndexCustomLegacyFieldMappingIndexSettings(SpaceType spaceType, Integer m, Integer ef_construction) {

--- a/src/testFixtures/java/org/opensearch/knn/TestUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/TestUtils.java
@@ -99,6 +99,11 @@ public class TestUtils {
     public static final String NUMBER_OF_SHARDS = "number_of_shards";
     public static final String NUMBER_OF_REPLICAS = "number_of_replicas";
     public static final String INDEX_KNN = "index.knn";
+    // Legacy index settings for configuring the k-NN field. They were removed from KNNSettings in 3.0, but 2.x
+    // clusters still support them, so BWC tests use them to create indices on old clusters.
+    public static final String LEGACY_KNN_SPACE_TYPE = "index.knn.space_type";
+    public static final String LEGACY_KNN_ALGO_PARAM_M = "index.knn.algo_param.m";
+    public static final String LEGACY_KNN_ALGO_PARAM_EF_CONSTRUCTION = "index.knn.algo_param.ef_construction";
     public static final String OLD_CLUSTER = "old_cluster";
     public static final String PROPERTIES = "properties";
     public static final String VECTOR_TYPE = "type";


### PR DESCRIPTION
### Description

Re-enables the muted flaky BWC test `WarmupIT.testKNNWarmupCustomLegacyFieldMapping`.

### Related Issues
Resolves #2415 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
