### PR TITLE
Simplifiy byte vector handling in exact search by removing an unnecessary float-to-byte conversion step.

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -42,7 +42,6 @@ public class KNNConstants {
     public static final String TOP_LEVEL_PARAMETER_SPACE_TYPE = METHOD_PARAMETER_SPACE_TYPE;
     public static final String TOP_LEVEL_PARAMETER_ENGINE = KNN_ENGINE;
     public static final String COMPOUND_EXTENSION = "c";
-    public static final String MODEL = "model";
     public static final String MODELS = "models";
     public static final String MODEL_ID = "model_id";
     public static final String MODEL_BLOB_PARAMETER = "model_blob";

--- a/src/main/java/org/opensearch/knn/index/KNNSettings.java
+++ b/src/main/java/org/opensearch/knn/index/KNNSettings.java
@@ -137,11 +137,9 @@ public class KNNSettings {
     public static final Integer INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE = 0;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MIN = -1;
     public static final Integer INDEX_KNN_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD_MAX = Integer.MAX_VALUE - 2;
-    public static final String INDEX_KNN_DEFAULT_SPACE_TYPE_FOR_BINARY = "hamming";
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_M = 16;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH = 100;
     public static final Integer INDEX_KNN_DEFAULT_ALGO_PARAM_EF_CONSTRUCTION = 100;
-    public static final Integer KNN_DEFAULT_ALGO_PARAM_INDEX_THREAD_QTY = 1;
     public static final Integer KNN_DEFAULT_CIRCUIT_BREAKER_UNSET_PERCENTAGE = 75;
     public static final Integer KNN_DEFAULT_MODEL_CACHE_SIZE_LIMIT_PERCENTAGE = 10; // By default, set aside 10% of the JVM for the limit
     public static final Integer KNN_MAX_MODEL_CACHE_SIZE_LIMIT_PERCENTAGE = 25; // Model cache limit cannot exceed 25% of the JVM heap

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -523,28 +523,13 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
 
         byte[] byteVector = new byte[0];
         switch (vectorDataType) {
-            case BINARY:
+            case BINARY, BYTE:
                 byteVector = new byte[vector.length];
                 for (int i = 0; i < vector.length; i++) {
                     validateByteVectorValue(vector[i], knnVectorFieldType.getVectorDataType());
                     byteVector[i] = (byte) vector[i];
                 }
                 spaceType.validateVector(byteVector);
-                break;
-            case BYTE:
-                if (isUsingLuceneQuery(knnEngine, memoryOptimizedSearchEnabled)) {
-                    byteVector = new byte[vector.length];
-                    for (int i = 0; i < vector.length; i++) {
-                        validateByteVectorValue(vector[i], knnVectorFieldType.getVectorDataType());
-                        byteVector[i] = (byte) vector[i];
-                    }
-                    spaceType.validateVector(byteVector);
-                } else {
-                    for (float v : vector) {
-                        validateByteVectorValue(v, knnVectorFieldType.getVectorDataType());
-                    }
-                    spaceType.validateVector(vector);
-                }
                 break;
             default:
                 spaceType.validateVector(vector);
@@ -563,7 +548,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                 .fieldName(this.fieldName)
                 .vector(getFloatVectorForCreatingQueryRequest(transformedQueryVector, vectorDataType, knnEngine))
                 .originalVector(vector)
-                .byteVector(getByteVectorForCreatingQueryRequest(vectorDataType, knnEngine, byteVector, memoryOptimizedSearchEnabled))
+                .byteVector(getByteVectorForCreatingQueryRequest(vectorDataType, byteVector))
                 .vectorDataType(vectorDataType)
                 .k(this.k)
                 .methodParameters(this.methodParameters)
@@ -582,7 +567,7 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
                 .fieldName(this.fieldName)
                 .vector(getFloatVectorForCreatingQueryRequest(transformedQueryVector, vectorDataType, knnEngine))
                 .originalVector(vector)
-                .byteVector(getByteVectorForCreatingQueryRequest(vectorDataType, knnEngine, byteVector, memoryOptimizedSearchEnabled))
+                .byteVector(getByteVectorForCreatingQueryRequest(vectorDataType, byteVector))
                 .vectorDataType(vectorDataType)
                 .vectorFieldType(knnVectorFieldType)
                 .radius(radius)
@@ -619,19 +604,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         }
 
         throw new IllegalArgumentException(String.format(Locale.ROOT, "Field '%s' is not built for ANN search.", this.fieldName));
-    }
-
-    /**
-     * Determine whether the query will be using Lucene query to perform vector search.
-     * Currently, if memory optimized search is enabled, it fallbacks to Lucene and delegate its HNSW graph searcher to perform ANN search
-     * on FAISS index. Hence, if it is true, then we need to use Lucene query.
-     *
-     * @param engine Engine type
-     * @param memoryOptimizedSearchEnabled A bool flag whether memory optimized search is enabled.
-     * @return True when it should use Lucene query False otherwise.
-     */
-    private static boolean isUsingLuceneQuery(final KNNEngine engine, final boolean memoryOptimizedSearchEnabled) {
-        return memoryOptimizedSearchEnabled || engine == KNNEngine.LUCENE;
     }
 
     private ModelMetadata getModelMetadataForField(String modelId) {
@@ -686,15 +658,8 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
         return null;
     }
 
-    private byte[] getByteVectorForCreatingQueryRequest(
-        VectorDataType vectorDataType,
-        KNNEngine knnEngine,
-        byte[] byteVector,
-        boolean memoryOptimizedSearchEnabled
-    ) {
-
-        if (VectorDataType.BINARY == vectorDataType
-            || (VectorDataType.BYTE == vectorDataType && isUsingLuceneQuery(knnEngine, memoryOptimizedSearchEnabled))) {
+    private byte[] getByteVectorForCreatingQueryRequest(VectorDataType vectorDataType, byte[] byteVector) {
+        if (VectorDataType.BINARY == vectorDataType || VectorDataType.BYTE == vectorDataType) {
             return byteVector;
         }
         return null;

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -338,14 +338,9 @@ public class ExactSearcher {
         }
 
         if (VectorDataType.BYTE == vectorDataType) {
-            final float[] floatQueryVector = context.getFloatQueryVector();
-            final byte[] byteQueryVector = new byte[floatQueryVector.length];
-            for (int i = 0; i < byteQueryVector.length; i++) {
-                byteQueryVector[i] = (byte) floatQueryVector[i];
-            }
             return VectorScorers.createScorer(
                 iteratorValues,
-                byteQueryVector,
+                context.getByteQueryVector(),
                 scorerMode,
                 spaceType,
                 fieldInfo,

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.knn.TopKnnCollectorManager;
 import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.Version;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -94,7 +93,6 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         final int k
     ) {
         try {
-            final Version segmentLuceneVersion = reader.getSegmentInfo().info.getVersion();
             if (k > 0) {
                 // KNN search
                 if (quantizedTargetVector != null) {

--- a/src/test/java/org/opensearch/knn/index/Compression32XIT.java
+++ b/src/test/java/org/opensearch/knn/index/Compression32XIT.java
@@ -25,6 +25,7 @@ import org.opensearch.knn.index.query.KNNQueryBuilder;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.util.ArrayList;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -80,17 +81,13 @@ public class Compression32XIT extends KNNCompressionRestTestCase {
     private static final int BASELINE_DOC_COUNT = 200;
     private static final int BASELINE_QUERY_COUNT = 20;
 
-    private static final float[][] INDEX_VECTORS = TestUtils.getIndexVectors(DOC_COUNT, DIMENSION, true);
-    private static final float[][] QUERY_VECTORS = TestUtils.getQueryVectors(QUERY_COUNT, DIMENSION, DOC_COUNT, true);
+    private static final TestUtils.TestData TEST_DATA = loadTestData();
+    private static final float[][] INDEX_VECTORS = Arrays.copyOf(TEST_DATA.indexData.vectors, DOC_COUNT);
+    private static final float[][] QUERY_VECTORS = Arrays.copyOf(TEST_DATA.queries, QUERY_COUNT);
     private static final float[][] INDEX_VECTORS_SMALL = TestUtils.getIndexVectors(DOC_COUNT, DIMENSION_SMALL, true);
     private static final float[][] QUERY_VECTORS_SMALL = TestUtils.getQueryVectors(QUERY_COUNT, DIMENSION_SMALL, DOC_COUNT, true);
-    private static final float[][] BASELINE_INDEX_VECTORS = TestUtils.getIndexVectors(BASELINE_DOC_COUNT, DIMENSION, true);
-    private static final float[][] BASELINE_QUERY_VECTORS = TestUtils.getQueryVectors(
-        BASELINE_QUERY_COUNT,
-        DIMENSION,
-        BASELINE_DOC_COUNT,
-        true
-    );
+    private static final float[][] BASELINE_INDEX_VECTORS = Arrays.copyOf(TEST_DATA.indexData.vectors, BASELINE_DOC_COUNT);
+    private static final float[][] BASELINE_QUERY_VECTORS = Arrays.copyOf(TEST_DATA.queries, BASELINE_QUERY_COUNT);
     private static final List<Set<String>> GROUND_TRUTH_L2 = TestUtils.computeGroundTruthValues(
         INDEX_VECTORS,
         QUERY_VECTORS,
@@ -115,6 +112,14 @@ public class Compression32XIT extends KNNCompressionRestTestCase {
         SpaceType.L2,
         K
     );
+
+    @SneakyThrows
+    private static TestUtils.TestData loadTestData() {
+        URL testIndexVectors = Compression32XIT.class.getClassLoader().getResource("data/test_vectors_1000x128.json");
+        URL testQueries = Compression32XIT.class.getClassLoader().getResource("data/test_queries_100x128.csv");
+        return new TestUtils.TestData(testIndexVectors.getPath(), testQueries.getPath());
+    }
+
     private static final List<Set<String>> GROUND_TRUTH_BASELINE = TestUtils.computeGroundTruthValues(
         BASELINE_INDEX_VECTORS,
         BASELINE_QUERY_VECTORS,

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -1205,14 +1205,16 @@ public class KNNQueryBuilderTests extends KNNTestCase {
                 }
             }
 
-            if (memoryOptimizedEnabled) {
-                if (vectorDataType == VectorDataType.FLOAT) {
-                    assertEquals(queryVector.length, knnQuery.getQueryVector().length);
-                } else if (vectorDataType == VectorDataType.BYTE) {
-                    assertEquals(queryVector.length, knnQuery.getByteQueryVector().length);
-                } else if (vectorDataType == VectorDataType.BINARY) {
-                    assertEquals(queryVector.length, knnQuery.getByteQueryVector().length);
+            if (vectorDataType == VectorDataType.BYTE || vectorDataType == VectorDataType.BINARY) {
+                assertNotNull("byteQueryVector should always be set for " + vectorDataType, knnQuery.getByteQueryVector());
+                byte[] expectedByteVector = new byte[queryVector.length];
+                for (int i = 0; i < queryVector.length; i++) {
+                    expectedByteVector[i] = (byte) queryVector[i];
                 }
+                assertArrayEquals(expectedByteVector, knnQuery.getByteQueryVector());
+            }
+            if (memoryOptimizedEnabled && vectorDataType == VectorDataType.FLOAT) {
+                assertArrayEquals(queryVector, knnQuery.getQueryVector(), 0f);
             }
         }
     }
@@ -1661,7 +1663,12 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertEquals(1 / MIN_SCORE - 1, query.getRadius(), 0);
         // We save the given vector in original vector field.
         assertEquals(QUERY_VECTOR, query.getOriginalQueryVector());
-        assertNull(query.getByteQueryVector());
+        assertNotNull(query.getByteQueryVector());
+        byte[] expectedByteVector = new byte[QUERY_VECTOR.length];
+        for (int i = 0; i < QUERY_VECTOR.length; i++) {
+            expectedByteVector[i] = (byte) QUERY_VECTOR[i];
+        }
+        assertArrayEquals(expectedByteVector, query.getByteQueryVector());
     }
 
     public void testDoToQuery_whenBinary_thenValid() throws Exception {

--- a/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/exactsearch/ExactSearcherTests.java
@@ -56,6 +56,7 @@ import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 public class ExactSearcherTests extends KNNTestCase {
 
@@ -119,6 +120,53 @@ public class ExactSearcherTests extends KNNTestCase {
             Mockito.verify(leafReaderContext).reader();
             assertEquals(1, docs.scoreDocs.length);
             assertEquals(spaceType.getKnnVectorSimilarityFunction().compare(queryVector, vector), docs.scoreDocs[0].score, 1e-6f);
+        }
+    }
+
+    @SneakyThrows
+    public void testExactSearchScorer_whenByteVectorDataType_thenUsesByteQueryVectorDirectly() {
+        final byte[] queryVector = new byte[] { 1, 2, 3 };
+        final byte[] vector = new byte[] { 4, 5, 6 };
+        final SpaceType spaceType = SpaceType.L2;
+
+        DocIdSetIterator matchedDocIdSetIterator = DocIdSetIterator.all(10);
+
+        final ExactSearcher.ExactSearcherContext.ExactSearcherContextBuilder exactSearcherContextBuilder =
+            ExactSearcher.ExactSearcherContext.builder()
+                .field(FIELD_NAME)
+                .byteQueryVector(queryVector)
+                .matchedDocsIterator(matchedDocIdSetIterator);
+
+        final KNNVectorValues knnByteVectorValues = KNNVectorValuesFactory.getVectorValues(
+            VectorDataType.BYTE,
+            new TestVectorValues.PreDefinedByteVectorValues(
+                List.of(vector),
+                spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction()
+            )
+        );
+
+        try (MockedStatic<KNNVectorValuesFactory> vectorValuesFactoryMockedStatic = Mockito.mockStatic(KNNVectorValuesFactory.class)) {
+            ExactSearcher exactSearcher = new ExactSearcher(null);
+            final LeafReaderContext leafReaderContext = mock(LeafReaderContext.class);
+            final SegmentReader reader = mock(SegmentReader.class);
+
+            final FieldInfos fieldInfos = mock(FieldInfos.class);
+            final FieldInfo fieldInfo = mock(FieldInfo.class);
+            when(fieldInfo.getAttribute(SPACE_TYPE)).thenReturn(spaceType.getValue());
+            when(fieldInfo.getAttribute(VECTOR_DATA_TYPE_FIELD)).thenReturn(VectorDataType.BYTE.getValue());
+            when(reader.getFieldInfos()).thenReturn(fieldInfos);
+            when(fieldInfos.fieldInfo(FIELD_NAME)).thenReturn(fieldInfo);
+            when(leafReaderContext.reader()).thenReturn(reader);
+            vectorValuesFactoryMockedStatic.when(() -> KNNVectorValuesFactory.getVectorValues(fieldInfo, reader))
+                .thenReturn(knnByteVectorValues);
+
+            final Scorer scorer = exactSearcher.exactSearchScorer(leafReaderContext, exactSearcherContextBuilder.build());
+            assertNotNull(scorer);
+            final DocIdSetIterator iterator = scorer.iterator();
+            int docId = iterator.nextDoc();
+            assertNotEquals(DocIdSetIterator.NO_MORE_DOCS, docId);
+            float expectedScore = spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction().compare(queryVector, vector);
+            assertEquals(expectedScore, scorer.score(), 1e-6f);
         }
     }
 


### PR DESCRIPTION
### Description
Simplifies byte vector handling in exact search by removing an unnecessary float-to-byte conversion step.

##### Changes:
  - KNNQueryBuilder: Always populate byteQueryVector for BYTE data type regardless of engine (previously only set for Lucene/memory-optimized paths). Removes the isUsingLuceneQuery guard that left byteQueryVector null for FAISS/NMSLIB.
  - ExactSearcher: For BYTE vector data type, use context.getByteQueryVector() directly instead of reading floatQueryVector and converting it back to bytes. Eliminates redundant float→byte conversion on every segment
  - ExactSearcherTests: Added unit test verifying that exactSearchScorer works correctly when only byteQueryVector is provided on the context.

Apart from this:
1. Fix the flakiness in the 32x compression tests.
2. Removed some unused variables.

#### Motivation
This is more of an inconsistencies in ExactSearch. This will ensure that if we use ExactSearcher next time in other path we should not see any failures.



### Related Issues
NA
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
