### PR TITLE
Fix CI: two-step compile so nmslib uses gcc10 and faiss+AVX-512 SPR uses gcc12+

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,10 +39,13 @@ jobs:
       matrix:
         java: [21, 25]
 
-    env:
-       CC: gcc10-gcc
-       CXX: gcc10-g++
-       FC: gcc10-gfortran
+    # No fleet-wide compiler env pin. The AL2 CI image provides two toolchains:
+    #   - gcc10-* : required to build nmslib (fails to compile under GCC 11+, see k-NN#2484).
+    #   - /usr/bin/gcc = GCC 12.4 (x86_64, built from source): required for faiss AVX-512 SPR
+    #     intrinsics (-mavx512fp16 / _mm512_cvt_roundps_ph).
+    # We use a two-step compile below (mirrors scripts/build.sh) so both libraries build with
+    # the compiler they need. On arm64 both aliases resolve to gcc10 via update-alternatives,
+    # so the two-step is harmless there.
 
     name: Build and Test k-NN Plugin on Linux
     runs-on: ubuntu-latest
@@ -75,26 +78,58 @@ jobs:
 
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
+        #
+        # Two-step compile (mirrors scripts/build.sh, keeps nmslib on gcc10 and faiss+SPR on
+        # GCC 12+). We detect the SIMD tier from lscpu and pass the same -Davx*.enabled flags
+        # to both compile stages, so cmake caches don't clash. Java build/tests run in the
+        # second stage under the default (GCC 12.4 on x86, gcc10 on arm64) toolchain.
         run: |
+          set -euo pipefail
           chown -R 1000:1000 `pwd`
-          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
+
+          if lscpu | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw > /dev/null
           then
