### PR TITLE
[SQ PR-3] Build SQ B-bit HNSW graph with multi-bit symmetric distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Parameterize integration test framework for compression level [#3416](https://github.com/opensearch-project/k-NN/pull/3416)
 * Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
+* Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/jni/include/faiss_index_service.h
+++ b/jni/include/faiss_index_service.h
@@ -106,7 +106,7 @@ public:
 
     jlong initFaissSQIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, faiss::MetricType metric,
                             std::string indexDescription, int dim, int numVectors, int threadCount,
-                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes);
+                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes, int docBits);
 
     /**
      * Add vectors to index

--- a/jni/include/faiss_wrapper.h
+++ b/jni/include/faiss_wrapper.h
@@ -28,7 +28,8 @@ namespace knn_jni {
                                 jobject parametersJ,
                                 BinaryIndexService *indexService,
                                 jfloat centroidDp,
-                                jint quantizedVecBytes);
+                                jint quantizedVecBytes,
+                                jint docBits);
 
         void InsertToIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, jintArray idsJ, jlong vectorsAddressJ, jint dimJ, jlong indexAddr, jint threadCount, IndexService *indexService);
 

--- a/jni/include/org_opensearch_knn_jni_FaissService.h
+++ b/jni/include/org_opensearch_knn_jni_FaissService.h
@@ -286,10 +286,10 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterrup
 /*
  * Class:     org_opensearch_knn_jni_FaissService
  * Method:    initFaissSQIndex
- * Signature: (IILjava/util/Map;FI)J
+ * Signature: (IILjava/util/Map;FII)J
  */
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initFaissSQIndex
-  (JNIEnv *, jclass, jint, jint, jobject, jfloat, jint);
+  (JNIEnv *, jclass, jint, jint, jobject, jfloat, jint, jint);
 
 /*
  * Class:     org_opensearch_knn_jni_FaissService

--- a/jni/include/sq/faiss_sq_flat.h
+++ b/jni/include/sq/faiss_sq_flat.h
@@ -41,10 +41,54 @@ namespace knn_jni {
         quantizedComponentSum = static_cast<float>(componentSum);
     }
 
+    // Only bit widths supported by the memory-optimized-search (MOS) path.
+    // Kept in sync with FaissSQEncoder.isMosBits on the Java side and with
+    // ScalarEncodingResolver.SUPPORTED_DOC_BITS.
+    static inline bool isMosDocBits(int32_t bits) {
+        return bits == 1 || bits == 2 || bits == 4;
+    }
+
+    // Validates a docBits value and returns it unchanged when supported. Called from
+    // FaissSQDistanceComputer's initializer list so the throw beats the `qvb / docBits`
+    // computation in `planeBytes`, which would otherwise trigger a SIGFPE for docBits == 0.
+    static inline int32_t validateDocBits(int32_t bits) {
+        if (!isMosDocBits(bits)) {
+            throw std::runtime_error(
+                "FaissSQDistanceComputer: unsupported docBits=" + std::to_string(bits)
+                + ". Supported: 1, 2, 4."
+            );
+        }
+        return bits;
+    }
+
+    // Validates that quantizedVectorBytes is compatible with the given docBits and returns it
+    // unchanged. For docBits == 2 the bit-plane kernel requires equal-length planes (qvb must
+    // be even). For docBits ∈ {1, 4} any positive qvb is valid — B=1 is a single plane, and
+    // B=4 uses PACKED_NIBBLE where each byte independently carries two elements.
+    static inline uint64_t validateQvbForDocBits(uint64_t qvb, int32_t bits) {
+        if (bits == 2 && qvb % 2 != 0) {
+            throw std::runtime_error(
+                "FaissSQDistanceComputer: quantizedVectorBytes=" + std::to_string(qvb)
+                + " must be even for docBits=2 (two bit planes of equal length)"
+            );
+        }
+        return qvb;
+    }
+
     template <bool IsMaxIP, bool IsBytesMultipleOf8>
     struct FaissSQDistanceComputer final : faiss::DistanceComputer {
         const int64_t oneElementByteSize;
         const uint64_t quantizedVectorBytes;
+        // Number of bits used to quantize each document dimension (1, 2, or 4).
+        const int32_t docBits;
+        // Byte length of a single bit plane. Only meaningful for the bit-plane popcount path
+        // (B=1, B=2): the quantized code is docBits contiguous planes, each planeBytes long,
+        // so quantizedVectorBytes == docBits * planeBytes. Unused for B=4 (PACKED_NIBBLE),
+        // where `bothPackedNibbleDp` iterates over quantizedVectorBytes directly.
+        const uint64_t planeBytes;
+        // Reconstruction scale for the quantization interval: 1 / (2^docBits - 1). For docBits == 1
+        // this is 1, preserving the legacy single-bit behavior.
+        const float dataScale;
         const uint8_t* data;
         const uint8_t* query;
         const float centroidDp;
@@ -55,11 +99,22 @@ namespace knn_jni {
         int32_t dimension;
         int32_t numVectors;
 
-        FaissSQDistanceComputer(int32_t _oneElementByteSize, const void* _data, float _centroidDp, int32_t _dimension, int32_t _numVectors)
+        FaissSQDistanceComputer(int32_t _oneElementByteSize, const void* _data, float _centroidDp, int32_t _dimension, int32_t _numVectors, int32_t _docBits)
           : faiss::DistanceComputer(),
             oneElementByteSize(_oneElementByteSize),
             // Memory layout : [Quantized Vector | lowerInterval (float) | upperInterval (float) | additionalCorrection (float) | quantizedComponentSum (int)]
-            quantizedVectorBytes(_oneElementByteSize - (sizeof(float) * 3 + sizeof(int32_t))),
+            quantizedVectorBytes(
+                validateQvbForDocBits(
+                    _oneElementByteSize - (sizeof(float) * 3 + sizeof(int32_t)),
+                    validateDocBits(_docBits))),
+            // validateDocBits above already rejected _docBits ∉ {1,2,4}, so:
+            //   - docBits / 0 division in `planeBytes` is unreachable
+            //   - `1 << _docBits` signed-shift UB (would need _docBits > 30) is unreachable
+            //   - silent wrong reconstruction for _docBits ∈ {3,5,6,7,...} is unreachable
+            // Fields below are computed only when validation has passed.
+            docBits(_docBits),
+            planeBytes(quantizedVectorBytes / _docBits),
+            dataScale(1.0f / static_cast<float>((1 << _docBits) - 1)),
             data((const uint8_t*) _data),
             query(),
             centroidDp(_centroidDp),
@@ -69,6 +124,74 @@ namespace knn_jni {
             y1(),
             dimension(_dimension),
             numVectors(_numVectors) {
+        }
+
+        // Popcount of (a AND b) over `planeBytes` bytes. Uses std::memcpy for 8-byte word loads so
+        // it is safe regardless of plane alignment (planeBytes need not be a multiple of 8 for B>1),
+        // with a byte remainder loop for the trailing bytes.
+        static inline uint64_t popcountAndPlane(const uint8_t* a, const uint8_t* b, const uint64_t planeBytes) {
+            const uint64_t words = planeBytes >> 3;
+            uint64_t pc = 0;
+            for (uint64_t w = 0; w < words; ++w) {
+                uint64_t wa, wb;
+                std::memcpy(&wa, a + w * 8, sizeof(uint64_t));
+                std::memcpy(&wb, b + w * 8, sizeof(uint64_t));
+                pc += __builtin_popcountll(wa & wb);
+            }
+            for (uint64_t r = words * 8; r < planeBytes; ++r) {
+                pc += __builtin_popcount((a[r] & b[r]) & 0xFF);
+            }
+            return pc;
+        }
+
+        // Byte-wise dot product over Lucene's PACKED_NIBBLE doc layout.
+        // packed[i] high nibble = element i, low nibble = element (packedBytes + i).
+        // Mirrors Lucene's VectorUtil.int4DotProductBothPacked. For each byte we extract two
+        // 4-bit values per side and accumulate two products. The compiler's auto-vectorizer
+        // turns this into wide 16-bit multiplies on x86 (PMULLW) and ARM (NEON MUL).
+        //
+        // WHY NOT a bit-plane popcount for B=4? PACKED_NIBBLE bytes are NOT bit planes — each
+        // byte carries two elements at four different bit-positions each. popcount-AND on that
+        // layout mixes place values (1, 2, 4, 8) into a uniform count and destroys the dot
+        // product.
+        static inline uint64_t bothPackedNibbleDp(const uint8_t* a, const uint8_t* b, const uint64_t packedBytes) {
+            uint64_t total = 0;
+            for (uint64_t i = 0; i < packedBytes; ++i) {
+                const uint32_t aLo = a[i] & 0x0Fu;
+                const uint32_t aHi = (a[i] >> 4) & 0x0Fu;
+                const uint32_t bLo = b[i] & 0x0Fu;
+                const uint32_t bHi = (b[i] >> 4) & 0x0Fu;
+                total += aLo * bLo + aHi * bHi;
+            }
+            return total;
+        }
+
+        // Multi-bit dot product between two quantized codes. The kernel shape depends on docBits:
+        //   B=1: single popcount(a AND b)                          — bit-plane (1 plane)
+        //   B=2: 2x2 popcount-AND-shift double sum across planes   — bit-plane (2 planes)
+        //   B=4: byte-wise nibble multiply-accumulate              — Lucene's PACKED_NIBBLE layout
+        //
+        // Performance trade-off: for B=4 the bit-plane formulation would need 16 popcount calls
+        // per distance (and a Java-side repack, since Lucene stores PACKED_NIBBLE not bit planes),
+        // while the byte-wise multiply matches Lucene's int4DotProductBothPacked and avoids both.
+        // The math is the same (Σ A_n B_n with A_n, B_n in [0, 2^B - 1]); only the byte layout differs.
+        uint64_t multiBitDp(const uint8_t* a, const uint8_t* b) const {
+            if (docBits == 1) {
+                return popcountAndPlane(a, b, planeBytes);
+            }
+            if (docBits == 4) {
+                return bothPackedNibbleDp(a, b, quantizedVectorBytes);
+            }
+            // docBits == 2: bit-plane popcount path.
+            uint64_t dp = 0;
+            for (int32_t i = 0; i < docBits; ++i) {
+                const uint8_t* pa = a + (uint64_t) i * planeBytes;
+                for (int32_t j = 0; j < docBits; ++j) {
+                    const uint8_t* pb = b + (uint64_t) j * planeBytes;
+                    dp += popcountAndPlane(pa, pb, planeBytes) << (i + j);
+                }
+            }
+            return dp;
         }
 
         void set_query(const float* x) final {
@@ -88,6 +211,9 @@ namespace knn_jni {
             } else {
                 readCorrectionFactorsSafe(ptr, lowerInterval, intervalLength, additionalCorrection, quantizedComponentSum);
             }
+            // Scale (upper - lower) by 1/(2^docBits - 1) so the reconstruction delta matches the
+            // quantization level range [0, 2^docBits - 1]. For docBits == 1 this is a no-op.
+            intervalLength *= dataScale;
         }
 
         float scoringSecondPart(const void* target, const float dp) {
@@ -120,30 +246,8 @@ namespace knn_jni {
         /// compute distance of vector i to current query
         float operator()(faiss::idx_t i) final {
             const uint8_t* target = data + i * oneElementByteSize;
-            const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-            uint32_t dp = 0;
-
-            if constexpr (IsBytesMultipleOf8) {
-                const auto* q = reinterpret_cast<const uint64_t*>(query);
-                const auto* t = reinterpret_cast<const uint64_t*>(target);
-                for (size_t j = 0; j < words; ++j) {
-                    dp += __builtin_popcountll(q[j] & t[j]);
-                }
-            } else {
-                for (size_t j = 0; j < words; ++j) {
-                    uint64_t queryWord, targetWord;
-                    std::memcpy(&queryWord, query + j * 8, sizeof(uint64_t));
-                    std::memcpy(&targetWord, target + j * 8, sizeof(uint64_t));
-                    dp += __builtin_popcountll(queryWord & targetWord);
-                }
-                // Remainder bytes that don't fill a full 8-byte word
-                const uint64_t remainStart = words * 8;
-                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
-                    dp += __builtin_popcount((query[r] & target[r]) & 0xFF);
-                }
-            }
-
-            return scoringSecondPart(target, dp);
+            const uint64_t dp = multiBitDp(query, target);
+            return scoringSecondPart(target, static_cast<float>(dp));
         }
 
         /// compute distances of current query to 4 stored vectors.
@@ -161,51 +265,10 @@ namespace knn_jni {
             const uint8_t* target3 = data + idx2 * oneElementByteSize;
             const uint8_t* target4 = data + idx3 * oneElementByteSize;
 
-            const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-
-            uint32_t dp1 = 0, dp2 = 0, dp3 = 0, dp4 = 0;
-
-            if constexpr (IsBytesMultipleOf8) {
-                const auto* q = reinterpret_cast<const uint64_t*>(query);
-                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
-                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
-                const auto* t3 = reinterpret_cast<const uint64_t*>(target3);
-                const auto* t4 = reinterpret_cast<const uint64_t*>(target4);
-                for (size_t i = 0; i < words; ++i) {
-                    dp1 += __builtin_popcountll(q[i] & t1[i]);
-                    dp2 += __builtin_popcountll(q[i] & t2[i]);
-                    dp3 += __builtin_popcountll(q[i] & t3[i]);
-                    dp4 += __builtin_popcountll(q[i] & t4[i]);
-                }
-            } else {
-                for (size_t i = 0; i < words; ++i) {
-                    uint64_t queryWord;
-                    std::memcpy(&queryWord, query + i * 8, sizeof(uint64_t));
-                    uint64_t w1, w2, w3, w4;
-                    std::memcpy(&w1, target1 + i * 8, sizeof(uint64_t));
-                    std::memcpy(&w2, target2 + i * 8, sizeof(uint64_t));
-                    std::memcpy(&w3, target3 + i * 8, sizeof(uint64_t));
-                    std::memcpy(&w4, target4 + i * 8, sizeof(uint64_t));
-                    dp1 += __builtin_popcountll(queryWord & w1);
-                    dp2 += __builtin_popcountll(queryWord & w2);
-                    dp3 += __builtin_popcountll(queryWord & w3);
-                    dp4 += __builtin_popcountll(queryWord & w4);
-                }
-                // Remainder bytes that don't fill a full 8-byte word
-                const uint64_t remainStart = words * 8;
-                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
-                    const uint8_t qb = query[r];
-                    dp1 += __builtin_popcount((qb & target1[r]) & 0xFF);
-                    dp2 += __builtin_popcount((qb & target2[r]) & 0xFF);
-                    dp3 += __builtin_popcount((qb & target3[r]) & 0xFF);
-                    dp4 += __builtin_popcount((qb & target4[r]) & 0xFF);
-                }
-            }
-
-            dis0 = scoringSecondPart(target1, dp1);
-            dis1 = scoringSecondPart(target2, dp2);
-            dis2 = scoringSecondPart(target3, dp3);
-            dis3 = scoringSecondPart(target4, dp4);
+            dis0 = scoringSecondPart(target1, static_cast<float>(multiBitDp(query, target1)));
+            dis1 = scoringSecondPart(target2, static_cast<float>(multiBitDp(query, target2)));
+            dis2 = scoringSecondPart(target3, static_cast<float>(multiBitDp(query, target3)));
+            dis3 = scoringSecondPart(target4, static_cast<float>(multiBitDp(query, target4)));
         }
 
         /// compute distance between two stored vectors
@@ -213,28 +276,7 @@ namespace knn_jni {
             const uint8_t* target1 = data + i * oneElementByteSize;
             const uint8_t* target2 = data + j * oneElementByteSize;
 
-            const uint64_t words = quantizedVectorBytes >> 3; // divide by 8
-            uint32_t dp = 0;
-
-            if constexpr (IsBytesMultipleOf8) {
-                const auto* t1 = reinterpret_cast<const uint64_t*>(target1);
-                const auto* t2 = reinterpret_cast<const uint64_t*>(target2);
-                for (size_t k = 0; k < words; ++k) {
-                    dp += __builtin_popcountll(t1[k] & t2[k]);
-                }
-            } else {
-                for (size_t k = 0; k < words; ++k) {
-                    uint64_t w1, w2;
-                    std::memcpy(&w1, target1 + k * 8, sizeof(uint64_t));
-                    std::memcpy(&w2, target2 + k * 8, sizeof(uint64_t));
-                    dp += __builtin_popcountll(w1 & w2);
-                }
-                // Remainder bytes that don't fill a full 8-byte word
-                const uint64_t remainStart = words * 8;
-                for (uint64_t r = remainStart; r < quantizedVectorBytes; ++r) {
-                    dp += __builtin_popcount((target1[r] & target2[r]) & 0xFF);
-                }
-            }
+            const uint64_t dp = multiBitDp(target1, target2);
 
             // Get correction factors
             float ax, lx, additional, x1;
@@ -247,7 +289,7 @@ namespace knn_jni {
             float score = ax * az * dimension
                    + az * lx * x1
                    + ax * lz * z1
-                   + lx * lz * dp;
+                   + lx * lz * static_cast<float>(dp);
 
             if constexpr (IsMaxIP) {
                 // Negate: Faiss HNSW always minimizes distance (CMax comparator).
@@ -269,8 +311,10 @@ namespace knn_jni {
         // For safely casting uint8_t* to float*, we should enforce 8-byte alignment for the vector.
         std::vector<uint8_t, knn_jni::NBytesAlignedAllocator<uint8_t, 8>> quantizedVectorsAndCorrectionFactors;
         int32_t dimension;
+        // Document bit width (1, 2, or 4). quantizedVectorBytes == docBits * binaryCodeBytes.
+        int32_t docBits;
 
-        FaissSQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric)
+        FaissSQFlat(int64_t _numVectors, int32_t _quantizedVectorBytes, float _centroidDp, int32_t _dimension, faiss::MetricType _metric, int32_t _docBits)
           : faiss::IndexBinary(_dimension, _metric, true),
             numVectors(_numVectors),
             quantizedVectorBytes(_quantizedVectorBytes),
@@ -278,7 +322,8 @@ namespace knn_jni {
             oneElementSize(_quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t)),
             // Pre allocate vector storage space
             quantizedVectorsAndCorrectionFactors(_numVectors * oneElementSize),
-            dimension(_dimension) {
+            dimension(_dimension),
+            docBits(_docBits) {
 
             // Just changing the size, not shrinking, thus allocated memory capacity remains the same.
             // This is to avoid reallocations when adding elements later on since we know the exact required memory space upfront.
@@ -300,15 +345,15 @@ namespace knn_jni {
             const bool aligned = (oneElementSize % 8) == 0;
             if (metric_type == faiss::MetricType::METRIC_L2) {
                 if (aligned) {
-                    return new FaissSQDistanceComputer<false, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<false, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 } else {
-                    return new FaissSQDistanceComputer<false, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<false, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 }
             } else if (metric_type == faiss::MetricType::METRIC_INNER_PRODUCT) {
                 if (aligned) {
-                    return new FaissSQDistanceComputer<true, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<true, true>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 } else {
-                    return new FaissSQDistanceComputer<true, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors);
+                    return new FaissSQDistanceComputer<true, false>(oneElementSize, quantizedVectorsAndCorrectionFactors.data(), centroidDp, dimension, numVectors, docBits);
                 }
             }
 

--- a/jni/src/faiss_index_service.cpp
+++ b/jni/src/faiss_index_service.cpp
@@ -208,7 +208,7 @@ jlong BinaryIndexService::initIndex(
 
 jlong BinaryIndexService::initFaissSQIndex(knn_jni::JNIUtilInterface *jniUtil, JNIEnv *env, faiss::MetricType metric,
                                             std::string indexDescription, int dim, int numVectors, int threadCount,
-                                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes) {
+                                            std::unordered_map<std::string, jobject> parameters, float centroidDp, int quantizedVectorBytes, int docBits) {
     if (auto it = parameters.find(M); it == parameters.end()) {
         throw std::runtime_error("Parameter [" + M + "] is required for Faiss scalar optimized index");
     }
@@ -218,7 +218,7 @@ jlong BinaryIndexService::initFaissSQIndex(knn_jni::JNIUtilInterface *jniUtil, J
 
     // Create Faiss SQ HNSW Index
     std::unique_ptr<knn_jni::FaissSQHnsw> faissSQHnsw (new knn_jni::FaissSQHnsw(
-        m, new knn_jni::FaissSQFlat(numVectors, quantizedVectorBytes, centroidDp, dim, metric)));
+        m, new knn_jni::FaissSQFlat(numVectors, quantizedVectorBytes, centroidDp, dim, metric, docBits)));
 
     // Set thread count if it is passed in as a parameter. Setting this variable will only impact the current thread
     if (threadCount != 0) {

--- a/jni/src/faiss_wrapper.cpp
+++ b/jni/src/faiss_wrapper.cpp
@@ -207,7 +207,8 @@ jlong knn_jni::faiss_wrapper::InitFaissSQIndex(knn_jni::JNIUtilInterface *jniUti
                                                 jobject parametersJ,
                                                 BinaryIndexService *indexService,
                                                 jfloat centroidDp,
-                                                jint quantizedVecBytes) {
+                                                jint quantizedVecBytes,
+                                                jint docBits) {
     if (dimJ <= 0) {
         throw std::runtime_error("Vectors dimensions cannot be less than or equal to 0");
     }
@@ -253,7 +254,8 @@ jlong knn_jni::faiss_wrapper::InitFaissSQIndex(knn_jni::JNIUtilInterface *jniUti
                                            threadCount,
                                            std::move(subParametersCpp),
                                            centroidDp,
-                                           quantizedVecBytes);
+                                           quantizedVecBytes,
+                                           docBits);
 }
 
 void knn_jni::faiss_wrapper::InsertToIndex(knn_jni::JNIUtilInterface * jniUtil, JNIEnv * env, jintArray idsJ, jlong vectorsAddressJ, jint dimJ,

--- a/jni/src/org_opensearch_knn_jni_FaissService.cpp
+++ b/jni/src/org_opensearch_knn_jni_FaissService.cpp
@@ -577,11 +577,11 @@ JNIEXPORT void JNICALL Java_org_opensearch_knn_jni_FaissService_setMergeInterrup
 }
 
 JNIEXPORT jlong JNICALL Java_org_opensearch_knn_jni_FaissService_initFaissSQIndex(
-    JNIEnv * env, jclass cls, jint totalLiveDocs, jint dimJ, jobject parametersJ, jfloat centroidDp, jint quantizedVecBytes) {
+    JNIEnv * env, jclass cls, jint totalLiveDocs, jint dimJ, jobject parametersJ, jfloat centroidDp, jint quantizedVecBytes, jint docBits) {
     try {
         std::unique_ptr<knn_jni::faiss_wrapper::FaissMethods> faissMethods(new knn_jni::faiss_wrapper::FaissMethods());
         knn_jni::faiss_wrapper::BinaryIndexService binaryIndexService(std::move(faissMethods));
-        return knn_jni::faiss_wrapper::InitFaissSQIndex(&jniUtil, env, totalLiveDocs, dimJ, parametersJ, &binaryIndexService, centroidDp, quantizedVecBytes);
+        return knn_jni::faiss_wrapper::InitFaissSQIndex(&jniUtil, env, totalLiveDocs, dimJ, parametersJ, &binaryIndexService, centroidDp, quantizedVecBytes, docBits);
     } catch (...) {
         jniUtil.CatchCppExceptionAndThrowJava(env);
     }

--- a/jni/tests/faiss_sq_distance_computer_test.cpp
+++ b/jni/tests/faiss_sq_distance_computer_test.cpp
@@ -189,13 +189,13 @@ TEST_P(FaissSQDistanceComputerTest, OperatorSingleVector) {
     // Create distance computer via template
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -234,13 +234,13 @@ TEST_P(FaissSQDistanceComputerTest, DistancesBatch4) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -276,13 +276,13 @@ TEST_P(FaissSQDistanceComputerTest, SymmetricDis) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     // symmetric_dis doesn't need set_query, it works on stored vectors only
     for (int i = 0; i < NUM_VECS; ++i) {
@@ -328,13 +328,13 @@ TEST_P(FaissSQDistanceComputerTest, CorrectionFactorsExtraction) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (isMaxIP && !isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else if (!isMaxIP && isBytesMultipleOf8)
-        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     // Verify correction factor extraction indirectly: set_query reads query correction
     // factors, then operator() uses both query and target correction factors in the
@@ -371,7 +371,7 @@ TEST_P(FaissSQDistanceComputerTest, GetDistanceComputerIntegration) {
     constexpr int NUM_VECS = 4;
 
     faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
-    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric, 1);
 
     // Populate the storage
     auto buf = makeBuffer(NUM_VECS, qvb);
@@ -439,9 +439,9 @@ TEST_P(FaissSQDistanceComputerTest, OperatorNonMultipleOf8Bytes) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -478,9 +478,9 @@ TEST_P(FaissSQDistanceComputerTest, DistancesBatch4NonMultipleOf8Bytes) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
 
@@ -505,9 +505,9 @@ TEST_P(FaissSQDistanceComputerTest, SymmetricDisNonMultipleOf8Bytes) {
 
     std::unique_ptr<faiss::DistanceComputer> dc;
     if (isMaxIP)
-        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<true, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
     else
-        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS));
+        dc.reset(new FaissSQDistanceComputer<false, false>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
 
     for (int i = 0; i < NUM_VECS; ++i) {
         for (int j = i; j < NUM_VECS; ++j) {
@@ -548,7 +548,7 @@ TEST_P(FaissSQDistanceComputerTest, GetDistanceComputerIntegrationNonMultipleOf8
     constexpr int NUM_VECS = 4;
 
     faiss::MetricType metric = isMaxIP ? faiss::METRIC_INNER_PRODUCT : faiss::METRIC_L2;
-    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric);
+    FaissSQFlat flat(NUM_VECS, qvb, CENTROID_DP, dim, metric, 1);
 
     auto buf = makeBuffer(NUM_VECS, qvb);
     flat.quantizedVectorsAndCorrectionFactors.assign(buf.data.begin(), buf.data.end());
@@ -595,5 +595,376 @@ INSTANTIATE_TEST_SUITE_P(
         return info.param.name();
     }
 );
+
+// ---------------------------------------------------------------------------
+// Multi-bit tests (docBits in {1, 2, 4})
+// ---------------------------------------------------------------------------
+//
+// The tests above all pass docBits=1. These new tests cover B=2 and B=4 by
+// comparing FaissSQDistanceComputer output against a scalar reference that
+// mirrors the production formula:
+//   dp = Σ_{i,j<docBits} popcount(planeA_i AND planeB_j) << (i + j)
+// and validates that the intervalLength scaling by 1/(2^docBits - 1) applies
+// correctly (no-op for B=1, 1/3 for B=2, 1/15 for B=4).
+
+struct MultiBitParams {
+    bool isMaxIP;
+    int32_t docBits;
+    std::string name() const {
+        return std::string(isMaxIP ? "MaxIP" : "L2") + "_B" + std::to_string(docBits);
+    }
+};
+
+class FaissSQDistanceComputerMultiBitTest : public ::testing::TestWithParam<MultiBitParams> {
+protected:
+    static constexpr float CENTROID_DP = 0.5f;
+    static constexpr float TOLERANCE  = 1e-4f;
+
+    std::mt19937 rng{123};
+
+    struct Buffer {
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> data;
+        int32_t oneElementSize;
+        int32_t quantizedVectorBytes;
+    };
+
+    // qvb must be a multiple of docBits so `planeBytes = qvb / docBits` is exact.
+    // Aligned qvb (multiple of 8) also exercises the fast reinterpret_cast path.
+    Buffer makeBuffer(int numVecs, int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        Buffer buf;
+        buf.oneElementSize = oneElementSize;
+        buf.quantizedVectorBytes = quantizedVectorBytes;
+        buf.data.resize(numVecs * oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int v = 0; v < numVecs; ++v) {
+            uint8_t* base = buf.data.data() + v * oneElementSize;
+            for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+                base[b] = static_cast<uint8_t>(byteDist(rng));
+            }
+            float lower = floatDist(rng);
+            float upper = lower + std::abs(floatDist(rng)) + 0.01f;
+            float additional = floatDist(rng);
+            int32_t componentSum = intDist(rng);
+            writeCorrectionFactors(base + quantizedVectorBytes, lower, upper, additional, componentSum);
+        }
+        return buf;
+    }
+
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> makeQuery(int32_t quantizedVectorBytes) {
+        const int32_t oneElementSize = quantizedVectorBytes + 3 * sizeof(float) + sizeof(int32_t);
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> q(oneElementSize, 0);
+
+        std::uniform_int_distribution<int> byteDist(0, 255);
+        std::uniform_real_distribution<float> floatDist(-2.0f, 2.0f);
+        std::uniform_int_distribution<int32_t> intDist(-1000, 1000);
+
+        for (int32_t b = 0; b < quantizedVectorBytes; ++b) {
+            q[b] = static_cast<uint8_t>(byteDist(rng));
+        }
+        float lower = floatDist(rng);
+        float upper = lower + std::abs(floatDist(rng)) + 0.01f;
+        float additional = floatDist(rng);
+        int32_t componentSum = intDist(rng);
+        writeCorrectionFactors(q.data() + quantizedVectorBytes, lower, upper, additional, componentSum);
+        return q;
+    }
+
+    // Reference multiBitDp. The formula depends on the docBits Lucene layout:
+    //   B=1, B=2 (bit-plane popcount): Σ_{i,j} popcount(planeA_i AND planeB_j) << (i + j)
+    //   B=4 (PACKED_NIBBLE):           Σ_i (aHi_i * bHi_i + aLo_i * bLo_i)
+    // We dispatch on docBits so this reference matches production for every supported width.
+    static uint64_t referenceMultiBitDp(const uint8_t* a, const uint8_t* b, int32_t quantizedVectorBytes, int32_t docBits) {
+        if (docBits == 4) {
+            // PACKED_NIBBLE byte-wise multiply: each byte holds two 4-bit elements.
+            uint64_t total = 0;
+            for (int32_t k = 0; k < quantizedVectorBytes; ++k) {
+                const uint32_t aLo = a[k] & 0x0Fu;
+                const uint32_t aHi = (a[k] >> 4) & 0x0Fu;
+                const uint32_t bLo = b[k] & 0x0Fu;
+                const uint32_t bHi = (b[k] >> 4) & 0x0Fu;
+                total += aLo * bLo + aHi * bHi;
+            }
+            return total;
+        }
+        // B=1, B=2: bit-plane popcount-AND-shift double sum.
+        const uint64_t planeBytes = static_cast<uint64_t>(quantizedVectorBytes) / static_cast<uint64_t>(docBits);
+        uint64_t dp = 0;
+        for (int32_t i = 0; i < docBits; ++i) {
+            const uint8_t* pa = a + static_cast<uint64_t>(i) * planeBytes;
+            for (int32_t j = 0; j < docBits; ++j) {
+                const uint8_t* pb = b + static_cast<uint64_t>(j) * planeBytes;
+                uint64_t pc = 0;
+                for (uint64_t k = 0; k < planeBytes; ++k) {
+                    pc += __builtin_popcount((pa[k] & pb[k]) & 0xFF);
+                }
+                dp += pc << (i + j);
+            }
+        }
+        return dp;
+    }
+
+    // Reference score using the docBits-scaled intervalLength.
+    static float referenceScoreMultiBit(bool isMaxIP, int32_t dim, float centroidDp,
+                                         float lowerY, float rawIntervalY, float additionalY, float y1,
+                                         float lowerX, float rawIntervalX, float additionalX, float x1,
+                                         uint64_t dp, int32_t docBits) {
+        const float scale = 1.0f / static_cast<float>((1 << docBits) - 1);
+        const float ay = lowerY;
+        const float ly = rawIntervalY * scale;
+        const float ax = lowerX;
+        const float lx = rawIntervalX * scale;
+        float score = ax * ay * dim + ay * lx * x1 + ax * ly * y1 + lx * ly * static_cast<float>(dp);
+        if (isMaxIP) {
+            score += additionalY + additionalX - centroidDp;
+            return -score;
+        } else {
+            return additionalY + additionalX - 2.0f * score;
+        }
+    }
+
+    struct RawCorr { float lower, rawInterval, additional; float componentSum; };
+    static RawCorr readRawCorr(const uint8_t* ptr) {
+        RawCorr c;
+        float lower, upper;
+        std::memcpy(&lower, ptr, sizeof(float));
+        std::memcpy(&upper, ptr + 4, sizeof(float));
+        std::memcpy(&c.additional, ptr + 8, sizeof(float));
+        int32_t cs;
+        std::memcpy(&cs, ptr + 12, sizeof(int32_t));
+        c.lower = lower;
+        c.rawInterval = upper - lower;
+        c.componentSum = static_cast<float>(cs);
+        return c;
+    }
+};
+
+// Operator() bit-identical to scalar reference across docBits ∈ {1, 2, 4}.
+TEST_P(FaissSQDistanceComputerMultiBitTest, OperatorMatchesReference) {
+    auto [isMaxIP, docBits] = GetParam();
+    // planeBytes must divide quantizedVectorBytes cleanly. Pick qvb = docBits * 16 (multiple of 8 → aligned path).
+    const int32_t qvb = docBits * 16;
+    const int32_t planeBytes = qvb / docBits;
+    // dim doesn't matter for correctness beyond feeding the score formula; use planeBytes*8.
+    const int32_t dim = planeBytes * 8;
+    constexpr int NUM_VECS = 8;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    // Use the aligned template path (qvb is a multiple of 8 by construction here).
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP) {
+        dc.reset(new FaissSQDistanceComputer<true,  true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    } else {
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    }
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    auto qCorr = readRawCorr(queryBuf.data() + qvb);
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        const uint64_t refDp = referenceMultiBitDp(queryBuf.data(), target, qvb, docBits);
+        auto tCorr = readRawCorr(target + qvb);
+        float expected = referenceScoreMultiBit(
+            isMaxIP, dim, CENTROID_DP,
+            qCorr.lower, qCorr.rawInterval, qCorr.additional, qCorr.componentSum,
+            tCorr.lower, tCorr.rawInterval, tCorr.additional, tCorr.componentSum,
+            refDp, docBits);
+        float actual = (*dc)(static_cast<idx_t>(i));
+        EXPECT_NEAR(actual, expected, TOLERANCE)
+            << "docBits=" << docBits << ", isMaxIP=" << isMaxIP << ", i=" << i;
+    }
+}
+
+// symmetric_dis (build-time distance between two stored codes) bit-identical to reference.
+TEST_P(FaissSQDistanceComputerMultiBitTest, SymmetricDisMatchesReference) {
+    auto [isMaxIP, docBits] = GetParam();
+    const int32_t qvb = docBits * 16;
+    const int32_t planeBytes = qvb / docBits;
+    const int32_t dim = planeBytes * 8;
+    constexpr int NUM_VECS = 6;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+
+    std::unique_ptr<FaissSQDistanceComputer<true, true>> dcMax;
+    std::unique_ptr<FaissSQDistanceComputer<false, true>> dcL2;
+    // We need the concrete type to call symmetric_dis (which isn't a virtual).
+    if (isMaxIP) {
+        dcMax.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    } else {
+        dcL2.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    }
+
+    for (int i = 0; i < NUM_VECS; ++i) {
+        for (int j = i; j < NUM_VECS; ++j) {
+            const uint8_t* a = buf.data.data() + i * buf.oneElementSize;
+            const uint8_t* b = buf.data.data() + j * buf.oneElementSize;
+            const uint64_t refDp = referenceMultiBitDp(a, b, qvb, docBits);
+            auto aCorr = readRawCorr(a + qvb);
+            auto bCorr = readRawCorr(b + qvb);
+
+            // symmetric_dis mirrors scoringSecondPart structure but with both sides scaled.
+            const float scale = 1.0f / static_cast<float>((1 << docBits) - 1);
+            const float ax = aCorr.lower;
+            const float lx = aCorr.rawInterval * scale;
+            const float az = bCorr.lower;
+            const float lz = bCorr.rawInterval * scale;
+            float score = ax * az * dim + az * lx * aCorr.componentSum + ax * lz * bCorr.componentSum
+                        + lx * lz * static_cast<float>(refDp);
+            float expected;
+            if (isMaxIP) {
+                score += aCorr.additional + bCorr.additional - CENTROID_DP;
+                expected = -score;
+            } else {
+                expected = aCorr.additional + bCorr.additional - 2.0f * score;
+            }
+
+            float actual = isMaxIP ? dcMax->symmetric_dis(i, j) : dcL2->symmetric_dis(i, j);
+            EXPECT_NEAR(actual, expected, TOLERANCE)
+                << "docBits=" << docBits << ", isMaxIP=" << isMaxIP << ", (i,j)=(" << i << "," << j << ")";
+        }
+    }
+}
+
+// distances_batch_4 must agree with per-element operator() at each docBits.
+TEST_P(FaissSQDistanceComputerMultiBitTest, DistancesBatch4MatchesSingle) {
+    auto [isMaxIP, docBits] = GetParam();
+    const int32_t qvb = docBits * 16;
+    const int32_t planeBytes = qvb / docBits;
+    const int32_t dim = planeBytes * 8;
+    constexpr int NUM_VECS = 6;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP) {
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    } else {
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, docBits));
+    }
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    float d0, d1, d2, d3;
+    dc->distances_batch_4(0, 1, 2, 3, d0, d1, d2, d3);
+    EXPECT_NEAR(d0, (*dc)(0), TOLERANCE) << "docBits=" << docBits;
+    EXPECT_NEAR(d1, (*dc)(1), TOLERANCE) << "docBits=" << docBits;
+    EXPECT_NEAR(d2, (*dc)(2), TOLERANCE) << "docBits=" << docBits;
+    EXPECT_NEAR(d3, (*dc)(3), TOLERANCE) << "docBits=" << docBits;
+}
+
+// docBits=1 must produce results bit-identical to the legacy single-bit path,
+// which is the "no regression on existing 1-bit graphs" invariant the POC commit relies on.
+TEST_P(FaissSQDistanceComputerMultiBitTest, DocBits1MatchesLegacyPopcount) {
+    auto [isMaxIP, docBits] = GetParam();
+    if (docBits != 1) {
+        GTEST_SKIP() << "This invariant only applies to docBits=1";
+    }
+    const int32_t qvb = 24;
+    const int32_t dim = qvb * 32;
+    constexpr int NUM_VECS = 4;
+
+    auto buf = makeBuffer(NUM_VECS, qvb);
+    auto queryBuf = makeQuery(qvb);
+
+    std::unique_ptr<faiss::DistanceComputer> dc;
+    if (isMaxIP) {
+        dc.reset(new FaissSQDistanceComputer<true, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
+    } else {
+        dc.reset(new FaissSQDistanceComputer<false, true>(buf.oneElementSize, buf.data.data(), CENTROID_DP, dim, NUM_VECS, 1));
+    }
+    dc->set_query(reinterpret_cast<const float*>(queryBuf.data()));
+
+    // For docBits=1, dataScale = 1.0 so intervalLength is unchanged, and multiBitDp reduces
+    // to popcount(a AND b). So the legacy referencePopcount + referenceScore path (used in
+    // the SQTestParams tests above) must agree with the multi-bit reference too.
+    for (int i = 0; i < NUM_VECS; ++i) {
+        const uint8_t* target = buf.data.data() + i * buf.oneElementSize;
+        uint32_t legacyDp = referencePopcount(queryBuf.data(), target, qvb);
+        uint64_t multiBitRef = referenceMultiBitDp(queryBuf.data(), target, qvb, 1);
+        EXPECT_EQ(legacyDp, multiBitRef)
+            << "docBits=1 multi-bit dp must equal legacy popcount, i=" << i;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MultiBit,
+    FaissSQDistanceComputerMultiBitTest,
+    ::testing::Values(
+        MultiBitParams{false, 1}, MultiBitParams{false, 2}, MultiBitParams{false, 4},
+        MultiBitParams{true,  1}, MultiBitParams{true,  2}, MultiBitParams{true,  4}
+    ),
+    [](const ::testing::TestParamInfo<MultiBitParams>& info) { return info.param.name(); }
+);
+
+// ---------------------------------------------------------------------------
+// docBits validation — constructor must reject unsupported / dangerous values
+// ---------------------------------------------------------------------------
+
+TEST(FaissSQDistanceComputerValidation, RejectsUnsupportedDocBits) {
+    // We only need a dummy buffer big enough to compute oneElementByteSize; nothing is dereferenced
+    // because the constructor validates docBits before touching any data.
+    // oneElementByteSize must be > 16 (correction factors) for quantizedVectorBytes to be positive.
+    constexpr int32_t qvb = 8;
+    constexpr int32_t oneElementByteSize = qvb + 3 * sizeof(float) + sizeof(int32_t);
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> dummy(oneElementByteSize, 0);
+
+    // docBits=0 would trigger div-by-zero in planeBytes computation.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/0)),
+        std::runtime_error);
+    // docBits=3 is not a supported MOS width.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/3)),
+        std::runtime_error);
+    // docBits=8 exceeds Lucene's MOS bit widths.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/8)),
+        std::runtime_error);
+    // Negative docBits — the (1 << bits) computation would be UB.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/-1)),
+        std::runtime_error);
+}
+
+TEST(FaissSQDistanceComputerValidation, RejectsOddQuantizedVectorBytesAtB2) {
+    // qvb=9 is not divisible by docBits=2. B=2 requires two bit planes of equal length,
+    // so quantizedVectorBytes must be even. B=1 and B=4 have no such requirement.
+    constexpr int32_t qvb = 9;
+    constexpr int32_t oneElementByteSize = qvb + 3 * sizeof(float) + sizeof(int32_t);
+    std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> dummy(oneElementByteSize, 0);
+
+    // B=2 must throw because 9 is odd.
+    EXPECT_THROW(
+        (FaissSQDistanceComputer<false, false>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/2)),
+        std::runtime_error);
+
+    // B=1 is fine (any qvb is valid — planeBytes == qvb).
+    EXPECT_NO_THROW(
+        (FaissSQDistanceComputer<false, false>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/1)));
+
+    // B=4 is fine too — PACKED_NIBBLE bytes are independent (each byte holds 2 elements),
+    // so qvb=9 doesn't need any divisibility property beyond "positive".
+    EXPECT_NO_THROW(
+        (FaissSQDistanceComputer<false, false>(oneElementByteSize, dummy.data(), 0.0f, 8, 1, /*docBits=*/4)));
+}
+
+TEST(FaissSQDistanceComputerValidation, AcceptsAllSupportedDocBits) {
+    // Verify the happy path for each supported docBits width. qvb must be a multiple of docBits.
+    for (int32_t docBits : {1, 2, 4}) {
+        const int32_t qvb = docBits * 16; // multiple of docBits AND multiple of 8
+        const int32_t oneElementByteSize = qvb + 3 * sizeof(float) + sizeof(int32_t);
+        std::vector<uint8_t, NBytesAlignedAllocator<uint8_t, 8>> dummy(oneElementByteSize, 0);
+
+        EXPECT_NO_THROW(
+            (FaissSQDistanceComputer<false, true>(oneElementByteSize, dummy.data(), 0.0f, 128, 1, docBits))
+        ) << "docBits=" << docBits << " must be accepted";
+    }
+}
 
 } // namespace knn_jni

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategy.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.util.quantization.OptimizedScalarQuantizer;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.KNN1040Codec.ScalarEncodingResolver;
 import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.vectorvalues.KNNVectorValues;
