### PR TITLE
Wire up ResolvedIndexSpec usage across classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,5 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
+* Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)
 
 ### Enhancements

--- a/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ResolvedIndexSpecIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/knn/bwc/ResolvedIndexSpecIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.bwc;
+
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.Version;
+import org.opensearch.client.Response;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.knn.KNNResult;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.query.KNNQueryBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_ENCODER_FP16;
+import static org.opensearch.knn.common.KNNConstants.FAISS_SQ_TYPE;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.NAME;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+
+/**
+ * BWC integration test for ResolvedIndexSpec. Verifies that indices created before
+ * ResolvedIndexSpec was introduced (with old-style encoder params) still work after
+ * a restart upgrade to the new version.
+ */
+public class ResolvedIndexSpecIT extends AbstractRestartUpgradeTestCase {
+    private static final String TEST_FIELD = "test-field";
+    private static final int DIMENSION = 128;
+    private static final int NUM_DOCS = 100;
+    private static final int K = 10;
+
+    /**
+     * Tests that an HNSW index with SQ encoder bits=1 (1-bit quantization) created on the old
+     * cluster is still queryable after a restart upgrade.
+     */
+    public void testHNSWSQOneBit_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        if (isSQEncoderSupported(getBWCVersion()) == false) {
+            logger.info("Skipping test as SQ encoder is not supported in version: {}", getBWCVersion());
+            return;
+        }
+        String indexName = testIndex + "-sq-1bit";
+        if (isRunningAgainstOldCluster()) {
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(TEST_FIELD)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject("method")
+                .field(NAME, "hnsw")
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .startObject(PARAMETERS)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_SQ)
+                .startObject(PARAMETERS)
+                .field(SQ_BITS, 1)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+
+            createKnnIndex(indexName, builder.toString());
+            indexTestData(indexName, TEST_FIELD, DIMENSION, NUM_DOCS);
+        } else {
+            queryAndValidate(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    /**
+     * Tests that an HNSW index with SQ encoder bits=16 (fp16 quantization) created on the old
+     * cluster is still queryable after a restart upgrade.
+     */
+    public void testHNSWSQSixteenBit_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        if (isSQEncoderSupported(getBWCVersion()) == false) {
+            logger.info("Skipping test as SQ encoder is not supported in version: {}", getBWCVersion());
+            return;
+        }
+        String indexName = testIndex + "-sq-16bit";
+        if (isRunningAgainstOldCluster()) {
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(TEST_FIELD)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject("method")
+                .field(NAME, "hnsw")
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .startObject(PARAMETERS)
+                .startObject(METHOD_ENCODER_PARAMETER)
+                .field(NAME, ENCODER_SQ)
+                .startObject(PARAMETERS)
+                .field(SQ_BITS, 16)
+                .field(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+
+            createKnnIndex(indexName, builder.toString());
+            indexTestData(indexName, TEST_FIELD, DIMENSION, NUM_DOCS);
+        } else {
+            queryAndValidate(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    /**
+     * Tests that an HNSW index with no encoder (flat/default) created on the old cluster
+     * is still queryable after a restart upgrade.
+     */
+    public void testHNSWNoEncoder_onOldClusterThenUpgraded_thenSucceed() throws Exception {
+        String indexName = testIndex + "-no-encoder";
+        if (isRunningAgainstOldCluster()) {
+            XContentBuilder builder = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject(TEST_FIELD)
+                .field("type", "knn_vector")
+                .field("dimension", DIMENSION)
+                .startObject("method")
+                .field(NAME, "hnsw")
+                .field(KNN_ENGINE, FAISS_NAME)
+                .field(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+
+            createKnnIndex(indexName, builder.toString());
+            indexTestData(indexName, TEST_FIELD, DIMENSION, NUM_DOCS);
+        } else {
+            queryAndValidate(indexName, TEST_FIELD, DIMENSION, NUM_DOCS, K);
+            deleteKNNIndex(indexName);
+        }
+    }
+
+    private boolean isSQEncoderSupported(final Optional<String> bwcVersion) {
+        if (bwcVersion.isEmpty()) {
+            return false;
+        }
+        String versionString = bwcVersion.get().replace("-SNAPSHOT", "");
+        return Version.fromString(versionString).onOrAfter(Version.V_3_6_0);
+    }
+
+    private void indexTestData(String indexName, String fieldName, int dimension, int numDocs) throws Exception {
+        for (int i = 0; i < numDocs; i++) {
+            float[] vector = new float[dimension];
+            Arrays.fill(vector, (float) i);
+            addKnnDoc(indexName, Integer.toString(i), fieldName, vector);
+        }
+        refreshAllNonSystemIndices();
+        assertEquals(numDocs, getDocCount(indexName));
+    }
+
+    private void queryAndValidate(String indexName, String fieldName, int dimension, int numDocs, int k) throws IOException,
+        ParseException {
+        float[] queryVector = new float[dimension];
+        Arrays.fill(queryVector, (float) numDocs);
+
+        Response searchResponse = searchKNNIndex(indexName, new KNNQueryBuilder(fieldName, queryVector, k), k);
+        List<KNNResult> results = parseSearchResponse(EntityUtils.toString(searchResponse.getEntity()), fieldName);
+        assertEquals(k, results.size());
+        for (int i = 0; i < k; i++) {
+            assertEquals(numDocs - i - 1, Integer.parseInt(results.get(i).getDocId()));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040BasePerFieldKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040BasePerFieldKnnVectorsFormat.java
@@ -13,6 +13,7 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
 
@@ -90,13 +91,14 @@ public abstract class KNN1040BasePerFieldKnnVectorsFormat extends PerFieldKnnVec
         nativeIndexBuildStrategyFactory.setKnnLibraryIndexingContext(knnMappingConfig.getKnnLibraryIndexingContext());
         final KNNEngine engine = knnMethodContext.getKnnEngine();
         final Map<String, Object> params = knnMethodContext.getMethodComponentContext().getParameters();
+        final ResolvedIndexSpec resolvedSpec = mappedFieldType.getResolvedSpec();
 
         if (engine == KNNEngine.LUCENE) {
-            return luceneFormatResolver.resolve(field, knnMethodContext, params, defaultMaxConnections, defaultBeamWidth);
+            return luceneFormatResolver.resolve(field, knnMethodContext, params, defaultMaxConnections, defaultBeamWidth, resolvedSpec);
         }
 
-        // Native engines — pass params so the resolver can detect SQ encoder
-        return nativeFormatResolver.resolve(field, knnMethodContext, params, defaultMaxConnections, defaultBeamWidth);
+        // Native engines — pass params so the resolver can detect SQ encoder when the spec is null
+        return nativeFormatResolver.resolve(field, knnMethodContext, params, defaultMaxConnections, defaultBeamWidth, resolvedSpec);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
@@ -10,8 +10,8 @@ import org.apache.lucene.index.FieldInfo;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNEngine;
-import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
 import org.opensearch.repositories.RepositoriesService;
@@ -61,7 +61,7 @@ public final class NativeIndexBuildStrategyFactory {
         final boolean isTemplate = fieldInfo.attributes().containsKey(MODEL_ID);
         final boolean iterative = !isTemplate && KNNEngine.FAISS == knnEngine;
         final boolean isFaissSQOneBitField = FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue();
+            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue();
 
         // Determine build strategy
         final NativeIndexBuildStrategy strategy;

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -20,6 +20,7 @@ import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategy;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.faiss.FaissHNSWMethod;
 import org.opensearch.knn.index.remote.RemoteIndexWaiter;
 import org.opensearch.knn.index.remote.RemoteIndexWaiterFactory;
@@ -224,7 +225,8 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
                 indexInfo,
                 repositoryContext.blobStoreRepository.getMetadata(),
                 repositoryContext.blobPath.buildAsString() + repositoryContext.blobName,
-                knnLibraryIndexingContext.getLibraryParameters()
+                knnLibraryIndexingContext.getLibraryParameters(),
+                knnLibraryIndexingContext.getResolvedSpec()
             );
             remoteBuildResponse = client.submitVectorBuild(buildRequest);
             success = true;
@@ -326,11 +328,17 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         return new RepositoryContext(repository, blobPath, vectorRepositoryAccessor, blobName);
     }
 
-    private static String determineVectorDataType(final VectorDataType dataType, final Map<String, Object> parameters) {
+    private static String determineVectorDataType(
+        final VectorDataType dataType,
+        final Map<String, Object> parameters,
+        final ResolvedIndexSpec resolvedSpec
+    ) {
         if (dataType == VectorDataType.FLOAT) {
-            // SQ 1-bit sends fp32 vectors. Once support is added for building 1 bit SQ graphs
-            // in the Remote Vector Index Builder, then this can be modified to send 1 bit SQ vectors.
-            if (FaissHNSWMethod.isSQOneBitIndex(dataType, parameters)) {
+            if (resolvedSpec != null) {
+                if (resolvedSpec.usesFaissSQ1BitCodecFormat()) {
+                    return dataType.getValue();
+                }
+            } else if (FaissHNSWMethod.isSQOneBitIndex(dataType, parameters)) {
                 return dataType.getValue();
             }
             if (FaissHNSWMethod.isFloat16Index(dataType, parameters)) {
@@ -341,12 +349,14 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         return dataType.getValue();
     }
 
-    /**
-     * Determines whether the Remote Vector Index Builder (RVIB) should skip writing flat vector storage (IO_FLAG_SKIP_STORAGE).
-     * When true, the RVIB writes only the HNSW graph, and the data node stitches it with locally-stored
-     * flat vectors at search time via {@link org.opensearch.knn.memoryoptsearch.faiss.FaissFlatIndexFactory}.
-     */
-    private static boolean shouldSkipStoredVectors(final VectorDataType vectorDataType, final Map<String, Object> parameters) {
+    private static boolean shouldSkipStoredVectors(
+        final VectorDataType vectorDataType,
+        final Map<String, Object> parameters,
+        final ResolvedIndexSpec resolvedSpec
+    ) {
+        if (resolvedSpec != null) {
+            return resolvedSpec.usesFaissSQ1BitCodecFormat();
+        }
         return FaissHNSWMethod.isSQOneBitIndex(vectorDataType, parameters);
     }
 
@@ -358,6 +368,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
      * @param repositoryMetadata RepositoryMetadata object
      * @param fullPath           Full blob path + file name representing location of the vectors/doc IDs (excludes repository-specific prefix)
      * @param parameters         Map of parameters to be parsed and passed to the remote build service
+     * @param resolvedSpec       ResolvedIndexSpec for spec-based decisions, may be null
      * @throws IOException if an I/O error occurs
      */
     static RemoteBuildRequest buildRemoteBuildRequest(
@@ -365,7 +376,8 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         BuildIndexParams indexInfo,
         RepositoryMetadata repositoryMetadata,
         String fullPath,
-        Map<String, Object> parameters
+        Map<String, Object> parameters,
+        ResolvedIndexSpec resolvedSpec
     ) throws IOException {
         final String repositoryType = repositoryMetadata.type();
         final String containerName;
@@ -376,7 +388,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             );
         }
 
-        final String vectorDataType = determineVectorDataType(indexInfo.getVectorDataType(), parameters);
+        final String vectorDataType = determineVectorDataType(indexInfo.getVectorDataType(), parameters, resolvedSpec);
 
         KNNVectorValues<?> vectorValues = decorateVectorValuesSupplier(indexInfo).get();
         initializeVectorValues(vectorValues);
@@ -393,7 +405,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             .vectorDataType(vectorDataType)
             .engine(indexInfo.getKnnEngine().getName())
             .indexParameters(indexInfo.getKnnEngine().createRemoteIndexingParameters(parameters))
-            .skipStoredVectors(shouldSkipStoredVectors(indexInfo.getVectorDataType(), parameters))
+            .skipStoredVectors(shouldSkipStoredVectors(indexInfo.getVectorDataType(), parameters, resolvedSpec))
             .build();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -21,7 +21,6 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategy;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.ResolvedIndexSpec;
-import org.opensearch.knn.index.engine.faiss.FaissHNSWMethod;
 import org.opensearch.knn.index.remote.RemoteIndexWaiter;
 import org.opensearch.knn.index.remote.RemoteIndexWaiterFactory;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
@@ -334,14 +333,12 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         final ResolvedIndexSpec resolvedSpec
     ) {
         if (dataType == VectorDataType.FLOAT) {
-            if (resolvedSpec != null) {
-                if (resolvedSpec.usesFaissSQ1BitCodecFormat()) {
-                    return dataType.getValue();
-                }
-            } else if (FaissHNSWMethod.isSQOneBitIndex(dataType, parameters)) {
+            // SQ 1-bit sends fp32 vectors. Once support is added for building 1 bit SQ graphs
+            // in the Remote Vector Index Builder, then this can be modified to send 1 bit SQ vectors.
+            if (resolvedSpec.isFaissSQOneBit()) {
                 return dataType.getValue();
             }
-            if (FaissHNSWMethod.isFloat16Index(dataType, parameters)) {
+            if (resolvedSpec.isFP16QuantizedIndex()) {
                 return FLOAT16_VECTOR_TYPE_STRING;
             }
         }
@@ -349,15 +346,17 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         return dataType.getValue();
     }
 
+    /**
+     * Determines whether the Remote Vector Index Builder (RVIB) should skip writing flat vector storage (IO_FLAG_SKIP_STORAGE).
+     * When true, the RVIB writes only the HNSW graph, and the data node stitches it with locally-stored
+     * flat vectors at search time via {@link org.opensearch.knn.memoryoptsearch.faiss.FaissFlatIndexFactory}.
+     */
     private static boolean shouldSkipStoredVectors(
         final VectorDataType vectorDataType,
         final Map<String, Object> parameters,
         final ResolvedIndexSpec resolvedSpec
     ) {
-        if (resolvedSpec != null) {
-            return resolvedSpec.usesFaissSQ1BitCodecFormat();
-        }
-        return FaissHNSWMethod.isSQOneBitIndex(vectorDataType, parameters);
+        return resolvedSpec.isFaissSQOneBit();
     }
 
     /**
@@ -368,7 +367,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
      * @param repositoryMetadata RepositoryMetadata object
      * @param fullPath           Full blob path + file name representing location of the vectors/doc IDs (excludes repository-specific prefix)
      * @param parameters         Map of parameters to be parsed and passed to the remote build service
-     * @param resolvedSpec       ResolvedIndexSpec for spec-based decisions, may be null
+     * @param resolvedSpec       ResolvedIndexSpec for spec-based decisions, non-null (guaranteed by AbstractKNNMethod.buildResolvedIndexSpec)
      * @throws IOException if an I/O error occurs
      */
     static RemoteBuildRequest buildRemoteBuildRequest(
@@ -379,6 +378,7 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         Map<String, Object> parameters,
         ResolvedIndexSpec resolvedSpec
     ) throws IOException {
+        java.util.Objects.requireNonNull(resolvedSpec, "resolvedSpec must not be null in remote build path");
         final String repositoryType = repositoryMetadata.type();
         final String containerName;
         switch (repositoryType) {

--- a/src/main/java/org/opensearch/knn/index/engine/CodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/CodecFormatResolver.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.engine;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.common.Nullable;
 
 import java.util.Map;
 
@@ -17,12 +18,14 @@ public interface CodecFormatResolver {
 
     /**
      * Resolves the appropriate {@link KnnVectorsFormat} for a given field.
+     * Implementations should prefer the resolved index spec when non-null and fall back to parameter inspection otherwise.
      *
      * @param field                 the field name
      * @param methodContext         the KNN method context (engine, space type, method component); may be null for model-based fields
      * @param params                the method component parameters; may be null
      * @param defaultMaxConnections default max connections for HNSW
      * @param defaultBeamWidth      default beam width for HNSW
+     * @param resolvedSpec          the resolved index spec; may be null
      * @return the resolved {@link KnnVectorsFormat}
      */
     KnnVectorsFormat resolve(
@@ -30,7 +33,8 @@ public interface CodecFormatResolver {
         KNNMethodContext methodContext,
         Map<String, Object> params,
         int defaultMaxConnections,
-        int defaultBeamWidth
+        int defaultBeamWidth,
+        @Nullable ResolvedIndexSpec resolvedSpec
     );
 
     KnnVectorsFormat resolve();

--- a/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/ResolvedIndexSpec.java
@@ -36,16 +36,11 @@ public final class ResolvedIndexSpec {
     private final int dimension;
     private final Version indexVersionCreated;
 
-    /** Faiss-specific: routes field to Faiss1040ScalarQuantizedKnnVectorsFormat. Temporary -- to be replaced by generalized codec format resolver. */
-    public boolean usesFaissSQ1BitCodecFormat() {
-        return engine == KNNEngine.FAISS && isSQOneBit();
-    }
-
     /**
      * Whether this configuration always uses memory optimized search.
      */
     public boolean alwaysUseMemoryOptimizedSearch() {
-        return engine == KNNEngine.FAISS && isSQOneBit();
+        return isSQOneBit();
     }
 
     /**
@@ -80,7 +75,6 @@ public final class ResolvedIndexSpec {
         if (encoderType == Encoder.EncoderType.BQ) {
             return false;
         }
-        // Among quantized indices, only flat method or SQ 1-bit supports radial
         if (isQuantizedIndex()) {
             return isMethodFlat() || isSQOneBit();
         }
@@ -109,8 +103,26 @@ public final class ResolvedIndexSpec {
         return getRescoreContext() != null;
     }
 
-    private boolean isSQOneBit() {
+    /**
+     * Whether this is an SQ encoder producing fp16 quantized output. Distinct from native halfFloat data type storage.
+     * Equivalent to FaissHNSWMethod.isFloat16Index:
+     * encoder is SQ, dataType is FLOAT, and bits is SIXTEEN or legacy (null/FULL_PRECISION defaults to fp16).
+     */
+    public boolean isFP16QuantizedIndex() {
+        // FULL_PRECISION represents the legacy path where SQ encoder is specified without explicit bits param.
+        // buildResolvedIndexSpec defaults to FULL_PRECISION in this case, and the old FaissHNSWMethod.isFloat16Index()
+        // treated SQ-with-no-bits as fp16 by convention.
+        return vectorDataType == VectorDataType.FLOAT
+            && encoderType == Encoder.EncoderType.SQ
+            && (quantizationBits == Encoder.QuantizationBits.SIXTEEN || quantizationBits == Encoder.QuantizationBits.FULL_PRECISION);
+    }
+
+    public boolean isSQOneBit() {
         return encoderType == Encoder.EncoderType.SQ && quantizationBits == Encoder.QuantizationBits.ONE;
+    }
+
+    public boolean isFaissSQOneBit() {
+        return engine == KNNEngine.FAISS && isSQOneBit();
     }
 
     private boolean isMethodFlat() {

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.common.Nullable;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
@@ -14,6 +15,7 @@ import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsForm
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.CodecFormatResolver;
 import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 
 import java.util.Map;
 import java.util.Optional;
@@ -41,7 +43,8 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
 
     /**
      * Resolves the format for a specific field. Returns {@link Faiss1040ScalarQuantizedKnnVectorsFormat} when
-     * the encoder is sq with bits=1, otherwise falls back to the default native format.
+     * the encoder is sq with bits=1, otherwise falls back to the default native format. Prefers the resolved
+     * index spec when non-null; otherwise inspects the method component parameters.
      */
     @Override
     public KnnVectorsFormat resolve(
@@ -49,9 +52,11 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
         KNNMethodContext methodContext,
         Map<String, Object> params,
         int defaultMaxConnections,
-        int defaultBeamWidth
+        int defaultBeamWidth,
+        @Nullable ResolvedIndexSpec resolvedSpec
     ) {
-        if (isSQOneBitEncoder(params)) {
+        final boolean isSQOneBit = resolvedSpec != null ? resolvedSpec.isFaissSQOneBit() : isSQOneBitEncoder(params);
+        if (isSQOneBit) {
             return new Faiss1040ScalarQuantizedKnnVectorsFormat(nativeIndexBuildStrategyFactory);
         }
         return resolve();

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFP16Util.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissFP16Util.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.engine.faiss;
 
+import org.opensearch.knn.index.engine.Encoder.QuantizationBits;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.PerDimensionProcessor;
 import org.opensearch.knn.index.mapper.PerDimensionValidator;
@@ -101,7 +102,7 @@ public class FaissFP16Util {
         }
 
         Object bitsObj = encoderContext.getParameters().get(SQ_BITS);
-        if (bitsObj instanceof Integer && (Integer) bitsObj == FaissSQEncoder.Bits.ONE.getValue()) {
+        if (bitsObj instanceof Integer && (Integer) bitsObj == QuantizationBits.ONE.getValue()) {
             return false;
         }
 

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissHNSWMethod.java
@@ -268,7 +268,7 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
             }
             // bits is null for legacy pre-3.6.0 indexes which default to fp16
             Object bits = encoderMap.get(SQ_BITS);
-            return bits == null || (bits instanceof Integer && (Integer) bits == FaissSQEncoder.Bits.SIXTEEN.getValue());
+            return bits == null || (bits instanceof Integer && (Integer) bits == Encoder.QuantizationBits.SIXTEEN.getValue());
         } catch (final Exception e) {
             log.debug(e.getMessage());
             // Ignore
@@ -346,7 +346,7 @@ public class FaissHNSWMethod extends AbstractFaissMethod {
                 return false;
             }
             Object bits = encoderMap.get(SQ_BITS);
-            return bits instanceof Integer && (Integer) bits == FaissSQEncoder.Bits.ONE.getValue();
+            return bits instanceof Integer && (Integer) bits == Encoder.QuantizationBits.ONE.getValue();
         } catch (final Exception e) {
             log.error("Failed to check if method parameters contain an sq encoder with bits=1", e);
             // Ignore

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolver.java
@@ -119,7 +119,7 @@ public class FaissMethodResolver extends AbstractMethodResolver {
             // On 3.6.0+, also set bits for consistency with the new bits-based validation
             if (knnMethodConfigContext.getVersionCreated() != null
                 && knnMethodConfigContext.getVersionCreated().onOrAfter(Version.V_3_6_0)) {
-                encoderComponentContext.getParameters().put(SQ_BITS, FaissSQEncoder.Bits.SIXTEEN.getValue());
+                encoderComponentContext.getParameters().put(SQ_BITS, Encoder.QuantizationBits.SIXTEEN.getValue());
             }
         }
 
@@ -139,7 +139,7 @@ public class FaissMethodResolver extends AbstractMethodResolver {
             if (shouldUseSQOneBitForX32(knnMethodConfigContext, encoderMap)) {
                 encoderComponentContext = new MethodComponentContext(ENCODER_SQ, new HashMap<>());
                 encoder = encoderMap.get(ENCODER_SQ);
-                encoderComponentContext.getParameters().put(SQ_BITS, FaissSQEncoder.Bits.ONE.getValue());
+                encoderComponentContext.getParameters().put(SQ_BITS, Encoder.QuantizationBits.ONE.getValue());
             } else {
                 encoderComponentContext = new MethodComponentContext(QFrameBitEncoder.NAME, new HashMap<>());
                 encoder = encoderMap.get(QFrameBitEncoder.NAME);
@@ -157,7 +157,7 @@ public class FaissMethodResolver extends AbstractMethodResolver {
         // When auto-resolved to bits=1, remove the type and clip defaults that were injected —
         // the 1-bit quantization path doesn't use them, and validateEncoderConfig would reject them.
         if (encoderComponentContext.getParameters().get(SQ_BITS) instanceof Integer bitsVal
-            && bitsVal == FaissSQEncoder.Bits.ONE.getValue()) {
+            && bitsVal == Encoder.QuantizationBits.ONE.getValue()) {
             encoderComponentContext.getParameters().remove(FAISS_SQ_TYPE);
             encoderComponentContext.getParameters().remove(FAISS_SQ_CLIP);
         }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -6,8 +6,6 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import com.google.common.collect.ImmutableSet;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.opensearch.Version;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
@@ -21,14 +19,12 @@ import org.opensearch.knn.index.engine.TrainingConfigValidationInput;
 import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.FAISS_FLAT_DESCRIPTION;
@@ -62,28 +58,7 @@ import static org.opensearch.knn.common.KNNConstants.NAME;
 public class FaissSQEncoder implements Encoder {
 
     private static final Set<VectorDataType> SUPPORTED_DATA_TYPES = ImmutableSet.of(VectorDataType.FLOAT);
-    private static final Set<Integer> VALID_BITS = Arrays.stream(Bits.values()).map(Bits::getValue).collect(Collectors.toUnmodifiableSet());
-
-    /**
-     * Supported bit widths for SQ quantization. Each maps to a specific quantization strategy
-     * and compression level.
-     */
-    @Getter
-    @RequiredArgsConstructor
-    public enum Bits {
-        ONE(1, CompressionLevel.x32),
-        SIXTEEN(16, CompressionLevel.x2);
-
-        private final int value;
-        private final CompressionLevel compressionLevel;
-
-        public static Bits fromValue(int value) {
-            for (Bits b : values()) {
-                if (b.value == value) return b;
-            }
-            throw new IllegalArgumentException(String.format(Locale.ROOT, "Unsupported bits value: %d", value));
-        }
-    }
+    private static final Set<Integer> VALID_BITS = Set.of(QuantizationBits.ONE.getValue(), QuantizationBits.SIXTEEN.getValue());
 
     private final static MethodComponent METHOD_COMPONENT = MethodComponent.Builder.builder(ENCODER_SQ)
         .addSupportedDataTypes(SUPPORTED_DATA_TYPES)
@@ -104,7 +79,7 @@ public class FaissSQEncoder implements Encoder {
             Object bitsObj = params.get(SQ_BITS);
 
             // bits=1 path: 1-bit quantization — use flat description, Faiss only builds the HNSW graph
-            if (bitsObj instanceof Integer && (Integer) bitsObj == Bits.ONE.getValue()) {
+            if (bitsObj instanceof Integer && (Integer) bitsObj == QuantizationBits.ONE.getValue()) {
                 int bits = (Integer) bitsObj;
                 return KNNLibraryIndexingContextImpl.builder().parameters(new HashMap<>() {
                     {
@@ -135,7 +110,7 @@ public class FaissSQEncoder implements Encoder {
         if (methodComponentContext != null && methodComponentContext.getParameters().containsKey(SQ_BITS)) {
             Object bitsObj = methodComponentContext.getParameters().get(SQ_BITS);
             if (bitsObj instanceof Integer) {
-                return Bits.fromValue((Integer) bitsObj).getCompressionLevel();
+                return QuantizationBits.fromValue((Integer) bitsObj).getCompressionLevel();
             }
         }
         // Legacy path — type=fp16 is x2
@@ -187,11 +162,18 @@ public class FaissSQEncoder implements Encoder {
                 .build();
         }
 
+        // Reject invalid bits values with original error message (BWC)
+        if (bitsObj instanceof Integer && !VALID_BITS.contains((Integer) bitsObj)) {
+            return builder.valid(false)
+                .errorMessage(String.format(Locale.ROOT, "Unsupported bits value: %d. Supported values: %s", (Integer) bitsObj, VALID_BITS))
+                .build();
+        }
+
         if (bitsObj instanceof Integer) {
             int bits = (Integer) bitsObj;
 
             // type and clip is only applicable for fp16 (bits=16)
-            if (Bits.SIXTEEN.getValue() != bits) {
+            if (QuantizationBits.SIXTEEN.getValue() != bits) {
                 if (hasType) {
                     return builder.valid(false)
                         .errorMessage(
@@ -229,7 +211,7 @@ public class FaissSQEncoder implements Encoder {
             // Validate compression level compatibility if explicitly set
             CompressionLevel configuredCompression = configContext.getCompressionLevel();
             if (CompressionLevel.isConfigured(configuredCompression)) {
-                CompressionLevel expectedCompression = Bits.fromValue(bits).getCompressionLevel();
+                CompressionLevel expectedCompression = QuantizationBits.fromValue(bits).getCompressionLevel();
                 if (configuredCompression != expectedCompression) {
                     return builder.valid(false)
                         .errorMessage(
@@ -273,7 +255,7 @@ public class FaissSQEncoder implements Encoder {
             return false;
         }
         Object bits = encoderCtx.getParameters().get(SQ_BITS);
-        return bits instanceof Integer && (Integer) bits == Bits.ONE.getValue();
+        return bits instanceof Integer && (Integer) bits == QuantizationBits.ONE.getValue();
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.engine.faiss;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.opensearch.knn.index.engine.Encoder;
 
 /**
  * Configuration for the SQ (Scalar Quantization) encoder stored as a field attribute.
@@ -17,7 +18,7 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class SQConfig {
     @Builder.Default
-    private int bits = FaissSQEncoder.Bits.ONE.getValue();
+    private int bits = Encoder.QuantizationBits.ONE.getValue();
 
     public static final SQConfig EMPTY = SQConfig.builder().bits(0).build();
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolver.java
@@ -7,10 +7,12 @@ package org.opensearch.knn.index.engine.lucene;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.opensearch.common.Nullable;
 import org.opensearch.knn.index.codec.KnnVectorsFormatContext;
 import org.opensearch.knn.index.codec.LuceneVectorsFormatType;
 import org.opensearch.knn.index.codec.params.KNNScalarQuantizedVectorsFormatParams;
 import org.opensearch.knn.index.engine.CodecFormatResolver;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.Map;
@@ -53,7 +55,8 @@ public class LuceneCodecFormatResolver implements CodecFormatResolver {
         KNNMethodContext methodContext,
         Map<String, Object> params,
         int defaultMaxConnections,
-        int defaultBeamWidth
+        int defaultBeamWidth,
+        @Nullable ResolvedIndexSpec resolvedSpec
     ) {
         LuceneVectorsFormatType formatType = determineFormatType(field, methodContext, params, defaultMaxConnections, defaultBeamWidth);
         Function<KnnVectorsFormatContext, KnnVectorsFormat> factory = formatResolvers.get(formatType);

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.mapper;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.opensearch.Version;
@@ -91,7 +90,7 @@ public enum CompressionLevel {
     }
 
     /**
-     * Returns the appropriate {@link RescoreContext} based on the given {@code mode} and {@code dimension}.
+     * Returns the appropriate {@link RescoreContext} based on the given parameters.
      *
      * <p>If the {@code mode} is present in the valid {@code modesForRescore} set, the method checks the value of
      * {@code dimension}:
@@ -103,33 +102,14 @@ public enum CompressionLevel {
      * </ul>
      * If the {@code mode} is not valid, the method returns {@code null}.
      *
-     * @param mode      The {@link Mode} for which to retrieve the {@link RescoreContext}.
-     * @param dimension The dimensional value that determines the {@link RescoreContext} behavior.
-     * @return A {@link RescoreContext} with an oversample factor of 5.0f if {@code dimension} is less than
-     * or equal to 1000, the default {@link RescoreContext} if greater, or {@code null} if the mode
-     * is invalid.
+     * @param mode         The {@link Mode} for which to retrieve the {@link RescoreContext}.
+     * @param dimension    The dimensional value that determines the {@link RescoreContext} behavior.
+     * @param version      The index created version.
+     * @param isFlatMethod Whether the method is flat.
+     * @param isSQOneBit   Whether the encoder is sq with bits=1.
+     * @param engine       The KNN engine; may be null.
+     * @return A {@link RescoreContext} or {@code null} if the mode is not valid for rescoring.
      */
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version) {
-        return getDefaultRescoreContext(mode, dimension, version, false, false, null);
-    }
-
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod) {
-        return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, false, null);
-    }
-
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod, KNNEngine engine) {
-        return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, false, engine);
-    }
-
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod, boolean isSQOneBit) {
-        return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, isSQOneBit, null);
-    }
-
-    @VisibleForTesting
-    RescoreContext getDefaultRescoreContext(Mode mode, int dimension) {
-        return getDefaultRescoreContext(mode, dimension, Version.CURRENT, false, false, null);
-    }
-
     public RescoreContext getDefaultRescoreContext(
         Mode mode,
         int dimension,

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -195,11 +195,11 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
             this.fieldType.putAttribute(DIMENSION, String.valueOf(knnMappingConfig.getDimension()));
             this.fieldType.putAttribute(SPACE_TYPE, resolvedKnnMethodContext.getSpaceType().getValue());
 
-            if (isSQOneBitEncoder(resolvedKnnMethodContext)) {
-                // 1-bit quantization has its own per-field format that handles quantization internally, so we
-                // don't set qframe_config (which drives the k-NN quantization framework). Instead
-                // we store a separate sq config attribute as a quick way for readers to
-                // identify 1-bit quantized fields without parsing the full PARAMETERS JSON.
+            ResolvedIndexSpec spec = knnLibraryIndexingContext.getResolvedSpec();
+            if (spec != null && spec.usesFaissSQ1BitCodecFormat()) {
+                SQConfig sqConfig = SQConfig.builder().bits(spec.getQuantizationBits().getValue()).build();
+                this.fieldType.putAttribute(SQ_CONFIG, SQConfigParser.toCsv(sqConfig));
+            } else if (spec == null && isSQOneBitEncoder(resolvedKnnMethodContext)) {
                 this.fieldType.putAttribute(SQ_CONFIG, getSQConfigValue(resolvedKnnMethodContext));
             } else {
                 // Conditionally add quantization config

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -19,6 +19,7 @@ import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.VectorField;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
@@ -196,11 +197,11 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
             this.fieldType.putAttribute(SPACE_TYPE, resolvedKnnMethodContext.getSpaceType().getValue());
 
             ResolvedIndexSpec spec = knnLibraryIndexingContext.getResolvedSpec();
-            if (spec != null && spec.usesFaissSQ1BitCodecFormat()) {
+            // 1-bit quantization has its own per-field format that handles quantization internally,
+            // so we set sq_config instead of qframe_config
+            if (spec.isSQOneBit()) {
                 SQConfig sqConfig = SQConfig.builder().bits(spec.getQuantizationBits().getValue()).build();
                 this.fieldType.putAttribute(SQ_CONFIG, SQConfigParser.toCsv(sqConfig));
-            } else if (spec == null && isSQOneBitEncoder(resolvedKnnMethodContext)) {
-                this.fieldType.putAttribute(SQ_CONFIG, getSQConfigValue(resolvedKnnMethodContext));
             } else {
                 // Conditionally add quantization config
                 if (quantizationConfig != null && quantizationConfig != QuantizationConfig.EMPTY) {
@@ -336,7 +337,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         MethodComponentContext encoderCtx = (MethodComponentContext) methodContext.getMethodComponentContext()
             .getParameters()
             .get(METHOD_ENCODER_PARAMETER);
-        Object bits = encoderCtx.getParameters().getOrDefault(SQ_BITS, FaissSQEncoder.Bits.ONE.getValue());
+        Object bits = encoderCtx.getParameters().getOrDefault(SQ_BITS, Encoder.QuantizationBits.ONE.getValue());
         SQConfig config = SQConfig.builder().bits((Integer) bits).build();
         return SQConfigParser.toCsv(config);
     }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -121,11 +121,12 @@ public class KNNVectorFieldType extends MappedFieldType {
             this.alwaysUseMemoryOptimizedSearch = resolvedSpec.alwaysUseMemoryOptimizedSearch();
             this.memoryOptimizedSearchAvailable = resolvedSpec.isMemoryOptimizedEligible();
         } else {
+            // TODO: Remove fallback once all field mapper paths supply a ResolvedIndexSpec (model-based, flat)
             this.alwaysUseMemoryOptimizedSearch = MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(
-                knnMappingConfig.getKnnMethodContext()
+                annConfig.getKnnMethodContext()
             );
             this.memoryOptimizedSearchAvailable = MemoryOptimizedSearchSupportSpec.isSupportedFieldType(
-                knnMappingConfig.getKnnMethodContext(),
+                annConfig.getKnnMethodContext(),
                 annConfig.getQuantizationConfig(),
                 annConfig.getModelId()
             );
@@ -209,6 +210,10 @@ public class KNNVectorFieldType extends MappedFieldType {
         if (userProvidedContext != null) {
             return userProvidedContext;
         }
+        if (resolvedSpec != null) {
+            return resolvedSpec.getRescoreContext();
+        }
+        // TODO: Remove fallback once all field mapper paths supply a ResolvedIndexSpec
         final KNNMappingConfig knnMappingConfig = getKnnMappingConfig();
         final Optional<KNNMethodContext> methodContext = knnMappingConfig.getKnnMethodContext();
         final boolean isFlatMethod = methodContext.isPresent()

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldType.java
@@ -116,16 +116,21 @@ public class KNNVectorFieldType extends MappedFieldType {
         ResolvedIndexSpec resolvedSpec
     ) {
         this(name, metadata, vectorDataType, annConfig);
-        this.alwaysUseMemoryOptimizedSearch = MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(
-            knnMappingConfig.getKnnMethodContext()
-        );
-        this.memoryOptimizedSearchAvailable = MemoryOptimizedSearchSupportSpec.isSupportedFieldType(
-            knnMappingConfig.getKnnMethodContext(),
-            annConfig.getQuantizationConfig(),
-            annConfig.getModelId()
-        );
-        this.indexCreatedVersion = indexCreatedVersion;
         this.resolvedSpec = resolvedSpec;
+        if (resolvedSpec != null) {
+            this.alwaysUseMemoryOptimizedSearch = resolvedSpec.alwaysUseMemoryOptimizedSearch();
+            this.memoryOptimizedSearchAvailable = resolvedSpec.isMemoryOptimizedEligible();
+        } else {
+            this.alwaysUseMemoryOptimizedSearch = MemoryOptimizedSearchSupportSpec.isAlwaysUseMemoryOptimizedSearch(
+                knnMappingConfig.getKnnMethodContext()
+            );
+            this.memoryOptimizedSearchAvailable = MemoryOptimizedSearchSupportSpec.isSupportedFieldType(
+                knnMappingConfig.getKnnMethodContext(),
+                annConfig.getQuantizationConfig(),
+                annConfig.getModelId()
+            );
+        }
+        this.indexCreatedVersion = indexCreatedVersion;
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -482,9 +482,10 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             ResolvedIndexSpec spec = knnVectorFieldType.getResolvedSpec();
             if (spec != null) {
                 if (!spec.supportsRadialSearch()) {
-                    throw new UnsupportedOperationException("Radial search is not supported for indices which have quantization enabled");
+                    throw new UnsupportedOperationException("Radial search is not supported for this quantization configuration");
                 }
             } else {
+                // TODO: Remove fallback once all field mapper paths supply a ResolvedIndexSpec
                 knnVectorFieldType.validateSupportRadialSearch(knnEngine);
             }
         }
@@ -787,14 +788,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     }
 
     private static RescoreContext resolveRescore(KNNVectorFieldType fieldType, RescoreContext userContext) {
-        ResolvedIndexSpec spec = fieldType.getResolvedSpec();
-        if (spec == null) {
-            return fieldType.resolveRescoreContext(userContext);
-        }
-        if (userContext != null) {
-            return userContext;
-        }
-        return spec.getRescoreContext();
+        return fieldType.resolveRescoreContext(userContext);
     }
 
     @Getter

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -35,6 +35,7 @@ import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MemoryOptimizedSearchSupportSpec;
 import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.model.QueryContext;
 import org.opensearch.knn.index.mapper.KNNMappingConfig;
 import org.opensearch.knn.index.mapper.KNNVectorFieldType;
@@ -443,7 +444,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         MethodComponentContext methodComponentContext = queryConfigFromMapping.getMethodComponentContext();
         SpaceType spaceType = queryConfigFromMapping.getSpaceType();
         VectorDataType vectorDataType = queryConfigFromMapping.getVectorDataType();
-        RescoreContext processedRescoreContext = knnVectorFieldType.resolveRescoreContext(rescoreContext);
+        RescoreContext processedRescoreContext = resolveRescore(knnVectorFieldType, rescoreContext);
         // Transform the query vector if it's required. It will return `vector` itself if transform is not needed.
         // Otherwise, it will return a new transformed vector.
         final float[] transformedQueryVector = knnVectorFieldType.transformQueryVector(vector);
@@ -478,7 +479,14 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         }
 
         if (this.maxDistance != null || this.minScore != null) {
-            knnVectorFieldType.validateSupportRadialSearch(knnEngine);
+            ResolvedIndexSpec spec = knnVectorFieldType.getResolvedSpec();
+            if (spec != null) {
+                if (!spec.supportsRadialSearch()) {
+                    throw new UnsupportedOperationException("Radial search is not supported for indices which have quantization enabled");
+                }
+            } else {
+                knnVectorFieldType.validateSupportRadialSearch(knnEngine);
+            }
         }
 
         // Currently, k-NN supports distance and score types radial search
@@ -776,6 +784,17 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             }
         }
         return super.doRewrite(queryShardContext);
+    }
+
+    private static RescoreContext resolveRescore(KNNVectorFieldType fieldType, RescoreContext userContext) {
+        ResolvedIndexSpec spec = fieldType.getResolvedSpec();
+        if (spec == null) {
+            return fieldType.resolveRescoreContext(userContext);
+        }
+        if (userContext != null) {
+            return userContext;
+        }
+        return spec.getRescoreContext();
     }
 
     @Getter

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -10,7 +10,7 @@ import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.SpaceType;
-import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryHnswIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.binary.FaissBinaryIndex;
 import org.opensearch.knn.memoryoptsearch.faiss.cagra.FaissHNSWCagraIndex;
@@ -34,7 +34,7 @@ public class FaissFlatIndexFactory {
      */
     static FaissIndex createFlatIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
         if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
+            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue()) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
         }
         return null;

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -19,7 +19,7 @@ import org.opensearch.knn.index.KNNVectorSimilarityFunction;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.codec.KNN1040Codec.KNN1040ScalarQuantizedVectorScorer;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer;
-import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.plugin.script.KNNScoringUtil;
 
 import java.io.IOException;
@@ -86,7 +86,7 @@ public class FlatVectorsScorerProvider {
             // Since Lucene doesn't provide hamming distance scorer, we return our own hamming distance scorer
             return HAMMING_VECTOR_SCORER;
         } else if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
+            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == Encoder.QuantizationBits.ONE.getValue()) {
                 return getKNN1040ScalarQuantizedVectorScorer(delegateScorer);
             } else if (delegateScorer != null) {
                 // For all other cases, return the delegate scorer

--- a/src/test/java/org/opensearch/knn/index/Compression32XIT.java
+++ b/src/test/java/org/opensearch/knn/index/Compression32XIT.java
@@ -64,6 +64,7 @@ public class Compression32XIT extends KNNRestTestCase {
     private static final int HNSW_EF_CONSTRUCTION = 100;
     private static final int HNSW_EF_SEARCH = 100;
     private static final double MIN_RECALL_X32_L2 = 0.70;
+    private static final double MIN_RECALL_X32_IN_MEMORY = 0.60;
     private static final double MIN_RECALL_X32_IP = 0.60;
     private static final double MIN_RECALL_X32_COSINE = 0.70;
     private static final double MIN_RECALL_FP32 = 0.95;
@@ -379,8 +380,8 @@ public class Compression32XIT extends KNNRestTestCase {
         double recall = TestUtils.calculateRecallValue(searchResults, GROUND_TRUTH_L2, K);
         logger.info("[{}] x32 in-memory recall: {}", engineName, recall);
         assertTrue(
-            engineName + " x32 in-memory recall should be >= " + MIN_RECALL_X32_L2 + " but was " + recall,
-            recall >= MIN_RECALL_X32_L2
+            engineName + " x32 in-memory recall should be >= " + MIN_RECALL_X32_IN_MEMORY + " but was " + recall,
+            recall >= MIN_RECALL_X32_IN_MEMORY
         );
 
         // On-disk x32 with rescore disabled should produce different scores than in-memory (quantization effect)

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -186,7 +186,8 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
-            getMockParameterMap()
+            getMockParameterMap(),
+            null
         );
         assertEquals(S3, request.getRepositoryType());
         assertEquals(TEST_BUCKET, request.getContainerName());
@@ -206,7 +207,8 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
-            getMockSQOneBitParameterMap()
+            getMockSQOneBitParameterMap(),
+            null
         );
         assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
         assertTrue(request.isSkipStoredVectors());
@@ -218,7 +220,8 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
-            getMockFP16ParameterMap()
+            getMockFP16ParameterMap(),
+            null
         );
         assertEquals("half_float", request.getVectorDataType());
         assertFalse(request.isSkipStoredVectors());

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -17,6 +17,10 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.common.exception.TerminalIOException;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
+import org.opensearch.knn.index.mapper.CompressionLevel;
 import org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue;
 import org.opensearch.remoteindexbuild.model.RemoteBuildRequest;
 import org.opensearch.repositories.RepositoriesService;
@@ -181,13 +185,21 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
     }
 
     public void testBuildRequest() throws IOException {
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(2)
+            .build();
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
             getMockParameterMap(),
-            null
+            resolvedSpec
         );
         assertEquals(S3, request.getRepositoryType());
         assertEquals(TEST_BUCKET, request.getContainerName());
@@ -202,26 +214,44 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
     }
 
     public void testBuildRequestSQOneBit() throws IOException {
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(2)
+            .build();
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
             getMockSQOneBitParameterMap(),
-            null
+            resolvedSpec
         );
         assertEquals(VectorDataType.FLOAT.getValue(), request.getVectorDataType());
         assertTrue(request.isSkipStoredVectors());
     }
 
     public void testBuildRequestFP16() throws IOException {
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x2)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(2)
+            .build();
         RemoteBuildRequest request = RemoteIndexBuildStrategy.buildRemoteBuildRequest(
             createTestIndexSettings(),
             buildIndexParams,
             createTestRepositoryMetadata(),
             MOCK_FULL_PATH,
             getMockFP16ParameterMap(),
-            null
+            resolvedSpec
         );
         assertEquals("half_float", request.getVectorDataType());
         assertFalse(request.isSkipStoredVectors());

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecBWCTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecBWCTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.Version;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_BINARY;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
+
+public class ResolvedIndexSpecBWCTests extends KNNTestCase {
+
+    public void testOldStyleSQEncoderParams_resolvesCorrectly() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(SQ_BITS, 1);
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, encoderParams);
+
+        Map<String, Object> methodParams = new HashMap<>();
+        methodParams.put(METHOD_ENCODER_PARAMETER, encoderCtx);
+
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, methodParams)
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.ON_DISK)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(Encoder.EncoderType.SQ, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.ONE, spec.getQuantizationBits());
+    }
+
+    public void testOldStyleBQEncoderParams_resolvesCorrectly() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put("bits", 1);
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_BINARY, encoderParams);
+
+        Map<String, Object> methodParams = new HashMap<>();
+        methodParams.put(METHOD_ENCODER_PARAMETER, encoderCtx);
+
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, methodParams)
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.ON_DISK)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(Encoder.EncoderType.BQ, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.ONE, spec.getQuantizationBits());
+    }
+
+    public void testNoEncoder_defaultsToFlat() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(Encoder.EncoderType.FLAT, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.FULL_PRECISION, spec.getQuantizationBits());
+    }
+
+    public void testSQWith16Bits_resolvesCorrectly() {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(SQ_BITS, 16);
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, encoderParams);
+
+        Map<String, Object> methodParams = new HashMap<>();
+        methodParams.put(METHOD_ENCODER_PARAMETER, encoderCtx);
+
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, methodParams)
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x2)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        assertNotNull(ctx);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertNotNull(spec);
+        assertEquals(Encoder.EncoderType.SQ, spec.getEncoderType());
+        assertEquals(Encoder.QuantizationBits.SIXTEEN, spec.getQuantizationBits());
+    }
+
+    public void testMethodComponentContextSerialization_unchanged() throws IOException {
+        Map<String, Object> encoderParams = new HashMap<>();
+        encoderParams.put(SQ_BITS, 1);
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, encoderParams);
+
+        Map<String, Object> methodParams = new HashMap<>();
+        methodParams.put(METHOD_ENCODER_PARAMETER, encoderCtx);
+        MethodComponentContext original = new MethodComponentContext(METHOD_HNSW, methodParams);
+
+        BytesStreamOutput streamOutput = new BytesStreamOutput();
+        original.writeTo(streamOutput);
+
+        MethodComponentContext deserialized = new MethodComponentContext(streamOutput.bytes().streamInput());
+        assertEquals(original, deserialized);
+        assertEquals(original.getName(), deserialized.getName());
+        assertEquals(original.getParameters().size(), deserialized.getParameters().size());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecConsumerTests.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.KNNMappingConfig;
+import org.opensearch.knn.index.mapper.KNNVectorFieldType;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.opensearch.knn.common.KNNConstants.ENCODER_FLAT;
+import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
+
+/**
+ * Tests verifying that consumers reading from ResolvedIndexSpec produce identical
+ * behavior to the old param-map based paths. These are BWC equivalence tests for
+ * the consumer switchover (PR 3).
+ */
+public class ResolvedIndexSpecConsumerTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "test-field";
+
+    public void testMemoryOptimizedSearch_specProducesSameAsOldPath_SQ1Bit() {
+        KNNVectorFieldType oldPathFieldType = buildFieldTypeWithoutSpec(buildSQ1BitMethodContext(), 128);
+        KNNVectorFieldType specPathFieldType = buildFieldTypeWithSpec(buildSQ1BitMethodContext(), 128, buildSQ1BitSpec());
+
+        assertEquals(oldPathFieldType.isAlwaysUseMemoryOptimizedSearch(), specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertEquals(oldPathFieldType.isMemoryOptimizedSearchAvailable(), specPathFieldType.isMemoryOptimizedSearchAvailable());
+        assertTrue(specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertTrue(specPathFieldType.isMemoryOptimizedSearchAvailable());
+    }
+
+    public void testMemoryOptimizedSearch_specProducesSameAsOldPath_FlatEncoder() {
+        KNNMethodContext flatMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_FLAT, Collections.emptyMap()))
+            )
+        );
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x1)
+            .mode(Mode.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNVectorFieldType oldPathFieldType = buildFieldTypeWithoutSpec(flatMethodContext, 128);
+        KNNVectorFieldType specPathFieldType = buildFieldTypeWithSpec(flatMethodContext, 128, spec);
+
+        assertEquals(oldPathFieldType.isAlwaysUseMemoryOptimizedSearch(), specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertEquals(oldPathFieldType.isMemoryOptimizedSearchAvailable(), specPathFieldType.isMemoryOptimizedSearchAvailable());
+        assertFalse(specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertTrue(specPathFieldType.isMemoryOptimizedSearchAvailable());
+    }
+
+    public void testMemoryOptimizedSearch_specProducesFalseForLucene() {
+        KNNMethodContext luceneMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Collections.emptyMap())
+        );
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.LUCENE)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x1)
+            .mode(Mode.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNVectorFieldType specPathFieldType = buildFieldTypeWithSpec(luceneMethodContext, 128, spec);
+        assertFalse(specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertFalse(specPathFieldType.isMemoryOptimizedSearchAvailable());
+    }
+
+    public void testRescore_specProducesSameResult_SQ1Bit() {
+        ResolvedIndexSpec spec = buildSQ1BitSpec();
+        RescoreContext rescoreContext = spec.getRescoreContext();
+        assertNotNull(rescoreContext);
+        assertEquals(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR, rescoreContext.getOversampleFactor(), 0.001f);
+        assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
+    }
+
+    public void testRescore_specProducesSameResult_x32OnDisk() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(500)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        RescoreContext rescoreContext = spec.getRescoreContext();
+        assertNotNull(rescoreContext);
+        assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.001f);
+    }
+
+    public void testRescore_specReturnsNull_forNoCompression() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.x1)
+            .mode(Mode.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        assertNull(spec.getRescoreContext());
+    }
+
+    public void testRadialSearch_specMatchesOldBehavior_SQ1BitSupported() {
+        ResolvedIndexSpec spec = buildSQ1BitSpec();
+        assertTrue(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_specMatchesOldBehavior_x32HNSWNotSupported() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testRadialSearch_specMatchesOldBehavior_binaryNotSupported() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.BINARY)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        assertFalse(spec.supportsRadialSearch());
+    }
+
+    public void testNullSpec_fallsBackToOldPath() {
+        KNNVectorFieldType fieldType = buildFieldTypeWithoutSpec(buildSQ1BitMethodContext(), 128);
+        assertNull(fieldType.getResolvedSpec());
+        assertTrue(fieldType.isAlwaysUseMemoryOptimizedSearch());
+        assertTrue(fieldType.isMemoryOptimizedSearchAvailable());
+    }
+
+    public void testSQ1BitCodecFormat_viaSPec() {
+        ResolvedIndexSpec spec = buildSQ1BitSpec();
+        assertTrue(spec.usesFaissSQ1BitCodecFormat());
+    }
+
+    public void testSQ16Bit_notSQ1BitCodecFormat() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x2)
+            .mode(Mode.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        assertFalse(spec.usesFaissSQ1BitCodecFormat());
+    }
+
+    // --- Helpers ---
+
+    private KNNMethodContext buildSQ1BitMethodContext() {
+        return new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext(ENCODER_SQ, Map.of("bits", 1)))
+            )
+        );
+    }
+
+    private ResolvedIndexSpec buildSQ1BitSpec() {
+        return ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+    }
+
+    private KNNVectorFieldType buildFieldTypeWithoutSpec(KNNMethodContext methodContext, int dimension) {
+        KNNMappingConfig mappingConfig = new KNNMappingConfig() {
+            @Override
+            public Optional<KNNMethodContext> getKnnMethodContext() {
+                return Optional.of(methodContext);
+            }
+
+            @Override
+            public int getDimension() {
+                return dimension;
+            }
+        };
+        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT);
+    }
+
+    private KNNVectorFieldType buildFieldTypeWithSpec(KNNMethodContext methodContext, int dimension, ResolvedIndexSpec spec) {
+        KNNMappingConfig mappingConfig = new KNNMappingConfig() {
+            @Override
+            public Optional<KNNMethodContext> getKnnMethodContext() {
+                return Optional.of(methodContext);
+            }
+
+            @Override
+            public int getDimension() {
+                return dimension;
+            }
+        };
+        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT, spec);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecConsumerTests.java
@@ -34,11 +34,8 @@ public class ResolvedIndexSpecConsumerTests extends KNNTestCase {
     private static final String FIELD_NAME = "test-field";
 
     public void testMemoryOptimizedSearch_specProducesSameAsOldPath_SQ1Bit() {
-        KNNVectorFieldType oldPathFieldType = buildFieldTypeWithoutSpec(buildSQ1BitMethodContext(), 128);
         KNNVectorFieldType specPathFieldType = buildFieldTypeWithSpec(buildSQ1BitMethodContext(), 128, buildSQ1BitSpec());
 
-        assertEquals(oldPathFieldType.isAlwaysUseMemoryOptimizedSearch(), specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
-        assertEquals(oldPathFieldType.isMemoryOptimizedSearchAvailable(), specPathFieldType.isMemoryOptimizedSearchAvailable());
         assertTrue(specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
         assertTrue(specPathFieldType.isMemoryOptimizedSearchAvailable());
     }
@@ -64,11 +61,8 @@ public class ResolvedIndexSpecConsumerTests extends KNNTestCase {
             .indexVersionCreated(Version.CURRENT)
             .build();
 
-        KNNVectorFieldType oldPathFieldType = buildFieldTypeWithoutSpec(flatMethodContext, 128);
         KNNVectorFieldType specPathFieldType = buildFieldTypeWithSpec(flatMethodContext, 128, spec);
 
-        assertEquals(oldPathFieldType.isAlwaysUseMemoryOptimizedSearch(), specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
-        assertEquals(oldPathFieldType.isMemoryOptimizedSearchAvailable(), specPathFieldType.isMemoryOptimizedSearchAvailable());
         assertFalse(specPathFieldType.isAlwaysUseMemoryOptimizedSearch());
         assertTrue(specPathFieldType.isMemoryOptimizedSearchAvailable());
     }
@@ -173,13 +167,15 @@ public class ResolvedIndexSpecConsumerTests extends KNNTestCase {
     public void testNullSpec_fallsBackToOldPath() {
         KNNVectorFieldType fieldType = buildFieldTypeWithoutSpec(buildSQ1BitMethodContext(), 128);
         assertNull(fieldType.getResolvedSpec());
+        // Fallback computes MOS flags from mapping config: SQ 1-bit always uses MOS
         assertTrue(fieldType.isAlwaysUseMemoryOptimizedSearch());
+        // isSupportedFieldType requires Faiss HNSW with FLAT/SQ/BQ + no model, which this satisfies
         assertTrue(fieldType.isMemoryOptimizedSearchAvailable());
     }
 
     public void testSQ1BitCodecFormat_viaSPec() {
         ResolvedIndexSpec spec = buildSQ1BitSpec();
-        assertTrue(spec.usesFaissSQ1BitCodecFormat());
+        assertTrue(spec.isFaissSQOneBit());
     }
 
     public void testSQ16Bit_notSQ1BitCodecFormat() {
@@ -194,7 +190,7 @@ public class ResolvedIndexSpecConsumerTests extends KNNTestCase {
             .dimension(128)
             .indexVersionCreated(Version.CURRENT)
             .build();
-        assertFalse(spec.usesFaissSQ1BitCodecFormat());
+        assertFalse(spec.isFaissSQOneBit());
     }
 
     // --- Helpers ---

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecTests.java
@@ -21,7 +21,7 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
 
     public void testFaissSQ1BitUsesSQ1BitCodecFormat() {
         ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
-        assertTrue(spec.usesFaissSQ1BitCodecFormat());
+        assertTrue(spec.isFaissSQOneBit());
         assertTrue(spec.alwaysUseMemoryOptimizedSearch());
         assertTrue(spec.isMemoryOptimizedEligible());
         assertTrue(spec.requiresRescore());
@@ -29,8 +29,8 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
 
     public void testLuceneSQ1BitDoesNotUseSQ1BitCodecFormat() {
         ResolvedIndexSpec spec = baseFaissSQ1Bit().engine(KNNEngine.LUCENE).build();
-        assertFalse(spec.usesFaissSQ1BitCodecFormat());
-        assertFalse(spec.alwaysUseMemoryOptimizedSearch());
+        assertFalse(spec.isFaissSQOneBit());
+        assertTrue(spec.alwaysUseMemoryOptimizedSearch());
     }
 
     // --- Memory optimized eligibility ---
@@ -209,6 +209,57 @@ public class ResolvedIndexSpecTests extends KNNTestCase {
     }
 
     // --- Helpers ---
+
+    // --- Coverage: alwaysUseMemoryOptimizedSearch engine-agnostic ---
+
+    public void testAlwaysUseMemoryOptimizedSearch() {
+        assertTrue("SQ 1-bit Faiss should always use memory optimized search", baseFaissSQ1Bit().build().alwaysUseMemoryOptimizedSearch());
+        assertTrue(
+            "SQ 1-bit Lucene should always use memory optimized search",
+            baseFaissSQ1Bit().engine(KNNEngine.LUCENE).build().alwaysUseMemoryOptimizedSearch()
+        );
+        assertFalse(
+            "SQ 16-bit should not always use memory optimized search",
+            baseFaiss().encoderType(Encoder.EncoderType.SQ)
+                .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+                .compressionLevel(CompressionLevel.x2)
+                .build()
+                .alwaysUseMemoryOptimizedSearch()
+        );
+        assertFalse("Flat encoder should not always use memory optimized search", baseFaiss().build().alwaysUseMemoryOptimizedSearch());
+    }
+
+    // --- Coverage: isFaissSQOneBit is Faiss-only ---
+
+    public void testIsFaissSQOneBit_FaissSQ1Bit_true() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
+        assertTrue(spec.isFaissSQOneBit());
+    }
+
+    public void testIsFaissSQOneBit_LuceneSQ1Bit_false() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().engine(KNNEngine.LUCENE).build();
+        assertFalse(spec.isFaissSQOneBit());
+    }
+
+    // --- Coverage: isSQOneBit public method ---
+
+    public void testIsSQOneBit_true() {
+        ResolvedIndexSpec spec = baseFaissSQ1Bit().build();
+        assertTrue(spec.isSQOneBit());
+    }
+
+    public void testIsSQOneBit_false_forSQ16() {
+        ResolvedIndexSpec spec = baseFaiss().encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x2)
+            .build();
+        assertFalse(spec.isSQOneBit());
+    }
+
+    public void testIsSQOneBit_false_forFlat() {
+        ResolvedIndexSpec spec = baseFaiss().build();
+        assertFalse(spec.isSQOneBit());
+    }
 
     private ResolvedIndexSpec.ResolvedIndexSpecBuilder baseFaiss() {
         return ResolvedIndexSpec.builder()

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolverTests.java
@@ -112,7 +112,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 1));
         Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);
 
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertTrue(
             "Expected Faiss104ScalarQuantizedKnnVectorsFormat but got " + result.getClass().getSimpleName(),
             result instanceof Faiss1040ScalarQuantizedKnnVectorsFormat
@@ -130,7 +130,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
             mock(NativeIndexBuildStrategyFactory.class)
         );
 
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, Map.of(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertTrue(
             "Expected NativeEngines990KnnVectorsFormat but got " + result.getClass().getSimpleName(),
             result instanceof NativeEngines990KnnVectorsFormat
@@ -151,7 +151,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         MethodComponentContext encoderContext = new MethodComponentContext("sq", Map.of());
         Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);
 
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertTrue(
             "Expected NativeEngines990KnnVectorsFormat but got " + result.getClass().getSimpleName(),
             result instanceof NativeEngines990KnnVectorsFormat
@@ -169,7 +169,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
             mock(NativeIndexBuildStrategyFactory.class)
         );
         // Null params should fall back to default native format
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, null, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, null, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertTrue(
             "Expected NativeEngines990KnnVectorsFormat but got " + result.getClass().getSimpleName(),
             result instanceof NativeEngines990KnnVectorsFormat
@@ -190,7 +190,7 @@ public class FaissCodecFormatResolverTests extends KNNTestCase {
         MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
         Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderContext);
 
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, null, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertTrue(
             "SQ with bits=16 should return NativeEngines990KnnVectorsFormat, got " + result.getClass().getSimpleName(),
             result instanceof NativeEngines990KnnVectorsFormat

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissFP16UtilTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissFP16UtilTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.Encoder.QuantizationBits;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 
 import java.util.HashMap;
@@ -85,7 +86,7 @@ public class FaissFP16UtilTests extends KNNTestCase {
 
     public void testIsFaissSQfp16_sqEncoderWithBits1_returnsFalse() {
         Map<String, Object> encoderParams = new HashMap<>();
-        encoderParams.put(SQ_BITS, FaissSQEncoder.Bits.ONE.getValue());
+        encoderParams.put(SQ_BITS, QuantizationBits.ONE.getValue());
         MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
         Map<String, Object> params = new HashMap<>();
         params.put(METHOD_ENCODER_PARAMETER, encoderContext);
@@ -105,7 +106,7 @@ public class FaissFP16UtilTests extends KNNTestCase {
 
     public void testIsFaissSQfp16_sqEncoderWithBits16_returnsTrue() {
         Map<String, Object> encoderParams = new HashMap<>();
-        encoderParams.put(SQ_BITS, FaissSQEncoder.Bits.SIXTEEN.getValue());
+        encoderParams.put(SQ_BITS, QuantizationBits.SIXTEEN.getValue());
         encoderParams.put(FAISS_SQ_TYPE, FAISS_SQ_ENCODER_FP16);
         MethodComponentContext encoderContext = new MethodComponentContext(ENCODER_SQ, encoderParams);
         Map<String, Object> params = new HashMap<>();

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneCodecFormatResolverTests.java
@@ -58,7 +58,14 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         );
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, flatContext, Collections.emptyMap(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(
+            TEST_FIELD,
+            flatContext,
+            Collections.emptyMap(),
+            DEFAULT_MAX_CONN,
+            DEFAULT_BEAM_WIDTH,
+            null
+        );
         assertSame(FLAT_FORMAT, result);
     }
 
@@ -81,7 +88,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         );
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertSame(SQ_FORMAT, result);
     }
 
@@ -99,7 +106,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
         Map<String, Object> params = Map.of(METHOD_PARAMETER_M, 32, METHOD_PARAMETER_EF_CONSTRUCTION, 256);
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, hnswContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, hnswContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertSame(HNSW_FORMAT, result);
     }
 
@@ -119,7 +126,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
         IllegalStateException ex = expectThrows(
             IllegalStateException.class,
-            () -> resolver.resolve(TEST_FIELD, flatContext, Collections.emptyMap(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH)
+            () -> resolver.resolve(TEST_FIELD, flatContext, Collections.emptyMap(), DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null)
         );
         assertTrue(ex.getMessage().contains("FLAT"));
     }
@@ -147,7 +154,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         );
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
-        resolver.resolve(TEST_FIELD, methodContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        resolver.resolve(TEST_FIELD, methodContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
 
         assertNotNull(capturedContext[0]);
         assertEquals(TEST_FIELD, capturedContext[0].getField());
@@ -170,7 +177,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         );
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, hnswContext, null, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, hnswContext, null, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertSame(HNSW_FORMAT, result);
     }
 
@@ -199,7 +206,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         );
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
-        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        KnnVectorsFormat result = resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
         assertSame("SQ with bits=1 should route to SCALAR_QUANTIZED resolver", SQ_FORMAT, result);
     }
 
@@ -227,7 +234,7 @@ public class LuceneCodecFormatResolverTests extends KNNTestCase {
         );
 
         LuceneCodecFormatResolver resolver = new LuceneCodecFormatResolver(resolvers);
-        resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+        resolver.resolve(TEST_FIELD, sqContext, params, DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH, null);
 
         assertNotNull(capturedContext[0]);
         assertEquals(TEST_FIELD, capturedContext[0].getField());

--- a/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/CompressionLevelTests.java
@@ -7,8 +7,8 @@ package org.opensearch.knn.index.mapper;
 
 import org.opensearch.core.common.Strings;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.engine.Encoder.QuantizationBits;
 import org.opensearch.knn.index.engine.KNNEngine;
-import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
 import org.opensearch.knn.index.engine.lucene.LuceneSQEncoder;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
@@ -54,72 +54,86 @@ public class CompressionLevelTests extends KNNTestCase {
         int aboveThresholdDimension = 1500; // A dimension above the threshold
 
         // x32 with dimension <= 1000 should have an oversample factor of 5.0f
-        RescoreContext rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, belowThresholdDimension);
+        RescoreContext rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(
+            mode,
+            belowThresholdDimension,
+            Version.CURRENT,
+            false,
+            false,
+            null
+        );
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
         // x32 with dimension > 1000 should have an oversample factor of 3.0f
-        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, aboveThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
         // x16 with dimension <= 1000 should have an oversample factor of 5.0f
-        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, belowThresholdDimension);
+        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
         // x16 with dimension > 1000 should have an oversample factor of 3.0f
-        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        rescoreContext = CompressionLevel.x16.getDefaultRescoreContext(mode, aboveThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(3.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
         // x8 with dimension <= 1000 should have an oversample factor of 5.0f
-        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, belowThresholdDimension);
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
         // x8 with dimension > 1000 should have an oversample factor of 2.0f
-        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(mode, aboveThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(2.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
 
-        // x4 with dimension <= 1000 should have an oversample factor of 5.0f
-        rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, belowThresholdDimension);
+        // x4 with dimension <= 1000 should have an oversample factor of 1.0f
+        rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
         // x4 with dimension > 1000 should have an oversample factor of 1.0f
-        rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        rescoreContext = CompressionLevel.x4.getDefaultRescoreContext(mode, aboveThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(1.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertTrue(rescoreContext.isRescoreEnabled());
         assertFalse(rescoreContext.isUserProvided());
         // Other compression levels should behave similarly with respect to dimension
-        rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, belowThresholdDimension);
+        rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, false, null);
         assertNull(rescoreContext);
         // x2 with dimension > 1000 should return null
-        rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        rescoreContext = CompressionLevel.x2.getDefaultRescoreContext(mode, aboveThresholdDimension, Version.CURRENT, false, false, null);
         assertNull(rescoreContext);
-        rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, belowThresholdDimension);
+        rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, false, null);
         assertNull(rescoreContext);
         // x1 with dimension > 1000 should return null
-        rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, aboveThresholdDimension);
+        rescoreContext = CompressionLevel.x1.getDefaultRescoreContext(mode, aboveThresholdDimension, Version.CURRENT, false, false, null);
         assertNull(rescoreContext);
-        // NOT_CONFIGURED with dimension <= 1000 should return a RescoreContext with an oversample factor of 5.0f
-        rescoreContext = CompressionLevel.NOT_CONFIGURED.getDefaultRescoreContext(mode, belowThresholdDimension);
+        // NOT_CONFIGURED with dimension <= 1000 should return null
+        rescoreContext = CompressionLevel.NOT_CONFIGURED.getDefaultRescoreContext(
+            mode,
+            belowThresholdDimension,
+            Version.CURRENT,
+            false,
+            false,
+            null
+        );
         assertNull(rescoreContext);
 
         // These tests test the 32x compression techniques, ensure that the correct rescoring factor is set for FAISS ADC/RR and Lucene
@@ -128,6 +142,7 @@ public class CompressionLevelTests extends KNNTestCase {
             mode,
             belowThresholdDimension,
             Version.CURRENT,
+            false,
             false,
             KNNEngine.LUCENE
         );
@@ -141,6 +156,7 @@ public class CompressionLevelTests extends KNNTestCase {
             aboveThresholdDimension,
             Version.CURRENT,
             false,
+            false,
             KNNEngine.LUCENE
         );
         assertNotNull(rescoreContext);
@@ -153,6 +169,7 @@ public class CompressionLevelTests extends KNNTestCase {
             belowThresholdDimension,
             Version.CURRENT,
             false,
+            false,
             KNNEngine.FAISS
         );
         assertNotNull(rescoreContext);
@@ -160,7 +177,7 @@ public class CompressionLevelTests extends KNNTestCase {
         assertFalse(rescoreContext.isUserProvided());
 
         // x32 with null engine should return default behavior
-        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, null);
+        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(mode, belowThresholdDimension, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(5.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertFalse(rescoreContext.isUserProvided());
@@ -171,15 +188,17 @@ public class CompressionLevelTests extends KNNTestCase {
         RescoreContext rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(
             Mode.NOT_CONFIGURED,
             500,
-            org.opensearch.Version.CURRENT,
-            true
+            Version.CURRENT,
+            true,
+            false,
+            null
         );
         assertNotNull(rescoreContext);
         assertEquals(2.0f, rescoreContext.getOversampleFactor(), 0.0f);
         assertFalse(rescoreContext.isUserProvided());
 
         // isFlatMethod=false on x32 with NOT_CONFIGURED mode should return null (no mode for rescore)
-        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(Mode.NOT_CONFIGURED, 500, Version.CURRENT, false);
+        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(Mode.NOT_CONFIGURED, 500, Version.CURRENT, false, false, null);
         assertNull(rescoreContext);
     }
 
@@ -190,7 +209,8 @@ public class CompressionLevelTests extends KNNTestCase {
             500,
             Version.CURRENT,
             false,
-            true
+            true,
+            null
         );
         assertNotNull(rescoreContext);
         assertEquals(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR, rescoreContext.getOversampleFactor(), 0.0f);
@@ -198,7 +218,7 @@ public class CompressionLevelTests extends KNNTestCase {
         assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
 
         // sq(bits=1) should also work with ON_DISK mode and high dimension
-        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(Mode.ON_DISK, 1500, Version.CURRENT, false, true);
+        rescoreContext = CompressionLevel.x32.getDefaultRescoreContext(Mode.ON_DISK, 1500, Version.CURRENT, false, true, null);
         assertNotNull(rescoreContext);
         assertEquals(RescoreContext.FAISS_SCALAR_QUANTIZED_INDEX_OVERSAMPLE_FACTOR, rescoreContext.getOversampleFactor(), 0.0f);
         assertFalse(rescoreContext.isAllowOverrideOversampleFactor());
@@ -206,13 +226,20 @@ public class CompressionLevelTests extends KNNTestCase {
 
     public void testGetDefaultRescoreContext_whenNonSQOneBitEncoder_thenFallsBackToNormalLogic() {
         // Non-sq(bits=1) encoder should fall through to normal compression level logic
-        RescoreContext rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(Mode.ON_DISK, 500, Version.CURRENT, false, false);
+        RescoreContext rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(
+            Mode.ON_DISK,
+            500,
+            Version.CURRENT,
+            false,
+            false,
+            null
+        );
         assertNotNull(rescoreContext);
         // x8 with dimension <= 1000 should use 5.0f oversample (normal logic)
         assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
 
         // null encoder should also fall through
-        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(Mode.ON_DISK, 500, Version.CURRENT, false, false);
+        rescoreContext = CompressionLevel.x8.getDefaultRescoreContext(Mode.ON_DISK, 500, Version.CURRENT, false, false, null);
         assertNotNull(rescoreContext);
         assertEquals(RescoreContext.OVERSAMPLE_FACTOR_BELOW_DIMENSION_THRESHOLD, rescoreContext.getOversampleFactor(), 0.0f);
     }
@@ -220,8 +247,8 @@ public class CompressionLevelTests extends KNNTestCase {
     public void testX32MapsToOneBitQuantization() {
         assertEquals(1, CompressionLevel.x32.numBitsForFloat32());
 
-        assertEquals(CompressionLevel.x32, FaissSQEncoder.Bits.ONE.getCompressionLevel());
-        assertEquals(1, FaissSQEncoder.Bits.ONE.getValue());
+        assertEquals(CompressionLevel.x32, QuantizationBits.ONE.getCompressionLevel());
+        assertEquals(1, QuantizationBits.ONE.getValue());
 
         assertEquals(CompressionLevel.x32, LuceneSQEncoder.Bits.ONE.getCompressionLevel());
         assertEquals(1, LuceneSQEncoder.Bits.ONE.getValue());
@@ -279,7 +306,7 @@ public class CompressionLevelTests extends KNNTestCase {
     }
 
     public void testX32ConsistentAcrossEngineEncoders() {
-        FaissSQEncoder.Bits faissBits1 = FaissSQEncoder.Bits.fromValue(1);
+        QuantizationBits faissBits1 = QuantizationBits.fromValue(1);
         LuceneSQEncoder.Bits luceneBits1 = LuceneSQEncoder.Bits.fromValue(1);
 
         assertEquals(faissBits1.getCompressionLevel(), luceneBits1.getCompressionLevel());

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldTypeTests.java
@@ -64,7 +64,6 @@ public class KNNVectorFieldTypeTests extends KNNTestCase {
         assertSame(userContext, buildFlatFieldType().resolveRescoreContext(userContext));
     }
 
-    // After resolution, flat method always has x32 compression set in the mapping config
     private KNNVectorFieldType buildFlatFieldType() {
         KNNMethodContext flatMethodContext = new KNNMethodContext(
             KNNEngine.LUCENE,
@@ -87,7 +86,16 @@ public class KNNVectorFieldTypeTests extends KNNTestCase {
                 return CompressionLevel.x32;
             }
         };
-        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig);
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.LUCENE)
+            .methodName(METHOD_FLAT)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .compressionLevel(CompressionLevel.x32)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT, spec);
     }
 
     public void testKNNVectorFieldType_whenSQOneBitEncoder_thenAlwaysUseMemoryOptimizedSearchIsTrue() {
@@ -127,7 +135,18 @@ public class KNNVectorFieldTypeTests extends KNNTestCase {
             )
         );
         KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(sqOneBitMethodContext, 128);
-        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT);
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT, spec);
     }
 
     public void testKNNVectorFieldType_resolvedSpecStoredWhenProvided() {
@@ -188,12 +207,22 @@ public class KNNVectorFieldTypeTests extends KNNTestCase {
             )
         );
         KNNMappingConfig mappingConfig = getMappingConfigForMethodMapping(flatMethodContext, 128);
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.FLAT)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
         KNNVectorFieldType fieldType = new KNNVectorFieldType(
             FIELD_NAME,
             Collections.emptyMap(),
             VectorDataType.FLOAT,
             mappingConfig,
-            Version.CURRENT
+            Version.CURRENT,
+            spec
         );
         assertFalse(fieldType.isAlwaysUseMemoryOptimizedSearch());
         assertTrue(fieldType.isMemoryOptimizedSearchAvailable());

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -46,8 +46,10 @@ import org.opensearch.knn.index.query.lucene.LuceneEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.knn.index.util.KNNClusterUtil;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponentContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -485,9 +487,15 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         );
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.HAMMING, methodComponentContext);
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(knnMethodContext, 8));
-        doCallRealMethod().when(mockKNNVectorField).validateSupportRadialSearch(any(KNNEngine.class));
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .vectorDataType(VectorDataType.BINARY)
+            .dimension(8)
+            .build();
+        when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
         Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
-        assertTrue(e.getMessage().contains("Binary data type does not support radial search"));
+        assertTrue(e.getMessage().contains("Radial search is not supported"));
     }
 
     public void testDoToQuery_whenRadialSearchOnDiskMode_thenException() {
@@ -531,12 +539,20 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         };
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(bqMappingConfig);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        // Call real validateSupportRadialSearch() so it uses the mocked fields
-        doCallRealMethod().when(mockKNNVectorField).validateSupportRadialSearch(any(KNNEngine.class));
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x4)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(1)
+            .build();
+        when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
 
         // When/Then: BQ (QuantizationConfig != EMPTY) is still blocked for radial search
         Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
-        assertTrue(e.getMessage().contains("binary quantization"));
+        assertEquals("Radial search is not supported for this quantization configuration", e.getMessage());
     }
 
     // Given: a Faiss index with unsupported SQ compression level (x4, x8, x16)
@@ -552,7 +568,12 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, methodComponentContext);
 
         CompressionLevel[] unsupportedLevels = { CompressionLevel.x4, CompressionLevel.x8, CompressionLevel.x16 };
-        for (CompressionLevel level : unsupportedLevels) {
+        Encoder.QuantizationBits[] unsupportedBits = {
+            Encoder.QuantizationBits.SEVEN,
+            Encoder.QuantizationBits.FOUR,
+            Encoder.QuantizationBits.TWO };
+        for (int i = 0; i < unsupportedLevels.length; i++) {
+            CompressionLevel level = unsupportedLevels[i];
             KNNQueryBuilder knnQueryBuilder = KNNQueryBuilder.builder()
                 .fieldName(FIELD_NAME)
                 .vector(queryVector)
@@ -582,10 +603,19 @@ public class KNNQueryBuilderTests extends KNNTestCase {
                     return compressionLevel;
                 }
             });
-            doCallRealMethod().when(mockKNNVectorField).validateSupportRadialSearch(any(KNNEngine.class));
+            ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+                .engine(KNNEngine.FAISS)
+                .methodName("hnsw")
+                .encoderType(Encoder.EncoderType.SQ)
+                .quantizationBits(unsupportedBits[i])
+                .compressionLevel(level)
+                .vectorDataType(VectorDataType.FLOAT)
+                .dimension(1)
+                .build();
+            when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
 
             Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
-            assertTrue("Expected compression level in error message for " + level, e.getMessage().contains("compression level=" + level));
+            assertEquals("Radial search is not supported for this quantization configuration", e.getMessage());
         }
     }
 
