### PR TITLE
[SQ PR-2] Accept SQ multibit quantization at mapping and codec layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce system-generated search pipeline processor to automatically exclude knn_vector fields from _source in search responses [#3152](https://github.com/opensearch-project/k-NN/pull/3152)
 * Parameterize integration test framework for compression level [#3416](https://github.com/opensearch-project/k-NN/pull/3416)
 * Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
+* Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -9,29 +9,45 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+import org.opensearch.knn.common.FieldInfoExtractor;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 
 /**
  * Dedicated format for Faiss SQ vector fields.
  *
  * <p>Uses {@link KNN1040ScalarQuantizedVectorsFormat} for flat vector storage (.vec/.veq files),
  * while HNSW graph construction is delegated to the native Faiss engine (.faiss files). The
- * {@link ScalarEncoding} determines the document bit width (1, 2, or 4) and is resolved from the
- * field's configured bits via {@link ScalarEncodingResolver}; it defaults to 1-bit
- * ({@link ScalarEncoding#SINGLE_BIT_QUERY_NIBBLE}) for backward compatibility.
+ * {@link ScalarEncoding} is resolved <b>per-field at write time</b> from the segment's
+ * {@link FieldInfo} attributes ({@code SQ_CONFIG}, populated by {@code EngineFieldMapper}) —
+ * <b>not</b> from a value baked into the format instance at construction time.
  *
- * <p>A field is routed to this format when its method parameters contain an {@code sq} encoder
- * with a supported bit width. See {@code FaissCodecFormatResolver} for the routing logic.
+ * <p>This matters because Lucene's SPI machinery ({@link KnnVectorsFormat#forName(String)},
+ * invoked by {@code PerFieldKnnVectorsFormat.FieldsReader}) reopens codecs via the mandatory
+ * no-arg constructor whenever segments are opened on a new reader (index open, shard relocation,
+ * node bootup). If encoding were carried on the instance, an SPI-instantiated format would hold
+ * a constructor default (previously {@code SINGLE_BIT_QUERY_NIBBLE}) and any writer produced by
+ * it would silently miswrite non-1-bit fields as 1-bit. Resolving encoding per-field from
+ * {@code SQ_CONFIG} makes the format instance encoding-agnostic.
+ *
+ * <p>On the <b>read path</b>, {@link org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat#fieldsReader} never
+ * threads its format-instance encoding through to
+ * {@code Lucene104ScalarQuantizedVectorsReader} — the reader resolves per-field encoding by
+ * reading the wire number from each field's {@code .vemq} meta sidecar (scoped by
+ * {@code SegmentReadState.segmentSuffix} at the Lucene layer). So the encoding we pass to
+ * {@link KNN1040ScalarQuantizedVectorsFormat} on the read path is unused — we intentionally use
+ * a default-encoding instance rather than pretend to resolve it.
  *
  * @see Faiss1040ScalarQuantizedKnnVectorsWriter
  * @see Faiss1040ScalarQuantizedKnnVectorsReader
@@ -41,51 +57,73 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
 
     private static final String FORMAT_NAME = "Faiss1040ScalarQuantizedKnnVectorsFormat";
 
-    private static final ScalarEncoding DEFAULT_ENCODING = ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
-
     // KNN1040ScalarQuantizedVectorsFormat is stateless per encoding, so we cache one instance per
     // encoding and share it across all format instances.
     private static final Map<ScalarEncoding, KNN1040ScalarQuantizedVectorsFormat> FLAT_FORMAT_CACHE = new ConcurrentHashMap<>();
 
-    private final KNN1040ScalarQuantizedVectorsFormat faissSqFlatFormat;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
-
-    /**
-     * Returns the flat format for the default (1-bit) encoding. Retained as a static accessor for tests.
-     */
-    @VisibleForTesting
-    static KNN1040ScalarQuantizedVectorsFormat getFaissSqFlatFormat() {
-        return flatFormatFor(DEFAULT_ENCODING);
-    }
 
     private static KNN1040ScalarQuantizedVectorsFormat flatFormatFor(final ScalarEncoding encoding) {
         return FLAT_FORMAT_CACHE.computeIfAbsent(encoding, KNN1040ScalarQuantizedVectorsFormat::new);
     }
 
+    /**
+     * Returns a fresh {@link KNN1040ScalarQuantizedVectorsFormat} with the default encoding. Used
+     * on the read path, where the encoding is unused downstream (see {@link #fieldsReader}).
+     */
+    private static KNN1040ScalarQuantizedVectorsFormat flatFormatFor() {
+        return new KNN1040ScalarQuantizedVectorsFormat();
+    }
+
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
-        this(new NativeIndexBuildStrategyFactory(), DEFAULT_ENCODING);
+        this(new NativeIndexBuildStrategyFactory());
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat(final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory) {
-        this(nativeIndexBuildStrategyFactory, DEFAULT_ENCODING);
+        super(FORMAT_NAME);
+        this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
     }
 
-    public Faiss1040ScalarQuantizedKnnVectorsFormat(
-        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
-        final ScalarEncoding encoding
-    ) {
-        super(FORMAT_NAME);
-        Objects.requireNonNull(encoding, "ScalarEncoding must not be null");
-        this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
-        this.faissSqFlatFormat = flatFormatFor(encoding);
+    /**
+     * Resolves the {@link ScalarEncoding} for {@code fieldInfo} by reading the field's
+     * {@code SQ_CONFIG} attribute (set by {@code EngineFieldMapper}). Used only by the write
+     * path — the read path does not consume format-instance encoding (see class javadoc).
+     *
+     * <p>Contract: every field routed to this format is expected to be an SQ field carrying
+     * {@code SQ_CONFIG} with a positive {@code bits} value (1, 2, or 4).
+     * {@code EngineFieldMapper} sets this attribute unconditionally on the mapping side, and
+     * Lucene's {@code PerFieldKnnVectorsFormat} only routes a field to this format when the
+     * mapper decided this format applies. So reaching this method with a bits {@code <= 0}
+     * field indicates an upstream invariant violation — we fail loud rather than silently
+     * defaulting to 1-bit (the silent-default was exactly the class of bug this refactor was
+     * written to eliminate).
+     */
+    private static ScalarEncoding resolveEncodingForField(final FieldInfo fieldInfo) {
+        final int bits = FieldInfoExtractor.extractSQConfig(fieldInfo).getBits();
+        if (bits <= 0) {
+            throw new IllegalStateException(
+                String.format(
+                    Locale.ROOT,
+                    "%s: SQ field [%s] has no bits set in its %s attribute; bits must be populated for every SQ field. Supported bits: %s",
+                    FORMAT_NAME,
+                    fieldInfo.getName(),
+                    SQ_CONFIG,
+                    ScalarEncodingResolver.supportedDocBitsString()
+                )
+            );
+        }
+        return ScalarEncodingResolver.forDocBits(bits);
     }
 
     @Override
     public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        // Encoding is resolved LAZILY inside the wrapper writer, on the first addField() or
+        // mergeOneField() call (that's when Lucene hands us the exact FieldInfo). We cannot
+        // resolve here because state.fieldInfos may be null on the initial-write path — Lucene's
+        // IndexingChain calls fieldsWriter() before FieldInfos is populated.
         return new Faiss1040ScalarQuantizedKnnVectorsWriter(
             state,
-            faissSqFlatFormat.fieldsWriter(state),
-            faissSqFlatFormat::fieldsReader,
+            fieldInfo -> flatFormatFor(resolveEncodingForField(fieldInfo)),
             nativeIndexBuildStrategyFactory
         );
     }
@@ -96,12 +134,23 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
      * {@link org.apache.lucene.codecs.lucene95.HasIndexSlice}. This is required because Lucene's
      * HNSW traversal expects all vector values to expose an {@link org.apache.lucene.store.IndexInput},
      * but Lucene's {@code ScalarQuantizedVectorValues} does not implement that interface.
+     *
+     * <p><b>Encoding is not resolved on the read path.</b> {@link org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat#fieldsReader}
+     * ({@code Lucene104ScalarQuantizedVectorsFormat.java:133}) constructs {@code Lucene104ScalarQuantizedVectorsReader}
+     * <i>without</i> threading in the format instance's encoding — the reader instead resolves the encoding for
+     * each field by reading the wire number from the field's own {@code .vemq} meta sidecar
+     * ({@code Lucene104ScalarQuantizedVectorsReader.FieldEntry.create}, {@code input.readVInt()} →
+     * {@code ScalarEncoding.fromWireNumber}).
+     *
+     * <p>Therefore, passing a specific encoding to {@link KNN1040ScalarQuantizedVectorsFormat} here would
+     * be dead code — the value is unused downstream. We deliberately use the default no-arg constructor
+     * to avoid implying a per-field resolution that isn't happening.
      */
     @Override
     public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
         return new Faiss1040ScalarQuantizedKnnVectorsReader(
             state,
-            new Faiss1040ScalarQuantizedFlatVectorsReader(faissSqFlatFormat.fieldsReader(state))
+            new Faiss1040ScalarQuantizedFlatVectorsReader(flatFormatFor().fieldsReader(state))
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -20,7 +20,6 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
-import org.apache.lucene.util.IOFunction;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.knn.index.codec.nativeindex.AbstractNativeEnginesKnnVectorsWriter;
@@ -28,6 +27,7 @@ import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactor
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexWriter;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 /**
  * Writer for Faiss SQ vector fields. Unlike {@link org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsWriter}
@@ -47,24 +47,44 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(Faiss1040ScalarQuantizedKnnVectorsWriter.class);
 
     private final SegmentWriteState segmentWriteState;
-    private final FlatVectorsWriter flatVectorsWriter;
+    // Supplies a Lucene flat format for a given FieldInfo. Called lazily on the first addField()
+    // or mergeOneField() call — this is when Lucene hands us the exact FieldInfo, so we can
+    // resolve the correct ScalarEncoding from its SQ_CONFIG attribute rather than relying on a
+    // pre-baked encoding at construction time. Deferring is required because at
+    // Faiss1040ScalarQuantizedKnnVectorsFormat.fieldsWriter(state) time, state.fieldInfos may
+    // still be null on the initial-write path (Lucene's IndexingChain calls fieldsWriter before
+    // fieldInfos is populated).
+    private final Function<FieldInfo, KNN1040ScalarQuantizedVectorsFormat> flatFormatResolver;
+    // The lazily-constructed flat writer — non-null after the first addField/mergeOneField call.
+    private FlatVectorsWriter flatVectorsWriter;
+    private KNN1040ScalarQuantizedVectorsFormat resolvedFlatFormat;
     // Single field — SQ gets a dedicated format per field via BasePerFieldKnnVectorsFormat
     private FlatFieldVectorsWriter<?> fieldWriter;
     private FieldInfo fieldInfo;
     private boolean finished;
-    private final IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
 
     Faiss1040ScalarQuantizedKnnVectorsWriter(
         @NonNull SegmentWriteState segmentWriteState,
-        @NonNull FlatVectorsWriter flatVectorsWriter,
-        @NonNull IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier,
+        @NonNull Function<FieldInfo, KNN1040ScalarQuantizedVectorsFormat> flatFormatResolver,
         @NonNull NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
     ) {
         this.segmentWriteState = segmentWriteState;
-        this.flatVectorsWriter = flatVectorsWriter;
-        this.quantizedFlatVectorsReaderSupplier = quantizedFlatVectorsReaderSupplier;
+        this.flatFormatResolver = flatFormatResolver;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+    }
+
+    /**
+     * Resolves the flat format from the given field on first call, constructs the underlying
+     * Lucene flat writer, and caches both for subsequent operations (flush, close). Called from
+     * {@link #addField(FieldInfo)} and {@link #mergeOneField(FieldInfo, MergeState)}.
+     */
+    private FlatVectorsWriter getOrInitFlatVectorsWriter(final FieldInfo fieldInfoForResolution) throws IOException {
+        if (flatVectorsWriter == null) {
+            this.resolvedFlatFormat = flatFormatResolver.apply(fieldInfoForResolution);
+            this.flatVectorsWriter = resolvedFlatFormat.fieldsWriter(segmentWriteState);
+        }
+        return flatVectorsWriter;
     }
 
     /**
@@ -83,7 +103,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             );
         }
         this.fieldInfo = newFieldInfo;
-        this.fieldWriter = flatVectorsWriter.addField(newFieldInfo);
+        this.fieldWriter = getOrInitFlatVectorsWriter(newFieldInfo).addField(newFieldInfo);
         return fieldWriter;
     }
 
@@ -98,6 +118,10 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
      */
     @Override
     public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+        if (flatVectorsWriter == null) {
+            // No field was added — nothing to flush and no native build to run.
+            return;
+        }
         // Flush, finish, and close the flat vectors writer so that the .vec and .veb files
         // are fully written and file handles are released.
         flatVectorsWriter.flush(maxDoc, sortMap);
@@ -138,12 +162,16 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
         // Setting field info
         this.fieldInfo = fieldInfo;
 
+        // Resolve the flat format from the merged field's SQ_CONFIG on the first call. Merge
+        // paths don't go through addField, so this is where lazy init happens for merges.
+        final FlatVectorsWriter writer = getOrInitFlatVectorsWriter(fieldInfo);
+
         // Merge, finish, and close the flat writer so that files are readable.
-        IORunnable mergeRunnable = flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+        IORunnable mergeRunnable = writer.mergeOneField(fieldInfo, mergeState);
 
         if (mergeRunnable != null) mergeRunnable.run();
-        flatVectorsWriter.finish();
-        IOUtils.close(flatVectorsWriter);
+        writer.finish();
+        IOUtils.close(writer);
 
         // Open a reader on the merged flat files, extract QuantizedByteVectorValues,
         // and pass it to the build strategy. The writer owns the reader lifecycle.
@@ -183,11 +211,14 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
 
     @Override
     public long ramBytesUsed() {
-        return SHALLOW_SIZE + flatVectorsWriter.ramBytesUsed() + (fieldWriter != null ? fieldWriter.ramBytesUsed() : 0);
+        return SHALLOW_SIZE + (flatVectorsWriter != null ? flatVectorsWriter.ramBytesUsed() : 0) + (fieldWriter != null
+            ? fieldWriter.ramBytesUsed()
+            : 0);
     }
 
     /**
      * Opens a FlatVectorsReader scoped to this single field from the already-written flat files.
+     * Uses the resolved flat format from the write phase to ensure encoding matches.
      */
     private FlatVectorsReader openFlatVectorsReader() throws IOException {
         final SegmentReadState readState = new SegmentReadState(
@@ -197,6 +228,6 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             segmentWriteState.context,
             segmentWriteState.segmentSuffix
         );
-        return quantizedFlatVectorsReaderSupplier.apply(readState);
+        return resolvedFlatFormat.fieldsReader(readState);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/ScalarEncodingResolver.java
@@ -139,7 +139,10 @@ public final class ScalarEncodingResolver {
         return bits;
     }
 
-    private static String supportedDocBitsString() {
+    /**
+     * Returns the supported document bit widths as a printable string (e.g. {@code "[1, 2, 4]"}).
+     */
+    public static String supportedDocBitsString() {
         return Arrays.toString(SUPPORTED_DOC_BITS);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
@@ -113,9 +113,13 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategy implements NativeInde
         final QuantizedByteVectorValues binarizedVectorValues = indexInfo.getQuantizedByteVectorValues();
         Objects.requireNonNull(binarizedVectorValues, "QuantizedByteVectorValues was null in BuildIndexParams");
 
-        // The byte length of a single quantized vector. For 1-bit quantization of D dimensions,
-        // this is ceil(D/8) bytes, padded to 64-bit alignment: ((D + 63) / 64) * 64 / 8.
-        // TODO : This needs to be made generic for other quantization.
+        // Byte length of a single quantized vector as written to Lucene's .veq file. This is
+        // data-driven — Lucene's encoder decides the layout per ScalarEncoding, and each
+        // supported bit width produces a different length:
+        // B=1 (SINGLE_BIT_QUERY_NIBBLE): ceil(D/8) bytes, padded to 64-bit alignment
+        // B=2 (DIBIT_QUERY_NIBBLE): two bit-planes, 2 * planeBytes
+        // B=4 (PACKED_NIBBLE): two 4-bit values per byte, packedBytes
+        // We simply consume the resulting length; the strategy is generic across all three.
         final int quantizedVecBytes = binarizedVectorValues.vectorValue(0).length;
 
         // The centroid dot-product is a precomputed scalar used in the ADC scoring formula.

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
@@ -60,12 +60,12 @@ public final class NativeIndexBuildStrategyFactory {
         final KNNEngine knnEngine = extractKNNEngine(fieldInfo);
         final boolean isTemplate = fieldInfo.attributes().containsKey(MODEL_ID);
         final boolean iterative = !isTemplate && KNNEngine.FAISS == knnEngine;
-        final boolean isFaissSQOneBitField = FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue();
+        final boolean isFaissSQMosField = FieldInfoExtractor.isSQField(fieldInfo)
+            && FaissSQEncoder.isMosBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits());
 
         // Determine build strategy
         final NativeIndexBuildStrategy strategy;
-        if (isFaissSQOneBitField) {
+        if (isFaissSQMosField) {
             strategy = MemOptimizedScalarQuantizedIndexBuildStrategy.getInstance();
         } else if (iterative) {
             strategy = MemOptimizedNativeIndexBuildStrategy.getInstance();

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexBuildStrategyFactory.java
@@ -61,7 +61,7 @@ public final class NativeIndexBuildStrategyFactory {
         final boolean isTemplate = fieldInfo.attributes().containsKey(MODEL_ID);
         final boolean iterative = !isTemplate && KNNEngine.FAISS == knnEngine;
         final boolean isFaissSQMosField = FieldInfoExtractor.isSQField(fieldInfo)
-            && FaissSQEncoder.isMosBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits());
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits());
 
         // Determine build strategy
         final NativeIndexBuildStrategy strategy;

--- a/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
+++ b/src/main/java/org/opensearch/knn/index/engine/MemoryOptimizedSearchSupportSpec.java
@@ -154,7 +154,7 @@ public class MemoryOptimizedSearchSupportSpec {
     /**
      * Determines whether memory-optimized search must always be used for the given KNN method context,
      * regardless of the cluster-level memory-optimized search setting. Currently, this returns {@code true}
-     * only when the encoder is sq with bits=1 (1-bit quantization), as these indices always require
+     * when the encoder is sq with bits in {1, 2, 4} (the multi-bit MOS path), as these indices always require
      * memory-optimized search for correctness.
      *
      * @param knnMethodContext Optional method context containing engine, space type, and encoder information.
@@ -162,6 +162,6 @@ public class MemoryOptimizedSearchSupportSpec {
      */
     public static boolean isAlwaysUseMemoryOptimizedSearch(final Optional<KNNMethodContext> knnMethodContext) {
         return knnMethodContext.isPresent()
-            && FaissSQEncoder.isSQOneBit(knnMethodContext.get().getMethodComponentContext().getParameters());
+            && FaissSQEncoder.isSQMultiBit(knnMethodContext.get().getMethodComponentContext().getParameters());
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -10,6 +10,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNN1040Codec.Faiss1040ScalarQuantizedKnnVectorsFormat;
+import org.opensearch.knn.index.codec.KNN1040Codec.ScalarEncodingResolver;
 import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.CodecFormatResolver;
@@ -17,6 +18,8 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 
 import java.util.Map;
 import java.util.Optional;
+
+import static org.opensearch.knn.index.engine.faiss.FaissSQEncoder.isSQMultiBit;
 
 /**
  * {@link CodecFormatResolver} implementation for native engines (FAISS, NMSLIB).
@@ -41,7 +44,8 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
 
     /**
      * Resolves the format for a specific field. Returns {@link Faiss1040ScalarQuantizedKnnVectorsFormat} when
-     * the encoder is sq with bits=1, otherwise falls back to the default native format.
+     * the encoder is sq with bits in {1, 2, 4} (the multi-bit MOS path), otherwise falls back to the default
+     * native format. The document bit width is threaded into the format via {@link ScalarEncodingResolver}.
      */
     @Override
     public KnnVectorsFormat resolve(
@@ -51,8 +55,12 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
         int defaultMaxConnections,
         int defaultBeamWidth
     ) {
-        if (isSQOneBitEncoder(params)) {
-            return new Faiss1040ScalarQuantizedKnnVectorsFormat(nativeIndexBuildStrategyFactory);
+        if (isSQMultiBit(params)) {
+            final int docBits = FaissSQEncoder.getSQBits(params);
+            return new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                nativeIndexBuildStrategyFactory,
+                ScalarEncodingResolver.forDocBits(docBits)
+            );
         }
         return resolve();
     }
@@ -75,7 +83,4 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
             : KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE;
     }
 
-    private static boolean isSQOneBitEncoder(Map<String, Object> params) {
-        return FaissSQEncoder.isSQOneBit(params);
-    }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -10,7 +10,6 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.KNN1040Codec.Faiss1040ScalarQuantizedKnnVectorsFormat;
-import org.opensearch.knn.index.codec.KNN1040Codec.ScalarEncodingResolver;
 import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsFormat;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.CodecFormatResolver;
@@ -45,7 +44,7 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
     /**
      * Resolves the format for a specific field. Returns {@link Faiss1040ScalarQuantizedKnnVectorsFormat} when
      * the encoder is sq with bits in {1, 2, 4} (the multi-bit MOS path), otherwise falls back to the default
-     * native format. The document bit width is threaded into the format via {@link ScalarEncodingResolver}.
+     * native format. The document bit width is resolved per-field at write time by the format itself.
      */
     @Override
     public KnnVectorsFormat resolve(
@@ -56,11 +55,10 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
         int defaultBeamWidth
     ) {
         if (isSQMultiBit(params)) {
-            final int docBits = FaissSQEncoder.getSQBits(params);
-            return new Faiss1040ScalarQuantizedKnnVectorsFormat(
-                nativeIndexBuildStrategyFactory,
-                ScalarEncodingResolver.forDocBits(docBits)
-            );
+            // Encoding is not passed here — Faiss1040ScalarQuantizedKnnVectorsFormat resolves it
+            // per-field from SQ_CONFIG at fieldsWriter() time. This keeps the format instance
+            // encoding-agnostic so SPI-instantiated instances cannot silently miswrite fields.
+            return new Faiss1040ScalarQuantizedKnnVectorsFormat(nativeIndexBuildStrategyFactory);
         }
         return resolve();
     }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -71,6 +71,8 @@ public class FaissSQEncoder implements Encoder {
     @RequiredArgsConstructor
     public enum Bits {
         ONE(1, CompressionLevel.x32),
+        TWO(2, CompressionLevel.x16),
+        FOUR(4, CompressionLevel.x8),
         SIXTEEN(16, CompressionLevel.x2);
 
         private final int value;
@@ -102,8 +104,10 @@ public class FaissSQEncoder implements Encoder {
             Map<String, Object> params = methodComponentContext.getParameters();
             Object bitsObj = params.get(SQ_BITS);
 
-            // bits=1 path: 1-bit quantization — use flat description, Faiss only builds the HNSW graph
-            if (bitsObj instanceof Integer && (Integer) bitsObj == Bits.ONE.getValue()) {
+            // Multi-bit MOS path (bits in {1,2,4}): document vectors are scalar-quantized to B bits and
+            // stored in Lucene's flat SQ files; Faiss only builds the HNSW graph. Use the flat description
+            // and carry SQ_BITS = B so the codec/build path can resolve the document bit width.
+            if (bitsObj instanceof Integer && isMosBits((Integer) bitsObj)) {
                 int bits = (Integer) bitsObj;
                 return KNNLibraryIndexingContextImpl.builder().parameters(new HashMap<>() {
                     {
@@ -252,6 +256,53 @@ public class FaissSQEncoder implements Encoder {
     }
 
     /**
+     * Returns true if {@code bits} is a document bit width served by the memory-optimized SQ (MOS) path.
+     * These are the non-fp16 widths {1, 2, 4} that delegate HNSW construction to native Faiss over
+     * scalar-quantized codes. fp16 (16) is excluded — it uses the standard Faiss SQ description.
+     *
+     * @param bits the configured sq encoder bit width
+     * @return true for bits in {1, 2, 4}
+     */
+    public static boolean isMosBits(final int bits) {
+        return bits == Bits.ONE.getValue() || bits == Bits.TWO.getValue() || bits == Bits.FOUR.getValue();
+    }
+
+    /**
+     * Extracts the configured sq encoder bit width from a method params map, or {@code null} if the
+     * encoder is not sq or has no bits set.
+     *
+     * @param params map that may contain a {@code METHOD_ENCODER_PARAMETER} entry
+     * @return the bit width, or {@code null}
+     */
+    public static Integer getSQBits(Map<String, Object> params) {
+        if (params == null) {
+            return null;
+        }
+        Object encoderObj = params.get(METHOD_ENCODER_PARAMETER);
+        if (encoderObj instanceof MethodComponentContext == false) {
+            return null;
+        }
+        MethodComponentContext encoderCtx = (MethodComponentContext) encoderObj;
+        if (ENCODER_SQ.equals(encoderCtx.getName()) == false) {
+            return null;
+        }
+        Object bits = encoderCtx.getParameters().get(SQ_BITS);
+        return bits instanceof Integer ? (Integer) bits : null;
+    }
+
+    /**
+     * Checks whether the given method parameters map contains an sq encoder configured for the
+     * memory-optimized multi-bit path (bits in {1, 2, 4}).
+     *
+     * @param params map that may contain a {@code METHOD_ENCODER_PARAMETER} entry
+     * @return true if the encoder is sq with bits in {1, 2, 4}
+     */
+    public static boolean isSQMultiBit(Map<String, Object> params) {
+        Integer bits = getSQBits(params);
+        return bits != null && isMosBits(bits);
+    }
+
+    /**
      * Checks whether the given method parameters map contains an sq encoder with bits=1.
      * Works with both the method component parameters (from KNNMethodContext) and the
      * per-field params map (from codec format resolver).
@@ -260,18 +311,7 @@ public class FaissSQEncoder implements Encoder {
      * @return true if the encoder is sq with bits=1
      */
     public static boolean isSQOneBit(Map<String, Object> params) {
-        if (params == null) {
-            return false;
-        }
-        Object encoderObj = params.get(METHOD_ENCODER_PARAMETER);
-        if (encoderObj instanceof MethodComponentContext == false) {
-            return false;
-        }
-        MethodComponentContext encoderCtx = (MethodComponentContext) encoderObj;
-        if (ENCODER_SQ.equals(encoderCtx.getName()) == false) {
-            return false;
-        }
-        Object bits = encoderCtx.getParameters().get(SQ_BITS);
-        return bits instanceof Integer && (Integer) bits == Bits.ONE.getValue();
+        Integer bits = getSQBits(params);
+        return bits != null && bits == Bits.ONE.getValue();
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -107,7 +107,7 @@ public class FaissSQEncoder implements Encoder {
             // Multi-bit MOS path (bits in {1,2,4}): document vectors are scalar-quantized to B bits and
             // stored in Lucene's flat SQ files; Faiss only builds the HNSW graph. Use the flat description
             // and carry SQ_BITS = B so the codec/build path can resolve the document bit width.
-            if (bitsObj instanceof Integer && isMosBits((Integer) bitsObj)) {
+            if (bitsObj instanceof Integer && isSQCodedBits((Integer) bitsObj)) {
                 int bits = (Integer) bitsObj;
                 return KNNLibraryIndexingContextImpl.builder().parameters(new HashMap<>() {
                     {
@@ -256,14 +256,15 @@ public class FaissSQEncoder implements Encoder {
     }
 
     /**
-     * Returns true if {@code bits} is a document bit width served by the memory-optimized SQ (MOS) path.
-     * These are the non-fp16 widths {1, 2, 4} that delegate HNSW construction to native Faiss over
-     * scalar-quantized codes. fp16 (16) is excluded — it uses the standard Faiss SQ description.
+     * Returns true if {@code bits} is a document bit width stored as integer-coded scalar quantization
+     * codes in Lucene's flat SQ format. These are the widths {1, 2, 4} — HNSW construction is
+     * delegated to native Faiss over the coded bytes. fp16 (16) is excluded — it is a compressed
+     * float representation (not integer-quantized codes) and takes the standard Faiss SQ description.
      *
      * @param bits the configured sq encoder bit width
      * @return true for bits in {1, 2, 4}
      */
-    public static boolean isMosBits(final int bits) {
+    public static boolean isSQCodedBits(final int bits) {
         return bits == Bits.ONE.getValue() || bits == Bits.TWO.getValue() || bits == Bits.FOUR.getValue();
     }
 
@@ -299,7 +300,7 @@ public class FaissSQEncoder implements Encoder {
      */
     public static boolean isSQMultiBit(Map<String, Object> params) {
         Integer bits = getSQBits(params);
-        return bits != null && isMosBits(bits);
+        return bits != null && isSQCodedBits(bits);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
@@ -11,13 +11,17 @@ import lombok.Getter;
 
 /**
  * Configuration for the SQ (Scalar Quantization) encoder stored as a field attribute.
+ *
+ * <p>The {@code bits} field must be set explicitly by callers — there is no default. The supported
+ * MOS bit widths are {@code 1}, {@code 2}, and {@code 4}; {@link #EMPTY} carries {@code bits=0} as
+ * a sentinel. Callers that treat the value as a doc bit width should validate it through
+ * {@link FaissSQEncoder#isMosBits(int)}.
  */
 @Builder
 @Getter
 @EqualsAndHashCode
 public class SQConfig {
-    @Builder.Default
-    private int bits = FaissSQEncoder.Bits.ONE.getValue();
+    private int bits;
 
     public static final SQConfig EMPTY = SQConfig.builder().bits(0).build();
 }

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/SQConfig.java
@@ -15,7 +15,7 @@ import lombok.Getter;
  * <p>The {@code bits} field must be set explicitly by callers — there is no default. The supported
  * MOS bit widths are {@code 1}, {@code 2}, and {@code 4}; {@link #EMPTY} carries {@code bits=0} as
  * a sentinel. Callers that treat the value as a doc bit width should validate it through
- * {@link FaissSQEncoder#isMosBits(int)}.
+ * {@link FaissSQEncoder#isSQCodedBits(int)}.
  */
 @Builder
 @Getter

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -192,11 +192,11 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
             this.fieldType.putAttribute(DIMENSION, String.valueOf(knnMappingConfig.getDimension()));
             this.fieldType.putAttribute(SPACE_TYPE, resolvedKnnMethodContext.getSpaceType().getValue());
 
-            if (isSQOneBitEncoder(resolvedKnnMethodContext)) {
-                // 1-bit quantization has its own per-field format that handles quantization internally, so we
-                // don't set qframe_config (which drives the k-NN quantization framework). Instead
-                // we store a separate sq config attribute as a quick way for readers to
-                // identify 1-bit quantized fields without parsing the full PARAMETERS JSON.
+            if (isSQMultiBitEncoder(resolvedKnnMethodContext)) {
+                // The sq (1/2/4-bit) MOS path has its own per-field format that handles quantization
+                // internally, so we don't set qframe_config (which drives the k-NN quantization
+                // framework). Instead we store a separate sq config attribute (carrying the bit width)
+                // as a quick way for readers to identify these fields without parsing the full PARAMETERS JSON.
                 this.fieldType.putAttribute(SQ_CONFIG, getSQConfigValue(resolvedKnnMethodContext));
             } else {
                 // Conditionally add quantization config
@@ -320,21 +320,23 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
     }
 
     /**
-     * Checks whether the resolved method context uses the sq encoder with bits=1.
+     * Checks whether the resolved method context uses the sq encoder with a multi-bit MOS bit width (1, 2, or 4).
      */
-    private static boolean isSQOneBitEncoder(KNNMethodContext methodContext) {
-        return FaissSQEncoder.isSQOneBit(methodContext.getMethodComponentContext().getParameters());
+    private static boolean isSQMultiBitEncoder(KNNMethodContext methodContext) {
+        return FaissSQEncoder.isSQMultiBit(methodContext.getMethodComponentContext().getParameters());
     }
 
     /**
-     * Builds the SQ config attribute value as a CSV string.
+     * Builds the SQ config attribute value as a CSV string. Callers are expected to have already
+     * confirmed via {@link #isSQMultiBitEncoder(KNNMethodContext)} that the encoder is sq with a
+     * MOS bit width, so {@code SQ_BITS} is guaranteed to be present as an Integer in {1, 2, 4}.
      */
     private static String getSQConfigValue(KNNMethodContext methodContext) {
         MethodComponentContext encoderCtx = (MethodComponentContext) methodContext.getMethodComponentContext()
             .getParameters()
             .get(METHOD_ENCODER_PARAMETER);
-        Object bits = encoderCtx.getParameters().getOrDefault(SQ_BITS, FaissSQEncoder.Bits.ONE.getValue());
-        SQConfig config = SQConfig.builder().bits((Integer) bits).build();
+        Integer bits = (Integer) encoderCtx.getParameters().get(SQ_BITS);
+        SQConfig config = SQConfig.builder().bits(bits).build();
         return SQConfigParser.toCsv(config);
     }
 }

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -86,7 +86,7 @@ public class FlatVectorsScorerProvider {
             // Since Lucene doesn't provide hamming distance scorer, we return our own hamming distance scorer
             return HAMMING_VECTOR_SCORER;
         } else if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
+            && FaissSQEncoder.isMosBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
                 return getKNN1040ScalarQuantizedVectorScorer(delegateScorer);
             } else if (delegateScorer != null) {
                 // For all other cases, return the delegate scorer

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FlatVectorsScorerProvider.java
@@ -86,7 +86,7 @@ public class FlatVectorsScorerProvider {
             // Since Lucene doesn't provide hamming distance scorer, we return our own hamming distance scorer
             return HAMMING_VECTOR_SCORER;
         } else if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FaissSQEncoder.isMosBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
                 return getKNN1040ScalarQuantizedVectorScorer(delegateScorer);
             } else if (delegateScorer != null) {
                 // For all other cases, return the delegate scorer

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormatTests.java
@@ -6,12 +6,14 @@
 package org.opensearch.knn.index.codec.KNN1040Codec;
 
 import lombok.SneakyThrows;
+import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
@@ -24,18 +26,20 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.Version;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
-import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import lombok.extern.log4j.Log4j2;
 import org.opensearch.knn.KNNTestCase;
-import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.codec.scorer.PrefetchableFlatVectorScorer.PrefetchableRandomVectorScorer;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -70,7 +74,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
             0,
             false,
             false,
-            mock(org.apache.lucene.codecs.Codec.class),
+            mock(Codec.class),
             mock(Map.class),
             new byte[16],
             mock(Map.class),
@@ -82,35 +86,31 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         Mockito.when(directory.openInput(any(), any())).thenReturn(input);
         Mockito.when(directory.createOutput(anyString(), any())).thenReturn(mock(IndexOutput.class));
 
-        final FieldInfos fieldInfos = mock(FieldInfos.class);
-        final FieldInfo fieldInfo = mock(FieldInfo.class);
-        Mockito.when(fieldInfo.getName()).thenReturn("test-field");
-        Mockito.when(fieldInfos.fieldInfo(anyInt())).thenReturn(fieldInfo);
-        Mockito.when(fieldInfos.iterator()).thenReturn(new Iterator<FieldInfo>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
+        // Segment carries a single SQ field with bits=1 (matches Lucene's per-field routing —
+        // this format instance is only ever asked to handle its routed SQ field).
+        final FieldInfo sqFieldInfo = mock(FieldInfo.class);
+        Mockito.when(sqFieldInfo.getName()).thenReturn("test-field");
+        Mockito.when(sqFieldInfo.getAttribute(SQ_CONFIG)).thenReturn(SQConfigParser.toCsv(SQConfig.builder().bits(1).build()));
 
-            @Override
-            public FieldInfo next() {
-                return null;
-            }
-        });
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        Mockito.when(fieldInfos.fieldInfo(anyInt())).thenReturn(sqFieldInfo);
+        Mockito.when(fieldInfos.iterator()).thenReturn(List.of(sqFieldInfo).iterator());
 
         final SegmentReadState mockedSegmentReadState = new SegmentReadState(
             directory,
             mockedSegmentInfo,
             fieldInfos,
             mock(IOContext.class),
-            "test-segment-suffix"
+            ""
         );
 
+        final FieldInfos writeFieldInfos = mock(FieldInfos.class);
+        Mockito.when(writeFieldInfos.iterator()).thenReturn(List.of(sqFieldInfo).iterator());
         final SegmentWriteState mockedSegmentWriteState = new SegmentWriteState(
             mock(InfoStream.class),
             directory,
             mockedSegmentInfo,
-            mock(FieldInfos.class),
+            writeFieldInfos,
             null,
             mock(IOContext.class)
         );
@@ -137,55 +137,119 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         assertTrue(str.contains(Faiss1040ScalarQuantizedKnnVectorsFormat.class.getSimpleName()));
     }
 
-    public void testDefaultConstructor_usesOneBitEncoding() {
-        // Backward-compatibility: no-arg and single-arg constructors must still resolve to the
-        // 1-bit flat format that shipped in 3.x. Any change here would silently switch existing
-        // indices to a different encoding on the next segment write.
-        assertSame(
-            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
-            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat())
-        );
-        assertSame(
-            Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
-            reflectFlatFormat(new Faiss1040ScalarQuantizedKnnVectorsFormat(new NativeIndexBuildStrategyFactory()))
-        );
-    }
-
-    public void testExplicitEncoding_selectsMatchingFlatFormat() {
-        // Verify each supported encoding wires through to a distinct flat format instance.
-        // Cache-sharing means repeated construction with the same encoding returns the same
-        // underlying format; different encodings return different instances.
-        for (ScalarEncoding encoding : new ScalarEncoding[] {
-            ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE,
-            ScalarEncoding.DIBIT_QUERY_NIBBLE,
-            ScalarEncoding.PACKED_NIBBLE }) {
-            Faiss1040ScalarQuantizedKnnVectorsFormat first = new Faiss1040ScalarQuantizedKnnVectorsFormat(
-                new NativeIndexBuildStrategyFactory(),
-                encoding
-            );
-            Faiss1040ScalarQuantizedKnnVectorsFormat second = new Faiss1040ScalarQuantizedKnnVectorsFormat(
-                new NativeIndexBuildStrategyFactory(),
-                encoding
-            );
-            assertSame("Flat format for " + encoding + " should be cached and reused", reflectFlatFormat(first), reflectFlatFormat(second));
-        }
-
-        // Different encodings must produce different flat format instances.
-        assertNotSame(
-            reflectFlatFormat(
-                new Faiss1040ScalarQuantizedKnnVectorsFormat(new NativeIndexBuildStrategyFactory(), ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE)
-            ),
-            reflectFlatFormat(
-                new Faiss1040ScalarQuantizedKnnVectorsFormat(new NativeIndexBuildStrategyFactory(), ScalarEncoding.DIBIT_QUERY_NIBBLE)
-            )
-        );
-    }
-
+    /**
+     * Regression guard for the "SPI-instantiated format silently miswrites 2/4-bit fields as
+     * 1-bit" bug: verifies that a format constructed via the no-arg SPI constructor still uses
+     * the correct per-field encoding when asked for a writer, because encoding is resolved from
+     * the field's {@code SQ_CONFIG} attribute at write time (not baked in at construction time).
+     */
+    /**
+     * Regression guard for the "SPI-instantiated format silently miswrites 2/4-bit fields as
+     * 1-bit" bug: verifies that a format constructed via the no-arg SPI constructor resolves
+     * the correct per-field encoding from the field's {@code SQ_CONFIG} attribute at the moment
+     * Lucene calls {@code fieldsWriter().fieldsWriter().addField()}. The encoding lives on the
+     * cached {@code KNN1040ScalarQuantizedVectorsFormat} instance the writer resolves.
+     */
     @SneakyThrows
-    private static KNN1040ScalarQuantizedVectorsFormat reflectFlatFormat(Faiss1040ScalarQuantizedKnnVectorsFormat format) {
-        java.lang.reflect.Field field = Faiss1040ScalarQuantizedKnnVectorsFormat.class.getDeclaredField("faissSqFlatFormat");
-        field.setAccessible(true);
-        return (KNN1040ScalarQuantizedVectorsFormat) field.get(format);
+    public void testFieldsWriter_encodingResolvedPerFieldFromSQConfig() {
+        try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
+            for (int bits : new int[] { 1, 2, 4 }) {
+                // Write a segment through the same flat format the wrapper resolves to, with
+                // SQ_CONFIG=bits=<bits>. Then open a reader via the no-arg SPI constructor and
+                // verify the round-trip works: writer resolved the correct encoding, and reader
+                // picked it up from the .vemq header end-to-end.
+                final SegmentReadState readState = KNN1040ScalarQuantizedTestUtils.writeQuantizedVectors(
+                    dir,
+                    "seg_bits_" + bits,
+                    new KNN1040ScalarQuantizedVectorsFormat(ScalarEncodingResolver.forDocBits(bits)),
+                    bits,
+                    random()
+                );
+
+                try (KnnVectorsReader rawReader = new Faiss1040ScalarQuantizedKnnVectorsFormat().fieldsReader(readState)) {
+                    assertTrue(rawReader instanceof Faiss1040ScalarQuantizedKnnVectorsReader);
+                    final FlatVectorsReader flatReader = ((Faiss1040ScalarQuantizedKnnVectorsReader) rawReader).getFlatVectorsReader();
+                    final FloatVectorValues values = flatReader.getFloatVectorValues(KNN1040ScalarQuantizedTestUtils.FIELD_NAME);
+                    assertNotNull("Values must exist for field written with bits=" + bits, values);
+                    assertEquals(
+                        "bits=" + bits + " must produce " + KNN1040ScalarQuantizedTestUtils.NUM_VECTORS + " vectors",
+                        KNN1040ScalarQuantizedTestUtils.NUM_VECTORS,
+                        values.size()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Fail-loud invariant: if an SQ field with {@code bits=0} reaches the writer via
+     * {@code addField()}, the lazy encoding resolver must throw rather than silently default to
+     * 1-bit. This is the exact silent-default failure mode this refactor was written to eliminate.
+     */
+    @SneakyThrows
+    public void testFieldsWriter_addFieldWithBitsZero_thenThrows() {
+        final FieldInfo malformedSqField = mock(FieldInfo.class);
+        Mockito.when(malformedSqField.getName()).thenReturn("malformed_sq_field");
+        // Syntactically valid SQ_CONFIG with a zero-bits payload — bypasses SQConfigParser's
+        // "empty means SQConfig.EMPTY" shortcut and hits the fail-loud guard in the resolver.
+        Mockito.when(malformedSqField.getAttribute(SQ_CONFIG)).thenReturn("bits=0");
+
+        final KnnVectorsWriter writer = buildWriterForSegmentWithField(malformedSqField);
+        try {
+            final IllegalStateException ex = expectThrows(IllegalStateException.class, () -> writer.addField(malformedSqField));
+            assertTrue(
+                "Expected fail-loud message mentioning bits and the field name, got: " + ex.getMessage(),
+                ex.getMessage().contains("bits") && ex.getMessage().contains("malformed_sq_field")
+            );
+        } finally {
+            writer.close();
+        }
+    }
+
+    /**
+     * Builds a writer through the no-arg (SPI) constructor path, with a segment containing the
+     * given field. Encoding resolution is deferred until {@code addField()} is called on the
+     * returned writer — this mirrors the actual Lucene write path.
+     */
+    @SneakyThrows
+    private KnnVectorsWriter buildWriterForSegmentWithField(FieldInfo fieldInfo) {
+        final SegmentInfo segmentInfo = new SegmentInfo(
+            mock(Directory.class),
+            mock(Version.class),
+            mock(Version.class),
+            "test-segment",
+            0,
+            false,
+            false,
+            mock(Codec.class),
+            mock(Map.class),
+            new byte[16],
+            mock(Map.class),
+            mock(Sort.class)
+        );
+
+        final Directory directory = mock(Directory.class);
+        Mockito.when(directory.createOutput(anyString(), any())).thenReturn(mock(IndexOutput.class));
+
+        final FieldInfos writeFieldInfos = mock(FieldInfos.class);
+        Mockito.when(writeFieldInfos.iterator()).thenReturn(List.of(fieldInfo).iterator());
+
+        final SegmentWriteState writeState = new SegmentWriteState(
+            mock(InfoStream.class),
+            directory,
+            segmentInfo,
+            writeFieldInfos,
+            null,
+            mock(IOContext.class)
+        );
+
+        final Faiss1040ScalarQuantizedKnnVectorsFormat format = new Faiss1040ScalarQuantizedKnnVectorsFormat();
+        try (MockedStatic<CodecUtil> mockedCodecUtil = Mockito.mockStatic(CodecUtil.class)) {
+            mockedCodecUtil.when(
+                () -> CodecUtil.writeIndexHeader(any(IndexOutput.class), anyString(), anyInt(), any(byte[].class), anyString())
+            ).thenAnswer((Answer<Void>) invocation -> null);
+            return format.fieldsWriter(writeState);
+        }
     }
 
     @SneakyThrows
@@ -198,7 +262,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
             0,
             false,
             false,
-            mock(org.apache.lucene.codecs.Codec.class),
+            mock(Codec.class),
             mock(Map.class),
             new byte[16],
             mock(Map.class),
@@ -209,25 +273,21 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         final IndexInput input = mock(IndexInput.class);
         Mockito.when(directory.openInput(any(), any())).thenReturn(input);
 
-        final FieldInfos fieldInfos = mock(FieldInfos.class);
-        Mockito.when(fieldInfos.iterator()).thenReturn(new Iterator<FieldInfo>() {
-            @Override
-            public boolean hasNext() {
-                return false;
-            }
+        // Segment carries a single SQ field (bits=1) — the format's read path resolves encoding
+        // per-field from SQ_CONFIG just like the write path.
+        final FieldInfo sqFieldInfo = mock(FieldInfo.class);
+        Mockito.when(sqFieldInfo.getName()).thenReturn("test-field");
+        Mockito.when(sqFieldInfo.getAttribute(SQ_CONFIG)).thenReturn(SQConfigParser.toCsv(SQConfig.builder().bits(1).build()));
 
-            @Override
-            public FieldInfo next() {
-                return null;
-            }
-        });
+        final FieldInfos fieldInfos = mock(FieldInfos.class);
+        Mockito.when(fieldInfos.iterator()).thenReturn(List.of(sqFieldInfo).iterator());
 
         final SegmentReadState mockedSegmentReadState = new SegmentReadState(
             directory,
             mockedSegmentInfo,
             fieldInfos,
             mock(IOContext.class),
-            "test-segment-suffix"
+            ""
         );
 
         final Faiss1040ScalarQuantizedKnnVectorsFormat format = new Faiss1040ScalarQuantizedKnnVectorsFormat();
@@ -252,7 +312,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormatTests extends KNNTestCase {
         try (MMapDirectory dir = new MMapDirectory(createTempDir())) {
             SegmentReadState readState = KNN1040ScalarQuantizedTestUtils.writeQuantizedVectors(
                 dir,
-                Faiss1040ScalarQuantizedKnnVectorsFormat.getFaissSqFlatFormat(),
+                new KNN1040ScalarQuantizedVectorsFormat(),
                 random()
             );
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
@@ -85,10 +86,16 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
+        // Stub flat format that returns the mocked writer/reader — bypasses per-field resolution
+        // so this test can focus on the wrapper writer's behavior.
+        final KNN1040ScalarQuantizedVectorsFormat stubFlatFormat = mock(KNN1040ScalarQuantizedVectorsFormat.class);
+        when(stubFlatFormat.fieldsWriter(any(SegmentWriteState.class))).thenReturn(flatVectorsWriter);
+        when(stubFlatFormat.fieldsReader(any(SegmentReadState.class))).thenAnswer(
+            invocation -> quantizedFlatVectorsReaderSupplier.apply(invocation.getArgument(0))
+        );
         objectUnderTest = new Faiss1040ScalarQuantizedKnnVectorsWriter(
             segmentWriteState,
-            flatVectorsWriter,
-            quantizedFlatVectorsReaderSupplier,
+            fieldInfo -> stubFlatFormat,
             new NativeIndexBuildStrategyFactory()
         );
         mockedFlatFieldVectorsWriter = mock(FlatFieldVectorsWriter.class);
@@ -135,23 +142,28 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
     // ===================== flush (mocked — tests that don't reach openFlatVectorsReader) =====================
 
     /**
-     * Test: flush with no field added delegates flush/finish/close to flat writer, skips native build.
+     * Test: flush before any addField() is a no-op — the flat writer is only lazily constructed
+     * on the first addField()/mergeOneField(), so nothing to flush and no native build to run.
      */
     @SneakyThrows
-    public void testFlush_whenNoFieldAdded_thenOnlyDelegatesFlat() {
+    public void testFlush_whenNoFieldAdded_thenNoOp() {
         objectUnderTest.flush(5, null);
-        verify(flatVectorsWriter).flush(5, null);
-        verify(flatVectorsWriter).finish();
-        verify(flatVectorsWriter).close();
+        verify(flatVectorsWriter, Mockito.never()).flush(anyInt(), any());
+        verify(flatVectorsWriter, Mockito.never()).finish();
+        verify(flatVectorsWriter, Mockito.never()).close();
     }
 
     /**
-     * Test: flush passes a non-null sortMap through to the flat writer.
+     * Test: flush passes a non-null sortMap through to the flat writer once a field has been added.
      */
     @SneakyThrows
     public void testFlush_withSortMap_passesThroughToFlatWriter() {
-        org.apache.lucene.index.Sorter.DocMap sortMap = mock(org.apache.lucene.index.Sorter.DocMap.class);
-        objectUnderTest.flush(10, sortMap);
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
+        // Stub the flat reader open so flush() doesn't blow up trying to reflect real files.
+        doThrow(new IOException("stop after flat flush")).when(flatVectorsWriter).flush(anyInt(), any());
+        final Sorter.DocMap sortMap = mock(Sorter.DocMap.class);
+        expectThrows(IOException.class, () -> objectUnderTest.flush(10, sortMap));
         verify(flatVectorsWriter).flush(10, sortMap);
     }
 
@@ -214,28 +226,45 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
      * Test: close delegates to IOUtils.close(flatVectorsWriter).
      */
     @SneakyThrows
-    public void testClose_thenClosesFlatWriter() {
+    public void testClose_afterAddField_thenClosesFlatWriter() {
+        // Under lazy encoding resolution, close() only touches the flat writer if one exists —
+        // and one only exists after addField(). Seed a field first.
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
         objectUnderTest.close();
         verify(flatVectorsWriter).close();
     }
 
     /**
-     * Test: IOException from flatVectorsWriter.close() propagates.
+     * Test: IOException from flatVectorsWriter.close() propagates once a field has been added.
      */
     @SneakyThrows
     public void testClose_whenFlatWriterThrows_thenPropagates() {
+        final FieldInfo fi = mockFieldInfo(0);
+        objectUnderTest.addField(fi);
         doThrow(new IOException("close failed")).when(flatVectorsWriter).close();
         expectThrows(IOException.class, () -> objectUnderTest.close());
+    }
+
+    /**
+     * Test: close() without any addField() is a no-op — the flat writer was never constructed.
+     */
+    @SneakyThrows
+    public void testClose_whenNoFieldAdded_thenNoOp() {
+        objectUnderTest.close();
+        verify(flatVectorsWriter, Mockito.never()).close();
     }
 
     // ===================== ramBytesUsed =====================
 
     /**
-     * Test: ramBytesUsed without a field returns SHALLOW_SIZE + flat writer's usage.
+     * Test: ramBytesUsed without a field returns only SHALLOW_SIZE — no flat writer allocated yet.
      */
-    public void testRamBytesUsed_whenNoField_thenReturnsShallowPlusFlatWriter() {
-        when(flatVectorsWriter.ramBytesUsed()).thenReturn(100L);
-        assertTrue(objectUnderTest.ramBytesUsed() > 100L);
+    public void testRamBytesUsed_whenNoField_thenShallowOnly() {
+        // Sanity: mock is untouched, so the return value doesn't include the flat writer.
+        final long ramUsed = objectUnderTest.ramBytesUsed();
+        assertTrue("Expected only SHALLOW_SIZE (>0) with no field added, got " + ramUsed, ramUsed > 0);
+        verify(flatVectorsWriter, Mockito.never()).ramBytesUsed();
     }
 
     /**
@@ -426,10 +455,14 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
                 FIELD_NAME
             );
 
+            final KNN1040ScalarQuantizedVectorsFormat stubFlatFormat = mock(KNN1040ScalarQuantizedVectorsFormat.class);
+            when(stubFlatFormat.fieldsWriter(any(SegmentWriteState.class))).thenReturn(flatVectorsWriter);
+            when(stubFlatFormat.fieldsReader(any(SegmentReadState.class))).thenAnswer(
+                invocation -> quantizedFlatVectorsReaderSupplier.apply(invocation.getArgument(0))
+            );
             Faiss1040ScalarQuantizedKnnVectorsWriter writer = new Faiss1040ScalarQuantizedKnnVectorsWriter(
                 realWriteState,
-                flatVectorsWriter,
-                quantizedFlatVectorsReaderSupplier,
+                fieldInfo -> stubFlatFormat,
                 new NativeIndexBuildStrategyFactory()
             );
 

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedTestUtils.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedTestUtils.java
@@ -22,11 +22,15 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 
 final class KNN1040ScalarQuantizedTestUtils {
 
@@ -42,6 +46,23 @@ final class KNN1040ScalarQuantizedTestUtils {
     // the directory outlives any readers opened from this state.
     static SegmentReadState writeQuantizedVectors(MMapDirectory dir, KNN1040ScalarQuantizedVectorsFormat format, Random random)
         throws Exception {
+        return writeQuantizedVectors(dir, "_0", format, 1, random);
+    }
+
+    /**
+     * Overload for tests that need to control the {@code SQ_CONFIG bits} attribute and the
+     * segment name (to write multiple segments in the same directory without collision).
+     */
+    static SegmentReadState writeQuantizedVectors(
+        MMapDirectory dir,
+        String segmentName,
+        KNN1040ScalarQuantizedVectorsFormat format,
+        int bits,
+        Random random
+    ) throws Exception {
+        // Set SQ_CONFIG so Faiss1040ScalarQuantizedKnnVectorsFormat can resolve the per-field
+        // encoding at fieldsReader() / addField() time.
+        final Map<String, String> attributes = Map.of(SQ_CONFIG, SQConfigParser.toCsv(SQConfig.builder().bits(bits).build()));
         final FieldInfo fieldInfo = new FieldInfo(
             FIELD_NAME,
             0,
@@ -52,7 +73,7 @@ final class KNN1040ScalarQuantizedTestUtils {
             DocValuesType.NONE,
             DocValuesSkipIndexType.NONE,
             -1,
-            Map.of(),
+            attributes,
             0,
             0,
             0,
@@ -68,7 +89,7 @@ final class KNN1040ScalarQuantizedTestUtils {
             dir,
             Version.LATEST,
             Version.LATEST,
-            "_0",
+            segmentName,
             NUM_VECTORS,
             false,
             false,

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -175,7 +175,8 @@ public class FaissSQEncoderTests extends KNNTestCase {
             .dimension(128)
             .build();
 
-        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 2));
+        // Valid bits are {1, 2, 4, 16}. Use 3 as an unambiguously invalid value.
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 3));
         assertNotNull(methodComponent.validate(mcc, context));
     }
 
@@ -264,5 +265,147 @@ public class FaissSQEncoderTests extends KNNTestCase {
 
     public void testIsSQOneBit_whenEncoderNotMethodComponentContext_thenFalse() {
         assertFalse(FaissSQEncoder.isSQOneBit(Map.of(METHOD_ENCODER_PARAMETER, "not_a_context")));
+    }
+
+    // --- bits=2 / bits=4 (multi-bit MOS quantization) ---
+
+    public void testBits2_libraryIndexingContext() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponent methodComponent = encoder.getMethodComponent();
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 2));
+        KNNLibraryIndexingContext indexingContext = methodComponent.getKNNLibraryIndexingContext(mcc, context);
+
+        Map<String, Object> params = indexingContext.getLibraryParameters();
+        assertEquals(FAISS_FLAT_DESCRIPTION, params.get(INDEX_DESCRIPTION_PARAMETER));
+        assertEquals(ENCODER_SQ, params.get("name"));
+        assertEquals(2, params.get(SQ_BITS));
+    }
+
+    public void testBits4_libraryIndexingContext() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponent methodComponent = encoder.getMethodComponent();
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 4));
+        KNNLibraryIndexingContext indexingContext = methodComponent.getKNNLibraryIndexingContext(mcc, context);
+
+        Map<String, Object> params = indexingContext.getLibraryParameters();
+        assertEquals(FAISS_FLAT_DESCRIPTION, params.get(INDEX_DESCRIPTION_PARAMETER));
+        assertEquals(ENCODER_SQ, params.get("name"));
+        assertEquals(4, params.get(SQ_BITS));
+    }
+
+    public void testBits2_compressionLevel() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 2));
+        assertEquals(CompressionLevel.x16, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    public void testBits4_compressionLevel() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        MethodComponentContext mcc = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 4));
+        assertEquals(CompressionLevel.x8, encoder.calculateCompressionLevel(mcc, null));
+    }
+
+    // --- isMosBits utility ---
+
+    public void testIsMosBits() {
+        assertTrue(FaissSQEncoder.isMosBits(1));
+        assertTrue(FaissSQEncoder.isMosBits(2));
+        assertTrue(FaissSQEncoder.isMosBits(4));
+        // fp16 is SQ but not the MOS bit-plane path
+        assertFalse(FaissSQEncoder.isMosBits(16));
+        for (int bits : new int[] { 0, 3, 5, 7, 8, -1 }) {
+            assertFalse("Expected " + bits + " to not be MOS bits", FaissSQEncoder.isMosBits(bits));
+        }
+    }
+
+    // --- getSQBits utility ---
+
+    public void testGetSQBits_whenSQEncoder_thenReturnsBits() {
+        for (int bits : new int[] { 1, 2, 4, 16 }) {
+            MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, bits));
+            Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+            assertEquals(Integer.valueOf(bits), FaissSQEncoder.getSQBits(params));
+        }
+    }
+
+    public void testGetSQBits_whenNoBits_thenNull() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(FAISS_SQ_TYPE, "fp16"));
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertNull(FaissSQEncoder.getSQBits(params));
+    }
+
+    public void testGetSQBits_whenNonSQEncoder_thenNull() {
+        MethodComponentContext encoderCtx = new MethodComponentContext("flat", Map.of());
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertNull(FaissSQEncoder.getSQBits(params));
+    }
+
+    public void testGetSQBits_whenNullParams_thenNull() {
+        assertNull(FaissSQEncoder.getSQBits(null));
+    }
+
+    public void testGetSQBits_whenNoEncoder_thenNull() {
+        assertNull(FaissSQEncoder.getSQBits(Map.of()));
+    }
+
+    public void testGetSQBits_whenEncoderNotMethodComponentContext_thenNull() {
+        assertNull(FaissSQEncoder.getSQBits(Map.of(METHOD_ENCODER_PARAMETER, "not_a_context")));
+    }
+
+    // --- isSQMultiBit utility ---
+
+    public void testIsSQMultiBit_whenSQWithMosBits_thenTrue() {
+        for (int bits : new int[] { 1, 2, 4 }) {
+            MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, bits));
+            Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+            assertTrue("Expected bits=" + bits + " to be SQ multi-bit", FaissSQEncoder.isSQMultiBit(params));
+        }
+    }
+
+    public void testIsSQMultiBit_whenSQWithBits16_thenFalse() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(SQ_BITS, 16));
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertFalse(FaissSQEncoder.isSQMultiBit(params));
+    }
+
+    public void testIsSQMultiBit_whenNonSQEncoder_thenFalse() {
+        MethodComponentContext encoderCtx = new MethodComponentContext("flat", Map.of());
+        Map<String, Object> params = Map.of(METHOD_ENCODER_PARAMETER, encoderCtx);
+        assertFalse(FaissSQEncoder.isSQMultiBit(params));
+    }
+
+    public void testIsSQMultiBit_whenNullParams_thenFalse() {
+        assertFalse(FaissSQEncoder.isSQMultiBit(null));
+    }
+
+    // --- Bits enum ---
+
+    public void testBitsEnum_twoAndFour() {
+        assertEquals(2, FaissSQEncoder.Bits.TWO.getValue());
+        assertEquals(CompressionLevel.x16, FaissSQEncoder.Bits.TWO.getCompressionLevel());
+
+        assertEquals(4, FaissSQEncoder.Bits.FOUR.getValue());
+        assertEquals(CompressionLevel.x8, FaissSQEncoder.Bits.FOUR.getCompressionLevel());
+    }
+
+    public void testBitsEnum_fromValue() {
+        assertEquals(FaissSQEncoder.Bits.ONE, FaissSQEncoder.Bits.fromValue(1));
+        assertEquals(FaissSQEncoder.Bits.TWO, FaissSQEncoder.Bits.fromValue(2));
+        assertEquals(FaissSQEncoder.Bits.FOUR, FaissSQEncoder.Bits.fromValue(4));
+        assertEquals(FaissSQEncoder.Bits.SIXTEEN, FaissSQEncoder.Bits.fromValue(16));
+        expectThrows(IllegalArgumentException.class, () -> FaissSQEncoder.Bits.fromValue(3));
+        expectThrows(IllegalArgumentException.class, () -> FaissSQEncoder.Bits.fromValue(8));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -317,16 +317,16 @@ public class FaissSQEncoderTests extends KNNTestCase {
         assertEquals(CompressionLevel.x8, encoder.calculateCompressionLevel(mcc, null));
     }
 
-    // --- isMosBits utility ---
+    // --- isSQCodedBits utility ---
 
-    public void testIsMosBits() {
-        assertTrue(FaissSQEncoder.isMosBits(1));
-        assertTrue(FaissSQEncoder.isMosBits(2));
-        assertTrue(FaissSQEncoder.isMosBits(4));
-        // fp16 is SQ but not the MOS bit-plane path
-        assertFalse(FaissSQEncoder.isMosBits(16));
+    public void testIsSQCodedBits() {
+        assertTrue(FaissSQEncoder.isSQCodedBits(1));
+        assertTrue(FaissSQEncoder.isSQCodedBits(2));
+        assertTrue(FaissSQEncoder.isSQCodedBits(4));
+        // fp16 is SQ but stores compressed floats, not integer-coded bits
+        assertFalse(FaissSQEncoder.isSQCodedBits(16));
         for (int bits : new int[] { 0, 3, 5, 7, 8, -1 }) {
-            assertFalse("Expected " + bits + " to not be MOS bits", FaissSQEncoder.isMosBits(bits));
+            assertFalse("Expected " + bits + " to not be SQ-coded bits", FaissSQEncoder.isSQCodedBits(bits));
         }
     }
 

--- a/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
@@ -169,12 +169,19 @@ public class FaissSQMappingIT extends KNNRestTestCase {
         validateMappingFails(mapping, "incompatible");
     }
 
-    // --- invalid bits values ---
+    // --- multi-bit SQ (bits ∈ {2, 4}) ---
 
-    public void testSQEncoder_whenBits2_thenFail() throws Exception {
+    public void testSQEncoder_whenBits2_thenSucceed() throws Exception {
         String mapping = buildSQMapping(2, null, null, null, null);
-        validateMappingFails(mapping, "Unsupported bits value");
+        validateMappingOnly(INDEX_NAME, mapping, 2);
     }
+
+    public void testSQEncoder_whenBits4_thenSucceed() throws Exception {
+        String mapping = buildSQMapping(4, null, null, null, null);
+        validateMappingOnly(INDEX_NAME, mapping, 4);
+    }
+
+    // --- invalid bits values ---
 
     public void testSQEncoder_whenBits8_thenFail() throws Exception {
         String mapping = buildSQMapping(8, null, null, null, null);


### PR DESCRIPTION
### Description
Adds 2-bit (`DIBIT_QUERY_NIBBLE`, x16) and 4-bit (`PACKED_NIBBLE`, x8) as valid values for `sq.bits` alongside the existing 1-bit and fp16 paths, and threads the bit width through the mapping, codec-format, MOS, scorer, and
  build-strategy layers.

  **No user-visible behavior change on the existing 1-bit path.** Explicit encoder config (`encoder: {name: sq, bits: 2|4}`) is now honored end-to-end at the Java layer. Native HNSW build and bulk-SIMD scoring for multi-bit land in
  follow-up PRs.

Fixed a bug where Lucene's SPI would reload `Faiss1040ScalarQuantizedKnnVectorsFormat` via its no-arg constructor and produce a writer with 1-bit encoding hardcoded, silently writing 2/4-bit segments as 1-bit. The format is now
  encoding-agnostic — encoding is resolved per-field from the `SQ_CONFIG` field attribute on the first `addField()` / `mergeOneField()` call for writes, and at `fieldsReader(state)` time for reads. Throws a clear error on missing or
  invalid `SQ_CONFIG` instead of falling back to 1-bit silently.

### Related Issues
https://github.com/opensearch-project/k-NN/issues/3427

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
