### PR TITLE
Fix flaky BWC knn query serialization by gating on stream version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 
 ### Bug Fixes
+* Fix flaky BWC serialization failure for knn queries during rolling upgrades by gating optional fields on the transport stream version instead of cluster minimum version [#1622](https://github.com/opensearch-project/k-NN/issues/1622)
 * Turn off ACORN for MOS to match default Lucene HNSW behavior [#3346](https://github.com/opensearch-project/k-NN/pull/3346)
 * Preserve mixed-case derived source vector field names and add backward-compatible field resolution for previously lowercased segment metadata [#3313](https://github.com/opensearch-project/k-NN/pull/3313)
 * Fix rescore flag not propagating over transport layer in multi-node clusters [#3343](https://github.com/opensearch-project/k-NN/pull/3343)
 * Integrated proper ef_search functionality into MOS and Lucene with oversample_factor [#3331](https://github.com/opensearch-project/k-NN/pull/3331)
 * Fix skip warm up in old indices when MOS is enabled [#3344](https://github.com/opensearch-project/k-NN/pull/3344)
-* Check to see if Lucene's search budget has exhausted when deciding to exact search in MOS [#3354](https://github.com/opensearch-project/k-NN/pull/3354)
 
 ### Refactoring
 

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -346,7 +346,14 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
      */
     public KNNQueryBuilder(StreamInput in) throws IOException {
         super(in);
-        KNNQueryBuilder.Builder builder = KNNQueryBuilderParser.streamInput(in, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+        // Gate optional fields on the transport stream version (the version negotiated for this specific
+        // connection), not the cluster minimum version. Cluster state propagates asynchronously, so two nodes
+        // can transiently disagree on it during a rolling upgrade; the stream version is always identical on
+        // both ends of a connection, so writer and reader can never disagree about which fields are on the wire.
+        KNNQueryBuilder.Builder builder = KNNQueryBuilderParser.streamInput(
+            in,
+            key -> IndexUtil.isVersionOnOrAfterMinRequiredVersion(in.getVersion(), key)
+        );
         fieldName = builder.fieldName;
         vector = builder.vector;
         k = builder.k;
@@ -361,7 +368,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        KNNQueryBuilderParser.streamOutput(out, this, IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+        // See the matching comment in the StreamInput constructor: gate on stream version, not cluster version.
+        KNNQueryBuilderParser.streamOutput(out, this, key -> IndexUtil.isVersionOnOrAfterMinRequiredVersion(out.getVersion(), key));
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/KNNQueryBuilderParser.java
@@ -17,7 +17,6 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
-import org.opensearch.knn.index.util.IndexUtil;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
 
 import java.io.IOException;
@@ -119,39 +118,43 @@ public final class KNNQueryBuilderParser {
      * Stream input for KNNQueryBuilder
      *
      * @param in stream out
-     * @param minClusterVersionCheck function to check min version
+     * @param minVersionCheck function to check, for a given feature key, whether the stream version supports it.
+     *                        Callers must derive this from the transport stream version ({@code in.getVersion()}),
+     *                        not from cluster state, so that the writer and reader always agree (see #1622).
      * @return KNNQueryBuilder.Builder class
      * @throws IOException on stream failure
      */
-    public static KNNQueryBuilder.Builder streamInput(StreamInput in, Function<String, Boolean> minClusterVersionCheck) throws IOException {
+    public static KNNQueryBuilder.Builder streamInput(StreamInput in, Function<String, Boolean> minVersionCheck) throws IOException {
         KNNQueryBuilder.Builder builder = new KNNQueryBuilder.Builder();
         builder.fieldName(in.readString());
         builder.vector(in.readFloatArray());
-        if (minClusterVersionCheck.apply(KNNConstants.NULL_K)) {
+        if (minVersionCheck.apply(KNNConstants.NULL_K)) {
             builder.k(in.readOptionalInt());
         } else {
             builder.k(in.readInt());
         }
         builder.filter(in.readOptionalNamedWriteable(QueryBuilder.class));
 
-        if (minClusterVersionCheck.apply("ignore_unmapped")) {
+        if (minVersionCheck.apply("ignore_unmapped")) {
             builder.ignoreUnmapped(in.readOptionalBoolean());
         }
-        if (minClusterVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
+        if (minVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
             builder.maxDistance(in.readOptionalFloat());
         }
-        if (minClusterVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
+        if (minVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
             builder.minScore(in.readOptionalFloat());
         }
-        if (minClusterVersionCheck.apply(METHOD_PARAMETER)) {
-            builder.methodParameters(MethodParametersParser.streamInput(in, IndexUtil::isClusterOnOrAfterMinRequiredVersion));
+        if (minVersionCheck.apply(METHOD_PARAMETER)) {
+            // Forward the same (stream-version-based) predicate instead of re-deriving one from cluster state,
+            // so the nested method-parameters read agrees with everything else in this stream. See #1622.
+            builder.methodParameters(MethodParametersParser.streamInput(in, minVersionCheck));
         }
 
-        if (minClusterVersionCheck.apply(RESCORE_PARAMETER)) {
+        if (minVersionCheck.apply(RESCORE_PARAMETER)) {
             builder.rescoreContext(RescoreParser.streamInput(in));
         }
 
-        if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
+        if (minVersionCheck.apply(EXPAND_NESTED)) {
             builder.expandNested(in.readOptionalBoolean());
         }
 
@@ -163,35 +166,39 @@ public final class KNNQueryBuilderParser {
      *
      * @param out stream out
      * @param builder KNNQueryBuilder to stream
-     * @param minClusterVersionCheck function to check min version
+     * @param minVersionCheck function to check, for a given feature key, whether the stream version supports it.
+     *                        Callers must derive this from the transport stream version ({@code out.getVersion()}),
+     *                        not from cluster state, so that the writer and reader always agree (see #1622).
      * @throws IOException on stream failure
      */
-    public static void streamOutput(StreamOutput out, KNNQueryBuilder builder, Function<String, Boolean> minClusterVersionCheck)
+    public static void streamOutput(StreamOutput out, KNNQueryBuilder builder, Function<String, Boolean> minVersionCheck)
         throws IOException {
         out.writeString(builder.fieldName());
         out.writeFloatArray((float[]) builder.vector());
-        if (minClusterVersionCheck.apply(KNNConstants.NULL_K)) {
+        if (minVersionCheck.apply(KNNConstants.NULL_K)) {
             out.writeOptionalInt(builder.getK());
         } else {
             out.writeInt(Optional.ofNullable(builder.getK()).orElse(0));
         }
         out.writeOptionalNamedWriteable(builder.getFilter());
-        if (minClusterVersionCheck.apply("ignore_unmapped")) {
+        if (minVersionCheck.apply("ignore_unmapped")) {
             out.writeOptionalBoolean(builder.isIgnoreUnmapped());
         }
-        if (minClusterVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
+        if (minVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
             out.writeOptionalFloat(builder.getMaxDistance());
         }
-        if (minClusterVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
+        if (minVersionCheck.apply(KNNConstants.RADIAL_SEARCH_KEY)) {
             out.writeOptionalFloat(builder.getMinScore());
         }
-        if (minClusterVersionCheck.apply(METHOD_PARAMETER)) {
-            MethodParametersParser.streamOutput(out, builder.getMethodParameters(), IndexUtil::isClusterOnOrAfterMinRequiredVersion);
+        if (minVersionCheck.apply(METHOD_PARAMETER)) {
+            // Forward the same (stream-version-based) predicate instead of re-deriving one from cluster state,
+            // so the nested method-parameters write agrees with everything else in this stream. See #1622.
+            MethodParametersParser.streamOutput(out, builder.getMethodParameters(), minVersionCheck);
         }
-        if (minClusterVersionCheck.apply(RESCORE_PARAMETER)) {
+        if (minVersionCheck.apply(RESCORE_PARAMETER)) {
             RescoreParser.streamOutput(out, builder.getRescoreContext());
         }
-        if (minClusterVersionCheck.apply(EXPAND_NESTED)) {
+        if (minVersionCheck.apply(EXPAND_NESTED)) {
             out.writeOptionalBoolean(builder.getExpandNested());
         }
     }

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderRollingUpgradeSerializationTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderRollingUpgradeSerializationTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterModule;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.util.KNNClusterUtil;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.opensearch.knn.index.KNNClusterTestUtils.mockClusterService;
+
+/**
+ * Regression tests for issue #1622 (flaky BWC failure: {@code unexpected byte [0x05]}).
+ *
+ * <p><b>Root cause (fixed):</b> {@link org.opensearch.knn.index.query.parser.KNNQueryBuilderParser} used to decide
+ * which optional fields go on the transport wire using the <i>cluster</i> minimum version
+ * ({@code IndexUtil.isClusterOnOrAfterMinRequiredVersion} -&gt; {@code KNNClusterUtil.getClusterMinVersion()})
+ * instead of the <i>transport stream</i> version ({@code StreamOutput#getVersion()} / {@code StreamInput#getVersion()}).
+ *
+ * <p>Cluster minimum version is derived from cluster state, which propagates <i>eventually</i>. During a rolling
+ * upgrade two communicating nodes could transiently hold different views of it, so the writer and the reader made
+ * different decisions about whether an optional field was present. The byte stream then desynced, and a later
+ * {@code readBoolean} in {@code SearchSourceBuilder} landed on a stray byte -&gt; 0x05.
+ *
+ * <p>The fix (see {@link KNNQueryBuilder#doWriteTo} and the {@code StreamInput} constructor) gates serialization on
+ * the stream version instead, matching the pattern already used by
+ * {@link org.opensearch.knn.index.query.parser.RescoreParser}. The stream version is the min of the two nodes for a
+ * given connection and is therefore identical on both ends, so writer and reader can no longer disagree.
+ *
+ * <p>These tests hold the stream version fixed and vary only the mocked cluster-min-version view to prove that the
+ * mocked view (previously the culprit) no longer has any effect on wire format or round-trip correctness.
+ */
+public class KNNQueryBuilderRollingUpgradeSerializationTests extends KNNTestCase {
+
+    private static final String FIELD_NAME = "myvector";
+    private static final float[] QUERY_VECTOR = { 1.0f, 2.0f, 3.0f, 4.0f };
+    private static final int K = 5;
+
+    // expandNested is gated on EXPAND_NESTED == Version.V_2_19_0 (see IndexUtil). It is also the LAST field
+    // written by KNNQueryBuilderParser.streamOutput, so a writer/reader disagreement about it produces a clean,
+    // isolated trailing-byte desync -- which made it a good field to characterize the original bug with.
+    private static final Version NEW_NODE_VIEW = Version.V_2_19_0; // believes cluster supports expand_nested
+    private static final Version OLD_NODE_VIEW = Version.V_2_18_0; // believes it does not
+
+    // Stream version at/after the expand_nested threshold: the feature should always be included.
+    private static final Version STREAM_VERSION_SUPPORTS_FEATURE = Version.V_2_19_0;
+    // Stream version before the threshold: the feature should always be omitted.
+    private static final Version STREAM_VERSION_BELOW_FEATURE = Version.V_2_18_0;
+
+    private NamedWriteableRegistry registry() {
+        final List<NamedWriteableRegistry.Entry> entries = ClusterModule.getNamedWriteables();
+        entries.add(new NamedWriteableRegistry.Entry(QueryBuilder.class, KNNQueryBuilder.NAME, KNNQueryBuilder::new));
+        return new NamedWriteableRegistry(entries);
+    }
+
+    /** Points KNNClusterUtil.getClusterMinVersion() at the given version (what a node currently "believes"). */
+    private void setClusterMinVersionView(final Version version) {
+        final ClusterService clusterService = mockClusterService(version);
+        KNNClusterUtil.instance().initialize(clusterService, mock(IndexNameExpressionResolver.class));
+    }
+
+    private KNNQueryBuilder queryWithExpandNested() {
+        return KNNQueryBuilder.builder().fieldName(FIELD_NAME).vector(QUERY_VECTOR).k(K).expandNested(Boolean.TRUE).build();
+    }
+
+    private BytesReference serialize(final KNNQueryBuilder query, final Version streamVersion) throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(streamVersion);
+            out.writeNamedWriteable(query);
+            return out.bytes();
+        }
+    }
+
+    /**
+     * Proves the root cause is fixed: with the stream version held constant, changing only the mocked cluster-min
+     * version view no longer changes the serialized byte length. Before the fix, this produced two DIFFERENT
+     * lengths for the same object over the same stream version -- wire format must depend only on the stream.
+     */
+    public void testWireFormatDependsOnlyOnStreamVersion_notClusterMinVersion() throws Exception {
+        final KNNQueryBuilder query = queryWithExpandNested();
+
+        setClusterMinVersionView(NEW_NODE_VIEW);
+        final int lengthWithNewNodeView = serialize(query, STREAM_VERSION_SUPPORTS_FEATURE).length();
+
+        setClusterMinVersionView(OLD_NODE_VIEW);
+        final int lengthWithOldNodeView = serialize(query, STREAM_VERSION_SUPPORTS_FEATURE).length();
+
+        assertEquals(
+            "Wire format must depend only on the stream version, not on the mutable cluster-min version view",
+            lengthWithNewNodeView,
+            lengthWithOldNodeView
+        );
+    }
+
+    /**
+     * Proves the desync is fixed: a "new" node writes the query while it happens to believe cluster-min is 2.19,
+     * and an "old" node reads it while it happens to believe cluster-min is 2.18 -- over the SAME stream version
+     * that supports the feature. Both nodes must now agree on the wire format (based on the stream), so the field
+     * round-trips correctly and no bytes are left unconsumed.
+     */
+    public void testRoundTrip_isStableAcrossClusterMinVersionViews() throws Exception {
+        final KNNQueryBuilder query = queryWithExpandNested();
+
+        setClusterMinVersionView(NEW_NODE_VIEW);
+        final BytesReference bytes = serialize(query, STREAM_VERSION_SUPPORTS_FEATURE);
+
+        setClusterMinVersionView(OLD_NODE_VIEW);
+        try (StreamInput in = new NamedWriteableAwareStreamInput(bytes.streamInput(), registry())) {
+            in.setVersion(STREAM_VERSION_SUPPORTS_FEATURE);
+            final QueryBuilder deserialized = in.readNamedWriteable(QueryBuilder.class);
+
+            assertTrue(deserialized instanceof KNNQueryBuilder);
+            assertEquals(Boolean.TRUE, ((KNNQueryBuilder) deserialized).getExpandNested());
+            assertEquals("No bytes should be left unconsumed regardless of cluster-min view", 0, in.available());
+        }
+    }
+
+    /**
+     * Symmetric case: when the stream version is BELOW the feature threshold, the field must be consistently
+     * omitted by both nodes regardless of their cluster-min view -- proving genuine backwards compatibility with
+     * older nodes still works correctly after the fix.
+     */
+    public void testRoundTrip_whenStreamVersionBelowFeatureThreshold_fieldOmittedConsistently() throws Exception {
+        final KNNQueryBuilder query = queryWithExpandNested();
+
+        setClusterMinVersionView(NEW_NODE_VIEW);
+        final BytesReference bytes = serialize(query, STREAM_VERSION_BELOW_FEATURE);
+
+        setClusterMinVersionView(OLD_NODE_VIEW);
+        try (StreamInput in = new NamedWriteableAwareStreamInput(bytes.streamInput(), registry())) {
+            in.setVersion(STREAM_VERSION_BELOW_FEATURE);
+            final QueryBuilder deserialized = in.readNamedWriteable(QueryBuilder.class);
+
+            assertTrue(deserialized instanceof KNNQueryBuilder);
+            assertNull(
+                "Below the feature threshold, expand_nested must not be on the wire regardless of cluster-min view",
+                ((KNNQueryBuilder) deserialized).getExpandNested()
+            );
+            assertEquals("No bytes should be left unconsumed regardless of cluster-min view", 0, in.available());
+        }
+    }
+}


### PR DESCRIPTION
  ## What does this PR do?

  Gates `KNNQueryBuilder`'s optional-field serialization on the transport stream version
  (`StreamInput#getVersion()` / `StreamOutput#getVersion()`) instead of the cluster
  minimum version, so the writing and reading nodes always agree on the wire format during
  a rolling upgrade. Also fixes the two internal delegations to `MethodParametersParser`
  in `KNNQueryBuilderParser`, which were hardcoding the cluster-version predicate instead
  of forwarding the one passed in.

  ## Why was this PR needed?

  During a rolling upgrade, cluster state propagates asynchronously, so two communicating
  nodes can transiently hold different views of `KNNClusterUtil#getClusterMinVersion()`.
  The writer and reader then disagree on whether a given optional field is present on the
  wire, desyncing the byte stream. A later `readBoolean()` in `SearchSourceBuilder` lands
  on a stray byte, producing the flaky `unexpected byte [0x05]` 500 error reported in #1622.

  The fix uses the transport stream version instead, which is negotiated per connection and
  is always identical on both ends — matching the pattern already used by `RescoreParser`
  in the same package.

  ## What are the relevant issue numbers?

  Closes #1622

  ## Does this PR meet the acceptance criteria?

  - [x] Tests added for new/changed behavior (`KNNQueryBuilderRollingUpgradeSerializationTests`)
  - [x] All tests passing
  - [x] Follows project style guide
  - [x] No breaking changes introduced
  - [x] Changelog entry added
