### PR TITLE
[SQ PR-1] Refactor(SQ): Add ScalarEncodingResolver and parameterize Faiss SQ format by encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
+* Add ScalarEncodingResolver and parameterize Faiss SQ format by encoding to unblock multi-bit SQ support [#3428](https://github.com/opensearch-project/k-NN/pull/3428)
 
 ### Enhancements

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -17,17 +17,21 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Dedicated format for Faiss SQ vector fields.
  *
- * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} with 1-bit quantization
- * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for flat vector storage (.vec/.veq files),
- * while HNSW graph construction is delegated to the native Faiss engine (.faiss files).
+ * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} for flat vector storage (.vec/.veq files),
+ * while HNSW graph construction is delegated to the native Faiss engine (.faiss files). The
+ * {@link ScalarEncoding} determines the document bit width (1, 2, or 4) and is resolved from the
+ * field's configured bits via {@link ScalarEncodingResolver}; it defaults to 1-bit
+ * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for backward compatibility.
  *
- * <p>A field is routed to this format when its method parameters contain
- * {@code "encoder": {"name": "sq", "bits": 1}}. See {@code FaissCodecFormatResolver} for the
- * routing logic in {@code BasePerFieldKnnVectorsFormat.getKnnVectorsFormatForField}.
+ * <p>A field is routed to this format when its method parameters contain an {@code sq} encoder
+ * with a supported bit width. See {@code FaissCodecFormatResolver} for the routing logic.
  *
  * @see Faiss1040ScalarQuantizedKnnVectorsWriter
  * @see Faiss1040ScalarQuantizedKnnVectorsReader
@@ -37,26 +41,43 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
 
     private static final String FORMAT_NAME = "Faiss1040ScalarQuantizedKnnVectorsFormat";
 
-    // Shared across all format instances; KNN1040ScalarQuantizedVectorsFormat is stateless.
-    // TODO : We have to make it scalable for other encoding types, not limit this on `ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE`.
-    private static final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat = new KNN1040ScalarQuantizedVectorsFormat(
-        ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE
-    );
+    private static final ScalarEncoding DEFAULT_ENCODING = ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
 
+    // KNN1040ScalarQuantizedVectorsFormat is stateless per encoding, so we cache one instance per
+    // encoding and share it across all format instances.
+    private static final Map<ScalarEncoding, KNN1040ScalarQuantizedVectorsFormat> FLAT_FORMAT_CACHE = new ConcurrentHashMap<>();
+
+    private final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
 