@@ -641,31 +671,14 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertTrue(query instanceof RescoreRadialSearchQuery);
     }
 
-    // Validates that radial search on a Faiss index with 32x scalar quantization (SQ) is allowed.
-    //
-    // Previously, radial search was blocked for ALL quantized indices. We now allow it specifically
-    // for 32x SQ because the rescoring layer (RescoreRadialSearchQuery) handles false positive
-    // elimination by recomputing scores against full-precision vectors.
-    //
-    // 32x SQ is identified by: QuantizationConfig == EMPTY (not BQ) && CompressionLevel == x32.
-    // BQ indices (QuantizationConfig != EMPTY) remain blocked — see testDoToQuery_whenRadialSearchOnDiskMode_thenException.
-    //
-    // The test verifies doToQuery() produces a KNNQuery (Faiss radial path) without throwing
-    // UnsupportedOperationException, for both max_distance and min_score query types.
-    public void testDoToQuery_whenRadialSearchOnFaissSQ32x_thenNoUnsupportedOperationException() {
+    public void testDoToQuery_whenRadialSearchOnFaissSQ32x_thenException() {
         float[] queryVector = { 1.0f };
         Index dummyIndex = new Index("dummy", "dummy");
-
-        // Configure Faiss HNSW with L2 space type — standard Faiss engine setup
         MethodComponentContext methodComponentContext = new MethodComponentContext(
             org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
             ImmutableMap.of()
         );
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, methodComponentContext);
-
-        // Simulate a 32x SQ mapping config:
-        // - QuantizationConfig defaults to EMPTY (not BQ) — passes the BQ guard
-        // - CompressionLevel is x32 — passes the "non-32x SQ" guard
         KNNMappingConfig faissSQ32xMappingConfig = new KNNMappingConfig() {
             @Override
             public Optional<KNNMethodContext> getKnnMethodContext() {
@@ -682,10 +695,17 @@ public class KNNQueryBuilderTests extends KNNTestCase {
                 return CompressionLevel.x32;
             }
         };
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x32)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(1)
+            .build();
 
-        // --- Test with maxDistance ---
-        // maxDistance triggers the radial search path (radius != null) in doToQuery().
-        // For Faiss engine, RNNQueryFactory.create() produces a KNNQuery with radius set.
+        // Test with maxDistance
         KNNQueryBuilder knnQueryBuilderWithDistance = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -693,29 +713,15 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
-        IndexSettings indexSettings = mock(IndexSettings.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        // transformQueryVector is required so that the processed vector (e.g., L2-normalized for cosine)
-        // is non-null when passed to RescoreRadialSearchQuery
-        when(mockKNNVectorField.transformQueryVector(queryVector)).thenReturn(queryVector);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(faissSQ32xMappingConfig);
-        when(mockKNNVectorField.isRescoringRequiredForRadial()).thenReturn(true);
+        when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext));
+        assertEquals("Radial search is not supported for this quantization configuration", e.getMessage());
 
