### PR TITLE
[SQ PR-4] Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
 * Accept SQ 2-bit and 4-bit quantization at the mapping and codec layers [#3429](https://github.com/opensearch-project/k-NN/pull/3429)
 * Build SQ B-bit HNSW graph with multi-bit symmetric distance for SQ bits ∈ {1, 2, 4} [#3431](https://github.com/opensearch-project/k-NN/pull/3431
+* Wire multi-bit SQ search through Lucene scorer for bits ∈ {2, 4} [#3432](https://github.com/opensearch-project/k-NN/pull/3432)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorer.java
@@ -105,6 +105,19 @@ public class KNN1040ScalarQuantizedVectorScorer extends Lucene104ScalarQuantized
         final QuantizedByteVectorValues quantizedByteVectorValues,
         final float[] target
     ) throws IOException {
+        // Native bulk-SIMD scoring is implemented for 1-bit documents only. Multi-bit docs
+        // (B=2, B=4) share the same .veq layout but need width-specific kernels that are not
+        // yet in the native SIMD path — route them to Lucene's pure-Java reference scorer,
+        // which scores the same codes correctly.
+        final ScalarEncoding scalarEncoding = quantizedByteVectorValues.getScalarEncoding();
+        if (ScalarEncodingResolver.docBits(scalarEncoding) != 1) {
+            return (RandomVectorScorer.AbstractRandomVectorScorer) super.getRandomVectorScorer(
+                similarityFunction,
+                quantizedByteVectorValues,
+                target
+            );
+        }
+
         final IndexInput indexInput = quantizedByteVectorValues.getSlice();
         final long[] addressAndSize = MemorySegmentAddressExtractorUtil.tryExtractAddressAndSize(indexInput, 0, indexInput.length());
         if (addressAndSize != null) {

--- a/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
+++ b/src/main/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactory.java
@@ -29,12 +29,13 @@ public class FaissFlatIndexFactory {
      * indices where flat storage was skipped (IO_FLAG_SKIP_STORAGE). Returns {@code null} if the field
      * does not require externally-provided flat storage.
      *
-     * <p>Currently supports SQ 1-bit. To add support for other flat storage types (e.g., fp32 flat),
-     * add new conditions here.
+     * <p>Supports the SQ memory-optimized-search path for bits in {1, 2, 4} — for all of these the
+     * .faiss file holds only the HNSW graph and the quantized codes live in Lucene's flat .veq file.
+     * To add support for other flat storage types (e.g., fp32 flat), add new conditions here.
      */
     static FaissIndex createFlatIndex(final FieldInfo fieldInfo, final FlatVectorsReader flatVectorsReader) {
         if (FieldInfoExtractor.isSQField(fieldInfo)
-            && FieldInfoExtractor.extractSQConfig(fieldInfo).getBits() == FaissSQEncoder.Bits.ONE.getValue()) {
+            && FaissSQEncoder.isSQCodedBits(FieldInfoExtractor.extractSQConfig(fieldInfo).getBits())) {
             return new FaissScalarQuantizedFlatIndex(flatVectorsReader, fieldInfo.getName());
         }
         return null;

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/KNN1040ScalarQuantizedVectorScorerTests.java
@@ -59,6 +59,61 @@ public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
         }
     }
 
+    /**
+     * For multi-bit encodings (B=2, B=4) the scorer must route to Lucene's reference scorer without
+     * touching {@code MemorySegmentAddressExtractorUtil} — native bulk SIMD is not wired for
+     * multi-bit yet. Parameterizing over {@link ScalarEncoding#DIBIT_QUERY_NIBBLE} and
+     * {@link ScalarEncoding#PACKED_NIBBLE} verifies the gate for both widths.
+     */
+    @SneakyThrows
+    private void assertMultiBitFallback(final ScalarEncoding encoding) {
+        final FlatVectorsScorer mockDelegate = mock(FlatVectorsScorer.class);
+        final KNN1040ScalarQuantizedVectorScorer scorer = new KNN1040ScalarQuantizedVectorScorer(mockDelegate);
+
+        final int dimension = 8;
+        final QuantizedByteVectorValues mockQuantizedValues = mock(QuantizedByteVectorValues.class);
+        when(mockQuantizedValues.dimension()).thenReturn(dimension);
+        when(mockQuantizedValues.getScalarEncoding()).thenReturn(encoding);
+
+        // Parent Lucene104ScalarQuantizedVectorScorer's reference path also runs a quantization —
+        // supply the same mocks the null-address test uses so it can complete without NPEs.
+        final OptimizedScalarQuantizer mockQuantizer = mock(OptimizedScalarQuantizer.class);
+        when(mockQuantizedValues.getQuantizer()).thenReturn(mockQuantizer);
+        when(mockQuantizedValues.getCentroid()).thenReturn(new float[dimension]);
+        final OptimizedScalarQuantizer.QuantizationResult quantizationResult = new OptimizedScalarQuantizer.QuantizationResult(
+            0.0f,
+            1.0f,
+            0.0f,
+            0
+        );
+        when(mockQuantizer.scalarQuantize(any(float[].class), any(byte[].class), anyByte(), any(float[].class))).thenReturn(
+            quantizationResult
+        );
+
+        final StubVectorValues stub = new StubVectorValues();
+        final java.lang.reflect.Field field = StubVectorValues.class.getDeclaredField("quantizedVectorValues");
+        field.setAccessible(true);
+        field.set(stub, mockQuantizedValues);
+
+        try (MockedStatic<MemorySegmentAddressExtractorUtil> mockedStatic = Mockito.mockStatic(MemorySegmentAddressExtractorUtil.class)) {
+            final RandomVectorScorer result = scorer.getRandomVectorScorer(VectorSimilarityFunction.EUCLIDEAN, stub, new float[dimension]);
+
+            assertNotNull(result);
+            // The multi-bit gate must fire before we even ask about the address — no interaction.
+            mockedStatic.verifyNoInteractions();
+        }
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_whenTwoBitEncoding_thenRoutesToLuceneScorerWithoutAddressExtraction() {
+        assertMultiBitFallback(ScalarEncoding.DIBIT_QUERY_NIBBLE);
+    }
+
+    @SneakyThrows
+    public void testGetRandomVectorScorer_whenFourBitEncoding_thenRoutesToLuceneScorerWithoutAddressExtraction() {
+        assertMultiBitFallback(ScalarEncoding.PACKED_NIBBLE);
+    }
+
     @SneakyThrows
     public void testGetRandomVectorScorer_whenAddressExtractionReturnsNull_thenFallsBackToLuceneScorer() {
         // Arrange: set up the mock delegate scorer
@@ -74,9 +129,11 @@ public class KNN1040ScalarQuantizedVectorScorerTests extends KNNTestCase {
         when(mockQuantizedValues.getSlice()).thenReturn(mockIndexInput);
         when(mockIndexInput.length()).thenReturn(1024L);
 
-        // Set up quantization mocks needed by the parent Lucene104ScalarQuantizedVectorScorer
+        // Set up quantization mocks needed by the parent Lucene104ScalarQuantizedVectorScorer.
+        // Encoding is SINGLE_BIT_QUERY_NIBBLE (docBits == 1) so the multi-bit fallback gate does
+        // not fire — this test exercises the address-extractor null fallback specifically.
         when(mockQuantizedValues.dimension()).thenReturn(dimension);
-        when(mockQuantizedValues.getScalarEncoding()).thenReturn(ScalarEncoding.UNSIGNED_BYTE);
+        when(mockQuantizedValues.getScalarEncoding()).thenReturn(ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE);
 
         final OptimizedScalarQuantizer mockQuantizer = mock(OptimizedScalarQuantizer.class);
         when(mockQuantizedValues.getQuantizer()).thenReturn(mockQuantizer);

--- a/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
+++ b/src/test/java/org/opensearch/knn/integ/FaissSQMappingIT.java
@@ -72,6 +72,20 @@ public class FaissSQMappingIT extends KNNRestTestCase {
         deleteKNNIndex(indexName);
     }
 
+    /**
+     * Validates a multi-bit SQ ({@code bits ∈ {2, 4}}) index end-to-end: mapping is applied,
+     * documents index without error, and search returns the requested top-k. Correctness of
+     * ranking is a recall concern owned by benchmark tests; this smoke test only asserts the
+     * search path does not crash and returns k hits.
+     */
+    private void validateMultiBitIndex(String indexName, String mapping, Integer expectedBits) throws Exception {
+        createKnnIndex(indexName, mapping);
+        validateMapping(indexName, expectedBits, null, null);
+        addKNNDocs(indexName, FIELD_NAME, TEST_DIMENSION, 0, NUM_DOCS);
+        validateKNNSearch(indexName, FIELD_NAME, TEST_DIMENSION, NUM_DOCS, K);
+        deleteKNNIndex(indexName);
+    }
+
     @SuppressWarnings("unchecked")
     private void validateMapping(String indexName, Integer expectedBits, String expectedType, Boolean expectedClip) throws Exception {
         Map<String, Object> actualMapping = getIndexMappingAsMap(indexName);

--- a/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/memoryoptsearch/faiss/FaissFlatIndexFactoryTests.java
@@ -34,6 +34,39 @@ public class FaissFlatIndexFactoryTests extends KNNTestCase {
     }
 
     @SneakyThrows
+    public void testCreate_whenSQTwoBitField_thenReturnsFaissScalarQuantizedFlatIndex() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=2").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNotNull(result);
+        assertTrue(result instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenSQFourBitField_thenReturnsFaissScalarQuantizedFlatIndex() {
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=4").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNotNull(result);
+        assertTrue(result instanceof FaissScalarQuantizedFlatIndex);
+    }
+
+    @SneakyThrows
+    public void testCreate_whenSQFP16Field_thenReturnsNull() {
+        // bits=16 is fp16 (not an MOS width); the flat proxy should not be wired.
+        FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").addAttribute(SQ_CONFIG, "bits=16").build();
+        FlatVectorsReader mockReader = mock(FlatVectorsReader.class);
+
+        FaissBinaryIndex result = FaissFlatIndexFactory.createBinaryIndex(fieldInfo, mockReader);
+
+        assertNull(result);
+    }
+
+    @SneakyThrows
     public void testCreate_whenNonSQField_thenReturnsNull() {
         FieldInfo fieldInfo = KNNCodecTestUtil.FieldInfoBuilder.builder("test_field").build();
         FlatVectorsReader mockReader = mock(FlatVectorsReader.class);


### PR DESCRIPTION
### Description
Wires the multi-bit SQ (bits ∈ {2, 4}) search path so HNSW + SQ becomes queryable. Two targeted changes:

  - KNN1040ScalarQuantizedVectorScorer.getScorer — before attempting the native bulk-SIMD path (which is still B=1 only), read the on-disk ScalarEncoding and, when docBits != 1, route to Lucene's pure-Java reference scorer
  (super.getRandomVectorScorer). B=1 behavior is byte-for-byte unchanged.
  - FaissFlatIndexFactory.createFlatIndex — was gated on bits == Bits.ONE; now uses FaissSQEncoder.isMosBits(bits) so B=2 and B=4 fields also receive the FaissScalarQuantizedFlatIndex proxy when the .faiss file was written with
  IO_FLAG_SKIP_STORAGE.

### Related Issues
#3427 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
