### PR TITLE
Enable approximate graph threshold for Faiss SQ x32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduce system-generated search pipeline processor to automatically exclude knn_vector fields from _source in search responses [#3152](https://github.com/opensearch-project/k-NN/pull/3152)
 * Parameterize integration test framework for compression level [#3416](https://github.com/opensearch-project/k-NN/pull/3416)
 * Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
+* Enable the approximate graph threshold for Faiss SQ x32 (sq bits=1) indices [#3434](https://github.com/opensearch-project/k-NN/pull/3434)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncod
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import com.google.common.annotations.VisibleForTesting;
+import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 import org.opensearch.knn.index.engine.KNNEngine;
 
@@ -44,6 +45,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
     );
 
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final int approximateThreshold;
 
     @VisibleForTesting
     static KNN1040ScalarQuantizedVectorsFormat getFaissSqFlatFormat() {
@@ -55,7 +57,15 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat(final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory) {
+        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, nativeIndexBuildStrategyFactory);
+    }
+
+    public Faiss1040ScalarQuantizedKnnVectorsFormat(
+        final int approximateThreshold,
+        final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
+    ) {
         super(FORMAT_NAME);
+        this.approximateThreshold = approximateThreshold;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
     }
 
@@ -65,7 +75,8 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
             state,
             faissSqFlatFormat.fieldsWriter(state),
             faissSqFlatFormat::fieldsReader,
-            nativeIndexBuildStrategyFactory
+            nativeIndexBuildStrategyFactory,
+            approximateThreshold
         );
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsFormat.java
@@ -53,11 +53,7 @@ public class Faiss1040ScalarQuantizedKnnVectorsFormat extends KnnVectorsFormat {
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat() {
-        this(new NativeIndexBuildStrategyFactory());
-    }
-
-    public Faiss1040ScalarQuantizedKnnVectorsFormat(final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory) {
-        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, nativeIndexBuildStrategyFactory);
+        this(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD_DEFAULT_VALUE, new NativeIndexBuildStrategyFactory());
     }
 
     public Faiss1040ScalarQuantizedKnnVectorsFormat(

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
@@ -9,12 +9,15 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.store.IndexInput;
 import org.opensearch.knn.index.codec.KNN990Codec.NativeEngines990KnnVectorsReader;
 import org.opensearch.knn.index.codec.nativeindex.AbstractNativeEnginesKnnVectorsReader;
+import org.opensearch.knn.index.codec.util.KNNCodecUtil;
 import org.opensearch.knn.index.util.WarmupUtil;
 import org.opensearch.knn.memoryoptsearch.VectorSearcher;
 
@@ -78,12 +81,14 @@ public class Faiss1040ScalarQuantizedKnnVectorsReader extends AbstractNativeEngi
     /**
      * Warms up the on-disk data for the given scalar-quantized field.
      * <p>
-     * This warms up both the HNSW graph (via the memory-optimized searcher), quantized vectors and the
-     * full-precision vectors. The full-precision vectors cannot be warmed up through
-     * {@link WarmupUtil} because the {@link FloatVectorValues}
-     * returned by the flat vectors reader is backed by quantized data. Instead, each vector
-     * is read explicitly through the underlying
-     * {@link ScalarQuantizedFloatVectorValues}.
+     * The full-precision vectors are always warmed by reading each vector explicitly through the underlying
+     * {@link ScalarQuantizedFloatVectorValues} (they cannot be warmed through {@link WarmupUtil}, whose slice
+     * is backed by the quantized data).
+     * <p>
+     * When a native engine (.faiss) graph file is present, the HNSW graph and the quantized vectors are warmed
+     * via the memory-optimized searcher. When the graph was skipped by the approximate threshold there is no
+     * .faiss file - search is served by exact search over the quantized {@code .veq} codes, so those are warmed
+     * directly through the flat reader's index slice instead of loading a (non-existent) searcher.
      *
      * @param fieldName the name of the vector field to warm up
      * @throws IOException if an I/O error occurs while reading the underlying data
@@ -107,7 +112,24 @@ public class Faiss1040ScalarQuantizedKnnVectorsReader extends AbstractNativeEngi
             vectorValues.vectorValue(i);
         }
 
-        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfos.fieldInfo(fieldName));
+        // When the graph was skipped by the approximate threshold there is no native engine (.faiss) file, so
+        // there is no memory-optimized searcher to load. In that case search is served by exact search over the
+        // quantized .veq codes, so warm those directly through the flat reader's index slice. Only attempt the
+        // memory-optimized searcher when a graph file is actually present; that path keeps warming the .veq codes
+        // and the graph, and still surfaces the error/warn logs for a genuine load failure.
+        final FieldInfo fieldInfo = fieldInfos.fieldInfo(fieldName);
+        final boolean hasGraphFile = KNNCodecUtil.getNativeEngineFileFromFieldInfo(fieldInfo, segmentReadState.segmentInfo) != null;
+        if (hasGraphFile == false) {
+            // Warm the quantized .veq codes directly through the flat reader's index slice
+            // (ScalarQuantizedFloatVectorValues exposes them via HasIndexSlice#getSlice).
+            final IndexInput veqSlice = vectorValues.getSlice();
+            if (veqSlice != null) {
+                WarmupUtil.readAll(veqSlice);
+            }
+            return;
+        }
+
+        final VectorSearcher memoryOptimizedSearcher = loadMemoryOptimizedSearcherIfRequired(fieldInfo);
         if (memoryOptimizedSearcher != null) {
             // MOS is supported, warm up search parts
             memoryOptimizedSearcher.warmUp();

--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriter.java
@@ -54,17 +54,20 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
     private boolean finished;
     private final IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier;
     private final NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory;
+    private final Integer approximateThreshold;
 
     Faiss1040ScalarQuantizedKnnVectorsWriter(
         @NonNull SegmentWriteState segmentWriteState,
         @NonNull FlatVectorsWriter flatVectorsWriter,
         @NonNull IOFunction<SegmentReadState, FlatVectorsReader> quantizedFlatVectorsReaderSupplier,
-        @NonNull NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory
+        @NonNull NativeIndexBuildStrategyFactory nativeIndexBuildStrategyFactory,
+        Integer approximateThreshold
     ) {
         this.segmentWriteState = segmentWriteState;
         this.flatVectorsWriter = flatVectorsWriter;
         this.quantizedFlatVectorsReaderSupplier = quantizedFlatVectorsReaderSupplier;
         this.nativeIndexBuildStrategyFactory = nativeIndexBuildStrategyFactory;
+        this.approximateThreshold = approximateThreshold;
     }
 
     /**
@@ -120,7 +123,7 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
                 fieldWriter,
                 fieldWriter.getVectors(),
                 null,
-                null,
+                approximateThreshold,
                 segmentWriteState,
                 nativeIndexBuildStrategyFactory,
                 quantizedValues
@@ -157,7 +160,15 @@ class Faiss1040ScalarQuantizedKnnVectorsWriter extends AbstractNativeEnginesKnnV
             final QuantizedByteVectorValues quantizedValues = KNN1040ScalarQuantizedUtils.extractQuantizedByteVectorValues(
                 floatVectorValues
             );
-            doMergeOneField(fieldInfo, mergeState, null, null, segmentWriteState, nativeIndexBuildStrategyFactory, quantizedValues);
+            doMergeOneField(
+                fieldInfo,
+                mergeState,
+                null,
+                approximateThreshold,
+                segmentWriteState,
+                nativeIndexBuildStrategyFactory,
+                quantizedValues
+            );
         } finally {
             IOUtils.close(flatVectorsReader);
         }

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/AbstractNativeEnginesKnnVectorsWriter.java
@@ -68,17 +68,20 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
 
         QuantizationState quantizationState = null;
         if (quantizationStateSupplier != null) {
-            // should skip graph building only for non quantization use case and if threshold is met
             quantizationState = quantizationStateSupplier.apply(fieldInfo, knnVectorValuesSupplier, totalLiveDocs);
-            if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs, approximateThreshold)) {
-                log.debug(
-                    "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during flush",
-                    fieldInfo.name,
-                    totalLiveDocs,
-                    approximateThreshold
-                );
-                return;
-            }
+        }
+        // Skip the graph build when there is no native quantization state and the segment is below the
+        // approximate threshold. This fires for x1/x2 (train() returns null) and for Faiss SQ x32
+        // (supplier is null, so quantizationState stays null). x8/x16/binary produce a non-null quantization
+        // state, so this clause keeps them building the graph until their graph-less exact-search path exists.
+        if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs, approximateThreshold)) {
+            log.debug(
+                "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during flush",
+                fieldInfo.name,
+                totalLiveDocs,
+                approximateThreshold
+            );
+            return;
         }
 
         final NativeIndexWriter writer = NativeIndexWriter.getWriter(
@@ -120,16 +123,19 @@ public abstract class AbstractNativeEnginesKnnVectorsWriter extends KnnVectorsWr
         QuantizationState quantizationState = null;
         if (quantizationStateSupplier != null) {
             quantizationState = quantizationStateSupplier.apply(fieldInfo, knnVectorValuesSupplier, totalLiveDocs);
-            // should skip graph building only for non quantization use case and if threshold is met
-            if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs, approximateThreshold)) {
-                log.debug(
-                    "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during merge",
-                    fieldInfo.name,
-                    totalLiveDocs,
-                    approximateThreshold
-                );
-                return;
-            }
+        }
+        // Skip the graph build when there is no native quantization state and the segment is below the
+        // approximate threshold. This fires for x1/x2 (train() returns null) and for Faiss SQ x32
+        // (supplier is null, so quantizationState stays null). x8/x16/binary produce a non-null quantization
+        // state, so this clause keeps them building the graph until their graph-less exact-search path exists.
+        if (quantizationState == null && shouldSkipBuildingVectorDataStructure(totalLiveDocs, approximateThreshold)) {
+            log.debug(
+                "Skip building vector data structure for field: {}, as liveDoc: {} is less than the threshold {} during merge",
+                fieldInfo.name,
+                totalLiveDocs,
+                approximateThreshold
+            );
+            return;
         }
 
         final NativeIndexWriter writer = NativeIndexWriter.getWriter(

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissCodecFormatResolver.java
@@ -52,7 +52,10 @@ public class FaissCodecFormatResolver implements CodecFormatResolver {
         int defaultBeamWidth
     ) {
         if (isSQOneBitEncoder(params)) {
-            return new Faiss1040ScalarQuantizedKnnVectorsFormat(nativeIndexBuildStrategyFactory);
+            return new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                KNNSettings.getApproximateThresholdValue(mapperService),
+                nativeIndexBuildStrategyFactory
+            );
         }
         return resolve();
     }

--- a/src/test/java/org/opensearch/knn/index/Compression32XIT.java
+++ b/src/test/java/org/opensearch/knn/index/Compression32XIT.java
@@ -19,6 +19,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.knn.CompressionTestConfig;
 import org.opensearch.knn.KNNCompressionRestTestCase;
+import org.opensearch.knn.KNNJsonQueryBuilder;
 import org.opensearch.knn.KNNResult;
 import org.opensearch.knn.TestUtils;
 import org.opensearch.knn.index.query.KNNQueryBuilder;
@@ -35,7 +36,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.opensearch.knn.common.KNNConstants.ANN_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.COMPRESSION_LEVEL_PARAMETER;
+import static org.opensearch.knn.common.KNNConstants.EXACT_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.FAISS_NAME;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
 import static org.opensearch.knn.common.KNNConstants.KNN_METHOD;
@@ -838,7 +841,153 @@ public class Compression32XIT extends KNNCompressionRestTestCase {
         }
     }
 
+    // Approximate-threshold graph skip under x32 SQ: a below-threshold segment builds no graph and must be
+    // served by exact search over the quantized .veq codes, on the same score scale as a graph-backed sibling
+    // segment in the same index. This is the end-to-end proof of the SQ x32 approximate-threshold change.
+    //
+    // Both rescore states are checked. With rescore off there is no full-precision second pass, so if the
+    // graph-less segment wrongly scored against raw .vec (FP32) instead of the .veq codes its graph-backed
+    // sibling uses, the identical-vector scores would diverge and this test would catch it.
+    @SneakyThrows
+    public void testX32_approximateThreshold_graphlessSegmentServedByExactSearch() {
+        assumeTrue("Faiss SQ x32 dedicated format only applies to the compressed config", compressionConfig.isCompressed());
+        assumeTrue("Faiss SQ x32 dedicated format only applies to the FAISS engine", FAISS_NAME.equals(engineName));
+
+        String indexName = prefix() + "approx_threshold_graphless";
+        // Graph is built for the first segment (threshold 0 => never skip).
+        createVectorIndex(indexName, SpaceType.L2, DIMENSION);
+
+        float[] vector = INDEX_VECTORS[0];
+        addKnnDoc(indexName, "graph_backed", FIELD_NAME, toObjectArray(vector));
+        refreshIndex(indexName);
+        assertEquals(1, getDocCount(indexName));
+
+        // Flip the threshold so the next segment skips the graph build entirely.
+        updateIndexSettings(indexName, Settings.builder().put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, -1));
+
+        // Identical vector in a new (graph-less) segment.
+        addKnnDoc(indexName, "graph_less", FIELD_NAME, toObjectArray(vector));
+        refreshIndex(indexName);
+        assertEquals(2, getDocCount(indexName));
+
+        // Default rescore, then rescore explicitly off (the stricter case: no full-precision pass to re-align).
+        assertGraphlessSegmentMatchesGraphBacked(indexName, null);
+        assertGraphlessSegmentMatchesGraphBacked(indexName, false);
+    }
+
+    // Searches the mixed graph-backed + graph-less index and asserts (1) both docs are returned, (2) the two
+    // identical vectors score identically (same .veq scale), and (3) explain shows one segment fell back to
+    // exact search due to missing native engine files while the other used approximate search.
+    @SneakyThrows
+    private void assertGraphlessSegmentMatchesGraphBacked(String indexName, Boolean rescoreEnabled) {
+        final int k = 2;
+        String context = engineName + " [rescore=" + rescoreEnabled + "]";
+        // Build the query as raw JSON (non-deprecated path) to mimic a real user request and, for the
+        // rescore-off case, emit "rescore": false as literal JSON (KNNQueryBuilder XContent drops the flag).
+        String query = KNNJsonQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(toObjectArray(QUERY_VECTORS[0]))
+            .k(k)
+            .rescoreEnabled(rescoreEnabled)
+            .build()
+            .getQueryString();
+        Response response = searchKNNIndex(indexName, query, k);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, FIELD_NAME);
+
+        // Both docs must be found: the graph-backed one via ANN, the graph-less one via exact-search fallback.
+        assertEquals(context + " both segments should return a hit", k, results.size());
+
+        // Identical vectors must score identically across the ANN and exact-search paths, i.e. the graph-less
+        // exact search scores against the same quantized .veq codes as the graph-backed sibling (same scale).
+        List<Float> scores = parseSearchResponseScore(responseBody, FIELD_NAME);
+        assertEquals(
+            context + " graph-backed and graph-less segments must score identical vectors on the same scale",
+            scores.get(0),
+            scores.get(1),
+            0.001
+        );
+
+        // Prove the routing directly (not just via score equality): with explain on, the graph-backed
+        // segment reports Approximate-NN while the graph-less segment reports exact search because its
+        // native engine files are missing. Asserting both appear confirms the two segments took different
+        // paths and that the graph-less one truly fell back to exact search.
+        String explainResponseBody = EntityUtils.toString(performSearch(indexName, query, "explain=true").getEntity());
+        List<String> explanations = parseSearchResponseHits(explainResponseBody).stream()
+            .map(hit -> ((Map<String, Object>) hit).get("_explanation").toString())
+            .collect(Collectors.toList());
+        assertTrue(
+            context + " graph-less segment must explain as exact search due to missing native engine files: " + explanations,
+            explanations.stream().anyMatch(e -> e.contains(EXACT_SEARCH) && e.contains("no native engine files are available"))
+        );
+        assertTrue(
+            context + " graph-backed segment must explain as approximate search: " + explanations,
+            explanations.stream().anyMatch(e -> e.contains(ANN_SEARCH))
+        );
+    }
+
+    // Guard: x8 must NOT honor the approximate threshold yet. x8 produces a native quantization state, so the
+    // shared writer's `quantizationState == null` clause blocks the skip and the graph is always built - even
+    // with the threshold set to always-skip. This protects against accidentally flipping x8 into the SQ x32
+    // skip path before its graph-less exact-search byte source exists. Requested in review (#3434).
+    @SneakyThrows
+    public void testX8_approximateThreshold_stillBuildsGraph() {
+        // x8 is expressed as on_disk + 8x compression, independent of the class compression parameter, so run
+        // this once under the FAISS engine rather than per compression config.
+        assumeTrue("x8 quantized graph build is a FAISS engine concern", FAISS_NAME.equals(engineName));
+        assumeTrue("Run once; use the compressed config to avoid duplicate runs", compressionConfig.isCompressed());
+
+        String indexName = prefix() + "x8_threshold_still_builds";
+        // Threshold -1 would skip the graph for a level that honored the threshold; x8 must ignore it.
+        Settings settings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put(KNN_INDEX, true)
+            .put(INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, -1)
+            .build();
+        createX8OnDiskIndex(indexName, SpaceType.L2, settings);
+
+        for (int i = 0; i < 5; i++) {
+            addKnnDoc(indexName, String.valueOf(i), FIELD_NAME, toObjectArray(INDEX_VECTORS[i]));
+        }
+        refreshIndex(indexName);
+
+        final int k = 5;
+        String query = KNNJsonQueryBuilder.builder()
+            .fieldName(FIELD_NAME)
+            .vector(toObjectArray(QUERY_VECTORS[0]))
+            .k(k)
+            .build()
+            .getQueryString();
+        String explainBody = EntityUtils.toString(performSearch(indexName, query, "explain=true").getEntity());
+        List<String> explanations = parseSearchResponseHits(explainBody).stream()
+            .map(hit -> ((Map<String, Object>) hit).get("_explanation").toString())
+            .collect(Collectors.toList());
+
+        assertFalse(engineName + " x8 explanations should not be empty", explanations.isEmpty());
+        // No segment should have fallen back to exact search for want of native engine files: the graph is built.
+        assertFalse(
+            engineName + " x8 must build its graph despite the skip threshold; no missing-engine-files fallback expected: " + explanations,
+            explanations.stream().anyMatch(e -> e.contains("no native engine files are available"))
+        );
+    }
+
     // --- Helper methods ---
+
+    @SneakyThrows
+    private void createX8OnDiskIndex(String indexName, SpaceType spaceType, Settings settings) {
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(FIELD_NAME)
+            .field("type", "knn_vector")
+            .field("dimension", DIMENSION)
+            .field(MODE_PARAMETER, "on_disk")
+            .field(COMPRESSION_LEVEL_PARAMETER, "8x");
+        addMethodParams(builder, spaceType);
+        builder.endObject().endObject().endObject();
+        createKnnIndex(indexName, settings, builder.toString());
+    }
 
     @SneakyThrows
     private void validateScoreRanges(String indexName, SpaceType spaceType, float minScore, float maxScore) {

--- a/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
+++ b/src/test/java/org/opensearch/knn/index/LuceneEngineIT.java
@@ -1495,4 +1495,78 @@ public class LuceneEngineIT extends KNNCompressionRestTestCase {
         results = parseSearchResponse(responseBody, fieldName);
         assertEquals(k, results.size());
     }
+
+    /**
+     * Confirms that the Lucene SQ 1-bit (x32) path still works with the approximate threshold after the
+     * Faiss SQ x32 threshold changes in PR #3434. The two are independent engine paths (Lucene uses its own
+     * tinySegmentsThreshold); this test guards that their coexistence is safe.
+     */
+    public void testKNNIndex_whenApproximateThresholdSetForLuceneSQ1Bit_thenBehaviorUnchanged() throws Exception {
+        final String indexName = "lucene_sq1bit_threshold_test";
+        final String fieldName = FIELD_NAME;
+        final int dimension = DIMENSION;
+
+        // Create a Lucene SQ 1-bit (x32) index with threshold = -1 (never build HNSW graph)
+        final Settings knnIndexSettings = buildKNNIndexSettings(-1);
+
+        final XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject(fieldName)
+            .field("type", "knn_vector")
+            .field("dimension", dimension)
+            .startObject(KNNConstants.KNN_METHOD)
+            .field(KNNConstants.NAME, KNNConstants.METHOD_HNSW)
+            .field(KNNConstants.KNN_ENGINE, KNNEngine.LUCENE.getName())
+            .field(KNNConstants.METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue())
+            .startObject(KNNConstants.PARAMETERS)
+            .field(KNNConstants.METHOD_PARAMETER_M, M)
+            .field(KNNConstants.METHOD_PARAMETER_EF_CONSTRUCTION, EF_CONSTRUCTION)
+            .startObject(KNNConstants.METHOD_ENCODER_PARAMETER)
+            .field(KNNConstants.NAME, ENCODER_SQ)
+            .startObject(KNNConstants.PARAMETERS)
+            .field(LUCENE_SQ_BITS, 1)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+
+        createKnnIndex(indexName, knnIndexSettings, builder.toString());
+
+        // Index two identical vectors (duplicate with different doc id)
+        addKnnDoc(indexName, "1", fieldName, TEST_INDEX_VECTORS[0]);
+        refreshAllIndices();
+        addKnnDoc(indexName, "2", fieldName, TEST_INDEX_VECTORS[0]);
+        refreshAllIndices();
+        assertEquals(2, getDocCount(indexName));
+
+        // Search: both docs should be found and score identically (exact search, no HNSW graph)
+        final int k = 2;
+        Response response = searchKNNIndex(
+            indexName,
+            KNNQueryBuilder.builder().fieldName(fieldName).vector(TEST_QUERY_VECTORS[0]).k(k).build(),
+            k
+        );
+        String responseBody = EntityUtils.toString(response.getEntity());
+        List<KNNResult> results = parseSearchResponse(responseBody, fieldName);
+        assertEquals(k, results.size());
+        List<Float> scores = parseSearchResponseScore(responseBody, fieldName);
+        assertEquals(
+            "Lucene SQ 1-bit: both duplicate vectors should score identically (exact search, graph skipped)",
+            scores.get(0),
+            scores.get(1),
+            0.001
+        );
+
+        // Flip threshold to 0 (build graph) and force-merge: search should still work with the graph
+        updateIndexSettings(indexName, Settings.builder().put(KNNSettings.INDEX_KNN_ADVANCED_APPROXIMATE_THRESHOLD, 0));
+        forceMergeKnnIndex(indexName, 1);
+        response = searchKNNIndex(indexName, KNNQueryBuilder.builder().fieldName(fieldName).vector(TEST_QUERY_VECTORS[0]).k(k).build(), k);
+        responseBody = EntityUtils.toString(response.getEntity());
+        results = parseSearchResponse(responseBody, fieldName);
+        assertEquals(k, results.size());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
@@ -186,19 +186,25 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
     }
 
     @SneakyThrows
-    public void testWarmUp_whenMOSNotSupported_thenLogsWarning() {
+    public void testWarmUp_whenGraphSkippedByThreshold_thenWarmsVeqWithoutError() {
+        // No native engine (.faiss) file (the approximate threshold skipped the graph). Search is served by
+        // exact search over the quantized .veq codes, so warmUp should warm those codes via the flat reader's
+        // index slice and NOT attempt to load a memory-optimized searcher, so no error/warn is logged.
         final FieldInfo fi = createFieldInfo("field1", KNNEngine.FAISS, 0);
 
-        // Mock flatVectorsReader to return a ScalarQuantizedFloatVectorValues with non-zero size
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
         final ScalarQuantizedFloatVectorValues mockVectorValues = mock(ScalarQuantizedFloatVectorValues.class);
         when(mockVectorValues.size()).thenReturn(3);
         when(mockVectorValues.vectorValue(org.mockito.ArgumentMatchers.anyInt())).thenReturn(new float[] { 1.0f, 2.0f, 3.0f });
+        // The .veq codes are exposed through the index slice; warmUp should read through it.
+        final IndexInput veqSlice = mock(IndexInput.class);
+        when(veqSlice.length()).thenReturn(0L);
+        when(mockVectorValues.getSlice()).thenReturn(veqSlice);
         when(fvr.getFloatVectorValues("field1")).thenReturn(mockVectorValues);
 
-        // Set up a log appender to capture log events
         final List<LogEvent> logEvents = new ArrayList<>();
         final Logger logger = (Logger) LogManager.getLogger(Faiss1040ScalarQuantizedKnnVectorsReader.class);
+        final Logger baseLogger = (Logger) LogManager.getLogger(AbstractNativeEnginesKnnVectorsReader.class);
         final AbstractAppender appender = new AbstractAppender("test-appender", null, null, true, null) {
             @Override
             public void append(LogEvent event) {
@@ -207,37 +213,31 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
         };
         appender.start();
         logger.addAppender(appender);
+        baseLogger.addAppender(appender);
         final Level originalLevel = logger.getLevel();
-        logger.setLevel(Level.WARN);
+        final Level baseOriginalLevel = baseLogger.getLevel();
+        logger.setLevel(Level.INFO);
+        baseLogger.setLevel(Level.INFO);
 
         try {
-            // Make KNNEngine return null factory so loadMemoryOptimizedSearcherIfRequired returns null
-            KNNEngine mockFaiss = spy(KNNEngine.FAISS);
-            when(mockFaiss.getVectorSearcherFactory()).thenReturn(null);
+            final Faiss1040ScalarQuantizedKnnVectorsReader reader = createReader(
+                new FieldInfos(new FieldInfo[] { fi }),
+                Collections.emptySet(),
+                fvr
+            );
 
-            try (MockedStatic<KNNEngine> ms = mockStatic(KNNEngine.class)) {
-                ms.when(() -> KNNEngine.getEngine(any())).thenReturn(mockFaiss);
-                ms.when(KNNEngine::getEnginesThatCreateCustomSegmentFiles).thenReturn(ImmutableSet.of(mockFaiss));
+            reader.warmUp("field1");
 
-                final Faiss1040ScalarQuantizedKnnVectorsReader reader = createReader(
-                    new FieldInfos(new FieldInfo[] { fi }),
-                    Collections.emptySet(),
-                    fvr
-                );
-
-                reader.warmUp("field1");
-
-                // Verify warning was logged
-                boolean foundWarning = logEvents.stream()
-                    .anyMatch(e -> e.getLevel() == Level.WARN && e.getMessage().getFormattedMessage().contains("field1"));
-                assertTrue("Expected a WARN log about MOS not supported for field1", foundWarning);
-
-                // Verify the searcher warmUp was never called (no searcher available)
-                // This is implicitly verified since the searcher is null
-            }
+            // The .veq slice must be warmed (read through).
+            verify(veqSlice).seek(0);
+            // No misleading error/warn should be logged for a legitimately graph-less segment.
+            final boolean sawErrorOrWarn = logEvents.stream().anyMatch(e -> e.getLevel() == Level.ERROR || e.getLevel() == Level.WARN);
+            assertFalse("Graph-less warmup must not log error/warn: " + logEvents, sawErrorOrWarn);
         } finally {
             logger.removeAppender(appender);
+            baseLogger.removeAppender(appender);
             logger.setLevel(originalLevel);
+            baseLogger.setLevel(baseOriginalLevel);
             appender.stop();
         }
     }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsWriterTests.java
@@ -12,8 +12,6 @@ import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatFieldVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsReader;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
-import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
-import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
@@ -27,12 +25,15 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.IOFunction;
 import org.apache.lucene.util.InfoStream;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -41,7 +42,9 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.codec.nativeindex.NativeIndexBuildStrategyFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
@@ -56,6 +59,12 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
 
     private static final int DIMENSION = 128;
     private static final String FIELD_NAME = "test_field";
+    // Approximate-threshold values, named for intent (mirrors FaissIT). 0 => never skip (default, always
+    // build the graph); -1 => always skip (short-circuits on the threshold value alone); a value above the
+    // segment doc count => the segment is below threshold, so skip.
+    private static final int ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = 0;
+    private static final int NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD = -1;
+    private static final int BELOW_VECTOR_DATA_STRUCTURE_THRESHOLD = 10_000;
     private static final String PARAMETERS_JSON = "{"
         + "\"index_description\":\"BHNSW16,Flat\","
         + "\"spaceType\":\"innerproduct\","
@@ -89,7 +98,8 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
             segmentWriteState,
             flatVectorsWriter,
             quantizedFlatVectorsReaderSupplier,
-            new NativeIndexBuildStrategyFactory()
+            new NativeIndexBuildStrategyFactory(),
+            ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
         );
         mockedFlatFieldVectorsWriter = mock(FlatFieldVectorsWriter.class);
         Mockito.doNothing().when(mockedFlatFieldVectorsWriter).addValue(Mockito.anyInt(), Mockito.any());
@@ -430,7 +440,8 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
                 realWriteState,
                 flatVectorsWriter,
                 quantizedFlatVectorsReaderSupplier,
-                new NativeIndexBuildStrategyFactory()
+                new NativeIndexBuildStrategyFactory(),
+                ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD
             );
 
             // mergeOneField should complete without error — the empty vectors should be skipped
@@ -549,6 +560,108 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
         }
     }
 