-        // IndexSettings is required by RNNQueryFactory.create() to get maxResultWindow for KNNQuery.Context
-        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
-        when(indexSettings.getMaxResultWindow()).thenReturn(1000);
-
-        Query query = knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext);
-        assertNotNull(query);
-        // 32x SQ radial search wraps the inner KNNQuery in RescoreRadialSearchQuery
-        assertTrue(query instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof KNNQuery);
-
-        // --- Test with minScore ---
-        // minScore is the alternative radial search parameter (converted to radius internally).
-        // Should follow the same path as maxDistance for Faiss engine.
+        // Test with minScore
         KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -723,48 +729,23 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
         QueryShardContext mockQueryShardContext2 = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField2 = mock(KNNVectorFieldType.class);
-        IndexSettings indexSettings2 = mock(IndexSettings.class);
         when(mockQueryShardContext2.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField2.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        when(mockKNNVectorField2.transformQueryVector(queryVector)).thenReturn(queryVector);
         when(mockQueryShardContext2.fieldMapper(anyString())).thenReturn(mockKNNVectorField2);
         when(mockKNNVectorField2.getKnnMappingConfig()).thenReturn(faissSQ32xMappingConfig);
-        when(mockKNNVectorField2.isRescoringRequiredForRadial()).thenReturn(true);
-        when(mockQueryShardContext2.getIndexSettings()).thenReturn(indexSettings2);
-        when(indexSettings2.getMaxResultWindow()).thenReturn(1000);
-
-        Query query2 = knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2);
-        assertNotNull(query2);
-        assertTrue(query2 instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof KNNQuery);
+        when(mockKNNVectorField2.getResolvedSpec()).thenReturn(spec);
+        Exception e2 = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2));
+        assertEquals("Radial search is not supported for this quantization configuration", e2.getMessage());
     }
 
