### PR TITLE
Validate inverted lists type in template index deserialization

### DIFF
--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -27,6 +27,7 @@
 #include "commons.h"
 #include "faiss/IndexBinaryIVF.h"
 #include "faiss/IndexBinaryHNSW.h"
+#include "faiss/invlists/InvertedLists.h"
 
 #include <algorithm>
 #include <jni.h>
@@ -80,6 +81,51 @@ void InternalTrainIndex(faiss::Index * index, faiss::idx_t n, const float* x);
 
 // Train a binary index with data provided
 void InternalTrainBinaryIndex(faiss::IndexBinary * index, faiss::idx_t n, const uint8_t* x);
+
+// Validates that a deserialized template index is one of the types that the
+// k-NN train path legitimately produces. For IVF types, additionally validates
+// that inverted lists use only ArrayInvertedLists.
+//
+// Allowed types:
+//   IndexIVFFlat, IndexIVFPQ, IndexIVFScalarQuantizer (all are IndexIVF)
+//   IndexHNSWPQ
+static void validateTemplateIndex(faiss::Index* index) {
+    if (dynamic_cast<faiss::IndexIVF*>(index) != nullptr) {
+        auto* ivf = dynamic_cast<faiss::IndexIVF*>(index);
+        if (ivf->invlists != nullptr &&
+            dynamic_cast<faiss::ArrayInvertedLists*>(ivf->invlists) == nullptr) {
+            throw std::runtime_error(
+                "Template index contains unsupported inverted lists type. "
+                "Only ArrayInvertedLists is allowed.");
+        }
+        return;
+    }
+    if (auto* hnswpq = dynamic_cast<faiss::IndexHNSWPQ*>(index)) {
+        // With HNSWPQ no other storage type is supported
+        if (dynamic_cast<faiss::IndexPQ*>(hnswpq->storage) == nullptr) {
+            throw std::runtime_error(
+                "Template index HNSWPQ has unsupported storage type. "
+                "Only IndexPQ is allowed.");
+        }
+        return;
+    }
+    throw std::runtime_error(
+        "Template index is not a supported index type.");
+}
+
+static void validateTemplateIndex(faiss::IndexBinary* index) {
+    auto* ivf = dynamic_cast<faiss::IndexBinaryIVF*>(index);
+    if (ivf == nullptr) {
+        throw std::runtime_error(
+            "Template index is not a valid IVF index type.");
+    }
+    if (ivf->invlists != nullptr &&
+        dynamic_cast<faiss::ArrayInvertedLists*>(ivf->invlists) == nullptr) {
+        throw std::runtime_error(
+            "Template index contains unsupported inverted lists type. "
+            "Only ArrayInvertedLists is allowed.");
+    }
+}
 
 // Converts the int FilterIds to Faiss ids type array.
 void convertFilterIdsToFaissIdType(const int* filterIds, int filterIdsLength, faiss::idx_t* convertedFilterIds);
@@ -307,9 +353,13 @@ void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface *
     }
     jniUtil->ReleaseByteArrayElements(env, templateIndexJ, indexBytesJ, JNI_ABORT);
 
-    // Create faiss index
+    // IO_FLAG_READ_ONLY is an added guard to make sure only on-heap inverted lists
+    // are written since k-NN only supports ArrayInvertedLists. This does not affect
+    // ArrayInvertedLists which has no read_only check and writes to in-memory
+    // std::vectors unconditionally.
     std::unique_ptr<faiss::Index> indexWriter;
