### PR TITLE
[Bug-fix] Fix the error log in warmup flow of Faiss when a segment has no vectors in it.

### DIFF
--- a/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReader.java
@@ -97,6 +97,12 @@ public class Faiss1040ScalarQuantizedKnnVectorsReader extends AbstractNativeEngi
         final ScalarQuantizedFloatVectorValues vectorValues = (ScalarQuantizedFloatVectorValues) flatVectorsReader.getFloatVectorValues(
             fieldName
         );
+        // This would mean that vectors are not present for this segment hence we should not proceed in warmup setup.
+        if (vectorValues == null || vectorValues.size() == 0) {
+            log.info("No vectors present in the segment {} for field {}", this.segmentReadState.segmentInfo.name, fieldName);
+            return;
+        }
+
         for (int i = 0; i < vectorValues.size(); ++i) {
             vectorValues.vectorValue(i);
         }

--- a/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN1040Codec/Faiss1040ScalarQuantizedKnnVectorsReaderTests.java
@@ -189,10 +189,11 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
     public void testWarmUp_whenMOSNotSupported_thenLogsWarning() {
         final FieldInfo fi = createFieldInfo("field1", KNNEngine.FAISS, 0);
 
-        // Mock flatVectorsReader to return a ScalarQuantizedFloatVectorValues
+        // Mock flatVectorsReader to return a ScalarQuantizedFloatVectorValues with non-zero size
         final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
         final ScalarQuantizedFloatVectorValues mockVectorValues = mock(ScalarQuantizedFloatVectorValues.class);
-        when(mockVectorValues.size()).thenReturn(0);
+        when(mockVectorValues.size()).thenReturn(3);
+        when(mockVectorValues.vectorValue(org.mockito.ArgumentMatchers.anyInt())).thenReturn(new float[] { 1.0f, 2.0f, 3.0f });
         when(fvr.getFloatVectorValues("field1")).thenReturn(mockVectorValues);
 
         // Set up a log appender to capture log events
@@ -234,6 +235,69 @@ public class Faiss1040ScalarQuantizedKnnVectorsReaderTests extends KNNTestCase {
                 // Verify the searcher warmUp was never called (no searcher available)
                 // This is implicitly verified since the searcher is null
             }
+        } finally {
+            logger.removeAppender(appender);
+            logger.setLevel(originalLevel);
+            appender.stop();
+        }
+    }
+
+    @SneakyThrows
+    public void testWarmUp_whenVectorValuesIsNull_thenReturnsEarly() {
+        final FieldInfo fi = createFieldInfo("field1", KNNEngine.FAISS, 0);
+        final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
+        when(fvr.getFloatVectorValues("field1")).thenReturn(null);
+
+        final Faiss1040ScalarQuantizedKnnVectorsReader reader = createReader(
+            new FieldInfos(new FieldInfo[] { fi }),
+            Collections.emptySet(),
+            fvr
+        );
+
+        // Should not throw — returns early
+        reader.warmUp("field1");
+        verify(fvr).getFloatVectorValues("field1");
+    }
+
+    @SneakyThrows
+    public void testWarmUp_whenVectorValuesIsEmpty_thenReturnsEarly() {
+        final FieldInfo fi = createFieldInfo("field1", KNNEngine.FAISS, 0);
+        final FlatVectorsReader fvr = mock(FlatVectorsReader.class);
+        final ScalarQuantizedFloatVectorValues mockVectorValues = mock(ScalarQuantizedFloatVectorValues.class);
+        when(mockVectorValues.size()).thenReturn(0);
+        when(fvr.getFloatVectorValues("field1")).thenReturn(mockVectorValues);
+
+        final List<LogEvent> logEvents = new ArrayList<>();
+        final Logger logger = (Logger) LogManager.getLogger(Faiss1040ScalarQuantizedKnnVectorsReader.class);
+        final AbstractAppender appender = new AbstractAppender("test-appender", null, null, true, null) {
+            @Override
+            public void append(LogEvent event) {
+                logEvents.add(event.toImmutable());
+            }
+        };
+        appender.start();
+        logger.addAppender(appender);
+        final Level originalLevel = logger.getLevel();
+        logger.setLevel(Level.INFO);
+
+        try {
+            final Faiss1040ScalarQuantizedKnnVectorsReader reader = createReader(
+                new FieldInfos(new FieldInfo[] { fi }),
+                Collections.emptySet(),
+                fvr
+            );
+
+            // Should not throw — returns early with info log
+            reader.warmUp("field1");
+
+            boolean foundInfoLog = logEvents.stream()
+                .anyMatch(
+                    e -> e.getLevel() == Level.INFO && e.getMessage().getFormattedMessage().contains("No vectors present in the segment")
+                );
+            assertTrue("Expected INFO log about no vectors present", foundInfoLog);
+
+            // vectorValue should never be called since size is 0
+            verify(mockVectorValues, org.mockito.Mockito.never()).vectorValue(org.mockito.ArgumentMatchers.anyInt());
         } finally {
             logger.removeAppender(appender);
             logger.setLevel(originalLevel);


### PR DESCRIPTION
### Description
Fix the error log in warmup flow of Faiss when a segment has no vectors in it.


Script to repro the error log that can be seen in logs during warmup api. but no error during search.

```
#!/bin/bash
# Test warmup and search on a FAISS SQ index with a vectorless segment.
# Usage:
#   ./scripts/test-warmup-empty-segment.sh warmup   # run warmup only
#   ./scripts/test-warmup-empty-segment.sh search   # run search only
#   ./scripts/test-warmup-empty-segment.sh both     # run both (default)

set -xe

HOST="${OS_HOST:-localhost}"
PORT="${OS_PORT:-9200}"
BASE="http://${HOST}:${PORT}"
INDEX="test_sq_warmup_empty_segment"
FIELD="test_field"
FIELD_NON_KNN="text_field"
DIMENSION=16
DOC_COUNT=10

ACTION="${1:-both}"

echo "=== Target: ${BASE} ==="
echo "=== Action: ${ACTION} ==="
echo ""

# Cleanup
echo "--- Deleting index (if exists) ---"
curl -s -X DELETE "${BASE}/${INDEX}" | jq . 2>/dev/null || true
echo ""

# Create index with FAISS SQ 1-bit
echo "--- Creating FAISS SQ index ---"
curl -s -X PUT "${BASE}/${INDEX}" -H 'Content-Type: application/json' -d '{
  "settings": {
    "index.knn": true,
    "number_of_shards": 1,
    "number_of_replicas": 0,
    "index.soft_deletes.retention_lease.period": "0ms"
  },
  "mappings": {
    "properties": {
      "'${FIELD}'": {
        "type": "knn_vector",
        "dimension": '${DIMENSION}',
        "method": {
          "name": "hnsw",
          "engine": "faiss",
          "parameters": {
            "encoder": {
              "name": "sq",
              "parameters": { "bits": 1 }
            }
          }
        }
      },
      "'${FIELD_NON_KNN}'": {
        "type": "text"
      }
    }
  }
}' | jq .
echo ""

# Index docs WITH vectors + one anchor
echo "--- Indexing ${DOC_COUNT} docs with vectors + 1 anchor ---"
BULK_BODY=""
for i in $(seq 0 $((DOC_COUNT - 1))); do
  VEC=$(python3 -c "import json; print(json.dumps([float($i)] * ${DIMENSION}))")
  BULK_BODY="${BULK_BODY}{\"index\":{\"_index\":\"${INDEX}\",\"_id\":\"${i}\"}}\n{\"${FIELD}\":${VEC}}\n"
done
BULK_BODY="${BULK_BODY}{\"index\":{\"_index\":\"${INDEX}\",\"_id\":\"anchor\"}}\n{\"${FIELD_NON_KNN}\":\"anchor\"}\n"

echo -e "${BULK_BODY}" | curl -s -X POST "${BASE}/_bulk?refresh=true" -H 'Content-Type: application/x-ndjson' --data-binary @- | jq '{took, errors, items_count: (.items | length)}'
echo ""

echo "--- Segment count after initial ingest ---"
curl -s "${BASE}/${INDEX}/_segments" | jq '.indices[].shards[][] | .num_committed_segments'
echo ""

# Replace vector docs with non-vector docs (soft delete vectors)
echo "--- Replacing vector docs with non-vector docs ---"
REPLACE_BODY=""
for i in $(seq 0 $((DOC_COUNT - 1))); do
  REPLACE_BODY="${REPLACE_BODY}{\"index\":{\"_index\":\"${INDEX}\",\"_id\":\"${i}\"}}\n{\"${FIELD_NON_KNN}\":\"replacement ${i}\"}\n"
done

echo -e "${REPLACE_BODY}" | curl -s -X POST "${BASE}/_bulk?refresh=true" -H 'Content-Type: application/x-ndjson' --data-binary @- | jq '{took, errors, items_count: (.items | length)}'
echo ""

echo "--- Segment count after replacement ---"
curl -s "${BASE}/${INDEX}/_segments" | jq '.indices[].shards[][] | .num_committed_segments'
echo ""

# Flush + close + reopen + force merge to create segment with SQ metadata but no live vectors
echo "--- Flush ---"
curl -s -X POST "${BASE}/${INDEX}/_flush" | jq .
echo ""

echo "--- Close index ---"
curl -s -X POST "${BASE}/${INDEX}/_close" | jq .
echo ""

echo "--- Open index ---"
curl -s -X POST "${BASE}/${INDEX}/_open" | jq .
sleep 2
echo ""

echo "--- Force merge to 1 segment ---"
curl -s -X POST "${BASE}/${INDEX}/_forcemerge?max_num_segments=1" | jq .
echo ""

echo "--- Segment count after force merge ---"
curl -s "${BASE}/${INDEX}/_segments" | jq '.indices[].shards[][] | .num_committed_segments'
echo ""

echo "--- Doc count ---"
curl -s "${BASE}/${INDEX}/_count" | jq .
echo ""

# Warmup
if [ "${ACTION}" = "warmup" ] || [ "${ACTION}" = "both" ]; then
  echo "=== WARMUP on vectorless segment ==="
  WARMUP_RESPONSE=$(curl -s "${BASE}/_plugins/_knn/warmup/${INDEX}")
  echo "${WARMUP_RESPONSE}" | jq .
  echo ""

  # Check for failures
  FAILED=$(echo "${WARMUP_RESPONSE}" | jq '._shards.failed // 0')
  if [ "${FAILED}" != "0" ]; then
    echo "ERROR: Warmup had ${FAILED} shard failures!"
    exit 1
  else
    echo "OK: Warmup succeeded with 0 failures"
  fi
  echo ""
fi

# Search
if [ "${ACTION}" = "search" ] || [ "${ACTION}" = "both" ]; then
  echo "=== SEARCH on vectorless segment ==="
  QUERY_VEC=$(python3 -c "import json; print(json.dumps([1.0] * ${DIMENSION}))")
  SEARCH_BODY=$(cat <<EOF
{"size":5,"query":{"knn":{"${FIELD}":{"vector":${QUERY_VEC},"k":5}}}}
EOF
)
  SEARCH_RESPONSE=$(curl -s -X POST "${BASE}/${INDEX}/_search" -H 'Content-Type: application/json' -d "${SEARCH_BODY}")
  echo "${SEARCH_RESPONSE}" | jq .
  echo ""

  HITS=$(echo "${SEARCH_RESPONSE}" | jq '.hits.total.value')
  echo "Total hits: ${HITS} (expected 0 since all vectors were replaced)"
  echo ""
fi

echo "=== Done ==="

```

### Related Issues
Follow up of this: https://github.com/opensearch-project/k-NN/pull/3433
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