-    // Validates that radial search on a Lucene HNSW index with 32x scalar quantization (SQ) is allowed.
-    //
-    // This is the Lucene engine counterpart to testDoToQuery_whenRadialSearchOnFaissSQ32x. The key
-    // difference is the query type produced: Lucene radial search goes through RNNQueryFactory's
-    // Lucene branch, which creates a FloatVectorSimilarityQuery (Lucene's built-in radial query)
-    // instead of a KNNQuery (used by Faiss for JNI-based native search).
-    //
-    // The quantization guard logic is identical for both engines — it only checks QuantizationConfig
-    // and CompressionLevel, which are engine-agnostic mapping properties.
-    //
-    // Unlike the Faiss path, the Lucene path requires transformQueryVector to be mocked because
-    // doToQuery() transforms the query vector before passing it to RNNQueryFactory. For Faiss,
-    // the vector passes through without transformation for FLOAT data type.
-    public void testDoToQuery_whenRadialSearchOnLuceneSQ32x_thenNoUnsupportedOperationException() {
+    public void testDoToQuery_whenRadialSearchOnLuceneSQ32x_thenException() {
         float[] queryVector = { 1.0f };
         Index dummyIndex = new Index("dummy", "dummy");
-
-        // Configure Lucene HNSW with L2 space type
         MethodComponentContext methodComponentContext = new MethodComponentContext(
             org.opensearch.knn.common.KNNConstants.METHOD_HNSW,
             ImmutableMap.of()
         );
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
-
-        // Simulate a 32x SQ mapping config — same structure as Faiss test.
-        // QuantizationConfig defaults to EMPTY (not BQ), CompressionLevel is x32.
         KNNMappingConfig luceneSQ32xMappingConfig = new KNNMappingConfig() {
             @Override
             public Optional<KNNMethodContext> getKnnMethodContext() {
@@ -781,10 +762,17 @@ public class KNNQueryBuilderTests extends KNNTestCase {
                 return CompressionLevel.x32;
             }
         };
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.LUCENE)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.FOUR)
+            .compressionLevel(CompressionLevel.x32)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(1)
+            .build();
 
-        // --- Test with maxDistance ---
-        // For Lucene engine, RNNQueryFactory.create() takes the non-custom-segment-files branch,
-        // producing a FloatVectorSimilarityQuery via getFloatVectorSimilarityQuery().
+        // Test with maxDistance
         KNNQueryBuilder knnQueryBuilderWithDistance = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -792,28 +780,15 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
-        IndexSettings indexSettings = mock(IndexSettings.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        // transformQueryVector is required for Lucene path — doToQuery() calls it to normalize/transform
-        // the query vector before building the Lucene query. Without this mock, the vector becomes null
-        // and FloatVectorSimilarityQuery's constructor throws NPE.
-        when(mockKNNVectorField.transformQueryVector(queryVector)).thenReturn(queryVector);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(luceneSQ32xMappingConfig);
-        when(mockKNNVectorField.isRescoringRequiredForRadial()).thenReturn(true);
-        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
-        when(indexSettings.getMaxResultWindow()).thenReturn(1000);
+        when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext));
+        assertEquals("Radial search is not supported for this quantization configuration", e.getMessage());
 
