### PR TITLE
Fix test compilation for ProcessorGenerationContext parentAction arg

### DIFF
--- a/src/test/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessorTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessorTests.java
@@ -594,7 +594,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
 
     public void testFactory_shouldGenerate_nullSearchRequest_returnsFalse() {
         KNNSourceExcludesProcessor.Factory factory = new KNNSourceExcludesProcessor.Factory(clusterService, indexNameExpressionResolver);
-        ProcessorGenerationContext context = new ProcessorGenerationContext(null);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(null, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -604,7 +604,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         request.source(new SearchSourceBuilder());
         request.setParentTask(new TaskId("node1", 1));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -613,7 +613,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(false));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -622,7 +622,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[0], new String[0])));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -631,7 +631,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().storedField("_none_"));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertFalse(factory.shouldGenerate(context));
     }
 
@@ -640,7 +640,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder());
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(context));
     }
 
@@ -649,7 +649,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[0], new String[] { "some_field" })));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(context));
     }
 
@@ -658,7 +658,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder().fetchSource(new FetchSourceContext(true, new String[] { "title" }, new String[0])));
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         assertTrue(factory.shouldGenerate(context));
     }
 
@@ -667,7 +667,7 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder());
 
-        ProcessorGenerationContext context = new ProcessorGenerationContext(request);
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
         factory.shouldGenerate(context);
 
         var processor = factory.create(Map.of(), "tag", "desc", false, Map.of(), null);

--- a/src/test/java/org/opensearch/knn/search/processor/mmr/MMRUtilTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/mmr/MMRUtilTests.java
@@ -463,7 +463,7 @@ public class MMRUtilTests extends MMRTestCase {
         searchSourceBuilder.ext(Collections.singletonList(new MMRSearchExtBuilder.Builder().build()));
         searchRequest.source(searchSourceBuilder);
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest, null);
 
         assertTrue(MMRUtil.shouldGenerateMMRProcessor(ctx));
     }
@@ -471,7 +471,7 @@ public class MMRUtilTests extends MMRTestCase {
     public void testShouldGenerateMMRProcessor_whenNoExt_thenReturnFalse() {
         SearchRequest searchRequest = new SearchRequest();
 
-        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest);
+        ProcessorGenerationContext ctx = new ProcessorGenerationContext(searchRequest, null);
 
         assertFalse(MMRUtil.shouldGenerateMMRProcessor(ctx));
     }


### PR DESCRIPTION
### Description

Core added a parentAction component to the ProcessorGenerationContext record; pass null at test call sites.


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
