### PR TITLE
Use codecExcludes for inner-hit vector reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix isFaissSQfp16 to skip FP16 validation when SQ encoder uses bits=1 [#3366](https://github.com/opensearch-project/k-NN/pull/3366)
 * Fix score corruption in multi-segment FAISS indices with ADC [#3385](https://github.com/opensearch-project/k-NN/pull/3385)
 * Fix radial search max_distance threshold conversion for inner product with memory-optimized search [#3369](https://github.com/opensearch-project/k-NN/pull/3369)
+* Fix inner-hits returning mask value for top level source excludes [#3446](https://github.com/opensearch-project/k-NN/pull/3446)
 
 ### Refactoring
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -57,16 +57,6 @@ allprojects {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-
-    // BWC resolves the target distribution/build-tools as SNAPSHOTs. Gradle caches changing
-    // modules for 24h by default, so a run can pick up a stale snapshot that predates a core
-    // change k-NN main depends on (e.g. a newly added FieldsVisitor method), causing a
-    // runtime NoSuchMethodError on the upgraded node. Re-check snapshot metadata every run so
-    // BWC always resolves the latest 3.x snapshot. Metadata-only unless the snapshot moved, so
-    // the cost is negligible next to building the JNI libs and booting test clusters.
-    configurations.all {
-        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-    }
 }
 
 // Task to pull k-NN plugin from archive

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -57,6 +57,16 @@ allprojects {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
+
+    // BWC resolves the target distribution/build-tools as SNAPSHOTs. Gradle caches changing
+    // modules for 24h by default, so a run can pick up a stale snapshot that predates a core
+    // change k-NN main depends on (e.g. a newly added FieldsVisitor method), causing a
+    // runtime NoSuchMethodError on the upgraded node. Re-check snapshot metadata every run so
+    // BWC always resolves the latest 3.x snapshot. Metadata-only unless the snapshot moved, so
+    // the cost is negligible next to building the JNI libs and booting test clusters.
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
 }
 
 // Task to pull k-NN plugin from archive

--- a/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
+++ b/src/main/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReader.java
@@ -81,16 +81,29 @@ public class KNN10010DerivedSourceStoredFieldsReader extends StoredFieldsReader 
         if (transformerInitialized) {
             return;
         }
-        String[] includes = null;
-        String[] excludes = null;
-
-        if (visitor instanceof FieldsVisitor) {
-            includes = ((FieldsVisitor) visitor).includes();
-            excludes = ((FieldsVisitor) visitor).excludes();
-        }
-
-        derivedSourceVectorTransformer.initialize(includes, excludes);
+        derivedSourceVectorTransformer.initialize(resolveIncludes(visitor), resolveExcludes(visitor));
         transformerInitialized = true;
+    }
+
+    /**
+     * Resolves the source include patterns to use for vector injection from the visitor, or {@code null}
+     * when the visitor is not a {@link FieldsVisitor}.
+     */
+    static String[] resolveIncludes(StoredFieldVisitor visitor) {
+        return visitor instanceof FieldsVisitor ? ((FieldsVisitor) visitor).includes() : null;
+    }
+
+    /**
+     * Resolves the source exclude patterns to use for vector injection from the visitor, or {@code null}
+     * when the visitor is not a {@link FieldsVisitor}.
+     *
+     * <p>Uses {@link FieldsVisitor#codecExcludes()} rather than {@link FieldsVisitor#excludes()}: codec
+     * excludes are the response-level excludes minus any field an inner hit (or the fields API) requests,
+     * so a vector excluded from the top-level response is still reconstructed here when a nested inner hit
+     * needs it. See OpenSearch core PR #22521 and k-NN issue #3303.
+     */
+    static String[] resolveExcludes(StoredFieldVisitor visitor) {
+        return visitor instanceof FieldsVisitor ? ((FieldsVisitor) visitor).codecExcludes() : null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessor.java
+++ b/src/main/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessor.java
@@ -9,6 +9,8 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.apache.lucene.search.BooleanClause;
+import org.opensearch.action.search.MultiSearchAction;
+import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -109,18 +111,9 @@ public final class KNNSourceExcludesProcessor extends AbstractProcessor implemen
         final List<InnerHitBuilder> innerHitBuilders = innerHitsExtractor.getInnerHitBuilders();
         for (InnerHitBuilder innerHitBuilder : innerHitBuilders) {
             FetchSourceContext fetchSourceContext = innerHitBuilder.getFetchSourceContext();
-            List<String> fetchFields = innerHitBuilder.getFetchFields() != null
-                ? innerHitBuilder.getFetchFields().stream().map(fieldAndFormat -> fieldAndFormat.field).toList()
-                : List.of();
+            StoredFieldsContext storedFieldsContext = innerHitBuilder.getStoredFieldsContext();
 
-            if (SourceInspector.isExplicitTrue(fetchSourceContext)
-                || SourceInspector.innerHitRequestsVector(fetchSourceContext, fetchFields, vectorFields)) {
-                return request;
-            }
-        }
-
-        for (InnerHitBuilder innerHitBuilder : innerHitBuilders) {
-            if (SourceInspector.isExplicitFalse(innerHitBuilder.getFetchSourceContext()) == false) {
+            if (shouldAppendExcludes(fetchSourceContext, storedFieldsContext)) {
                 innerHitBuilder.setFetchSourceContext(applyExcludes(innerHitBuilder.getFetchSourceContext(), vectorFields));
             }
         }
@@ -217,6 +210,13 @@ public final class KNNSourceExcludesProcessor extends AbstractProcessor implemen
         return new FetchSourceContext(true, userIncludes, mergedExcludes.toArray(new String[0]));
     }
 
+    private static boolean shouldAppendExcludes(FetchSourceContext fetchSource, StoredFieldsContext storedFieldsContext) {
+        if (SourceInspector.isExplicitFalse(fetchSource) || SourceInspector.isExplicitTrue(fetchSource)) {
+            return false;
+        }
+        return storedFieldsContext == null || storedFieldsContext.fetchFields();
+    }
+
     @Override
     public String getType() {
         return TYPE;
@@ -271,20 +271,6 @@ public final class KNNSourceExcludesProcessor extends AbstractProcessor implemen
             }
             return false;
         }
-
-        private static boolean innerHitRequestsVector(
-            final FetchSourceContext fetchSourceContext,
-            final List<String> fetchFields,
-            final Set<String> vectorFields
-        ) {
-            for (String vectorField : vectorFields) {
-                if ((fetchSourceContext != null && patternMatchesAny(vectorField, Arrays.asList(fetchSourceContext.includes())))
-                    || patternMatchesAny(vectorField, fetchFields)) {
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 
     /**
@@ -299,6 +285,14 @@ public final class KNNSourceExcludesProcessor extends AbstractProcessor implemen
     public static class Factory implements SystemGeneratedProcessor.SystemGeneratedFactory<SearchRequestProcessor> {
         public static final String TYPE = "knn_default_excludes_factory";
 
+        /**
+         * Parent actions for which this processor should be generated.
+         * <p>A {@code null} parent action denotes a top-level user search with no parent task and is always allowed.
+         * {@link SearchAction#NAME} covers the leaf search executed on a remote cluster during cross-cluster search;
+         * {@link MultiSearchAction#NAME} covers the child searches fanned out from a multi-search request.
+         */
+        private static final Set<String> ALLOWED_PARENT_ACTIONS = Set.of(SearchAction.NAME, MultiSearchAction.NAME);
+
         private final ClusterService clusterService;
         private final IndexNameExpressionResolver indexNameExpressionResolver;
 
@@ -309,9 +303,14 @@ public final class KNNSourceExcludesProcessor extends AbstractProcessor implemen
 
         @Override
         public boolean shouldGenerate(ProcessorGenerationContext context) {
-            // TODO: Access parent action and use an allowlisted list of action to generate the processor
-            // For now, we will add this processor for all search requests except parent task requests
-            if (context.searchRequest() == null || context.searchRequest().getParentTask().isSet()) {
+            if (context.searchRequest() == null) {
+                return false;
+            }
+
+            // Only generate the processor for allowlisted parent actions. A null parent action is a top-level
+            // user search; msearch and cross-cluster leaf searches are the other cases where excluding vector
+            // fields from the response is meaningful. Any other parent action is skipped.
+            if (context.parentAction() != null && ALLOWED_PARENT_ACTIONS.contains(context.parentAction()) == false) {
                 return false;
             }
 
@@ -324,13 +323,6 @@ public final class KNNSourceExcludesProcessor extends AbstractProcessor implemen
             }
             // In all other cases do not add this processor
             return false;
-        }
-
-        private boolean shouldAppendExcludes(FetchSourceContext fetchSource, StoredFieldsContext storedFieldsContext) {
-            if (SourceInspector.isExplicitFalse(fetchSource) || SourceInspector.isExplicitTrue(fetchSource)) {
-                return false;
-            }
-            return storedFieldsContext == null || storedFieldsContext.fetchFields();
         }
 
         @Override

--- a/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReaderTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/KNN10010Codec/KNN10010DerivedSourceStoredFieldsReaderTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.codec.KNN10010Codec;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.opensearch.index.fieldvisitor.FieldsVisitor;
+import org.opensearch.knn.KNNTestCase;
+
+public class KNN10010DerivedSourceStoredFieldsReaderTests extends KNNTestCase {
+
+    public void testResolveExcludes_usesCodecExcludesNotResponseExcludes() {
+        // Response-level excludes strip the vector from the top-level _source, but codec excludes omit it
+        // because an inner hit requested the field — so injection must key off codec excludes (#3303 / core #22521).
+        String[] responseExcludes = { "nested_obj.vec" };
+        String[] codecExcludes = new String[0];
+        FieldsVisitor visitor = new FieldsVisitor(true, new String[0], responseExcludes, codecExcludes);
+
+        assertArrayEquals(codecExcludes, KNN10010DerivedSourceStoredFieldsReader.resolveExcludes(visitor));
+        assertFalse(
+            "resolveExcludes must not return the response-level excludes",
+            java.util.Arrays.equals(responseExcludes, KNN10010DerivedSourceStoredFieldsReader.resolveExcludes(visitor))
+        );
+    }
+
+    public void testResolveExcludes_returnsCodecExcludesWhenBothPresent() {
+        String[] responseExcludes = { "a", "b" };
+        String[] codecExcludes = { "a" };
+        FieldsVisitor visitor = new FieldsVisitor(true, new String[0], responseExcludes, codecExcludes);
+
+        assertArrayEquals(codecExcludes, KNN10010DerivedSourceStoredFieldsReader.resolveExcludes(visitor));
+    }
+
+    public void testResolveIncludes_returnsVisitorIncludes() {
+        String[] includes = { "nested_obj.vec" };
+        FieldsVisitor visitor = new FieldsVisitor(true, includes, new String[0], new String[0]);
+
+        assertArrayEquals(includes, KNN10010DerivedSourceStoredFieldsReader.resolveIncludes(visitor));
+    }
+
+    public void testResolveIncludesAndExcludes_nonFieldsVisitor_returnsNull() {
+        // A visitor that is not a FieldsVisitor carries no include/exclude context — inject everything.
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return Status.NO;
+            }
+        };
+
+        assertNull(KNN10010DerivedSourceStoredFieldsReader.resolveIncludes(visitor));
+        assertNull(KNN10010DerivedSourceStoredFieldsReader.resolveExcludes(visitor));
+    }
+}

--- a/src/test/java/org/opensearch/knn/integ/KNNSourceExcludesProcessorIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNSourceExcludesProcessorIT.java
@@ -892,7 +892,15 @@ public class KNNSourceExcludesProcessorIT extends KNNRestTestCase {
 
         // Two search bodies in one _msearch request, both plain match_all.
         String matchAllBody = "{\"query\":{\"match_all\":{}}}";
-        String ndjson = "{\"index\":\"" + indexName + "\"}\n" + matchAllBody + "\n" + "{\"index\":\"" + indexName + "\"}\n" + matchAllBody
+        String ndjson = "{\"index\":\""
+            + indexName
+            + "\"}\n"
+            + matchAllBody
+            + "\n"
+            + "{\"index\":\""
+            + indexName
+            + "\"}\n"
+            + matchAllBody
             + "\n";
 
         Request request = new Request("GET", "/_msearch");

--- a/src/test/java/org/opensearch/knn/integ/KNNSourceExcludesProcessorIT.java
+++ b/src/test/java/org/opensearch/knn/integ/KNNSourceExcludesProcessorIT.java
@@ -791,7 +791,7 @@ public class KNNSourceExcludesProcessorIT extends KNNRestTestCase {
     }
 
     @SneakyThrows
-    public void testSearchResponse_innerHitExplicitTrueSource_noTopLevelExcludes() {
+    public void testSearchResponse_innerHitExplicitTrueSource_topLevelExcludedInnerHitReturnsVector() {
         String indexName = INDEX_NAME + "-inner-hit-true";
         String nestedField = "nested_obj";
         String nestedVecField = "vec";
@@ -833,7 +833,8 @@ public class KNNSourceExcludesProcessorIT extends KNNRestTestCase {
         addKnnDoc(indexName, "1", doc);
         refreshIndex(indexName);
 
-        // Inner hit with _source: true — processor should not add top-level excludes (issue #3303)
+        // Inner hit with _source: true. Post core PR #22521, the top-level vector is excluded while the
+        // inner hit still returns it — core preserves the field at the codec level for the inner hit (issue #3303).
         String query = XContentFactory.jsonBuilder()
             .startObject()
             .startObject("query")
@@ -857,12 +858,15 @@ public class KNNSourceExcludesProcessorIT extends KNNRestTestCase {
         assertEquals(1, hits.size());
         Map<String, Object> hit = hits.get(0);
 
-        // Top-level source should contain the nested object (vector not excluded at top level)
+        // Top-level source: the nested vector is excluded, but the nested object's other content remains.
         Map<String, Object> source = getSource(hit);
         assertNotNull(source);
-        assertTrue("Nested object should be present in top-level source", source.containsKey(nestedField));
+        if (source.containsKey(nestedField)) {
+            Map<String, Object> nestedSource = (Map<String, Object>) source.get(nestedField);
+            assertFalse("Nested vector should be excluded from top-level source", nestedSource.containsKey(nestedVecField));
+        }
 
-        // Inner hit source should contain the vector
+        // Inner hit source should still contain the vector even though it is excluded at the top level.
         Map<String, Object> innerHits = (Map<String, Object>) hit.get("inner_hits");
         assertNotNull(innerHits);
         Map<String, Object> nestedInnerHit = (Map<String, Object>) innerHits.get(nestedField);
@@ -872,6 +876,45 @@ public class KNNSourceExcludesProcessorIT extends KNNRestTestCase {
         Map<String, Object> innerSource = (Map<String, Object>) innerHitsList.get(0).get("_source");
         assertNotNull("Inner hit should have _source", innerSource);
         assertTrue("Vector field should be present in inner hit _source", innerSource.containsKey(nestedVecField));
+
+        deleteIndex(indexName);
+    }
+
+    @SneakyThrows
+    public void testMultiSearch_childSearchesExcludeVectorField() {
+        // msearch fans out child SearchRequests whose parent action is indices:data/read/msearch, which is
+        // allowlisted — so the processor is still generated for them and vectors are excluded from each response.
+        String indexName = INDEX_NAME + "-msearch";
+        createIndexWithVectorAndTextField(indexName);
+        indexDocumentWithVectorAndText(indexName, "1", TEST_VECTOR, "msearch doc one");
+        indexDocumentWithVectorAndText(indexName, "2", new Float[] { 5.0f, 6.0f, 7.0f, 8.0f }, "msearch doc two");
+        refreshIndex(indexName);
+
+        // Two search bodies in one _msearch request, both plain match_all.
+        String matchAllBody = "{\"query\":{\"match_all\":{}}}";
+        String ndjson = "{\"index\":\"" + indexName + "\"}\n" + matchAllBody + "\n" + "{\"index\":\"" + indexName + "\"}\n" + matchAllBody
+            + "\n";
+
+        Request request = new Request("GET", "/_msearch");
+        request.setJsonEntity(ndjson);
+        Response response = client().performRequest(request);
+
+        String responseBody = EntityUtils.toString(response.getEntity());
+        Map<String, Object> responseMap = createParser(JsonXContent.jsonXContent, responseBody).map();
+        List<Map<String, Object>> responses = (List<Map<String, Object>>) responseMap.get("responses");
+        assertEquals("msearch should return two responses", 2, responses.size());
+
+        for (Map<String, Object> singleResponse : responses) {
+            Map<String, Object> hitsOuter = (Map<String, Object>) singleResponse.get("hits");
+            List<Map<String, Object>> hits = (List<Map<String, Object>>) hitsOuter.get("hits");
+            assertFalse("Each msearch child response should have hits", hits.isEmpty());
+            for (Map<String, Object> hit : hits) {
+                Map<String, Object> source = getSource(hit);
+                assertNotNull(source);
+                assertTrue("Text field should be present in msearch child response", source.containsKey(TEXT_FIELD));
+                assertFalse("Vector field should be excluded in msearch child response", source.containsKey(VECTOR_FIELD));
+            }
+        }
 
         deleteIndex(indexName);
     }

--- a/src/test/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessorTests.java
+++ b/src/test/java/org/opensearch/knn/search/processor/KNNSourceExcludesProcessorTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.knn.search.processor;
 
+import org.opensearch.action.search.MultiSearchAction;
+import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
@@ -20,7 +22,6 @@ import org.opensearch.knn.KNNTestCase;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.search.pipeline.ProcessorGenerationContext;
-import org.opensearch.core.tasks.TaskId;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -230,7 +231,10 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         assertArrayEquals(new String[] { "vec" }, ctx.excludes());
     }
 
-    public void testProcessRequest_innerHitExplicitTrueSource_skipsExcludes() {
+    public void testProcessRequest_innerHitExplicitTrueSource_appliesTopLevelExcludesInnerHitUnchanged() {
+        // Post-#22521: core preserves excluded fields at the codec level for inner hits, so adding
+        // top-level excludes no longer starves an inner hit that fetches full source. Top-level excludes
+        // are applied; the explicit-true inner hit is left untouched.
         mockClusterStateWithMapping(
             "test-index",
             Map.of("properties", Map.of("nested_obj", Map.of("properties", Map.of("vec", Map.of("type", "knn_vector", "dimension", 3)))))
@@ -242,9 +246,11 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         KNNSourceExcludesProcessor processor = createProcessor();
         SearchRequest result = processor.processRequest(requestWithNestedQuery("test-index", innerHit));
 
-        assertNull("Top-level excludes should not be added when inner hit has explicit true _source", result.source().fetchSource());
+        FetchSourceContext ctx = result.source().fetchSource();
+        assertNotNull("Top-level excludes should be applied", ctx);
+        assertTrue(Set.of(ctx.excludes()).contains("nested_obj.vec"));
 
-        // Inner hit source context should remain exactly as set — {true, [], []}
+        // Inner hit with explicit true _source is left exactly as set — {true, [], []}
         FetchSourceContext innerCtx = innerHit.getFetchSourceContext();
         assertNotNull(innerCtx);
         assertTrue(innerCtx.fetchSource());
@@ -252,7 +258,9 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         assertEquals(0, innerCtx.excludes().length);
     }
 
-    public void testProcessRequest_innerHitSourceIncludesVectorField_skipsExcludes() {
+    public void testProcessRequest_innerHitSourceIncludesVectorField_appliesTopLevelExcludesInnerHitKeepsIncludes() {
+        // Post-#22521: top-level excludes are applied even when an inner hit includes the vector field.
+        // The inner hit keeps its includes (the field is not added to its excludes since it is included).
         mockClusterStateWithMapping(
             "test-index",
             Map.of("properties", Map.of("nested_obj", Map.of("properties", Map.of("vec", Map.of("type", "knn_vector", "dimension", 3)))))
@@ -264,10 +272,12 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         KNNSourceExcludesProcessor processor = createProcessor();
         SearchRequest result = processor.processRequest(requestWithNestedQuery("test-index", innerHit));
 
-        // Early return — top-level source unchanged
-        assertNull(result.source().fetchSource());
+        // Top-level gets the vector excluded
+        FetchSourceContext ctx = result.source().fetchSource();
+        assertNotNull(ctx);
+        assertTrue(Set.of(ctx.excludes()).contains("nested_obj.vec"));
 
-        // Inner hit source context unchanged — includes still has the vector field
+        // Inner hit still includes the vector field and gains no excludes for it
         FetchSourceContext innerCtx = innerHit.getFetchSourceContext();
         assertNotNull(innerCtx);
         assertTrue(innerCtx.fetchSource());
@@ -275,7 +285,9 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         assertEquals(0, innerCtx.excludes().length);
     }
 
-    public void testProcessRequest_innerHitFetchFieldsIncludesVectorField_skipsExcludes() {
+    public void testProcessRequest_innerHitFetchFieldsIncludesVectorField_appliesExcludesToSource() {
+        // Post-#22521: an inner hit requesting the vector via the fields API keeps that request; the
+        // field is reconstructed from the codec even though the inner hit's _source now excludes it.
         mockClusterStateWithMapping(
             "test-index",
             Map.of("properties", Map.of("nested_obj", Map.of("properties", Map.of("vec", Map.of("type", "knn_vector", "dimension", 3)))))
@@ -287,11 +299,19 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         KNNSourceExcludesProcessor processor = createProcessor();
         SearchRequest result = processor.processRequest(requestWithNestedQuery("test-index", innerHit));
 
-        // Early return — top-level source unchanged
-        assertNull(result.source().fetchSource());
+        // Top-level gets the vector excluded
+        FetchSourceContext ctx = result.source().fetchSource();
+        assertNotNull(ctx);
+        assertTrue(Set.of(ctx.excludes()).contains("nested_obj.vec"));
 
-        // Inner hit source context was null before and remains null — only fetchFields was set
-        assertNull(innerHit.getFetchSourceContext());
+        // Inner hit source now excludes the vector (fields API request is preserved separately)
+        FetchSourceContext innerCtx = innerHit.getFetchSourceContext();
+        assertNotNull(innerCtx);
+        assertTrue(Set.of(innerCtx.excludes()).contains("nested_obj.vec"));
+
+        // The fields API request on the inner hit is untouched
+        assertEquals(1, innerHit.getFetchFields().size());
+        assertEquals("nested_obj.vec", innerHit.getFetchFields().get(0).field);
     }
 
     public void testProcessRequest_innerHitFetchFieldsWithoutVectorField_appliesExcludes() {
@@ -386,17 +406,19 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         assertEquals(0, innerCtx.excludes().length);
     }
 
-    public void testProcessRequest_multipleInnerHits_firstSkipsTriggers_noExcludes() {
+    public void testProcessRequest_multipleInnerHits_eachHandledIndependently() {
+        // Post-#22521: there is no longer a global skip triggered by one inner hit requesting the vector.
+        // Each inner hit is handled independently and top-level excludes are always applied.
         mockClusterStateWithMapping(
             "test-index",
             Map.of("properties", Map.of("nested_obj", Map.of("properties", Map.of("vec", Map.of("type", "knn_vector", "dimension", 3)))))
         );
 
-        // First inner hit explicitly requests the vector — should cause entire processor to skip
+        // First inner hit includes the vector — keeps its includes, gains no excludes for it.
         InnerHitBuilder innerHit1 = new InnerHitBuilder();
         innerHit1.setFetchSourceContext(new FetchSourceContext(true, new String[] { "nested_obj.vec" }, new String[0]));
 
-        // Second inner hit has no constraints — would otherwise get excludes applied
+        // Second inner hit has no constraints — gets the vector excluded.
         InnerHitBuilder innerHit2 = new InnerHitBuilder();
 
         NestedQueryBuilder nestedQuery1 = new NestedQueryBuilder("nested_obj", new MatchAllQueryBuilder(), ScoreMode.None);
@@ -412,10 +434,21 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         KNNSourceExcludesProcessor processor = createProcessor();
         SearchRequest result = processor.processRequest(request);
 
-        // No excludes added at top level since first inner hit requests vector
-        assertNull(result.source().fetchSource());
-        // Second inner hit also unchanged — apply loop never ran
-        assertNull(innerHit2.getFetchSourceContext());
+        // Top-level excludes are applied.
+        FetchSourceContext ctx = result.source().fetchSource();
+        assertNotNull(ctx);
+        assertTrue(Set.of(ctx.excludes()).contains("nested_obj.vec"));
+
+        // First inner hit keeps its includes and gets no exclude for the included field.
+        FetchSourceContext inner1 = innerHit1.getFetchSourceContext();
+        assertNotNull(inner1);
+        assertArrayEquals(new String[] { "nested_obj.vec" }, inner1.includes());
+        assertEquals(0, inner1.excludes().length);
+
+        // Second inner hit gets the vector excluded.
+        FetchSourceContext inner2 = innerHit2.getFetchSourceContext();
+        assertNotNull(inner2);
+        assertTrue(Set.of(inner2.excludes()).contains("nested_obj.vec"));
     }
 
     public void testProcessRequest_multiIndexOneSourceDisabled_onlyEnabledIndexVectorsExcluded() {
@@ -598,13 +631,43 @@ public class KNNSourceExcludesProcessorTests extends KNNTestCase {
         assertFalse(factory.shouldGenerate(context));
     }
 
-    public void testFactory_shouldGenerate_withParentTask_returnsFalse() {
+    public void testFactory_shouldGenerate_nullParentAction_returnsTrue() {
+        // A null parent action denotes a top-level user search with no parent task.
         KNNSourceExcludesProcessor.Factory factory = new KNNSourceExcludesProcessor.Factory(clusterService, indexNameExpressionResolver);
         SearchRequest request = new SearchRequest("test-index");
         request.source(new SearchSourceBuilder());
-        request.setParentTask(new TaskId("node1", 1));
 
         ProcessorGenerationContext context = new ProcessorGenerationContext(request, null);
+        assertTrue(factory.shouldGenerate(context));
+    }
+
+    public void testFactory_shouldGenerate_searchParentAction_returnsTrue() {
+        // indices:data/read/search — leaf search executed on a remote cluster during cross-cluster search.
+        KNNSourceExcludesProcessor.Factory factory = new KNNSourceExcludesProcessor.Factory(clusterService, indexNameExpressionResolver);
+        SearchRequest request = new SearchRequest("test-index");
+        request.source(new SearchSourceBuilder());
+
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, SearchAction.NAME);
+        assertTrue(factory.shouldGenerate(context));
+    }
+
+    public void testFactory_shouldGenerate_msearchParentAction_returnsTrue() {
+        // indices:data/read/msearch — child search fanned out from a multi-search request.
+        KNNSourceExcludesProcessor.Factory factory = new KNNSourceExcludesProcessor.Factory(clusterService, indexNameExpressionResolver);
+        SearchRequest request = new SearchRequest("test-index");
+        request.source(new SearchSourceBuilder());
+
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, MultiSearchAction.NAME);
+        assertTrue(factory.shouldGenerate(context));
+    }
+
+    public void testFactory_shouldGenerate_disallowedParentAction_returnsFalse() {
+        // Any parent action outside the allowlist must be skipped, even if the request is otherwise valid.
+        KNNSourceExcludesProcessor.Factory factory = new KNNSourceExcludesProcessor.Factory(clusterService, indexNameExpressionResolver);
+        SearchRequest request = new SearchRequest("test-index");
+        request.source(new SearchSourceBuilder());
+
+        ProcessorGenerationContext context = new ProcessorGenerationContext(request, "indices:data/read/some_other_action");
         assertFalse(factory.shouldGenerate(context));
     }
 


### PR DESCRIPTION
With core PR #22521 adding codecExcludes, the processor no longer needs to skip top-level _source.excludes when an inner hit requests a vector field:

 - KNNSourceExcludesProcessor always applies top-level excludes; shouldGenerate gates on a parent-action allowlist (search, msearch, and null top-level).
 - KNN10010DerivedSourceStoredFieldsReader reads FieldsVisitor.codecExcludes() instead of excludes(), so vectors excluded from the response are still reconstructed for nested inner hits.

Adds/updates unit tests and inner-hit + msearch IT coverage.


### Related Issues
Resolves #[3303](https://github.com/opensearch-project/k-NN/issues/3303)

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