+    // ===================== approximate threshold: graph-skip on flush/merge =====================
+
+    /**
+     * Below-threshold flush skips the native graph build (no .faiss) while the flat .vec/.veq byte sources
+     * are still written and readable. Covered for both a threshold above the doc count and the -1
+     * (always-skip) sentinel, which short-circuits on the threshold value alone.
+     */
+    @SneakyThrows
+    public void testFlush_whenBelowApproximateThreshold_thenSkipsGraphButWritesFlatVectors() {
+        assertFlushSkipsGraphButWritesFlatVectors(BELOW_VECTOR_DATA_STRUCTURE_THRESHOLD);
+    }
+
+    @SneakyThrows
+    public void testFlush_whenAlwaysSkipThreshold_thenSkipsGraphButWritesFlatVectors() {
+        assertFlushSkipsGraphButWritesFlatVectors(NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD);
+    }
+
+    /**
+     * At the default threshold (0 => never skip), an SQ x32 segment must still build the native graph AND
+     * write the flat vectors, and the built graph must be searchable. Guards that the plumbing does not
+     * accidentally skip in the default configuration.
+     */
+    @SneakyThrows
+    public void testFlush_whenDefaultThreshold_thenBuildsGraph() {
+        final int numVectors = 3;
+        final float[][] vectors = generateRandomVectors(numVectors, DIMENSION);
+
+        try (org.apache.lucene.store.Directory directory = newDirectory()) {
+            final SegmentWriteState writeState = createWriteState(directory, "_0", numVectors);
+            final FieldInfo fi = createRealFieldInfo();
+            final Faiss1040ScalarQuantizedKnnVectorsFormat format = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+                new NativeIndexBuildStrategyFactory()
+            );
+
+            flushVectors(format, writeState, fi, vectors);
+
+            final List<String> files = Arrays.asList(directory.listAll());
+            assertTrue("Default-threshold SQ segment must build a .faiss graph file. Files: " + files, hasFaissFile(files));
+            assertTrue(".vec must be written. Files: " + files, files.stream().anyMatch(f -> f.endsWith(".vec")));
+            assertTrue(".veq quantized codes must be written. Files: " + files, files.stream().anyMatch(f -> f.endsWith(".veq")));
+            verifyVectorsReadable(format, directory, writeState, fi, vectors, numVectors);
+            // The segment's vectors must be scoreable, not just present on disk.
+            assertSegmentScoreable(format, directory, writeState, fi, vectors[0], numVectors);
+        }
+    }
+
+    // Merge combinations. mergeOneField reads only the flat .vec/.veq from the source segments (never the
+    // source .faiss), so source segments may be graph-backed or graph-less independently. Each source's
+    // per-segment threshold decides whether it built a graph; the merge threshold decides the merged segment.
+    // In every case the merged flat vectors must remain readable.
+
+    /** graph + graph -> merge below threshold: merged segment skips the graph. */
+    @SneakyThrows
+    public void testMergeOneField_whenGraphBackedSourcesMergedBelowThreshold_thenMergedSkipsGraph() {
+        assertMergeGraphOutcome(
+            new int[] { ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD },
+            BELOW_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            false
+        );
+    }
+
+    /** no-graph + no-graph -> merge below threshold: merged segment skips the graph. */
+    @SneakyThrows
+    public void testMergeOneField_whenGraphlessSourcesMergedBelowThreshold_thenMergedSkipsGraph() {
+        assertMergeGraphOutcome(
+            new int[] { NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD },
+            BELOW_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            false
+        );
+    }
+
+    /** no-graph + no-graph -> merge at default threshold: merged segment builds the graph. */
+    @SneakyThrows
+    public void testMergeOneField_whenGraphlessSourcesMergedAtDefault_thenMergedBuildsGraph() {
+        assertMergeGraphOutcome(
+            new int[] { NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD },
+            ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            true
+        );
+    }
+
+    /** mixed (graph + no-graph) -> merge at default threshold: merged segment builds the graph. */
+    @SneakyThrows
+    public void testMergeOneField_whenMixedSourcesMergedAtDefault_thenMergedBuildsGraph() {
+        assertMergeGraphOutcome(
+            new int[] { ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD },
+            ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            true
+        );
+    }
+
+    /** mixed (graph + no-graph) -> merge below threshold: merged segment skips the graph. */
+    @SneakyThrows
+    public void testMergeOneField_whenMixedSourcesMergedBelowThreshold_thenMergedSkipsGraph() {
+        assertMergeGraphOutcome(
+            new int[] { ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD, NEVER_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD },
+            BELOW_VECTOR_DATA_STRUCTURE_THRESHOLD,
+            false
+        );
+    }
+
     // ===================== helpers =====================
 
     private void writeEmptyScalarQuantizedSegment(
@@ -560,6 +673,246 @@ public class Faiss1040ScalarQuantizedKnnVectorsWriterTests extends KNNTestCase {
             writer.addField(fieldInfo);
             writer.flush(writeState.segmentInfo.maxDoc(), null);
             writer.finish();
+        }
+    }
+
+    /** True if any file is a native Faiss graph file (.faiss, or .faissc when using compound files). */
+    private static boolean hasFaissFile(List<String> files) {
+        return files.stream().anyMatch(f -> f.endsWith(".faiss") || f.endsWith(".faissc"));
+    }
+
+    /**
+     * True if a file belongs to the named segment. Lucene names segment files "{segment}_...", so match on
+     * the "{segment}_" prefix rather than a substring (e.g. "_1" would otherwise match "_0_165...").
+     */
+    private static boolean belongsToSegment(String file, String segmentName) {
+        return file.startsWith(segmentName + "_");
+    }
+
+    /** True if a native Faiss graph file exists for the named segment. */
+    private static boolean hasFaissFileForSegment(List<String> files, String segmentName) {
+        return files.stream().anyMatch(f -> (f.endsWith(".faiss") || f.endsWith(".faissc")) && belongsToSegment(f, segmentName));
+    }
+
+    /** Writes vectors through the format's writer for a single segment (flush path). */
+    @SneakyThrows
+    private void flushVectors(
+        Faiss1040ScalarQuantizedKnnVectorsFormat format,
+        SegmentWriteState writeState,
+        FieldInfo fi,
+        float[][] vectors
+    ) {
+        try (KnnVectorsWriter knnWriter = format.fieldsWriter(writeState)) {
+            @SuppressWarnings("unchecked")
+            KnnFieldVectorsWriter<float[]> fw = (KnnFieldVectorsWriter<float[]>) knnWriter.addField(fi);
+            for (int i = 0; i < vectors.length; i++) {
+                fw.addValue(i, vectors[i]);
+            }
+            knnWriter.flush(vectors.length, null);
+            knnWriter.finish();
+        }
+    }
+
+    /**
+     * Below-threshold flush at the given threshold must skip the native graph build (no .faiss) while the
+     * flat .vec/.veq byte sources are still written and readable.
+     */
+    @SneakyThrows
+    private void assertFlushSkipsGraphButWritesFlatVectors(int threshold) {
+        final int numVectors = 3; // below any positive threshold used here; -1 always skips
+        final float[][] vectors = generateRandomVectors(numVectors, DIMENSION);
+
+        try (org.apache.lucene.store.Directory directory = newDirectory()) {
+            final SegmentWriteState writeState = createWriteState(directory, "_0", numVectors);
+            final FieldInfo fi = createRealFieldInfo();
+            final Faiss1040ScalarQuantizedKnnVectorsFormat format = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                threshold,
+                new NativeIndexBuildStrategyFactory()
+            );
+
+            flushVectors(format, writeState, fi, vectors);
+
+            final List<String> files = Arrays.asList(directory.listAll());
+            assertFalse(
+                "Below-threshold SQ segment must not write a .faiss graph file (threshold=" + threshold + "). Files: " + files,
+                hasFaissFile(files)
+            );
+            // Flat vectors must survive the skip so exact search can score against them.
+            assertTrue(".vec must be written. Files: " + files, files.stream().anyMatch(f -> f.endsWith(".vec")));
+            assertTrue(".veq quantized codes must be written. Files: " + files, files.stream().anyMatch(f -> f.endsWith(".veq")));
+            verifyVectorsReadable(format, directory, writeState, fi, vectors, numVectors);
+        }
+    }
+
+    /**
+     * Proves the written segment's vectors are scoreable (not merely present on disk) by obtaining a
+     * RandomVectorScorer from the flat reader over the .veq codes and scoring every doc. This is the
+     * searchability signal available at the writer/component layer: the codec reader's full search() needs
+     * the memory-optimized native searcher (warmup + a loaded .faiss), and the graph-less exact-search
+     * fallback is a KNNWeight/ExactSearcher path, both of which are exercised end-to-end at the integ layer
+     * (Compression32XIT). Works for graph-backed and graph-less segments alike.
+     */
+    @SneakyThrows
+    private void assertSegmentScoreable(
+        Faiss1040ScalarQuantizedKnnVectorsFormat format,
+        org.apache.lucene.store.Directory directory,
+        SegmentWriteState writeState,
+        FieldInfo fi,
+        float[] query,
+        int numDocs
+    ) {
+        final SegmentReadState readState = new SegmentReadState(
+            directory,
+            writeState.segmentInfo,
+            new FieldInfos(new FieldInfo[] { fi }),
+            IOContext.DEFAULT,
+            FIELD_NAME
+        );
+        try (KnnVectorsReader knnReader = format.fieldsReader(readState)) {
+            final FlatVectorsReader flatReader = ((Faiss1040ScalarQuantizedKnnVectorsReader) knnReader).getFlatVectorsReader();
+            final RandomVectorScorer scorer = flatReader.getRandomVectorScorer(FIELD_NAME, query);
+            assertNotNull("Flat reader must provide a scorer over the .veq codes", scorer);
+            for (int doc = 0; doc < numDocs; doc++) {
+                final float score = scorer.score(doc);
+                assertTrue("Score for doc " + doc + " must be finite", Float.isFinite(score));
+            }
+        }
+    }
+
+    /**
+     * Builds N source segments (one per entry in {@code sourceThresholds}, each deciding whether that source
+     * builds its graph), asserts each source's flat files are present before merging, merges them with a
+     * writer configured at {@code mergeThreshold}, then asserts whether the merged segment built a graph and
+     * that all merged vectors are readable. mergeOneField reads only the flat files, so graph-less sources
+     * merge fine.
+     */
+    @SneakyThrows
+    private void assertMergeGraphOutcome(int[] sourceThresholds, int mergeThreshold, boolean expectMergedGraph) {
+        final int numSegments = sourceThresholds.length;
+        final int vectorsPerSegment = 3;
+        final int totalVectors = numSegments * vectorsPerSegment;
+
+        final float[][][] segmentVectors = new float[numSegments][][];
+        for (int s = 0; s < numSegments; s++) {
+            segmentVectors[s] = generateRandomVectors(vectorsPerSegment, DIMENSION);
+        }
+
+        final FieldInfo fi = createRealFieldInfo();
+        final FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { fi });
+        final Faiss1040ScalarQuantizedKnnVectorsFormat mergeFormat = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+            mergeThreshold,
+            new NativeIndexBuildStrategyFactory()
+        );
+
+        try (org.apache.lucene.store.Directory directory = newDirectory()) {
+            final SegmentInfo[] segInfos = new SegmentInfo[numSegments];
+            final KnnVectorsReader[] readers = new KnnVectorsReader[numSegments];
+
+            for (int s = 0; s < numSegments; s++) {
+                final String segName = "_" + s;
+                segInfos[s] = createSegmentInfo(directory, segName, vectorsPerSegment);
+                final SegmentWriteState ws = new SegmentWriteState(
+                    InfoStream.NO_OUTPUT,
+                    directory,
+                    segInfos[s],
+                    fieldInfos,
+                    null,
+                    IOContext.DEFAULT,
+                    FIELD_NAME
+                );
+                final Faiss1040ScalarQuantizedKnnVectorsFormat sourceFormat = new Faiss1040ScalarQuantizedKnnVectorsFormat(
+                    sourceThresholds[s],
+                    new NativeIndexBuildStrategyFactory()
+                );
+                flushVectors(sourceFormat, ws, fi, segmentVectors[s]);
+
+                // Verify the source segment is reliable to merge: its flat vectors must exist, and its graph
+                // must match the source threshold (built when not skipped, absent when skipped).
+                final List<String> sourceFiles = Arrays.asList(directory.listAll());
+                assertTrue(
+                    "Source segment " + segName + " must have .vec before merge. Files: " + sourceFiles,
+                    sourceFiles.stream().anyMatch(f -> f.endsWith(".vec") && belongsToSegment(f, segName))
+                );
+                assertTrue(
+                    "Source segment " + segName + " must have .veq before merge. Files: " + sourceFiles,
+                    sourceFiles.stream().anyMatch(f -> f.endsWith(".veq") && belongsToSegment(f, segName))
+                );
+                final boolean sourceBuiltGraph = sourceThresholds[s] == ALWAYS_BUILD_VECTOR_DATA_STRUCTURE_THRESHOLD;
+                assertEquals(
+                    "Source segment " + segName + " graph presence must match its threshold. Files: " + sourceFiles,
+                    sourceBuiltGraph,
+                    hasFaissFileForSegment(sourceFiles, segName)
+                );
+
+                readers[s] = sourceFormat.fieldsReader(
+                    new SegmentReadState(directory, segInfos[s], fieldInfos, IOContext.DEFAULT, FIELD_NAME)
+                );
+            }
+
+            final MergeState.DocMap[] docMaps = new MergeState.DocMap[numSegments];
+            final int[] maxDocs = new int[numSegments];
+            final FieldInfos[] perSegFieldInfos = new FieldInfos[numSegments];
+            int docBase = 0;
+            for (int s = 0; s < numSegments; s++) {
+                final int base = docBase;
+                docMaps[s] = docID -> base + docID;
+                maxDocs[s] = vectorsPerSegment;
+                perSegFieldInfos[s] = fieldInfos;
+                docBase += vectorsPerSegment;
+            }
+
+            final SegmentInfo mergedSegInfo = createSegmentInfo(directory, "_merged", totalVectors);
+            final MergeState mergeState = new MergeState(
+                docMaps,
+                mergedSegInfo,
+                fieldInfos,
+                null,
+                null,
+                null,
+                null,
+                perSegFieldInfos,
+                new org.apache.lucene.util.Bits[numSegments],
+                null,
+                null,
+                readers,
+                maxDocs,
+                InfoStream.NO_OUTPUT,
+                Runnable::run,
+                false,
+                null
+            );
+
+            final SegmentWriteState mergedWriteState = new SegmentWriteState(
+                InfoStream.NO_OUTPUT,
+                directory,
+                mergedSegInfo,
+                fieldInfos,
+                null,
+                IOContext.DEFAULT,
+                FIELD_NAME
+            );
+
+            try (KnnVectorsWriter mergedWriter = mergeFormat.fieldsWriter(mergedWriteState)) {
+                mergedWriter.mergeOneField(fi, mergeState);
+                mergedWriter.finish();
+            }
+
+            for (KnnVectorsReader reader : readers) {
+                reader.close();
+            }
+
+            final List<String> files = Arrays.asList(directory.listAll());
+            assertEquals(
+                "Merged segment graph presence must match the merge threshold. Files: " + files,
+                expectMergedGraph,
+                hasFaissFileForSegment(files, "_merged")
+            );
+
+            final float[][] allVectors = new float[totalVectors][];
+            for (int s = 0; s < numSegments; s++) {
+                System.arraycopy(segmentVectors[s], 0, allVectors, s * vectorsPerSegment, vectorsPerSegment);
+            }
+            verifyVectorsReadable(mergeFormat, directory, mergedWriteState, fi, allVectors, totalVectors);
         }
     }
 