-        Query query = knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext);
-        assertNotNull(query);
-        // 32x SQ radial search wraps the inner FloatVectorSimilarityQuery in RescoreRadialSearchQuery
-        assertTrue(query instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof FloatVectorSimilarityQuery);
-
-        // --- Test with minScore ---
-        // minScore follows the same Lucene radial path. Internally converted to a similarity threshold
-        // via KNNEngine.LUCENE.scoreToRadialThreshold() before being passed to FloatVectorSimilarityQuery.
+        // Test with minScore
         KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -821,47 +796,23 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
         QueryShardContext mockQueryShardContext2 = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField2 = mock(KNNVectorFieldType.class);
-        IndexSettings indexSettings2 = mock(IndexSettings.class);
         when(mockQueryShardContext2.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField2.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        when(mockKNNVectorField2.transformQueryVector(queryVector)).thenReturn(queryVector);
         when(mockQueryShardContext2.fieldMapper(anyString())).thenReturn(mockKNNVectorField2);
         when(mockKNNVectorField2.getKnnMappingConfig()).thenReturn(luceneSQ32xMappingConfig);
-        when(mockKNNVectorField2.isRescoringRequiredForRadial()).thenReturn(true);
-        when(mockQueryShardContext2.getIndexSettings()).thenReturn(indexSettings2);
-        when(indexSettings2.getMaxResultWindow()).thenReturn(1000);
-
-        Query query2 = knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2);
-        assertNotNull(query2);
-        assertTrue(query2 instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof FloatVectorSimilarityQuery);
+        when(mockKNNVectorField2.getResolvedSpec()).thenReturn(spec);
+        Exception e2 = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2));
+        assertEquals("Radial search is not supported for this quantization configuration", e2.getMessage());
     }
 
