### PR TITLE
Deprecate mode, clean up engine field mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
 * Wire ResolvedIndexSpec consumers through spec-driven resolution flow [#3421](https://github.com/opensearch-project/k-NN/pull/3421)
+* Refactor engine field mapper, deprecate mode parameter, add encoder validation [#3436](https://github.com/opensearch-project/k-NN/pull/3436)
 
 ### Enhancements

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.common;
 
+import org.opensearch.Version;
 import org.opensearch.knn.index.VectorDataType;
 
 import java.util.List;
@@ -192,6 +193,8 @@ public class KNNConstants {
 
     public static final String MODE_PARAMETER = "mode";
     public static final String COMPRESSION_LEVEL_PARAMETER = "compression_level";
+    // Version at which the default compression level flips to x32 and the 'mode' parameter is deprecated.
+    public static final Version KNN_DEFAULT_COMPRESSION_FLIP_VERSION = Version.V_3_8_0;
 
     // Repository filepath constants
     public static final String VECTOR_BLOB_FILE_EXTENSION = ".knnvec";

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractKNNMethod.java
@@ -10,6 +10,7 @@ import org.opensearch.common.ValidationException;
 import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.mapper.Mode;
 import org.opensearch.knn.index.mapper.PerDimensionProcessor;
 import org.opensearch.knn.index.mapper.PerDimensionValidator;
 import org.opensearch.knn.index.mapper.SpaceVectorValidator;
@@ -174,7 +175,7 @@ public abstract class AbstractKNNMethod implements KNNMethod {
             .encoderType(encoderType)
             .quantizationBits(quantizationBits)
             .compressionLevel(knnMethodConfigContext.getCompressionLevel())
-            .mode(knnMethodConfigContext.getMode())
+            .mode(resolveEffectiveMode(knnMethodConfigContext))
             .vectorDataType(knnMethodConfigContext.getVectorDataType())
             .dimension(dimension != null ? dimension : 0)
             .indexVersionCreated(knnMethodConfigContext.getVersionCreated())
@@ -184,6 +185,16 @@ public abstract class AbstractKNNMethod implements KNNMethod {
     @Override
     public KNNLibrarySearchContext getKNNLibrarySearchContext() {
         return knnLibrarySearchContext;
+    }
+
+    private static Mode resolveEffectiveMode(KNNMethodConfigContext ctx) {
+        if (Mode.isConfigured(ctx.getMode())) {
+            return ctx.getMode();
+        }
+        // Only user-configured compression implies a mode. Compression derived from the encoder during
+        // resolution (e.g. binary encoder bits=1 -> x32) must not silently opt the index into on_disk
+        // behavior such as fp32 rescoring.
+        return KNNMethodConfigContext.deriveMode(ctx.getUserConfiguredCompressionLevel());
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractMethodResolver.java
@@ -200,13 +200,13 @@ public abstract class AbstractMethodResolver implements MethodResolver {
         if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())) {
             return knnMethodConfigContext.getCompressionLevel();
         }
-        if (knnMethodConfigContext.getMode() == Mode.ON_DISK) {
-            Version version = knnMethodConfigContext.getVersionCreated();
-            if (version != null && version.onOrAfter(Version.V_3_6_0)) {
-                return CompressionLevel.x32;
-            }
-            return priorVersionOnDiskDefault;
+        if (knnMethodConfigContext.getMode() != Mode.ON_DISK) {
+            return CompressionLevel.x1;
         }
-        return CompressionLevel.x1;
+        Version version = knnMethodConfigContext.getVersionCreated();
+        if (version != null && version.onOrAfter(Version.V_3_6_0)) {
+            return CompressionLevel.x32;
+        }
+        return priorVersionOnDiskDefault;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/AbstractMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/AbstractMethodResolver.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.engine;
 
+import org.opensearch.Version;
 import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -181,5 +182,31 @@ public abstract class AbstractMethodResolver implements MethodResolver {
             validationException.addValidationError("Cannot specify an encoder that conflicts with the provided compression level");
             throw validationException;
         }
+    }
+
+    /**
+     * Resolves the default compression level from the config context. If the compression level is explicitly
+     * configured, returns it directly. Otherwise, for ON_DISK mode on V_3_6_0+, returns x32; for ON_DISK mode
+     * on earlier versions, returns the provided fallback; otherwise returns x1.
+     *
+     * @param knnMethodConfigContext the config context
+     * @param priorVersionOnDiskDefault the default compression for ON_DISK mode before V_3_6_0
+     * @return the resolved default compression level
+     */
+    protected CompressionLevel getDefaultCompressionLevel(
+        KNNMethodConfigContext knnMethodConfigContext,
+        CompressionLevel priorVersionOnDiskDefault
+    ) {
+        if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())) {
+            return knnMethodConfigContext.getCompressionLevel();
+        }
+        if (knnMethodConfigContext.getMode() == Mode.ON_DISK) {
+            Version version = knnMethodConfigContext.getVersionCreated();
+            if (version != null && version.onOrAfter(Version.V_3_6_0)) {
+                return CompressionLevel.x32;
+            }
+            return priorVersionOnDiskDefault;
+        }
+        return CompressionLevel.x1;
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/Encoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/Encoder.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.engine;
 
+import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.Locale;
@@ -121,6 +122,19 @@ public interface Encoder {
      *          return {@link CompressionLevel#NOT_CONFIGURED}
      */
     CompressionLevel calculateCompressionLevel(MethodComponentContext encoderContext, KNNMethodConfigContext knnMethodConfigContext);
+
+    /**
+     * Validates encoder configuration for the create-index path.
+     * Throws ValidationException if the configuration is invalid.
+     * Training-specific validation remains in {@link #validateEncoderConfig(TrainingConfigValidationInput)}.
+     *
+     * @param resolvedMethodContext the resolved method context
+     * @param configContext method config context
+     * @throws ValidationException if validation fails
+     */
+    default void validate(KNNMethodContext resolvedMethodContext, KNNMethodConfigContext configContext) {
+        // no-op by default — encoders without validation constraints inherit this
+    }
 
     /**
      * Validates config of encoder

--- a/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.Locale;
 
+import static org.opensearch.knn.common.KNNConstants.KNN_DEFAULT_COMPRESSION_FLIP_VERSION;
 import static org.opensearch.knn.common.KNNConstants.METHOD_FLAT;
 import static org.opensearch.knn.index.engine.KNNEngine.DEPRECATED_ENGINES;
 
@@ -104,8 +105,18 @@ public final class EngineResolver {
         Mode mode = knnMethodConfigContext.getMode();
         CompressionLevel compressionLevel = knnMethodConfigContext.getCompressionLevel();
 
-        // If both mode and compression are not specified, we can just default
-        if (Mode.isConfigured(mode) == false && CompressionLevel.isConfigured(compressionLevel) == false) {
+        // Mode deprecation is tied to the default compression flip: log deprecation warning if user explicitly provided mode
+        if (version != null && version.onOrAfter(KNN_DEFAULT_COMPRESSION_FLIP_VERSION) && Mode.isConfigured(mode)) {
+            logger.warn(
+                "[Deprecation] The 'mode' parameter is deprecated starting with version "
+                    + KNN_DEFAULT_COMPRESSION_FLIP_VERSION
+                    + ". Mode is now derived from 'compression_level'. Explicitly setting 'mode' will be "
+                    + "removed in a future release."
+            );
+        }
+
+        // If compression is not specified, we can default unless mode is configured (legacy path)
+        if (CompressionLevel.isConfigured(compressionLevel) == false && Mode.isConfigured(mode) == false) {
             return KNNEngine.DEFAULT;
         }
 

--- a/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/EngineResolver.java
@@ -6,10 +6,9 @@
 package org.opensearch.knn.index.engine;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.Version;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.index.mapper.MapperParsingException;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.mapper.CompressionLevel;
@@ -26,7 +25,7 @@ import static org.opensearch.knn.index.engine.KNNEngine.DEPRECATED_ENGINES;
  */
 public final class EngineResolver {
 
-    private static Logger logger = LogManager.getLogger(EngineResolver.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(EngineResolver.class);
     public static final EngineResolver INSTANCE = new EngineResolver();
 
     private EngineResolver() {}
@@ -107,11 +106,11 @@ public final class EngineResolver {
 
         // Mode deprecation is tied to the default compression flip: log deprecation warning if user explicitly provided mode
         if (version != null && version.onOrAfter(KNN_DEFAULT_COMPRESSION_FLIP_VERSION) && Mode.isConfigured(mode)) {
-            logger.warn(
-                "[Deprecation] The 'mode' parameter is deprecated starting with version "
-                    + KNN_DEFAULT_COMPRESSION_FLIP_VERSION
-                    + ". Mode is now derived from 'compression_level'. Explicitly setting 'mode' will be "
-                    + "removed in a future release."
+            deprecationLogger.deprecate(
+                "knn_mode_parameter",
+                "The 'mode' parameter is deprecated starting with version {}. Mode is now derived from "
+                    + "'compression_level'. Explicitly setting 'mode' will be removed in a future release.",
+                KNN_DEFAULT_COMPRESSION_FLIP_VERSION
             );
         }
 
@@ -179,7 +178,11 @@ public final class EngineResolver {
 
     private KNNEngine logAndReturnEngine(KNNEngine knnEngine) {
         if (DEPRECATED_ENGINES.contains(knnEngine)) {
-            logger.warn("[Deprecation] {} engine is deprecated and will be removed in a future release.", knnEngine);
+            deprecationLogger.deprecate(
+                "knn_engine_deprecated",
+                "{} engine is deprecated and will be removed in a future release.",
+                knnEngine
+            );
         }
         return knnEngine;
     }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -292,9 +292,7 @@ public enum KNNEngine implements KNNLibrary {
         switch (this) {
             case LUCENE:
                 return LuceneFieldStrategy.INSTANCE;
-            case FAISS:
-                return FaissFieldStrategy.INSTANCE;
-            case NMSLIB:
+            case FAISS, NMSLIB:
                 return FaissFieldStrategy.INSTANCE;
             default:
                 throw new UnsupportedOperationException("Engine " + name + " does not support field strategies");

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -13,6 +13,9 @@ import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 import org.opensearch.knn.index.engine.faiss.Faiss;
 import org.opensearch.knn.index.engine.lucene.Lucene;
 import org.opensearch.knn.index.engine.nmslib.Nmslib;
+import org.opensearch.knn.index.mapper.EngineFieldStrategy;
+import org.opensearch.knn.index.mapper.FaissFieldStrategy;
+import org.opensearch.knn.index.mapper.LuceneFieldStrategy;
 import org.opensearch.remoteindexbuild.model.RemoteIndexParameters;
 
 import java.util.List;
@@ -276,5 +279,25 @@ public enum KNNEngine implements KNNLibrary {
     @Override
     public VectorSearcherFactory getVectorSearcherFactory() {
         return knnLibrary.getVectorSearcherFactory();
+    }
+
+    /**
+     * Returns the field strategy for this engine, used to construct field types
+     * and create vector fields during indexing.
+     *
+     * @return the engine's field strategy
+     * @throws UnsupportedOperationException if this engine does not support field strategies
+     */
+    public EngineFieldStrategy getFieldStrategy() {
+        switch (this) {
+            case LUCENE:
+                return LuceneFieldStrategy.INSTANCE;
+            case FAISS:
+                return FaissFieldStrategy.INSTANCE;
+            case NMSLIB:
+                return FaissFieldStrategy.INSTANCE;
+            default:
+                throw new UnsupportedOperationException("Engine " + name + " does not support field strategies");
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodConfigContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodConfigContext.java
@@ -29,10 +29,62 @@ public final class KNNMethodConfigContext {
     private VectorDataType vectorDataType;
     private Integer dimension;
     private Version versionCreated;
+    @Deprecated
     @Builder.Default
     private Mode mode = Mode.NOT_CONFIGURED;
     @Builder.Default
     private CompressionLevel compressionLevel = CompressionLevel.NOT_CONFIGURED;
+    /**
+     * Snapshot of the compression level as it was configured by the user, taken before method resolution
+     * overwrites {@link #compressionLevel} with an encoder-derived value (e.g. binary encoder bits=1
+     * resolves to x32). A null value means resolution has not overwritten the compression level, so
+     * {@link #compressionLevel} still holds the user-configured value.
+     */
+    @EqualsAndHashCode.Exclude
+    private CompressionLevel userConfiguredCompressionLevel;
 
     public static final KNNMethodConfigContext EMPTY = KNNMethodConfigContext.builder().build();
+
+    /**
+     * Sets the resolved compression level. On the first call, snapshots the current (user-configured)
+     * compression level so that consumers can distinguish compression the user explicitly requested from
+     * compression derived from the encoder during method resolution.
+     *
+     * @param compressionLevel the resolved compression level
+     */
+    public void setCompressionLevel(CompressionLevel compressionLevel) {
+        if (userConfiguredCompressionLevel == null) {
+            userConfiguredCompressionLevel = this.compressionLevel;
+        }
+        this.compressionLevel = compressionLevel;
+    }
+
+    /**
+     * Returns the compression level explicitly configured by the user, which may differ from
+     * {@link #getCompressionLevel()} when resolution derived the compression from the encoder. Mode
+     * derivation must be based on this value: a user asking for compression_level=32x implies on_disk
+     * behavior, but an encoder that internally maps to x32 does not.
+     *
+     * @return the user-configured compression level
+     */
+    public CompressionLevel getUserConfiguredCompressionLevel() {
+        return userConfiguredCompressionLevel == null ? compressionLevel : userConfiguredCompressionLevel;
+    }
+
+    /**
+     * Derives the appropriate {@link Mode} from the given {@link CompressionLevel}.
+     * For V_3_7_0+ indices, mode is derived from compression rather than being an independent axis.
+     *
+     * @param compressionLevel the compression level to derive mode from
+     * @return the derived mode
+     */
+    public static Mode deriveMode(CompressionLevel compressionLevel) {
+        if (!CompressionLevel.isConfigured(compressionLevel)) {
+            return Mode.NOT_CONFIGURED;
+        }
+        if (compressionLevel == CompressionLevel.x1 || compressionLevel == CompressionLevel.x2) {
+            return Mode.IN_MEMORY;
+        }
+        return Mode.ON_DISK;
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodConfigContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodConfigContext.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.knn.index.engine;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -23,7 +22,6 @@ import org.opensearch.knn.index.mapper.Mode;
 @Setter
 @Getter
 @Builder
-@AllArgsConstructor
 @EqualsAndHashCode
 public final class KNNMethodConfigContext {
     private VectorDataType vectorDataType;
@@ -35,45 +33,39 @@ public final class KNNMethodConfigContext {
     @Builder.Default
     private CompressionLevel compressionLevel = CompressionLevel.NOT_CONFIGURED;
     /**
-     * Snapshot of the compression level as it was configured by the user, taken before method resolution
-     * overwrites {@link #compressionLevel} with an encoder-derived value (e.g. binary encoder bits=1
-     * resolves to x32). A null value means resolution has not overwritten the compression level, so
-     * {@link #compressionLevel} still holds the user-configured value.
+     * Snapshot of the compression level as it was configured by the user, captured at construction time
+     * before method resolution overwrites {@link #compressionLevel} with an encoder-derived value (e.g.
+     * binary encoder bits=1 resolves to x32). Mode derivation must be based on this value: a user asking
+     * for compression_level=32x implies on_disk behavior, but an encoder that internally maps to x32
+     * does not.
      */
     @EqualsAndHashCode.Exclude
-    private CompressionLevel userConfiguredCompressionLevel;
+    private final CompressionLevel userConfiguredCompressionLevel;
 
     public static final KNNMethodConfigContext EMPTY = KNNMethodConfigContext.builder().build();
 
-    /**
-     * Sets the resolved compression level. On the first call, snapshots the current (user-configured)
-     * compression level so that consumers can distinguish compression the user explicitly requested from
-     * compression derived from the encoder during method resolution.
-     *
-     * @param compressionLevel the resolved compression level
-     */
-    public void setCompressionLevel(CompressionLevel compressionLevel) {
-        if (userConfiguredCompressionLevel == null) {
-            userConfiguredCompressionLevel = this.compressionLevel;
-        }
+    KNNMethodConfigContext(
+        VectorDataType vectorDataType,
+        Integer dimension,
+        Version versionCreated,
+        Mode mode,
+        CompressionLevel compressionLevel,
+        CompressionLevel userConfiguredCompressionLevel
+    ) {
+        this.vectorDataType = vectorDataType;
+        this.dimension = dimension;
+        this.versionCreated = versionCreated;
+        this.mode = mode;
         this.compressionLevel = compressionLevel;
-    }
-
-    /**
-     * Returns the compression level explicitly configured by the user, which may differ from
-     * {@link #getCompressionLevel()} when resolution derived the compression from the encoder. Mode
-     * derivation must be based on this value: a user asking for compression_level=32x implies on_disk
-     * behavior, but an encoder that internally maps to x32 does not.
-     *
-     * @return the user-configured compression level
-     */
-    public CompressionLevel getUserConfiguredCompressionLevel() {
-        return userConfiguredCompressionLevel == null ? compressionLevel : userConfiguredCompressionLevel;
+        // At build time, compressionLevel still holds the user's value since resolution has not run yet.
+        // Callers reconstructing a context post-resolution (e.g. mapper merge) pass the user value explicitly.
+        this.userConfiguredCompressionLevel = userConfiguredCompressionLevel == null ? compressionLevel : userConfiguredCompressionLevel;
     }
 
     /**
      * Derives the appropriate {@link Mode} from the given {@link CompressionLevel}.
-     * For V_3_7_0+ indices, mode is derived from compression rather than being an independent axis.
+     * Starting with {@code KNNConstants.KNN_DEFAULT_COMPRESSION_FLIP_VERSION} (V_3_8_0), mode is derived
+     * from compression rather than being an independent axis.
      *
      * @param compressionLevel the compression level to derive mode from
      * @return the derived mode

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoder.java
@@ -99,6 +99,22 @@ public abstract class AbstractFaissPQEncoder implements Encoder {
     }
 
     @Override
+    public void validate(KNNMethodContext resolvedMethodContext, KNNMethodConfigContext configContext) {
+        if (resolvedMethodContext == null || configContext == null) {
+            return;
+        }
+        if (resolvedMethodContext.getMethodComponentContext().getParameters().containsKey(ENCODER_PARAMETER_PQ_M)
+            && configContext.getDimension() != null
+            && configContext.getDimension() % (Integer) resolvedMethodContext.getMethodComponentContext()
+                .getParameters()
+                .get(ENCODER_PARAMETER_PQ_M) != 0) {
+            ValidationException validationException = new ValidationException();
+            validationException.addValidationError("Training request ENCODER_PARAMETER_PQ_M is not divisible by vector dimensions");
+            throw validationException;
+        }
+    }
+
+    @Override
     public TrainingConfigValidationOutput validateEncoderConfig(TrainingConfigValidationInput trainingConfigValidationInput) {
         KNNMethodContext knnMethodContext = trainingConfigValidationInput.getKnnMethodContext();
         KNNMethodConfigContext knnMethodConfigContext = trainingConfigValidationInput.getKnnMethodConfigContext();

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolver.java
@@ -16,10 +16,7 @@ import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.ResolvedMethodContext;
-import org.opensearch.knn.index.engine.TrainingConfigValidationInput;
-import org.opensearch.knn.index.engine.TrainingConfigValidationOutput;
 import org.opensearch.knn.index.mapper.CompressionLevel;
-import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -192,27 +189,11 @@ public class FaissMethodResolver extends AbstractMethodResolver {
             return;
         }
 
-        TrainingConfigValidationInput.TrainingConfigValidationInputBuilder inputBuilder = TrainingConfigValidationInput.builder();
-
-        TrainingConfigValidationOutput validationOutput = encoder.validateEncoderConfig(
-            inputBuilder.knnMethodContext(resolvedKnnMethodContext).knnMethodConfigContext(knnMethodConfigContext).build()
-        );
-
-        if (validationOutput.getValid() != null && !validationOutput.getValid()) {
-            ValidationException validationException = new ValidationException();
-            validationException.addValidationError(validationOutput.getErrorMessage());
-            throw validationException;
-        }
+        encoder.validate(resolvedKnnMethodContext, knnMethodConfigContext);
     }
 
     private CompressionLevel getDefaultCompressionLevel(KNNMethodConfigContext knnMethodConfigContext) {
-        if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())) {
-            return knnMethodConfigContext.getCompressionLevel();
-        }
-        if (knnMethodConfigContext.getMode() == Mode.ON_DISK) {
-            return CompressionLevel.x32;
-        }
-        return CompressionLevel.x1;
+        return getDefaultCompressionLevel(knnMethodConfigContext, CompressionLevel.x32);
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoder.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.engine.faiss;
 
 import com.google.common.collect.ImmutableSet;
 import org.opensearch.Version;
+import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContextImpl;
@@ -117,26 +118,17 @@ public class FaissSQEncoder implements Encoder {
         return CompressionLevel.x2;
     }
 
-    // TODO: The Encoder interface's validateEncoderConfig uses TrainingConfigValidation* types that were
-    // designed for model training. We should add a general-purpose validation method to the Encoder interface
-    // (e.g. Encoder.validate(KNNMethodContext, KNNMethodConfigContext)) that both Faiss and Lucene resolvers
-    // can delegate to, decoupled from training concerns. See LuceneHNSWMethodResolver.validateEncoderParams()
-    // for the Lucene equivalent that avoids the training interface.
     @Override
-    public TrainingConfigValidationOutput validateEncoderConfig(TrainingConfigValidationInput validationInput) {
-        TrainingConfigValidationOutput.TrainingConfigValidationOutputBuilder builder = TrainingConfigValidationOutput.builder();
-        KNNMethodContext knnMethodContext = validationInput.getKnnMethodContext();
-        KNNMethodConfigContext configContext = validationInput.getKnnMethodConfigContext();
-
-        if (knnMethodContext == null || configContext == null) {
-            return builder.build();
+    public void validate(KNNMethodContext resolvedMethodContext, KNNMethodConfigContext configContext) {
+        if (resolvedMethodContext == null || configContext == null) {
+            return;
         }
 
-        MethodComponentContext encoderContext = (MethodComponentContext) knnMethodContext.getMethodComponentContext()
+        MethodComponentContext encoderContext = (MethodComponentContext) resolvedMethodContext.getMethodComponentContext()
             .getParameters()
             .get(METHOD_ENCODER_PARAMETER);
         if (encoderContext == null) {
-            return builder.build();
+            return;
         }
 
         Map<String, Object> encoderParams = encoderContext.getParameters();
@@ -146,92 +138,92 @@ public class FaissSQEncoder implements Encoder {
         boolean hasType = encoderParams.containsKey(FAISS_SQ_TYPE);
         boolean hasClip = encoderParams.containsKey(FAISS_SQ_CLIP);
 
-        // On 3.6.0+, bits is required when the user explicitly specifies the sq encoder for FLOAT data
+        ValidationException validationException = new ValidationException();
+
         if (isV360OrLater && bitsObj == null && configContext.getVectorDataType() == VectorDataType.FLOAT) {
-            return builder.valid(false)
-                .errorMessage(
-                    String.format(
-                        Locale.ROOT,
-                        "Parameter [%s] is required for encoder [%s] on indices created with version 3.6.0 or later. "
-                            + "Supported values: %s",
-                        SQ_BITS,
-                        ENCODER_SQ,
-                        VALID_BITS
-                    )
+            validationException.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "Parameter [%s] is required for encoder [%s] on indices created with version 3.6.0 or later. " + "Supported values: %s",
+                    SQ_BITS,
+                    ENCODER_SQ,
+                    VALID_BITS
                 )
-                .build();
+            );
+            throw validationException;
         }
 
-        // Reject invalid bits values with original error message (BWC)
         if (bitsObj instanceof Integer && !VALID_BITS.contains((Integer) bitsObj)) {
-            return builder.valid(false)
-                .errorMessage(String.format(Locale.ROOT, "Unsupported bits value: %d. Supported values: %s", (Integer) bitsObj, VALID_BITS))
-                .build();
+            validationException.addValidationError(
+                String.format(Locale.ROOT, "Unsupported bits value: %d. Supported values: %s", (Integer) bitsObj, VALID_BITS)
+            );
+            throw validationException;
         }
 
         if (bitsObj instanceof Integer) {
             int bits = (Integer) bitsObj;
 
-            // type and clip is only applicable for fp16 (bits=16)
             if (QuantizationBits.SIXTEEN.getValue() != bits) {
                 if (hasType) {
-                    return builder.valid(false)
-                        .errorMessage(
-                            String.format(
-                                Locale.ROOT,
-                                "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
-                                    + "The type parameter is only applicable for fp16 quantization (bits=16).",
-                                FAISS_SQ_TYPE,
-                                SQ_BITS,
-                                bits,
-                                ENCODER_SQ
-                            )
+                    validationException.addValidationError(
+                        String.format(
+                            Locale.ROOT,
+                            "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
+                                + "The type parameter is only applicable for fp16 quantization (bits=16).",
+                            FAISS_SQ_TYPE,
+                            SQ_BITS,
+                            bits,
+                            ENCODER_SQ
                         )
-                        .build();
+                    );
+                    throw validationException;
                 }
 
                 if (hasClip) {
-                    return builder.valid(false)
-                        .errorMessage(
-                            String.format(
-                                Locale.ROOT,
-                                "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
-                                    + "Clipping is only applicable for fp16 quantization (bits=16).",
-                                FAISS_SQ_CLIP,
-                                SQ_BITS,
-                                bits,
-                                ENCODER_SQ
-                            )
+                    validationException.addValidationError(
+                        String.format(
+                            Locale.ROOT,
+                            "Parameter [%s] is not supported when [%s=%d] for encoder [%s]. "
+                                + "Clipping is only applicable for fp16 quantization (bits=16).",
+                            FAISS_SQ_CLIP,
+                            SQ_BITS,
+                            bits,
+                            ENCODER_SQ
                         )
-                        .build();
+                    );
+                    throw validationException;
                 }
-
             }
 
-            // Validate compression level compatibility if explicitly set
             CompressionLevel configuredCompression = configContext.getCompressionLevel();
             if (CompressionLevel.isConfigured(configuredCompression)) {
                 CompressionLevel expectedCompression = QuantizationBits.fromValue(bits).getCompressionLevel();
                 if (configuredCompression != expectedCompression) {
-                    return builder.valid(false)
-                        .errorMessage(
-                            String.format(
-                                Locale.ROOT,
-                                "Compression level [%s] is incompatible with [%s=%d] for encoder [%s]. "
-                                    + "Expected compression level: [%s]",
-                                configuredCompression.getName(),
-                                SQ_BITS,
-                                bits,
-                                ENCODER_SQ,
-                                expectedCompression.getName()
-                            )
+                    validationException.addValidationError(
+                        String.format(
+                            Locale.ROOT,
+                            "Compression level [%s] is incompatible with [%s=%d] for encoder [%s]. " + "Expected compression level: [%s]",
+                            configuredCompression.getName(),
+                            SQ_BITS,
+                            bits,
+                            ENCODER_SQ,
+                            expectedCompression.getName()
                         )
-                        .build();
+                    );
+                    throw validationException;
                 }
             }
         }
+    }
 
-        return builder.build();
+    @Override
+    public TrainingConfigValidationOutput validateEncoderConfig(TrainingConfigValidationInput validationInput) {
+        try {
+            validate(validationInput.getKnnMethodContext(), validationInput.getKnnMethodConfigContext());
+            return TrainingConfigValidationOutput.builder().build();
+        } catch (ValidationException e) {
+            return TrainingConfigValidationOutput.builder().valid(false).errorMessage(e.getMessage()).build();
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolver.java
@@ -19,12 +19,9 @@ import org.opensearch.knn.index.engine.ResolvedMethodContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SCALAR_QUANTIZER_DEFAULT_BITS_AFTER_V360;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_DEFAULT_BITS;
@@ -32,9 +29,6 @@ import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_HNSW;
 import static org.opensearch.knn.index.engine.lucene.LuceneHNSWMethod.HNSW_METHOD_COMPONENT;
 import static org.opensearch.knn.index.engine.lucene.LuceneHNSWMethod.SUPPORTED_ENCODERS;
-import static org.opensearch.knn.index.engine.lucene.LuceneSQEncoder.Bits;
-import static org.opensearch.knn.index.engine.lucene.LuceneSQEncoder.LUCENE_PRE_360_SUPPORTED_SQ_BITS;
-import static org.opensearch.knn.index.engine.lucene.LuceneSQEncoder.LUCENE_SQ_BITS_SUPPORTED;
 
 /**
  * Resolves method configuration for the Lucene HNSW method. Supports optional scalar quantization
@@ -162,100 +156,5 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
 
     private CompressionLevel getDefaultCompressionLevel(KNNMethodConfigContext knnMethodConfigContext) {
         return getDefaultCompressionLevel(knnMethodConfigContext, CompressionLevel.x4);
-    }
-
-    // TODO: The Encoder interface currently only has validateEncoderConfig() which uses
-    // TrainingConfigValidation* types designed for model training. We should add a general-purpose
-    // validation method to the Encoder interface (e.g. Encoder.validate(KNNMethodContext, KNNMethodConfigContext))
-    // that both Faiss and Lucene resolvers can delegate to, decoupled from training concerns.
-    // See: FaissSQEncoder.validateEncoderConfig() for the Faiss equivalent of this validation.
-    protected static void validateEncoderParams(KNNMethodContext resolvedMethodContext, KNNMethodConfigContext configContext) {
-        if (resolvedMethodContext == null || configContext == null) {
-            return;
-        }
-
-        MethodComponentContext encoderContext = (MethodComponentContext) resolvedMethodContext.getMethodComponentContext()
-            .getParameters()
-            .get(METHOD_ENCODER_PARAMETER);
-        if (encoderContext == null) {
-            return;
-        }
-
-        Map<String, Object> encoderParams = encoderContext.getParameters();
-        Version version = configContext.getVersionCreated();
-        boolean isV360OrLater = version != null && version.onOrAfter(Version.V_3_6_0);
-        Object bitsObj = encoderParams.get(LUCENE_SQ_BITS);
-        Set<String> nonBitParameters = encoderParams.keySet().stream().filter(k -> !k.equals(LUCENE_SQ_BITS)).collect(Collectors.toSet());
-
-        ValidationException validationException = new ValidationException();
-
-        // On 3.6.0+, bits is required when the user explicitly specifies the lucene sq encoder
-        if (isV360OrLater && bitsObj == null) {
-            validationException.addValidationError(
-                String.format(
-                    Locale.ROOT,
-                    "Parameter [%s] is required for encoder [%s] on indices created with version 3.6.0 or later. " + "Supported values: %s",
-                    LUCENE_SQ_BITS,
-                    ENCODER_SQ,
-                    LUCENE_SQ_BITS_SUPPORTED
-                )
-            );
-            throw validationException;
-        }
-
-        if (bitsObj instanceof Integer) {
-            int bits = (Integer) bitsObj;
-
-            // bits=1 does not support other parameters
-            if (bits == Bits.ONE.getValue()) {
-                if (!nonBitParameters.isEmpty()) {
-                    validationException.addValidationError(
-                        String.format(
-                            Locale.ROOT,
-                            "Parameters [%s] are not supported when [%s=%d] for encoder [%s]. "
-                                + "The 1-bit scalar quantization path does not use additional parameters.",
-                            nonBitParameters,
-                            LUCENE_SQ_BITS,
-                            bits,
-                            ENCODER_SQ
-                        )
-                    );
-                    throw validationException;
-                }
-                if (!isV360OrLater) {
-                    validationException.addValidationError(
-                        String.format(
-                            Locale.ROOT,
-                            "Parameter [%s=%d] is only supported for indices created with version 3.6.0 or later. "
-                                + "Supported values: %s",
-                            LUCENE_SQ_BITS,
-                            bits,
-                            LUCENE_PRE_360_SUPPORTED_SQ_BITS
-                        )
-                    );
-                    throw validationException;
-                }
-            }
-
-            // Validate compression level compatibility if explicitly set
-            CompressionLevel configuredCompression = configContext.getCompressionLevel();
-            if (CompressionLevel.isConfigured(configuredCompression)) {
-                CompressionLevel expectedCompression = Bits.fromValue(bits).getCompressionLevel();
-                if (configuredCompression != expectedCompression) {
-                    validationException.addValidationError(
-                        String.format(
-                            Locale.ROOT,
-                            "Compression level [%s] is incompatible with [%s=%d] for encoder [%s]. " + "Expected compression level: [%s]",
-                            configuredCompression.getName(),
-                            LUCENE_SQ_BITS,
-                            bits,
-                            ENCODER_SQ,
-                            expectedCompression.getName()
-                        )
-                    );
-                    throw validationException;
-                }
-            }
-        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolver.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolver.java
@@ -17,7 +17,6 @@ import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.ResolvedMethodContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
-import org.opensearch.knn.index.mapper.Mode;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -39,9 +38,7 @@ import static org.opensearch.knn.index.engine.lucene.LuceneSQEncoder.LUCENE_SQ_B
 
 /**
  * Resolves method configuration for the Lucene HNSW method. Supports optional scalar quantization
- * encoding and {@link org.opensearch.knn.index.mapper.Mode}-based compression resolution, with
- * supported compression levels of {@link org.opensearch.knn.index.mapper.CompressionLevel#x1} and
- * {@link org.opensearch.knn.index.mapper.CompressionLevel#x4}.
+ * encoding and compression-level-based resolution, with supported compression levels of x1, x4, and x32.
  */
 public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
 
@@ -142,12 +139,10 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
         String encoderName = encoderComponentContext.getName();
         Encoder encoder = SUPPORTED_ENCODERS.get(encoderName);
 
-        // Skip the additional validation at the end if not using SQ
-        // TODO: Once validateEncoderParams is defined as an interface method, we can clean this up
-        if (encoder == null || !encoderName.equals(ENCODER_SQ)) {
+        if (encoder == null) {
             return;
         }
-        validateEncoderParams(resolvedKNNMethodContext, knnMethodConfigContext);
+        encoder.validate(resolvedKNNMethodContext, knnMethodConfigContext);
     }
 
     // Method validates for explicit contradictions in the config
@@ -166,17 +161,7 @@ public class LuceneHNSWMethodResolver extends AbstractMethodResolver {
     }
 
     private CompressionLevel getDefaultCompressionLevel(KNNMethodConfigContext knnMethodConfigContext) {
-        if (CompressionLevel.isConfigured(knnMethodConfigContext.getCompressionLevel())) {
-            return knnMethodConfigContext.getCompressionLevel();
-        }
-        if (knnMethodConfigContext.getMode() == Mode.ON_DISK) {
-            // Starting with version 3.6, supporting 32x compression by default
-            if (Version.V_3_6_0.onOrBefore(knnMethodConfigContext.getVersionCreated())) {
-                return CompressionLevel.x32;
-            }
-            return CompressionLevel.x4;
-        }
-        return CompressionLevel.x1;
+        return getDefaultCompressionLevel(knnMethodConfigContext, CompressionLevel.x4);
     }
 
     // TODO: The Encoder interface currently only has validateEncoderConfig() which uses

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
@@ -85,6 +85,22 @@ public class LuceneSQEncoder implements Encoder {
         )
         .build();
 
+    /**
+     * Validates the SQ encoder configuration on the resolved method context. Checks performed:
+     * <ul>
+     *     <li>The {@code bits} parameter is required on indices created with version 3.6.0 or later and must be a
+     *     supported value (see {@link #LUCENE_SQ_BITS_SUPPORTED}); {@code bits=1} is rejected on earlier versions.</li>
+     *     <li>The {@code bits} value must be compatible with any explicitly configured compression level
+     *     (e.g. {@code bits=1} requires x32 compression, {@code bits=7} requires x4).</li>
+     *     <li>Non-bit parameters (e.g. {@code confidence_interval}) are rejected when {@code bits=1}, since the
+     *     1-bit scalar quantization path does not use them.</li>
+     * </ul>
+     * Returns silently without validation if either the method context or the config context is null.
+     *
+     * @param resolvedMethodContext the resolved method context containing the encoder parameters
+     * @param configContext the config context containing index version and compression level
+     * @throws ValidationException if any of the above checks fail
+     */
     @Override
     public void validate(KNNMethodContext resolvedMethodContext, KNNMethodConfigContext configContext) {
         if (resolvedMethodContext == null || configContext == null) {
@@ -102,7 +118,6 @@ public class LuceneSQEncoder implements Encoder {
         Version version = configContext.getVersionCreated();
         boolean isV360OrLater = version != null && version.onOrAfter(Version.V_3_6_0);
         Object bitsObj = encoderParams.get(LUCENE_SQ_BITS);
-        Set<String> nonBitParameters = encoderParams.keySet().stream().filter(k -> !k.equals(LUCENE_SQ_BITS)).collect(Collectors.toSet());
 
         ValidationException validationException = new ValidationException();
 
@@ -119,10 +134,12 @@ public class LuceneSQEncoder implements Encoder {
             throw validationException;
         }
 
-        if (bitsObj instanceof Integer) {
-            int bits = (Integer) bitsObj;
-
+        if (bitsObj instanceof Integer bits) {
             if (bits == Bits.ONE.getValue()) {
+                Set<String> nonBitParameters = encoderParams.keySet()
+                    .stream()
+                    .filter(k -> !k.equals(LUCENE_SQ_BITS))
+                    .collect(Collectors.toSet());
                 if (!nonBitParameters.isEmpty()) {
                     validationException.addValidationError(
                         String.format(

--- a/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
+++ b/src/main/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoder.java
@@ -11,9 +11,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import org.opensearch.Version;
+import org.opensearch.common.ValidationException;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.Parameter;
@@ -22,6 +24,7 @@ import org.opensearch.knn.index.mapper.CompressionLevel;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,6 +33,7 @@ import static org.opensearch.knn.common.KNNConstants.ENCODER_SQ;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_BITS;
 import static org.opensearch.knn.common.KNNConstants.LUCENE_SQ_CONFIDENCE_INTERVAL;
 import static org.opensearch.knn.common.KNNConstants.MAXIMUM_CONFIDENCE_INTERVAL;
+import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.MINIMUM_CONFIDENCE_INTERVAL;
 
 /**
@@ -80,6 +84,94 @@ public class LuceneSQEncoder implements Encoder {
             new Parameter.IntegerParameter(LUCENE_SQ_BITS, null, (v, context) -> LUCENE_SQ_BITS_SUPPORTED.contains(v))
         )
         .build();
+
+    @Override
+    public void validate(KNNMethodContext resolvedMethodContext, KNNMethodConfigContext configContext) {
+        if (resolvedMethodContext == null || configContext == null) {
+            return;
+        }
+
+        MethodComponentContext encoderContext = (MethodComponentContext) resolvedMethodContext.getMethodComponentContext()
+            .getParameters()
+            .get(METHOD_ENCODER_PARAMETER);
+        if (encoderContext == null) {
+            return;
+        }
+
+        Map<String, Object> encoderParams = encoderContext.getParameters();
+        Version version = configContext.getVersionCreated();
+        boolean isV360OrLater = version != null && version.onOrAfter(Version.V_3_6_0);
+        Object bitsObj = encoderParams.get(LUCENE_SQ_BITS);
+        Set<String> nonBitParameters = encoderParams.keySet().stream().filter(k -> !k.equals(LUCENE_SQ_BITS)).collect(Collectors.toSet());
+
+        ValidationException validationException = new ValidationException();
+
+        if (isV360OrLater && bitsObj == null) {
+            validationException.addValidationError(
+                String.format(
+                    Locale.ROOT,
+                    "Parameter [%s] is required for encoder [%s] on indices created with version 3.6.0 or later. " + "Supported values: %s",
+                    LUCENE_SQ_BITS,
+                    ENCODER_SQ,
+                    LUCENE_SQ_BITS_SUPPORTED
+                )
+            );
+            throw validationException;
+        }
+
+        if (bitsObj instanceof Integer) {
+            int bits = (Integer) bitsObj;
+
+            if (bits == Bits.ONE.getValue()) {
+                if (!nonBitParameters.isEmpty()) {
+                    validationException.addValidationError(
+                        String.format(
+                            Locale.ROOT,
+                            "Parameters [%s] are not supported when [%s=%d] for encoder [%s]. "
+                                + "The 1-bit scalar quantization path does not use additional parameters.",
+                            nonBitParameters,
+                            LUCENE_SQ_BITS,
+                            bits,
+                            ENCODER_SQ
+                        )
+                    );
+                    throw validationException;
+                }
+                if (!isV360OrLater) {
+                    validationException.addValidationError(
+                        String.format(
+                            Locale.ROOT,
+                            "Parameter [%s=%d] is only supported for indices created with version 3.6.0 or later. "
+                                + "Supported values: %s",
+                            LUCENE_SQ_BITS,
+                            bits,
+                            LUCENE_PRE_360_SUPPORTED_SQ_BITS
+                        )
+                    );
+                    throw validationException;
+                }
+            }
+
+            CompressionLevel configuredCompression = configContext.getCompressionLevel();
+            if (CompressionLevel.isConfigured(configuredCompression)) {
+                CompressionLevel expectedCompression = Bits.fromValue(bits).getCompressionLevel();
+                if (configuredCompression != expectedCompression) {
+                    validationException.addValidationError(
+                        String.format(
+                            Locale.ROOT,
+                            "Compression level [%s] is incompatible with [%s=%d] for encoder [%s]. " + "Expected compression level: [%s]",
+                            configuredCompression.getName(),
+                            LUCENE_SQ_BITS,
+                            bits,
+                            ENCODER_SQ,
+                            expectedCompression.getName()
+                        )
+                    );
+                    throw validationException;
+                }
+            }
+        }
+    }
 
     @Override
     public MethodComponent getMethodComponent() {

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -7,49 +7,19 @@ package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.opensearch.Version;
 import org.opensearch.common.Explicit;
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.knn.index.DerivedKnnByteVectorField;
-import org.opensearch.knn.index.DerivedKnnFloatVectorField;
-import org.opensearch.knn.index.KNNVectorSimilarityFunction;
-import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
-import org.opensearch.knn.index.VectorField;
-import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
-import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.engine.ResolvedIndexSpec;
-import org.opensearch.knn.index.engine.faiss.FaissSQEncoder;
-import org.opensearch.knn.index.engine.faiss.SQConfig;
-import org.opensearch.knn.index.engine.faiss.SQConfigParser;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
-import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.opensearch.knn.common.KNNConstants.DIMENSION;
-import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
-import static org.opensearch.knn.common.KNNConstants.SQ_BITS;
-import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
-import static org.opensearch.knn.common.KNNConstants.METHOD_ENCODER_PARAMETER;
-import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
-import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
-import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
-import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForByteVector;
-import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForFloatVector;
 
 /**
  *  Field mapper for all supported engines.
@@ -61,7 +31,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
     private final PerDimensionValidator perDimensionValidator;
     private final VectorValidator vectorValidator;
     private final VectorTransformer vectorTransformer;
-    private final boolean isLuceneEngine;
+    private final EngineFieldStrategy fieldStrategy;
 
     public static EngineFieldMapper createFieldMapper(
         String fullname,
@@ -79,7 +49,6 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         KNNMethodContext methodContext = originalMappingParameters.getResolvedKnnMethodContext();
         KNNLibraryIndexingContext libraryContext = methodContext.getKnnEngine()
             .getKNNLibraryIndexingContext(methodContext, knnMethodConfigContext);
-        boolean isLuceneEngine = KNNEngine.LUCENE.equals(methodContext.getKnnEngine());
         ResolvedIndexSpec resolvedSpec = libraryContext.getResolvedSpec();
 
         KNNVectorFieldType mappedFieldType = new KNNVectorFieldType(
@@ -137,8 +106,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
             stored,
             hasDocValues,
             knnMethodConfigContext,
-            originalMappingParameters,
-            isLuceneEngine
+            originalMappingParameters
         );
     }
 
@@ -151,8 +119,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         boolean stored,
         boolean hasDocValues,
         KNNMethodConfigContext knnMethodConfigContext,
-        OriginalMappingParameters originalMappingParameters,
-        boolean isLuceneEngine
+        OriginalMappingParameters originalMappingParameters
     ) {
         super(
             name,
@@ -165,114 +132,49 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
             knnMethodConfigContext.getVersionCreated(),
             originalMappingParameters
         );
-        this.isLuceneEngine = isLuceneEngine;
         updateEngineStats();
+
         KNNMappingConfig knnMappingConfig = mappedFieldType.getKnnMappingConfig();
         VectorDataType vectorDataType = mappedFieldType.getVectorDataType();
         KNNMethodContext resolvedKnnMethodContext = originalMappingParameters.getResolvedKnnMethodContext();
+        KNNEngine knnEngine = resolvedKnnMethodContext.getKnnEngine();
+        KNNLibraryIndexingContext knnLibraryIndexingContext = knnEngine.getKNNLibraryIndexingContext(
+            resolvedKnnMethodContext,
+            knnMethodConfigContext
+        );
 
-        final KNNVectorSimilarityFunction knnVectorSimilarityFunction = resolvedKnnMethodContext.getSpaceType()
-            .getKnnVectorSimilarityFunction();
-        KNNLibraryIndexingContext knnLibraryIndexingContext = resolvedKnnMethodContext.getKnnEngine()
-            .getKNNLibraryIndexingContext(resolvedKnnMethodContext, knnMethodConfigContext);
+        this.fieldStrategy = knnEngine.getFieldStrategy();
+        FieldTypeConfig config = fieldStrategy.buildFieldTypeConfig(
+            knnMappingConfig,
+            resolvedKnnMethodContext,
+            knnLibraryIndexingContext,
+            vectorDataType,
+            indexCreatedVersion,
+            hasDocValues
+        );
 
-        // LuceneFieldMapper attributes
-        if (this.isLuceneEngine) {
-            this.fieldType = vectorDataType.createKnnVectorFieldType(knnMappingConfig.getDimension(), knnVectorSimilarityFunction);
+        this.fieldType = config.getFieldType();
+        this.vectorFieldType = config.getVectorFieldType();
+        this.vectorTransformer = config.getVectorTransformer();
+        this.useLuceneBasedVectorField = config.isUseLuceneBasedVectorField();
 
-            if (this.hasDocValues) {
-                this.vectorFieldType = buildDocValuesFieldType(resolvedKnnMethodContext.getKnnEngine());
-            } else {
-                this.vectorFieldType = null;
-            }
-            this.vectorTransformer = null;
-        } else {
-            // MethodFieldMapper attributes
-            this.vectorFieldType = null;
-            this.useLuceneBasedVectorField = KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(indexCreatedVersion);
-            KNNEngine knnEngine = resolvedKnnMethodContext.getKnnEngine();
-            QuantizationConfig quantizationConfig = knnLibraryIndexingContext.getQuantizationConfig();
-            this.fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
-            this.fieldType.putAttribute(DIMENSION, String.valueOf(knnMappingConfig.getDimension()));
-            this.fieldType.putAttribute(SPACE_TYPE, resolvedKnnMethodContext.getSpaceType().getValue());
-
-            ResolvedIndexSpec spec = knnLibraryIndexingContext.getResolvedSpec();
-            // 1-bit quantization has its own per-field format that handles quantization internally,
-            // so we set sq_config instead of qframe_config
-            if (spec.isSQOneBit()) {
-                SQConfig sqConfig = SQConfig.builder().bits(spec.getQuantizationBits().getValue()).build();
-                this.fieldType.putAttribute(SQ_CONFIG, SQConfigParser.toCsv(sqConfig));
-            } else {
-                // Conditionally add quantization config
-                if (quantizationConfig != null && quantizationConfig != QuantizationConfig.EMPTY) {
-                    this.fieldType.putAttribute(QFRAMEWORK_CONFIG, QuantizationConfigParser.toCsv(quantizationConfig));
-                }
-            }
-
-            this.fieldType.putAttribute(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
-            this.fieldType.putAttribute(KNN_ENGINE, knnEngine.getName());
-            try {
-                this.fieldType.putAttribute(
-                    PARAMETERS,
-                    XContentFactory.jsonBuilder().map(knnLibraryIndexingContext.getLibraryParameters()).toString()
-                );
-            } catch (IOException ioe) {
-                throw new RuntimeException(String.format("Unable to create KNNVectorFieldMapper: %s", ioe), ioe);
-            }
-
-            if (useLuceneBasedVectorField) {
-                int adjustedDimension = mappedFieldType.vectorDataType == VectorDataType.BINARY
-                    ? knnMappingConfig.getDimension() / 8
-                    : knnMappingConfig.getDimension();
-                final VectorEncoding encoding = mappedFieldType.vectorDataType == VectorDataType.FLOAT
-                    ? VectorEncoding.FLOAT32
-                    : VectorEncoding.BYTE;
-                final VectorSimilarityFunction similarityFunction = findBestMatchingVectorSimilarityFunction(
-                    resolvedKnnMethodContext.getSpaceType()
-                );
-                fieldType.setVectorAttributes(adjustedDimension, encoding, similarityFunction);
-            } else {
-                fieldType.setDocValuesType(DocValuesType.BINARY);
-            }
-
-            this.fieldType.freeze();
-            this.vectorTransformer = knnLibraryIndexingContext.getVectorTransformer();
-        }
-
-        // Common Attributes
         this.perDimensionProcessor = knnLibraryIndexingContext.getPerDimensionProcessor();
         this.perDimensionValidator = knnLibraryIndexingContext.getPerDimensionValidator();
         this.vectorValidator = knnLibraryIndexingContext.getVectorValidator();
     }
 
-    private VectorSimilarityFunction findBestMatchingVectorSimilarityFunction(final SpaceType spaceType) {
-        if (indexCreatedVersion.onOrAfter(Version.V_3_0_0)) {
-            // We need to find the best matching similarity function and not just save DEFAULT space type after 3.0.
-            // This is required for memory optimized search where utilizing .vec file to retrieve vectors.
-            // During the retrieval, it will locate similarity function from the meta info. Without this best effort, always the default
-            // similarity function will be used even when other space type is configured in a mapping.
-            // However, for keeping the backward compatibility, we only apply this to indices created after 3.0+.
-            try {
-                return spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
-            } catch (Exception e) {
-                // ignore
-            }
-        }
-
-        return SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
-    }
-
     @Override
     protected List<Field> getFieldsForFloatVector(final float[] array, boolean isDerivedSourceEnabled) {
-        if (this.isLuceneEngine) {
-            final List<Field> fields = new ArrayList<>();
-            fields.add(new DerivedKnnFloatVectorField(name(), array, fieldType, isDerivedSourceEnabled));
-            if (hasDocValues && vectorFieldType != null) {
-                fields.add(new VectorField(name(), array, vectorFieldType));
-            }
-            if (stored) {
-                fields.add(createStoredFieldForFloatVector(name(), array));
-            }
+        List<Field> fields = fieldStrategy.createFloatFields(
+            name(),
+            array,
+            fieldType,
+            vectorFieldType,
+            stored,
+            hasDocValues,
+            isDerivedSourceEnabled
+        );
+        if (fields != null) {
             return fields;
         }
         return super.getFieldsForFloatVector(array, isDerivedSourceEnabled);
@@ -280,15 +182,16 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
 
     @Override
     protected List<Field> getFieldsForByteVector(final byte[] array, boolean isDerivedSourceEnabled) {
-        if (this.isLuceneEngine) {
-            final List<Field> fields = new ArrayList<>();
-            fields.add(new DerivedKnnByteVectorField(name(), array, fieldType, isDerivedSourceEnabled));
-            if (hasDocValues && vectorFieldType != null) {
-                fields.add(new VectorField(name(), array, vectorFieldType));
-            }
-            if (stored) {
-                fields.add(createStoredFieldForByteVector(name(), array));
-            }
+        List<Field> fields = fieldStrategy.createByteFields(
+            name(),
+            array,
+            fieldType,
+            vectorFieldType,
+            stored,
+            hasDocValues,
+            isDerivedSourceEnabled
+        );
+        if (fields != null) {
             return fields;
         }
         return super.getFieldsForByteVector(array, isDerivedSourceEnabled);
@@ -311,7 +214,7 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
 
     @Override
     protected VectorTransformer getVectorTransformer() {
-        if (isLuceneEngine) {
+        if (vectorTransformer == null) {
             return super.getVectorTransformer();
         }
         return vectorTransformer;
@@ -321,24 +224,5 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
     void updateEngineStats() {
         Optional.ofNullable(originalMappingParameters)
             .ifPresent(params -> params.getResolvedKnnMethodContext().getKnnEngine().setInitialized(true));
-    }
-
-    /**
-     * Checks whether the resolved method context uses the sq encoder with bits=1.
-     */
-    private static boolean isSQOneBitEncoder(KNNMethodContext methodContext) {
-        return FaissSQEncoder.isSQOneBit(methodContext.getMethodComponentContext().getParameters());
-    }
-
-    /**
-     * Builds the SQ config attribute value as a CSV string.
-     */
-    private static String getSQConfigValue(KNNMethodContext methodContext) {
-        MethodComponentContext encoderCtx = (MethodComponentContext) methodContext.getMethodComponentContext()
-            .getParameters()
-            .get(METHOD_ENCODER_PARAMETER);
-        Object bits = encoderCtx.getParameters().getOrDefault(SQ_BITS, Encoder.QuantizationBits.ONE.getValue());
-        SQConfig config = SQConfig.builder().bits((Integer) bits).build();
-        return SQConfigParser.toCsv(config);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldMapper.java
@@ -106,7 +106,8 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
             stored,
             hasDocValues,
             knnMethodConfigContext,
-            originalMappingParameters
+            originalMappingParameters,
+            libraryContext
         );
     }
 
@@ -119,7 +120,8 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         boolean stored,
         boolean hasDocValues,
         KNNMethodConfigContext knnMethodConfigContext,
-        OriginalMappingParameters originalMappingParameters
+        OriginalMappingParameters originalMappingParameters,
+        KNNLibraryIndexingContext knnLibraryIndexingContext
     ) {
         super(
             name,
@@ -138,10 +140,6 @@ public class EngineFieldMapper extends KNNVectorFieldMapper {
         VectorDataType vectorDataType = mappedFieldType.getVectorDataType();
         KNNMethodContext resolvedKnnMethodContext = originalMappingParameters.getResolvedKnnMethodContext();
         KNNEngine knnEngine = resolvedKnnMethodContext.getKnnEngine();
-        KNNLibraryIndexingContext knnLibraryIndexingContext = knnEngine.getKNNLibraryIndexingContext(
-            resolvedKnnMethodContext,
-            knnMethodConfigContext
-        );
 
         this.fieldStrategy = knnEngine.getFieldStrategy();
         FieldTypeConfig config = fieldStrategy.buildFieldTypeConfig(

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldStrategy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.opensearch.Version;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+
+import java.util.List;
+
+/**
+ * Strategy interface for engine-specific field construction and vector field creation.
+ * Each KNN engine provides its own implementation to handle field type building,
+ * vector field creation, and attribute formatting.
+ */
+public interface EngineFieldStrategy {
+
+    /**
+     * Builds the field type configuration for this engine.
+     *
+     * @param knnMappingConfig the mapping configuration
+     * @param resolvedKnnMethodContext the resolved method context
+     * @param knnLibraryIndexingContext the library indexing context
+     * @param vectorDataType the vector data type
+     * @param indexCreatedVersion the version when the index was created
+     * @param hasDocValues whether the field has doc values
+     * @return a FieldTypeConfig containing the field type, vector field type, and transformer
+     */
+    FieldTypeConfig buildFieldTypeConfig(
+        KNNMappingConfig knnMappingConfig,
+        KNNMethodContext resolvedKnnMethodContext,
+        KNNLibraryIndexingContext knnLibraryIndexingContext,
+        VectorDataType vectorDataType,
+        Version indexCreatedVersion,
+        boolean hasDocValues
+    );
+
+    /**
+     * Creates the list of fields for indexing a float vector.
+     *
+     * @param name the field name
+     * @param array the float vector
+     * @param fieldType the primary field type
+     * @param vectorFieldType the doc values field type (may be null)
+     * @param stored whether the field is stored
+     * @param hasDocValues whether the field has doc values
+     * @param isDerivedSourceEnabled whether derived source is enabled
+     * @return list of fields to add to the document
+     */
+    List<Field> createFloatFields(
+        String name,
+        float[] array,
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        boolean stored,
+        boolean hasDocValues,
+        boolean isDerivedSourceEnabled
+    );
+
+    /**
+     * Creates the list of fields for indexing a byte vector.
+     *
+     * @param name the field name
+     * @param array the byte vector
+     * @param fieldType the primary field type
+     * @param vectorFieldType the doc values field type (may be null)
+     * @param stored whether the field is stored
+     * @param hasDocValues whether the field has doc values
+     * @param isDerivedSourceEnabled whether derived source is enabled
+     * @return list of fields to add to the document
+     */
+    List<Field> createByteFields(
+        String name,
+        byte[] array,
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        boolean stored,
+        boolean hasDocValues,
+        boolean isDerivedSourceEnabled
+    );
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/EngineFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/EngineFieldStrategy.java
@@ -43,6 +43,9 @@ public interface EngineFieldStrategy {
 
     /**
      * Creates the list of fields for indexing a float vector.
+     * <p>
+     * Returns null to signal the caller should use the parent class default field creation path.
+     * Override only when the engine requires custom field construction (e.g. Lucene doc-values fields).
      *
      * @param name the field name
      * @param array the float vector
@@ -51,9 +54,9 @@ public interface EngineFieldStrategy {
      * @param stored whether the field is stored
      * @param hasDocValues whether the field has doc values
      * @param isDerivedSourceEnabled whether derived source is enabled
-     * @return list of fields to add to the document
+     * @return list of fields to add to the document, or null to use the default field creation path
      */
-    List<Field> createFloatFields(
+    default List<Field> createFloatFields(
         String name,
         float[] array,
         FieldType fieldType,
@@ -61,10 +64,15 @@ public interface EngineFieldStrategy {
         boolean stored,
         boolean hasDocValues,
         boolean isDerivedSourceEnabled
-    );
+    ) {
+        return null;
+    }
 
     /**
      * Creates the list of fields for indexing a byte vector.
+     * <p>
+     * Returns null to signal the caller should use the parent class default field creation path.
+     * Override only when the engine requires custom field construction (e.g. Lucene doc-values fields).
      *
      * @param name the field name
      * @param array the byte vector
@@ -73,9 +81,9 @@ public interface EngineFieldStrategy {
      * @param stored whether the field is stored
      * @param hasDocValues whether the field has doc values
      * @param isDerivedSourceEnabled whether derived source is enabled
-     * @return list of fields to add to the document
+     * @return list of fields to add to the document, or null to use the default field creation path
      */
-    List<Field> createByteFields(
+    default List<Field> createByteFields(
         String name,
         byte[] array,
         FieldType fieldType,
@@ -83,5 +91,7 @@ public interface EngineFieldStrategy {
         boolean stored,
         boolean hasDocValues,
         boolean isDerivedSourceEnabled
-    );
+    ) {
+        return null;
+    }
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.opensearch.Version;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
+import org.opensearch.knn.index.engine.faiss.SQConfig;
+import org.opensearch.knn.index.engine.faiss.SQConfigParser;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
+import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+
+/**
+ * Faiss (and NMSLIB) engine implementation of {@link EngineFieldStrategy}.
+ * Handles field type construction and vector field creation for non-Lucene KNN engines.
+ * Vector field creation delegates to the parent class default behavior via returning null
+ * from createFloatFields/createByteFields, signaling the caller to use its default path.
+ */
+public final class FaissFieldStrategy implements EngineFieldStrategy {
+
+    public static final FaissFieldStrategy INSTANCE = new FaissFieldStrategy();
+
+    private FaissFieldStrategy() {}
+
+    @Override
+    public FieldTypeConfig buildFieldTypeConfig(
+        KNNMappingConfig knnMappingConfig,
+        KNNMethodContext resolvedKnnMethodContext,
+        KNNLibraryIndexingContext knnLibraryIndexingContext,
+        VectorDataType vectorDataType,
+        Version indexCreatedVersion,
+        boolean hasDocValues
+    ) {
+        boolean useLuceneBasedVectorField = KNNVectorFieldMapperUtil.useLuceneKNNVectorsFormat(indexCreatedVersion);
+        KNNEngine knnEngine = resolvedKnnMethodContext.getKnnEngine();
+        QuantizationConfig quantizationConfig = knnLibraryIndexingContext.getQuantizationConfig();
+
+        FieldType fieldType = new FieldType(KNNVectorFieldMapper.Defaults.FIELD_TYPE);
+        fieldType.putAttribute(DIMENSION, String.valueOf(knnMappingConfig.getDimension()));
+        fieldType.putAttribute(SPACE_TYPE, resolvedKnnMethodContext.getSpaceType().getValue());
+
+        ResolvedIndexSpec spec = knnLibraryIndexingContext.getResolvedSpec();
+        // 1-bit quantization has its own per-field format that handles quantization internally,
+        // so we set sq_config instead of qframe_config
+        if (spec != null && spec.isSQOneBit()) {
+            SQConfig sqConfig = SQConfig.builder().bits(spec.getQuantizationBits().getValue()).build();
+            fieldType.putAttribute(SQ_CONFIG, SQConfigParser.toCsv(sqConfig));
+        } else {
+            if (quantizationConfig != null && quantizationConfig != QuantizationConfig.EMPTY) {
+                fieldType.putAttribute(QFRAMEWORK_CONFIG, QuantizationConfigParser.toCsv(quantizationConfig));
+            }
+        }
+
+        fieldType.putAttribute(VECTOR_DATA_TYPE_FIELD, vectorDataType.getValue());
+        fieldType.putAttribute(KNN_ENGINE, knnEngine.getName());
+        try {
+            fieldType.putAttribute(
+                PARAMETERS,
+                XContentFactory.jsonBuilder().map(knnLibraryIndexingContext.getLibraryParameters()).toString()
+            );
+        } catch (IOException ioe) {
+            throw new RuntimeException(String.format("Unable to create KNNVectorFieldMapper: %s", ioe), ioe);
+        }
+
+        if (useLuceneBasedVectorField) {
+            int adjustedDimension = vectorDataType == VectorDataType.BINARY
+                ? knnMappingConfig.getDimension() / 8
+                : knnMappingConfig.getDimension();
+            final VectorEncoding encoding = vectorDataType == VectorDataType.FLOAT ? VectorEncoding.FLOAT32 : VectorEncoding.BYTE;
+            final VectorSimilarityFunction similarityFunction = findBestMatchingVectorSimilarityFunction(
+                resolvedKnnMethodContext.getSpaceType(),
+                indexCreatedVersion
+            );
+            fieldType.setVectorAttributes(adjustedDimension, encoding, similarityFunction);
+        } else {
+            fieldType.setDocValuesType(DocValuesType.BINARY);
+        }
+
+        fieldType.freeze();
+
+        VectorTransformer vectorTransformer = knnLibraryIndexingContext.getVectorTransformer();
+        return new FieldTypeConfig(fieldType, null, vectorTransformer, useLuceneBasedVectorField);
+    }
+
+    @Override
+    public List<Field> createFloatFields(
+        String name,
+        float[] array,
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        boolean stored,
+        boolean hasDocValues,
+        boolean isDerivedSourceEnabled
+    ) {
+        return null;
+    }
+
+    @Override
+    public List<Field> createByteFields(
+        String name,
+        byte[] array,
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        boolean stored,
+        boolean hasDocValues,
+        boolean isDerivedSourceEnabled
+    ) {
+        return null;
+    }
+
+    private static VectorSimilarityFunction findBestMatchingVectorSimilarityFunction(SpaceType spaceType, Version indexCreatedVersion) {
+        if (indexCreatedVersion.onOrAfter(Version.V_3_0_0)) {
+            try {
+                return spaceType.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+            } catch (Exception e) {
+                // SpaceType may not have a direct Lucene VectorSimilarityFunction mapping (e.g. HAMMING, L1).
+                // Fall back to DEFAULT similarity function for backward compatibility with pre-3.0 behavior.
+            }
+        }
+        return SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.mapper;
 
 import lombok.extern.log4j.Log4j2;
 
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.VectorEncoding;
@@ -26,7 +25,6 @@ import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfigParser;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
@@ -38,9 +36,8 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 
 /**
  * Faiss (and NMSLIB) engine implementation of {@link EngineFieldStrategy}.
- * Handles field type construction and vector field creation for non-Lucene KNN engines.
- * Vector field creation delegates to the parent class default behavior via returning null
- * from createFloatFields/createByteFields, signaling the caller to use its default path.
+ * Handles field type construction for non-Lucene KNN engines. Vector field creation uses the
+ * {@link EngineFieldStrategy} interface defaults, signaling the caller to use its default path.
  */
 @Log4j2
 public final class FaissFieldStrategy implements EngineFieldStrategy {
@@ -107,32 +104,6 @@ public final class FaissFieldStrategy implements EngineFieldStrategy {
 
         VectorTransformer vectorTransformer = knnLibraryIndexingContext.getVectorTransformer();
         return new FieldTypeConfig(fieldType, null, vectorTransformer, useLuceneBasedVectorField);
-    }
-
-    @Override
-    public List<Field> createFloatFields(
-        String name,
-        float[] array,
-        FieldType fieldType,
-        FieldType vectorFieldType,
-        boolean stored,
-        boolean hasDocValues,
-        boolean isDerivedSourceEnabled
-    ) {
-        return null;
-    }
-
-    @Override
-    public List<Field> createByteFields(
-        String name,
-        byte[] array,
-        FieldType fieldType,
-        FieldType vectorFieldType,
-        boolean stored,
-        boolean hasDocValues,
-        boolean isDerivedSourceEnabled
-    ) {
-        return null;
     }
 
     private static VectorSimilarityFunction findBestMatchingVectorSimilarityFunction(SpaceType spaceType, Version indexCreatedVersion) {

--- a/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FaissFieldStrategy.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.index.mapper;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.DocValuesType;
@@ -40,6 +42,7 @@ import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
  * Vector field creation delegates to the parent class default behavior via returning null
  * from createFloatFields/createByteFields, signaling the caller to use its default path.
  */
+@Log4j2
 public final class FaissFieldStrategy implements EngineFieldStrategy {
 
     public static final FaissFieldStrategy INSTANCE = new FaissFieldStrategy();
@@ -139,6 +142,7 @@ public final class FaissFieldStrategy implements EngineFieldStrategy {
             } catch (Exception e) {
                 // SpaceType may not have a direct Lucene VectorSimilarityFunction mapping (e.g. HAMMING, L1).
                 // Fall back to DEFAULT similarity function for backward compatibility with pre-3.0 behavior.
+                log.info("No direct VectorSimilarityFunction for {}, using DEFAULT", spaceType);
             }
         }
         return SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction();

--- a/src/main/java/org/opensearch/knn/index/mapper/FieldTypeConfig.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FieldTypeConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.FieldType;
+
+/**
+ * Immutable value object holding the field type configuration produced by an {@link EngineFieldStrategy}.
+ */
+public final class FieldTypeConfig {
+    private final FieldType fieldType;
+    private final FieldType vectorFieldType;
+    private final VectorTransformer vectorTransformer;
+    private final boolean useLuceneBasedVectorField;
+
+    public FieldTypeConfig(
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        VectorTransformer vectorTransformer,
+        boolean useLuceneBasedVectorField
+    ) {
+        this.fieldType = fieldType;
+        this.vectorFieldType = vectorFieldType;
+        this.vectorTransformer = vectorTransformer;
+        this.useLuceneBasedVectorField = useLuceneBasedVectorField;
+    }
+
+    public FieldType getFieldType() {
+        return fieldType;
+    }
+
+    public FieldType getVectorFieldType() {
+        return vectorFieldType;
+    }
+
+    public VectorTransformer getVectorTransformer() {
+        return vectorTransformer;
+    }
+
+    public boolean isUseLuceneBasedVectorField() {
+        return useLuceneBasedVectorField;
+    }
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/FieldTypeConfig.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/FieldTypeConfig.java
@@ -5,42 +5,16 @@
 
 package org.opensearch.knn.index.mapper;
 
+import lombok.Value;
 import org.apache.lucene.document.FieldType;
 
 /**
  * Immutable value object holding the field type configuration produced by an {@link EngineFieldStrategy}.
  */
-public final class FieldTypeConfig {
-    private final FieldType fieldType;
-    private final FieldType vectorFieldType;
-    private final VectorTransformer vectorTransformer;
-    private final boolean useLuceneBasedVectorField;
-
-    public FieldTypeConfig(
-        FieldType fieldType,
-        FieldType vectorFieldType,
-        VectorTransformer vectorTransformer,
-        boolean useLuceneBasedVectorField
-    ) {
-        this.fieldType = fieldType;
-        this.vectorFieldType = vectorFieldType;
-        this.vectorTransformer = vectorTransformer;
-        this.useLuceneBasedVectorField = useLuceneBasedVectorField;
-    }
-
-    public FieldType getFieldType() {
-        return fieldType;
-    }
-
-    public FieldType getVectorFieldType() {
-        return vectorFieldType;
-    }
-
-    public VectorTransformer getVectorTransformer() {
-        return vectorTransformer;
-    }
-
-    public boolean isUseLuceneBasedVectorField() {
-        return useLuceneBasedVectorField;
-    }
+@Value
+public class FieldTypeConfig {
+    FieldType fieldType;
+    FieldType vectorFieldType;
+    VectorTransformer vectorTransformer;
+    boolean useLuceneBasedVectorField;
 }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -943,6 +943,9 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 .versionCreated(indexCreatedVersion)
                 .dimension(fieldType().getKnnMappingConfig().getDimension())
                 .compressionLevel(fieldType().getKnnMappingConfig().getCompressionLevel())
+                // The mapping config carries the resolved compression, which may have been derived from the
+                // encoder. Preserve what the user originally configured so mode derivation stays correct on merge.
+                .userConfiguredCompressionLevel(CompressionLevel.fromName(originalMappingParameters.getCompressionLevel()))
                 .mode(fieldType().getKnnMappingConfig().getMode())
                 .build();
         }

--- a/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapper.java
@@ -938,6 +938,11 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
         if (fieldType().getKnnMappingConfig().getModelId().isPresent()) {
             knnMethodConfigContext = null;
         } else {
+            // compression_level may never have been specified by the user, in which case it is null
+            String userCompressionLevelName = originalMappingParameters.getCompressionLevel();
+            CompressionLevel userConfiguredCompressionLevel = userCompressionLevelName == null
+                ? CompressionLevel.NOT_CONFIGURED
+                : CompressionLevel.fromName(userCompressionLevelName);
             knnMethodConfigContext = KNNMethodConfigContext.builder()
                 .vectorDataType(vectorDataType)
                 .versionCreated(indexCreatedVersion)
@@ -945,7 +950,7 @@ public abstract class KNNVectorFieldMapper extends ParametrizedFieldMapper {
                 .compressionLevel(fieldType().getKnnMappingConfig().getCompressionLevel())
                 // The mapping config carries the resolved compression, which may have been derived from the
                 // encoder. Preserve what the user originally configured so mode derivation stays correct on merge.
-                .userConfiguredCompressionLevel(CompressionLevel.fromName(originalMappingParameters.getCompressionLevel()))
+                .userConfiguredCompressionLevel(userConfiguredCompressionLevel)
                 .mode(fieldType().getKnnMappingConfig().getMode())
                 .build();
         }

--- a/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/LuceneFieldStrategy.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.opensearch.Version;
+import org.opensearch.knn.index.DerivedKnnByteVectorField;
+import org.opensearch.knn.index.DerivedKnnFloatVectorField;
+import org.opensearch.knn.index.KNNVectorSimilarityFunction;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.VectorField;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.buildDocValuesFieldType;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForByteVector;
+import static org.opensearch.knn.index.mapper.KNNVectorFieldMapperUtil.createStoredFieldForFloatVector;
+
+/**
+ * Lucene engine implementation of {@link EngineFieldStrategy}.
+ * Handles field type construction and vector field creation for the Lucene KNN engine.
+ */
+public final class LuceneFieldStrategy implements EngineFieldStrategy {
+
+    public static final LuceneFieldStrategy INSTANCE = new LuceneFieldStrategy();
+
+    private LuceneFieldStrategy() {}
+
+    @Override
+    public FieldTypeConfig buildFieldTypeConfig(
+        KNNMappingConfig knnMappingConfig,
+        KNNMethodContext resolvedKnnMethodContext,
+        KNNLibraryIndexingContext knnLibraryIndexingContext,
+        VectorDataType vectorDataType,
+        Version indexCreatedVersion,
+        boolean hasDocValues
+    ) {
+        KNNVectorSimilarityFunction knnVectorSimilarityFunction = resolvedKnnMethodContext.getSpaceType().getKnnVectorSimilarityFunction();
+
+        FieldType fieldType = vectorDataType.createKnnVectorFieldType(knnMappingConfig.getDimension(), knnVectorSimilarityFunction);
+
+        FieldType vectorFieldType;
+        if (hasDocValues) {
+            vectorFieldType = buildDocValuesFieldType(resolvedKnnMethodContext.getKnnEngine());
+        } else {
+            vectorFieldType = null;
+        }
+
+        return new FieldTypeConfig(fieldType, vectorFieldType, null, false);
+    }
+
+    @Override
+    public List<Field> createFloatFields(
+        String name,
+        float[] array,
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        boolean stored,
+        boolean hasDocValues,
+        boolean isDerivedSourceEnabled
+    ) {
+        final List<Field> fields = new ArrayList<>();
+        fields.add(new DerivedKnnFloatVectorField(name, array, fieldType, isDerivedSourceEnabled));
+        if (hasDocValues && vectorFieldType != null) {
+            fields.add(new VectorField(name, array, vectorFieldType));
+        }
+        if (stored) {
+            fields.add(createStoredFieldForFloatVector(name, array));
+        }
+        return fields;
+    }
+
+    @Override
+    public List<Field> createByteFields(
+        String name,
+        byte[] array,
+        FieldType fieldType,
+        FieldType vectorFieldType,
+        boolean stored,
+        boolean hasDocValues,
+        boolean isDerivedSourceEnabled
+    ) {
+        final List<Field> fields = new ArrayList<>();
+        fields.add(new DerivedKnnByteVectorField(name, array, fieldType, isDerivedSourceEnabled));
+        if (hasDocValues && vectorFieldType != null) {
+            fields.add(new VectorField(name, array, vectorFieldType));
+        }
+        if (stored) {
+            fields.add(createStoredFieldForByteVector(name, array));
+        }
+        return fields;
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.engine;
 
+import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.VectorDataType;
@@ -108,6 +109,35 @@ public class AbstractMethodResolverTests extends KNNTestCase {
                 )
             )
         );
+    }
+
+    public void testGetDefaultCompressionLevel_whenCompressionConfigured_thenReturnConfigured() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder()
+            .compressionLevel(CompressionLevel.x16)
+            .mode(Mode.ON_DISK)
+            .versionCreated(Version.V_3_6_0)
+            .build();
+        assertEquals(CompressionLevel.x16, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenOnDiskAndV360OrLater_thenReturnX32() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.ON_DISK).versionCreated(Version.V_3_6_0).build();
+        assertEquals(CompressionLevel.x32, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenOnDiskAndBeforeV360_thenReturnFallback() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.ON_DISK).versionCreated(Version.V_2_17_0).build();
+        assertEquals(CompressionLevel.x4, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenNotOnDisk_thenReturnX1() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).versionCreated(Version.V_3_6_0).build();
+        assertEquals(CompressionLevel.x1, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
+    public void testGetDefaultCompressionLevel_whenNotConfigured_thenReturnX1() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().versionCreated(Version.V_3_6_0).build();
+        assertEquals(CompressionLevel.x1, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
     }
 
     public void testShouldEncoderBeResolved() {

--- a/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/AbstractMethodResolverTests.java
@@ -130,6 +130,11 @@ public class AbstractMethodResolverTests extends KNNTestCase {
         assertEquals(CompressionLevel.x4, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
     }
 
+    public void testGetDefaultCompressionLevel_whenOnDiskAndNullVersion_thenReturnFallback() {
+        KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.ON_DISK).build();
+        assertEquals(CompressionLevel.x4, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));
+    }
+
     public void testGetDefaultCompressionLevel_whenNotOnDisk_thenReturnX1() {
         KNNMethodConfigContext ctx = KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).versionCreated(Version.V_3_6_0).build();
         assertEquals(CompressionLevel.x1, TEST_RESOLVER.getDefaultCompressionLevel(ctx, CompressionLevel.x4));

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -17,6 +17,7 @@ import org.opensearch.knn.index.mapper.Mode;
 import java.io.IOException;
 import java.util.Map;
 
+import static org.opensearch.knn.common.KNNConstants.KNN_DEFAULT_COMPRESSION_FLIP_VERSION;
 import static org.opensearch.knn.common.KNNConstants.NAME;
 import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
 
@@ -324,8 +325,8 @@ public class EngineResolverTests extends KNNTestCase {
         );
     }
 
-    public void testResolveEngine_whenModeProvidedOnV370_thenStillResolvesCorrectly() {
-        // On V_3_7_0+ mode is deprecated but still honored — verify correct resolution
+    public void testResolveEngine_whenModeProvidedOnV380_thenStillResolvesCorrectly() {
+        // On KNN_DEFAULT_COMPRESSION_FLIP_VERSION (V_3_8_0)+ mode is deprecated but still honored — verify correct resolution
         assertEquals(
             KNNEngine.FAISS,
             ENGINE_RESOLVER.resolveEngine(
@@ -333,7 +334,7 @@ public class EngineResolverTests extends KNNTestCase {
                 null,
                 null,
                 false,
-                Version.V_3_7_0
+                KNN_DEFAULT_COMPRESSION_FLIP_VERSION
             )
         );
         assertEquals(
@@ -343,16 +344,22 @@ public class EngineResolverTests extends KNNTestCase {
                 null,
                 null,
                 false,
-                Version.V_3_7_0
+                KNN_DEFAULT_COMPRESSION_FLIP_VERSION
             )
         );
     }
 
-    public void testResolveEngine_whenOnlyModeProvidedOnV370_thenResolvesLegacyPath() {
+    public void testResolveEngine_whenOnlyModeProvidedOnV380_thenResolvesLegacyPath() {
         // Mode-only (no compression) still resolves via legacy path
         assertEquals(
             KNNEngine.FAISS,
-            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().mode(Mode.ON_DISK).build(), null, null, false, Version.V_3_7_0)
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).build(),
+                null,
+                null,
+                false,
+                KNN_DEFAULT_COMPRESSION_FLIP_VERSION
+            )
         );
     }
 
@@ -383,8 +390,8 @@ public class EngineResolverTests extends KNNTestCase {
     }
 
     public void testResolveEngine_whenNoModeNoCompressionAcrossVersions_thenDefault() {
-        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_7_0 → assert DEFAULT,
-        // indexVersionCreated >= V_3_7_0 → assert x32 default triggers engine resolution
+        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < KNN_DEFAULT_COMPRESSION_FLIP_VERSION → assert DEFAULT,
+        // indexVersionCreated >= KNN_DEFAULT_COMPRESSION_FLIP_VERSION → assert x32 default triggers engine resolution
         Version[] versions = new Version[] { Version.V_2_18_0, Version.V_3_0_0, Version.V_3_5_0, Version.V_3_6_0, Version.CURRENT };
 
         for (Version version : versions) {

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -349,6 +349,48 @@ public class EngineResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveEngine_whenModeProvidedWithNullVersion_thenNoDeprecationAndResolves() {
+        // Null version skips the deprecation check and falls through to legacy resolution
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x32).build(),
+                null,
+                null,
+                false,
+                null
+            )
+        );
+    }
+
+    public void testResolveEngine_whenModeProvidedBeforeFlipVersion_thenNoDeprecationAndResolves() {
+        // Versions before KNN_DEFAULT_COMPRESSION_FLIP_VERSION do not log deprecation for mode
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x32).build(),
+                null,
+                null,
+                false,
+                Version.V_3_6_0
+            )
+        );
+    }
+
+    public void testResolveEngine_whenDeprecatedEngineResolved_thenStillReturnsEngine() {
+        // NMSLIB is deprecated; logAndReturnEngine should log via deprecation logger and return it unchanged
+        assertEquals(
+            KNNEngine.NMSLIB,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().build(),
+                new KNNMethodContext(KNNEngine.NMSLIB, SpaceType.DEFAULT, MethodComponentContext.EMPTY),
+                null,
+                false,
+                Version.V_2_18_0
+            )
+        );
+    }
+
     public void testResolveEngine_whenOnlyModeProvidedOnV380_thenResolvesLegacyPath() {
         // Mode-only (no compression) still resolves via legacy path
         assertEquals(

--- a/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/EngineResolverTests.java
@@ -324,6 +324,38 @@ public class EngineResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveEngine_whenModeProvidedOnV370_thenStillResolvesCorrectly() {
+        // On V_3_7_0+ mode is deprecated but still honored — verify correct resolution
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.ON_DISK).compressionLevel(CompressionLevel.x32).build(),
+                null,
+                null,
+                false,
+                Version.V_3_7_0
+            )
+        );
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(
+                KNNMethodConfigContext.builder().mode(Mode.IN_MEMORY).compressionLevel(CompressionLevel.x1).build(),
+                null,
+                null,
+                false,
+                Version.V_3_7_0
+            )
+        );
+    }
+
+    public void testResolveEngine_whenOnlyModeProvidedOnV370_thenResolvesLegacyPath() {
+        // Mode-only (no compression) still resolves via legacy path
+        assertEquals(
+            KNNEngine.FAISS,
+            ENGINE_RESOLVER.resolveEngine(KNNMethodConfigContext.builder().mode(Mode.ON_DISK).build(), null, null, false, Version.V_3_7_0)
+        );
+    }
+
     public void testValidateTopLevelEngine() throws IOException {
         // only top-level defined; set to faiss with compression 4x
         expectThrows(

--- a/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNEngineTests.java
@@ -16,6 +16,8 @@ import org.opensearch.knn.index.engine.faiss.Faiss;
 import org.opensearch.knn.index.engine.faiss.FaissHNSWMethod;
 import org.opensearch.knn.index.engine.lucene.Lucene;
 import org.opensearch.knn.index.engine.nmslib.Nmslib;
+import org.opensearch.knn.index.mapper.FaissFieldStrategy;
+import org.opensearch.knn.index.mapper.LuceneFieldStrategy;
 import org.opensearch.remoteindexbuild.model.RemoteFaissHNSWIndexParameters;
 import org.opensearch.remoteindexbuild.model.RemoteIndexParameters;
 
@@ -350,6 +352,13 @@ public class KNNEngineTests extends KNNTestCase {
         Map<String, Object> in = xContentBuilderToMap(xContentBuilder);
         KNNMethodContext knnMethodContext = KNNMethodContext.parse(in);
         return Faiss.INSTANCE.getKNNLibraryIndexingContext(knnMethodContext, knnMethodConfigContext);
+    }
+
+    public void testGetFieldStrategy() {
+        assertEquals(LuceneFieldStrategy.INSTANCE, KNNEngine.LUCENE.getFieldStrategy());
+        assertEquals(FaissFieldStrategy.INSTANCE, KNNEngine.FAISS.getFieldStrategy());
+        assertEquals(FaissFieldStrategy.INSTANCE, KNNEngine.NMSLIB.getFieldStrategy());
+        expectThrows(UnsupportedOperationException.class, () -> KNNEngine.UNDEFINED.getFieldStrategy());
     }
 
     @SneakyThrows

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodConfigContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodConfigContextTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+
+public class KNNMethodConfigContextTests extends KNNTestCase {
+
+    public void testDeriveMode_whenNotConfigured_thenNotConfigured() {
+        assertEquals(Mode.NOT_CONFIGURED, KNNMethodConfigContext.deriveMode(CompressionLevel.NOT_CONFIGURED));
+    }
+
+    public void testDeriveMode_whenX1_thenInMemory() {
+        assertEquals(Mode.IN_MEMORY, KNNMethodConfigContext.deriveMode(CompressionLevel.x1));
+    }
+
+    public void testDeriveMode_whenX2_thenInMemory() {
+        assertEquals(Mode.IN_MEMORY, KNNMethodConfigContext.deriveMode(CompressionLevel.x2));
+    }
+
+    public void testDeriveMode_whenX4_thenOnDisk() {
+        assertEquals(Mode.ON_DISK, KNNMethodConfigContext.deriveMode(CompressionLevel.x4));
+    }
+
+    public void testDeriveMode_whenX16_thenOnDisk() {
+        assertEquals(Mode.ON_DISK, KNNMethodConfigContext.deriveMode(CompressionLevel.x16));
+    }
+
+    public void testDeriveMode_whenX32_thenOnDisk() {
+        assertEquals(Mode.ON_DISK, KNNMethodConfigContext.deriveMode(CompressionLevel.x32));
+    }
+
+    public void testUserConfiguredCompressionLevel_whenNotResolved_thenMatchesCompressionLevel() {
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x32).build();
+        assertEquals(CompressionLevel.x32, context.getUserConfiguredCompressionLevel());
+    }
+
+    public void testUserConfiguredCompressionLevel_whenResolutionOverwrites_thenPreservesOriginal() {
+        // Simulates encoder-derived compression: user did not configure compression, but method
+        // resolution derived x32 from the encoder (e.g. binary encoder with bits=1)
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder().build();
+        context.setCompressionLevel(CompressionLevel.x32);
+        assertEquals(CompressionLevel.x32, context.getCompressionLevel());
+        assertEquals(CompressionLevel.NOT_CONFIGURED, context.getUserConfiguredCompressionLevel());
+    }
+
+    public void testUserConfiguredCompressionLevel_whenUserConfiguredAndResolved_thenPreservesUserValue() {
+        // User configured x32; resolution re-sets the same value after validating the encoder
+        KNNMethodConfigContext context = KNNMethodConfigContext.builder().compressionLevel(CompressionLevel.x32).build();
+        context.setCompressionLevel(CompressionLevel.x32);
+        assertEquals(CompressionLevel.x32, context.getCompressionLevel());
+        assertEquals(CompressionLevel.x32, context.getUserConfiguredCompressionLevel());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecConsumerTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecConsumerTests.java
@@ -235,6 +235,89 @@ public class ResolvedIndexSpecConsumerTests extends KNNTestCase {
         return new KNNVectorFieldType(FIELD_NAME, Collections.emptyMap(), VectorDataType.FLOAT, mappingConfig, Version.CURRENT);
     }
 
+    public void testRescore_derivedOnDiskMode_producesNonNullRescore() {
+        ResolvedIndexSpec spec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+        RescoreContext rescoreContext = spec.getRescoreContext();
+        assertNotNull(rescoreContext);
+    }
+
+    public void testRescore_notConfiguredModeWithX32_sameAsOnDisk() {
+        ResolvedIndexSpec specOnDisk = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        ResolvedIndexSpec specNotConfigured = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.NOT_CONFIGURED)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        RescoreContext onDiskRescore = specOnDisk.getRescoreContext();
+        RescoreContext notConfiguredRescore = specNotConfigured.getRescoreContext();
+
+        assertNotNull(onDiskRescore);
+        assertNotNull(notConfiguredRescore);
+        assertEquals(onDiskRescore.getOversampleFactor(), notConfiguredRescore.getOversampleFactor(), 0.001f);
+    }
+
+    public void testRescore_explicitOnDiskVsDerivedOnDisk_identical() {
+        ResolvedIndexSpec specExplicit = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(500)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        ResolvedIndexSpec specDerived = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName(METHOD_HNSW)
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.SIXTEEN)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(500)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        RescoreContext explicit = specExplicit.getRescoreContext();
+        RescoreContext derived = specDerived.getRescoreContext();
+
+        assertNotNull(explicit);
+        assertNotNull(derived);
+        assertEquals(explicit.getOversampleFactor(), derived.getOversampleFactor(), 0.001f);
+        assertEquals(explicit.isAllowOverrideOversampleFactor(), derived.isAllowOverrideOversampleFactor());
+    }
+
     private KNNVectorFieldType buildFieldTypeWithSpec(KNNMethodContext methodContext, int dimension, ResolvedIndexSpec spec) {
         KNNMappingConfig mappingConfig = new KNNMappingConfig() {
             @Override

--- a/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/ResolvedIndexSpecWiringTests.java
@@ -218,4 +218,120 @@ public class ResolvedIndexSpecWiringTests extends KNNTestCase {
         assertEquals(Encoder.EncoderType.BQ, spec.getEncoderType());
         assertEquals(Encoder.QuantizationBits.ONE, spec.getQuantizationBits());
     }
+
+    // --- Mode derivation tests ---
+
+    public void testModeDerivation_whenX32NoExplicitMode_thenOnDisk() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Mode.ON_DISK, spec.getMode());
+    }
+
+    public void testModeDerivation_whenX1NoExplicitMode_thenInMemory() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x1)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Mode.IN_MEMORY, spec.getMode());
+    }
+
+    public void testModeDerivation_whenExplicitOnDisk_thenUserWins() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.ON_DISK)
+            .compressionLevel(CompressionLevel.x32)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Mode.ON_DISK, spec.getMode());
+    }
+
+    public void testModeDerivation_whenNoModeNoCompression_thenNotConfigured() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.V_3_5_0)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Mode.NOT_CONFIGURED, spec.getMode());
+    }
+
+    public void testModeDerivation_whenX2NoExplicitMode_thenInMemory() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x2)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.FAISS.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Mode.IN_MEMORY, spec.getMode());
+    }
+
+    public void testModeDerivation_whenX4NoExplicitMode_thenOnDisk() {
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, new java.util.HashMap<>())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .versionCreated(Version.CURRENT)
+            .mode(Mode.NOT_CONFIGURED)
+            .compressionLevel(CompressionLevel.x4)
+            .build();
+
+        KNNLibraryIndexingContext ctx = KNNEngine.LUCENE.getKNNLibraryIndexingContext(knnMethodContext, configContext);
+        ResolvedIndexSpec spec = ctx.getResolvedSpec();
+        assertEquals(Mode.ON_DISK, spec.getMode());
+    }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/AbstractFaissPQEncoderTests.java
@@ -6,9 +6,13 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import lombok.SneakyThrows;
+import org.opensearch.common.ValidationException;
 import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
 import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.MethodComponent;
 import org.opensearch.knn.index.engine.MethodComponentContext;
 import org.opensearch.knn.index.mapper.CompressionLevel;
@@ -18,6 +22,7 @@ import java.util.Map;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_CODE_SIZE;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PARAMETER_PQ_M;
 import static org.opensearch.knn.common.KNNConstants.ENCODER_PQ;
+import static org.opensearch.knn.common.KNNConstants.METHOD_IVF;
 
 public class AbstractFaissPQEncoderTests extends KNNTestCase {
 
@@ -60,6 +65,50 @@ public class AbstractFaissPQEncoderTests extends KNNTestCase {
         // actual_compression = (128*32)/(128*8) = 4x
         // expected_compression = Max compression level
         assertCompressionLevel(128, 8, 128, CompressionLevel.x4, encoder);
+    }
+
+    public void testValidate_whenNullInputs_thenNoException() {
+        AbstractFaissPQEncoder encoder = buildTestEncoder();
+        encoder.validate(null, null);
+        encoder.validate(buildMethodContext(Map.of(ENCODER_PARAMETER_PQ_M, 4)), null);
+        encoder.validate(null, generateKNNMethodConfigContext(128));
+    }
+
+    public void testValidate_whenDimensionNotDivisibleByM_thenThrow() {
+        AbstractFaissPQEncoder encoder = buildTestEncoder();
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> encoder.validate(buildMethodContext(Map.of(ENCODER_PARAMETER_PQ_M, 5)), generateKNNMethodConfigContext(128))
+        );
+        assertTrue(e.getMessage().contains("not divisible"));
+    }
+
+    public void testValidate_whenDimensionDivisibleByM_thenNoException() {
+        AbstractFaissPQEncoder encoder = buildTestEncoder();
+        encoder.validate(buildMethodContext(Map.of(ENCODER_PARAMETER_PQ_M, 4)), generateKNNMethodConfigContext(128));
+    }
+
+    public void testValidate_whenPQMNotSpecified_thenNoException() {
+        AbstractFaissPQEncoder encoder = buildTestEncoder();
+        encoder.validate(buildMethodContext(Map.of()), generateKNNMethodConfigContext(128));
+    }
+
+    public void testValidate_whenDimensionIsNull_thenNoException() {
+        AbstractFaissPQEncoder encoder = buildTestEncoder();
+        encoder.validate(buildMethodContext(Map.of(ENCODER_PARAMETER_PQ_M, 5)), KNNMethodConfigContext.builder().build());
+    }
+
+    private AbstractFaissPQEncoder buildTestEncoder() {
+        return new AbstractFaissPQEncoder() {
+            @Override
+            public MethodComponent getMethodComponent() {
+                return FaissIVFPQEncoder.METHOD_COMPONENT;
+            }
+        };
+    }
+
+    private KNNMethodContext buildMethodContext(Map<String, Object> methodParams) {
+        return new KNNMethodContext(KNNEngine.FAISS, SpaceType.L2, new MethodComponentContext(METHOD_IVF, methodParams));
     }
 
     private void assertCompressionLevel(int m, int codeSize, int d, CompressionLevel expectedCompression, Encoder encoder) {

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissMethodResolverTests.java
@@ -359,7 +359,7 @@ public class FaissMethodResolverTests extends KNNTestCase {
     }
 
     public void testResolveMethod_whenNoCompressionSpecified_thenResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_7_0+, keep x1 for older versions
+        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_8_0+, keep x1 for older versions
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
@@ -443,8 +443,8 @@ public class FaissMethodResolverTests extends KNNTestCase {
     }
 
     public void testResolveMethod_whenNoCompressionAcrossVersions_thenAlwaysResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_7_0 → assert x1,
-        // indexVersionCreated >= V_3_7_0 → assert x32
+        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_8_0 → assert x1,
+        // indexVersionCreated >= V_3_8_0 → assert x32
         Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
 
         for (Version version : versions) {

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.engine.faiss;
 
 import org.opensearch.Version;
+import org.opensearch.common.ValidationException;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.VectorDataType;
 import org.opensearch.knn.index.engine.KNNEngine;
@@ -264,5 +265,91 @@ public class FaissSQEncoderTests extends KNNTestCase {
 
     public void testIsSQOneBit_whenEncoderNotMethodComponentContext_thenFalse() {
         assertFalse(FaissSQEncoder.isSQOneBit(Map.of(METHOD_ENCODER_PARAMETER, "not_a_context")));
+    }
+
+    // --- validate() direct tests ---
+
+    public void testValidateDirectly_whenInvalidBits_thenThrows() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> encoder.validate(
+                buildMethodContext(Map.of(SQ_BITS, 99)),
+                buildConfigContext(Version.CURRENT, CompressionLevel.NOT_CONFIGURED)
+            )
+        );
+        assertTrue(e.getMessage().contains("Unsupported bits value"));
+    }
+
+    public void testValidateDirectly_whenV360NoBitsFloat_thenThrows() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> encoder.validate(
+                buildMethodContext(Map.of(FAISS_SQ_TYPE, "fp16")),
+                buildConfigContext(Version.CURRENT, CompressionLevel.NOT_CONFIGURED)
+            )
+        );
+        assertTrue(e.getMessage().contains("required"));
+    }
+
+    public void testValidateDirectly_whenV360WithTypeOnBits1_thenThrows() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> encoder.validate(
+                buildMethodContext(Map.of(SQ_BITS, 1, FAISS_SQ_TYPE, "fp16")),
+                buildConfigContext(Version.CURRENT, CompressionLevel.NOT_CONFIGURED)
+            )
+        );
+        assertTrue(e.getMessage().contains("type"));
+    }
+
+    public void testValidateDirectly_whenV360WithClipOnBits1_thenThrows() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        ValidationException e = expectThrows(
+            ValidationException.class,
+            () -> encoder.validate(
+                buildMethodContext(Map.of(SQ_BITS, 1, FAISS_SQ_CLIP, true)),
+                buildConfigContext(Version.CURRENT, CompressionLevel.NOT_CONFIGURED)
+            )
+        );
+        assertTrue(e.getMessage().contains("clip"));
+    }
+
+    public void testValidateDirectly_whenValidConfig_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        encoder.validate(buildMethodContext(Map.of(SQ_BITS, 1)), buildConfigContext(Version.CURRENT, CompressionLevel.x32));
+    }
+
+    public void testValidateDirectly_whenNullInputs_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        encoder.validate(null, null);
+    }
+
+    public void testValidateDirectly_whenPreV360NoBits_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        encoder.validate(
+            buildMethodContext(Map.of(FAISS_SQ_TYPE, "fp16")),
+            buildConfigContext(Version.V_3_5_0, CompressionLevel.NOT_CONFIGURED)
+        );
+    }
+
+    private KNNMethodContext buildMethodContext(Map<String, Object> encoderParams) {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, new HashMap<>(encoderParams));
+        return new KNNMethodContext(
+            KNNEngine.FAISS,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, encoderCtx))
+        );
+    }
+
+    private KNNMethodConfigContext buildConfigContext(Version version, CompressionLevel compressionLevel) {
+        return KNNMethodConfigContext.builder()
+            .versionCreated(version)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .compressionLevel(compressionLevel)
+            .build();
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/faiss/FaissSQEncoderTests.java
@@ -335,6 +335,45 @@ public class FaissSQEncoderTests extends KNNTestCase {
         );
     }
 
+    public void testValidateDirectly_whenNullConfigContext_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        encoder.validate(buildMethodContext(Map.of(SQ_BITS, 1)), null);
+    }
+
+    public void testValidateDirectly_whenEncoderContextMissing_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.FAISS,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of())
+        );
+        encoder.validate(methodContext, buildConfigContext(Version.CURRENT, CompressionLevel.NOT_CONFIGURED));
+    }
+
+    public void testValidateDirectly_whenNullVersionNoBits_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        encoder.validate(buildMethodContext(Map.of(FAISS_SQ_TYPE, "fp16")), buildConfigContext(null, CompressionLevel.NOT_CONFIGURED));
+    }
+
+    public void testValidateDirectly_whenV360NoBitsByteDataType_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.BYTE)
+            .dimension(128)
+            .compressionLevel(CompressionLevel.NOT_CONFIGURED)
+            .build();
+        encoder.validate(buildMethodContext(Map.of(FAISS_SQ_TYPE, "fp16")), configContext);
+    }
+
+    public void testValidateDirectly_whenBits16WithNoCompressionConfigured_thenNoException() {
+        FaissSQEncoder encoder = new FaissSQEncoder();
+        encoder.validate(
+            buildMethodContext(Map.of(SQ_BITS, 16, FAISS_SQ_TYPE, "fp16", FAISS_SQ_CLIP, true)),
+            buildConfigContext(Version.CURRENT, CompressionLevel.NOT_CONFIGURED)
+        );
+    }
+
     private KNNMethodContext buildMethodContext(Map<String, Object> encoderParams) {
         MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, new HashMap<>(encoderParams));
         return new KNNMethodContext(

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneHNSWMethodResolverTests.java
@@ -434,6 +434,32 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
         );
     }
 
+    public void testResolveMethod_whenUnknownEncoderSpecified_thenSkipsEncoderValidation() {
+        // An encoder name that is not in SUPPORTED_ENCODERS should be skipped by validation rather than throw
+        KNNMethodContext knnMethodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            SpaceType.INNER_PRODUCT,
+            new MethodComponentContext(
+                METHOD_HNSW,
+                Map.of(METHOD_ENCODER_PARAMETER, new MethodComponentContext("unknown-encoder", Map.of()))
+            )
+        );
+        ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
+            knnMethodContext,
+            KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
+            false,
+            SpaceType.INNER_PRODUCT
+        );
+        assertEquals(
+            "unknown-encoder",
+            ((MethodComponentContext) resolvedMethodContext.getKnnMethodContext()
+                .getMethodComponentContext()
+                .getParameters()
+                .get(METHOD_ENCODER_PARAMETER)).getName()
+        );
+        assertEquals(CompressionLevel.NOT_CONFIGURED, resolvedMethodContext.getCompressionLevel());
+    }
+
     public void testResolveMethod_whenExplicitCompression32x_thenResolvesToSQOneBit() {
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
@@ -519,7 +545,7 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
     }
 
     public void testResolveMethod_whenNoCompressionSpecified_thenResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_7_0+, keep x1 for older versions
+        // TODO: [DEFAULT_FLIP] After Step 4, assert CompressionLevel.x32 for V_3_8_0+, keep x1 for older versions
         ResolvedMethodContext resolvedMethodContext = TEST_RESOLVER.resolveMethod(
             null,
             KNNMethodConfigContext.builder().vectorDataType(VectorDataType.FLOAT).versionCreated(Version.CURRENT).build(),
@@ -576,8 +602,8 @@ public class LuceneHNSWMethodResolverTests extends KNNTestCase {
     }
 
     public void testResolveMethod_whenNoCompressionAcrossVersions_thenAlwaysResolvesToX1() {
-        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_7_0 → assert x1,
-        // indexVersionCreated >= V_3_7_0 → assert x32
+        // TODO: [DEFAULT_FLIP] After Step 4, split into: indexVersionCreated < V_3_8_0 → assert x1,
+        // indexVersionCreated >= V_3_8_0 → assert x32
         Version[] versions = new Version[] { Version.V_3_5_0, Version.V_3_6_0, Version.V_3_7_0, Version.CURRENT };
 
         for (Version version : versions) {

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
 import org.opensearch.knn.index.engine.KNNEngine;
 import org.opensearch.knn.index.engine.KNNMethodConfigContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
@@ -162,6 +163,35 @@ public class LuceneSQEncoderTests extends KNNTestCase {
         callValidateEncoderParams(Version.CURRENT, CompressionLevel.x32, Map.of(LUCENE_SQ_BITS, 1));
     }
 
+    public void testValidateDirectly_whenNullInputs_thenNoException() {
+        new LuceneSQEncoder().validate(null, null);
+    }
+
+    public void testDefaultValidate_noOp() {
+        Encoder encoder = new Encoder() {
+            @Override
+            public MethodComponent getMethodComponent() {
+                return null;
+            }
+
+            @Override
+            public CompressionLevel calculateCompressionLevel(MethodComponentContext ctx, KNNMethodConfigContext configCtx) {
+                return CompressionLevel.NOT_CONFIGURED;
+            }
+
+            @Override
+            public EncoderType getEncoderType() {
+                return EncoderType.FLAT;
+            }
+
+            @Override
+            public java.util.Set<QuantizationBits> getSupportedBits() {
+                return java.util.EnumSet.of(QuantizationBits.FULL_PRECISION);
+            }
+        };
+        encoder.validate(null, null);
+    }
+
     private void callValidateEncoderParams(Version version, CompressionLevel compressionLevel, Map<String, Object> encoderParams) {
         KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
             .versionCreated(version)
@@ -177,6 +207,6 @@ public class LuceneSQEncoderTests extends KNNTestCase {
             new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, encoderCtx))
         );
 
-        LuceneHNSWMethodResolver.validateEncoderParams(methodContext, configContext);
+        new LuceneSQEncoder().validate(methodContext, configContext);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/lucene/LuceneSQEncoderTests.java
@@ -167,6 +167,38 @@ public class LuceneSQEncoderTests extends KNNTestCase {
         new LuceneSQEncoder().validate(null, null);
     }
 
+    public void testValidateDirectly_whenNullConfigContext_thenNoException() {
+        MethodComponentContext encoderCtx = new MethodComponentContext(ENCODER_SQ, Map.of(LUCENE_SQ_BITS, 7));
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of(METHOD_ENCODER_PARAMETER, encoderCtx))
+        );
+        new LuceneSQEncoder().validate(methodContext, null);
+    }
+
+    public void testValidateDirectly_whenEncoderContextMissing_thenNoException() {
+        KNNMethodContext methodContext = new KNNMethodContext(
+            KNNEngine.LUCENE,
+            org.opensearch.knn.index.SpaceType.L2,
+            new MethodComponentContext(METHOD_HNSW, Map.of())
+        );
+        KNNMethodConfigContext configContext = KNNMethodConfigContext.builder()
+            .versionCreated(Version.CURRENT)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(128)
+            .build();
+        new LuceneSQEncoder().validate(methodContext, configContext);
+    }
+
+    public void testValidate_whenNullVersionWithBits_thenOk() {
+        callValidateEncoderParams(null, CompressionLevel.NOT_CONFIGURED, Map.of(LUCENE_SQ_BITS, 7));
+    }
+
+    public void testValidate_whenBits7NoCompressionConfigured_thenOk() {
+        callValidateEncoderParams(Version.CURRENT, CompressionLevel.NOT_CONFIGURED, Map.of(LUCENE_SQ_BITS, 7));
+    }
+
     public void testDefaultValidate_noOp() {
         Encoder encoder = new Encoder() {
             @Override

--- a/src/test/java/org/opensearch/knn/index/mapper/FaissFieldStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/FaissFieldStrategyTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.knn.index.mapper;
 
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.DocValuesType;
 import org.opensearch.Version;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.SpaceType;
@@ -16,12 +17,14 @@ import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
 import org.opensearch.knn.index.engine.KNNMethodContext;
 import org.opensearch.knn.index.engine.ResolvedIndexSpec;
 import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+import org.opensearch.knn.quantization.enums.ScalarQuantizationType;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.opensearch.knn.common.KNNConstants.DIMENSION;
 import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.QFRAMEWORK_CONFIG;
 import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
 import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
@@ -186,6 +189,122 @@ public class FaissFieldStrategyTests extends KNNTestCase {
         FieldType fieldType = config.getFieldType();
         assertEquals(String.valueOf(TEST_DIMENSION), fieldType.getAttributes().get(DIMENSION));
         assertNull(fieldType.getAttributes().get(SQ_CONFIG));
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithQuantizationConfig() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        QuantizationConfig quantizationConfig = QuantizationConfig.builder().quantizationType(ScalarQuantizationType.ONE_BIT).build();
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(quantizationConfig);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(null);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            true
+        );
+
+        FieldType fieldType = config.getFieldType();
+        assertNotNull(fieldType.getAttributes().get(QFRAMEWORK_CONFIG));
+        assertNull(fieldType.getAttributes().get(SQ_CONFIG));
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithPre217Version_thenDocValuesBased() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(null);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.V_2_16_0,
+            true
+        );
+
+        assertFalse(config.isUseLuceneBasedVectorField());
+        assertEquals(DocValuesType.BINARY, config.getFieldType().docValuesType());
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithBinaryDataType_thenDimensionAdjusted() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.HAMMING);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(null);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        // HAMMING has no direct Lucene VectorSimilarityFunction, so the fallback to DEFAULT is exercised
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.BINARY,
+            Version.CURRENT,
+            true
+        );
+
+        assertTrue(config.isUseLuceneBasedVectorField());
+        assertEquals(TEST_DIMENSION / 8, config.getFieldType().vectorDimension());
+        assertEquals(VectorDataType.BINARY.getValue(), config.getFieldType().getAttributes().get(VECTOR_DATA_TYPE_FIELD));
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithPre30Version_thenDefaultSimilarity() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.INNER_PRODUCT);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(null);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        // Pre-3.0 versions always use the DEFAULT space type's similarity function
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.V_2_19_0,
+            true
+        );
+
+        assertTrue(config.isUseLuceneBasedVectorField());
+        assertEquals(
+            SpaceType.DEFAULT.getKnnVectorSimilarityFunction().getVectorSimilarityFunction(),
+            config.getFieldType().vectorSimilarityFunction()
+        );
     }
 
     public void testBuildFieldTypeConfigForFaissWithNullResolvedSpec() {

--- a/src/test/java/org/opensearch/knn/index/mapper/FaissFieldStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/FaissFieldStrategyTests.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.FieldType;
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.Encoder;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+import org.opensearch.knn.index.engine.ResolvedIndexSpec;
+import org.opensearch.knn.index.engine.qframe.QuantizationConfig;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.knn.common.KNNConstants.DIMENSION;
+import static org.opensearch.knn.common.KNNConstants.KNN_ENGINE;
+import static org.opensearch.knn.common.KNNConstants.SPACE_TYPE;
+import static org.opensearch.knn.common.KNNConstants.SQ_CONFIG;
+import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FaissFieldStrategyTests extends KNNTestCase {
+
+    private static final int TEST_DIMENSION = 128;
+
+    public void testBuildFieldTypeConfigForFaissWithSQ1Bit() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.SQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(TEST_DIMENSION)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(resolvedSpec);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            true
+        );
+
+        assertNotNull(config.getFieldType());
+        assertNull(config.getVectorFieldType());
+        assertTrue(config.isUseLuceneBasedVectorField());
+
+        FieldType fieldType = config.getFieldType();
+        assertEquals(String.valueOf(TEST_DIMENSION), fieldType.getAttributes().get(DIMENSION));
+        assertEquals(SpaceType.L2.getValue(), fieldType.getAttributes().get(SPACE_TYPE));
+        assertEquals(KNNEngine.FAISS.getName(), fieldType.getAttributes().get(KNN_ENGINE));
+        assertEquals(VectorDataType.FLOAT.getValue(), fieldType.getAttributes().get(VECTOR_DATA_TYPE_FIELD));
+        assertNotNull(fieldType.getAttributes().get(SQ_CONFIG));
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithoutQuantization() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.INNER_PRODUCT);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.FLAT)
+            .quantizationBits(Encoder.QuantizationBits.FULL_PRECISION)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(TEST_DIMENSION)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(resolvedSpec);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            true
+        );
+
+        assertNotNull(config.getFieldType());
+        assertNull(config.getVectorFieldType());
+        assertTrue(config.isUseLuceneBasedVectorField());
+
+        FieldType fieldType = config.getFieldType();
+        assertEquals(String.valueOf(TEST_DIMENSION), fieldType.getAttributes().get(DIMENSION));
+        assertEquals(SpaceType.INNER_PRODUCT.getValue(), fieldType.getAttributes().get(SPACE_TYPE));
+        assertNull(fieldType.getAttributes().get(SQ_CONFIG));
+    }
+
+    public void testCreateFloatFieldsReturnsNull() {
+        List<?> result = FaissFieldStrategy.INSTANCE.createFloatFields(
+            "test_field",
+            new float[] { 1.0f, 2.0f },
+            mock(FieldType.class),
+            null,
+            true,
+            true,
+            false
+        );
+        assertNull(result);
+    }
+
+    public void testCreateByteFieldsReturnsNull() {
+        List<?> result = FaissFieldStrategy.INSTANCE.createByteFields(
+            "test_field",
+            new byte[] { 1, 2 },
+            mock(FieldType.class),
+            null,
+            true,
+            true,
+            false
+        );
+        assertNull(result);
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithBQEncoder() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        ResolvedIndexSpec resolvedSpec = ResolvedIndexSpec.builder()
+            .engine(KNNEngine.FAISS)
+            .methodName("hnsw")
+            .encoderType(Encoder.EncoderType.BQ)
+            .quantizationBits(Encoder.QuantizationBits.ONE)
+            .compressionLevel(CompressionLevel.x32)
+            .mode(Mode.ON_DISK)
+            .vectorDataType(VectorDataType.FLOAT)
+            .dimension(TEST_DIMENSION)
+            .indexVersionCreated(Version.CURRENT)
+            .build();
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(resolvedSpec);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            true
+        );
+
+        assertNotNull(config.getFieldType());
+        assertTrue(config.isUseLuceneBasedVectorField());
+        FieldType fieldType = config.getFieldType();
+        assertEquals(String.valueOf(TEST_DIMENSION), fieldType.getAttributes().get(DIMENSION));
+        assertNull(fieldType.getAttributes().get(SQ_CONFIG));
+    }
+
+    public void testBuildFieldTypeConfigForFaissWithNullResolvedSpec() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.FAISS);
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+        when(libraryContext.getQuantizationConfig()).thenReturn(QuantizationConfig.EMPTY);
+        when(libraryContext.getLibraryParameters()).thenReturn(Collections.emptyMap());
+        when(libraryContext.getResolvedSpec()).thenReturn(null);
+        when(libraryContext.getVectorTransformer()).thenReturn(null);
+
+        FieldTypeConfig config = FaissFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            true
+        );
+
+        assertNotNull(config.getFieldType());
+        assertTrue(config.isUseLuceneBasedVectorField());
+        assertNull(config.getFieldType().getAttributes().get(SQ_CONFIG));
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/KNNVectorFieldMapperTests.java
@@ -1227,6 +1227,50 @@ public class KNNVectorFieldMapperTests extends KNNTestCase {
         );
     }
 
