### PR TITLE
Radial efsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add base64 encoded vector indexing support for knn_vector fields [#3350](https://github.com/opensearch-project/k-NN/pull/3350)
 * Introduce system-generated search pipeline processor to automatically exclude knn_vector fields from _source in search responses [#3152](https://github.com/opensearch-project/k-NN/pull/3152)
 * Parameterize integration test framework for compression level [#3416](https://github.com/opensearch-project/k-NN/pull/3416)
+* Do ef_search approximate search to find entry points for radial search [#3430](https://github.com/opensearch-project/k-NN/pull/3430)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -510,6 +510,9 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
             }
         }
 
+        log.info("[RADIAL-DEBUG] KNNQueryBuilder: maxDistance={}, minScore={}, radius={}, spaceType={}, engine={}, MOS={}",
+            this.maxDistance, this.minScore, radius, spaceType, knnEngine, memoryOptimizedSearchEnabled);
+
         final int vectorLength = VectorDataType.BINARY == vectorDataType ? vector.length * Byte.SIZE : vector.length;
         if (knnMappingConfig.getDimension() != vectorLength) {
             throw new IllegalArgumentException(

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -12,14 +12,14 @@ import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPE
 import java.util.Locale;
 
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.search.ByteVectorSimilarityQuery;
-import org.apache.lucene.search.FloatVectorSimilarityQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.util.IndexHyperParametersUtil;
 
 /**
  * Class to create radius nearest neighbor queries
@@ -67,7 +67,10 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float[] vector = createQueryRequest.getVector();
 
         final Query innerQuery;
-        if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
+        if (createQueryRequest.isMemoryOptimizedSearchEnabled()) {
+            // MOS (Faiss HNSW via Lucene's vector reader): use the unified seeded radial search.
+            innerQuery = createSeededRadialQuery(createQueryRequest);
+        } else if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
             innerQuery = createNativeEngineRadialQuery(createQueryRequest);
         } else {
             innerQuery = createLuceneRadialQuery(createQueryRequest);
@@ -95,11 +98,36 @@ public class RNNQueryFactory extends BaseQueryFactory {
     }
 
     /**
+     * Creates a {@link RadialSearchQuery} for memory-optimized search (Faiss HNSW via Lucene's vector reader).
+     * <p>
+     * This uses the same two-phase seeded radial search as the Lucene engine path, since both
+     * ultimately search via {@code LeafReader.searchNearestVectors()}.
+     *
+     * @param request the query creation request containing all parameters
+     * @return a {@link RadialSearchQuery} configured for seeded radius-based search
+     */
+    private static Query createSeededRadialQuery(CreateQueryRequest request) {
+        final String fieldName = request.getFieldName();
+        final Float radius = request.getRadius();
+        final Query filterQuery = getFilterQuery(request);
+        final int efSearch = resolveEfSearch(request);
+
+        log.debug(
+            "Creating seeded radial query for index: {}, field: {}, radius: {}, efSearch: {}",
+            request.getIndexName(),
+            fieldName,
+            radius,
+            efSearch
+        );
+
+        return new RadialSearchQuery(fieldName, request.getVector(), radius, efSearch, filterQuery);
+    }
+
+    /**
      * Creates a {@link KNNQuery} for native engines (Faiss, NMSLIB) that use custom segment files.
      *
      * <p>The returned query carries the radius threshold and is executed via JNI through
-     * {@code JNIService.radiusQueryIndex()} in {@code DefaultKNNWeight}, or via
-     * {@code RadiusVectorSimilarityCollector} in {@code MemoryOptimizedKNNWeight}.</p>
+     * {@code JNIService.radiusQueryIndex()} in {@code DefaultKNNWeight}.</p>
      *
      * @param request the query creation request containing all parameters
      * @return a {@link KNNQuery} configured for radius-based search
@@ -131,15 +159,13 @@ public class RNNQueryFactory extends BaseQueryFactory {
     }
 
     /**
-     * Creates a Lucene-native radial search query ({@link FloatVectorSimilarityQuery} or
-     * {@link ByteVectorSimilarityQuery}) for engines that do not use custom segment files.
-     *
-     * <p>These queries use Lucene's built-in HNSW graph traversal with a similarity threshold.
-     * The traversal similarity is set to {@code 0.95 * resultSimilarity} to allow the graph
-     * to be explored slightly beyond the threshold for better recall.</p>
+     * Creates a radial search query for engines that do not use custom segment files (i.e., Lucene engine).
+     * <p>
+     * For float vectors, uses {@link RadialSearchQuery} which performs a two-phase seeded radial
+     * search via Lucene's HNSW graph. For byte vectors, falls back to {@link ByteVectorSimilarityQuery}.
      *
      * @param request the query creation request containing all parameters
-     * @return a Lucene similarity query configured for radius-based search
+     * @return a query configured for radius-based search
      * @throws IllegalArgumentException if the vector data type is not supported
      */
     private static Query createLuceneRadialQuery(CreateQueryRequest request) {
@@ -153,9 +179,9 @@ public class RNNQueryFactory extends BaseQueryFactory {
 
         switch (request.getVectorDataType()) {
             case BYTE:
-                return getByteVectorSimilarityQuery(fieldName, request.getByteVector(), radius, filterQuery);
+                return new RadialSearchQuery(fieldName, request.getByteVector(), radius, resolveEfSearch(request), filterQuery);
             case FLOAT:
-                return getFloatVectorSimilarityQuery(fieldName, request.getVector(), radius, filterQuery);
+                return new RadialSearchQuery(fieldName, request.getVector(), radius, resolveEfSearch(request), filterQuery);
             default:
                 throw new IllegalArgumentException(
                     String.format(
@@ -169,29 +195,11 @@ public class RNNQueryFactory extends BaseQueryFactory {
         }
     }
 
-    /**
-     * If radius is greater than 0, we return {@link FloatVectorSimilarityQuery} which will return all documents with similarity
-     * greater than or equal to the resultSimilarity. If filterQuery is not null, it will be used to filter the documents.
-     */
-    private static Query getFloatVectorSimilarityQuery(
-        final String fieldName,
-        final float[] floatVector,
-        final float resultSimilarity,
-        final Query filterQuery
-    ) {
-        return new FloatVectorSimilarityQuery(fieldName, floatVector, resultSimilarity, 1.0f, filterQuery);
-    }
-
-    /**
-     * If radius is greater than 0, we return {@link ByteVectorSimilarityQuery} which will return all documents with similarity
-     * greater than or equal to the resultSimilarity. If filterQuery is not null, it will be used to filter the documents.
-     */
-    private static Query getByteVectorSimilarityQuery(
-        final String fieldName,
-        final byte[] byteVector,
-        final float resultSimilarity,
-        final Query filterQuery
-    ) {
-        return new ByteVectorSimilarityQuery(fieldName, byteVector, resultSimilarity, 1.0f, filterQuery);
+    private static int resolveEfSearch(final CreateQueryRequest request) {
+        try {
+            return IndexHyperParametersUtil.getHNSWEFSearchValue(request.getMethodParameters(), request.getIndexName());
+        } catch (Exception e) {
+            return KNNSettings.INDEX_KNN_DEFAULT_ALGO_PARAM_EF_SEARCH;
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -66,13 +66,19 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Float radius = createQueryRequest.getRadius();
         final float[] vector = createQueryRequest.getVector();
 
+        log.info("[RADIAL-DEBUG] RNNQueryFactory.create: field={}, radius={}, engine={}, MOS={}",
+            fieldName, radius, createQueryRequest.getKnnEngine(), createQueryRequest.isMemoryOptimizedSearchEnabled());
+
         final Query innerQuery;
         if (createQueryRequest.isMemoryOptimizedSearchEnabled()) {
             // MOS (Faiss HNSW via Lucene's vector reader): use the unified seeded radial search.
+            log.info("[RADIAL-DEBUG] Routing to createSeededRadialQuery (MOS path)");
             innerQuery = createSeededRadialQuery(createQueryRequest);
         } else if (KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(createQueryRequest.getKnnEngine())) {
+            log.info("[RADIAL-DEBUG] Routing to createNativeEngineRadialQuery (native FAISS/NMSLIB path)");
             innerQuery = createNativeEngineRadialQuery(createQueryRequest);
         } else {
+            log.info("[RADIAL-DEBUG] Routing to createLuceneRadialQuery (Lucene engine path)");
             innerQuery = createLuceneRadialQuery(createQueryRequest);
         }
 
@@ -85,6 +91,8 @@ public class RNNQueryFactory extends BaseQueryFactory {
             } else {
                 maxResultsSize = MAX_RESULTS_RADIAL_RESCORING;
             }
+            log.info("[RADIAL-DEBUG] Wrapping with RescoreRadialSearchQuery: radius={}, MOS={}, maxResultsSize={}",
+                radius, createQueryRequest.isMemoryOptimizedSearchEnabled(), maxResultsSize);
             return new RescoreRadialSearchQuery(
                 innerQuery,
                 fieldName,
@@ -112,13 +120,8 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Query filterQuery = getFilterQuery(request);
         final int efSearch = resolveEfSearch(request);
 
-        log.debug(
-            "Creating seeded radial query for index: {}, field: {}, radius: {}, efSearch: {}",
-            request.getIndexName(),
-            fieldName,
-            radius,
-            efSearch
-        );
+        log.info("[RADIAL-DEBUG] createSeededRadialQuery: index={}, field={}, radius={}, efSearch={}",
+            request.getIndexName(), fieldName, radius, efSearch);
 
         return new RadialSearchQuery(fieldName, request.getVector(), radius, efSearch, filterQuery);
     }
@@ -173,9 +176,8 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final Float radius = request.getRadius();
         final Query filterQuery = getFilterQuery(request);
 
-        log.debug(
-            String.format("Creating Lucene r-NN query for index: %s \"\", field: %s \"\", k: %f", request.getIndexName(), fieldName, radius)
-        );
+        log.info("[RADIAL-DEBUG] createLuceneRadialQuery: index={}, field={}, radius={}, efSearch={}",
+            request.getIndexName(), fieldName, radius, resolveEfSearch(request));
 
         switch (request.getVectorDataType()) {
             case BYTE:

--- a/src/main/java/org/opensearch/knn/index/query/RadialSearchQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/RadialSearchQuery.java
@@ -156,6 +156,8 @@ public class RadialSearchQuery extends Query {
         }
 
         // Phase 1: top-k ANN with k = ef_search to find seed entry points.
+        log.info("[RADIAL-DEBUG] RadialSearchQuery.searchLeaf: field={}, similarity={}, efSearch={}, maxDoc={}",
+            field, similarity, efSearch, reader.maxDoc());
         KnnCollector seedCollector = new TopKnnCollectorManager(efSearch, searcher).newCollector(
             visitLimit,
             DEFAULT_HNSW_SEARCH_STRATEGY,
@@ -167,6 +169,10 @@ public class RadialSearchQuery extends Query {
             reader.searchNearestVectors(field, target, seedCollector, acceptDocs);
         }
         TopDocs seedTopDocs = seedCollector.topDocs();
+        log.info("[RADIAL-DEBUG] Phase 1 seeds: count={}, minScore={}, maxScore={}",
+            seedTopDocs.scoreDocs.length,
+            seedTopDocs.scoreDocs.length > 0 ? seedTopDocs.scoreDocs[seedTopDocs.scoreDocs.length - 1].score : "N/A",
+            seedTopDocs.scoreDocs.length > 0 ? seedTopDocs.scoreDocs[0].score : "N/A");
 
         // Phase 2: radial search, seeded from phase-1 results.
         final KnnCollectorManager radialCollectorManager;
@@ -186,6 +192,10 @@ public class RadialSearchQuery extends Query {
             reader.searchNearestVectors(field, target, radialCollector, acceptDocs);
         }
         TopDocs results = radialCollector.topDocs();
+
+        log.info("[RADIAL-DEBUG] Phase 2 results: count={}, visited={}",
+            results == null ? 0 : results.scoreDocs.length,
+            radialCollector.visitedCount());
 
         if (results == null || results.scoreDocs.length == 0) {
             return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);

--- a/src/main/java/org/opensearch/knn/index/query/RadialSearchQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/RadialSearchQuery.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.query;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.knn.KnnCollectorManager;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.apache.lucene.search.knn.TopKnnCollectorManager;
+import org.apache.lucene.util.Bits;
+import org.opensearch.knn.index.query.common.QueryUtils;
+import org.opensearch.knn.index.query.memoryoptsearch.RadiusVectorSimilarityCollector;
+import org.opensearch.lucene.ReentrantKnnCollectorManager;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+/**
+ * Two-phase radial (similarity-threshold) search query.
+ * <p>
+ * Phase 1 runs a top-k ANN search (k = ef_search) to discover high-quality seed entry points
+ * in the HNSW graph. Phase 2 runs a radial search seeded from those entry points, collecting
+ * all vectors at or above the similarity threshold.
+ * <p>
+ * This query is engine-agnostic: it calls {@code LeafReader.searchNearestVectors()} which works
+ * for both Lucene-native HNSW indices and Faiss memory-optimized indices (via their respective
+ * {@code KnnVectorsReader} implementations).
+ */
+@Log4j2
+public class RadialSearchQuery extends Query {
+    private static final KnnSearchStrategy.Hnsw DEFAULT_HNSW_SEARCH_STRATEGY = new KnnSearchStrategy.Hnsw(0);
+
+    private final String field;
+    private final float[] target;
+    private final byte[] byteTarget;
+    private final float similarity;
+    private final int efSearch;
+    private final Query filter;
+
+    public RadialSearchQuery(String field, float[] target, float similarity, int efSearch, Query filter) {
+        this.field = Objects.requireNonNull(field);
+        this.target = Objects.requireNonNull(target);
+        this.byteTarget = null;
+        this.similarity = similarity;
+        this.efSearch = efSearch;
+        this.filter = filter;
+    }
+
+    public RadialSearchQuery(String field, byte[] byteTarget, float similarity, int efSearch, Query filter) {
+        this.field = Objects.requireNonNull(field);
+        this.target = null;
+        this.byteTarget = Objects.requireNonNull(byteTarget);
+        this.similarity = similarity;
+        this.efSearch = efSearch;
+        this.filter = filter;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        final Weight filterWeight;
+        if (filter != null) {
+            Query rewritten = searcher.rewrite(filter);
+            filterWeight = searcher.createWeight(rewritten, ScoreMode.COMPLETE_NO_SCORES, 1f);
+        } else {
+            filterWeight = null;
+        }
+
+        List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+        List<Callable<TopDocs>> tasks = new ArrayList<>(leaves.size());
+        for (LeafReaderContext ctx : leaves) {
+            tasks.add(() -> searchLeaf(ctx, filterWeight, searcher));
+        }
+
+        List<TopDocs> leafResults = searcher.getTaskExecutor().invokeAll(tasks);
+
+        // Merge all per-leaf results; add docBase offsets
+        int totalHits = 0;
+        for (int i = 0; i < leafResults.size(); i++) {
+            TopDocs leafTopDocs = leafResults.get(i);
+            int docBase = leaves.get(i).docBase;
+            for (ScoreDoc sd : leafTopDocs.scoreDocs) {
+                sd.doc += docBase;
+            }
+            totalHits += leafTopDocs.scoreDocs.length;
+        }
+
+        // Flatten all results into a single TopDocs
+        ScoreDoc[] allDocs = new ScoreDoc[totalHits];
+        int idx = 0;
+        for (TopDocs leafTopDocs : leafResults) {
+            for (ScoreDoc sd : leafTopDocs.scoreDocs) {
+                allDocs[idx++] = sd;
+            }
+        }
+        TopDocs merged = new TopDocs(new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), allDocs);
+
+        if (merged.scoreDocs.length == 0) {
+            return new MatchNoDocsQuery().createWeight(searcher, scoreMode, boost);
+        }
+
+        return QueryUtils.getInstance().createDocAndScoreQuery(searcher.getIndexReader(), merged).createWeight(searcher, scoreMode, boost);
+    }
+
+    private TopDocs searchLeaf(LeafReaderContext ctx, Weight filterWeight, IndexSearcher searcher) throws IOException {
+        final LeafReader reader = ctx.reader();
+        final boolean isByteVector = byteTarget != null;
+
+        if (isByteVector) {
+            if (reader.getByteVectorValues(field) == null) {
+                return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+            }
+        } else {
+            if (reader.getFloatVectorValues(field) == null) {
+                return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+            }
+        }
+
+        // Determine accepted docs and visit limit
+        final AcceptDocs acceptDocs;
+        final int visitLimit;
+        if (filterWeight != null) {
+            Scorer scorer = filterWeight.scorer(ctx);
+            if (scorer == null) {
+                return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+            }
+            Bits liveDocs = reader.getLiveDocs();
+            acceptDocs = AcceptDocs.fromIteratorSupplier(() -> scorer.iterator(), liveDocs, reader.maxDoc());
+            visitLimit = acceptDocs.cost();
+            if (visitLimit == 0) {
+                return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+            }
+        } else {
+            acceptDocs = AcceptDocs.fromLiveDocs(reader.getLiveDocs(), reader.maxDoc());
+            visitLimit = Integer.MAX_VALUE;
+        }
+
+        // Phase 1: top-k ANN with k = ef_search to find seed entry points.
+        KnnCollector seedCollector = new TopKnnCollectorManager(efSearch, searcher).newCollector(
+            visitLimit,
+            DEFAULT_HNSW_SEARCH_STRATEGY,
+            ctx
+        );
+        if (isByteVector) {
+            reader.searchNearestVectors(field, byteTarget, seedCollector, acceptDocs);
+        } else {
+            reader.searchNearestVectors(field, target, seedCollector, acceptDocs);
+        }
+        TopDocs seedTopDocs = seedCollector.topDocs();
+
+        // Phase 2: radial search, seeded from phase-1 results.
+        final KnnCollectorManager radialCollectorManager;
+        KnnCollectorManager baseRadialManager = (vl, strategy, context) -> new RadiusVectorSimilarityCollector(similarity, vl, strategy);
+
+        if (seedTopDocs != null && seedTopDocs.scoreDocs.length > 0) {
+            Object queryVector = isByteVector ? byteTarget : target;
+            radialCollectorManager = new ReentrantKnnCollectorManager(baseRadialManager, Map.of(ctx.ord, seedTopDocs), queryVector, field);
+        } else {
+            radialCollectorManager = baseRadialManager;
+        }
+
+        KnnCollector radialCollector = radialCollectorManager.newCollector(visitLimit, DEFAULT_HNSW_SEARCH_STRATEGY, ctx);
+        if (isByteVector) {
+            reader.searchNearestVectors(field, byteTarget, radialCollector, acceptDocs);
+        } else {
+            reader.searchNearestVectors(field, target, radialCollector, acceptDocs);
+        }
+        TopDocs results = radialCollector.topDocs();
+
+        if (results == null || results.scoreDocs.length == 0) {
+            return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+        }
+
+        return results;
+    }
+
+    @Override
+    public String toString(String field) {
+        return "RadialSearchQuery[field=" + this.field + " similarity=" + similarity + " efSearch=" + efSearch + "]";
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RadialSearchQuery that = (RadialSearchQuery) o;
+        return Float.compare(that.similarity, similarity) == 0
+            && efSearch == that.efSearch
+            && field.equals(that.field)
+            && Arrays.equals(target, that.target)
+            && Arrays.equals(byteTarget, that.byteTarget)
+            && Objects.equals(filter, that.filter);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(field, similarity, efSearch, filter);
+        result = 31 * result + Arrays.hashCode(target);
+        result = 31 * result + Arrays.hashCode(byteTarget);
+        return result;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  *
  * <h2>Solution</h2>
  * <p>This query wraps the inner radial search query ({@link KNNQuery} for Faiss or
- * {@code FloatVectorSimilarityQuery} for Lucene) and adds a second-phase rescoring step.
+ * {@link RadialSearchQuery} for Lucene/MOS) and adds a second-phase rescoring step.
  * The inner query performs the first-pass radial search on quantized vectors with the user's
  * radius. The wrapper then rescores the first-pass candidates using full-precision vectors
  * and filters out any results that fall outside the true radius.</p>

--- a/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
+++ b/src/main/java/org/opensearch/knn/index/query/RescoreRadialSearchQuery.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.query;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -46,6 +47,7 @@ import java.util.Objects;
  * @see RescoreKNNVectorQuery similar pattern for Lucene engine top-K rescoring
  * @see org.opensearch.knn.index.query.nativelib.NativeEngineKnnVectorQuery similar pattern for Faiss engine top-K rescoring
  */
+@Log4j2
 @Getter
 @EqualsAndHashCode(callSuper = false)
 public class RescoreRadialSearchQuery extends Query {
@@ -251,6 +253,9 @@ public class RescoreRadialSearchQuery extends Query {
                         numDocsToRescore = matchedDocs.cost();
                     }
 
+                    log.info("[RADIAL-DEBUG] RescoreRadialSearchQuery: candidatesFromInner={}, radius={}, MOS={}",
+                        numDocsToRescore, radius, memoryOptimizedSearchEnabled);
+
                     // 4. Build ExactSearcherContext — rescore with full-precision vectors
                     final ExactSearcher.ExactSearcherContext exactSearcherContext = ExactSearcher.ExactSearcherContext.builder()
                         .matchedDocsIterator(docsToRescore)
@@ -265,6 +270,8 @@ public class RescoreRadialSearchQuery extends Query {
 
                     // 5. Rescore — ExactSearcher handles radius → minScore conversion internally
                     final TopDocs rescored = EXACT_SEARCHER_SINGLETON.searchLeaf(context, exactSearcherContext);
+
+                    log.info("[RADIAL-DEBUG] RescoreRadialSearchQuery: afterRescore={}", rescored.scoreDocs.length);
 
                     // 6. Return scorer over rescored results
                     return new KNNScorer(rescored, boost);

--- a/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
+++ b/src/main/java/org/opensearch/knn/index/query/exactsearch/ExactSearcher.java
@@ -30,6 +30,7 @@ import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.query.SegmentLevelQuantizationInfo;
 import org.opensearch.knn.index.query.SegmentLevelQuantizationUtil;
+import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.scorers.VectorScorerMode;
 import org.opensearch.knn.index.query.scorers.VectorScorers;
@@ -211,7 +212,22 @@ public class ExactSearcher {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "Engine [%s] does not support radial search", engine));
         }
         final SpaceType spaceType = getSpaceType(modelDao, fieldInfo);
-        final float minScore = context.isMemoryOptimizedSearchEnabled ? context.getRadius() : engine.score(context.getRadius(), spaceType);
+        final float minScore;
+        if (context.isMemoryOptimizedSearchEnabled) {
+            if (spaceType == SpaceType.COSINESIMIL) {
+                // The radius is in MAXIMUM_INNER_PRODUCT score space (from MemoryOptimizedSearchScoreConverter),
+                // but the rescore step uses Lucene's native COSINE function which returns (1+cos_sim)/2.
+                // Convert: IP score → raw cos_sim → Lucene cosine score.
+                minScore = MemoryOptimizedSearchScoreConverter.convertInnerProductScoreToCosineScore(context.getRadius());
+            } else {
+                minScore = context.getRadius();
+            }
+        } else {
+            minScore = engine.score(context.getRadius(), spaceType);
+        }
+
+        log.info("[RADIAL-DEBUG] ExactSearcher.doRadialSearch: engine={}, spaceType={}, radius={}, MOS={}, minScore={}",
+            engine, spaceType, context.getRadius(), context.isMemoryOptimizedSearchEnabled, minScore);
 
         return collectTopK(BulkVectorScorer.forRadialSearch(vectorScorer, matchedDocs, minScore), context.getMaxResultWindow(), false);
     }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -37,7 +37,6 @@ import org.opensearch.lucene.ReentrantKnnCollectorManager;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 
 /**
@@ -72,12 +71,9 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                 this.knnCollectorManager = new DiversifyingNearestChildrenKnnCollectorManager(k, query.getParentsFilter(), searcher);
             }
         } else {
-            // Radius search.
-            // Forward the incoming searchStrategy so that a re-entrant (seeded) radial search can begin
-            // the graph traversal from pre-computed entry points instead of the default entry node.
+            final float radius = query.getRadius();
             this.knnCollectorManager = (visitLimit, searchStrategy, context) -> new RadiusVectorSimilarityCollector(
-                query.getRadius(),
-                query.getRadius(),
+                radius,
                 visitLimit,
                 searchStrategy
             );

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -30,10 +30,12 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
+import org.opensearch.knn.index.util.IndexHyperParametersUtil;
 import org.opensearch.lucene.OptimisticKnnCollectorManager;
 import org.opensearch.lucene.ReentrantKnnCollectorManager;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
@@ -52,11 +54,13 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
     private static final KnnSearchStrategy.Hnsw DEFAULT_HNSW_SEARCH_STRATEGY = new KnnSearchStrategy.Hnsw(0);
 
     private final KnnCollectorManager knnCollectorManager;
+    private final IndexSearcher searcher;
     @Setter
     private ReentrantKnnCollectorManager reentrantKNNCollectorManager;
 
     public MemoryOptimizedKNNWeight(KNNQuery query, float boost, final Weight filterWeight, IndexSearcher searcher, Integer k) {
         super(query, boost, filterWeight);
+        this.searcher = searcher;
 
         if (k != null && k > 0) {
             // ANN Search
@@ -68,11 +72,14 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                 this.knnCollectorManager = new DiversifyingNearestChildrenKnnCollectorManager(k, query.getParentsFilter(), searcher);
             }
         } else {
-            // Radius search
+            // Radius search.
+            // Forward the incoming searchStrategy so that a re-entrant (seeded) radial search can begin
+            // the graph traversal from pre-computed entry points instead of the default entry node.
             this.knnCollectorManager = (visitLimit, searchStrategy, context) -> new RadiusVectorSimilarityCollector(
                 DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * query.getRadius(),
                 query.getRadius(),
-                visitLimit
+                visitLimit,
+                searchStrategy
             );
         }
     }
@@ -160,12 +167,76 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                     spaceType
                 );
             } else {
-                // Radius search
-                return queryIndex(knnQuery.getVector(), cardinality, cardinality, context, filterIdsBitSet, reader, knnEngine, spaceType);
+                // Radius (radial) search via the memory-optimized path.
+                //
+                // Instead of running Lucene's radial graph traversal from the default entry node, we:
+                //   1. Run a top-k ANN search with k = ef_search to discover good entry points.
+                //   2. Run the radial (similarity-threshold) search re-entrant from those seeds.
+                return radialSearch(context, reader, knnEngine, spaceType, filterIdsBitSet, cardinality);
             }
         } catch (Exception e) {
             GRAPH_QUERY_ERRORS.increment();
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Two-phase radial search for the memory-optimized path.
+     * <p>
+     * Phase 1 performs a top-k approximate search with {@code k = ef_search} to collect a set of
+     * high-quality entry points. Phase 2 runs the radial (similarity-threshold) search seeded with
+     * those entry points via {@link ReentrantKnnCollectorManager}, so the graph traversal re-enters
+     * from known-good nodes rather than the default graph entry node. If phase 1 yields no seeds, the
+     * search falls back to a plain (un-seeded) radial search.
+     */
+    private TopDocs radialSearch(
+        final LeafReaderContext context,
+        final SegmentReader reader,
+        final KNNEngine knnEngine,
+        final SpaceType spaceType,
+        final BitSet filterIdsBitSet,
+        final int cardinality
+    ) throws IOException {
+        final Object targetVector = knnQuery.getVector();
+        final int visitedLimit = getFilterWeight() == null ? Integer.MAX_VALUE : cardinality;
+        final AcceptDocs acceptDocs = getAcceptedDocs(reader, cardinality, filterIdsBitSet);
+
+        // Phase 1: top-k ANN with k = ef_search to find seed entry points.
+        final int efSearch = IndexHyperParametersUtil.getHNSWEFSearchValue(knnQuery.getMethodParameters(), knnQuery.getIndexName());
+        final KnnCollector seedCollector = new TopKnnCollectorManager(efSearch, searcher).newCollector(
+            visitedLimit,
+            DEFAULT_HNSW_SEARCH_STRATEGY,
+            context
+        );
+        searchVector(targetVector, seedCollector, acceptDocs, reader);
+        final TopDocs seedTopDocs = seedCollector.topDocs();
+
+        // Phase 2: radial search, seeded from phase-1 results when available.
+        final KnnCollectorManager radialCollectorManager;
+        if (seedTopDocs != null && seedTopDocs.scoreDocs.length > 0) {
+            radialCollectorManager = new ReentrantKnnCollectorManager(
+                knnCollectorManager,
+                Map.of(context.ord, seedTopDocs),
+                targetVector,
+                knnQuery.getField()
+            );
+        } else {
+            radialCollectorManager = knnCollectorManager;
+        }
+
+        return queryIndex(targetVector, cardinality, cardinality, context, filterIdsBitSet, reader, knnEngine, spaceType, radialCollectorManager);
+    }
+
+    /**
+     * Issues the vector search against the segment using the given collector.
+     */
+    private void searchVector(final Object targetVector, final KnnCollector collector, final AcceptDocs acceptDocs, final SegmentReader reader)
+        throws IOException {
+        assert (targetVector instanceof float[] || targetVector instanceof byte[]);
+        if (targetVector instanceof float[] floatTargetVector) {
+            reader.getVectorReader().search(knnQuery.getField(), floatTargetVector, collector, acceptDocs);
+        } else {
+            reader.getVectorReader().search(knnQuery.getField(), (byte[]) targetVector, collector, acceptDocs);
         }
     }
 
@@ -179,6 +250,33 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         final KNNEngine knnEngine,
         final SpaceType spaceType
     ) throws IOException {
+        final KnnCollectorManager collectorManager = reentrantKNNCollectorManager != null
+            ? reentrantKNNCollectorManager
+            : knnCollectorManager;
+        return queryIndex(
+            targetVector,
+            cardinality,
+            visitLimitWhenFilterExists,
+            context,
+            filterIdsBitSet,
+            reader,
+            knnEngine,
+            spaceType,
+            collectorManager
+        );
+    }
+
+    private TopDocs queryIndex(
+        final Object targetVector,
+        final int cardinality,
+        final int visitLimitWhenFilterExists,
+        final LeafReaderContext context,
+        final BitSet filterIdsBitSet,
+        final SegmentReader reader,
+        final KNNEngine knnEngine,
+        final SpaceType spaceType,
+        final KnnCollectorManager collectorManager
+    ) throws IOException {
         assert (targetVector instanceof float[] || targetVector instanceof byte[]);
 
         // Determine visit limit
@@ -190,18 +288,11 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         }
 
         // Create a collector + bitset
-        final KnnCollectorManager collectorManager = reentrantKNNCollectorManager != null
-            ? reentrantKNNCollectorManager
-            : knnCollectorManager;
         final KnnCollector knnCollector = collectorManager.newCollector(visitedLimit, DEFAULT_HNSW_SEARCH_STRATEGY, context);
         final AcceptDocs acceptDocs = getAcceptedDocs(reader, cardinality, filterIdsBitSet);
 
         // Start searching index
-        if (targetVector instanceof float[] floatTargetVector) {
-            reader.getVectorReader().search(knnQuery.getField(), floatTargetVector, knnCollector, acceptDocs);
-        } else {
-            reader.getVectorReader().search(knnQuery.getField(), (byte[]) targetVector, knnCollector, acceptDocs);
-        }
+        searchVector(targetVector, knnCollector, acceptDocs, reader);
 
         // Make results to return
         TopDocs topDocs = knnCollector.topDocs();

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -30,12 +30,10 @@ import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.query.KNNQuery;
 import org.opensearch.knn.index.query.KNNWeight;
 import org.opensearch.knn.index.query.MemoryOptimizedSearchScoreConverter;
-import org.opensearch.knn.index.util.IndexHyperParametersUtil;
 import org.opensearch.lucene.OptimisticKnnCollectorManager;
 import org.opensearch.lucene.ReentrantKnnCollectorManager;
 
 import java.io.IOException;
-import java.util.Map;
 
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 
@@ -61,22 +59,12 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         super(query, boost, filterWeight);
         this.searcher = searcher;
 
-        if (k != null && k > 0) {
-            // ANN Search
-            if (query.getParentsFilter() == null) {
-                // Non-nested case
-                this.knnCollectorManager = new OptimisticKnnCollectorManager(k, new TopKnnCollectorManager(k, searcher));
-            } else {
-                // Nested case
-                this.knnCollectorManager = new DiversifyingNearestChildrenKnnCollectorManager(k, query.getParentsFilter(), searcher);
-            }
+        if (query.getParentsFilter() == null) {
+            // Non-nested case
+            this.knnCollectorManager = new OptimisticKnnCollectorManager(k, new TopKnnCollectorManager(k, searcher));
         } else {
-            final float radius = query.getRadius();
-            this.knnCollectorManager = (visitLimit, searchStrategy, context) -> new RadiusVectorSimilarityCollector(
-                radius,
-                visitLimit,
-                searchStrategy
-            );
+            // Nested case
+            this.knnCollectorManager = new DiversifyingNearestChildrenKnnCollectorManager(k, query.getParentsFilter(), searcher);
         }
     }
 
@@ -96,37 +84,11 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         final int k
     ) {
         try {
-            if (k > 0) {
-                // KNN search
-                if (quantizedTargetVector != null) {
-                    // Quantization case
-                    if (quantizationService.getVectorDataTypeForTransfer(fieldInfo) == VectorDataType.BINARY) {
-                        return queryIndex(
-                            quantizedTargetVector,
-                            cardinality,
-                            cardinality + 1,
-                            context,
-                            filterIdsBitSet,
-                            reader,
-                            knnEngine,
-                            spaceType
-                        );
-                    }
-
-                    // Should never occur, safety if ever any other quantization is added
-                    throw new IllegalStateException(
-                        "VectorDataType for transfer acquired ["
-                            + quantizationService.getVectorDataTypeForTransfer(fieldInfo)
-                            + "] while it is expected to get ["
-                            + VectorDataType.BINARY
-                            + "]"
-                    );
-                }
-
-                if (knnQuery.getVectorDataType() == VectorDataType.BINARY || knnQuery.getVectorDataType() == VectorDataType.BYTE) {
-                    // when data_type is set byte or binary
+            if (quantizedTargetVector != null) {
+                // Quantization case
+                if (quantizationService.getVectorDataTypeForTransfer(fieldInfo) == VectorDataType.BINARY) {
                     return queryIndex(
-                        knnQuery.getByteQueryVector(),
+                        quantizedTargetVector,
                         cardinality,
                         cardinality + 1,
                         context,
@@ -137,23 +99,18 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                     );
                 }
 
-                if (adcTransformedVector != null) {
-                    // ADC case
-                    return queryIndex(
-                        adcTransformedVector,
-                        cardinality,
-                        cardinality + 1,
-                        context,
-                        filterIdsBitSet,
-                        reader,
-                        knnEngine,
-                        spaceType
-                    );
-                }
+                throw new IllegalStateException(
+                    "VectorDataType for transfer acquired ["
+                        + quantizationService.getVectorDataTypeForTransfer(fieldInfo)
+                        + "] while it is expected to get ["
+                        + VectorDataType.BINARY
+                        + "]"
+                );
+            }
 
-                // fallback to float
+            if (knnQuery.getVectorDataType() == VectorDataType.BINARY || knnQuery.getVectorDataType() == VectorDataType.BYTE) {
                 return queryIndex(
-                    knnQuery.getQueryVector(),
+                    knnQuery.getByteQueryVector(),
                     cardinality,
                     cardinality + 1,
                     context,
@@ -162,77 +119,34 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                     knnEngine,
                     spaceType
                 );
-            } else {
-                // Radius (radial) search via the memory-optimized path.
-                //
-                // Instead of running Lucene's radial graph traversal from the default entry node, we:
-                //   1. Run a top-k ANN search with k = ef_search to discover good entry points.
-                //   2. Run the radial (similarity-threshold) search re-entrant from those seeds.
-                return radialSearch(context, reader, knnEngine, spaceType, filterIdsBitSet, cardinality);
             }
+
+            if (adcTransformedVector != null) {
+                return queryIndex(
+                    adcTransformedVector,
+                    cardinality,
+                    cardinality + 1,
+                    context,
+                    filterIdsBitSet,
+                    reader,
+                    knnEngine,
+                    spaceType
+                );
+            }
+
+            return queryIndex(
+                knnQuery.getQueryVector(),
+                cardinality,
+                cardinality + 1,
+                context,
+                filterIdsBitSet,
+                reader,
+                knnEngine,
+                spaceType
+            );
         } catch (Exception e) {
             GRAPH_QUERY_ERRORS.increment();
             throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Two-phase radial search for the memory-optimized path.
-     * <p>
-     * Phase 1 performs a top-k approximate search with {@code k = ef_search} to collect a set of
-     * high-quality entry points. Phase 2 runs the radial (similarity-threshold) search seeded with
-     * those entry points via {@link ReentrantKnnCollectorManager}, so the graph traversal re-enters
-     * from known-good nodes rather than the default graph entry node. If phase 1 yields no seeds, the
-     * search falls back to a plain (un-seeded) radial search.
-     */
-    private TopDocs radialSearch(
-        final LeafReaderContext context,
-        final SegmentReader reader,
-        final KNNEngine knnEngine,
-        final SpaceType spaceType,
-        final BitSet filterIdsBitSet,
-        final int cardinality
-    ) throws IOException {
-        final Object targetVector = knnQuery.getVector();
-        final int visitedLimit = getFilterWeight() == null ? Integer.MAX_VALUE : cardinality;
-        final AcceptDocs acceptDocs = getAcceptedDocs(reader, cardinality, filterIdsBitSet);
-
-        // Phase 1: top-k ANN with k = ef_search to find seed entry points.
-        final int efSearch = IndexHyperParametersUtil.getHNSWEFSearchValue(knnQuery.getMethodParameters(), knnQuery.getIndexName());
-        final KnnCollector seedCollector = new TopKnnCollectorManager(efSearch, searcher).newCollector(
-            visitedLimit,
-            DEFAULT_HNSW_SEARCH_STRATEGY,
-            context
-        );
-        searchVector(targetVector, seedCollector, acceptDocs, reader);
-        final TopDocs seedTopDocs = seedCollector.topDocs();
-
-        // Phase 2: radial search, seeded from phase-1 results when available.
-        final KnnCollectorManager radialCollectorManager;
-        if (seedTopDocs != null && seedTopDocs.scoreDocs.length > 0) {
-            radialCollectorManager = new ReentrantKnnCollectorManager(
-                knnCollectorManager,
-                Map.of(context.ord, seedTopDocs),
-                targetVector,
-                knnQuery.getField()
-            );
-        } else {
-            radialCollectorManager = knnCollectorManager;
-        }
-
-        return queryIndex(targetVector, cardinality, cardinality, context, filterIdsBitSet, reader, knnEngine, spaceType, radialCollectorManager);
-    }
-
-    /**
-     * Issues the vector search against the segment using the given collector.
-     */
-    private void searchVector(final Object targetVector, final KnnCollector collector, final AcceptDocs acceptDocs, final SegmentReader reader)
-        throws IOException {
-        assert (targetVector instanceof float[] || targetVector instanceof byte[]);
-        if (targetVector instanceof float[] floatTargetVector) {
-            reader.getVectorReader().search(knnQuery.getField(), floatTargetVector, collector, acceptDocs);
-        } else {
-            reader.getVectorReader().search(knnQuery.getField(), (byte[]) targetVector, collector, acceptDocs);
         }
     }
 
@@ -306,6 +220,20 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
         }
         addExplainIfRequired(topDocs, knnEngine, spaceType);
         return topDocs;
+    }
+
+    private void searchVector(
+        final Object targetVector,
+        final KnnCollector collector,
+        final AcceptDocs acceptDocs,
+        final SegmentReader reader
+    ) throws IOException {
+        assert (targetVector instanceof float[] || targetVector instanceof byte[]);
+        if (targetVector instanceof float[] floatTargetVector) {
+            reader.getVectorReader().search(knnQuery.getField(), floatTargetVector, collector, acceptDocs);
+        } else {
+            reader.getVectorReader().search(knnQuery.getField(), (byte[]) targetVector, collector, acceptDocs);
+        }
     }
 
     private AcceptDocs getAcceptedDocs(SegmentReader reader, int cardinality, BitSet filterIdsBitSet) {

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -76,7 +76,7 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
             // Forward the incoming searchStrategy so that a re-entrant (seeded) radial search can begin
             // the graph traversal from pre-computed entry points instead of the default entry node.
             this.knnCollectorManager = (visitLimit, searchStrategy, context) -> new RadiusVectorSimilarityCollector(
-                DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * query.getRadius(),
+                query.getRadius(),
                 query.getRadius(),
                 visitLimit,
                 searchStrategy

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/RadiusVectorSimilarityCollector.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/RadiusVectorSimilarityCollector.java
@@ -15,75 +15,60 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Clone of Lucene's VectorSimilarityCollector, which cannot be used directly due to its package-private visibility.
+ * Collector for radial (similarity-threshold) search over an HNSW graph.
+ * <p>
+ * Uses a fixed similarity threshold as a hard cutoff: collects all visited nodes at or above
+ * the threshold and refuses to explore below it. This is designed for the two-phase radial
+ * search where phase-1 seeds provide good entry points, so no exploration beyond the threshold
+ * is needed.
+ * <p>
+ * Compatible with Lucene 10.5's {@code HnswGraphSearcher} which computes the traversal bound as
+ * {@code Math.nextUp(minCompetitiveSimilarity())}. We return {@code Math.nextDown(similarity)}
+ * so the effective cutoff equals the threshold exactly.
  */
 public class RadiusVectorSimilarityCollector extends AbstractKnnCollector {
     private static final KnnSearchStrategy.Hnsw DEFAULT_STRATEGY = new KnnSearchStrategy.Hnsw(0);
 
-    private final float traversalSimilarity, resultSimilarity;
-    private float maxSimilarity;
+    private final float similarity;
     private final List<ScoreDoc> scoreDocList;
 
     /**
-     * Perform a similarity-based graph search using the default HNSW strategy.
-     *
-     * @param traversalSimilarity (lower) similarity score for graph traversal.
-     * @param resultSimilarity (higher) similarity score for result collection.
+     * @param similarity minimum similarity for both traversal and collection.
      * @param visitLimit limit on number of nodes to visit.
      */
-    public RadiusVectorSimilarityCollector(float traversalSimilarity, float resultSimilarity, long visitLimit) {
-        this(traversalSimilarity, resultSimilarity, visitLimit, DEFAULT_STRATEGY);
+    public RadiusVectorSimilarityCollector(float similarity, long visitLimit) {
+        this(similarity, visitLimit, DEFAULT_STRATEGY);
     }
 
     /**
-     * Perform a similarity-based graph search. The graph is traversed till better scoring nodes are
-     * available, or the best candidate is below {@link #traversalSimilarity}. All traversed nodes
-     * above {@link #resultSimilarity} are collected.
-     * <p>
-     * The provided {@code searchStrategy} is forwarded to the underlying collector, which allows
-     * callers to pass a {@link KnnSearchStrategy.Seeded} strategy so that the radial graph traversal
-     * begins from a set of pre-computed entry points (re-entrant search) instead of the default
-     * graph entry node.
-     *
-     * @param traversalSimilarity (lower) similarity score for graph traversal.
-     * @param resultSimilarity (higher) similarity score for result collection.
-     * @param visitLimit limit on number of nodes to visit.
-     * @param searchStrategy the HNSW search strategy to use (e.g. {@link KnnSearchStrategy.Seeded}).
+     * @param similarity     minimum similarity for both traversal and collection.
+     * @param visitLimit     limit on number of nodes to visit.
+     * @param searchStrategy the HNSW search strategy (e.g. {@link KnnSearchStrategy.Seeded}).
      */
-    public RadiusVectorSimilarityCollector(
-        float traversalSimilarity,
-        float resultSimilarity,
-        long visitLimit,
-        KnnSearchStrategy searchStrategy
-    ) {
+    public RadiusVectorSimilarityCollector(float similarity, long visitLimit, KnnSearchStrategy searchStrategy) {
         super(1, visitLimit, searchStrategy);
-        if (traversalSimilarity > resultSimilarity) {
-            throw new IllegalArgumentException("traversalSimilarity should be <= resultSimilarity");
-        }
-        this.traversalSimilarity = traversalSimilarity;
-        this.resultSimilarity = resultSimilarity;
-        this.maxSimilarity = Float.NEGATIVE_INFINITY;
+        this.similarity = similarity;
         this.scoreDocList = new ArrayList<>();
     }
 
     @Override
     public boolean collect(int docId, float similarity) {
-        maxSimilarity = Math.max(maxSimilarity, similarity);
-        if (similarity >= resultSimilarity) {
+        if (similarity >= this.similarity) {
             scoreDocList.add(new ScoreDoc(docId, similarity));
         }
-        return true;
+        // Return false: our minCompetitiveSimilarity is constant, no re-read needed.
+        return false;
     }
 
     @Override
     public float minCompetitiveSimilarity() {
-        return Math.min(traversalSimilarity, maxSimilarity);
+        // Lucene 10.5's HnswGraphSearcher uses Math.nextUp(this) as the traversal bound.
+        // Returning nextDown(similarity) makes the effective cutoff exactly equal to similarity.
+        return Math.nextDown(similarity);
     }
 
     @Override
     public TopDocs topDocs() {
-        // Results are not returned in a sorted order to prevent unnecessary calculations (because we do
-        // not need to maintain the topK)
         TotalHits.Relation relation = earlyTerminated() ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO : TotalHits.Relation.EQUAL_TO;
         return new TopDocs(new TotalHits(visitedCount(), relation), scoreDocList.toArray(ScoreDoc[]::new));
     }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/RadiusVectorSimilarityCollector.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/RadiusVectorSimilarityCollector.java
@@ -25,17 +25,38 @@ public class RadiusVectorSimilarityCollector extends AbstractKnnCollector {
     private final List<ScoreDoc> scoreDocList;
 
     /**
-     * Perform a similarity-based graph search. The graph is traversed till better scoring nodes are
-     * available, or the best candidate is below {@link #traversalSimilarity}. All traversed nodes
-     * above {@link #resultSimilarity} are collected.
+     * Perform a similarity-based graph search using the default HNSW strategy.
      *
      * @param traversalSimilarity (lower) similarity score for graph traversal.
      * @param resultSimilarity (higher) similarity score for result collection.
      * @param visitLimit limit on number of nodes to visit.
      */
     public RadiusVectorSimilarityCollector(float traversalSimilarity, float resultSimilarity, long visitLimit) {
-        // TODO: add search strategy support
-        super(1, visitLimit, DEFAULT_STRATEGY);
+        this(traversalSimilarity, resultSimilarity, visitLimit, DEFAULT_STRATEGY);
+    }
+
+    /**
+     * Perform a similarity-based graph search. The graph is traversed till better scoring nodes are
+     * available, or the best candidate is below {@link #traversalSimilarity}. All traversed nodes
+     * above {@link #resultSimilarity} are collected.
+     * <p>
+     * The provided {@code searchStrategy} is forwarded to the underlying collector, which allows
+     * callers to pass a {@link KnnSearchStrategy.Seeded} strategy so that the radial graph traversal
+     * begins from a set of pre-computed entry points (re-entrant search) instead of the default
+     * graph entry node.
+     *
+     * @param traversalSimilarity (lower) similarity score for graph traversal.
+     * @param resultSimilarity (higher) similarity score for result collection.
+     * @param visitLimit limit on number of nodes to visit.
+     * @param searchStrategy the HNSW search strategy to use (e.g. {@link KnnSearchStrategy.Seeded}).
+     */
+    public RadiusVectorSimilarityCollector(
+        float traversalSimilarity,
+        float resultSimilarity,
+        long visitLimit,
+        KnnSearchStrategy searchStrategy
+    ) {
+        super(1, visitLimit, searchStrategy);
         if (traversalSimilarity > resultSimilarity) {
             throw new IllegalArgumentException("traversalSimilarity should be <= resultSimilarity");
         }

--- a/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/KNNQueryBuilderTests.java
@@ -7,8 +7,6 @@ package org.opensearch.knn.index.query;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
-import org.apache.lucene.search.ByteVectorSimilarityQuery;
-import org.apache.lucene.search.FloatVectorSimilarityQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.VectorUtil;
@@ -259,14 +257,13 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(knnMethodContext, 4));
 
         // Build a query
-        FloatVectorSimilarityQuery query = (FloatVectorSimilarityQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
+        RadialSearchQuery query = (RadialSearchQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
 
         // Get Lucene similarity as a threshold e.g. distance -> radial threshold
         float resultSimilarity = KNNEngine.LUCENE.distanceToRadialThreshold(MAX_DISTANCE, SpaceType.L2);
 
         // Validations
-        assertTrue(query.toString().contains("resultSimilarity=" + resultSimilarity));
-        // traversalSimilarity replaced by decay in Lucene 10.5 - no longer in toString
+        assertTrue(query.toString().contains("similarity=" + resultSimilarity));
     }
 
     @SneakyThrows
@@ -293,10 +290,10 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         when(mockKNNVectorField.getKnnMappingConfig()).thenReturn(getMappingConfigForMethodMapping(knnMethodContext, 4));
 
         // Build a query
-        FloatVectorSimilarityQuery query = (FloatVectorSimilarityQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
+        RadialSearchQuery query = (RadialSearchQuery) knnQueryBuilder.doToQuery(mockQueryShardContext);
 
         // Validation
-        assertTrue(query.toString().contains("resultSimilarity=" + 0.5f));
+        assertTrue(query.toString().contains("similarity=" + 0.5f));
     }
 
     @SneakyThrows
@@ -809,7 +806,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         assertNotNull(query);
         // 32x SQ radial search wraps the inner FloatVectorSimilarityQuery in RescoreRadialSearchQuery
         assertTrue(query instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof FloatVectorSimilarityQuery);
+        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof RadialSearchQuery);
 
         // --- Test with minScore ---
         // minScore follows the same Lucene radial path. Internally converted to a similarity threshold
@@ -834,7 +831,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         Query query2 = knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2);
         assertNotNull(query2);
         assertTrue(query2 instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof FloatVectorSimilarityQuery);
+        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof RadialSearchQuery);
     }
 
     // Validates that radial search on a Lucene FLAT index with 32x SQ is allowed.
@@ -903,7 +900,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         Query query = knnQueryBuilderWithDistance.doToQuery(mockQueryShardContext);
         assertNotNull(query);
         assertTrue(query instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof FloatVectorSimilarityQuery);
+        assertTrue(((RescoreRadialSearchQuery) query).getInnerQuery() instanceof RadialSearchQuery);
 
         // --- Test with minScore ---
         KNNQueryBuilder knnQueryBuilderWithScore = KNNQueryBuilder.builder()
@@ -926,7 +923,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         Query query2 = knnQueryBuilderWithScore.doToQuery(mockQueryShardContext2);
         assertNotNull(query2);
         assertTrue(query2 instanceof RescoreRadialSearchQuery);
-        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof FloatVectorSimilarityQuery);
+        assertTrue(((RescoreRadialSearchQuery) query2).getInnerQuery() instanceof RadialSearchQuery);
     }
 
     public void testDoToQuery_KnnQueryWithFilter_Lucene() {
@@ -997,7 +994,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
         // Validations
         assertNotNull(query);
-        assertTrue(query.getClass().isAssignableFrom(FloatVectorSimilarityQuery.class));
+        assertTrue(query.getClass().isAssignableFrom(RadialSearchQuery.class));
     }
 
     @SneakyThrows
@@ -1033,7 +1030,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
 
         // Validations
         assertNotNull(query);
-        assertTrue(query.getClass().isAssignableFrom(FloatVectorSimilarityQuery.class));
+        assertTrue(query.getClass().isAssignableFrom(RadialSearchQuery.class));
     }
 
     @SneakyThrows
@@ -1629,7 +1626,7 @@ public class KNNQueryBuilderTests extends KNNTestCase {
         IndexSettings indexSettings = mock(IndexSettings.class);
         when(mockQueryShardContext.getIndexSettings()).thenReturn(indexSettings);
         when(indexSettings.getMaxResultWindow()).thenReturn(1000);
-        assertTrue(knnQueryBuilder.doToQuery(mockQueryShardContext) instanceof ByteVectorSimilarityQuery);
+        assertTrue(knnQueryBuilder.doToQuery(mockQueryShardContext) instanceof RadialSearchQuery);
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.lucene.search.ByteVectorSimilarityQuery;
-import org.apache.lucene.search.FloatVectorSimilarityQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.opensearch.index.IndexSettings;
@@ -66,7 +64,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
                 testRadius,
                 DEFAULT_VECTOR_DATA_TYPE_FIELD
             );
-            assertEquals(FloatVectorSimilarityQuery.class, query.getClass());
+            assertEquals(RadialSearchQuery.class, query.getClass());
         }
     }
 
@@ -92,7 +90,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
                 .filter(FILTER_QUERY_BUILDER)
                 .build();
             Query query = RNNQueryFactory.create(createQueryRequest);
-            assertEquals(ByteVectorSimilarityQuery.class, query.getClass());
+            assertEquals(RadialSearchQuery.class, query.getClass());
         }
     }
 
@@ -115,7 +113,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
                 .radius(testRadius)
                 .build();
             Query query = RNNQueryFactory.create(createQueryRequest);
-            assertEquals(FloatVectorSimilarityQuery.class, query.getClass());
+            assertEquals(RadialSearchQuery.class, query.getClass());
         }
     }
 
@@ -244,7 +242,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
         assertEquals(customMaxResultWindow, rescoreQuery.getMaxResultsSize());
     }
 
-    // Verify that Lucene radial search with 32x SQ wraps the inner FloatVectorSimilarityQuery
+    // Verify that Lucene radial search with 32x SQ wraps the inner RadialSearchQuery
     // in RescoreRadialSearchQuery.
     public void testCreate_whenLuceneSQ32x_thenWrapsInRescoreRadialSearchQuery() {
         List<KNNEngine> luceneEngines = Arrays.stream(KNNEngine.values())
@@ -269,7 +267,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
 
             assertTrue(query instanceof RescoreRadialSearchQuery);
             RescoreRadialSearchQuery rescoreQuery = (RescoreRadialSearchQuery) query;
-            assertTrue(rescoreQuery.getInnerQuery() instanceof FloatVectorSimilarityQuery);
+            assertTrue(rescoreQuery.getInnerQuery() instanceof RadialSearchQuery);
             assertEquals(testFieldName, rescoreQuery.getField());
             assertEquals(testRadius, rescoreQuery.getRadius(), 0.0f);
         }
@@ -300,7 +298,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
         assertFalse(query instanceof RescoreRadialSearchQuery);
     }
 
-    // Verify that non-quantized Lucene radial search returns bare FloatVectorSimilarityQuery (no wrapper).
+    // Verify that non-quantized Lucene radial search returns bare RadialSearchQuery (no wrapper).
     public void testCreate_whenLuceneNotQuantized_thenNoWrapper() {
         List<KNNEngine> luceneEngines = Arrays.stream(KNNEngine.values())
             .filter(knnEngine -> !KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine))
@@ -318,7 +316,7 @@ public class RNNQueryFactoryTests extends KNNTestCase {
 
             Query query = RNNQueryFactory.create(createQueryRequest);
 
-            assertTrue(query instanceof FloatVectorSimilarityQuery);
+            assertTrue(query instanceof RadialSearchQuery);
             assertFalse(query instanceof RescoreRadialSearchQuery);
         }
     }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/RadiusVectorSimilarityCollectorTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/RadiusVectorSimilarityCollectorTests.java
@@ -36,11 +36,7 @@ public class RadiusVectorSimilarityCollectorTests {
         final DocIdSetIterator seedDocs = DocIdSetIterator.all(5);
         final KnnSearchStrategy.Seeded seededStrategy = new KnnSearchStrategy.Seeded(seedDocs, 5, KnnSearchStrategy.Hnsw.DEFAULT);
 
-        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
-            SIMILARITY,
-            VISIT_LIMIT,
-            seededStrategy
-        );
+        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(SIMILARITY, VISIT_LIMIT, seededStrategy);
 
         assertSame(
             "RadiusVectorSimilarityCollector must forward the provided search strategy so seeding takes effect",

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/RadiusVectorSimilarityCollectorTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/RadiusVectorSimilarityCollectorTests.java
@@ -13,23 +13,18 @@ import org.junit.Test;
 import org.opensearch.knn.index.query.memoryoptsearch.RadiusVectorSimilarityCollector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class RadiusVectorSimilarityCollectorTests {
 
-    private static final float TRAVERSAL_SIMILARITY = 0.5f;
-    private static final float RESULT_SIMILARITY = 0.8f;
+    private static final float SIMILARITY = 0.8f;
     private static final long VISIT_LIMIT = 1000L;
 
     @Test
     public void testDefaultConstructor_usesHnswStrategy() {
-        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
-            TRAVERSAL_SIMILARITY,
-            RESULT_SIMILARITY,
-            VISIT_LIMIT
-        );
+        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(SIMILARITY, VISIT_LIMIT);
         assertTrue(
             "Expected default Hnsw search strategy but got " + collector.getSearchStrategy(),
             collector.getSearchStrategy() instanceof KnnSearchStrategy.Hnsw
@@ -38,13 +33,11 @@ public class RadiusVectorSimilarityCollectorTests {
 
     @Test
     public void testStrategyConstructor_forwardsSeededStrategyToCollector() {
-        // A Seeded strategy is what enables re-entrant radial search (entry points from a prior phase).
         final DocIdSetIterator seedDocs = DocIdSetIterator.all(5);
         final KnnSearchStrategy.Seeded seededStrategy = new KnnSearchStrategy.Seeded(seedDocs, 5, KnnSearchStrategy.Hnsw.DEFAULT);
 
         final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
-            TRAVERSAL_SIMILARITY,
-            RESULT_SIMILARITY,
+            SIMILARITY,
             VISIT_LIMIT,
             seededStrategy
         );
@@ -57,34 +50,41 @@ public class RadiusVectorSimilarityCollectorTests {
     }
 
     @Test
-    public void testCollect_onlyCollectsDocsAtOrAboveResultSimilarity() {
+    public void testCollect_onlyCollectsDocsAtOrAboveThreshold() {
         final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
-            TRAVERSAL_SIMILARITY,
-            RESULT_SIMILARITY,
+            SIMILARITY,
             VISIT_LIMIT,
             KnnSearchStrategy.Hnsw.DEFAULT
         );
 
-        // Below result similarity -> dropped
-        collector.collect(1, 0.6f);
-        // At result similarity -> collected
-        collector.collect(2, RESULT_SIMILARITY);
-        // Above result similarity -> collected
-        collector.collect(3, 0.95f);
+        // Below threshold -> dropped
+        assertFalse(collector.collect(1, 0.6f));
+        // At threshold -> collected
+        assertFalse(collector.collect(2, SIMILARITY));
+        // Above threshold -> collected
+        assertFalse(collector.collect(3, 0.95f));
 
         final TopDocs topDocs = collector.topDocs();
         assertEquals(2, topDocs.scoreDocs.length);
         for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
-            assertTrue("Collected docs must have similarity >= resultSimilarity", scoreDoc.score >= RESULT_SIMILARITY);
+            assertTrue("Collected docs must have similarity >= threshold", scoreDoc.score >= SIMILARITY);
         }
     }
 
     @Test
-    public void testConstructor_rejectsTraversalGreaterThanResult() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new RadiusVectorSimilarityCollector(0.9f, 0.5f, VISIT_LIMIT, KnnSearchStrategy.Hnsw.DEFAULT)
+    public void testMinCompetitiveSimilarity_isConstantHardCutoff() {
+        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
+            SIMILARITY,
+            VISIT_LIMIT,
+            KnnSearchStrategy.Hnsw.DEFAULT
         );
-        assertThrows(IllegalArgumentException.class, () -> new RadiusVectorSimilarityCollector(0.9f, 0.5f, VISIT_LIMIT));
+
+        // Before any collection, the bound is already set as a hard cutoff.
+        float expected = Math.nextDown(SIMILARITY);
+        assertEquals(expected, collector.minCompetitiveSimilarity(), 0f);
+
+        // After collecting, the bound doesn't change.
+        collector.collect(1, 0.95f);
+        assertEquals(expected, collector.minCompetitiveSimilarity(), 0f);
     }
 }

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/RadiusVectorSimilarityCollectorTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/RadiusVectorSimilarityCollectorTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.memoryoptsearch;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.knn.KnnSearchStrategy;
+import org.junit.Test;
+import org.opensearch.knn.index.query.memoryoptsearch.RadiusVectorSimilarityCollector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class RadiusVectorSimilarityCollectorTests {
+
+    private static final float TRAVERSAL_SIMILARITY = 0.5f;
+    private static final float RESULT_SIMILARITY = 0.8f;
+    private static final long VISIT_LIMIT = 1000L;
+
+    @Test
+    public void testDefaultConstructor_usesHnswStrategy() {
+        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
+            TRAVERSAL_SIMILARITY,
+            RESULT_SIMILARITY,
+            VISIT_LIMIT
+        );
+        assertTrue(
+            "Expected default Hnsw search strategy but got " + collector.getSearchStrategy(),
+            collector.getSearchStrategy() instanceof KnnSearchStrategy.Hnsw
+        );
+    }
+
+    @Test
+    public void testStrategyConstructor_forwardsSeededStrategyToCollector() {
+        // A Seeded strategy is what enables re-entrant radial search (entry points from a prior phase).
+        final DocIdSetIterator seedDocs = DocIdSetIterator.all(5);
+        final KnnSearchStrategy.Seeded seededStrategy = new KnnSearchStrategy.Seeded(seedDocs, 5, KnnSearchStrategy.Hnsw.DEFAULT);
+
+        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
+            TRAVERSAL_SIMILARITY,
+            RESULT_SIMILARITY,
+            VISIT_LIMIT,
+            seededStrategy
+        );
+
+        assertSame(
+            "RadiusVectorSimilarityCollector must forward the provided search strategy so seeding takes effect",
+            seededStrategy,
+            collector.getSearchStrategy()
+        );
+    }
+
+    @Test
+    public void testCollect_onlyCollectsDocsAtOrAboveResultSimilarity() {
+        final RadiusVectorSimilarityCollector collector = new RadiusVectorSimilarityCollector(
+            TRAVERSAL_SIMILARITY,
+            RESULT_SIMILARITY,
+            VISIT_LIMIT,
+            KnnSearchStrategy.Hnsw.DEFAULT
+        );
+
+        // Below result similarity -> dropped
+        collector.collect(1, 0.6f);
+        // At result similarity -> collected
+        collector.collect(2, RESULT_SIMILARITY);
+        // Above result similarity -> collected
+        collector.collect(3, 0.95f);
+
+        final TopDocs topDocs = collector.topDocs();
+        assertEquals(2, topDocs.scoreDocs.length);
+        for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+            assertTrue("Collected docs must have similarity >= resultSimilarity", scoreDoc.score >= RESULT_SIMILARITY);
+        }
+    }
+
+    @Test
+    public void testConstructor_rejectsTraversalGreaterThanResult() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new RadiusVectorSimilarityCollector(0.9f, 0.5f, VISIT_LIMIT, KnnSearchStrategy.Hnsw.DEFAULT)
+        );
+        assertThrows(IllegalArgumentException.class, () -> new RadiusVectorSimilarityCollector(0.9f, 0.5f, VISIT_LIMIT));
+    }
+}


### PR DESCRIPTION
### Description
Instead of going through either the decay method or traversalSimilarity method for radial search, do a two phase search where we first find qualifying seeds, then expand up to the exact radius. Unifies the lucene and MOS logic as we are seeing better performance with this method across engines.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