-    // Validates that radial search on a Lucene FLAT index with 32x SQ is allowed.
-    //
-    // This test complements testDoToQuery_whenRadialSearchOnLuceneSQ32x by using METHOD_FLAT
-    // instead of METHOD_HNSW. The distinction matters because:
-    // - HNSW uses graph-based approximate search (traversal with similarity threshold)
-    // - FLAT uses brute-force exhaustive search (no graph)
-    //
-    // Both methods produce the same query type (FloatVectorSimilarityQuery) for radial search
-    // on the Lucene engine. The quantization guard logic is method-agnostic — it only checks
-    // QuantizationConfig and CompressionLevel, not the search method.
-    //
-    // This test ensures that the guard removal works for FLAT as well, since FLAT with 32x SQ
-    // is a valid production configuration (small indices or exact search requirements).
-    public void testDoToQuery_whenRadialSearchOnLuceneFlat32x_thenNoUnsupportedOperationException() {
+    public void testDoToQuery_whenRadialSearchOnLuceneFlat32x_thenException() {
         float[] queryVector = { 1.0f };
         Index dummyIndex = new Index("dummy", "dummy");
-
-        // Configure Lucene FLAT (brute-force) with L2 — no HNSW graph
         MethodComponentContext methodComponentContext = new MethodComponentContext(
             org.opensearch.knn.common.KNNConstants.METHOD_FLAT,
             ImmutableMap.of()
         );
         KNNMethodContext knnMethodContext = new KNNMethodContext(KNNEngine.LUCENE, SpaceType.L2, methodComponentContext);
-
-        // Same 32x SQ mapping config as the HNSW test — guard logic is identical
         KNNMappingConfig luceneFlat32xMappingConfig = new KNNMappingConfig() {
             @Override
             public Optional<KNNMethodContext> getKnnMethodContext() {
@@ -878,11 +829,16 @@ public class KNNQueryBuilderTests extends KNNTestCase {
                 return CompressionLevel.x32;
             }
         };
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.LUCENE)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.BQ)
+            .compressionLevel(CompressionLevel.x32)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(1)
+            .build();
 
-        // --- Test with maxDistance ---
-        // FLAT and HNSW both take the same Lucene branch in RNNQueryFactory.create(),
-        // producing FloatVectorSimilarityQuery. The method type only affects how Lucene
-        // internally executes the search (exhaustive vs graph traversal).
+        // Test with maxDistance
         KNNQueryBuilder knnQueryBuilderWithDistance = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -890,22 +846,15 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField = mock(KNNVectorFieldType.class);
-        IndexSettings indexSettings = mock(IndexSettings.class);
         when(mockQueryShardContext.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        when(mockKNNVectorField.transformQueryVector(queryVector)).thenReturn(queryVector);
         when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(luceneFlat32xMappingConfig);
-        when(mockKNNVectorField.isRescoringRequiredForRadial()).thenReturn(true);
-        when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
-        when(indexSettings.getMaxResultWindow()).thenReturn(1000);
+        when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
+        Exception e = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext));
+        assertEquals("Radial search is not supported for this quantization configuration", e.getMessage());
 