+    public void testKNNVectorFieldMapperMerge_whenCompressionNotSpecified_thenSuccess() throws IOException {
+        // Exercises the getMergeBuilder path where the user never configured compression_level:
+        // userConfiguredCompressionLevel resolves to NOT_CONFIGURED instead of CompressionLevel.fromName(null)
+        String fieldName = "test-field-name";
+        String indexName = "test-index-name";
+
+        Settings settings = Settings.builder().put(settings(CURRENT).build()).put(KNN_INDEX, true).build();
+        ModelDao modelDao = mock(ModelDao.class);
+        KNNVectorFieldMapper.TypeParser typeParser = new KNNVectorFieldMapper.TypeParser(() -> modelDao);
+
+        int dimension = 133;
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field(TYPE_FIELD_NAME, KNN_VECTOR_TYPE)
+            .field(DIMENSION_FIELD_NAME, dimension)
+            .field(MODE_PARAMETER, Mode.IN_MEMORY.getName())
+            .endObject();
+
+        KNNVectorFieldMapper.Builder builder = (KNNVectorFieldMapper.Builder) typeParser.parse(
+            fieldName,
+            xContentBuilderToMap(xContentBuilder),
+            buildParserContext(indexName, settings)
+        );
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(settings, new ContentPath());
+        KNNVectorFieldMapper knnVectorFieldMapper1 = builder.build(builderContext);
+
+        KNNVectorFieldMapper knnVectorFieldMapperMerge1 = (KNNVectorFieldMapper) knnVectorFieldMapper1.merge(knnVectorFieldMapper1);
+        assertEquals(
+            knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getCompressionLevel(),
+            knnVectorFieldMapperMerge1.fieldType().getKnnMappingConfig().getCompressionLevel()
+        );
+        assertEquals(
+            knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getMode(),
+            knnVectorFieldMapperMerge1.fieldType().getKnnMappingConfig().getMode()
+        );
+
+        KNNVectorFieldMapper knnVectorFieldMapper2 = builder.build(builderContext);
+        KNNVectorFieldMapper knnVectorFieldMapperMerge2 = (KNNVectorFieldMapper) knnVectorFieldMapper1.merge(knnVectorFieldMapper2);
+        assertEquals(
+            knnVectorFieldMapper1.fieldType().getKnnMappingConfig().getMode(),
+            knnVectorFieldMapperMerge2.fieldType().getKnnMappingConfig().getMode()
+        );
+    }
+
     public void testKNNVectorFieldMapper_merge_fromKnnMethodContext() throws IOException {
         String fieldName = "test-field-name";
         String indexName = "test-index-name";

--- a/src/test/java/org/opensearch/knn/index/mapper/LuceneFieldStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/LuceneFieldStrategyTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.opensearch.Version;
+import org.opensearch.knn.KNNTestCase;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.KNNLibraryIndexingContext;
+import org.opensearch.knn.index.engine.KNNMethodContext;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LuceneFieldStrategyTests extends KNNTestCase {
+
+    private static final int TEST_DIMENSION = 128;
+
+    public void testBuildFieldTypeConfigForFloatVector() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.LUCENE);
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+
+        FieldTypeConfig config = LuceneFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            true
+        );
+
+        assertNotNull(config.getFieldType());
+        assertNotNull(config.getVectorFieldType());
+        assertNull(config.getVectorTransformer());
+        assertFalse(config.isUseLuceneBasedVectorField());
+    }
+
+    public void testBuildFieldTypeConfigWithoutDocValues() {
+        KNNMappingConfig mappingConfig = mock(KNNMappingConfig.class);
+        when(mappingConfig.getDimension()).thenReturn(TEST_DIMENSION);
+
+        KNNMethodContext methodContext = mock(KNNMethodContext.class);
+        when(methodContext.getSpaceType()).thenReturn(SpaceType.L2);
+        when(methodContext.getKnnEngine()).thenReturn(KNNEngine.LUCENE);
+
+        KNNLibraryIndexingContext libraryContext = mock(KNNLibraryIndexingContext.class);
+
+        FieldTypeConfig config = LuceneFieldStrategy.INSTANCE.buildFieldTypeConfig(
+            mappingConfig,
+            methodContext,
+            libraryContext,
+            VectorDataType.FLOAT,
+            Version.CURRENT,
+            false
+        );
+
+        assertNotNull(config.getFieldType());
+        assertNull(config.getVectorFieldType());
+    }
+
+    public void testCreateFloatFieldsWithDocValuesAndStored() {
+        int dimension = 3;
+        FieldType fieldType = KnnFloatVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
+        FieldType vectorFieldType = new FieldType();
+        vectorFieldType.setDocValuesType(DocValuesType.BINARY);
+        vectorFieldType.freeze();
+
+        float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
+
+        List<Field> fields = LuceneFieldStrategy.INSTANCE.createFloatFields(
+            "test_field",
+            vector,
+            fieldType,
+            vectorFieldType,
+            true,
+            true,
+            false
+        );
+
+        assertEquals(3, fields.size());
+    }
+
+    public void testCreateFloatFieldsWithoutDocValuesOrStored() {
+        int dimension = 3;
+        FieldType fieldType = KnnFloatVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
+
+        float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
+
+        List<Field> fields = LuceneFieldStrategy.INSTANCE.createFloatFields("test_field", vector, fieldType, null, false, false, false);
+
+        assertEquals(1, fields.size());
+    }
+
+    public void testCreateByteFieldsWithDocValuesAndStored() {
+        int dimension = 3;
+        FieldType fieldType = KnnByteVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
+        FieldType vectorFieldType = new FieldType();
+        vectorFieldType.setDocValuesType(DocValuesType.BINARY);
+        vectorFieldType.freeze();
+
+        byte[] vector = new byte[] { 1, 2, 3 };
+
+        List<Field> fields = LuceneFieldStrategy.INSTANCE.createByteFields(
+            "test_field",
+            vector,
+            fieldType,
+            vectorFieldType,
+            true,
+            true,
+            false
+        );
+
+        assertEquals(3, fields.size());
+    }
+
+    public void testCreateByteFieldsWithoutDocValuesOrStored() {
+        int dimension = 3;
+        FieldType fieldType = KnnByteVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
+
+        byte[] vector = new byte[] { 1, 2, 3 };
+
+        List<Field> fields = LuceneFieldStrategy.INSTANCE.createByteFields("test_field", vector, fieldType, null, false, false, false);
+
+        assertEquals(1, fields.size());
+    }
+}