-            if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq
+            if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq > /dev/null
             then
               echo "the system is an Intel(R) Sapphire Rapids or a newer-generation processor"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc`"
+              SIMD_FLAGS="-Davx512_spr.enabled=true"
             else
               echo "avx512 available on system"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+              SIMD_FLAGS="-Davx512_spr.enabled=false"
             fi
-          elif lscpu  | grep -i avx2
+          elif lscpu | grep -i avx2 > /dev/null
           then
             echo "avx2 available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+            SIMD_FLAGS="-Davx512.enabled=false -Davx512_spr.enabled=false"
           else
             echo "avx512 and avx2 not available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
-          fi  
+            SIMD_FLAGS="-Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false"
+          fi
+
+          NPROC=`nproc`
+          # Step 1: build nmslib with gcc10 (nmslib does not compile under GCC 11+, see k-NN#2484).
+          # Explicitly disable all faiss SIMD tiers here so init-simd.cmake doesn't probe AVX-512
+          # SPR intrinsics against GCC 10 (that probe requires GCC 12+ and would fail loud). The
+          # per-arch faiss SIMD variant we actually want is built in step 2 with the default gcc.
+          echo "=== Step 1: build nmslib with gcc10 ==="
+          su `id -un 1000` -c "whoami && java -version && \
+              env CC=gcc10-gcc CXX=gcc10-g++ FC=gcc10-gfortran \
+                  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib \
+                                         -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false \
+                                         -Dnproc.count=${NPROC}"
+
+          # Wipe cmake configure cache so step 2 re-runs cmake with the default (GCC 12+) toolchain
+          # and the correct SIMD tier for this runner. The release/ output dir is preserved, so
+          # libopensearchknn_nmslib.so from step 1 stays intact.
+          rm -rf jni/build/CMakeCache.txt jni/build/CMakeFiles
+
+          # Step 2: build faiss/simd and run the full gradle build (Java compile, test, integTest)
+          # with the default toolchain (GCC 12.4 on x86 -> AVX-512 SPR supported; gcc10 on arm64).
+          # -Dbuild.lib.apply_patches=false: patches were already applied in step 1.
+          echo "=== Step 2: build faiss/simd + run Java build with default gcc ==="
+          su `id -un 1000` -c "whoami && java -version && \
+              ./gradlew build -Pknn_libs=opensearchknn_faiss,opensearchknn_simd ${SIMD_FLAGS} \
+                              -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC}"
 
 
       - name: Upload Coverage Report

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -36,10 +36,13 @@ jobs:
     strategy:
       matrix:
         java: [21, 25]
-    env:
-       CC: gcc10-gcc
-       CXX: gcc10-g++
-       FC: gcc10-gfortran
+    # No fleet-wide compiler env pin. The AL2 CI image provides two toolchains:
+    #   - gcc10-* : required to build nmslib (fails to compile under GCC 11+, see k-NN#2484).
+    #   - /usr/bin/gcc = GCC 12.4 (x86_64, built from source): required for faiss AVX-512 SPR
+    #     intrinsics (-mavx512fp16 / _mm512_cvt_roundps_ph).
+    # We use a two-step compile below (mirrors scripts/build.sh) so both libraries build with
+    # the compiler they need. On arm64 both aliases resolve to gcc10 via update-alternatives,
+    # so the two-step is harmless there.
 
     name: Run Integration Tests on Linux
     runs-on: ubuntu-latest
@@ -70,26 +73,58 @@ jobs:
 
       - name: Run build
         # switching the user, as OpenSearch cluster can only be started as root/Administrator on linux-deb/linux-rpm/windows-zip.
+        #
+        # Two-step compile (mirrors scripts/build.sh, keeps nmslib on gcc10 and faiss+SPR on
+        # GCC 12+). We detect the SIMD tier from lscpu and pass the same -Davx*.enabled flags
+        # to both compile stages, so cmake caches don't clash. Java build/tests run in the
+        # second stage under the default (GCC 12.4 on x86, gcc10 on arm64) toolchain.
         run: |
+          set -euo pipefail
           chown -R 1000:1000 `pwd`
-          if lscpu  | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw          
+
+          if lscpu | grep -i avx512f | grep -i avx512cd | grep -i avx512vl | grep -i avx512dq | grep -i avx512bw > /dev/null
           then
-            if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq
+            if lscpu | grep -q "GenuineIntel" && lscpu | grep -i avx512_fp16 | grep -i avx512_bf16 | grep -i avx512_vpopcntdq > /dev/null
             then
               echo "the system is an Intel(R) Sapphire Rapids or a newer-generation processor"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=true -Dnproc.count=`nproc`"
+              SIMD_FLAGS="-Davx512_spr.enabled=true"
             else
               echo "avx512 available on system"
-              su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+              SIMD_FLAGS="-Davx512_spr.enabled=false"
             fi
-          elif lscpu  | grep -i avx2
+          elif lscpu | grep -i avx2 > /dev/null
           then
             echo "avx2 available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+            SIMD_FLAGS="-Davx512.enabled=false -Davx512_spr.enabled=false"
           else
             echo "avx512 and avx2 not available on system"
-            su `id -un 1000` -c "whoami && java -version && ./gradlew build -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false -Dnproc.count=`nproc`"
+            SIMD_FLAGS="-Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false"
           fi
+
+          NPROC=`nproc`
+          # Step 1: build nmslib with gcc10 (nmslib does not compile under GCC 11+, see k-NN#2484).
+          # Explicitly disable all faiss SIMD tiers here so init-simd.cmake doesn't probe AVX-512
+          # SPR intrinsics against GCC 10 (that probe requires GCC 12+ and would fail loud). The
+          # per-arch faiss SIMD variant we actually want is built in step 2 with the default gcc.
+          echo "=== Step 1: build nmslib with gcc10 ==="
+          su `id -un 1000` -c "whoami && java -version && \
+              env CC=gcc10-gcc CXX=gcc10-g++ FC=gcc10-gfortran \
+                  ./gradlew :buildJniLib -Pknn_libs=opensearchknn_nmslib \
+                                         -Davx2.enabled=false -Davx512.enabled=false -Davx512_spr.enabled=false \
+                                         -Dnproc.count=${NPROC}"
+
+          # Wipe cmake configure cache so step 2 re-runs cmake with the default (GCC 12+) toolchain
+          # and the correct SIMD tier for this runner. The release/ output dir is preserved, so
+          # libopensearchknn_nmslib.so from step 1 stays intact.
+          rm -rf jni/build/CMakeCache.txt jni/build/CMakeFiles
+
+          # Step 2: build faiss/simd and run the full gradle build (Java compile, test, integTest)
+          # with the default toolchain (GCC 12.4 on x86 -> AVX-512 SPR supported; gcc10 on arm64).
+          # -Dbuild.lib.apply_patches=false: patches were already applied in step 1.
+          echo "=== Step 2: build faiss/simd + run Java build with default gcc ==="
+          su `id -un 1000` -c "whoami && java -version && \
+              ./gradlew build -Pknn_libs=opensearchknn_faiss,opensearchknn_simd ${SIMD_FLAGS} \
+                              -Dbuild.lib.apply_patches=false -Dnproc.count=${NPROC}"
 
   check-results:
     needs: [check-files, integ-test-with-security-linux]


### PR DESCRIPTION
### Description
Fix CI failures on Sapphire Rapids runners by splitting the native lib build into two stages, matching what `scripts/build.sh` already does for distribution builds.

  - **Step 1**: build `opensearchknn_nmslib` with `gcc10-*` (nmslib does not compile under GCC 11+, see #2484). All faiss SIMD flags forced off so `init-simd.cmake` doesn't probe SPR intrinsics against GCC 10.
  - **Step 2**: wipe the cmake configure cache, then run the full `./gradlew build` with the default toolchain (GCC 12.4 on x86, gcc10 on arm64) and the runner-appropriate SIMD tier. This is what produces `libopensearchknn_faiss_avx512_spr.so` on SPR CPUs.

  Root cause: GitHub runners upgraded to Sapphire Rapids-class CPUs, which made the `avx512_spr.enabled=true` branch reachable for the first time. The previous workflow pinned `CC=gcc10-*` fleet-wide, so cmake's SPR compiler probe (`_mm512_cvt_roundps_ph` / `-mavx512fp16`, requires GCC 12+) failed with `FATAL_ERROR: AVX512_SPR was explicitly enabled, but compiler does not support it`.

  Applied to both `CI.yml` and `test_security.yml`. BWC and remote-index-build workflows already work (BWC uses ubuntu-latest with GCC 13; remote-index-build doesn't currently trigger the SPR branch on its GPU runner).

### Related Issues
```
CMake Error at cmake/init-simd.cmake:95 (message):

  [SIMD] AVX512_SPR was explicitly enabled, but compiler does not support it.
> Task :cmakeJniLib FAILED
Call Stack (most recent call first):
  CMakeLists.txt:133 (include)


FAILURE: Build failed with an exception.
```
https://github.com/opensearch-project/k-NN/actions/runs/29952349411/job/89040847522?pr=3429

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