-        Query query = knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext);
-        assertNotNull(query);
-        assertTrue(query instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof FloatVectorSimilarityQuery);
-
-        // --- Test with minScore ---
+        // Test with minScore
         KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
             .fieldName(FIELD_NAME)
             .vector(queryVector)
@@ -913,20 +862,13 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             .build();
         QueryShardContext mockQueryShardContext2 = mock(QueryShardContext.class);
         KNNVectorFieldType mockKNNVectorField2 = mock(KNNVectorFieldType.class);
-        IndexSettings indexSettings2 = mock(IndexSettings.class);
         when(mockQueryShardContext2.index()).thenReturn(dummyIndex);
         when(mockKNNVectorField2.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
-        when(mockKNNVectorField2.transformQueryVector(queryVector)).thenReturn(queryVector);
         when(mockQueryShardContext2.fieldMapper(anyString())).thenReturn(mockKNNVectorField2);
         when(mockKNNVectorField2.getKnnMappingConfig()).thenReturn(luceneFlat32xMappingConfig);
-        when(mockKNNVectorField2.isRescoringRequiredForRadial()).thenReturn(true);
-        when(mockQueryShardContext2.getIndexSettings()).thenReturn(indexSettings2);
-        when(indexSettings2.getMaxResultWindow()).thenReturn(1000);
-
-        Query query2 = knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2);
-        assertNotNull(query2);
-        assertTrue(query2 instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof FloatVectorSimilarityQuery);
+        when(mockKNNVectorField2.getResolvedSpec()).thenReturn(spec);
+        Exception e2 = expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2));
+        assertEquals("Radial search is not supported for this quantization configuration", e2.getMessage());
     }
 
     public void testDoToQuery_KnnQueryWithFilter_Lucene() {
@@ -1543,7 +1485,13 @@ public class KNNQueryBuilderTests extends KNNTestCase {
             when(mockQueryShardContext.index()).thenReturn(dummyIndex);
             when(mockKNNVectorField.getVectorDataType()).thenReturn(VectorDataType.FLOAT);
             when(mockQueryShardContext.fieldMapper(anyString())).thenReturn(mockKNNVectorField);
-            doCallRealMethod().when(mockKNNVectorField).validateSupportRadialSearch(any(KNNEngine.class));
+            ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+                .engine(knnEngine)
+                .methodName("hnsw")
+                .vectorDataType(VectorDataType.FLOAT)
+                .dimension(4)
+                .build();
+            when(mockKNNVectorField.getResolvedSpec()).thenReturn(spec);
 
             expectThrows(UnsupportedOperationException.class, () -> knnQueryBuilder.doToQuery(mockQueryShardContext));
         }

--- a/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
+++ b/src/test/java/org/opensearch/knn/integ/BinaryIndexIT.java
@@ -165,7 +165,7 @@ public class BinaryIndexIT extends KNNRestTestCase {
         // Query
         float[] queryVector = { (byte) 0b10001111, (byte) 0b10000000 };
         Exception e = expectThrows(Exception.class, () -> runRnnQuery(INDEX_NAME, FIELD_NAME, queryVector, 1, 4));
-        assertTrue(e.getMessage(), e.getMessage().contains("Binary data type does not support radial search"));
+        assertTrue(e.getMessage(), e.getMessage().contains("Radial search is not supported for this quantization configuration"));
     }
 
     private float getRecall(final Set<String> truth, final Set<String> result) {


### PR DESCRIPTION
### Description
Wire ResolvedIndexSpec consumers through spec-driven resolution flow

Wires codec format selection, memory-optimized search, rescore context, radial search validation, remote index build, and field attribute mapping through ResolvedIndexSpec instead of independently inspecting method parameters at each call site.

Key changes:
- KNNQueryBuilder resolves rescore and radial validation via ResolvedIndexSpec
- FaissCodecFormatResolver and EngineFieldMapper use ResolvedIndexSpec for SQ 1-bit routing
- RemoteIndexBuildStrategy uses ResolvedIndexSpec for data type and skip-storage decisions
- Added engine-agnostic isSQOneBit() for radial search and MOS gating


### Related Issues
Related #3290 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
