### PR TITLE
Fix corrupt index file when remote build falls back to local build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix FAISS SQ merges when an input segment has no vectors [#3433](https://github.com/opensearch-project/k-NN/pull/3433)
 * Fix isFaissSQfp16 to skip FP16 validation when SQ encoder uses bits=1 [#3366](https://github.com/opensearch-project/k-NN/pull/3366)
 * Fix score corruption in multi-segment FAISS indices with ADC [#3385](https://github.com/opensearch-project/k-NN/pull/3385)
+* Fix corrupt index file when remote build falls back to local build [#3448](https://github.com/opensearch-project/k-NN/pull/3448)
 * Fix radial search max_distance threshold conversion for inner product with memory-optimized search [#3369](https://github.com/opensearch-project/k-NN/pull/3369)
 
 ### Refactoring

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -12,7 +12,6 @@ import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.SegmentWriteState;
-import org.apache.lucene.store.IndexOutput;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.core.common.bytes.BytesArray;
@@ -171,8 +170,10 @@ public class NativeIndexWriter {
             fieldInfo.name,
             knnEngine.getExtension()
         );
-        try (IndexOutput output = state.directory.createOutput(engineFileName, state.context)) {
-            final IndexOutputWithBuffer indexOutputWithBuffer = new IndexOutputWithBuffer(output);
+        final IndexOutputWithBuffer indexOutputWithBuffer = new IndexOutputWithBuffer(
+            state.directory.createOutput(engineFileName, state.context)
+        );
+        try {
             final BuildIndexParams nativeIndexParams = indexParams(
                 fieldInfo,
                 indexOutputWithBuffer,
@@ -187,7 +188,9 @@ public class NativeIndexWriter {
                 knnVectorValuesSupplier.get()
             );
             indexBuilder.buildAndWriteIndex(nativeIndexParams);
-            CodecUtil.writeFooter(output);
+            CodecUtil.writeFooter(indexOutputWithBuffer.getIndexOutput());
+        } finally {
+            indexOutputWithBuffer.getIndexOutput().close();
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/NativeIndexWriter.java
@@ -7,7 +7,6 @@ package org.opensearch.knn.index.codec.nativeindex;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.MergePolicy;
@@ -170,10 +169,11 @@ public class NativeIndexWriter {
             fieldInfo.name,
             knnEngine.getExtension()
         );
-        final IndexOutputWithBuffer indexOutputWithBuffer = new IndexOutputWithBuffer(
-            state.directory.createOutput(engineFileName, state.context)
-        );
-        try {
+        try (
+            IndexOutputWithBuffer indexOutputWithBuffer = new IndexOutputWithBuffer(
+                state.directory.createOutput(engineFileName, state.context)
+            )
+        ) {
             final BuildIndexParams nativeIndexParams = indexParams(
                 fieldInfo,
                 indexOutputWithBuffer,
@@ -188,9 +188,7 @@ public class NativeIndexWriter {
                 knnVectorValuesSupplier.get()
             );
             indexBuilder.buildAndWriteIndex(nativeIndexParams);
-            CodecUtil.writeFooter(indexOutputWithBuffer.getIndexOutput());
-        } finally {
-            indexOutputWithBuffer.getIndexOutput().close();
+            indexOutputWithBuffer.writeFooter();
         }
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -177,6 +177,8 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
         } finally {
             metrics.endRemoteIndexBuildMetrics(success);
         }
+        // Recreate the IndexOutput before fallback to discard any partially written remote data
+        indexInfo.getIndexOutputWithBuffer().recreate(indexInfo.getSegmentWriteState().directory, indexInfo.getSegmentWriteState().context);
         fallbackStrategy.buildAndWriteIndex(indexInfo);
     }
 

--- a/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
+++ b/src/main/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategy.java
@@ -178,7 +178,16 @@ public class RemoteIndexBuildStrategy implements NativeIndexBuildStrategy {
             metrics.endRemoteIndexBuildMetrics(success);
         }
         // Recreate the IndexOutput before fallback to discard any partially written remote data
-        indexInfo.getIndexOutputWithBuffer().recreate(indexInfo.getSegmentWriteState().directory, indexInfo.getSegmentWriteState().context);
+        assert !success : "Should not reach fallback path when remote build succeeded";
+        if (indexInfo.getIndexOutputWithBuffer().getBytesWritten() > 0) {
+            log.info(
+                "Clearing the indexOutput buffer since some data has been written in file: {} : {} bytes, before falling back to local index build",
+                indexInfo.getIndexOutputWithBuffer().getName(),
+                indexInfo.getIndexOutputWithBuffer().getBytesWritten()
+            );
+            indexInfo.getIndexOutputWithBuffer()
+                .reset(indexInfo.getSegmentWriteState().directory, indexInfo.getSegmentWriteState().context);
+        }
         fallbackStrategy.buildAndWriteIndex(indexInfo);
     }
 

--- a/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
+++ b/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
@@ -7,6 +7,7 @@ package org.opensearch.knn.index.store;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
@@ -15,15 +16,15 @@ import org.opensearch.knn.common.exception.TerminalIOException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
+import java.util.Arrays;
 
 /**
  * Wrapper around {@link IndexOutput} to perform writes in a buffered manner. This class is created per flush/merge, and may be used twice if
  * {@link org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy} needs to fall back to a different build strategy.
  */
 @Log4j2
-public class IndexOutputWithBuffer {
+public class IndexOutputWithBuffer implements AutoCloseable {
     // Underlying `IndexOutput` obtained from Lucene's Directory.
-    @Getter
     private IndexOutput indexOutput;
     // Write buffer. Native engine will copy bytes into this buffer.
     // Allocating 64KB here since it show better performance in NMSLIB with the size. (We had slightly improvement in FAISS than having 4KB)
@@ -31,10 +32,13 @@ public class IndexOutputWithBuffer {
     // 64KB to accumulate bytes as possible to reduce the times of calling `writeBytes`.
     private static final int CHUNK_SIZE = 64 * 1024;
     private final byte[] buffer;
+    @Getter
+    private long bytesWritten;
 
     public IndexOutputWithBuffer(IndexOutput indexOutput) {
         this.indexOutput = indexOutput;
         this.buffer = new byte[CHUNK_SIZE];
+        this.bytesWritten = 0;
     }
 
     // This method will be called in JNI layer which precisely knows
@@ -43,6 +47,7 @@ public class IndexOutputWithBuffer {
         try {
             // Delegate Lucene `indexOuptut` to write bytes.
             indexOutput.writeBytes(buffer, 0, length);
+            bytesWritten += length;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -82,6 +87,7 @@ public class IndexOutputWithBuffer {
             if (bytesRead != -1) {
                 try {
                     indexOutput.writeBytes(outputBuffer, 0, bytesRead);
+                    bytesWritten += bytesRead;
                 } catch (IOException e) {
                     throw new TerminalIOException("Failed to write to indexOutput", e);
                 }
@@ -90,15 +96,22 @@ public class IndexOutputWithBuffer {
     }
 
     /**
-     * Closes the current {@link IndexOutput}, deletes the partially written file, and creates a fresh
-     * output with the same file name. This is used when a remote index build partially writes data
-     * and then fails — the fallback strategy needs a clean output to write to.
+     * Returns the name of the underlying output file.
+     */
+    public String getName() {
+        return indexOutput.getName();
+    }
+
+    /**
+     * Resets this buffer by closing the current {@link IndexOutput}, deleting the partially written
+     * file, and opening a fresh output with the same file name. This is used when a remote index
+     * build partially writes data and then fails — the fallback strategy needs a clean output.
      *
      * @param directory the directory to create the new output in
      * @param context   the IO context for creating the new output
      * @throws IOException if closing, deleting, or creating the output fails
      */
-    public void recreate(final Directory directory, final IOContext context) throws IOException {
+    public void reset(final Directory directory, final IOContext context) throws IOException {
         final String fileName = indexOutput.getName();
         indexOutput.close();
         try {
@@ -108,6 +121,20 @@ public class IndexOutputWithBuffer {
             log.debug("File not found: {}, while trying to delete the file", fileName);
         }
         this.indexOutput = directory.createOutput(fileName, context);
+        bytesWritten = 0;
+        Arrays.fill(buffer, (byte) 0);
+    }
+
+    /**
+     * Writes the Lucene codec footer to the underlying {@link IndexOutput}.
+     */
+    public void writeFooter() throws IOException {
+        CodecUtil.writeFooter(indexOutput);
+    }
+
+    @Override
+    public void close() throws IOException {
+        indexOutput.close();
     }
 
     @Override

--- a/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
+++ b/src/main/java/org/opensearch/knn/index/store/IndexOutputWithBuffer.java
@@ -5,18 +5,25 @@
 
 package org.opensearch.knn.index.store;
 
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexOutput;
 import org.opensearch.knn.common.exception.TerminalIOException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
 
 /**
  * Wrapper around {@link IndexOutput} to perform writes in a buffered manner. This class is created per flush/merge, and may be used twice if
  * {@link org.opensearch.knn.index.codec.nativeindex.remote.RemoteIndexBuildStrategy} needs to fall back to a different build strategy.
  */
+@Log4j2
 public class IndexOutputWithBuffer {
     // Underlying `IndexOutput` obtained from Lucene's Directory.
+    @Getter
     private IndexOutput indexOutput;
     // Write buffer. Native engine will copy bytes into this buffer.
     // Allocating 64KB here since it show better performance in NMSLIB with the size. (We had slightly improvement in FAISS than having 4KB)
@@ -80,6 +87,27 @@ public class IndexOutputWithBuffer {
                 }
             }
         }
+    }
+
+    /**
+     * Closes the current {@link IndexOutput}, deletes the partially written file, and creates a fresh
+     * output with the same file name. This is used when a remote index build partially writes data
+     * and then fails — the fallback strategy needs a clean output to write to.
+     *
+     * @param directory the directory to create the new output in
+     * @param context   the IO context for creating the new output
+     * @throws IOException if closing, deleting, or creating the output fails
+     */
+    public void recreate(final Directory directory, final IOContext context) throws IOException {
+        final String fileName = indexOutput.getName();
+        indexOutput.close();
+        try {
+            directory.deleteFile(fileName);
+        } catch (NoSuchFileException e) {
+            // File may not exist if nothing was written — safe to ignore
+            log.debug("File not found: {}, while trying to delete the file", fileName);
+        }
+        this.indexOutput = directory.createOutput(fileName, context);
     }
 
     @Override

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -5,6 +5,12 @@
 
 package org.opensearch.knn.index.codec.nativeindex.remote;
 
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.InfoStream;
 import org.opensearch.common.SetOnce;
 import org.opensearch.common.blobstore.BlobContainer;
 import org.opensearch.common.blobstore.BlobPath;
@@ -17,6 +23,8 @@ import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.common.exception.TerminalIOException;
 import org.opensearch.knn.index.KNNSettings;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.index.codec.nativeindex.model.BuildIndexParams;
+import org.opensearch.knn.index.store.IndexOutputWithBuffer;
 import org.opensearch.knn.plugin.stats.KNNRemoteIndexBuildValue;
 import org.opensearch.remoteindexbuild.model.RemoteBuildRequest;
 import org.opensearch.repositories.RepositoriesService;
@@ -114,6 +122,132 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
 
         assertThrows(TerminalIOException.class, () -> { objectUnderTest.buildAndWriteIndex(buildIndexParams); });
         assertFalse(fallback.get());
+    }
+
+    /**
+     * Test that when remote build fails after partially writing to IndexOutput, the fallback
+     * strategy receives a fresh IndexOutput (via recreate) so it doesn't produce a corrupt file.
+     * Simulates partial data written to a real IndexOutput, then verifies the file is clean after recreate.
+     */
+    public void testFallback_whenPartialRemoteWrite_thenRecreatesIndexOutput() throws IOException {
+        // Use a real directory so we can verify file contents
+        try (Directory directory = newDirectory()) {
+            final String fileName = "test_field.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+
+            // Simulate partial remote write — write some garbage bytes as if S3 download partially completed
+            byte[] partialData = new byte[] { 0x49, 0x78, 0x4d, 0x70, 0x00, 0x04, 0x00, 0x00 }; // "IxMp" header fragment
+            output.writeBytes(partialData, partialData.length);
+            assertEquals(partialData.length, output.getFilePointer());
+
+            // Create a real IndexOutputWithBuffer wrapping this partially-written output
+            IndexOutputWithBuffer realIndexOutputWithBuffer = new IndexOutputWithBuffer(output);
+
+            // Build params with the real IndexOutputWithBuffer and this directory
+            SegmentWriteState realSegmentWriteState = new SegmentWriteState(
+                mock(InfoStream.class),
+                directory,
+                segmentInfo,
+                mock(FieldInfos.class),
+                null,
+                IOContext.DEFAULT
+            );
+            BuildIndexParams realBuildIndexParams = BuildIndexParams.builder()
+                .indexOutputWithBuffer(realIndexOutputWithBuffer)
+                .segmentWriteState(realSegmentWriteState)
+                .knnEngine(buildIndexParams.getKnnEngine())
+                .field(buildIndexParams.getField())
+                .vectorDataType(buildIndexParams.getVectorDataType())
+                .indexParameters(buildIndexParams.getIndexParameters())
+                .knnVectorValuesSupplier(buildIndexParams.getKnnVectorValuesSupplier())
+                .totalLiveDocs(buildIndexParams.getTotalLiveDocs())
+                .isFlush(buildIndexParams.isFlush())
+                .build();
+
+            // Set up remote strategy to fail (triggering fallback)
+            RepositoriesService repositoriesService = mock(RepositoriesService.class);
+            when(repositoriesService.repository(any())).thenThrow(new RepositoryMissingException("Fallback"));
+
+            final SetOnce<Boolean> fallback = new SetOnce<>();
+            RemoteIndexBuildStrategy objectUnderTest = new RemoteIndexBuildStrategy(
+                () -> repositoriesService,
+                new TestIndexBuildStrategy(fallback),
+                mock(IndexSettings.class),
+                null
+            );
+
+            objectUnderTest.buildAndWriteIndex(realBuildIndexParams);
+
+            // Verify fallback was called
+            assertTrue(fallback.get());
+
+            // Verify the IndexOutput was recreated — file pointer should be at 0 (fresh output)
+            assertEquals(0, realIndexOutputWithBuffer.getIndexOutput().getFilePointer());
+
+            // Close and verify file exists with zero length (clean slate for fallback to write)
+            realIndexOutputWithBuffer.getIndexOutput().close();
+            assertEquals(0, directory.fileLength(fileName));
+        }
+    }
+
+    /**
+     * Test that when remote build fails BEFORE any data is written to IndexOutput, the recreate
+     * still works correctly — deleting an empty file and creating a fresh one.
+     */
+    public void testFallback_whenNothingWritten_thenRecreatesIndexOutput() throws IOException {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "test_field_empty.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+
+            // Nothing written — file exists but is empty (file pointer at 0)
+            assertEquals(0, output.getFilePointer());
+
+            IndexOutputWithBuffer realIndexOutputWithBuffer = new IndexOutputWithBuffer(output);
+
+            SegmentWriteState realSegmentWriteState = new SegmentWriteState(
+                mock(InfoStream.class),
+                directory,
+                segmentInfo,
+                mock(FieldInfos.class),
+                null,
+                IOContext.DEFAULT
+            );
+            BuildIndexParams realBuildIndexParams = BuildIndexParams.builder()
+                .indexOutputWithBuffer(realIndexOutputWithBuffer)
+                .segmentWriteState(realSegmentWriteState)
+                .knnEngine(buildIndexParams.getKnnEngine())
+                .field(buildIndexParams.getField())
+                .vectorDataType(buildIndexParams.getVectorDataType())
+                .indexParameters(buildIndexParams.getIndexParameters())
+                .knnVectorValuesSupplier(buildIndexParams.getKnnVectorValuesSupplier())
+                .totalLiveDocs(buildIndexParams.getTotalLiveDocs())
+                .isFlush(buildIndexParams.isFlush())
+                .build();
+
+            // Remote fails before any write happens
+            RepositoriesService repositoriesService = mock(RepositoriesService.class);
+            when(repositoriesService.repository(any())).thenThrow(new RepositoryMissingException("Fallback"));
+
+            final SetOnce<Boolean> fallback = new SetOnce<>();
+            RemoteIndexBuildStrategy objectUnderTest = new RemoteIndexBuildStrategy(
+                () -> repositoriesService,
+                new TestIndexBuildStrategy(fallback),
+                mock(IndexSettings.class),
+                null
+            );
+
+            objectUnderTest.buildAndWriteIndex(realBuildIndexParams);
+
+            // Verify fallback was called
+            assertTrue(fallback.get());
+
+            // Verify the IndexOutput was recreated — file pointer should be at 0
+            assertEquals(0, realIndexOutputWithBuffer.getIndexOutput().getFilePointer());
+
+            // Close and verify file is empty (recreate deleted the empty file and created a new one)
+            realIndexOutputWithBuffer.getIndexOutput().close();
+            assertEquals(0, directory.fileLength(fileName));
+        }
     }
 
     public void testShouldBuildIndexRemotely() {

--- a/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
+++ b/src/test/java/org/opensearch/knn/index/codec/nativeindex/remote/RemoteIndexBuildStrategyTests.java
@@ -135,13 +135,13 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             final String fileName = "test_field.faiss";
             IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
 
-            // Simulate partial remote write — write some garbage bytes as if S3 download partially completed
-            byte[] partialData = new byte[] { 0x49, 0x78, 0x4d, 0x70, 0x00, 0x04, 0x00, 0x00 }; // "IxMp" header fragment
-            output.writeBytes(partialData, partialData.length);
-            assertEquals(partialData.length, output.getFilePointer());
-
-            // Create a real IndexOutputWithBuffer wrapping this partially-written output
+            // Create IndexOutputWithBuffer first, then write THROUGH it to track bytesWritten
             IndexOutputWithBuffer realIndexOutputWithBuffer = new IndexOutputWithBuffer(output);
+
+            // Simulate partial remote write via writeFromStreamWithBuffer (as S3 download would)
+            byte[] partialData = new byte[] { 0x49, 0x78, 0x4d, 0x70, 0x00, 0x04, 0x00, 0x00 }; // "IxMp" header fragment
+            realIndexOutputWithBuffer.writeFromStreamWithBuffer(new java.io.ByteArrayInputStream(partialData), partialData.length);
+            assertTrue(realIndexOutputWithBuffer.getBytesWritten() > 0);
 
             // Build params with the real IndexOutputWithBuffer and this directory
             SegmentWriteState realSegmentWriteState = new SegmentWriteState(
@@ -181,20 +181,20 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             // Verify fallback was called
             assertTrue(fallback.get());
 
-            // Verify the IndexOutput was recreated — file pointer should be at 0 (fresh output)
-            assertEquals(0, realIndexOutputWithBuffer.getIndexOutput().getFilePointer());
+            // Verify bytesWritten was reset to 0 after recreate
+            assertEquals(0, realIndexOutputWithBuffer.getBytesWritten());
 
             // Close and verify file exists with zero length (clean slate for fallback to write)
-            realIndexOutputWithBuffer.getIndexOutput().close();
+            realIndexOutputWithBuffer.close();
             assertEquals(0, directory.fileLength(fileName));
         }
     }
 
     /**
-     * Test that when remote build fails BEFORE any data is written to IndexOutput, the recreate
-     * still works correctly — deleting an empty file and creating a fresh one.
+     * Test that when remote build fails BEFORE any data is written to IndexOutput, recreate
+     * is NOT called (bytesWritten == 0), and the fallback writes to the original output directly.
      */
-    public void testFallback_whenNothingWritten_thenRecreatesIndexOutput() throws IOException {
+    public void testFallback_whenNothingWritten_thenSkipsRecreate() throws IOException {
         try (Directory directory = newDirectory()) {
             final String fileName = "test_field_empty.faiss";
             IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
@@ -203,6 +203,7 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             assertEquals(0, output.getFilePointer());
 
             IndexOutputWithBuffer realIndexOutputWithBuffer = new IndexOutputWithBuffer(output);
+            assertEquals(0, realIndexOutputWithBuffer.getBytesWritten());
 
             SegmentWriteState realSegmentWriteState = new SegmentWriteState(
                 mock(InfoStream.class),
@@ -241,12 +242,11 @@ public class RemoteIndexBuildStrategyTests extends RemoteIndexBuildTests {
             // Verify fallback was called
             assertTrue(fallback.get());
 
-            // Verify the IndexOutput was recreated — file pointer should be at 0
-            assertEquals(0, realIndexOutputWithBuffer.getIndexOutput().getFilePointer());
+            // Verify bytesWritten is still 0 (reset was not called since nothing was written)
+            assertEquals(0, realIndexOutputWithBuffer.getBytesWritten());
 
-            // Close and verify file is empty (recreate deleted the empty file and created a new one)
-            realIndexOutputWithBuffer.getIndexOutput().close();
-            assertEquals(0, directory.fileLength(fileName));
+            // Close
+            realIndexOutputWithBuffer.close();
         }
     }
 

--- a/src/test/java/org/opensearch/knn/index/store/IndexOutputWithBufferTests.java
+++ b/src/test/java/org/opensearch/knn/index/store/IndexOutputWithBufferTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.knn.index.store;
+
+import lombok.SneakyThrows;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.opensearch.knn.KNNTestCase;
+
+import java.io.ByteArrayInputStream;
+
+public class IndexOutputWithBufferTests extends KNNTestCase {
+
+    @SneakyThrows
+    public void testWriteFromStream_thenTracksBytesWritten() {
+        try (Directory directory = newDirectory()) {
+            IndexOutput output = directory.createOutput("test.faiss", IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            assertEquals(0, buffer.getBytesWritten());
+
+            byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            buffer.writeFromStreamWithBuffer(new ByteArrayInputStream(data), data.length);
+
+            assertEquals(data.length, buffer.getBytesWritten());
+
+            buffer.close();
+        }
+    }
+
+    @SneakyThrows
+    public void testWriteBytes_thenTracksBytesWritten() {
+        try (Directory directory = newDirectory()) {
+            IndexOutput output = directory.createOutput("test.faiss", IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            assertEquals(0, buffer.getBytesWritten());
+
+            // writeBytes is called from JNI — it reads from the internal buffer
+            // We can't easily fill the internal buffer without JNI, but we can verify 0-length write
+            buffer.writeBytes(0);
+            assertEquals(0, buffer.getBytesWritten());
+
+            buffer.close();
+        }
+    }
+
+    @SneakyThrows
+    public void testReset_whenBytesWritten_thenClearsFileAndResetsBytesWritten() {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "test_reset.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            // Write some data
+            byte[] data = new byte[] { 0x49, 0x78, 0x4d, 0x70, 0x00, 0x04, 0x00, 0x00 };
+            buffer.writeFromStreamWithBuffer(new ByteArrayInputStream(data), data.length);
+            assertEquals(data.length, buffer.getBytesWritten());
+
+            // Reset should close old file, delete it, and create a fresh one
+            buffer.reset(directory, IOContext.DEFAULT);
+
+            assertEquals(0, buffer.getBytesWritten());
+            assertEquals(fileName, buffer.getName());
+
+            // Write to the new output — should work without error
+            byte[] newData = new byte[] { 1, 2, 3 };
+            buffer.writeFromStreamWithBuffer(new ByteArrayInputStream(newData), newData.length);
+            assertEquals(newData.length, buffer.getBytesWritten());
+
+            buffer.close();
+            assertEquals(newData.length, directory.fileLength(fileName));
+        }
+    }
+
+    @SneakyThrows
+    public void testReset_whenNothingWritten_thenStillWorks() {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "test_reset_empty.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            assertEquals(0, buffer.getBytesWritten());
+
+            // Reset on empty file — should not throw
+            buffer.reset(directory, IOContext.DEFAULT);
+
+            assertEquals(0, buffer.getBytesWritten());
+            assertEquals(fileName, buffer.getName());
+
+            buffer.close();
+        }
+    }
+
+    @SneakyThrows
+    public void testGetName_thenReturnsFileName() {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "my_field.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            assertEquals(fileName, buffer.getName());
+
+            buffer.close();
+        }
+    }
+
+    @SneakyThrows
+    public void testWriteFooter_thenWritesCodecFooter() {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "footer_test.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            // Write some data first (footer needs non-zero content for CRC)
+            byte[] data = new byte[] { 1, 2, 3, 4 };
+            buffer.writeFromStreamWithBuffer(new ByteArrayInputStream(data), data.length);
+
+            buffer.writeFooter();
+            buffer.close();
+
+            // Lucene codec footer is 16 bytes (magic + algorithmID + CRC)
+            assertEquals(data.length + 16, directory.fileLength(fileName));
+        }
+    }
+
+    @SneakyThrows
+    public void testClose_thenClosesUnderlyingOutput() {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "close_test.faiss";
+            IndexOutput output = directory.createOutput(fileName, IOContext.DEFAULT);
+            IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(output);
+
+            buffer.close();
+
+            // Writing after close should throw
+            expectThrows(Exception.class, () -> buffer.writeFromStreamWithBuffer(new ByteArrayInputStream(new byte[] { 1 }), 1));
+        }
+    }
+
+    @SneakyThrows
+    public void testAutoCloseable_withTryWithResources() {
+        try (Directory directory = newDirectory()) {
+            final String fileName = "autocloseable_test.faiss";
+            try (IndexOutputWithBuffer buffer = new IndexOutputWithBuffer(directory.createOutput(fileName, IOContext.DEFAULT))) {
+                byte[] data = new byte[] { 10, 20, 30 };
+                buffer.writeFromStreamWithBuffer(new ByteArrayInputStream(data), data.length);
+                buffer.writeFooter();
+            }
+            // File should exist and have content after try-with-resources closes it
+            assertEquals(3 + 16, directory.fileLength(fileName));
+        }
+    }
+}


### PR DESCRIPTION
### Description
When a remote index build partially writes data to the IndexOutput (e.g., S3 download fails mid-transfer) and then falls back to the local build strategy, the fallback previously appended to the already-written partial data, producing a corrupt .faiss file with two concatenated index structures.

Fix: call IndexOutputWithBuffer.recreate() before fallback to close the corrupt output, delete the partial file, and create a fresh output. NativeIndexWriter now manages IndexOutput lifecycle manually (instead of try-with-resources) so that CodecUtil.writeFooter and close operate on the potentially-replaced output.

### Related Issues
NA
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