@@ -125,6 +126,9 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategy implements NativeInde
         // The centroid dot-product is a precomputed scalar used in the ADC scoring formula.
         // It appears as a correction term: score += additionalCorrection + indexCorrection - centroidDp
         final float centroidDp = binarizedVectorValues.getCentroidDP();
+        // Document bit width (1, 2, or 4), derived from the stored encoding. The native build path
+        // splits the quantized code into docBits bit planes for the symmetric distance computation.
+        final int docBits = ScalarEncodingResolver.docBits(binarizedVectorValues.getScalarEncoding());
         final Map<String, Object> indexParameters = new HashMap<>(indexInfo.getIndexParameters());
         // Force override vector data type as binary so that Faiss can treat it as binary index.
         indexParameters.put(KNNConstants.VECTOR_DATA_TYPE_FIELD, VectorDataType.BINARY.getValue());
@@ -140,6 +144,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategy implements NativeInde
                 indexParameters,
                 centroidDp,
                 quantizedVecBytes,
+                docBits,
                 indexInfo.getKnnEngine()
             )
         );

--- a/src/main/java/org/opensearch/knn/jni/FaissService.java
+++ b/src/main/java/org/opensearch/knn/jni/FaissService.java
@@ -506,7 +506,8 @@ class FaissService {
         final int dimension,
         final Map<String, Object> indexParameters,
         final float centroidDp,
-        final int quantizedVecBytes
+        final int quantizedVecBytes,
+        final int docBits
     );
 
     /**

--- a/src/main/java/org/opensearch/knn/jni/JNIService.java
+++ b/src/main/java/org/opensearch/knn/jni/JNIService.java
@@ -480,10 +480,11 @@ public class JNIService {
         final Map<String, Object> indexParameters,
         final float centroidDp,
         final int quantizedVecBytes,
+        final int docBits,
         final KNNEngine knnEngine
     ) {
         if (KNNEngine.FAISS == knnEngine) {
-            return FaissService.initFaissSQIndex(totalLiveDocs, dimension, indexParameters, centroidDp, quantizedVecBytes);
+            return FaissService.initFaissSQIndex(totalLiveDocs, dimension, indexParameters, centroidDp, quantizedVecBytes, docBits);
         }
 
         throw new IllegalArgumentException(

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/MemOptimizedScalarQuantizedIndexBuildStrategyTests.java
@@ -275,6 +275,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
         when(quantizedValues.vectorValue(0)).thenReturn(new byte[] { 0x01 });
         when(quantizedValues.getCentroidDP()).thenReturn(1.0f);
         when(quantizedValues.size()).thenReturn(1);
+        when(quantizedValues.getScalarEncoding()).thenReturn(SINGLE_BIT_QUERY_NIBBLE);
         when(quantizedValues.getCorrectiveTerms(0)).thenReturn(new OptimizedScalarQuantizer.QuantizationResult(0.0f, 1.0f, 0.0f, 0));
 
         IndexOutputWithBuffer indexOutputWithBuffer = mock(IndexOutputWithBuffer.class);
@@ -294,7 +295,7 @@ public class MemOptimizedScalarQuantizedIndexBuildStrategyTests extends KNNTestC
 
         try (MockedStatic<JNIService> mockedJNIService = Mockito.mockStatic(JNIService.class)) {
             mockedJNIService.when(
-                () -> JNIService.initFaissSQIndex(anyInt(), anyInt(), anyMap(), anyFloat(), anyInt(), any(KNNEngine.class))
+                () -> JNIService.initFaissSQIndex(anyInt(), anyInt(), anyMap(), anyFloat(), anyInt(), anyInt(), any(KNNEngine.class))
             ).thenReturn(fakeIndexAddress);
 
             // Phase 1 throws


### PR DESCRIPTION
### Description
Generalize the native FAISS HNSW build path from 1-bit to `bits ∈ {1, 2, 4}` scalar quantization.
  Before this PR, `FaissSQDistanceComputer` (the FAISS `DistanceComputer` the HNSW builder queries
  millions of times) hard-coded a single-plane `popcount(a & b)`; after it, the same class computes
  symmetric distances at any of the three supported doc bit widths.
  
  The change threads a new `docBits` int through:
  - Java: `MemOptimizedScalarQuantizedIndexBuildStrategy` → `JNIService.initFaissSQIndex`
    → `FaissService.initFaissSQIndex`. `docBits` is derived from the on-disk `ScalarEncoding`
    (materialised by the codec writer, source of truth vs. field mapping) via
    `ScalarEncodingResolver.docBits(enc)`.
  - JNI: descriptor `(IILjava/util/Map;FI)J` → `(IILjava/util/Map;FII)J`.
  - C++: `InitFaissSQIndex` → `BinaryIndexService::initFaissSQIndex` → `FaissSQFlat` → per-computer.

  #### Two kernel families, dispatched by `docBits` in `multiBitDp`

  | docBits | Kernel | Notes |
  |---|---|---|
  | 1 | `popcountAndPlane` | single-plane popcount — bit-identical to the legacy path |
  | 2 | 2×2 `popcountAndPlane` over bit planes, `<< (i+j)` | matches the DIBIT layout |
  | 4 | `bothPackedNibbleDp` (byte-wise `aHi*bHi + aLo*bLo`) | mirrors Lucene's `int4DotProductBothPacked` for PACKED_NIBBLE |

  PACKED_NIBBLE isn't a bit-plane layout, so bit-plane popcount is arithmetically wrong for B=4 —
  byte-wise nibble multiply is the correct kernel and lets Java-side ingest stay as a single
  `arraycopy` for all three widths (no repack). Modern clang/gcc/msvc auto-vectorise the
  branch-free nibble loop to `PMULLW` / NEON `MUL`.

  Correction-factor scaling: `intervalLength *= 1 / (2^B - 1)` is applied once in
  `setCorrectionFactors`; for B=1 it's a no-op (`dataScale = 1.0`).

  #### Correctness invariant

  For `docBits == 1` the new path produces exactly the same numeric result as the legacy inline
  popcount. Existing 1-bit graphs are byte-for-byte unchanged. `DocBits1MatchesLegacyPopcount` is
  the regression guard.

### Related Issues
https://github.com/opensearch-project/k-NN/issues/3427

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
