### PR TITLE
[Fix] Fix incorrect decay value and missing MOS wiring after Lucene 10.5 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Refactor ExactSearcher to use BulkVectorScorer directly and rename factory methods [#3361](https://github.com/opensearch-project/k-NN/pull/3361)
 
 ### Enhancements
+* Set decay value to experimentally found value 0.95 and use decay method in MOS [#3447](https://github.com/opensearch-project/k-NN/pull/3447)

--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -186,6 +186,11 @@ public class KNNConstants {
     public static int MAX_DISTANCE_COMPUTATIONS = 2048000;
 
     public static final Float DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO = 0.95f;
+
+    // Decay factor for the adaptive graph-traversal buffer used by Lucene 10.5's decay-based radial
+    // search (VectorSimilarityCollector). Must lie in [0, 1]; higher values explore more of the graph
+    // for better recall. Mirrors the value used on the Lucene engine radial path.
+    public static final float DEFAULT_LUCENE_RADIAL_SEARCH_DECAY = 0.95f;
     public static final String MIN_SCORE = "min_score";
     public static final String MAX_DISTANCE = "max_distance";
 

--- a/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
+++ b/src/main/java/org/opensearch/knn/index/query/RNNQueryFactory.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.knn.index.query;
 
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_DECAY;
 import static org.opensearch.knn.common.KNNConstants.MAX_RESULTS_RADIAL_RESCORING;
 import static org.opensearch.knn.common.KNNConstants.VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.index.VectorDataType.SUPPORTED_VECTOR_DATA_TYPES;
@@ -135,8 +136,9 @@ public class RNNQueryFactory extends BaseQueryFactory {
      * {@link ByteVectorSimilarityQuery}) for engines that do not use custom segment files.
      *
      * <p>These queries use Lucene's built-in HNSW graph traversal with a similarity threshold.
-     * The traversal similarity is set to {@code 0.95 * resultSimilarity} to allow the graph
-     * to be explored slightly beyond the threshold for better recall.</p>
+     * The graph-traversal buffer decays with {@code DEFAULT_LUCENE_RADIAL_SEARCH_DECAY}
+     * so the graph is explored slightly beyond the threshold for better recall, matching the
+     * decay-based behavior used on the memory-optimized search (MOS) path.</p>
      *
      * @param request the query creation request containing all parameters
      * @return a Lucene similarity query configured for radius-based search
@@ -179,7 +181,7 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float resultSimilarity,
         final Query filterQuery
     ) {
-        return new FloatVectorSimilarityQuery(fieldName, floatVector, resultSimilarity, 1.0f, filterQuery);
+        return new FloatVectorSimilarityQuery(fieldName, floatVector, resultSimilarity, DEFAULT_LUCENE_RADIAL_SEARCH_DECAY, filterQuery);
     }
 
     /**
@@ -192,6 +194,6 @@ public class RNNQueryFactory extends BaseQueryFactory {
         final float resultSimilarity,
         final Query filterQuery
     ) {
-        return new ByteVectorSimilarityQuery(fieldName, byteVector, resultSimilarity, 1.0f, filterQuery);
+        return new ByteVectorSimilarityQuery(fieldName, byteVector, resultSimilarity, DEFAULT_LUCENE_RADIAL_SEARCH_DECAY, filterQuery);
     }
 }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/MemoryOptimizedKNNWeight.java
@@ -35,7 +35,7 @@ import org.opensearch.lucene.ReentrantKnnCollectorManager;
 
 import java.io.IOException;
 
-import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_DECAY;
 import static org.opensearch.knn.plugin.stats.KNNCounter.GRAPH_QUERY_ERRORS;
 
 /**
@@ -68,10 +68,10 @@ public class MemoryOptimizedKNNWeight extends KNNWeight {
                 this.knnCollectorManager = new DiversifyingNearestChildrenKnnCollectorManager(k, query.getParentsFilter(), searcher);
             }
         } else {
-            // Radius search
+            // Radius search: use Lucene 10.5's decay-based radial search with resultSimilarity = radius.
             this.knnCollectorManager = (visitLimit, searchStrategy, context) -> new RadiusVectorSimilarityCollector(
-                DEFAULT_LUCENE_RADIAL_SEARCH_TRAVERSAL_SIMILARITY_RATIO * query.getRadius(),
                 query.getRadius(),
+                DEFAULT_LUCENE_RADIAL_SEARCH_DECAY,
                 visitLimit
             );
         }

--- a/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/RadiusVectorSimilarityCollector.java
+++ b/src/main/java/org/opensearch/knn/index/query/memoryoptsearch/RadiusVectorSimilarityCollector.java
@@ -15,48 +15,67 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Clone of Lucene's VectorSimilarityCollector, which cannot be used directly due to its package-private visibility.
+ * Clone of Lucene's {@code VectorSimilarityCollector}, which cannot be used directly due to its
+ * package-private visibility.
+ *
+ * <p>This mirrors Lucene 10.5's decay-based radial search: instead of a fixed lower
+ * {@code traversalSimilarity} threshold, the graph-traversal buffer is adaptive. It starts high and
+ * decays towards the scores of nodes that were traversed but not collected, using the provided
+ * {@code decay} factor. The decay factor lies in {@code [0, 1]}; higher values explore more of the
+ * graph for better recall. All traversed nodes at or above {@code resultSimilarity} are collected.
  */
 public class RadiusVectorSimilarityCollector extends AbstractKnnCollector {
     private static final KnnSearchStrategy.Hnsw DEFAULT_STRATEGY = new KnnSearchStrategy.Hnsw(0);
 
-    private final float traversalSimilarity, resultSimilarity;
-    private float maxSimilarity;
+    // Bounds for the decay factor, matching Lucene's AbstractVectorSimilarityQuery.
+    static final float DECAY_MAX_APPROXIMATION = 0f;
+    static final float DECAY_MAX_QUALITY = 1f;
+
+    private final float resultSimilarity, decay;
     private final List<ScoreDoc> scoreDocList;
+    private float minCompetitiveSimilarity;
 
     /**
-     * Perform a similarity-based graph search. The graph is traversed till better scoring nodes are
-     * available, or the best candidate is below {@link #traversalSimilarity}. All traversed nodes
-     * above {@link #resultSimilarity} are collected.
+     * Perform a decay-based, similarity-based graph search. The graph is traversed while candidates
+     * remain competitive with the adaptive buffer; all traversed nodes at or above
+     * {@link #resultSimilarity} are collected.
      *
-     * @param traversalSimilarity (lower) similarity score for graph traversal.
-     * @param resultSimilarity (higher) similarity score for result collection.
+     * @param resultSimilarity similarity score for result collection.
+     * @param decay decay factor for the graph-traversal buffer, in range {@code [0, 1]}.
      * @param visitLimit limit on number of nodes to visit.
      */
-    public RadiusVectorSimilarityCollector(float traversalSimilarity, float resultSimilarity, long visitLimit) {
+    public RadiusVectorSimilarityCollector(float resultSimilarity, float decay, long visitLimit) {
         // TODO: add search strategy support
         super(1, visitLimit, DEFAULT_STRATEGY);
-        if (traversalSimilarity > resultSimilarity) {
-            throw new IllegalArgumentException("traversalSimilarity should be <= resultSimilarity");
+        if (Float.isNaN(resultSimilarity)) {
+            throw new IllegalArgumentException("resultSimilarity must have a valid value; got " + resultSimilarity);
         }
-        this.traversalSimilarity = traversalSimilarity;
+        if (Float.isNaN(decay) || decay < DECAY_MAX_APPROXIMATION || decay > DECAY_MAX_QUALITY) {
+            throw new IllegalArgumentException(
+                "decay must lie in range [DECAY_MAX_APPROXIMATION = 0, DECAY_MAX_QUALITY = 1]; got " + decay
+            );
+        }
         this.resultSimilarity = resultSimilarity;
-        this.maxSimilarity = Float.NEGATIVE_INFINITY;
+        this.decay = decay;
         this.scoreDocList = new ArrayList<>();
+        this.minCompetitiveSimilarity = Math.nextUp(Float.NEGATIVE_INFINITY);
     }
 
     @Override
     public boolean collect(int docId, float similarity) {
-        maxSimilarity = Math.max(maxSimilarity, similarity);
         if (similarity >= resultSimilarity) {
             scoreDocList.add(new ScoreDoc(docId, similarity));
+        } else if (decay < DECAY_MAX_QUALITY) {
+            // Decay the traversal buffer towards the score of the current (uncollected) node.
+            minCompetitiveSimilarity = (float) (similarity + ((double) minCompetitiveSimilarity - similarity) * decay);
+            return true;
         }
-        return true;
+        return false;
     }
 
     @Override
     public float minCompetitiveSimilarity() {
-        return Math.min(traversalSimilarity, maxSimilarity);
+        return minCompetitiveSimilarity;
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/query/MemoryOptimizedKNNWeightTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/MemoryOptimizedKNNWeightTests.java
@@ -5,11 +5,19 @@
 
 package org.opensearch.knn.index.query;
 
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.search.knn.KnnCollectorManager;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
 import org.opensearch.knn.KNNTestCase;
 import org.opensearch.knn.index.query.memoryoptsearch.MemoryOptimizedKNNWeight;
+import org.opensearch.knn.index.query.memoryoptsearch.RadiusVectorSimilarityCollector;
 
 import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_DECAY;
 
 public class MemoryOptimizedKNNWeightTests extends KNNTestCase {
 
@@ -24,5 +32,35 @@ public class MemoryOptimizedKNNWeightTests extends KNNTestCase {
             strategy.filteredSearchThreshold()
         );
         assertFalse("useFilteredSearch must return false for any filtering rate when threshold is 0", strategy.useFilteredSearch(0.5f));
+    }
+
+    // Validates that the memory-optimized search (MOS) radius path builds the decay-based
+    // RadiusVectorSimilarityCollector and wires in the shared decay factor
+    // (DEFAULT_LUCENE_RADIAL_SEARCH_DECAY = 0.95). A radius (r-NN) query is simulated by passing k = null,
+    // which routes the constructor to the radius branch that builds the collector manager.
+    public void testRadiusSearch_usesDecayBasedCollector() throws Exception {
+        final KNNQuery knnQuery = mock(KNNQuery.class);
+        when(knnQuery.getRadius()).thenReturn(0.5f);
+        final IndexSearcher searcher = mock(IndexSearcher.class);
+
+        // k == null -> radius search branch, which creates the RadiusVectorSimilarityCollector manager.
+        final MemoryOptimizedKNNWeight weight = new MemoryOptimizedKNNWeight(knnQuery, 1.0f, null, searcher, null);
+
+        // Reach the private collector manager built for the radius search path.
+        final Field managerField = MemoryOptimizedKNNWeight.class.getDeclaredField("knnCollectorManager");
+        managerField.setAccessible(true);
+        final KnnCollectorManager manager = (KnnCollectorManager) managerField.get(weight);
+
+        // The radius lambda ignores the search strategy and context, so null is acceptable here.
+        final KnnCollector collector = manager.newCollector(Integer.MAX_VALUE, null, null);
+        assertTrue(
+            "MOS radius search must use the decay-based RadiusVectorSimilarityCollector",
+            collector instanceof RadiusVectorSimilarityCollector
+        );
+
+        // Verify the decay factor wired into the collector is the shared default (0.95).
+        final Field decayField = RadiusVectorSimilarityCollector.class.getDeclaredField("decay");
+        decayField.setAccessible(true);
+        assertEquals(DEFAULT_LUCENE_RADIAL_SEARCH_DECAY, (float) decayField.get(collector), 0.0f);
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/RNNQueryFactoryTests.java
@@ -8,6 +8,7 @@ package org.opensearch.knn.index.query;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.knn.common.KNNConstants.DEFAULT_LUCENE_RADIAL_SEARCH_DECAY;
 import static org.opensearch.knn.common.KNNConstants.DEFAULT_VECTOR_DATA_TYPE_FIELD;
 import static org.opensearch.knn.common.KNNConstants.MAX_RESULTS_RADIAL_RESCORING;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
@@ -93,6 +94,64 @@ public class RNNQueryFactoryTests extends KNNTestCase {
                 .build();
             Query query = RNNQueryFactory.create(createQueryRequest);
             assertEquals(ByteVectorSimilarityQuery.class, query.getClass());
+        }
+    }
+
+    // Validates that the Lucene radial search path is actually taken and that the shared decay factor
+    // (DEFAULT_LUCENE_RADIAL_SEARCH_DECAY = 0.95) is wired into the produced Lucene similarity query.
+    // A mocked KNNVectorFieldType (non-quantized: isRescoringRequiredForRadial() == false) exercises the
+    // real Lucene branch without the rescore wrapper. FloatVectorSimilarityQuery#equals compares the decay
+    // field, so equality against a query constructed with the expected decay proves the value is wired.
+    public void testCreate_whenLucene_thenDecayIsWiredIntoSimilarityQuery() {
+        final KNNVectorFieldType mockFieldType = mock(KNNVectorFieldType.class);
+        when(mockFieldType.isRescoringRequiredForRadial()).thenReturn(false);
+
+        final List<KNNEngine> luceneEngines = Arrays.stream(KNNEngine.values())
+            .filter(knnEngine -> !KNNEngine.getEnginesThatCreateCustomSegmentFiles().contains(knnEngine))
+            .collect(Collectors.toList());
+
+        for (KNNEngine knnEngine : luceneEngines) {
+            // FLOAT -> FloatVectorSimilarityQuery
+            final RNNQueryFactory.CreateQueryRequest floatRequest = RNNQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(knnEngine)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .vector(testQueryVector)
+                .radius(testRadius)
+                .vectorDataType(VectorDataType.FLOAT)
+                .vectorFieldType(mockFieldType)
+                .build();
+            final Query floatQuery = RNNQueryFactory.create(floatRequest);
+            assertTrue("Lucene radial path must produce a FloatVectorSimilarityQuery", floatQuery instanceof FloatVectorSimilarityQuery);
+            final FloatVectorSimilarityQuery expectedFloatQuery = new FloatVectorSimilarityQuery(
+                testFieldName,
+                testQueryVector,
+                testRadius,
+                DEFAULT_LUCENE_RADIAL_SEARCH_DECAY,
+                null
+            );
+            assertEquals("Decay must be wired into the Lucene FloatVectorSimilarityQuery", expectedFloatQuery, floatQuery);
+
+            // BYTE -> ByteVectorSimilarityQuery
+            final RNNQueryFactory.CreateQueryRequest byteRequest = RNNQueryFactory.CreateQueryRequest.builder()
+                .knnEngine(knnEngine)
+                .indexName(testIndexName)
+                .fieldName(testFieldName)
+                .byteVector(testByteQueryVector)
+                .radius(testRadius)
+                .vectorDataType(VectorDataType.BYTE)
+                .vectorFieldType(mockFieldType)
+                .build();
+            final Query byteQuery = RNNQueryFactory.create(byteRequest);
+            assertTrue("Lucene radial path must produce a ByteVectorSimilarityQuery", byteQuery instanceof ByteVectorSimilarityQuery);
+            final ByteVectorSimilarityQuery expectedByteQuery = new ByteVectorSimilarityQuery(
+                testFieldName,
+                testByteQueryVector,
+                testRadius,
+                DEFAULT_LUCENE_RADIAL_SEARCH_DECAY,
+                null
+            );
+            assertEquals("Decay must be wired into the Lucene ByteVectorSimilarityQuery", expectedByteQuery, byteQuery);
         }
     }
 


### PR DESCRIPTION
### Description
The Lucene 10.5 upgrade introduced the decay parameter to replace the deprecated traversalSimilarity in HNSW graph traversal. The placeholder value of 1.0f used during the upgrade causes the graph search to over-explore, degrading latency without proportional recall gains.

This fix:

- Sets decay to 0.95, the experimentally validated value that achieves >90% recall across all 1M-scale benchmark datasets while maintaining acceptable latency
- Wires the MOS code path through the decay-based collector to match Lucene's native search behavior
Benchmark results:

<img width="2084" height="740" alt="fp32_decay_sweep" src="https://github.com/user-attachments/assets/042bdd53-7dd5-4738-9a5d-0f16bcce42b3" />

0.95 is the only value that sees >90% recall on all 1M datasets

### Related Issues
Resolves issue TBD

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