### PR DESCRIPTION
### Description
Enables the approximate graph threshold (`index.knn.advanced.approximate_threshold`) for Faiss SQ x32 (`sq` encoder, `bits=1`) indices. Previously the threshold only took effect for x1 (FP32) and x2 (FP16); quantized levels always built the HNSW graph regardless of the setting.

Two root causes are addressed on the write path:
- The skip check in `AbstractNativeEnginesKnnVectorsWriter` was nested inside the quantization-supplier block, which the SQ writer never enters. It is hoisted so it also runs for the SQ path. The existing `quantizationState == null` clause is retained as an interim guard so x8/x16/binary keep building their graph until their graph-less exact-search byte source exists. Native x1/x2 behavior is unchanged.
- The threshold was never plumbed to the SQ format/writer. It is now supplied by `FaissCodecFormatResolver` from index settings (matching the native format) and carried through `Faiss1040ScalarQuantizedKnnVectorsFormat`/`...Writer` into `doFlush`/`doMergeOneField`.

A skipped SQ segment writes no `.faiss` graph file; its `.vec`/`.veq` flat files survive, so exact search scores against the `.veq` quantized codes on the same scale as graph-backed sibling segments. Default behavior is unchanged: at the default threshold (0) every graph is still built. Scope is x32 SQ only; x8/x16 remain out of scope pending their own graph-less byte source.

### Related Issues
Related #3306
<!-- x32 SQ is the first slice of #3306; x8/x16 remain tracked there. -->

### Check List
- [x] New functionality includes testing.
  - Unit: below-threshold SQ flush/merge writes no `.faiss` while `.vec`/`.veq` remain readable; default threshold still builds the graph.
  - Integration (`Compression32XIT`): a graph-less SQ x32 segment is served by exact search and scores an identical vector identically to its graph-backed sibling, verified via explain output, with rescore both on and off.
- [ ] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