--- a/src/test/java/org/opensearch/knn/index/mapper/LuceneFieldStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/mapper/LuceneFieldStrategyTests.java
@@ -141,4 +141,26 @@ public class LuceneFieldStrategyTests extends KNNTestCase {
 
         assertEquals(1, fields.size());
     }
+
+    public void testCreateFloatFieldsWithDocValuesButNullVectorFieldType() {
+        int dimension = 3;
+        FieldType fieldType = KnnFloatVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
+
+        float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
+
+        List<Field> fields = LuceneFieldStrategy.INSTANCE.createFloatFields("test_field", vector, fieldType, null, false, true, false);
+
+        assertEquals(1, fields.size());
+    }
+
+    public void testCreateByteFieldsWithDocValuesButNullVectorFieldType() {
+        int dimension = 3;
+        FieldType fieldType = KnnByteVectorField.createFieldType(dimension, VectorSimilarityFunction.EUCLIDEAN);
+
+        byte[] vector = new byte[] { 1, 2, 3 };
+
+        List<Field> fields = LuceneFieldStrategy.INSTANCE.createByteFields("test_field", vector, fieldType, null, false, true, false);
+
+        assertEquals(1, fields.size());
+    }
 }

--- a/src/test/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessorTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessorTests.java
@@ -594,7 +594,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
 
     public void testFactory_shouldGenerate_nullSearchRequest_returnsFalse() {
         KNNSourceExcludesProcessor.Factory factory = new KNNSourceExcludesProcessor.Factory(clusterService, indexNameExpressionResolver);
-        ProcessorGenerationContext context = new ProcessorGenerationContext(null);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(null, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -604,7 +604,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         request.source(new SearchSourceBuilder());
         request.setParentTask(new TaskId("node1", 1));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -613,7 +613,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(false));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -622,7 +622,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[0], new String[0])));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -631,7 +631,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().storedField("_none_"));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -640,7 +640,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder());
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(context));
     }
 