+    /**
+     * Returns the flat format for the default (1-bit) encoding. Retained as a static accessor for tests.
+     */
     @VisibleForTesting
     static KNN1040ScalarQuantizedVectorsFormat getFaissSqFlatFormat() {
-        return faissSqFlatFormat;
+        return flatFormatFor(DEFAULT_ENCODING);
+    }
+
+    private static KNN1040ScalarQuantizedVectorsFormat flatFormatFor(final ScalarEncoding encoding) {
+        return FLAT_FORMAT_CACHE.computeIfAbsent(encoding, KNN1040ScalarQuantizedVectorsFormat::new);
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
-        this(new NativeIndexBuildStrategyFactory());
+        this(new NativeIndexBuildStrategyFactory(), DEFAULT_ENCODING);
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat(final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory) {
+        this(nativeIndexBuildStrategyFactory, DEFAULT_ENCODING);
+    }
+
+    public Faiss1040ScalarQuantizedKnnVectorsFormat(
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        final ScalarEncoding encoding
+    ) {
         super(FORMAT_NAME);
+        Objects.requireNonNull(encoding, "ScalarEncoding must not be null");
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.faissSqFlatFormat = flatFormatFor(encoding);
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Single decision point that maps a document bit width (the number of bits used to quantize each
+ * dimension of a stored vector) to the Lucene {@link ScalarEncoding} used by the FAISS SQ
+ * memory-optimized-search path, and back.
+ *
+ * <p>The FAISS SQ path always uses a 4-bit (nibble) query, so the relevant encodings are exactly
+ * those whose query bit width is {@link #QUERY_BITS}. In Lucene 10.4 these are:
+ * <ul>
+ *   <li>1-bit document → {@code SINGLE_BIT_QUERY_NIBBLE} (x32)</li>
+ *   <li>2-bit document → {@code DIBIT_QUERY_NIBBLE} (x16)</li>
+ *   <li>4-bit document → {@code PACKED_NIBBLE} (x8)</li>
+ * </ul>
+ *
+ * <p>The mapping is resolved dynamically from {@link ScalarEncoding#getBits()} and
+ * {@link ScalarEncoding#getQueryBits()} rather than by hardcoding enum names, so it stays correct
+ * if Lucene renames constants and so adding a new supported bit width only requires updating
+ * {@link #SUPPORTED_DOC_BITS}. This keeps the {@code SINGLE_BIT_QUERY_NIBBLE} reference out of the
+ * codec format, the build strategy, and the scorer (Requirement 11.4).
+ */
+public final class ScalarEncodingResolver {
+
+    private ScalarEncodingResolver() {
+        // Utility class; not instantiable.
+    }
+
+    /** The FAISS SQ path always quantizes the query to a 4-bit nibble. */
+    public static final int QUERY_BITS = 4;
+
+    /** Document bit widths supported by the FAISS SQ memory-optimized-search path. */
+    private static final int[] SUPPORTED_DOC_BITS = { 1, 2, 4 };
+
+    /** docBits -> ScalarEncoding, resolved once from the enum metadata. */
+    private static final Map<Integer, ScalarEncoding> DOC_BITS_TO_ENCODING = buildDocBitsToEncoding();
+
+    /**
+     * Builds the docBits → {@link ScalarEncoding} lookup table by matching entries in
+     * {@link ScalarEncoding#values()} against each supported width paired with the fixed
+     * {@link #QUERY_BITS} (4). Called once at class-load; the returned map is stored in
+     * {@link #DOC_BITS_TO_ENCODING} and consulted for every {@link #forDocBits(int)} call.
+     *
+     * <p>Current mapping (Lucene 10.4, kept here for reference and to track deviations
+     * over time — if this diverges, either Lucene renamed constants or the enum's
+     * {@code getBits()}/{@code getQueryBits()} metadata changed):
+     * <table>
+     *   <caption>Current docBits → ScalarEncoding mapping</caption>
+     *   <tr><th>docBits</th><th>ScalarEncoding</th><th>Compression</th></tr>
+     *   <tr><td>1</td><td>{@code SINGLE_BIT_QUERY_NIBBLE}</td><td>x32</td></tr>
+     *   <tr><td>2</td><td>{@code DIBIT_QUERY_NIBBLE}</td><td>x16</td></tr>
+     *   <tr><td>4</td><td>{@code PACKED_NIBBLE}</td><td>x8</td></tr>
+     * </table>
+     *
+     * <p>Throws at class-load time (via the static initializer of {@link #DOC_BITS_TO_ENCODING})
+     * if any supported width is missing from the installed Lucene version, so upgrades that
+     * silently drop an encoding fail fast rather than corrupting on-disk segments.
+     */
+    private static Map<Integer, ScalarEncoding> buildDocBitsToEncoding() {
+        final Map<Integer, ScalarEncoding> map = new HashMap<>();
+        for (int docBits : SUPPORTED_DOC_BITS) {
+            for (ScalarEncoding encoding : ScalarEncoding.values()) {
+                if (encoding.getBits() == docBits && encoding.getQueryBits() == QUERY_BITS) {
+                    map.put(docBits, encoding);
+                    break;
+                }
+            }
+            if (map.containsKey(docBits) == false) {
+                throw new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "No Lucene ScalarEncoding found for document bits=%d with a %d-bit query. "
+                            + "The installed Lucene version may not expose this encoding.",
+                        docBits,
+                        QUERY_BITS
+                    )
+                );
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Returns the {@link ScalarEncoding} used to store documents quantized to {@code docBits} bits
+     * per dimension with a 4-bit nibble query.
+     *
+     * @param docBits the document bit width (1, 2, or 4)
+     * @return the corresponding Lucene scalar encoding
+     * @throws IllegalArgumentException if {@code docBits} is not a supported document bit width
+     */
+    public static ScalarEncoding forDocBits(final int docBits) {
+        final ScalarEncoding encoding = DOC_BITS_TO_ENCODING.get(docBits);
+        if (encoding == null) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Unsupported SQ document bit width: %d. Supported: %s", docBits, supportedDocBitsString())
+            );
+        }
+        return encoding;
+    }
+
+    /**
+     * Inverse of {@link #forDocBits(int)} — returns the document bit width for {@code encoding},
+     * rejecting encodings outside the {@link #SUPPORTED_DOC_BITS} set (1, 2, 4). {@link ScalarEncoding}
+     * exposes bit widths for encodings the FAISS SQ path doesn't support (e.g. {@code SEVEN_BIT},
+     * {@code UNSIGNED_BYTE}); validating here keeps the round-trip guarantee symmetric with
+     * {@link #forDocBits(int)} and fails loud if a caller ever passes an unexpected encoding.
+     *
+     * @param encoding a Lucene scalar encoding
+     * @return the document bit width ({@link ScalarEncoding#getBits()})
+     * @throws NullPointerException if {@code encoding} is {@code null}
+     * @throws IllegalArgumentException if {@code encoding} is not one of the supported FAISS SQ encodings
+     */
+    public static int docBits(final ScalarEncoding encoding) {
+        Objects.requireNonNull(encoding, "ScalarEncoding must not be null");
+        final int bits = encoding.getBits();
+        if (DOC_BITS_TO_ENCODING.containsKey(bits) == false) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Unsupported SQ scalar encoding: %s (bits=%d). Supported bits: %s",
+                    encoding,
+                    bits,
+                    supportedDocBitsString()
+                )
+            );
+        }
+        return bits;
+    }
+
+    private static String supportedDocBitsString() {
+        return Arrays.toString(SUPPORTED_DOC_BITS);
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
@@ -24,11 +24,13 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -133,6 +135,57 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
     public void testToString_thenContainsFormatInfo() {
         final String str = new Faiss1040ScalarQuantizedKnnVectorsFormat().toString();
         assertTrue(str.contains(Faiss1040ScalarQuantizedKnnVectorsFormat.class.getSimpleName()));
+    }
+
+    public void testDefaultConstructor_usesOneBitEncoding() {
+        // Backward-compatibility: no-arg and single-arg constructors must still resolve to the
+        // 1-bit flat format that shipped in 3.x. Any change here would silently switch existing
+        // indices to a different encoding on the next segment write.
+        assertSame(
+            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat())
+        );
+        assertSame(
+            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat(new NativeIndexBuildStrategyFactory()))
+        );
+    }
+
+    public void testExplicitEncoding_selectsMatchingFlatFormat() {
+        // Verify each supported encoding wires through to a distinct flat format instance.
+        // Cache-sharing means repeated construction with the same encoding returns the same
+        // underlying format; different encodings return different instances.
+        for (ScalarEncoding encoding : new ScalarEncoding[] {
+            ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE,
+            ScalarEncoding.DIBIT_QUERY_NIBBLE,
+            ScalarEncoding.PACKED_NIBBLE }) {
+            Faiss1040ScalarQuantizedKnnVectorsFormat first = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                new NativeIndexBuildStrategyFactory(),
+                encoding
+            );
+            Faiss1040ScalarQuantizedKnnVectorsFormat second = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                new NativeIndexBuildStrategyFactory(),
+                encoding
+            );
+            assertSame("Flat format for " + encoding + " should be cached and reused", reflectFlatFormat(first), reflectFlatFormat(second));
+        }
+
+        // Different encodings must produce different flat format instances.
+        assertNotSame(
+            reflectFlatFormat(
+                new Faiss1040ScalarQuantizedKnnVectorsFormat(new NativeIndexBuildStrategyFactory(), ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
+            ),
+            reflectFlatFormat(
+                new Faiss1040ScalarQuantizedKnnVectorsFormat(new NativeIndexBuildStrategyFactory(), ScalarEncoding.DIBIT_QUERY_NIBBLE)
+            )
+        );
+    }
+
+    @SneakyThrows
+    private static KNN1040ScalarQuantizedVectorsFormat reflectFlatFormat(Faiss1040ScalarQuantizedKnnVectorsFormat format) {
+        java.lang.reflect.Field field = Faiss1040ScalarQuantizedKnnVectorsFormat.class.getDeclaredField("faissSqFlatFormat");
+        field.setAccessible(true);
+        return (KNN1040ScalarQuantizedVectorsFormat) field.get(format);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolverTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN1040Codec;
+
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.opensearch.knn.KNNTestCase;
+
+public class ScalarEncodingResolverTests extends KNNTestCase {
+
+    public void testForDocBits_returnsExpectedEncoding() {
+        assertEquals(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE, ScalarEncodingResolver.forDocBits(1));
+        assertEquals(ScalarEncoding.DIBIT_QUERY_NIBBLE, ScalarEncodingResolver.forDocBits(2));
+        assertEquals(ScalarEncoding.PACKED_NIBBLE, ScalarEncodingResolver.forDocBits(4));
+    }
+
+    public void testForDocBits_unsupportedBits_throws() {
+        for (int docBits : new int[] { 0, 3, 5, 7, 8, 16, -1 }) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> ScalarEncodingResolver.forDocBits(docBits));
+            assertTrue(
+                "Expected message to mention the unsupported bit width, got: " + ex.getMessage(),
+                ex.getMessage().contains(String.valueOf(docBits))
+            );
+            assertTrue("Expected message to list supported widths, got: " + ex.getMessage(), ex.getMessage().contains("[1, 2, 4]"));
+        }
+    }
+
+    public void testDocBits_isInverseOfForDocBits() {
+        for (int docBits : new int[] { 1, 2, 4 }) {
+            ScalarEncoding encoding = ScalarEncodingResolver.forDocBits(docBits);
+            assertEquals(docBits, ScalarEncodingResolver.docBits(encoding));
+        }
+    }
+
+    public void testDocBits_rejectsUnsupportedEncodings() {
+        // Encodings whose bit widths are not in SUPPORTED_DOC_BITS must fail loud so that unexpected
+        // Lucene encodings can never leak into downstream code that assumes bits ∈ {1, 2, 4}.
+        for (ScalarEncoding encoding : new ScalarEncoding[] { ScalarEncoding.SEVEN_BIT, ScalarEncoding.UNSIGNED_BYTE }) {
+            IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> ScalarEncodingResolver.docBits(encoding));
+            assertTrue("Expected message to name the encoding, got: " + ex.getMessage(), ex.getMessage().contains(encoding.name()));
+            assertTrue("Expected message to list supported widths, got: " + ex.getMessage(), ex.getMessage().contains("[1, 2, 4]"));
+        }
+    }
+
+    public void testDocBits_nullEncoding_throwsNPE() {
+        expectThrows(NullPointerException.class, () -> ScalarEncodingResolver.docBits(null));
+    }
+
+    public void testQueryBits_isFourForAllSupportedEncodings() {
+        assertEquals(4, ScalarEncodingResolver.QUERY_BITS);
+        for (int docBits : new int[] { 1, 2, 4 }) {
+            ScalarEncoding encoding = ScalarEncodingResolver.forDocBits(docBits);
+            assertEquals(
+                "Encoding " + encoding + " should use " + ScalarEncodingResolver.QUERY_BITS + "-bit query",
+                ScalarEncodingResolver.QUERY_BITS,
+                encoding.getQueryBits()
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Description
Adds `ScalarEncodingResolver` — a single decision point mapping doc bit width (1/2/4) to the Lucene `ScalarEncoding` used by the Faiss SQ memory-optimized-search path — and parameterizes `Faiss1040ScalarQuantizedKnnVectorsFormat`
  by that encoding.

  **No functional change.** Existing 1-bit path is preserved: default constructor resolves to `SINGLE_BIT_QUERY_NIBBLE`, and all current call sites get the same cached flat-format instance as before.

### Related Issues
https://github.com/opensearch-project/k-NN/issues/3427

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
