### PR TITLE
Introduce extensible VectorSearchEngine API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add base64 encoded vector indexing support for knn_vector fields [#3350](https://github.com/opensearch-project/k-NN/pull/3350)
 * Introduce system-generated search pipeline processor to automatically exclude knn_vector fields from _source in search responses [#3152](https://github.com/opensearch-project/k-NN/pull/3152)
 * Parameterize integration test framework for compression level [#3416](https://github.com/opensearch-project/k-NN/pull/3416)
+* Introduce extensible VectorSearchEngine API [#3288](https://github.com/opensearch-project/k-NN/pull/3443)
 
 ### Maintenance
 * Upgrade Lucene to 10.5.0 [#3411](https://github.com/opensearch-project/k-NN/pull/3411)

--- a/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNEngine.java
@@ -13,6 +13,9 @@ import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
 import org.opensearch.knn.index.engine.faiss.Faiss;
 import org.opensearch.knn.index.engine.lucene.Lucene;
 import org.opensearch.knn.index.engine.nmslib.Nmslib;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
 import org.opensearch.remoteindexbuild.model.RemoteIndexParameters;
 
 import java.util.List;
@@ -27,7 +30,7 @@ import static org.opensearch.knn.common.KNNConstants.NMSLIB_NAME;
  * KNNEngine provides the functionality to validate and transform user defined indices into information that can be
  * passed to the respective k-NN library's JNI layer.
  */
-public enum KNNEngine implements KNNLibrary {
+public enum KNNEngine implements KNNLibrary, VectorSearchEngine {
     @Deprecated(since = "2.19.0", forRemoval = true)
     NMSLIB(NMSLIB_NAME, Nmslib.INSTANCE, Version.V_3_0_0),
     FAISS(FAISS_NAME, Faiss.INSTANCE),
@@ -276,5 +279,27 @@ public enum KNNEngine implements KNNLibrary {
     @Override
     public VectorSearcherFactory getVectorSearcherFactory() {
         return knnLibrary.getVectorSearcherFactory();
+    }
+
+    @Override
+    public RescoreContext getRescoreContext(
+        CompressionLevel compression,
+        Mode mode,
+        int dimension,
+        Version version,
+        boolean isFlatMethod,
+        boolean isSQOneBit
+    ) {
+
+        // Special handling for Lucene Scalar Quantizer (x32 compression)
+        // Engine check is temporary until binary scalar quantizer is finalized for FAISS as well
+        if (compression == CompressionLevel.x32 && this == LUCENE && version.onOrAfter(Version.V_3_6_0)) {
+            return RescoreContext.builder()
+                .oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_DEFAULT_FOR_LUCENE_SCALAR_QUANTIZER_AFTER_V360)
+                .userProvided(false)
+                .build();
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/opensearch/knn/index/engine/VectorSearchEngine.java
+++ b/src/main/java/org/opensearch/knn/index/engine/VectorSearchEngine.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.engine;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.Version;
+import org.opensearch.common.ValidationException;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.knn.index.SpaceType;
+import org.opensearch.knn.index.mapper.CompressionLevel;
+import org.opensearch.knn.index.mapper.Mode;
+import org.opensearch.knn.index.query.rescore.RescoreContext;
+import org.opensearch.knn.memoryoptsearch.VectorSearcherFactory;
+import org.opensearch.remoteindexbuild.model.RemoteIndexParameters;
+
+/**
+ * Abstract interface to represent the SPI of the generic vector engine that is available
+ * to the plugin.
+ */
+@ExperimentalApi
+public interface VectorSearchEngine {
+    /**
+     * Validates that the KNN method is compatible with the KNN engine.
+     * @param knnMethodContext KNN method context
+     * @param knnMethodConfigContext KNN method configuration context
+     * @return an {@link ValidationException} instance on case of validation failure, otherwise {@code null}
+     */
+    ValidationException validateMethod(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext);
+
+    /**
+     * Checks if training is required or not
+     * @param knnMethodContext KNN method context
+     * @return {@code true} if training is required, {@code false} otherwise
+     */
+    boolean isTrainingRequired(KNNMethodContext knnMethodContext);
+
+    /**
+     * Estimates the overhead the KNN method adds irrespective of the number of vectors
+     * @param knnMethodContext KNN method context
+     * @param knnMethodConfigContext KNN method configuration context
+     * @return size in Kilobytes
+     */
+    int estimateOverheadInKB(KNNMethodContext knnMethodContext, KNNMethodConfigContext knnMethodConfigContext);
+
+    /**
+     * Returns this KNN engine name
+     * @return engine name
+     */
+    String getName();
+
+    /**
+     * Gets the extension that files written with this KNN engine should have
+     *
+     * @return extension
+     */
+    String getExtension();
+
+    /**
+     * Checks if the KNN engine is deprecated for a given OpenSearch version.
+     *
+     * @param indexVersionCreated the OpenSearch version where the index is created
+     * @return {@code true} if deprecated, {@code false} otherwise
+     */
+    boolean isRestricted(Version indexVersionCreated);
+
+    /**
+     * Gets the deprecated version
+     *
+     * @return deprecated vsersion
+     */
+    Version getRestrictedFromVersion();
+
+    /**
+     * Gets the version of the KNN engine that is being used. In general, this can be used for ensuring compatibility of
+     * serialized artifacts. For instance, this can be used to check if a given file that was created on a different
+     * cluster is compatible with this instance of the KNN engine.
+     *
+     * @return the string representing the KNN engine's version
+     */
+    String getVersion();
+
+    /**
+     * Gets the compound extension that files written with this KNN engine should have
+     *
+     * @return compound extension
+     */
+    String getCompoundExtension();
+
+    /**
+     * Generate the Lucene score from the rawScore returned by the KNN engine. With k-NN, often times the engine
+     * will return a score where the lower the score, the better the result. This is the opposite of how Lucene scores
+     * documents.
+     *
+     * @param rawScore  returned by the KNN engine
+     * @param spaceType spaceType used to compute the score
+     * @return Lucene score for the rawScore
+     */
+    float score(float rawScore, SpaceType spaceType);
+
+    /**
+     * Translates the distance radius input from end user to the engine's threshold.
+     *
+     * @param distance distance radius input from end user
+     * @param spaceType spaceType used to compute the radius
+     *
+     * @return transformed distance for the KNN engine
+     */
+    Float distanceToRadialThreshold(Float distance, SpaceType spaceType);
+
+    /**
+     * Translates the score threshold input from end user to the engine's threshold.
+     *
+     * @param score score threshold input from end user
+     * @param spaceType spaceType used to compute the threshold
+     *
+     * @return transformed score for the KNN engine
+     */
+    Float scoreToRadialThreshold(Float score, SpaceType spaceType);
+
+    /**
+     * Gets the context from the KNN engine needed to build the index.
+     *
+     * @param knnMethodContext KNN method context to get build context for
+     * @param knnMethodConfigContext configuration context for the KNN method
+     * @return parameter map
+     */
+    KNNLibraryIndexingContext getKNNLibraryIndexingContext(
+        KNNMethodContext knnMethodContext,
+        KNNMethodConfigContext knnMethodConfigContext
+    );
+
+    /**
+     * Gets metadata related to methods supported by the KNN engine
+     *
+     * @param methodName name of method
+     * @return {@link KNNLibrarySearchContext} instance
+     */
+    KNNLibrarySearchContext getKNNLibrarySearchContext(String methodName);
+
+    /**
+     * Returns if KNN engine has been initialized or not
+     *
+     * @return whether KNN engine has been initialized
+     */
+    Boolean isInitialized();
+
+    /**
+     * Sets initialized to true
+     *
+     * @param isInitialized whether KNN engine has been initialized
+     */
+    void setInitialized(Boolean isInitialized);
+
+    /**
+     * Gets mmap file extensions
+     *
+     * @return list of file extensions that will be read/write with mmap
+     */
+    List<String> mmapFileExtensions();
+
+    /**
+     * Creates a new {@link ResolvedMethodContext} filling parameters based on other configuration details. A validation
+     * exception will be thrown if the {@link KNNMethodConfigContext} is not compatible with the
+     * parameters provided by the user.
+     *
+     * @param knnMethodContext User provided information regarding the method context. A new context should be
+     *                         constructed. This variable will not be modified.
+     * @param knnMethodConfigContext Configuration details that can be used for resolving the defaults. Should not be null
+     * @param shouldRequireTraining Should the provided context require training
+     * @param spaceType Space type for the method. Cannot be null or undefined
+     * @return {@link ResolvedMethodContext} with dynamic defaults configured. This will include both the resolved
+     *                                       compression as well as the completely resolve {@link KNNMethodContext}.
+     *                                       This is guanteed to be a copy of the user provided context.
+     * @throws org.opensearch.common.ValidationException on invalid configuration and user-provided context.
+     */
+    ResolvedMethodContext resolveMethod(
+        KNNMethodContext knnMethodContext,
+        KNNMethodConfigContext knnMethodConfigContext,
+        boolean shouldRequireTraining,
+        final SpaceType spaceType
+    );
+
+    /**
+     * Returns whether the engine implementation supports remote index build
+     * @return {@code true} if remote index build is supported, {@code false} otherwise
+     */
+    boolean supportsRemoteIndexBuild(KNNLibraryIndexingContext knnLibraryIndexingContext);
+
+    /**
+     * Creates the set of index parameters needed to build the remote index
+     * @param parameters parameters
+     * @return {@link RemoteIndexParameters} instance
+     */
+    RemoteIndexParameters createRemoteIndexingParameters(Map<String, Object> parameters);
+
+    /**
+     * Create a new vector searcher factory that compatible with on Lucene search API.
+     * @return New searcher factory that returns {@link org.opensearch.knn.memoryoptsearch.VectorSearcher}
+     *         If it is not supported, it should return null.
+     *         But, if it is supported, the factory shall not return null searcher.
+     */
+    VectorSearcherFactory getVectorSearcherFactory();
+
+    /**
+     * Returns {@link RescoreContext} that is specific to the KNN engine
+     * @param compression compression level
+     * @param mode mode
+     * @param dimension vector dimensions
+     * @param version OpenSearch version
+     * @param isFlatMethod flat method or not
+     * @param isSQOneBit SQ one bit or not
+     * @return {@link RescoreContext} that is specific to the KNN engine, {@code null} otherwise
+     */
+    RescoreContext getRescoreContext(
+        CompressionLevel compression,
+        Mode mode,
+        int dimension,
+        Version version,
+        boolean isFlatMethod,
+        boolean isSQOneBit
+    );
+}

--- a/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
+++ b/src/main/java/org/opensearch/knn/index/mapper/CompressionLevel.java
@@ -10,7 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.opensearch.Version;
 import org.opensearch.core.common.Strings;
-import org.opensearch.knn.index.engine.KNNEngine;
+import org.opensearch.knn.index.engine.VectorSearchEngine;
 import org.opensearch.knn.index.query.rescore.RescoreContext;
 
 import java.util.Collections;
@@ -117,7 +117,13 @@ public enum CompressionLevel {
         return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, false, null);
     }
 
-    public RescoreContext getDefaultRescoreContext(Mode mode, int dimension, Version version, boolean isFlatMethod, KNNEngine engine) {
+    public RescoreContext getDefaultRescoreContext(
+        Mode mode,
+        int dimension,
+        Version version,
+        boolean isFlatMethod,
+        VectorSearchEngine engine
+    ) {
         return getDefaultRescoreContext(mode, dimension, version, isFlatMethod, false, engine);
     }
 
@@ -136,7 +142,7 @@ public enum CompressionLevel {
         Version version,
         boolean isFlatMethod,
         boolean isSQOneBit,
-        KNNEngine engine
+        VectorSearchEngine engine
     ) {
         // For sq(bits=1) encoder, use fixed oversample factor.
         if (isSQOneBit) {
@@ -151,13 +157,11 @@ public enum CompressionLevel {
             return RescoreContext.builder().oversampleFactor(FLAT_OVERSAMPLE_FACTOR).userProvided(false).build();
         }
         if (modesForRescore.contains(mode)) {
-            // Special handling for Lucene Scalar Quantizer (x32 compression)
-            // Engine check is temporary until binary scalar quantizer is finalized for FAISS as well
-            if (this == x32 && engine == KNNEngine.LUCENE && version.onOrAfter(Version.V_3_6_0)) {
-                return RescoreContext.builder()
-                    .oversampleFactor(RescoreContext.OVERSAMPLE_FACTOR_DEFAULT_FOR_LUCENE_SCALAR_QUANTIZER_AFTER_V360)
-                    .userProvided(false)
-                    .build();
+            if (engine != null) {
+                final RescoreContext rescoreContext = engine.getRescoreContext(this, mode, dimension, version, isFlatMethod, isSQOneBit);
+                if (rescoreContext != null) {
+                    return rescoreContext;
+                }
             }
 
             if (this == x4 && version.before(Version.V_3_1_0)) {


### PR DESCRIPTION
### Description
Introduce extensible VectorSearchEngine API.

In scope of https://github.com/opensearch-project/OpenSearch/issues/20050, we have discussed the possible ways how new KNN/Vector engines could be introduced, and most importantly, co-exist with the ones provided by K-NN plugin. The `KNNEngine` is one of the key component here, unfortunately is it designed as enumeration and is not extensible (from the outside) but fixed. 

This is smaller scope change extracted from https://github.com/opensearch-project/k-NN/pull/3288

### Related Issues
Part of https://github.com/opensearch-project/OpenSearch/issues/20050
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