@@ -649,7 +649,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[0], new String[] { "some_field" })));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(context));
     }
 
@@ -658,7 +658,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[] { "title" }, new String[0])));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(context));
     }
 
@@ -667,7 +667,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder());
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         factory.shouldGenerate(context);
 
         var processor = factory.create(Map.of(), "tag", "desc", false, Map.of(), null);

--- a/src/test/java/org/opensearch/knn/search/processor/mmr/MMRUtilTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/mmr/MMRUtilTests.java
@@ -463,7 +463,7 @@ public class MMRUtilTests extends MMRTestCase {
         searchSourceBuilder.ext(Collections.singletonList(new MMRSearchExtBuilder.Builder().build()));
         searchRequest.source(searchSourceBuilder);
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest, null);
 
         assertTrue(MMRUtil.shouldGenerateMMRProcessor(ctx));
     }
@@ -471,7 +471,7 @@ public class MMRUtilTests extends MMRTestCase {
     public void testShouldGenerateMMRProcessor_whenNoExt_thenReturnFalse() {
         SearchRequest searchRequest = new SearchRequest();
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest, null);
 
         assertFalse(MMRUtil.shouldGenerateMMRProcessor(ctx));
     }


### PR DESCRIPTION
### Description
- Refactor engine field mapper, deprecate mode parameter, add encoder validation
- Extracts engine-specific field attribute logic from EngineFieldMapper into FaissFieldStrategy and LuceneFieldStrategy. 
- Moves mode-to-compression derivation into AbstractMethodResolver so users no longer need to specify mode when compression_level implies it (mode is deprecated starting V_3_8_0 with a log warning). 
- Adds encoder.validate() to the Encoder interface so validation logic lives on the encoder rather than scattered across method resolvers.

### Related Issues
Related #3290 
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).~
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