-    indexWriter.reset(faiss::read_index(&vectorIoReader, 0));
+    indexWriter.reset(faiss::read_index(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
+    validateTemplateIndex(indexWriter.get());
 
     auto idVector = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexIDMap idMap =  faiss::IndexIDMap(indexWriter.get());
@@ -380,9 +430,13 @@ void knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInter
     }
     jniUtil->ReleaseByteArrayElements(env, templateIndexJ, indexBytesJ, JNI_ABORT);
 
-    // Create faiss index
+    // IO_FLAG_READ_ONLY is an added guard to make sure only on-heap inverted lists
+    // are written since k-NN only supports ArrayInvertedLists. This does not affect
+    // ArrayInvertedLists which has no read_only check and writes to in-memory
+    // std::vectors unconditionally.
     std::unique_ptr<faiss::IndexBinary> indexWriter;
-    indexWriter.reset(faiss::read_index_binary(&vectorIoReader, 0));
+    indexWriter.reset(faiss::read_index_binary(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
+    validateTemplateIndex(indexWriter.get());
 
     auto idVector = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexBinaryIDMap idMap =  faiss::IndexBinaryIDMap(indexWriter.get());
@@ -453,8 +507,12 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
     }
     jniUtil->ReleaseByteArrayElements(env, templateIndexJ, indexBytesJ, JNI_ABORT);
 
-    // Create faiss index
-    std::unique_ptr<faiss::Index> indexWriter (faiss::read_index(&vectorIoReader, 0));
+    // IO_FLAG_READ_ONLY is an added guard to make sure only on-heap inverted lists
+    // are written since k-NN only supports ArrayInvertedLists. This does not affect
+    // ArrayInvertedLists which has no read_only check and writes to in-memory
+    // std::vectors unconditionally.
+    std::unique_ptr<faiss::Index> indexWriter (faiss::read_index(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
+    validateTemplateIndex(indexWriter.get());
 
     auto ids = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexIDMap idMap =  faiss::IndexIDMap(indexWriter.get());

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -358,8 +358,13 @@ void knn_jni::faiss_wrapper::CreateIndexFromTemplate(knn_jni::JNIUtilInterface *
     // ArrayInvertedLists which has no read_only check and writes to in-memory
     // std::vectors unconditionally.
     std::unique_ptr<faiss::Index> indexWriter;
-    indexWriter.reset(faiss::read_index(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
-    validateTemplateIndex(indexWriter.get());
+    try {
+        indexWriter.reset(faiss::read_index(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
+        validateTemplateIndex(indexWriter.get());
+    } catch (...) {
+        delete inputVectors;
+        throw;
+    }
 
     auto idVector = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexIDMap idMap =  faiss::IndexIDMap(indexWriter.get());
@@ -435,8 +440,13 @@ void knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(knn_jni::JNIUtilInter
     // ArrayInvertedLists which has no read_only check and writes to in-memory
     // std::vectors unconditionally.
     std::unique_ptr<faiss::IndexBinary> indexWriter;
-    indexWriter.reset(faiss::read_index_binary(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
-    validateTemplateIndex(indexWriter.get());
+    try {
+        indexWriter.reset(faiss::read_index_binary(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
+        validateTemplateIndex(indexWriter.get());
+    } catch (...) {
+        delete inputVectors;
+        throw;
+    }
 
     auto idVector = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexBinaryIDMap idMap =  faiss::IndexBinaryIDMap(indexWriter.get());
@@ -511,8 +521,14 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
     // are written since k-NN only supports ArrayInvertedLists. This does not affect
     // ArrayInvertedLists which has no read_only check and writes to in-memory
     // std::vectors unconditionally.
-    std::unique_ptr<faiss::Index> indexWriter (faiss::read_index(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
-    validateTemplateIndex(indexWriter.get());
+    std::unique_ptr<faiss::Index> indexWriter;
+    try {
+        indexWriter.reset(faiss::read_index(&vectorIoReader, faiss::IO_FLAG_READ_ONLY));
+        validateTemplateIndex(indexWriter.get());
+    } catch (...) {
+        delete inputVectors;
+        throw;
+    }
 
     auto ids = jniUtil->ConvertJavaIntArrayToCppIntVector(env, idsJ);
     faiss::IndexIDMap idMap =  faiss::IndexIDMap(indexWriter.get());
@@ -522,7 +538,6 @@ void knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(knn_jni::JNIUtilInterfa
     int batchSize = 1000;
     std::vector <float> inputFloatVectors(batchSize * dim);
     std::vector <int64_t> floatVectorsIds(batchSize);
-    int id = 0;
     auto iter = inputVectors->begin();
 
     for (int id = 0; id < numVectors; id += batchSize) {

--- a/jni/tests/faiss_index_service_test.cpp
+++ b/jni/tests/faiss_index_service_test.cpp
@@ -67,7 +67,7 @@ TEST(CreateIndexTest, BasicAssertions) {
     knn_jni::faiss_wrapper::IndexService indexService(std::move(mockFaissMethods));
     long indexAddress = indexService.initIndex(&mockJNIUtil, jniEnv, metricType, indexDescription, dim, numIds, threadCount, parametersMap);
     indexService.insertToIndex(dim, numIds, threadCount, (int64_t) &vectors, ids, indexAddress);
-    indexService.writeIndex(&fileIOWriter, indexAddress);
+    indexService.writeIndex(&fileIOWriter, indexAddress, false);
 }
 
 TEST(CreateBinaryIndexTest, BasicAssertions) {
@@ -107,14 +107,14 @@ TEST(CreateBinaryIndexTest, BasicAssertions) {
         .WillOnce(Return(index));
     EXPECT_CALL(*mockFaissMethods, indexBinaryIdMap(index))
         .WillOnce(Return(indexIdMap));
-    EXPECT_CALL(*mockFaissMethods, writeIndexBinary(indexIdMap, ::testing::Eq(&fileIOWriter)))
+    EXPECT_CALL(*mockFaissMethods, writeIndexBinary(indexIdMap, ::testing::Eq(&fileIOWriter), false))
         .Times(1);
 
     // Create the index
     knn_jni::faiss_wrapper::BinaryIndexService indexService(std::move(mockFaissMethods));
     long indexAddress = indexService.initIndex(&mockJNIUtil, jniEnv, metricType, indexDescription, dim, numIds, threadCount, parametersMap);
     indexService.insertToIndex(dim, numIds, threadCount, (int64_t) &vectors, ids, indexAddress);
-    indexService.writeIndex(&fileIOWriter, indexAddress);
+    indexService.writeIndex(&fileIOWriter, indexAddress, false);
 }
 
 TEST(CreateByteIndexTest, BasicAssertions) {
@@ -159,5 +159,5 @@ TEST(CreateByteIndexTest, BasicAssertions) {
     knn_jni::faiss_wrapper::ByteIndexService indexService(std::move(mockFaissMethods));
     long indexAddress = indexService.initIndex(&mockJNIUtil, jniEnv, metricType, indexDescription, dim, numIds, threadCount, parametersMap);
     indexService.insertToIndex(dim, numIds, threadCount, (int64_t) &vectors, ids, indexAddress);
-    indexService.writeIndex(&fileIOWriter, indexAddress);
+    indexService.writeIndex(&fileIOWriter, indexAddress, false);
 }

--- a/jni/tests/faiss_wrapper_test.cpp
+++ b/jni/tests/faiss_wrapper_test.cpp
@@ -20,6 +20,10 @@
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexBinaryHNSW.h"
 #include "faiss/IndexIVFPQ.h"
+#include "faiss/IndexIVFFlat.h"
+#include "faiss/IndexBinaryIVF.h"
+#include "faiss/index_factory.h"
+#include "faiss/invlists/BlockInvertedLists.h"
 #include "mocks/faiss_index_service_mock.h"
 #include "native_stream_support_util.h"
 
@@ -147,7 +151,7 @@ TEST(FaissCreateIndexTest, BasicAssertions) {
         .Times(1);
     EXPECT_CALL(mockIndexService, insertToIndex(dim, numIds / insertions, 0, _, _, _))
         .Times(insertions);
-    EXPECT_CALL(mockIndexService, writeIndex(_, _))
+    EXPECT_CALL(mockIndexService, writeIndex(_, _, _))
         .Times(1);
 
     createIndexIteratively(&mockJNIUtil,
@@ -199,7 +203,7 @@ TEST(FaissCreateBinaryIndexTest, BasicAssertions) {
         .Times(1);
     EXPECT_CALL(mockIndexService, insertToIndex(dim, numIds / insertions, 0, _, _, _))
         .Times(insertions);
-    EXPECT_CALL(mockIndexService, writeIndex(_, _))
+    EXPECT_CALL(mockIndexService, writeIndex(_, _, _))
         .Times(1);
 
     // This method calls delete vectors at the end
@@ -220,7 +224,7 @@ TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
         faiss::idx_t numIds = 100;
         std::vector<faiss::idx_t> ids;
         auto *vectors = new std::vector<float>();
-        int dim = 2;
+        int dim = 8;
         vectors->reserve(dim * numIds);
         for (int64_t i = 0; i < numIds; ++i) {
           ids.push_back(i);
@@ -231,10 +235,15 @@ TEST(FaissCreateIndexFromTemplateTest, BasicAssertions) {
 
         std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
         faiss::MetricType metricType = faiss::METRIC_L2;
-        std::string method = "HNSW32,Flat";
 
+        // Train an IVF index to use as template
         std::unique_ptr<faiss::Index> createdIndex(
-            test_util::FaissCreateIndex(dim, method, metricType));
+            faiss::index_factory(dim, "IVF4,Flat", metricType));
+        std::vector<float> trainingData(256 * dim);
+        for (auto& v : trainingData) {
+            v = test_util::RandomFloat(-500.0, 500.0);
+        }
+        createdIndex->train(256, trainingData.data());
         auto vectorIoWriter = test_util::FaissGetSerializedIndex(createdIndex.get());
 
         // Setup jni
@@ -286,10 +295,15 @@ TEST(FaissCreateByteIndexFromTemplateTest, BasicAssertions) {
 
         std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
         faiss::MetricType metricType = faiss::METRIC_L2;
-        std::string method = "HNSW32,SQ8_direct_signed";
 
+        // Train an IVF index to use as template
         std::unique_ptr<faiss::Index> createdIndex(
-            test_util::FaissCreateIndex(dim, method, metricType));
+            faiss::index_factory(dim, "IVF4,Flat", metricType));
+        std::vector<float> trainingData(256 * dim);
+        for (auto& v : trainingData) {
+            v = test_util::RandomFloat(-500.0, 500.0);
+        }
+        createdIndex->train(256, trainingData.data());
         auto vectorIoWriter = test_util::FaissGetSerializedIndex(createdIndex.get());
 
         // Setup jni
@@ -325,6 +339,307 @@ TEST(FaissCreateByteIndexFromTemplateTest, BasicAssertions) {
         // Clean up
         std::remove(indexPath.c_str());
     }  // End for
+}
+
+TEST(FaissCreateIndexFromTemplateTest, RejectsNonArrayInvertedLists) {
+    // Create and train an IVF index
+    int dim = 8;
+    int numTrainingVectors = 256;
+
+    std::unique_ptr<faiss::Index> index(
+        faiss::index_factory(dim, "IVF4,Flat", faiss::METRIC_L2));
+
+    std::vector<float> trainingData(numTrainingVectors * dim);
+    for (auto& v : trainingData) {
+        v = test_util::RandomFloat(-500.0, 500.0);
+    }
+    index->train(numTrainingVectors, trainingData.data());
+
+    // Replace ArrayInvertedLists with BlockInvertedLists to simulate tampering
+    auto* ivf = dynamic_cast<faiss::IndexIVF*>(index.get());
+    auto* block = new faiss::BlockInvertedLists(ivf->nlist, ivf->code_size, ivf->code_size);
+    ivf->replace_invlists(block, true);
+
+    // Serialize the tampered index
+    auto vectorIoWriter = test_util::FaissGetSerializedIndex(index.get());
+
+    // Setup test vectors
+    faiss::idx_t numIds = 10;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    auto* vectors = new std::vector<float>(
+        test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax));
+
+    // Setup jni
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    NiceMock<JNIEnv> jniEnv;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    JavaFileIndexOutputMock javaFileIndexOutputMock{indexPath};
+    setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, false);
+
+    std::string spaceType = knn_jni::L2;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+    EXPECT_THROW(
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(
+            &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+            (jlong)vectors, dim, (jobject)(&javaFileIndexOutputMock),
+            reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
+            (jobject)&parametersMap),
+        std::runtime_error);
+
+    std::remove(indexPath.c_str());
+}
+
+TEST(FaissCreateIndexFromTemplateTest, RejectsWrappedIndex) {
+    // Create and train an IVF index, then wrap it in IndexIDMap to simulate
+    // an attacker hiding the IVF inside a wrapper
+    int dim = 8;
+    int numTrainingVectors = 256;
+
+    std::unique_ptr<faiss::Index> index(
+        faiss::index_factory(dim, "IVF4,Flat", faiss::METRIC_L2));
+
+    std::vector<float> trainingData(numTrainingVectors * dim);
+    for (auto& v : trainingData) {
+        v = test_util::RandomFloat(-500.0, 500.0);
+    }
+    index->train(numTrainingVectors, trainingData.data());
+
+    // Wrap in IndexIDMap — this is not a legitimate template structure
+    faiss::IndexIDMap wrappedIndex(index.get());
+    faiss::VectorIOWriter vectorIoWriter;
+    faiss::write_index(&wrappedIndex, &vectorIoWriter);
+
+    // Setup test vectors
+    faiss::idx_t numIds = 10;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    auto* vectors = new std::vector<float>(
+        test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax));
+
+    // Setup jni
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    NiceMock<JNIEnv> jniEnv;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    JavaFileIndexOutputMock javaFileIndexOutputMock{indexPath};
+    setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, false);
+
+    std::string spaceType = knn_jni::L2;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+    EXPECT_THROW(
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(
+            &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+            (jlong)vectors, dim, (jobject)(&javaFileIndexOutputMock),
+            reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
+            (jobject)&parametersMap),
+        std::runtime_error);
+
+    std::remove(indexPath.c_str());
+}
+
+TEST(FaissCreateIndexFromTemplateTest, AcceptsValidIVFTemplate) {
+    // Create and train a legitimate IVF index with ArrayInvertedLists
+    int dim = 8;
+    int numTrainingVectors = 256;
+
+    std::unique_ptr<faiss::Index> index(
+        faiss::index_factory(dim, "IVF4,Flat", faiss::METRIC_L2));
+
+    std::vector<float> trainingData(numTrainingVectors * dim);
+    for (auto& v : trainingData) {
+        v = test_util::RandomFloat(-500.0, 500.0);
+    }
+    index->train(numTrainingVectors, trainingData.data());
+
+    // Serialize without tampering — should have ArrayInvertedLists
+    auto vectorIoWriter = test_util::FaissGetSerializedIndex(index.get());
+
+    // Setup test vectors
+    faiss::idx_t numIds = 10;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    auto* vectors = new std::vector<float>(
+        test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax));
+
+    // Setup jni
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    NiceMock<JNIEnv> jniEnv;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    JavaFileIndexOutputMock javaFileIndexOutputMock{indexPath};
+    setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, false);
+
+    std::string spaceType = knn_jni::L2;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+    EXPECT_NO_THROW(
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(
+            &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+            (jlong)vectors, dim, (jobject)(&javaFileIndexOutputMock),
+            reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
+            (jobject)&parametersMap));
+
+    javaFileIndexOutputMock.file_writer.close();
+
+    // Verify index can be loaded
+    std::unique_ptr<faiss::Index> loadedIndex(test_util::FaissLoadIndex(indexPath));
+    EXPECT_NE(loadedIndex, nullptr);
+
+    std::remove(indexPath.c_str());
+}
+
+TEST(FaissCreateIndexFromTemplateTest, AcceptsValidHNSWPQTemplate) {
+    // Create and train an HNSWPQ index — a legitimate non-IVF template
+    int dim = 8;
+    int numTrainingVectors = 256;
+
+    std::unique_ptr<faiss::Index> index(
+        faiss::index_factory(dim, "HNSW32,PQ4", faiss::METRIC_L2));
+
+    std::vector<float> trainingData(numTrainingVectors * dim);
+    for (auto& v : trainingData) {
+        v = test_util::RandomFloat(-500.0, 500.0);
+    }
+    index->train(numTrainingVectors, trainingData.data());
+
+    auto vectorIoWriter = test_util::FaissGetSerializedIndex(index.get());
+
+    // Setup test vectors
+    faiss::idx_t numIds = 10;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    auto* vectors = new std::vector<float>(
+        test_util::RandomVectors(dim, numIds, randomDataMin, randomDataMax));
+
+    // Setup jni
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    NiceMock<JNIEnv> jniEnv;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    JavaFileIndexOutputMock javaFileIndexOutputMock{indexPath};
+    setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, false);
+
+    std::string spaceType = knn_jni::L2;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+    EXPECT_NO_THROW(
+        knn_jni::faiss_wrapper::CreateIndexFromTemplate(
+            &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+            (jlong)vectors, dim, (jobject)(&javaFileIndexOutputMock),
+            reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
+            (jobject)&parametersMap));
+
+    javaFileIndexOutputMock.file_writer.close();
+
+    std::unique_ptr<faiss::Index> loadedIndex(test_util::FaissLoadIndex(indexPath));
+    EXPECT_NE(loadedIndex, nullptr);
+
+    std::remove(indexPath.c_str());
+}
+
+TEST(FaissCreateByteIndexFromTemplateTest, RejectsNonArrayInvertedLists) {
+    // Create and train an IVF index
+    int dim = 8;
+    int numTrainingVectors = 256;
+
+    std::unique_ptr<faiss::Index> index(
+        faiss::index_factory(dim, "IVF4,Flat", faiss::METRIC_L2));
+
+    std::vector<float> trainingData(numTrainingVectors * dim);
+    for (auto& v : trainingData) {
+        v = test_util::RandomFloat(-500.0, 500.0);
+    }
+    index->train(numTrainingVectors, trainingData.data());
+
+    // Replace ArrayInvertedLists with BlockInvertedLists
+    auto* ivf = dynamic_cast<faiss::IndexIVF*>(index.get());
+    auto* block = new faiss::BlockInvertedLists(ivf->nlist, ivf->code_size, ivf->code_size);
+    ivf->replace_invlists(block, true);
+
+    // Serialize the tampered index
+    auto vectorIoWriter = test_util::FaissGetSerializedIndex(index.get());
+
+    // Setup test vectors (byte type)
+    faiss::idx_t numIds = 10;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    auto* vectors = new std::vector<int8_t>(numIds * dim);
+    for (auto& v : *vectors) {
+        v = static_cast<int8_t>(test_util::RandomInt(-128, 127));
+    }
+
+    // Setup jni
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    NiceMock<JNIEnv> jniEnv;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    JavaFileIndexOutputMock javaFileIndexOutputMock{indexPath};
+    setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, false);
+
+    std::string spaceType = knn_jni::L2;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+    EXPECT_THROW(
+        knn_jni::faiss_wrapper::CreateByteIndexFromTemplate(
+            &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+            (jlong)vectors, dim, (jobject)(&javaFileIndexOutputMock),
+            reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
+            (jobject)&parametersMap),
+        std::runtime_error);
+
+    std::remove(indexPath.c_str());
+}
+
+TEST(FaissCreateBinaryIndexFromTemplateTest, RejectsNonArrayInvertedLists) {
+    // Create and train a binary IVF index
+    int dim = 128;
+    int numTrainingVectors = 256;
+
+    std::unique_ptr<faiss::IndexBinary> index(
+        faiss::index_binary_factory(dim, "BIVF4"));
+
+    std::vector<uint8_t> trainingData(numTrainingVectors * (dim / 8));
+    for (auto& v : trainingData) {
+        v = static_cast<uint8_t>(test_util::RandomInt(0, 255));
+    }
+    index->train(numTrainingVectors, trainingData.data());
+
+    // Replace ArrayInvertedLists with BlockInvertedLists by direct assignment
+    // (replace_invlists has a strict code_size check that BlockInvertedLists can't satisfy)
+    auto* ivf = dynamic_cast<faiss::IndexBinaryIVF*>(index.get());
+    delete ivf->invlists;
+    ivf->invlists = new faiss::BlockInvertedLists(ivf->nlist, 1, ivf->code_size);
+    ivf->own_invlists = true;
+
+    // Serialize the tampered index
+    auto vectorIoWriter = test_util::FaissGetSerializedBinaryIndex(index.get());
+
+    // Setup test vectors
+    faiss::idx_t numIds = 10;
+    std::vector<faiss::idx_t> ids = test_util::Range(numIds);
+    auto* vectors = new std::vector<uint8_t>(numIds * (dim / 8));
+    for (auto& v : *vectors) {
+        v = static_cast<uint8_t>(test_util::RandomInt(0, 255));
+    }
+
+    // Setup jni
+    std::string indexPath = test_util::RandomString(10, "tmp/", ".faiss");
+    NiceMock<JNIEnv> jniEnv;
+    NiceMock<test_util::MockJNIUtil> mockJNIUtil;
+    JavaFileIndexOutputMock javaFileIndexOutputMock{indexPath};
+    setUpJavaFileOutputMocking(javaFileIndexOutputMock, mockJNIUtil, false);
+
+    std::string spaceType = knn_jni::HAMMING;
+    std::unordered_map<std::string, jobject> parametersMap;
+    parametersMap[knn_jni::SPACE_TYPE] = (jobject)&spaceType;
+
+    EXPECT_ANY_THROW(
+        knn_jni::faiss_wrapper::CreateBinaryIndexFromTemplate(
+            &mockJNIUtil, &jniEnv, reinterpret_cast<jintArray>(&ids),
+            (jlong)vectors, dim, (jobject)(&javaFileIndexOutputMock),
+            reinterpret_cast<jbyteArray>(&(vectorIoWriter.data)),
+            (jobject)&parametersMap));
+
+    std::remove(indexPath.c_str());
 }
 
 TEST(FaissLoadIndexTest, BasicAssertions) {

--- a/jni/tests/mocks/faiss_index_service_mock.h
+++ b/jni/tests/mocks/faiss_index_service_mock.h
@@ -58,7 +58,8 @@ public:
         writeIndex,
         (
             faiss::IOWriter* writer,
-            long indexPtr
+            jlong idMapAddress,
+            bool skipFlat
         ),
         (override));
 };

--- a/jni/tests/mocks/faiss_methods_mock.h
+++ b/jni/tests/mocks/faiss_methods_mock.h
@@ -22,7 +22,7 @@ public:
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::Index>*, indexIdMap, (faiss::Index* index), (override));
     MOCK_METHOD(faiss::IndexIDMapTemplate<faiss::IndexBinary>*, indexBinaryIdMap, (faiss::IndexBinary* index), (override));
     MOCK_METHOD(void, writeIndex, (const faiss::Index* idx, faiss::IOWriter* writer), (override));
-    MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, faiss::IOWriter* writer), (override));
+    MOCK_METHOD(void, writeIndexBinary, (const faiss::IndexBinary* idx, faiss::IOWriter* writer, bool skipFlat), (override));
 };
 
 #endif  // OPENSEARCH_KNN_FAISS_METHODS_MOCK_H

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -240,7 +240,7 @@ public class KNNCodecTestCase extends KNNTestCase {
         }
         long vectorsPointer = JNICommons.storeVectorData(0, trainingData, numTrainingVectors * dimension);
         byte[] modelBlob = JNIService.trainIndex(
-            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "IVF4,Flat", SPACE_TYPE, spaceType.getValue()),
+            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "IVF1,Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,
             vectorsPointer,
             KNNEngine.FAISS

--- a/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNNCodecTestCase.java
@@ -230,10 +230,17 @@ public class KNNCodecTestCase extends KNNTestCase {
         SpaceType spaceType = SpaceType.L2;
         int dimension = 3;
 
-        // "Train" a faiss flat index - this really just creates an empty index that does brute force k-NN
-        long vectorsPointer = JNICommons.storeVectorData(0, new float[0][0], 0);
+        // Train a faiss IVF index to use as a model template
+        int numTrainingVectors = 64;
+        float[][] trainingData = new float[numTrainingVectors][dimension];
+        for (int i = 0; i < numTrainingVectors; i++) {
+            for (int j = 0; j < dimension; j++) {
+                trainingData[i][j] = random().nextFloat();
+            }
+        }
+        long vectorsPointer = JNICommons.storeVectorData(0, trainingData, numTrainingVectors * dimension);
         byte[] modelBlob = JNIService.trainIndex(
-            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "Flat", SPACE_TYPE, spaceType.getValue()),
+            ImmutableMap.of(INDEX_DESCRIPTION_PARAMETER, "IVF4,Flat", SPACE_TYPE, spaceType.getValue()),
             dimension,
             vectorsPointer,
             KNNEngine.FAISS


### PR DESCRIPTION
When creating an index from a trained model template, validate that the deserialized faiss index only contains ArrayInvertedLists. Reject any other InvertedLists implementation (e.g. OnDiskInvertedLists, BlockInvertedLists) which could perform unintended filesystem operations during index construction.

The validation is applied to all three CreateIndexFromTemplate variants: float, byte, and binary.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
